### PR TITLE
style: clear two of the lint backlog items blocking every merge (fmt + GC knob kill-policy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,18 @@ Generational mark-sweep GC in `crates/perry-runtime/src/gc.rs` (default since v0
 
 **Escape hatches**: `PERRY_GEN_GC=0`/`off`/`false` reverts to full mark-sweep (bisection only). `PERRY_GEN_GC_EVACUATE=0`/`off`/`false` disables policy evacuation; `=1`/`on`/`true` is accepted as auto-policy allowed, not unconditional evacuation. `PERRY_GC_FORCE_EVACUATE=1` stress-copies every marked non-pinned nursery object only when generated write barriers are active and policy evacuation is allowed. `PERRY_GC_VERIFY_EVACUATION=1` panics if any mutable live slot still points at a forwarded nursery object after an evacuation/rewrite cycle. `PERRY_WRITE_BARRIERS=0`/`off`/`false` disables codegen-emitted write barriers at compile time and runtime exact helper barriers at runtime for benchmark/debug bisection; unset, `=1`/`on`/`true` keep barriers enabled. `PERRY_GC_DIAG=1` prints per-cycle diagnostics, including evacuation-policy decisions for considered cycles and `barriers_inactive` skips.
 
+### GC knob kill-policy (binding)
+
+**Every GC env knob either has a required CI arm exercising its OFF state, or it is deleted after one release of soak.** At most one diagnostic-only knob may exist at a time, and it must be labelled untested.
+
+This is not tidiness. An unexercised mode is a configuration nobody has verified, and this project has repeatedly paid for that:
+
+- `PERRY_GC_FORCE_EVACUATE` was **inert** for every `gc()`-driven test — it is read only on the minor path, while `gc()` runs a full mark-sweep with a forced conservative scan (#6942/#6946). Months of "passes under evacuation" meant nothing.
+- The matrix's `--pressure` knob **disabled the very path it was measuring** — the defer hard cap and the arena-trigger ceiling shared a formula and collapsed together, so the `default` arm ran zero copying minors on all 22 rows (#7024).
+- `gc_incremental_enabled`'s doc said "EXPERIMENTAL — default OFF" eight lines above a body comment saying "DEFAULT ON" (#6987). A merge decision was made on the wrong one.
+
+**A mode that still exists is a decision that hasn't been made.** When a knob's off-state stops being exercised, delete the off-state and the branch behind it — the losing mode should stop compiling, not linger as an untested configuration that a future bisect will trust.
+
 ## Threading (`perry/thread`)
 
 Single-threaded by default. `perry/thread` provides:

--- a/changelog.d/7042-lint-fmt-backlog.md
+++ b/changelog.d/7042-lint-fmt-backlog.md
@@ -1,0 +1,8 @@
+Applied `cargo fmt` to four files that had drifted out of rustfmt compliance on
+`main`: `lower_call/native/mod.rs`, `global_this/install_static.rs`,
+`commands/check.rs`, and `commands/deps.rs`.
+
+Pure formatting — line breaking only, no semantic change. These were failing the
+`lint` gate's `cargo fmt --all -- --check` step, which sits behind the stale
+public-benchmark-baseline step and so was invisible until the baseline failure
+was investigated.

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -409,10 +409,7 @@ pub(crate) fn lower_native_method_call(
                 blk.call(
                     DOUBLE,
                     "js_node_submodule_namespace",
-                    &[
-                        (PTR, &submod_label),
-                        (I32, &submod_key.len().to_string()),
-                    ],
+                    &[(PTR, &submod_label), (I32, &submod_key.len().to_string())],
                 )
             };
             let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());

--- a/crates/perry-runtime/src/object/global_this/install_static.rs
+++ b/crates/perry-runtime/src/object/global_this/install_static.rs
@@ -899,7 +899,11 @@ pub(crate) fn install_reflect_namespace_members(ns_obj: *mut ObjectHeader) {
             1,
         ),
         ("set", reflect_set_thunk as *const u8, 3),
-        ("setPrototypeOf", reflect_set_prototype_of_thunk as *const u8, 2),
+        (
+            "setPrototypeOf",
+            reflect_set_prototype_of_thunk as *const u8,
+            2,
+        ),
     ];
     for (name, func_ptr, arity) in methods {
         install_proto_method(ns_obj, name, func_ptr, arity);

--- a/crates/perry/src/commands/check.rs
+++ b/crates/perry/src/commands/check.rs
@@ -783,6 +783,10 @@ mod tests {
         let mut walked =
             collect_ts_files(&dir.path().to_path_buf()).expect("collect from directory input");
         walked.sort();
-        assert_eq!(walked, vec![main, other], "directory input walks all sources");
+        assert_eq!(
+            walked,
+            vec![main, other],
+            "directory input walks all sources"
+        );
     }
 }

--- a/crates/perry/src/commands/deps.rs
+++ b/crates/perry/src/commands/deps.rs
@@ -819,10 +819,7 @@ mod tests {
     /// found" because the full specifier was joined as a path).
     #[test]
     fn package_base_name_splits_scoped_subpath_exports() {
-        assert_eq!(
-            package_base_name("@acme/toolkit/fs/safe"),
-            "@acme/toolkit"
-        );
+        assert_eq!(package_base_name("@acme/toolkit/fs/safe"), "@acme/toolkit");
         assert_eq!(package_base_name("@acme/toolkit"), "@acme/toolkit");
         assert_eq!(package_base_name("@scope/name/a/b/c"), "@scope/name");
         assert_eq!(package_base_name("lodash/map"), "lodash");


### PR DESCRIPTION
`lint` is red repo-wide, so nothing merges. The failures are stacked — each one hides the next, which is why they surfaced one at a time:

| # | step | state |
|---|---|---|
| 1 | Public benchmark evidence freshness | **red** — maintainer-only (needs Node v22.23.1 + Bun 1.3.14, AC power, quiet host). #7012 also reports it cannot regenerate from a clean checkout. |
| 2 | `cargo fmt --all -- --check` | **red** — fixed here |
| 3 | `check_file_size.sh` (2000-line cap) | **red** — 7 files, listed below, not touched here |
| 4 | `addr_class_inventory.py` | red on `native_module/constants.rs:2088` |

This PR clears **(2)** and adds the knob kill-policy. It does not pretend to unblock `lint` on its own — (1) is not delegable and (3)/(4) are separate changes.

## Part 1 — rustfmt

Four files had drifted:

```
crates/perry-codegen/src/lower_call/native/mod.rs
crates/perry-runtime/src/object/global_this/install_static.rs
crates/perry/src/commands/check.rs
crates/perry/src/commands/deps.rs
```

Pure formatting — the entire diff is four call/macro argument lists being wrapped. +12/−10.

## Part 2 — GC knob kill-policy in `CLAUDE.md`

> Every GC env knob either has a required CI arm exercising its OFF state, or it is deleted after one release of soak. At most one diagnostic-only knob, labelled untested.

Written down because this project has paid for unexercised modes three times in the last week:

- **`PERRY_GC_FORCE_EVACUATE` was inert** for every `gc()`-driven test — it is read only on the minor path, while `gc()` runs a full mark-sweep with a forced conservative scan (#6942/#6946). Months of "passes under evacuation" meant nothing.
- **The matrix's `--pressure` knob disabled the very path it was measuring** — the defer hard cap and the arena-trigger ceiling share a formula and collapse together, so the `default` arm ran zero copying minors on all 22 rows (#7024).
- **`gc_incremental_enabled`'s doc said "EXPERIMENTAL — default OFF"** eight lines above a body comment saying "DEFAULT ON" (#6987). A merge decision was made on the wrong one.

The principle: *a mode that still exists is a decision that hasn't been made.* When a knob's off-state stops being exercised, the off-state and the branch behind it should stop compiling, rather than lingering as an untested configuration a future bisect will trust.

## For whoever takes item (3)

The 7 files over the cap:

```
2054  crates/perry-codegen/src/codegen/typed_abi.rs
2135  crates/perry-codegen/src/expr/index_get.rs
2013  crates/perry-runtime/src/array/generic.rs
2081  crates/perry-runtime/src/gc/tests/layout_trace.rs
2210  crates/perry-runtime/src/object/native_module/callable_export_check.rs
2255  crates/perry-runtime/src/object/native_module/callable_exports.rs
2421  crates/perry-runtime/src/object/native_module/constants.rs
```

Deliberately untouched: splitting seven files is a mechanical but non-trivial change and folding it into a formatting PR would make both unreviewable.

## Validation

`cargo fmt --all -- --check` clean on this branch. No semantic change, so no behavioural verification is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added binding guidance for managing and testing garbage-collection environment toggles.
  * Documented requirements for removing stale or untested diagnostic modes.

* **Style**
  * Applied Rust formatting fixes across several files and test assertions.
  * Updated the changelog to record formatting-only maintenance with no behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->