### PR TITLE
test(gc): report the two relocating collectors separately in the matrix (#7025)

### DIFF
--- a/changelog.d/7040-matrix-moved-counter.md
+++ b/changelog.d/7040-matrix-moved-counter.md
@@ -1,0 +1,19 @@
+`scripts/gc_repsel_matrix.sh` now reports the two relocating collectors separately
+instead of summing them into one `moved=` figure.
+
+`moved_objects=` comes from the C4b evacuation policy inside the mark-sweep
+collector; `[gc-copy-minor] ran copied_objects=` comes from the copying young-gen
+minor that #7019 made default-on. Summing them let a `requires=move` cell report
+green on relocation the arm was not testing — a cell could show a healthy
+moved-objects count while running zero copying minors, which is the exact shape
+#7024 describes.
+
+Cell evidence is now `cycles=N evacuated=X scavenged=Y`, and the per-arm liveness
+summary gains a `copy-minor n/N` column alongside `moved-objects n/N`.
+
+Verdicts are deliberately unchanged: the `move` predicate still tests
+`evacuated + scavenged > 0`, so this run is directly comparable to the recorded
+baselines. Tightening the predicate to require a copying minor where the arm
+demands one needs #7024 fixed first — under `--pressure` the copying minor
+currently never runs at all, so a stricter gate would fail arms for a harness
+defect rather than a real one.

--- a/scripts/gc_repsel_matrix.sh
+++ b/scripts/gc_repsel_matrix.sh
@@ -373,11 +373,27 @@ while [ "$ai" -lt "$NARMS" ]; do
             # per collection; one built WITH it prints the full JSON trace
             # object. Count either -- both are exactly one line per cycle.
             cycles=$(grep -cE '^\[gc\] cycle|^\{.*"phase_progression"' "$WORK/out/$b.$id.err" 2>/dev/null | tr -d ' ')
-            moved=$( { grep -oE 'moved_objects=[0-9]+' "$WORK/out/$b.$id.err" 2>/dev/null || true; \
-                       grep -oE '\[gc-copy-minor\] ran copied_objects=[0-9]+' "$WORK/out/$b.$id.err" 2>/dev/null || true; } \
-                     | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
-            : "${cycles:=0}"; : "${moved:=0}"
-            ev="cycles=$cycles moved=$moved"
+            # #7025: these are TWO different collectors and must be reported
+            # separately. Summing them lets a `requires=move` cell go green on
+            # relocation the arm was not testing:
+            #   evacuated= : `moved_objects=` from the C4b evacuation policy
+            #                inside the mark-sweep collector -- the pre-existing
+            #                non-moving-minor path that relocates tenured objects
+            #                during a full cycle.
+            #   scavenged= : `[gc-copy-minor] ran copied_objects=` from the
+            #                copying young-gen minor -- the path #7019 made
+            #                default-on, and the one the evacuating arms exist
+            #                to exercise.
+            # A cell showing `evacuated=N scavenged=0` did relocate something,
+            # but it did NOT run a copying minor, and the distinction is exactly
+            # what tells you whether the arm bit.
+            evacuated=$(grep -oE 'moved_objects=[0-9]+' "$WORK/out/$b.$id.err" 2>/dev/null \
+                        | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
+            scavenged=$(grep -oE '\[gc-copy-minor\] ran copied_objects=[0-9]+' "$WORK/out/$b.$id.err" 2>/dev/null \
+                        | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
+            : "${cycles:=0}"; : "${evacuated:=0}"; : "${scavenged:=0}"
+            moved=$((evacuated + scavenged))
+            ev="cycles=$cycles evacuated=$evacuated scavenged=$scavenged"
             if [ "$rc" -ne 0 ]; then
                 result="FAIL"; ev="exit=$rc $ev"
             elif ! cmp -s "$WORK/out/$b.$id.out" "$WORK/oracle/$b.out"; then
@@ -437,18 +453,24 @@ echo
 echo "arm liveness across the corpus (cells where the arm actually bit):"
 ai=0
 while [ "$ai" -lt "$NARMS" ]; do
-    tot=0; livec=0; livem=0; ti=0
+    tot=0; livec=0; livem=0; lives=0; ti=0
     while [ "$ti" -lt "${#CORPUS[@]}" ]; do
         ev="${EVID[$((ti*NARMS+ai))]:-}"
         cy="$(printf '%s' "$ev" | sed -nE 's/.*cycles=([0-9]+).*/\1/p')"
-        mv="$(printf '%s' "$ev" | sed -nE 's/.*moved=([0-9]+).*/\1/p')"
+        evac="$(printf '%s' "$ev" | sed -nE 's/.*evacuated=([0-9]+).*/\1/p')"
+        scav="$(printf '%s' "$ev" | sed -nE 's/.*scavenged=([0-9]+).*/\1/p')"
         tot=$((tot+1))
         [ "${cy:-0}" -gt 0 ] 2>/dev/null && livec=$((livec+1))
-        [ "${mv:-0}" -gt 0 ] 2>/dev/null && livem=$((livem+1))
+        [ $(( ${evac:-0} + ${scav:-0} )) -gt 0 ] 2>/dev/null && livem=$((livem+1))
+        [ "${scav:-0}" -gt 0 ] 2>/dev/null && lives=$((lives+1))
         ti=$((ti+1))
     done
-    printf '  %-24s requires=%-8s collected %2d/%2d   moved-objects %2d/%2d\n' \
-        "${ARM_IDS[$ai]}" "${ARM_LIVES[$ai]}" "$livec" "$tot" "$livem" "$tot"
+    # #7025: `copy-minor` is reported separately from `moved-objects` because the
+    # latter counts BOTH collectors. An evacuating arm showing a healthy
+    # moved-objects count but `copy-minor 0/N` did not run the path it exists to
+    # test -- that is the shape #7024 describes, and summing the two hid it.
+    printf '  %-24s requires=%-8s collected %2d/%2d   moved-objects %2d/%2d   copy-minor %2d/%2d\n' \
+        "${ARM_IDS[$ai]}" "${ARM_LIVES[$ai]}" "$livec" "$tot" "$livem" "$tot" "$lives" "$tot"
     ai=$((ai+1))
 done
 


### PR DESCRIPTION
Closes #7025.

## The problem

`scripts/gc_repsel_matrix.sh` derived its `moved=` evidence — the liveness predicate for every `requires=move` arm — by summing **two different collectors** into one number:

```sh
moved=$( { grep -oE 'moved_objects=[0-9]+' ... ; \
           grep -oE '\[gc-copy-minor\] ran copied_objects=[0-9]+' ... ; } | awk '{s+=$1}')
```

- `moved_objects=` — the **C4b evacuation policy inside the mark-sweep collector**, the pre-existing path that relocates tenured objects during a full cycle.
- `[gc-copy-minor] ran copied_objects=` — the **copying young-gen minor**, the path #7019 made default-on and the one the evacuating arms exist to exercise.

Both relocate objects, so both look like "moved". But a cell can show a healthy moved count having run **zero** copying minors — reporting green for a collector it never invoked. That is exactly the shape #7024 describes (`--pressure` makes the `default` arm run zero copying minors on all 22 rows), and summing the counters is what hid it.

## The change

Cell evidence is now `cycles=N evacuated=X scavenged=Y`, and the per-arm liveness summary gains a `copy-minor n/N` column beside `moved-objects n/N`.

Exercising the extraction against synthetic evidence shows the defect made visible:

```
cycles=3 evacuated=1200 scavenged=0       moved=1200   move-verdict=PASS   copy-minor=NO
cycles=5 evacuated=0 scavenged=44933      moved=44933  move-verdict=PASS   copy-minor=yes
cycles=0 evacuated=0 scavenged=0          moved=0      move-verdict=UNVER  copy-minor=NO
```

Row 1 is the bug: green on `move`, having never run a copying minor.

## Verdicts are unchanged, by construction

`moved` is still `evacuated + scavenged` and feeds the same predicate, so **every cell reaches the same verdict as before** and results stay directly comparable to the recorded baselines (`PASS=302 UNVER=91 XFAIL=1 FAIL=46` over 440 cells on `4340bffc9`).

That is deliberate. Tightening the predicate — requiring a copying minor where the arm demands one — is the obvious follow-up, but it is **gated on #7024**: under `--pressure` the copying minor currently never runs at all, so a stricter gate would fail arms for a harness defect rather than a real one. Landing the visibility first, then the fix, then the stricter gate keeps each step attributable.

## Validation

`bash -n` clean. `shellcheck -S warning` reports one finding (`SC2164` at line 60, `cd "$ROOT"`) which is pre-existing and outside this diff. Extraction logic exercised against the four evidence shapes above, including the `output-mismatch` prefix case.

**Not run:** the full matrix. It needs a release build plus a quiet box, and the mini is currently occupied by the #7022 crash investigation. Since verdicts are unchanged by construction and the parsing is exercised directly, a full run is confirmatory rather than load-bearing — but it has not been done, and I would rather say so than imply it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection stress reporting by separating evacuation activity from copying minor collections.
  - Updated evidence output to show collection cycles, evacuated objects, and scavenged objects independently.
  - Added distinct liveness counts for collected cycles, moved objects, and copying minor collections.
  - Prevented misleading healthy results when copying minor collections did not run.

- **Documentation**
  - Clarified how relocation metrics and verdicts are calculated for existing baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->