### PR TITLE
fix(benchmarks): public baseline must build the -static wrapper crates (#7012)

### DIFF
--- a/benchmarks/run_public_baseline.sh
+++ b/benchmarks/run_public_baseline.sh
@@ -83,7 +83,23 @@ PY
 }
 
 echo "Building Perry at $(git rev-parse HEAD)..."
-cargo build --release -p perry-runtime -p perry-stdlib -p perry
+# The `-static` wrappers are NOT optional (#7012). `perry-runtime` and
+# `perry-stdlib` are `crate-type = ["rlib"]`, so building them alone leaves
+# `target/release/` with the `perry` binary and no `libperry_runtime.a` /
+# `libperry_stdlib.a` -- every `perry compile` in the measurement legs below
+# then dies with "Could not find libperry_runtime.a".
+#
+# This is invisible on a long-lived working copy, which already has the
+# archives from unrelated builds; it only bites a clean checkout, which is
+# exactly the situation someone regenerating the published artifact is in.
+cargo build --release \
+    -p perry-runtime -p perry-stdlib -p perry \
+    -p perry-runtime-static -p perry-stdlib-static
+
+for archive in libperry_runtime.a libperry_stdlib.a; do
+    [[ -f "target/release/$archive" ]] \
+        || fail "build did not produce target/release/$archive -- the -static wrapper crates are required (#7012)"
+done
 wait_for_quiet
 
 echo "=== suite ==="

--- a/changelog.d/7044-baseline-static-crates.md
+++ b/changelog.d/7044-baseline-static-crates.md
@@ -1,0 +1,13 @@
+`benchmarks/run_public_baseline.sh` can now regenerate the published artifact from
+a clean checkout. It built only `-p perry-runtime -p perry-stdlib -p perry`, but
+those crates are `crate-type = ["rlib"]` — `libperry_runtime.a` and
+`libperry_stdlib.a` come from the separate `perry-runtime-static` /
+`perry-stdlib-static` wrappers. Without them `target/release/` held the `perry`
+binary and no archives, so every `perry compile` in the measurement legs died with
+"Could not find libperry_runtime.a".
+
+Invisible on a long-lived working copy, which already has the archives from
+unrelated builds — and only reachable from a clean checkout, which is exactly the
+state someone regenerating the public artifact is in. The build now includes the
+wrappers and asserts both archives exist before measuring, so the failure is loud
+and immediate rather than appearing as a compile error inside a benchmark leg.


### PR DESCRIPTION
Closes #7012. **This unblocks regenerating the public benchmark artifact, which is the first of the four stacked `lint` failures currently blocking every merge in the repo.**

## The bug

`benchmarks/run_public_baseline.sh` built:

```bash
cargo build --release -p perry-runtime -p perry-stdlib -p perry
```

But `perry-runtime` and `perry-stdlib` are `crate-type = ["rlib"]`. `libperry_runtime.a` and `libperry_stdlib.a` come from the separate `perry-runtime-static` / `perry-stdlib-static` wrapper crates (`crate-type = ["staticlib"]`, both already workspace members).

So a clean checkout ends up with the `perry` binary and **no static archives**, and every `perry compile` in the measurement legs dies with `Could not find libperry_runtime.a`.

## Why it went unnoticed

It is invisible on a long-lived working copy — the maintainer's tree already has the archives from unrelated builds. It is only reachable from a **clean checkout**, which is exactly the state someone regenerating the published artifact is in. That inverts the usual failure ordering: the people most likely to hit it are the ones doing the rarest and most consequential operation.

This is the same trap `CLAUDE.md` documents under *"Verifying a runtime change"* — `cargo build -p perry-runtime -p perry-stdlib` does **not** emit the archives, so a stale `.a` gets linked and a change looks like a no-op. Same root cause, different symptom.

## The change

Adds the two wrapper crates to the build, and asserts both archives exist before any measurement runs:

```bash
cargo build --release \
    -p perry-runtime -p perry-stdlib -p perry \
    -p perry-runtime-static -p perry-stdlib-static

for archive in libperry_runtime.a libperry_stdlib.a; do
    [[ -f "target/release/$archive" ]] \
        || fail "build did not produce target/release/$archive -- the -static wrapper crates are required (#7012)"
done
```

The assertion matters as much as the fix: a future packaging change that drops an archive now fails **loudly at the build step**, rather than surfacing an hour later as a mysterious compile error inside a benchmark leg on a machine someone has just quiesced for measurement.

## Validation

`bash -n` clean; `fail()` is defined at line 17, well before use; both wrapper crates confirmed present in the workspace and emitting `crate-type = ["staticlib"]`.

**Not run:** the script itself. It requires Node v22.23.1 + Bun 1.3.14 exactly, macOS on AC power, and waits for CPU-quiet for 60 consecutive seconds before measuring — so a full run is a maintainer operation on a dedicated idle host, not something to do speculatively. The change is a build-command edit plus an existence check, and the failure mode it fixes is deterministic and understood.

I would suggest this lands before the next baseline regeneration attempt rather than after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark artifact generation from clean checkouts.
  * Added verification that required static libraries are produced before measurements run.
  * Benchmark setup now reports clear errors when required build artifacts are missing.

* **Documentation**
  * Documented the static wrapper requirement in the benchmark regeneration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->