### PR TITLE
test(gc): pin the GC performance/RSS ratchet baseline and gate on it

### DIFF
--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -38,11 +38,16 @@ jobs:
     # a linux runner would turn the gate red, not silently weaken it.
     runs-on: macos-14
     timeout-minutes: 90
+    permissions:
+      contents: read
+      # Read-only listing of the PR's changed files, to decide whether this
+      # change can touch the collector. Same approach `changeset-gate` uses, and
+      # it avoids a fetch-depth: 0 clone of a large history.
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
         with:
-          # Needed to diff against the PR base when deciding relevance.
-          fetch-depth: 0
+          persist-credentials: false
 
       # Fast structural failure first: a broken harness or a tampered artifact
       # should not cost a 20-minute compiler build to discover.
@@ -54,21 +59,25 @@ jobs:
       - name: Decide whether this change can affect the collector
         id: relevance
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "Not a pull request; measuring."
             exit 0
           fi
+          gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' > changed.txt
           # Anything under crates/ can move the collector: a codegen change
           # alters what is allocated, a transform change alters what escapes,
           # and a dependency bump can change allocator behaviour. The filter is
           # deliberately broad; it exists only to spare docs-only PRs a build.
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
-             | grep -qE '^(crates/|benchmarks/gc_ratchet/|Cargo\.(toml|lock)$|\.github/workflows/gc-ratchet\.yml$|tests/test_gc_ratchet\.py$)'; then
+          # If the listing is empty or the API failed, `set -e` already aborted
+          # — the job does not silently fall through to "not relevant".
+          if grep -qE '^(crates/|benchmarks/gc_ratchet/|Cargo\.(toml|lock)$|\.github/workflows/gc-ratchet\.yml$|tests/test_gc_ratchet\.py$)' changed.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "Change touches collector-relevant paths; measuring."
           else

--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -1,0 +1,164 @@
+name: GC Ratchet
+
+# Regression gate for GC retention, evacuation accounting, and memory against
+# the pinned baseline in benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json.
+#
+# THIS JOB IS DESIGNED TO BE ABLE TO FAIL. There is no `continue-on-error`, no
+# `|| true`, and no pipe between the checker and the shell's exit status. That
+# is deliberate and load-bearing: `gc-stress` in test.yml is
+# `continue-on-error: true`, which is why a regression sat behind it through
+# three merges. A gate that cannot fail is not a gate.
+#
+# NOT the public benchmark baseline. benchmarks/run_public_baseline.sh produces
+# benchmarks/results/public-node-bun-v1.json (published Node/Bun evidence, gates
+# `lint`). This is the internal Perry-vs-Perry GC ratchet. Do not conflate them.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gc-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  MACOSX_DEPLOYMENT_TARGET: "13.0"
+
+jobs:
+  gc-ratchet:
+    # macos-14 is arm64, which matches the `darwin-arm64` platform key the
+    # baseline was captured under. The checker refuses a platform mismatch
+    # rather than comparing numbers that are not comparable, so moving this to
+    # a linux runner would turn the gate red, not silently weaken it.
+    runs-on: macos-14
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Needed to diff against the PR base when deciding relevance.
+          fetch-depth: 0
+
+      # Fast structural failure first: a broken harness or a tampered artifact
+      # should not cost a 20-minute compiler build to discover.
+      - name: Harness unit tests and artifact validation
+        run: |
+          python3 -m unittest discover -s tests -p 'test_gc_ratchet.py' -v
+          python3 benchmarks/gc_ratchet/gc_ratchet.py validate
+
+      - name: Decide whether this change can affect the collector
+        id: relevance
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Not a pull request; measuring."
+            exit 0
+          fi
+          # Anything under crates/ can move the collector: a codegen change
+          # alters what is allocated, a transform change alters what escapes,
+          # and a dependency bump can change allocator behaviour. The filter is
+          # deliberately broad; it exists only to spare docs-only PRs a build.
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+             | grep -qE '^(crates/|benchmarks/gc_ratchet/|Cargo\.(toml|lock)$|\.github/workflows/gc-ratchet\.yml$|tests/test_gc_ratchet\.py$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Change touches collector-relevant paths; measuring."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No collector-relevant paths changed; the pinned baseline still holds."
+          fi
+
+      - name: Install Rust toolchain
+        if: steps.relevance.outputs.run == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        if: steps.relevance.outputs.run == 'true'
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Setup Node oracle
+        if: steps.relevance.outputs.run == 'true'
+        uses: actions/setup-node@v7
+        with:
+          # Single source of truth: .node-version at the repo root. Node is a
+          # correctness input here, not a peer benchmark: every probe's stdout
+          # is diffed against it, because a probe that silently stops
+          # allocating exits 0 and reports a beautifully small retained heap.
+          node-version-file: .node-version
+
+      - name: Build perry and the runtime archives
+        if: steps.relevance.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          # perry-runtime and perry-stdlib are rlib-only. libperry_runtime.a and
+          # libperry_stdlib.a come from the -static wrapper crates; building
+          # without them links a stale archive and makes the whole measurement
+          # vacuous. The package set is fixed here so cargo feature unification
+          # is identical to the set used to capture the baseline.
+          cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static
+          for artifact in perry libperry_runtime.a libperry_stdlib.a; do
+            test -s "target/release/$artifact" \
+              || { echo "::error::target/release/$artifact was not produced"; exit 1; }
+          done
+
+      - name: Verify the Node oracle version
+        if: steps.relevance.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          expected="v$(tr -d 'v \n' < .node-version)"
+          actual="$(node --version)"
+          test "$expected" = "$actual" \
+            || { echo "::error::expected Node $expected, found $actual"; exit 1; }
+
+      - name: Measure
+        if: steps.relevance.outputs.run == 'true'
+        env:
+          PERRY_RUNTIME_DIR: ${{ github.workspace }}/target/release
+          # Deterministic link: use the prebuilt full stdlib rather than letting
+          # the auto-optimizer rebuild a workload-specific archive mid-run.
+          PERRY_NO_AUTO_OPTIMIZE: "1"
+        run: |
+          set -euo pipefail
+          mkdir -p .bench-results
+          uptime
+          python3 benchmarks/gc_ratchet/gc_ratchet.py measure \
+            --perry target/release/perry \
+            --repeats 7 \
+            --output .bench-results/gc-ratchet-current.json
+
+      # No pipe, no `|| true`, no continue-on-error: this step's exit status is
+      # the gate. The `shared_ci` profile gates retention and the evacuation
+      # counters, which are semantic and transfer across machine classes, and
+      # explicitly does not gate RSS or wall time, which do not. See
+      # benchmarks/gc_ratchet/tolerances.json for every band and its reasoning.
+      - name: Check against the pinned baseline
+        if: steps.relevance.outputs.run == 'true'
+        run: |
+          python3 benchmarks/gc_ratchet/gc_ratchet.py check \
+            --current .bench-results/gc-ratchet-current.json \
+            --profile shared_ci
+
+      - name: Upload measurement
+        if: always() && steps.relevance.outputs.run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: gc-ratchet-${{ github.sha }}
+          path: |
+            .bench-results/gc-ratchet-current.json
+            benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
+          retention-days: 90

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -91,6 +91,37 @@ everywhere.
 different reason: a GitHub runner is a different machine class with a different
 baseline RSS, so the comparison is not meaningful there at any band.
 
+## The gate was validated against a real collector change
+
+Unit tests prove the checker fails on injected JSON. That is necessary but not
+sufficient — it says nothing about whether the *probes* are sensitive to the
+thing the campaign will actually do. So the gate was also run end-to-end against
+`PERRY_CONSERVATIVE_STACK_SCAN=full`, the runtime's existing escape hatch for
+the legacy conservative stack scan, which is the mechanism the campaign is
+adopting.
+
+Control arm (unchanged collector) reproduced the baseline exactly on all eight
+probes and exited 0. The conservative-scan arm exited 1 with 60 regression rows:
+
+| Probe | `heap_used_bytes` baseline | with conservative scan | Δ | `minor_cycles` |
+|---|---:|---:|---:|---:|
+| `01_nursery_churn` | 807,000 | 3,742,800 | +364% | 14 → 0 |
+| `02_survivor_promotion` | 5,022,864 | 25,242,760 | +403% | 10 → 0 |
+| `03_cross_gen_writes` | 705,320 | 6,494,536 | +821% | 22 → 0 |
+| `04_dead_after_deep_stack` | 1,000,728 | 9,187,088 | +818% | 104 → 0 |
+| `05_closure_capture` | 1,040,208 | 7,336,208 | +605% | 26 → 0 |
+| `06_string_retention` | 746,056 | 4,746,240 | +536% | 64 → 0 |
+| `07_array_grow_evacuate` | 1,816,232 | 99,362,360 | +5371% | 80 → 0 |
+| `08_map_set_sidetables` | 457,872 | 6,754,560 | +1375% | 84 → 0 |
+
+Two things follow. The probes are sensitive to conservative scanning by orders
+of magnitude, not by margin. And a collector that stops running copying minors
+at all is reported as a regression on `minor_cycles` rather than as a harness
+error — the "probe ran no collection" rule deliberately lives in
+`validate_artifact` (you may not *pin* such a probe) and not in `measure`, so
+that the largest possible regression is not misdiagnosed as "your probe is too
+small".
+
 ## Direction
 
 Retention, memory and timing regress only upward, so their bands are one-sided.

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -1,0 +1,167 @@
+# GC ratchet
+
+A pinned baseline of the current evacuating minor collector's observable
+behaviour, plus a checker that fails when a change regresses against it.
+
+It exists because the GC architecture campaign — replacing shadow-stack precise
+roots with a conservative stack scan plus per-object pinning — is a large
+deletion whose risks are exactly the things this measures: more retained
+garbage, less evacuation, higher memory. The rule for that campaign is that the
+gate decides, not argument.
+
+## This is not the public benchmark baseline
+
+Two artifacts in this repository sound alike and are unrelated. They get
+confused; this section exists so they stop being confused.
+
+| | public baseline | GC ratchet (this directory) |
+|---|---|---|
+| Artifact | `benchmarks/results/public-node-bun-v1.json` | `benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json` |
+| Produced by | `benchmarks/run_public_baseline.sh` | `benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh` |
+| Checked by | `benchmarks/ci_public_baseline_check.py` | `benchmarks/gc_ratchet/gc_ratchet.py check` |
+| Compares | Perry vs pinned Node vs pinned Bun | Perry vs its own past self |
+| Purpose | published performance evidence | internal regression ratchet |
+| Gates | `lint` | `gc-ratchet` |
+| Regenerated | on a release cadence, freshness-checked | only when a shift is deliberately accepted |
+| Owner | maintainer | whoever lands a collector change |
+
+Never regenerate one from the other. The quiet-host discipline in
+`run_gc_ratchet_baseline.sh` is copied from `run_public_baseline.sh` on purpose,
+because it is good discipline, not because the artifacts are related.
+
+## What is measured
+
+Eight probes in `probes/`, each a deterministic TypeScript workload that drives
+a different part of the collector: nursery churn with a zero live set, survivor
+aging and promotion, old-to-young stores and the remembered set, dead objects
+left under a deep stack high-water mark, closure environments, heap strings,
+array element-storage growth, and Map/Set side tables.
+
+Every probe parks its allocations in a heap container before dropping them. This
+is load-bearing. An earlier draft allocated into locals that never escaped, LLVM
+scalar-replaced the objects away, and the probe ran in 10 ms with zero
+collections and 600 retained bytes — a benchmark that measured nothing while
+looking healthy. The harness now refuses to pin any probe that triggers no minor
+collection.
+
+Each probe writes two streams:
+
+- **stdout** — `probe:` and `checksum:` lines only, diffed byte-for-byte against
+  the Node version pinned in `.node-version`. Exit 0 is not correctness: a probe
+  that quietly stops allocating still exits 0 and reports a beautifully small
+  retained heap.
+- **stderr** — `#gcmetric key=value` lines read from `process.memoryUsage()`
+  after an explicit full `gc()`.
+
+Four metric families, measured on the pinned quiet host over 3 independent
+sessions x 7 repeats (21 runs per probe), plus 5 traced runs per probe:
+
+| Family | Metrics | Observed spread | Gated in shared CI | Gated on pinned host |
+|---|---|---|---|---|
+| retention | `heap_used_bytes`, `heap_total_bytes` | **0.000%** | yes | yes |
+| GC accounting | `minor_cycles`, `step_cycles`, `copied_objects`, `copied_bytes`, `promoted_objects`, `promoted_bytes`, `freed_bytes` | **0.000%** | yes | yes |
+| memory | `rss_bytes`, `peak_rss_bytes` | <=0.41% | no | yes |
+| timing | `wall_ms` | <=0.75% (medians) | **no** | yes |
+
+The GC accounting family is parsed from `PERRY_GC_DIAG=1` output in a separate,
+untimed pass; enabling the trace was verified not to change `heap_used_bytes`,
+so the traced pass observes the same collector the untimed pass measures. The
+harness takes two traced runs on every invocation and fails if they disagree —
+that is the harness proving, each time it runs, that the counters it is about to
+gate on really are deterministic.
+
+Retention and GC accounting are semantic: they are a function of the allocation
+sequence and collector policy, not of CPU speed, core count, or machine load.
+That is why they can be gated on a shared CI runner and memory and time cannot.
+
+## Why wall time is excluded from the shared-CI gate
+
+On the pinned quiet host, wall time is stable enough to gate (0.75% spread on
+medians of 7). On a GitHub-hosted runner it is not, and no band both survives
+neighbour noise and catches a real GC slowdown. Rather than widen the band until
+it can never fire, `wall_ms` is marked non-gating in the `shared_ci` profile and
+gated in `pinned_host`.
+
+The GC-work dimension is not lost by that choice: `minor_cycles`,
+`copied_objects`, `copied_bytes` and `freed_bytes` measure how much work the
+collector did without measuring how fast the machine was, and they are gated
+everywhere.
+
+`rss_bytes` and `peak_rss_bytes` are excluded from the shared-CI gate for a
+different reason: a GitHub runner is a different machine class with a different
+baseline RSS, so the comparison is not meaningful there at any band.
+
+## Direction
+
+Retention, memory and timing regress only upward, so their bands are one-sided.
+The evacuation counters are two-sided: they are a behavioural fingerprint of the
+collector, not a score. A collector that suddenly copies fewer objects has
+changed — plausibly because objects are now pinned — and must be re-pinned
+deliberately rather than silently congratulated.
+
+## Running it
+
+Checking on the pinned quiet host, with memory and time gated:
+
+```bash
+cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static
+PERRY_BIN=$PWD/target/release/perry \
+PERRY_RUNTIME_DIR=$PWD/target/release \
+  ./benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh --check
+```
+
+The driver refuses to run unless the tree is clean, the host is on AC power,
+there are at least 9 GB free, the pinned Node is present at the expected
+version, and CPU-active has been at or below 25% for 60 consecutive seconds. It
+requires `PERRY_BIN` and `PERRY_RUNTIME_DIR` to be named explicitly rather than
+searching, because build outputs are invisible to `git status` and an implicit
+search can pick up an archive from an unrelated worktree.
+
+Ad-hoc, without the quiet-host gating (for a quick look, not for evidence):
+
+```bash
+python3 benchmarks/gc_ratchet/gc_ratchet.py measure \
+  --perry target/release/perry --repeats 7 --output /tmp/current.json
+python3 benchmarks/gc_ratchet/gc_ratchet.py check --current /tmp/current.json
+```
+
+## When the gate goes red
+
+1. **Read the table.** The failing rows name the probe and the metric. Retention
+   up means something is being kept alive that used to be collected.
+   `copied_objects` down means objects that used to be evacuated no longer are.
+   `freed_bytes` down means the same allocation sequence reclaimed less.
+2. **Reproduce locally** with the ad-hoc commands above. Retention and GC
+   counters do not need a quiet box — they are load-independent.
+3. **Fix it, or accept it.** If the shift is intentional and reviewed, re-pin:
+
+   ```bash
+   PERRY_BIN=... PERRY_RUNTIME_DIR=... \
+     ./benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh --pin \
+       --notes "why this shift is intentional and who reviewed it"
+   ```
+
+Re-pinning to make a red gate go green, without that reasoning written down in
+`--notes` and in the PR, defeats the entire purpose of the ratchet. The artifact
+records the commit, host, load average at capture, toolchain versions, and
+SHA-256 of the `perry` binary and both runtime archives, so a re-pin is
+auditable after the fact.
+
+## Adding a probe
+
+Adding or removing a probe changes the baseline's probe set, and the checker
+fails on a set mismatch rather than silently ignoring the new one. So a new
+probe requires a deliberate re-pin, which is the intended friction. The probe
+must trigger at least one minor collection or the harness refuses to pin it.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `probes/*.ts` | the workloads |
+| `gc_ratchet.py` | measure / assemble / check / validate |
+| `tolerances.json` | every band, with the variance it was derived from |
+| `baseline/gc-ratchet-v1.json` | the pinned artifact |
+| `run_gc_ratchet_baseline.sh` | quiet-host driver (`--check` / `--pin`) |
+| `../../tests/test_gc_ratchet.py` | proves the gate fails on each failure mode |
+| `../../.github/workflows/gc-ratchet.yml` | CI wiring |

--- a/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
+++ b/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
@@ -1,0 +1,4169 @@
+{
+  "schema_version": 1,
+  "kind": "gc-ratchet-baseline",
+  "artifact_id": "gc-ratchet-v1",
+  "not_the_public_baseline": "Internal Perry-vs-Perry GC ratchet. The public Node/Bun evidence is benchmarks/results/public-node-bun-v1.json, owned by benchmarks/run_public_baseline.sh. Never regenerate one from the other.",
+  "commit": "88dcee83b41d9c3824e748881ad1a5b047387de7",
+  "generated_at": "2026-07-30T06:47:15+00:00",
+  "platform": "darwin-arm64",
+  "host": {
+    "platform": "darwin-arm64",
+    "hostname": "perry-macos.fritz.box",
+    "system": "Darwin",
+    "release": "25.5.0",
+    "machine": "arm64",
+    "cpu_count": 8,
+    "load_average": {
+      "1m": 1.19,
+      "5m": 1.48,
+      "15m": 2.14
+    },
+    "cpu_brand": "Apple M1",
+    "memory_bytes": 8589934592,
+    "product_version": "26.5.1"
+  },
+  "toolchain": {
+    "perry_version": "perry 0.5.1265",
+    "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
+    "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)",
+    "python": "3.9.6",
+    "env": {
+      "PERRY_NO_AUTO_OPTIMIZE": "1",
+      "PERRY_GEN_GC": null,
+      "PERRY_GEN_GC_EVACUATE": null,
+      "PERRY_WRITE_BARRIERS": null
+    },
+    "binaries": {
+      "perry": {
+        "path": "/Users/perry/projects/perry/wt-ratchet-target/release/perry",
+        "size": 36187312,
+        "sha256": "f3de4f3edf8429f6646510143755f87f8cbab9d8356b98308fd095eb8e68d205"
+      },
+      "runtime_dir": "/Users/perry/projects/perry/wt-ratchet-target/release",
+      "libperry_runtime.a": {
+        "path": "/Users/perry/projects/perry/wt-ratchet-target/release/libperry_runtime.a",
+        "size": 30240784,
+        "sha256": "4f31a6fe96ba835d18be5157515025b700be350107d4b24db330277cc5cbc067"
+      },
+      "libperry_stdlib.a": {
+        "path": "/Users/perry/projects/perry/wt-ratchet-target/release/libperry_stdlib.a",
+        "size": 85427768,
+        "sha256": "237b63291f7c0c7573c14e758f37c08306d84a2a058af40447f8e5c2d95aba97"
+      }
+    }
+  },
+  "run_config": {
+    "repeats": 7,
+    "warmup": 1,
+    "traced_runs": 2,
+    "probes": [
+      "01_nursery_churn",
+      "02_survivor_promotion",
+      "03_cross_gen_writes",
+      "04_dead_after_deep_stack",
+      "05_closure_capture",
+      "06_string_retention",
+      "07_array_grow_evacuate",
+      "08_map_set_sidetables"
+    ]
+  },
+  "tolerances": {
+    "_readme": [
+      "Regression bands for the GC ratchet, one set per profile. Every band states",
+      "the run-to-run variance it was derived from. The measurements behind these",
+      "numbers are 3 independent sessions x 7 repeats (21 runs) per probe on the",
+      "pinned quiet host, plus 5 traced runs per probe for the GC counters; the",
+      "observed spreads are recorded in the artifact next to every number.",
+      "",
+      "allowance = max(|baseline| * pct/100, abs). direction 'increase' means only",
+      "growth is a regression; 'either' means any drift beyond the band is, which",
+      "is correct for the evacuation counters because they are a behavioural",
+      "fingerprint of the collector rather than a score.",
+      "",
+      "Profiles exist because the metric families do not share noise floors.",
+      "'shared_ci' runs on a GitHub-hosted runner, which is a different machine",
+      "class from the host the baseline was captured on: retention and GC counters",
+      "transfer because they are semantic, memory and time do not. 'pinned_host' is",
+      "for a maintainer re-running the suite on the same quiet box, where memory and",
+      "time are comparable and are gated."
+    ],
+    "shared_ci": {
+      "heap_used_bytes": {
+        "pct": 2.0,
+        "abs": 65536,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "Observed spread 0.000% over 21 runs on all 8 probes: bit-identical. The band is therefore pure anti-brittleness margin for incidental churn (a new runtime global, an extra interned string), not a noise allowance. The 64 KiB floor keeps the smallest probe (457,872 B retained) from being gated on sub-kilobyte drift while staying 16x below the smallest interesting regression, which is one falsely retained 1 MiB nursery block."
+      },
+      "heap_total_bytes": {
+        "pct": 2.0,
+        "abs": 1048576,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "Observed spread 0.000%. Arena capacity moves in 1 MiB block quanta, so any floor below one block turns this into a strict equality gate that a single extra block would trip. The floor tolerates exactly one extra block and fails at two."
+      },
+      "minor_cycles": {
+        "pct": 5.0,
+        "abs": 1,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000% over 5 traced runs per probe (baselines 14-104 cycles). One extra or missing collection is churn; two is a change in when the collector fires."
+      },
+      "step_cycles": {
+        "pct": 5.0,
+        "abs": 1,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000%. Same reasoning as minor_cycles; tracked separately because a change that splits or merges collection phases moves one without the other."
+      },
+      "copied_objects": {
+        "pct": 5.0,
+        "abs": 16,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000% (baselines 18k-43k). This is the metric that collapses if objects start being pinned instead of evacuated, which is the primary predicted effect of replacing precise roots with a conservative scan plus per-object pinning."
+      },
+      "copied_bytes": {
+        "pct": 5.0,
+        "abs": 65536,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000% (baselines 1.1 MB-24.4 MB). Pairs with copied_objects: a change in mean evacuated object size moves this without moving the count."
+      },
+      "promoted_objects": {
+        "pct": 5.0,
+        "abs": 16,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000%. Baselines range from 15 to 4,796, so on the smallest probe the 16-object floor dominates and this cell is effectively ungated; the other seven probes carry the signal. Stated rather than hidden."
+      },
+      "promoted_bytes": {
+        "pct": 5.0,
+        "abs": 65536,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000%. Rises when the collector starts tenuring garbage, which is how false retention from a conservative scan reaches old-gen and stops being reclaimable by a minor collection at all."
+      },
+      "freed_bytes": {
+        "pct": 5.0,
+        "abs": 1048576,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Observed spread 0.000% (baselines 29 MB-124 MB). A drop means the collector reclaimed less from the same allocation sequence, which is the definition of the regression this campaign risks. Floor is one arena block."
+      },
+      "rss_bytes": {
+        "pct": 15.0,
+        "abs": 8388608,
+        "direction": "increase",
+        "gating": false,
+        "rationale": "NOT GATED HERE. Observed spread on the pinned host is 0.408%, but a GitHub-hosted runner is a different machine class with a different allocator arena layout and a different baseline RSS, so a band tight enough to catch a real regression would fire on the host difference alone. Recorded and reported so a large shift is still visible; gated in the pinned_host profile instead."
+      },
+      "peak_rss_bytes": {
+        "pct": 15.0,
+        "abs": 8388608,
+        "direction": "increase",
+        "gating": false,
+        "rationale": "NOT GATED HERE, for the same reason as rss_bytes. Observed spread on the pinned host is 0.113%."
+      },
+      "wall_ms": {
+        "pct": 30.0,
+        "abs": 100,
+        "direction": "increase",
+        "gating": false,
+        "rationale": "EXCLUDED FROM THE SHARED-CI GATE. Wall time on a shared runner is dominated by neighbour noise; no band both survives that and catches a real GC slowdown. Rather than widen it until it cannot fire, it is marked non-gating and reported. The GC-work dimension is covered on this runner by the deterministic counters (minor_cycles, copied_objects, freed_bytes), which measure how much work the collector did without measuring how fast the machine was."
+      }
+    },
+    "pinned_host": {
+      "heap_used_bytes": {
+        "pct": 2.0,
+        "abs": 65536,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "heap_total_bytes": {
+        "pct": 2.0,
+        "abs": 1048576,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "minor_cycles": {
+        "pct": 5.0,
+        "abs": 1,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "step_cycles": {
+        "pct": 5.0,
+        "abs": 1,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "copied_objects": {
+        "pct": 5.0,
+        "abs": 16,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "copied_bytes": {
+        "pct": 5.0,
+        "abs": 65536,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "promoted_objects": {
+        "pct": 5.0,
+        "abs": 16,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "promoted_bytes": {
+        "pct": 5.0,
+        "abs": 65536,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "freed_bytes": {
+        "pct": 5.0,
+        "abs": 1048576,
+        "direction": "either",
+        "gating": true,
+        "rationale": "Same band as shared_ci; observed spread 0.000%."
+      },
+      "rss_bytes": {
+        "pct": 3.0,
+        "abs": 524288,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "GATED HERE. Worst cross-session spread of medians was 0.408% and worst within-session spread was 0.73%, so 3% is roughly 7x the observed noise and 4x the worst single-session spread. On the 23-38 MB baselines the percentage dominates the 512 KiB floor, which exists only so a future smaller probe is not gated on page-granularity jitter."
+      },
+      "peak_rss_bytes": {
+        "pct": 3.0,
+        "abs": 524288,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "GATED HERE. Worst cross-session spread of medians was 0.113%, worst within-session 0.72%. Same band as rss_bytes; peak is the number that decides whether a workload fits in memory."
+      },
+      "wall_ms": {
+        "pct": 10.0,
+        "abs": 15,
+        "direction": "increase",
+        "gating": true,
+        "rationale": "GATED HERE ONLY. Worst cross-session spread of medians-of-7 was 0.751% on an idle box (load 1.7-2.0); worst raw within-session spread was 5.3%, which the median-of-7 damps out. 10% is ~13x the cross-session figure and ~2x the worst raw spread, so it will not fire on scheduler jitter but will catch the tens-of-percent slowdown a whole-stack conservative scan would introduce. The 15 ms floor covers the fastest probe (126 ms)."
+      }
+    }
+  },
+  "notes": "Baseline for the shadow-stack-root removal campaign: frozen state of the evacuating minor before any of that work lands. Captured on the pinned quiet host at load 1.3.",
+  "probes": {
+    "01_nursery_churn": {
+      "stdout": "probe:01_nursery_churn\nchecksum:-1399701504\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            807000,
+            807000,
+            807000,
+            807000,
+            807000,
+            807000,
+            807000
+          ],
+          "sample_count": 7,
+          "median": 807000,
+          "min": 807000,
+          "max": 807000,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            28409856,
+            28524544,
+            28508160,
+            28475392,
+            28344320,
+            28540928,
+            28491776
+          ],
+          "sample_count": 7,
+          "median": 28491776,
+          "min": 28344320,
+          "max": 28540928,
+          "stdev": 64779.304975,
+          "spread": 196608,
+          "spread_pct": 0.690052
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            28835840,
+            28950528,
+            28934144,
+            28901376,
+            28770304,
+            28966912,
+            28917760
+          ],
+          "sample_count": 7,
+          "median": 28917760,
+          "min": 28770304,
+          "max": 28966912,
+          "stdev": 64779.304975,
+          "spread": 196608,
+          "spread_pct": 0.679887
+        },
+        "wall_ms": {
+          "samples": [
+            182.261667,
+            176.400625,
+            176.785375,
+            176.868291,
+            181.023042,
+            177.289709,
+            176.276
+          ],
+          "sample_count": 7,
+          "median": 176.868291,
+          "min": 176.276,
+          "max": 182.261667,
+          "stdev": 2.266981,
+          "spread": 5.985667,
+          "spread_pct": 3.384251
+        },
+        "minor_cycles": {
+          "samples": [
+            14,
+            14
+          ],
+          "sample_count": 2,
+          "median": 14,
+          "min": 14,
+          "max": 14,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            14,
+            14
+          ],
+          "sample_count": 2,
+          "median": 14,
+          "min": 14,
+          "max": 14,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            18961,
+            18961
+          ],
+          "sample_count": 2,
+          "median": 18961,
+          "min": 18961,
+          "max": 18961,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            1091152,
+            1091152
+          ],
+          "sample_count": 2,
+          "median": 1091152,
+          "min": 1091152,
+          "max": 1091152,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            4704,
+            4704
+          ],
+          "sample_count": 2,
+          "median": 4704,
+          "min": 4704,
+          "max": 4704,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            210824,
+            210824
+          ],
+          "sample_count": 2,
+          "median": 210824,
+          "min": 210824,
+          "max": 210824,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            29130768,
+            29130768
+          ],
+          "sample_count": 2,
+          "median": 29130768,
+          "min": 29130768,
+          "max": 29130768,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "02_survivor_promotion": {
+      "stdout": "probe:02_survivor_promotion\nchecksum:1679883264\nlive:40000\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            5022864,
+            5022864,
+            5022864,
+            5022864,
+            5022864,
+            5022864,
+            5022864
+          ],
+          "sample_count": 7,
+          "median": 5022864,
+          "min": 5022864,
+          "max": 5022864,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            23068672,
+            23068672,
+            23068672,
+            23068672,
+            23068672,
+            23068672,
+            23068672
+          ],
+          "sample_count": 7,
+          "median": 23068672,
+          "min": 23068672,
+          "max": 23068672,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            38191104,
+            37994496,
+            38289408,
+            38141952,
+            38109184,
+            38158336,
+            37978112
+          ],
+          "sample_count": 7,
+          "median": 38141952,
+          "min": 37978112,
+          "max": 38289408,
+          "stdev": 101160.352785,
+          "spread": 311296,
+          "spread_pct": 0.816151
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            38617088,
+            38420480,
+            38715392,
+            38567936,
+            38535168,
+            38584320,
+            38404096
+          ],
+          "sample_count": 7,
+          "median": 38567936,
+          "min": 38404096,
+          "max": 38715392,
+          "stdev": 101160.352785,
+          "spread": 311296,
+          "spread_pct": 0.807137
+        },
+        "wall_ms": {
+          "samples": [
+            195.276625,
+            206.5295,
+            199.593792,
+            196.149542,
+            206.390917,
+            198.554583,
+            206.426875
+          ],
+          "sample_count": 7,
+          "median": 199.593792,
+          "min": 195.276625,
+          "max": 206.5295,
+          "stdev": 4.672138,
+          "spread": 11.252875,
+          "spread_pct": 5.637888
+        },
+        "minor_cycles": {
+          "samples": [
+            10,
+            10
+          ],
+          "sample_count": 2,
+          "median": 10,
+          "min": 10,
+          "max": 10,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            10,
+            10
+          ],
+          "sample_count": 2,
+          "median": 10,
+          "min": 10,
+          "max": 10,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            125732,
+            125732
+          ],
+          "sample_count": 2,
+          "median": 125732,
+          "min": 125732,
+          "max": 125732,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            8776704,
+            8776704
+          ],
+          "sample_count": 2,
+          "median": 8776704,
+          "min": 8776704,
+          "max": 8776704,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            37473,
+            37473
+          ],
+          "sample_count": 2,
+          "median": 37473,
+          "min": 37473,
+          "max": 37473,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            2569176,
+            2569176
+          ],
+          "sample_count": 2,
+          "median": 2569176,
+          "min": 2569176,
+          "max": 2569176,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            20219896,
+            20219896
+          ],
+          "sample_count": 2,
+          "median": 20219896,
+          "min": 20219896,
+          "max": 20219896,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "03_cross_gen_writes": {
+      "stdout": "probe:03_cross_gen_writes\nchecksum:2034120704\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            705320,
+            705320,
+            705320,
+            705320,
+            705320,
+            705320,
+            705320
+          ],
+          "sample_count": 7,
+          "median": 705320,
+          "min": 705320,
+          "max": 705320,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            19922944,
+            19922944,
+            19922944,
+            19922944,
+            19922944,
+            19922944,
+            19922944
+          ],
+          "sample_count": 7,
+          "median": 19922944,
+          "min": 19922944,
+          "max": 19922944,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            28786688,
+            28786688,
+            28786688,
+            28803072,
+            28803072,
+            28770304,
+            28770304
+          ],
+          "sample_count": 7,
+          "median": 28786688,
+          "min": 28770304,
+          "max": 28803072,
+          "stdev": 12385.139852,
+          "spread": 32768,
+          "spread_pct": 0.11383
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            29245440,
+            29245440,
+            29245440,
+            29261824,
+            29261824,
+            29229056,
+            29229056
+          ],
+          "sample_count": 7,
+          "median": 29245440,
+          "min": 29229056,
+          "max": 29261824,
+          "stdev": 12385.139852,
+          "spread": 32768,
+          "spread_pct": 0.112045
+        },
+        "wall_ms": {
+          "samples": [
+            205.479084,
+            204.695417,
+            204.594792,
+            203.815625,
+            207.744042,
+            204.515833,
+            204.37525
+          ],
+          "sample_count": 7,
+          "median": 204.594792,
+          "min": 203.815625,
+          "max": 207.744042,
+          "stdev": 1.197426,
+          "spread": 3.928417,
+          "spread_pct": 1.920096
+        },
+        "minor_cycles": {
+          "samples": [
+            22,
+            22
+          ],
+          "sample_count": 2,
+          "median": 22,
+          "min": 22,
+          "max": 22,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            22,
+            22
+          ],
+          "sample_count": 2,
+          "median": 22,
+          "min": 22,
+          "max": 22,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            105154,
+            105154
+          ],
+          "sample_count": 2,
+          "median": 105154,
+          "min": 105154,
+          "max": 105154,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            7299544,
+            7299544
+          ],
+          "sample_count": 2,
+          "median": 7299544,
+          "min": 7299544,
+          "max": 7299544,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            4702,
+            4702
+          ],
+          "sample_count": 2,
+          "median": 4702,
+          "min": 4702,
+          "max": 4702,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            208728,
+            208728
+          ],
+          "sample_count": 2,
+          "median": 208728,
+          "min": 208728,
+          "max": 208728,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            36196760,
+            36196760
+          ],
+          "sample_count": 2,
+          "median": 36196760,
+          "min": 36196760,
+          "max": 36196760,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "04_dead_after_deep_stack": {
+      "stdout": "probe:04_dead_after_deep_stack\nchecksum:9814000\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            1000728,
+            1000728,
+            1000728,
+            1000728,
+            1000728,
+            1000728,
+            1000728
+          ],
+          "sample_count": 7,
+          "median": 1000728,
+          "min": 1000728,
+          "max": 1000728,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            28786688,
+            28770304,
+            28803072,
+            28803072,
+            28770304,
+            28786688,
+            28786688
+          ],
+          "sample_count": 7,
+          "median": 28786688,
+          "min": 28770304,
+          "max": 28803072,
+          "stdev": 12385.139852,
+          "spread": 32768,
+          "spread_pct": 0.11383
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            29212672,
+            29196288,
+            29229056,
+            29229056,
+            29196288,
+            29212672,
+            29212672
+          ],
+          "sample_count": 7,
+          "median": 29212672,
+          "min": 29196288,
+          "max": 29229056,
+          "stdev": 12385.139852,
+          "spread": 32768,
+          "spread_pct": 0.11217
+        },
+        "wall_ms": {
+          "samples": [
+            450.224083,
+            451.585542,
+            452.284375,
+            450.671708,
+            450.975333,
+            452.758375,
+            451.44225
+          ],
+          "sample_count": 7,
+          "median": 451.44225,
+          "min": 450.224083,
+          "max": 452.758375,
+          "stdev": 0.824117,
+          "spread": 2.534292,
+          "spread_pct": 0.561377
+        },
+        "minor_cycles": {
+          "samples": [
+            104,
+            104
+          ],
+          "sample_count": 2,
+          "median": 104,
+          "min": 104,
+          "max": 104,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            104,
+            104
+          ],
+          "sample_count": 2,
+          "median": 104,
+          "min": 104,
+          "max": 104,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            22522,
+            22522
+          ],
+          "sample_count": 2,
+          "median": 22522,
+          "min": 22522,
+          "max": 22522,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            1413696,
+            1413696
+          ],
+          "sample_count": 2,
+          "median": 1413696,
+          "min": 1413696,
+          "max": 1413696,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            4702,
+            4702
+          ],
+          "sample_count": 2,
+          "median": 4702,
+          "min": 4702,
+          "max": 4702,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            208736,
+            208736
+          ],
+          "sample_count": 2,
+          "median": 208736,
+          "min": 208736,
+          "max": 208736,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            123527360,
+            123527360
+          ],
+          "sample_count": 2,
+          "median": 123527360,
+          "min": 123527360,
+          "max": 123527360,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "05_closure_capture": {
+      "stdout": "probe:05_closure_capture\nchecksum:399974400\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            1040208,
+            1040208,
+            1040208,
+            1040208,
+            1040208,
+            1040208,
+            1040208
+          ],
+          "sample_count": 7,
+          "median": 1040208,
+          "min": 1040208,
+          "max": 1040208,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            37240832,
+            37240832,
+            37240832,
+            37257216,
+            37240832,
+            37257216,
+            37240832
+          ],
+          "sample_count": 7,
+          "median": 37240832,
+          "min": 37240832,
+          "max": 37257216,
+          "stdev": 7401.536741,
+          "spread": 16384,
+          "spread_pct": 0.043995
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            39763968,
+            39763968,
+            39763968,
+            39780352,
+            39763968,
+            39780352,
+            39763968
+          ],
+          "sample_count": 7,
+          "median": 39763968,
+          "min": 39763968,
+          "max": 39780352,
+          "stdev": 7401.536741,
+          "spread": 16384,
+          "spread_pct": 0.041203
+        },
+        "wall_ms": {
+          "samples": [
+            153.809708,
+            153.99325,
+            153.946542,
+            153.524209,
+            154.348458,
+            153.999,
+            153.71525
+          ],
+          "sample_count": 7,
+          "median": 153.946542,
+          "min": 153.524209,
+          "max": 154.348458,
+          "stdev": 0.240562,
+          "spread": 0.824249,
+          "spread_pct": 0.535412
+        },
+        "minor_cycles": {
+          "samples": [
+            26,
+            26
+          ],
+          "sample_count": 2,
+          "median": 26,
+          "min": 26,
+          "max": 26,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            26,
+            26
+          ],
+          "sample_count": 2,
+          "median": 26,
+          "min": 26,
+          "max": 26,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            38956,
+            38956
+          ],
+          "sample_count": 2,
+          "median": 38956,
+          "min": 38956,
+          "max": 38956,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            2196400,
+            2196400
+          ],
+          "sample_count": 2,
+          "median": 2196400,
+          "min": 2196400,
+          "max": 2196400,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            138,
+            138
+          ],
+          "sample_count": 2,
+          "median": 138,
+          "min": 138,
+          "max": 138,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            7096,
+            7096
+          ],
+          "sample_count": 2,
+          "median": 7096,
+          "min": 7096,
+          "max": 7096,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            41878592,
+            41878592
+          ],
+          "sample_count": 2,
+          "median": 41878592,
+          "min": 41878592,
+          "max": 41878592,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "06_string_retention": {
+      "stdout": "probe:06_string_retention\nchecksum:1112804\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            746056,
+            746056,
+            746056,
+            746056,
+            746056,
+            746056,
+            746056
+          ],
+          "sample_count": 7,
+          "median": 746056,
+          "min": 746056,
+          "max": 746056,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            28213248,
+            28049408,
+            28082176,
+            28213248,
+            28049408,
+            28114944,
+            28196864
+          ],
+          "sample_count": 7,
+          "median": 28114944,
+          "min": 28049408,
+          "max": 28213248,
+          "stdev": 69511.425018,
+          "spread": 163840,
+          "spread_pct": 0.582751
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            28639232,
+            28475392,
+            28508160,
+            28639232,
+            28475392,
+            28540928,
+            28622848
+          ],
+          "sample_count": 7,
+          "median": 28540928,
+          "min": 28475392,
+          "max": 28639232,
+          "stdev": 69511.425018,
+          "spread": 163840,
+          "spread_pct": 0.574053
+        },
+        "wall_ms": {
+          "samples": [
+            125.513417,
+            124.734666,
+            125.924875,
+            125.77875,
+            125.600417,
+            125.913709,
+            126.245333
+          ],
+          "sample_count": 7,
+          "median": 125.77875,
+          "min": 124.734666,
+          "max": 126.245333,
+          "stdev": 0.442612,
+          "spread": 1.510667,
+          "spread_pct": 1.201051
+        },
+        "minor_cycles": {
+          "samples": [
+            64,
+            64
+          ],
+          "sample_count": 2,
+          "median": 64,
+          "min": 64,
+          "max": 64,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            64,
+            64
+          ],
+          "sample_count": 2,
+          "median": 64,
+          "min": 64,
+          "max": 64,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            19476,
+            19476
+          ],
+          "sample_count": 2,
+          "median": 19476,
+          "min": 19476,
+          "max": 19476,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            1962384,
+            1962384
+          ],
+          "sample_count": 2,
+          "median": 1962384,
+          "min": 1962384,
+          "max": 1962384,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            4704,
+            4704
+          ],
+          "sample_count": 2,
+          "median": 4704,
+          "min": 4704,
+          "max": 4704,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            209288,
+            209288
+          ],
+          "sample_count": 2,
+          "median": 209288,
+          "min": 209288,
+          "max": 209288,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            81571800,
+            81571800
+          ],
+          "sample_count": 2,
+          "median": 81571800,
+          "min": 81571800,
+          "max": 81571800,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "07_array_grow_evacuate": {
+      "stdout": "probe:07_array_grow_evacuate\nchecksum:21891160\nsurvivors:94\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            1816232,
+            1816232,
+            1816232,
+            1816232,
+            1816232,
+            1816232,
+            1816232
+          ],
+          "sample_count": 7,
+          "median": 1816232,
+          "min": 1816232,
+          "max": 1816232,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            29671424,
+            29523968,
+            29655040,
+            29671424,
+            29671424,
+            29655040,
+            29671424
+          ],
+          "sample_count": 7,
+          "median": 29671424,
+          "min": 29523968,
+          "max": 29671424,
+          "stdev": 50199.664557,
+          "spread": 147456,
+          "spread_pct": 0.496963
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            30130176,
+            29982720,
+            30113792,
+            30130176,
+            30130176,
+            30113792,
+            30130176
+          ],
+          "sample_count": 7,
+          "median": 30130176,
+          "min": 29982720,
+          "max": 30130176,
+          "stdev": 50199.664557,
+          "spread": 147456,
+          "spread_pct": 0.489396
+        },
+        "wall_ms": {
+          "samples": [
+            146.096792,
+            147.107833,
+            146.086792,
+            146.135292,
+            146.087416,
+            146.979042,
+            146.054708
+          ],
+          "sample_count": 7,
+          "median": 146.096792,
+          "min": 146.054708,
+          "max": 147.107833,
+          "stdev": 0.431654,
+          "spread": 1.053125,
+          "spread_pct": 0.720841
+        },
+        "minor_cycles": {
+          "samples": [
+            80,
+            80
+          ],
+          "sample_count": 2,
+          "median": 80,
+          "min": 80,
+          "max": 80,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            80,
+            80
+          ],
+          "sample_count": 2,
+          "median": 80,
+          "min": 80,
+          "max": 80,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            18294,
+            18294
+          ],
+          "sample_count": 2,
+          "median": 18294,
+          "min": 18294,
+          "max": 18294,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            24404056,
+            24404056
+          ],
+          "sample_count": 2,
+          "median": 24404056,
+          "min": 24404056,
+          "max": 24404056,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            4796,
+            4796
+          ],
+          "sample_count": 2,
+          "median": 4796,
+          "min": 4796,
+          "max": 4796,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            957744,
+            957744
+          ],
+          "sample_count": 2,
+          "median": 957744,
+          "min": 957744,
+          "max": 957744,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            97546128,
+            97546128
+          ],
+          "sample_count": 2,
+          "median": 97546128,
+          "min": 97546128,
+          "max": 97546128,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    },
+    "08_map_set_sidetables": {
+      "stdout": "probe:08_map_set_sidetables\nchecksum:1109446656\nfinal_sizes:0,0\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.0",
+        "reason": ""
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            457872,
+            457872,
+            457872,
+            457872,
+            457872,
+            457872,
+            457872
+          ],
+          "sample_count": 7,
+          "median": 457872,
+          "min": 457872,
+          "max": 457872,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520,
+            20971520
+          ],
+          "sample_count": 7,
+          "median": 20971520,
+          "min": 20971520,
+          "max": 20971520,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            23199744,
+            23183360,
+            23183360,
+            23183360,
+            23199744,
+            23199744,
+            23199744
+          ],
+          "sample_count": 7,
+          "median": 23199744,
+          "min": 23183360,
+          "max": 23199744,
+          "stdev": 8107.977266,
+          "spread": 16384,
+          "spread_pct": 0.070621
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            26492928,
+            26476544,
+            26476544,
+            26492928,
+            26492928,
+            26492928,
+            26492928
+          ],
+          "sample_count": 7,
+          "median": 26492928,
+          "min": 26476544,
+          "max": 26492928,
+          "stdev": 7401.536741,
+          "spread": 16384,
+          "spread_pct": 0.061843
+        },
+        "wall_ms": {
+          "samples": [
+            499.628209,
+            500.48,
+            499.916084,
+            498.778375,
+            500.0575,
+            498.825,
+            499.090084
+          ],
+          "sample_count": 7,
+          "median": 499.628209,
+          "min": 498.778375,
+          "max": 500.48,
+          "stdev": 0.608786,
+          "spread": 1.701625,
+          "spread_pct": 0.340578
+        },
+        "minor_cycles": {
+          "samples": [
+            84,
+            84
+          ],
+          "sample_count": 2,
+          "median": 84,
+          "min": 84,
+          "max": 84,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            84,
+            84
+          ],
+          "sample_count": 2,
+          "median": 84,
+          "min": 84,
+          "max": 84,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            42973,
+            42973
+          ],
+          "sample_count": 2,
+          "median": 42973,
+          "min": 42973,
+          "max": 42973,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            3092544,
+            3092544
+          ],
+          "sample_count": 2,
+          "median": 3092544,
+          "min": 3092544,
+          "max": 3092544,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            15,
+            15
+          ],
+          "sample_count": 2,
+          "median": 15,
+          "min": 15,
+          "max": 15,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            576,
+            576
+          ],
+          "sample_count": 2,
+          "median": 576,
+          "min": 576,
+          "max": 576,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            102703104,
+            102703104
+          ],
+          "sample_count": 2,
+          "median": 102703104,
+          "min": 102703104,
+          "max": 102703104,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
+    }
+  },
+  "suite": {
+    "schema_version": 2,
+    "commit": "88dcee83b",
+    "generated_at": "2026-07-30T06:47:14Z",
+    "run_config": {
+      "requested_samples": 5,
+      "expected_benchmarks": [
+        "02_loop_overhead",
+        "03_array_write",
+        "04_array_read",
+        "05_fibonacci",
+        "06_math_intensive",
+        "07_object_create",
+        "08_string_concat",
+        "09_method_calls",
+        "10_nested_loops",
+        "11_prime_sieve",
+        "12_binary_trees",
+        "13_factorial",
+        "14_closure",
+        "15_mandelbrot",
+        "16_matrix_multiply",
+        "bench_gc_pressure",
+        "bench_json_roundtrip",
+        "bench_object_property",
+        "bench_int_arithmetic",
+        "bench_buffer_readwrite",
+        "bench_array_grow",
+        "bench_string_heavy",
+        "bench_numeric_array_numeric",
+        "bench_numeric_array_downgrade"
+      ]
+    },
+    "runtimes": {
+      "perry": {
+        "available": true,
+        "version": "perry 0.5.1265",
+        "command": [
+          "<compiled-binary>"
+        ],
+        "compile_command": [
+          "/Users/perry/projects/perry/wt-ratchet-target/release/perry",
+          "<source.ts>",
+          "-o",
+          "<compiled-binary>"
+        ]
+      },
+      "node": {
+        "available": true,
+        "version": "v26.5.0",
+        "command": [
+          "node",
+          "<source.ts>"
+        ]
+      },
+      "bun": {
+        "available": false,
+        "version": null,
+        "command": [
+          "bun",
+          "run",
+          "<source.ts>"
+        ]
+      }
+    },
+    "benchmarks": {
+      "02_loop_overhead": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                137,
+                94,
+                94,
+                94,
+                94
+              ],
+              "sample_count": 5,
+              "median": 94,
+              "p95": 137,
+              "min": 94,
+              "max": 137,
+              "mad": 0,
+              "stdev": 17.2
+            },
+            "rss_kb": {
+              "samples": [
+                4048,
+                4048,
+                4048,
+                4048,
+                4048
+              ],
+              "sample_count": 5,
+              "median": 4048,
+              "p95": 4048,
+              "min": 4048,
+              "max": 4048,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                52,
+                52,
+                51,
+                51,
+                51
+              ],
+              "sample_count": 5,
+              "median": 51,
+              "p95": 52,
+              "min": 51,
+              "max": 52,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                82480,
+                82480,
+                82400,
+                82544,
+                82496
+              ],
+              "sample_count": 5,
+              "median": 82480,
+              "p95": 82544,
+              "min": 82400,
+              "max": 82544,
+              "mad": 16,
+              "stdev": 46.372406
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.843137,
+            "rss": 0.049079
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:100000000"
+          ],
+          "expected_lines": [
+            "sum:100000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 94,
+        "perry_rss_kb": 4048,
+        "node_ms": 51,
+        "node_rss_kb": 82480,
+        "speed_ratio": 1.843137,
+        "memory_ratio": 0.049079
+      },
+      "03_array_write": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                3,
+                2,
+                1,
+                2,
+                1
+              ],
+              "sample_count": 5,
+              "median": 2,
+              "p95": 3,
+              "min": 1,
+              "max": 3,
+              "mad": 1,
+              "stdev": 0.748331
+            },
+            "rss_kb": {
+              "samples": [
+                98368,
+                98352,
+                98352,
+                98352,
+                98352
+              ],
+              "sample_count": 5,
+              "median": 98352,
+              "p95": 98368,
+              "min": 98352,
+              "max": 98368,
+              "mad": 0,
+              "stdev": 6.4
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                8,
+                7,
+                7,
+                7,
+                7
+              ],
+              "sample_count": 5,
+              "median": 7,
+              "p95": 8,
+              "min": 7,
+              "max": 8,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                386720,
+                386704,
+                386736,
+                386736,
+                386704
+              ],
+              "sample_count": 5,
+              "median": 386720,
+              "p95": 386736,
+              "min": 386704,
+              "max": 386736,
+              "mad": 16,
+              "stdev": 14.310835
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.285714,
+            "rss": 0.254324
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:9999999"
+          ],
+          "expected_lines": [
+            "checksum:9999999"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 2,
+        "perry_rss_kb": 98352,
+        "node_ms": 7,
+        "node_rss_kb": 386720,
+        "speed_ratio": 0.285714,
+        "memory_ratio": 0.254324
+      },
+      "04_array_read": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                39,
+                24,
+                24,
+                24,
+                23
+              ],
+              "sample_count": 5,
+              "median": 24,
+              "p95": 39,
+              "min": 23,
+              "max": 39,
+              "mad": 0,
+              "stdev": 6.112283
+            },
+            "rss_kb": {
+              "samples": [
+                98416,
+                98416,
+                98416,
+                98416,
+                98432
+              ],
+              "sample_count": 5,
+              "median": 98416,
+              "p95": 98432,
+              "min": 98416,
+              "max": 98432,
+              "mad": 0,
+              "stdev": 6.4
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                12,
+                13,
+                12,
+                12,
+                13
+              ],
+              "sample_count": 5,
+              "median": 12,
+              "p95": 13,
+              "min": 12,
+              "max": 13,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                387328,
+                387312,
+                387392,
+                387488,
+                387152
+              ],
+              "sample_count": 5,
+              "median": 387328,
+              "p95": 387488,
+              "min": 387152,
+              "max": 387488,
+              "mad": 64,
+              "stdev": 110.202722
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 2.0,
+            "rss": 0.25409
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:49999995000000"
+          ],
+          "expected_lines": [
+            "sum:49999995000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 24,
+        "perry_rss_kb": 98416,
+        "node_ms": 12,
+        "node_rss_kb": 387328,
+        "speed_ratio": 2.0,
+        "memory_ratio": 0.25409
+      },
+      "05_fibonacci": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                348,
+                299,
+                300,
+                300,
+                300
+              ],
+              "sample_count": 5,
+              "median": 300,
+              "p95": 348,
+              "min": 299,
+              "max": 348,
+              "mad": 0,
+              "stdev": 19.303886
+            },
+            "rss_kb": {
+              "samples": [
+                4176,
+                4176,
+                4176,
+                4176,
+                4176
+              ],
+              "sample_count": 5,
+              "median": 4176,
+              "p95": 4176,
+              "min": 4176,
+              "max": 4176,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                969,
+                968,
+                969,
+                968,
+                969
+              ],
+              "sample_count": 5,
+              "median": 969,
+              "p95": 969,
+              "min": 968,
+              "max": 969,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                82240,
+                82160,
+                82096,
+                82176,
+                82192
+              ],
+              "sample_count": 5,
+              "median": 82176,
+              "p95": 82240,
+              "min": 82096,
+              "max": 82240,
+              "mad": 16,
+              "stdev": 46.811964
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.309598,
+            "rss": 0.050818
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "fib(40):102334155"
+          ],
+          "expected_lines": [
+            "fib(40):102334155"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 300,
+        "perry_rss_kb": 4176,
+        "node_ms": 969,
+        "node_rss_kb": 82176,
+        "speed_ratio": 0.309598,
+        "memory_ratio": 0.050818
+      },
+      "06_math_intensive": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                89,
+                49,
+                49,
+                49,
+                49
+              ],
+              "sample_count": 5,
+              "median": 49,
+              "p95": 89,
+              "min": 49,
+              "max": 89,
+              "mad": 0,
+              "stdev": 16
+            },
+            "rss_kb": {
+              "samples": [
+                4128,
+                4128,
+                4128,
+                4128,
+                4128
+              ],
+              "sample_count": 5,
+              "median": 4128,
+              "p95": 4128,
+              "min": 4128,
+              "max": 4128,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                48,
+                48,
+                48,
+                48,
+                48
+              ],
+              "sample_count": 5,
+              "median": 48,
+              "p95": 48,
+              "min": 48,
+              "max": 48,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                83648,
+                83744,
+                83744,
+                83552,
+                83760
+              ],
+              "sample_count": 5,
+              "median": 83744,
+              "p95": 83760,
+              "min": 83552,
+              "max": 83760,
+              "mad": 16,
+              "stdev": 79.421911
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.020833,
+            "rss": 0.049293
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "result:19.30474921829397"
+          ],
+          "expected_lines": [
+            "result:19.30474921829397"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 49,
+        "perry_rss_kb": 4128,
+        "node_ms": 48,
+        "node_rss_kb": 83744,
+        "speed_ratio": 1.020833,
+        "memory_ratio": 0.049293
+      },
+      "07_object_create": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                21,
+                6,
+                5,
+                5,
+                6
+              ],
+              "sample_count": 5,
+              "median": 6,
+              "p95": 21,
+              "min": 5,
+              "max": 21,
+              "mad": 1,
+              "stdev": 6.216108
+            },
+            "rss_kb": {
+              "samples": [
+                4960,
+                4960,
+                4960,
+                4960,
+                4960
+              ],
+              "sample_count": 5,
+              "median": 4960,
+              "p95": 4960,
+              "min": 4960,
+              "max": 4960,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                9,
+                9,
+                8,
+                8,
+                8
+              ],
+              "sample_count": 5,
+              "median": 8,
+              "p95": 9,
+              "min": 8,
+              "max": 9,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                85296,
+                85200,
+                85024,
+                85280,
+                85296
+              ],
+              "sample_count": 5,
+              "median": 85280,
+              "p95": 85296,
+              "min": 85024,
+              "max": 85296,
+              "mad": 16,
+              "stdev": 103.889172
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.75,
+            "rss": 0.058161
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:1000000000000"
+          ],
+          "expected_lines": [
+            "sum:1000000000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 6,
+        "perry_rss_kb": 4960,
+        "node_ms": 8,
+        "node_rss_kb": 85280,
+        "speed_ratio": 0.75,
+        "memory_ratio": 0.058161
+      },
+      "08_string_concat": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                10,
+                2,
+                2,
+                2,
+                2
+              ],
+              "sample_count": 5,
+              "median": 2,
+              "p95": 10,
+              "min": 2,
+              "max": 10,
+              "mad": 0,
+              "stdev": 3.2
+            },
+            "rss_kb": {
+              "samples": [
+                4480,
+                4480,
+                4480,
+                4480,
+                4480
+              ],
+              "sample_count": 5,
+              "median": 4480,
+              "p95": 4480,
+              "min": 4480,
+              "max": 4480,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                4,
+                4,
+                4,
+                4,
+                4
+              ],
+              "sample_count": 5,
+              "median": 4,
+              "p95": 4,
+              "min": 4,
+              "max": 4,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                89024,
+                88992,
+                89120,
+                89008,
+                88960
+              ],
+              "sample_count": 5,
+              "median": 89008,
+              "p95": 89120,
+              "min": 88960,
+              "max": 89120,
+              "mad": 16,
+              "stdev": 53.927359
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.5,
+            "rss": 0.050333
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "length:100000"
+          ],
+          "expected_lines": [
+            "length:100000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 2,
+        "perry_rss_kb": 4480,
+        "node_ms": 4,
+        "node_rss_kb": 89008,
+        "speed_ratio": 0.5,
+        "memory_ratio": 0.050333
+      },
+      "09_method_calls": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                109,
+                78,
+                78,
+                78,
+                78
+              ],
+              "sample_count": 5,
+              "median": 78,
+              "p95": 109,
+              "min": 78,
+              "max": 109,
+              "mad": 0,
+              "stdev": 12.4
+            },
+            "rss_kb": {
+              "samples": [
+                9728,
+                9728,
+                9728,
+                9728,
+                9728
+              ],
+              "sample_count": 5,
+              "median": 9728,
+              "p95": 9728,
+              "min": 9728,
+              "max": 9728,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                11,
+                10,
+                11,
+                11,
+                11
+              ],
+              "sample_count": 5,
+              "median": 11,
+              "p95": 11,
+              "min": 10,
+              "max": 11,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                83072,
+                83008,
+                82960,
+                82992,
+                83008
+              ],
+              "sample_count": 5,
+              "median": 83008,
+              "p95": 83072,
+              "min": 82960,
+              "max": 83072,
+              "mad": 16,
+              "stdev": 36.485614
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 7.090909,
+            "rss": 0.117194
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "value:10000000"
+          ],
+          "expected_lines": [
+            "value:10000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 78,
+        "perry_rss_kb": 9728,
+        "node_ms": 11,
+        "node_rss_kb": 83008,
+        "speed_ratio": 7.090909,
+        "memory_ratio": 0.117194
+      },
+      "10_nested_loops": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                70,
+                42,
+                42,
+                43,
+                42
+              ],
+              "sample_count": 5,
+              "median": 42,
+              "p95": 70,
+              "min": 42,
+              "max": 70,
+              "mad": 0,
+              "stdev": 11.106755
+            },
+            "rss_kb": {
+              "samples": [
+                9760,
+                9760,
+                9760,
+                9744,
+                9744
+              ],
+              "sample_count": 5,
+              "median": 9760,
+              "p95": 9760,
+              "min": 9744,
+              "max": 9760,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                18,
+                18,
+                18,
+                18,
+                17
+              ],
+              "sample_count": 5,
+              "median": 18,
+              "p95": 18,
+              "min": 17,
+              "max": 18,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                84896,
+                84880,
+                84848,
+                84880,
+                84800
+              ],
+              "sample_count": 5,
+              "median": 84880,
+              "p95": 84896,
+              "min": 84800,
+              "max": 84896,
+              "mad": 16,
+              "stdev": 34.16665
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 2.333333,
+            "rss": 0.114986
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:26991000000"
+          ],
+          "expected_lines": [
+            "sum:26991000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 42,
+        "perry_rss_kb": 9760,
+        "node_ms": 18,
+        "node_rss_kb": 84880,
+        "speed_ratio": 2.333333,
+        "memory_ratio": 0.114986
+      },
+      "11_prime_sieve": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                134,
+                127,
+                127,
+                126,
+                127
+              ],
+              "sample_count": 5,
+              "median": 127,
+              "p95": 134,
+              "min": 126,
+              "max": 134,
+              "mad": 0,
+              "stdev": 2.925748
+            },
+            "rss_kb": {
+              "samples": [
+                28464,
+                28480,
+                28480,
+                28480,
+                28480
+              ],
+              "sample_count": 5,
+              "median": 28480,
+              "p95": 28480,
+              "min": 28464,
+              "max": 28480,
+              "mad": 0,
+              "stdev": 6.4
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                6,
+                6,
+                6,
+                6,
+                6
+              ],
+              "sample_count": 5,
+              "median": 6,
+              "p95": 6,
+              "min": 6,
+              "max": 6,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                113824,
+                113728,
+                113776,
+                113696,
+                113808
+              ],
+              "sample_count": 5,
+              "median": 113776,
+              "p95": 113824,
+              "min": 113696,
+              "max": 113824,
+              "mad": 48,
+              "stdev": 48.106548
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 21.166667,
+            "rss": 0.250316
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "primes:78498"
+          ],
+          "expected_lines": [
+            "primes:78498"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 127,
+        "perry_rss_kb": 28480,
+        "node_ms": 6,
+        "node_rss_kb": 113776,
+        "speed_ratio": 21.166667,
+        "memory_ratio": 0.250316
+      },
+      "12_binary_trees": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                25,
+                7,
+                6,
+                7,
+                7
+              ],
+              "sample_count": 5,
+              "median": 7,
+              "p95": 25,
+              "min": 6,
+              "max": 25,
+              "mad": 0,
+              "stdev": 7.310267
+            },
+            "rss_kb": {
+              "samples": [
+                5008,
+                5008,
+                5008,
+                5008,
+                5008
+              ],
+              "sample_count": 5,
+              "median": 5008,
+              "p95": 5008,
+              "min": 5008,
+              "max": 5008,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                9,
+                9,
+                9,
+                10,
+                9
+              ],
+              "sample_count": 5,
+              "median": 9,
+              "p95": 10,
+              "min": 9,
+              "max": 10,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                84992,
+                85120,
+                85120,
+                85024,
+                85136
+              ],
+              "sample_count": 5,
+              "median": 85120,
+              "p95": 85136,
+              "min": 84992,
+              "max": 85136,
+              "mad": 16,
+              "stdev": 58.656969
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.777778,
+            "rss": 0.058835
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:1500001500000"
+          ],
+          "expected_lines": [
+            "sum:1500001500000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 7,
+        "perry_rss_kb": 5008,
+        "node_ms": 9,
+        "node_rss_kb": 85120,
+        "speed_ratio": 0.777778,
+        "memory_ratio": 0.058835
+      },
+      "13_factorial": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                139,
+                94,
+                93,
+                94,
+                94
+              ],
+              "sample_count": 5,
+              "median": 94,
+              "p95": 139,
+              "min": 93,
+              "max": 139,
+              "mad": 0,
+              "stdev": 18.104143
+            },
+            "rss_kb": {
+              "samples": [
+                4112,
+                4112,
+                4112,
+                4112,
+                4112
+              ],
+              "sample_count": 5,
+              "median": 4112,
+              "p95": 4112,
+              "min": 4112,
+              "max": 4112,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                580,
+                579,
+                579,
+                578,
+                579
+              ],
+              "sample_count": 5,
+              "median": 579,
+              "p95": 580,
+              "min": 578,
+              "max": 580,
+              "mad": 0,
+              "stdev": 0.632456
+            },
+            "rss_kb": {
+              "samples": [
+                84592,
+                84496,
+                84560,
+                84464,
+                84352
+              ],
+              "sample_count": 5,
+              "median": 84496,
+              "p95": 84592,
+              "min": 84352,
+              "max": 84592,
+              "mad": 64,
+              "stdev": 83.69086
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.162349,
+            "rss": 0.048665
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:49950000000"
+          ],
+          "expected_lines": [
+            "sum:49950000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 94,
+        "perry_rss_kb": 4112,
+        "node_ms": 579,
+        "node_rss_kb": 84496,
+        "speed_ratio": 0.162349,
+        "memory_ratio": 0.048665
+      },
+      "14_closure": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                90,
+                47,
+                47,
+                47,
+                47
+              ],
+              "sample_count": 5,
+              "median": 47,
+              "p95": 90,
+              "min": 47,
+              "max": 90,
+              "mad": 0,
+              "stdev": 17.2
+            },
+            "rss_kb": {
+              "samples": [
+                4208,
+                4208,
+                4208,
+                4208,
+                4208
+              ],
+              "sample_count": 5,
+              "median": 4208,
+              "p95": 4208,
+              "min": 4208,
+              "max": 4208,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                297,
+                297,
+                296,
+                297,
+                297
+              ],
+              "sample_count": 5,
+              "median": 297,
+              "p95": 297,
+              "min": 296,
+              "max": 297,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                84400,
+                84432,
+                84096,
+                84368,
+                84368
+              ],
+              "sample_count": 5,
+              "median": 84368,
+              "p95": 84432,
+              "min": 84096,
+              "max": 84432,
+              "mad": 32,
+              "stdev": 120.754958
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.158249,
+            "rss": 0.049877
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:2500000000000000"
+          ],
+          "expected_lines": [
+            "sum:2500000000000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 47,
+        "perry_rss_kb": 4208,
+        "node_ms": 297,
+        "node_rss_kb": 84368,
+        "speed_ratio": 0.158249,
+        "memory_ratio": 0.049877
+      },
+      "15_mandelbrot": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                61,
+                21,
+                21,
+                22,
+                21
+              ],
+              "sample_count": 5,
+              "median": 21,
+              "p95": 61,
+              "min": 21,
+              "max": 61,
+              "mad": 0,
+              "stdev": 15.904716
+            },
+            "rss_kb": {
+              "samples": [
+                4048,
+                4048,
+                4048,
+                4048,
+                4048
+              ],
+              "sample_count": 5,
+              "median": 4048,
+              "p95": 4048,
+              "min": 4048,
+              "max": 4048,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                23,
+                23,
+                23,
+                24,
+                24
+              ],
+              "sample_count": 5,
+              "median": 23,
+              "p95": 24,
+              "min": 23,
+              "max": 24,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                84144,
+                84064,
+                83840,
+                83984,
+                83936
+              ],
+              "sample_count": 5,
+              "median": 83984,
+              "p95": 84144,
+              "min": 83840,
+              "max": 84144,
+              "mad": 80,
+              "stdev": 104.478897
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.913043,
+            "rss": 0.0482
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "total_iter:8011148"
+          ],
+          "expected_lines": [
+            "total_iter:8011148"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 21,
+        "perry_rss_kb": 4048,
+        "node_ms": 23,
+        "node_rss_kb": 83984,
+        "speed_ratio": 0.913043,
+        "memory_ratio": 0.0482
+      },
+      "16_matrix_multiply": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                725,
+                686,
+                686,
+                687,
+                686
+              ],
+              "sample_count": 5,
+              "median": 686,
+              "p95": 725,
+              "min": 686,
+              "max": 725,
+              "mad": 0,
+              "stdev": 15.504838
+            },
+            "rss_kb": {
+              "samples": [
+                13376,
+                13392,
+                13376,
+                13392,
+                13376
+              ],
+              "sample_count": 5,
+              "median": 13376,
+              "p95": 13392,
+              "min": 13376,
+              "max": 13392,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                33,
+                33,
+                33,
+                33,
+                32
+              ],
+              "sample_count": 5,
+              "median": 33,
+              "p95": 33,
+              "min": 32,
+              "max": 33,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                89504,
+                89488,
+                89744,
+                89552,
+                89552
+              ],
+              "sample_count": 5,
+              "median": 89552,
+              "p95": 89744,
+              "min": 89488,
+              "max": 89744,
+              "mad": 48,
+              "stdev": 91.634055
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 20.787879,
+            "rss": 0.149366
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:41079519680"
+          ],
+          "expected_lines": [
+            "checksum:41079519680"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 686,
+        "perry_rss_kb": 13376,
+        "node_ms": 33,
+        "node_rss_kb": 89552,
+        "speed_ratio": 20.787879,
+        "memory_ratio": 0.149366
+      },
+      "bench_gc_pressure": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                79,
+                34,
+                34,
+                34,
+                34
+              ],
+              "sample_count": 5,
+              "median": 34,
+              "p95": 79,
+              "min": 34,
+              "max": 79,
+              "mad": 0,
+              "stdev": 18
+            },
+            "rss_kb": {
+              "samples": [
+                22064,
+                22064,
+                22080,
+                22064,
+                22080
+              ],
+              "sample_count": 5,
+              "median": 22064,
+              "p95": 22080,
+              "min": 22064,
+              "max": 22080,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                13,
+                13,
+                13,
+                13,
+                13
+              ],
+              "sample_count": 5,
+              "median": 13,
+              "p95": 13,
+              "min": 13,
+              "max": 13,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                91824,
+                91360,
+                91424,
+                91360,
+                91504
+              ],
+              "sample_count": 5,
+              "median": 91424,
+              "p95": 91824,
+              "min": 91360,
+              "max": 91824,
+              "mad": 64,
+              "stdev": 173.096043
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 2.615385,
+            "rss": 0.241337
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:249999500000"
+          ],
+          "expected_lines": [
+            "checksum:249999500000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 34,
+        "perry_rss_kb": 22064,
+        "node_ms": 13,
+        "node_rss_kb": 91424,
+        "speed_ratio": 2.615385,
+        "memory_ratio": 0.241337
+      },
+      "bench_json_roundtrip": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                299,
+                290,
+                288,
+                290,
+                292
+              ],
+              "sample_count": 5,
+              "median": 290,
+              "p95": 299,
+              "min": 288,
+              "max": 299,
+              "mad": 2,
+              "stdev": 3.815757
+            },
+            "rss_kb": {
+              "samples": [
+                96272,
+                96352,
+                95856,
+                95840,
+                95872
+              ],
+              "sample_count": 5,
+              "median": 95872,
+              "p95": 96352,
+              "min": 95840,
+              "max": 96352,
+              "mad": 32,
+              "stdev": 225.048972
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                238,
+                245,
+                241,
+                239,
+                237
+              ],
+              "sample_count": 5,
+              "median": 239,
+              "p95": 245,
+              "min": 237,
+              "max": 245,
+              "mad": 2,
+              "stdev": 2.828427
+            },
+            "rss_kb": {
+              "samples": [
+                164224,
+                164176,
+                164240,
+                164160,
+                164064
+              ],
+              "sample_count": 5,
+              "median": 164176,
+              "p95": 164240,
+              "min": 164064,
+              "max": 164240,
+              "mad": 48,
+              "stdev": 61.885055
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.213389,
+            "rss": 0.583959
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:53735550"
+          ],
+          "expected_lines": [
+            "checksum:53735550"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 290,
+        "perry_rss_kb": 95872,
+        "node_ms": 239,
+        "node_rss_kb": 164176,
+        "speed_ratio": 1.213389,
+        "memory_ratio": 0.583959
+      },
+      "bench_object_property": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                157,
+                136,
+                133,
+                132,
+                132
+              ],
+              "sample_count": 5,
+              "median": 133,
+              "p95": 157,
+              "min": 132,
+              "max": 157,
+              "mad": 1,
+              "stdev": 9.612492
+            },
+            "rss_kb": {
+              "samples": [
+                20448,
+                20448,
+                20464,
+                20464,
+                20448
+              ],
+              "sample_count": 5,
+              "median": 20448,
+              "p95": 20464,
+              "min": 20448,
+              "max": 20464,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                13,
+                14,
+                12,
+                13,
+                13
+              ],
+              "sample_count": 5,
+              "median": 13,
+              "p95": 14,
+              "min": 12,
+              "max": 14,
+              "mad": 0,
+              "stdev": 0.632456
+            },
+            "rss_kb": {
+              "samples": [
+                84864,
+                84704,
+                84688,
+                84848,
+                84784
+              ],
+              "sample_count": 5,
+              "median": 84784,
+              "p95": 84864,
+              "min": 84688,
+              "max": 84864,
+              "mad": 80,
+              "stdev": 71.98222
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 10.230769,
+            "rss": 0.241178
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:1999990000"
+          ],
+          "expected_lines": [
+            "checksum:1999990000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 133,
+        "perry_rss_kb": 20448,
+        "node_ms": 13,
+        "node_rss_kb": 84784,
+        "speed_ratio": 10.230769,
+        "memory_ratio": 0.241178
+      },
+      "bench_int_arithmetic": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                387,
+                363,
+                363,
+                364,
+                358
+              ],
+              "sample_count": 5,
+              "median": 363,
+              "p95": 387,
+              "min": 358,
+              "max": 387,
+              "mad": 1,
+              "stdev": 10.217632
+            },
+            "rss_kb": {
+              "samples": [
+                4368,
+                4384,
+                4368,
+                4368,
+                4368
+              ],
+              "sample_count": 5,
+              "median": 4368,
+              "p95": 4384,
+              "min": 4368,
+              "max": 4384,
+              "mad": 0,
+              "stdev": 6.4
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                64,
+                63,
+                62,
+                63,
+                64
+              ],
+              "sample_count": 5,
+              "median": 63,
+              "p95": 64,
+              "min": 62,
+              "max": 64,
+              "mad": 1,
+              "stdev": 0.748331
+            },
+            "rss_kb": {
+              "samples": [
+                83360,
+                83312,
+                83296,
+                83392,
+                83424
+              ],
+              "sample_count": 5,
+              "median": 83360,
+              "p95": 83424,
+              "min": 83296,
+              "max": 83424,
+              "mad": 48,
+              "stdev": 47.893215
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 5.761905,
+            "rss": 0.052399
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:5760000"
+          ],
+          "expected_lines": [
+            "checksum:5760000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 363,
+        "perry_rss_kb": 4368,
+        "node_ms": 63,
+        "node_rss_kb": 83360,
+        "speed_ratio": 5.761905,
+        "memory_ratio": 0.052399
+      },
+      "bench_buffer_readwrite": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                138,
+                94,
+                94,
+                94,
+                94
+              ],
+              "sample_count": 5,
+              "median": 94,
+              "p95": 138,
+              "min": 94,
+              "max": 138,
+              "mad": 0,
+              "stdev": 17.6
+            },
+            "rss_kb": {
+              "samples": [
+                5328,
+                5328,
+                5328,
+                5328,
+                5328
+              ],
+              "sample_count": 5,
+              "median": 5328,
+              "p95": 5328,
+              "min": 5328,
+              "max": 5328,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                82,
+                81,
+                81,
+                81,
+                82
+              ],
+              "sample_count": 5,
+              "median": 81,
+              "p95": 82,
+              "min": 81,
+              "max": 82,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                83024,
+                83040,
+                82928,
+                82960,
+                83136
+              ],
+              "sample_count": 5,
+              "median": 83024,
+              "p95": 83136,
+              "min": 82928,
+              "max": 83136,
+              "mad": 64,
+              "stdev": 71.98222
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.160494,
+            "rss": 0.064174
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:12749385600"
+          ],
+          "expected_lines": [
+            "checksum:12749385600"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 94,
+        "perry_rss_kb": 5328,
+        "node_ms": 81,
+        "node_rss_kb": 83024,
+        "speed_ratio": 1.160494,
+        "memory_ratio": 0.064174
+      },
+      "bench_array_grow": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                62,
+                25,
+                25,
+                25,
+                25
+              ],
+              "sample_count": 5,
+              "median": 25,
+              "p95": 62,
+              "min": 25,
+              "max": 62,
+              "mad": 0,
+              "stdev": 14.8
+            },
+            "rss_kb": {
+              "samples": [
+                41920,
+                41920,
+                41920,
+                41920,
+                41920
+              ],
+              "sample_count": 5,
+              "median": 41920,
+              "p95": 41920,
+              "min": 41920,
+              "max": 41920,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                11,
+                11,
+                11,
+                10,
+                11
+              ],
+              "sample_count": 5,
+              "median": 11,
+              "p95": 11,
+              "min": 10,
+              "max": 11,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                141360,
+                145904,
+                145920,
+                145824,
+                141088
+              ],
+              "sample_count": 5,
+              "median": 145824,
+              "p95": 145920,
+              "min": 141088,
+              "max": 145920,
+              "mad": 96,
+              "stdev": 2284.123149
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 2.272727,
+            "rss": 0.28747
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "length:2000000",
+            "checksum:2998500000"
+          ],
+          "expected_lines": [
+            "length:2000000",
+            "checksum:2998500000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 25,
+        "perry_rss_kb": 41920,
+        "node_ms": 11,
+        "node_rss_kb": 145824,
+        "speed_ratio": 2.272727,
+        "memory_ratio": 0.28747
+      },
+      "bench_string_heavy": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                111,
+                63,
+                62,
+                63,
+                62
+              ],
+              "sample_count": 5,
+              "median": 63,
+              "p95": 111,
+              "min": 62,
+              "max": 111,
+              "mad": 1,
+              "stdev": 19.405154
+            },
+            "rss_kb": {
+              "samples": [
+                22944,
+                22928,
+                22944,
+                22944,
+                22928
+              ],
+              "sample_count": 5,
+              "median": 22944,
+              "p95": 22944,
+              "min": 22928,
+              "max": 22944,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                43,
+                43,
+                43,
+                43,
+                43
+              ],
+              "sample_count": 5,
+              "median": 43,
+              "p95": 43,
+              "min": 43,
+              "max": 43,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                82384,
+                82576,
+                82576,
+                82704,
+                82624
+              ],
+              "sample_count": 5,
+              "median": 82576,
+              "p95": 82704,
+              "min": 82384,
+              "max": 82704,
+              "mad": 48,
+              "stdev": 105.357297
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.465116,
+            "rss": 0.277853
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:21063000"
+          ],
+          "expected_lines": [
+            "checksum:21063000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 63,
+        "perry_rss_kb": 22944,
+        "node_ms": 43,
+        "node_rss_kb": 82576,
+        "speed_ratio": 1.465116,
+        "memory_ratio": 0.277853
+      },
+      "bench_numeric_array_numeric": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                81,
+                82,
+                81,
+                80,
+                80
+              ],
+              "sample_count": 5,
+              "median": 81,
+              "p95": 82,
+              "min": 80,
+              "max": 82,
+              "mad": 1,
+              "stdev": 0.748331
+            },
+            "rss_kb": {
+              "samples": [
+                30672,
+                30688,
+                30688,
+                30672,
+                30672
+              ],
+              "sample_count": 5,
+              "median": 30672,
+              "p95": 30688,
+              "min": 30672,
+              "max": 30688,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                5,
+                5,
+                5,
+                4,
+                4
+              ],
+              "sample_count": 5,
+              "median": 5,
+              "p95": 5,
+              "min": 4,
+              "max": 5,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                102976,
+                102944,
+                102960,
+                102896,
+                102960
+              ],
+              "sample_count": 5,
+              "median": 102960,
+              "p95": 102976,
+              "min": 102896,
+              "max": 102976,
+              "mad": 16,
+              "stdev": 27.527441
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 16.2,
+            "rss": 0.297902
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:6500625"
+          ],
+          "expected_lines": [
+            "checksum:6500625"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 81,
+        "perry_rss_kb": 30672,
+        "node_ms": 5,
+        "node_rss_kb": 102960,
+        "speed_ratio": 16.2,
+        "memory_ratio": 0.297902
+      },
+      "bench_numeric_array_downgrade": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                24,
+                23,
+                24,
+                24,
+                24
+              ],
+              "sample_count": 5,
+              "median": 24,
+              "p95": 24,
+              "min": 23,
+              "max": 24,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                30992,
+                30992,
+                30992,
+                30976,
+                30976
+              ],
+              "sample_count": 5,
+              "median": 30992,
+              "p95": 30992,
+              "min": 30976,
+              "max": 30992,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                5,
+                5,
+                5,
+                5,
+                4
+              ],
+              "sample_count": 5,
+              "median": 5,
+              "p95": 5,
+              "min": 4,
+              "max": 5,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                103232,
+                103184,
+                103280,
+                103280,
+                103184
+              ],
+              "sample_count": 5,
+              "median": 103232,
+              "p95": 103280,
+              "min": 103184,
+              "max": 103280,
+              "mad": 48,
+              "stdev": 42.932505
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 4.8,
+            "rss": 0.300217
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:6500875"
+          ],
+          "expected_lines": [
+            "checksum:6500875"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 24,
+        "perry_rss_kb": 30992,
+        "node_ms": 5,
+        "node_rss_kb": 103232,
+        "speed_ratio": 4.8,
+        "memory_ratio": 0.300217
+      }
+    }
+  }
+}

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -1,0 +1,974 @@
+#!/usr/bin/env python3
+"""GC performance/RSS ratchet: measurement, pinned artifact, and regression gate.
+
+This harness freezes the observable behaviour of the *current* evacuating minor
+collector so that a later change cannot quietly regress it. It exists because a
+large GC architecture campaign (replacing shadow-stack precise roots with a
+conservative stack scan plus per-object pinning) is about to start, and the
+whole point of that campaign is that the gate decides, not argument.
+
+NOT THE PUBLIC BASELINE
+-----------------------
+``benchmarks/run_public_baseline.sh`` / ``benchmarks/public_baseline.py`` /
+``benchmarks/results/public-node-bun-v1.json`` are a different, maintainer-owned
+artifact: published Perry-vs-Node-vs-Bun evidence, regenerated on a release
+cadence, gating ``lint``. This module is an internal Perry-vs-Perry ratchet over
+GC retention, evacuation accounting, and memory, regenerated only when a change
+is deliberately accepted, gating the ``gc-ratchet`` CI job. Different directory,
+different artifact, different gate. Never regenerate one from the other.
+
+METRIC FAMILIES AND WHY THEY ARE SEPARATED
+------------------------------------------
+Measured on the pinned quiet host, 3 independent sessions x 7 repeats:
+
+``retention``  ``heap_used_bytes``, ``heap_total_bytes``
+    Read from ``process.memoryUsage()`` after an explicit full ``gc()``.
+    Observed spread: **0.000%** — bit-identical across all 21 runs of all 8
+    probes. For a deterministic program these are a pure function of the
+    allocation sequence and collector policy, independent of CPU speed, core
+    count, and machine load.
+
+``gc``  ``minor_cycles``, ``copied_objects``, ``copied_bytes``,
+        ``promoted_objects``, ``promoted_bytes``, ``freed_bytes``, ``step_cycles``
+    Parsed from ``PERRY_GC_DIAG=1`` output in a separate, untimed pass.
+    Observed spread: **0.000%**. This is the evacuating minor's own accounting,
+    and it is the family that most directly answers "did the collector change
+    what it does?" — pinning collapses ``copied_objects``, over-retention
+    depresses ``freed_bytes`` and inflates ``promoted_bytes``.
+
+``memory``  ``rss_bytes``, ``peak_rss_bytes``
+    Observed spread: <=0.41% across sessions. Host-allocator dependent, so
+    comparable only within one platform *and* one machine class.
+
+``timing``  ``wall_ms``
+    Observed spread: <=0.75% on medians on the quiet host, but that number does
+    not transfer to a shared CI runner, where neighbour noise dominates. Gated
+    only on the pinned host.
+
+TRANSPORT
+---------
+Probes print ``probe:``/``checksum:`` lines on stdout, which are diffed
+byte-for-byte against the pinned Node oracle, and ``#gcmetric key=value`` lines
+on stderr, which are Perry-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import math
+import os
+import platform
+import re
+import resource
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+SCHEMA_VERSION = 1
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+PROBES_DIR = HERE / "probes"
+DEFAULT_ARTIFACT = HERE / "baseline" / "gc-ratchet-v1.json"
+DEFAULT_TOLERANCES = HERE / "tolerances.json"
+
+GCMETRIC_RE = re.compile(r"^#gcmetric\s+([a-z0-9_]+)=(-?[0-9]+)\s*$")
+COPY_MINOR_RE = re.compile(r"^\[gc-copy-minor\]\s+ran\s+(.*)$")
+GC_STEP_PREFIX = "[gc-step]"
+
+RETENTION_METRICS = ("heap_used_bytes", "heap_total_bytes")
+GC_METRICS = (
+    "minor_cycles",
+    "step_cycles",
+    "copied_objects",
+    "copied_bytes",
+    "promoted_objects",
+    "promoted_bytes",
+    "freed_bytes",
+)
+MEMORY_METRICS = ("rss_bytes", "peak_rss_bytes")
+TIMING_METRICS = ("wall_ms",)
+
+ALL_METRICS = RETENTION_METRICS + GC_METRICS + MEMORY_METRICS + TIMING_METRICS
+
+#: Metrics collected once per repeat from a normal (untraced) run.
+SAMPLED_METRICS = RETENTION_METRICS + MEMORY_METRICS + TIMING_METRICS
+
+PROFILES = ("shared_ci", "pinned_host")
+
+
+class RatchetError(RuntimeError):
+    """Raised when measurement, artifact validation, or comparison fails."""
+
+
+# ---------------------------------------------------------------------------
+# Environment description
+# ---------------------------------------------------------------------------
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def platform_key() -> str:
+    """Coarse identity of the measurement environment.
+
+    Retention and evacuation accounting are arch/OS sensitive in principle
+    (allocation granularity, page size, pointer-sized side tables), so a
+    comparison across platform keys is refused unless explicitly relaxed.
+    Deliberately coarse: neither CPU model nor core count belongs here, because
+    a metric that depends on them does not belong in a gating family.
+    """
+    return f"{platform.system().lower()}-{platform.machine().lower()}"
+
+
+def load_average() -> tuple[float, float, float]:
+    try:
+        return tuple(round(value, 2) for value in os.getloadavg())  # type: ignore[return-value]
+    except (OSError, AttributeError):
+        return (float("nan"),) * 3
+
+
+def _run_text(command: Sequence[str]) -> str | None:
+    if not shutil.which(command[0]):
+        return None
+    completed = subprocess.run(list(command), capture_output=True, text=True, check=False)
+    return completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else None
+
+
+def host_description() -> dict[str, Any]:
+    """Everything a later reader needs to judge whether a number is comparable.
+
+    The load average is recorded next to every number on purpose. This project
+    has twice recorded a wrong conclusion from a loaded machine — a "0% lever"
+    that was really 1.32x, and a "1.4x lever" that was really 0% — and a number
+    without its load is not evidence.
+    """
+    load1, load5, load15 = load_average()
+    info: dict[str, Any] = {
+        "platform": platform_key(),
+        "hostname": platform.node(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "load_average": {"1m": load1, "5m": load5, "15m": load15},
+    }
+    if platform.system() == "Darwin":
+        info["cpu_brand"] = _run_text(["sysctl", "-n", "machdep.cpu.brand_string"])
+        memsize = _run_text(["sysctl", "-n", "hw.memsize"])
+        if memsize and memsize.isdigit():
+            info["memory_bytes"] = int(memsize)
+        info["product_version"] = _run_text(["sw_vers", "-productVersion"])
+    elif platform.system() == "Linux":
+        try:
+            for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+                if line.startswith("MemTotal:"):
+                    info["memory_bytes"] = int(line.split()[1]) * 1024
+                    break
+        except OSError:
+            pass
+    return info
+
+
+def binary_fingerprints(perry: Path) -> dict[str, Any]:
+    """Content hashes of the binary and archives actually under test.
+
+    Content hashes, never mtimes. ``perry-runtime`` and ``perry-stdlib`` are
+    rlib-only; ``libperry_{runtime,stdlib}.a`` come from the ``-static`` wrapper
+    crates. Building without those wrappers leaves a stale archive in place,
+    which makes both arms of an A/B behave identically and yields a vacuous "no
+    regression". A recorded hash makes that visible after the fact: two runs
+    that claim different code but share a runtime hash did not build what they
+    thought they built.
+    """
+    import hashlib
+
+    def digest(path: Path) -> dict[str, Any] | None:
+        if not path.exists():
+            return None
+        hasher = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return {"path": str(path), "size": path.stat().st_size, "sha256": hasher.hexdigest()}
+
+    runtime_dir = os.environ.get("PERRY_RUNTIME_DIR")
+    search = Path(runtime_dir) if runtime_dir else perry.parent
+    out: dict[str, Any] = {"perry": digest(perry), "runtime_dir": str(search)}
+    for lib in ("libperry_runtime.a", "libperry_stdlib.a"):
+        out[lib] = digest(search / lib)
+    return out
+
+
+def toolchain_description(perry: Path) -> dict[str, Any]:
+    return {
+        "perry_version": _run_text([str(perry), "--version"]) or "unknown",
+        "rustc": _run_text(["rustc", "--version"]),
+        "cargo": _run_text(["cargo", "--version"]),
+        "cc": _run_text(["cc", "--version"]),
+        "python": sys.version.split()[0],
+        "env": {
+            "PERRY_NO_AUTO_OPTIMIZE": os.environ.get("PERRY_NO_AUTO_OPTIMIZE"),
+            "PERRY_GEN_GC": os.environ.get("PERRY_GEN_GC"),
+            "PERRY_GEN_GC_EVACUATE": os.environ.get("PERRY_GEN_GC_EVACUATE"),
+            "PERRY_WRITE_BARRIERS": os.environ.get("PERRY_WRITE_BARRIERS"),
+        },
+        "binaries": binary_fingerprints(perry),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Running probes
+# ---------------------------------------------------------------------------
+
+
+def run_once(
+    command: Sequence[str], *, extra_env: Mapping[str, str] | None = None
+) -> dict[str, Any]:
+    """Run a command, returning stdout, stderr, exit status, wall time, peak RSS.
+
+    Peak RSS comes from ``os.wait4`` — this specific child's ``ru_maxrss`` — and
+    not from ``getrusage(RUSAGE_CHILDREN)``, which is a running maximum over
+    every child the process has ever reaped and would report each probe's peak
+    as the largest peak seen so far. It also does not come from
+    ``/usr/bin/time -l``, which calls ``sysctl(kern.clockrate)`` and fails in
+    otherwise usable sandboxed macOS environments, masking a successful exit.
+    Darwin reports ``ru_maxrss`` in bytes, Linux in KiB.
+    """
+    import time
+
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
+
+    # Temporary files rather than pipes: os.wait4() must reap the child itself
+    # to obtain its rusage, so Popen.communicate() (which reaps) cannot be used,
+    # and waiting on an unread pipe would deadlock on any probe whose output
+    # outgrows the pipe buffer.
+    with tempfile.TemporaryFile(mode="w+") as out_file, tempfile.TemporaryFile(
+        mode="w+"
+    ) as err_file:
+        started = time.monotonic()
+        process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+            list(command), stdout=out_file, stderr=err_file, env=env
+        )
+        _, status, usage = os.wait4(process.pid, 0)
+        wall_ms = (time.monotonic() - started) * 1000.0
+        returncode = os.waitstatus_to_exitcode(status)
+        out_file.seek(0)
+        err_file.seek(0)
+        stdout, stderr = out_file.read(), err_file.read()
+
+    raw_peak = usage.ru_maxrss
+    peak_bytes = int(raw_peak) if platform.system() == "Darwin" else int(raw_peak) * 1024
+    return {
+        "stdout": stdout,
+        "stderr": stderr,
+        "returncode": returncode,
+        "wall_ms": wall_ms,
+        "peak_rss_bytes": peak_bytes,
+    }
+
+
+def parse_gcmetrics(stderr: str) -> dict[str, int]:
+    metrics: dict[str, int] = {}
+    for line in stderr.splitlines():
+        match = GCMETRIC_RE.match(line.strip())
+        if match:
+            metrics[match.group(1)] = int(match.group(2))
+    return metrics
+
+
+def parse_gc_diag(stderr: str) -> dict[str, int]:
+    """Aggregate ``PERRY_GC_DIAG=1`` output into deterministic counters.
+
+    ``[gc-copy-minor] ran copied_objects=.. copied_bytes=.. promoted_objects=..
+    promoted_bytes=.. freed_bytes=..`` is the evacuating minor's own accounting;
+    ``[gc-step]`` marks a completed collection step. Both are pure ``eprintln!``
+    diagnostics: enabling them was verified not to change ``heap_used_bytes``,
+    so the traced pass observes the same collector the untraced pass measures.
+    """
+    counters: collections.Counter[str] = collections.Counter()
+    for line in stderr.splitlines():
+        match = COPY_MINOR_RE.match(line)
+        if match:
+            counters["minor_cycles"] += 1
+            for pair in match.group(1).split():
+                if "=" not in pair:
+                    continue
+                key, _, value = pair.partition("=")
+                try:
+                    counters[key] += int(value)
+                except ValueError:
+                    continue
+        elif line.startswith(GC_STEP_PREFIX):
+            counters["step_cycles"] += 1
+    return {metric: int(counters.get(metric, 0)) for metric in GC_METRICS}
+
+
+def distribution(values: Sequence[float]) -> dict[str, Any]:
+    """Raw samples plus the statistics the gate reasons about.
+
+    ``spread_pct`` is ``(max-min)/median``, and it is the number that justifies
+    a tolerance band. A metric whose observed spread already approaches the band
+    you want to set is not gateable; the harness records the spread so that
+    judgement is auditable instead of asserted.
+    """
+    samples = [float(value) for value in values]
+    if not samples:
+        raise RatchetError("distribution has no samples")
+    if any(not math.isfinite(value) for value in samples):
+        raise RatchetError("distribution has a non-finite sample")
+    ordered = sorted(samples)
+    median = statistics.median(ordered)
+    spread = ordered[-1] - ordered[0]
+    return {
+        "samples": [_clean(value) for value in samples],
+        "sample_count": len(samples),
+        "median": _clean(median),
+        "min": _clean(ordered[0]),
+        "max": _clean(ordered[-1]),
+        "stdev": _clean(statistics.pstdev(ordered)),
+        "spread": _clean(spread),
+        "spread_pct": _clean(100.0 * spread / median) if median else 0,
+    }
+
+
+def _clean(value: float) -> int | float:
+    value = float(value)
+    return int(value) if value.is_integer() else round(value, 6)
+
+
+def probe_sources(probes_dir: Path) -> list[Path]:
+    sources = sorted(probes_dir.glob("*.ts"))
+    if not sources:
+        raise RatchetError(f"no probes found in {probes_dir}")
+    return sources
+
+
+def compile_probe(perry: Path, source: Path, out_dir: Path) -> Path:
+    binary = out_dir / source.stem
+    completed = subprocess.run(
+        [str(perry), source.name, "-o", str(binary)],
+        cwd=str(source.parent),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0 or not binary.exists():
+        raise RatchetError(
+            f"failed to compile {source.name}:\n{completed.stdout}\n{completed.stderr}"
+        )
+    return binary
+
+
+def _check_against_node(node: Path | None, source: Path, actual: str) -> dict[str, Any]:
+    """Diff probe stdout against the pinned Node oracle.
+
+    Exit 0 is not correctness. A probe that silently stops allocating still
+    exits 0 and reports a beautifully small retained heap, so every probe's
+    observable output is diffed against Node before its metrics are trusted.
+    """
+    if node is None:
+        return {"status": "unchecked", "reason": "no Node oracle supplied", "oracle_version": None}
+    version = subprocess.run(
+        [str(node), "--version"], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    completed = subprocess.run(
+        [str(node), "--expose-gc", "--experimental-strip-types", str(source)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return {
+            "status": "unchecked",
+            "reason": f"node exited {completed.returncode}: {completed.stderr.strip()[:400]}",
+            "oracle_version": version,
+        }
+    if completed.stdout == actual:
+        return {"status": "pass", "oracle_version": version, "reason": ""}
+    return {
+        "status": "fail",
+        "oracle_version": version,
+        "reason": "stdout differs from Node oracle",
+        "expected": completed.stdout.splitlines(),
+        "actual": actual.splitlines(),
+    }
+
+
+def measure(
+    *, perry: Path, probes_dir: Path, repeats: int, node: Path | None, warmup: int = 1
+) -> dict[str, Any]:
+    """Compile and run every probe, collecting all four metric families."""
+    if repeats < 3:
+        raise RatchetError("at least three repeats are required to state a spread")
+
+    sources = probe_sources(probes_dir)
+    results: dict[str, Any] = {}
+    with tempfile.TemporaryDirectory(prefix="gc-ratchet-") as tmp:
+        out_dir = Path(tmp)
+        for source in sources:
+            name = source.stem
+            binary = compile_probe(perry, source, out_dir)
+
+            for _ in range(warmup):
+                run_once([str(binary)])
+
+            samples: dict[str, list[float]] = {metric: [] for metric in SAMPLED_METRICS}
+            stdouts: list[str] = []
+            for _ in range(repeats):
+                run = run_once([str(binary)])
+                if run["returncode"] != 0:
+                    raise RatchetError(f"{name}: probe exited {run['returncode']}\n{run['stderr']}")
+                emitted = parse_gcmetrics(run["stderr"])
+                for metric in RETENTION_METRICS + ("rss_bytes",):
+                    if metric not in emitted:
+                        raise RatchetError(f"{name}: probe emitted no {metric}")
+                    if emitted[metric] <= 0:
+                        raise RatchetError(f"{name}: probe emitted non-positive {metric}")
+                    samples[metric].append(float(emitted[metric]))
+                samples["peak_rss_bytes"].append(float(run["peak_rss_bytes"]))
+                samples["wall_ms"].append(float(run["wall_ms"]))
+                stdouts.append(run["stdout"])
+
+            if len(set(stdouts)) != 1:
+                raise RatchetError(f"{name}: probe stdout is not deterministic across repeats")
+
+            # Separate traced pass. PERRY_GC_DIAG writes one line per collection
+            # phase, which perturbs wall time, so it must not share a pass with
+            # the timing samples. Two traced runs are taken and required to
+            # agree: that is the harness proving, every time it runs, that the
+            # counters it is about to gate on are actually deterministic.
+            traced = [
+                parse_gc_diag(
+                    run_once([str(binary)], extra_env={"PERRY_GC_DIAG": "1"})["stderr"]
+                )
+                for _ in range(2)
+            ]
+            if traced[0] != traced[1]:
+                differing = sorted(k for k in traced[0] if traced[0][k] != traced[1][k])
+                raise RatchetError(
+                    f"{name}: GC counters are not deterministic across traced runs "
+                    f"({', '.join(differing)}); they cannot be gated"
+                )
+            if traced[0]["minor_cycles"] < 1:
+                raise RatchetError(
+                    f"{name}: probe triggered no minor collection — it is not exercising "
+                    "the collector and must be rescaled before it can be pinned"
+                )
+
+            metrics = {metric: distribution(samples[metric]) for metric in SAMPLED_METRICS}
+            for metric in GC_METRICS:
+                metrics[metric] = distribution([traced[0][metric], traced[1][metric]])
+
+            results[name] = {
+                "stdout": stdouts[0],
+                "correctness": _check_against_node(node, source, stdouts[0]),
+                "metrics": metrics,
+            }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "gc-ratchet-measurement",
+        "generated_at": utc_now(),
+        "platform": platform_key(),
+        "host": host_description(),
+        "run_config": {
+            "repeats": repeats,
+            "warmup": warmup,
+            "traced_runs": 2,
+            "probes": [source.stem for source in sources],
+        },
+        "probes": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tolerances
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Tolerance:
+    """A regression band for one metric under one profile.
+
+    ``pct`` and ``abs`` combine as ``max(|baseline| * pct/100, abs)``, not as an
+    intersection. The absolute floor keeps a probe whose retained heap is
+    genuinely tiny from being gated on sub-kilobyte churn; the percentage keeps
+    a large probe from being handed a free multi-megabyte pass.
+
+    ``direction`` is ``"increase"`` when only growth is a regression (retention,
+    memory, time) and ``"either"`` when any drift is one. ``"either"`` is
+    correct for the evacuation counters: they are a behavioural fingerprint of
+    the collector, not a score, so a collector that suddenly copies fewer
+    objects has changed and must be re-pinned deliberately rather than silently
+    congratulated.
+    """
+
+    pct: float
+    abs: float
+    direction: str
+    gating: bool
+    rationale: str
+
+    def allowance(self, baseline: float) -> float:
+        return max(abs(baseline) * self.pct / 100.0, self.abs)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "pct": self.pct,
+            "abs": self.abs,
+            "direction": self.direction,
+            "gating": self.gating,
+            "rationale": self.rationale,
+        }
+
+
+def _tolerance_from_json(metric: str, raw: Mapping[str, Any]) -> Tolerance:
+    for field in ("pct", "abs", "direction", "gating", "rationale"):
+        if field not in raw:
+            raise RatchetError(f"tolerance for {metric} is missing {field}")
+    if raw["direction"] not in ("increase", "either"):
+        raise RatchetError(f"tolerance for {metric} has an invalid direction")
+    if not isinstance(raw["gating"], bool):
+        raise RatchetError(f"tolerance for {metric} has a non-boolean gating flag")
+    if float(raw["pct"]) < 0 or float(raw["abs"]) < 0:
+        raise RatchetError(f"tolerance for {metric} is negative")
+    if not str(raw["rationale"]).strip():
+        raise RatchetError(
+            f"tolerance for {metric} has no rationale; a band without a stated reason "
+            "is how gates drift until they cannot fire"
+        )
+    return Tolerance(
+        pct=float(raw["pct"]),
+        abs=float(raw["abs"]),
+        direction=str(raw["direction"]),
+        gating=bool(raw["gating"]),
+        rationale=str(raw["rationale"]),
+    )
+
+
+def tolerances_from_json(payload: Mapping[str, Any]) -> dict[str, dict[str, Tolerance]]:
+    profiles: dict[str, dict[str, Tolerance]] = {}
+    for profile in PROFILES:
+        if profile not in payload:
+            raise RatchetError(f"tolerances are missing the {profile!r} profile")
+        entries = payload[profile]
+        parsed = {
+            metric: _tolerance_from_json(metric, entries[metric])
+            for metric in entries
+            if metric in ALL_METRICS
+        }
+        unknown = sorted(set(entries) - set(ALL_METRICS))
+        if unknown:
+            raise RatchetError(f"{profile}: tolerance for unknown metric(s) {unknown}")
+        missing = [metric for metric in ALL_METRICS if metric not in parsed]
+        if missing:
+            raise RatchetError(f"{profile}: no tolerance for {', '.join(missing)}")
+        if not any(tolerance.gating for tolerance in parsed.values()):
+            raise RatchetError(
+                f"{profile}: no metric is gating, so this profile could never fail. "
+                "A gate that cannot fail is not a gate."
+            )
+        profiles[profile] = parsed
+    return profiles
+
+
+# ---------------------------------------------------------------------------
+# Artifact
+# ---------------------------------------------------------------------------
+
+
+def assemble(
+    *,
+    measurement: Mapping[str, Any],
+    tolerances_payload: Mapping[str, Any],
+    perry: Path,
+    commit: str,
+    suite: Mapping[str, Any] | None,
+    notes: str,
+) -> dict[str, Any]:
+    tolerances_from_json(tolerances_payload)
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "gc-ratchet-baseline",
+        "artifact_id": "gc-ratchet-v1",
+        "not_the_public_baseline": (
+            "Internal Perry-vs-Perry GC ratchet. The public Node/Bun evidence is "
+            "benchmarks/results/public-node-bun-v1.json, owned by "
+            "benchmarks/run_public_baseline.sh. Never regenerate one from the other."
+        ),
+        "commit": commit,
+        "generated_at": utc_now(),
+        "platform": measurement["platform"],
+        "host": measurement["host"],
+        "toolchain": toolchain_description(perry),
+        "run_config": dict(measurement["run_config"]),
+        "tolerances": dict(tolerances_payload),
+        "notes": notes,
+        "probes": measurement["probes"],
+        "suite": suite,
+    }
+    validate_artifact(artifact)
+    return artifact
+
+
+def validate_artifact(artifact: Mapping[str, Any]) -> None:
+    if artifact.get("schema_version") != SCHEMA_VERSION:
+        raise RatchetError(f"unsupported schema_version {artifact.get('schema_version')!r}")
+    if artifact.get("kind") != "gc-ratchet-baseline":
+        raise RatchetError("artifact is not a gc-ratchet baseline")
+    for field in ("commit", "generated_at", "platform"):
+        if not isinstance(artifact.get(field), str) or not artifact[field].strip():
+            raise RatchetError(f"artifact has an invalid {field}")
+    probes = artifact.get("probes")
+    if not isinstance(probes, Mapping) or not probes:
+        raise RatchetError("artifact records no probes")
+    expected = artifact.get("run_config", {}).get("probes")
+    if not isinstance(expected, list) or sorted(expected) != sorted(probes):
+        raise RatchetError("artifact probe set does not match its run_config")
+    tolerances_from_json(artifact.get("tolerances", {}))
+    for name, entry in probes.items():
+        metrics = entry.get("metrics")
+        if not isinstance(metrics, Mapping):
+            raise RatchetError(f"{name}: no metrics recorded")
+        for metric in ALL_METRICS:
+            if metric not in metrics:
+                raise RatchetError(f"{name}: baseline is missing {metric}")
+            recorded = metrics[metric]
+            samples = recorded.get("samples")
+            if not isinstance(samples, list) or len(samples) < 2:
+                raise RatchetError(f"{name}: {metric} has too few samples")
+            if recorded != distribution(samples):
+                raise RatchetError(f"{name}: {metric} summary is inconsistent with its samples")
+        if entry.get("correctness", {}).get("status") == "fail":
+            raise RatchetError(f"{name}: baseline pinned a probe whose output is wrong")
+        if metrics["minor_cycles"]["median"] < 1:
+            raise RatchetError(f"{name}: baseline pinned a probe that ran no minor collection")
+
+
+# ---------------------------------------------------------------------------
+# Regression check
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Row:
+    probe: str
+    metric: str
+    baseline: float
+    current: float
+    delta: float
+    delta_pct: float | None
+    allowance: float
+    gating: bool
+    status: str
+
+
+def evaluate(
+    baseline: Mapping[str, Any],
+    current: Mapping[str, Any],
+    *,
+    profile: str,
+    allow_platform_mismatch: bool = False,
+) -> tuple[list[Row], list[str]]:
+    """Compare a fresh measurement against the pinned artifact.
+
+    Failures come from two places on purpose: threshold breaches, and integrity
+    problems. A missing probe, a probe whose output no longer matches the Node
+    oracle, or too few repeats is a *failure*, not a skip. A gate that silently
+    drops the workload it was watching is exactly the shape of the ``gc-stress``
+    hole this ratchet exists to close — that job was ``continue-on-error: true``
+    and a regression sat behind it through three merges.
+    """
+    validate_artifact(baseline)
+    if profile not in PROFILES:
+        raise RatchetError(f"unknown profile {profile!r}; expected one of {PROFILES}")
+    if current.get("kind") != "gc-ratchet-measurement":
+        raise RatchetError("current payload is not a gc-ratchet measurement")
+
+    failures: list[str] = []
+    rows: list[Row] = []
+    tolerances = tolerances_from_json(baseline["tolerances"])[profile]
+
+    if baseline["platform"] != current.get("platform"):
+        message = (
+            f"platform mismatch: baseline {baseline['platform']!r} vs "
+            f"current {current.get('platform')!r}"
+        )
+        failures.append(f"NOTE (non-gating): {message}" if allow_platform_mismatch else message)
+
+    baseline_repeats = int(baseline["run_config"]["repeats"])
+    current_repeats = int(current.get("run_config", {}).get("repeats", 0))
+    if current_repeats < baseline_repeats:
+        failures.append(
+            f"current run used {current_repeats} repeats, baseline pinned {baseline_repeats}"
+        )
+
+    baseline_probes = baseline["probes"]
+    current_probes = current.get("probes", {})
+    missing = sorted(set(baseline_probes) - set(current_probes))
+    unexpected = sorted(set(current_probes) - set(baseline_probes))
+    if missing:
+        failures.append(f"probes missing from this run: {', '.join(missing)}")
+    if unexpected:
+        failures.append(
+            f"probes present now but absent from the baseline: {', '.join(unexpected)} "
+            "(regenerate the artifact deliberately)"
+        )
+
+    for name in sorted(set(baseline_probes) & set(current_probes)):
+        base_entry = baseline_probes[name]
+        cur_entry = current_probes[name]
+
+        if cur_entry.get("stdout") != base_entry.get("stdout"):
+            failures.append(f"{name}: observable output changed since the baseline")
+        if cur_entry.get("correctness", {}).get("status") == "fail":
+            failures.append(f"{name}: probe output no longer matches the Node oracle")
+
+        for metric in ALL_METRICS:
+            tolerance = tolerances[metric]
+            base_median = float(base_entry["metrics"][metric]["median"])
+            cur_median = float(cur_entry["metrics"][metric]["median"])
+            delta = cur_median - base_median
+            delta_pct = (100.0 * delta / base_median) if base_median else None
+            allowance = tolerance.allowance(base_median)
+
+            if delta > allowance:
+                breach = True
+            elif delta < -allowance:
+                breach = tolerance.direction == "either"
+            else:
+                breach = False
+
+            if breach:
+                status = "REGRESSION" if tolerance.gating else "drift (informational)"
+            elif delta < -allowance:
+                status = "improvement"
+            else:
+                status = "ok"
+
+            rows.append(
+                Row(
+                    probe=name,
+                    metric=metric,
+                    baseline=base_median,
+                    current=cur_median,
+                    delta=delta,
+                    delta_pct=delta_pct,
+                    allowance=allowance,
+                    gating=tolerance.gating,
+                    status=status,
+                )
+            )
+            if status == "REGRESSION":
+                shown = "n/a" if delta_pct is None else f"{delta_pct:+.2f}%"
+                failures.append(
+                    f"{name}: {metric} {base_median:,.0f} -> {cur_median:,.0f} ({shown}), "
+                    f"allowance {allowance:,.0f} [{tolerance.direction}]"
+                )
+
+    return rows, failures
+
+
+def render(rows: Iterable[Row], baseline: Mapping[str, Any], profile: str) -> str:
+    host = baseline.get("host", {})
+    lines = [
+        "## GC ratchet",
+        "",
+        f"- Profile: `{profile}`",
+        f"- Baseline commit: `{baseline['commit']}`",
+        f"- Baseline captured: {baseline['generated_at']} on `{baseline['platform']}`",
+        f"- Baseline host: {host.get('cpu_brand') or host.get('machine')}, "
+        f"{host.get('cpu_count')} cores, load at capture "
+        f"{host.get('load_average', {}).get('1m')}",
+        "",
+        "Only rows marked gating can fail the job. Non-gating rows are recorded so a",
+        "drift that is real but unmeasurable on this runner is still visible.",
+        "",
+        "| Probe | Metric | Baseline | Current | Δ | Allowance | Gating | Status |",
+        "|-------|--------|---------:|--------:|---:|----------:|:------:|--------|",
+    ]
+    for row in rows:
+        delta = "-" if row.delta_pct is None else f"{row.delta_pct:+.2f}%"
+        lines.append(
+            f"| `{row.probe}` | {row.metric} | {row.baseline:,.0f} | {row.current:,.0f} | "
+            f"{delta} | {row.allowance:,.0f} | {'yes' if row.gating else 'no'} | {row.status} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RatchetError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RatchetError(f"{path} is not valid JSON: {exc}") from exc
+
+
+def _write(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _resolve_node(explicit: str | None) -> Path | None:
+    if explicit:
+        return Path(explicit)
+    pinned = REPO_ROOT / ".node-version"
+    if pinned.exists():
+        version = pinned.read_text(encoding="utf-8").strip().lstrip("v")
+        arch = "arm64" if platform.machine() == "arm64" else "x64"
+        candidate = (
+            Path.home()
+            / f"node-v{version}-{platform.system().lower()}-{arch}"
+            / "bin"
+            / "node"
+        )
+        if candidate.exists():
+            return candidate
+    found = shutil.which("node")
+    return Path(found) if found else None
+
+
+def cmd_measure(args: argparse.Namespace) -> int:
+    perry = Path(args.perry).resolve()
+    if not perry.exists():
+        raise RatchetError(f"perry binary not found at {perry}")
+    payload = measure(
+        perry=perry,
+        probes_dir=Path(args.probes_dir).resolve(),
+        repeats=args.repeats,
+        node=_resolve_node(args.node),
+        warmup=args.warmup,
+    )
+    _write(Path(args.output), payload)
+    load = payload["host"]["load_average"]
+    print(f"gc-ratchet: wrote measurement to {args.output}")
+    print(f"  host {payload['host'].get('hostname')} load {load['1m']}/{load['5m']}/{load['15m']}")
+    for name, entry in payload["probes"].items():
+        spreads = " ".join(
+            f"{metric}={entry['metrics'][metric]['spread_pct']}%" for metric in SAMPLED_METRICS
+        )
+        print(f"  {name}: correctness={entry['correctness']['status']} {spreads}")
+    return 0
+
+
+def cmd_assemble(args: argparse.Namespace) -> int:
+    artifact = assemble(
+        measurement=_load(Path(args.measurement)),
+        tolerances_payload=_load(Path(args.tolerances)),
+        perry=Path(args.perry).resolve(),
+        commit=args.commit,
+        suite=_load(Path(args.suite)) if args.suite else None,
+        notes=args.notes,
+    )
+    _write(Path(args.output), artifact)
+    print(f"gc-ratchet: wrote pinned artifact to {args.output}")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    baseline = _load(Path(args.artifact))
+    current = _load(Path(args.current))
+    rows, failures = evaluate(
+        baseline,
+        current,
+        profile=args.profile,
+        allow_platform_mismatch=args.allow_platform_mismatch,
+    )
+    report = render(rows, baseline, args.profile)
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    hard = [failure for failure in failures if not failure.startswith("NOTE")]
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+            if failures:
+                handle.write("\n**Findings**\n\n")
+                for failure in failures:
+                    handle.write(f"- {failure}\n")
+            if hard:
+                handle.write(
+                    "\nRe-pin only if this shift is intentional: see "
+                    "`benchmarks/gc_ratchet/README.md`.\n"
+                )
+    if hard:
+        print("gc-ratchet: FAILED", file=sys.stderr)
+        for failure in hard:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    for failure in failures:
+        print(f"gc-ratchet: {failure}")
+    print("gc-ratchet: OK")
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    validate_artifact(_load(Path(args.artifact)))
+    print(f"gc-ratchet: {args.artifact} is a valid pinned baseline")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GC retention/memory ratchet")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    measure_cmd = sub.add_parser("measure", help="run the probes and record metrics")
+    measure_cmd.add_argument("--perry", required=True)
+    measure_cmd.add_argument("--probes-dir", default=str(PROBES_DIR))
+    measure_cmd.add_argument("--repeats", type=int, default=7)
+    measure_cmd.add_argument("--warmup", type=int, default=1)
+    measure_cmd.add_argument("--node", default=None)
+    measure_cmd.add_argument("--output", required=True)
+    measure_cmd.set_defaults(func=cmd_measure)
+
+    assemble_cmd = sub.add_parser("assemble", help="build the pinned baseline artifact")
+    assemble_cmd.add_argument("--measurement", required=True)
+    assemble_cmd.add_argument("--tolerances", default=str(DEFAULT_TOLERANCES))
+    assemble_cmd.add_argument("--perry", required=True)
+    assemble_cmd.add_argument("--commit", required=True)
+    assemble_cmd.add_argument("--suite", default=None)
+    assemble_cmd.add_argument("--notes", default="")
+    assemble_cmd.add_argument("--output", default=str(DEFAULT_ARTIFACT))
+    assemble_cmd.set_defaults(func=cmd_assemble)
+
+    check_cmd = sub.add_parser("check", help="fail on regression against the baseline")
+    check_cmd.add_argument("--artifact", default=str(DEFAULT_ARTIFACT))
+    check_cmd.add_argument("--current", required=True)
+    check_cmd.add_argument("--profile", choices=PROFILES, default="shared_ci")
+    check_cmd.add_argument("--allow-platform-mismatch", action="store_true")
+    check_cmd.set_defaults(func=cmd_check)
+
+    validate_cmd = sub.add_parser("validate", help="structural check of the pinned artifact")
+    validate_cmd.add_argument("--artifact", default=str(DEFAULT_ARTIFACT))
+    validate_cmd.set_defaults(func=cmd_validate)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except RatchetError as exc:
+        print(f"gc-ratchet error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -460,11 +460,13 @@ def measure(
                     f"{name}: GC counters are not deterministic across traced runs "
                     f"({', '.join(differing)}); they cannot be gated"
                 )
-            if traced[0]["minor_cycles"] < 1:
-                raise RatchetError(
-                    f"{name}: probe triggered no minor collection — it is not exercising "
-                    "the collector and must be rescaled before it can be pinned"
-                )
+            # Deliberately NOT rejecting minor_cycles == 0 here. A collector that
+            # has stopped running copying minors at all is the single largest
+            # regression this ratchet exists to catch, and it must surface as a
+            # REGRESSION row against the baseline's cycle count, not as a harness
+            # error that misdiagnoses it as "your probe is too small". The
+            # can't-pin-a-probe-that-never-collects rule lives in
+            # validate_artifact, where it belongs: pinning time, not measure time.
 
             metrics = {metric: distribution(samples[metric]) for metric in SAMPLED_METRICS}
             for metric in GC_METRICS:

--- a/benchmarks/gc_ratchet/probes/01_nursery_churn.ts
+++ b/benchmarks/gc_ratchet/probes/01_nursery_churn.ts
@@ -1,0 +1,48 @@
+// GC ratchet probe: nursery churn with a zero live set.
+//
+// Allocates a large number of objects that escape into a small ring buffer and
+// are then dropped, so at `gc()` time every one of them is unreachable.
+// Post-collect `heapUsed` is a direct measure of *false retention*: precise
+// shadow-stack roots leave only the fixed runtime floor behind, while a
+// conservative stack scan can pin arbitrary dead objects that stale words in
+// the machine stack still point at.
+//
+// The ring is load-bearing. Allocating into a local that never escapes lets
+// LLVM scalar-replace the object away entirely: an earlier draft of this probe
+// ran in 10 ms, triggered zero collections, and reported 600 retained bytes —
+// a benchmark that measured nothing. Every probe in this suite therefore parks
+// its allocations in a heap container before dropping them.
+//
+// Metric contract: stdout carries only `probe:`/`checksum:` lines and is diffed
+// byte-for-byte against the pinned Node oracle. Retention metrics go to stderr
+// as `#gcmetric` lines and are Perry-vs-Perry only.
+
+declare function gc(): void;
+
+const ITERATIONS = 400000;
+const RING = 256;
+
+const ring: ({ a: number; b: number; c: number } | null)[] = [];
+for (let i = 0; i < RING; i++) {
+  ring.push(null);
+}
+
+let checksum = 0;
+for (let i = 0; i < ITERATIONS; i++) {
+  const o = { a: i, b: i * 2, c: (i & 1023) + 1 };
+  ring[i % RING] = o;
+  checksum = (checksum + o.a + o.c) | 0;
+}
+
+for (let i = 0; i < RING; i++) {
+  ring[i] = null;
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:01_nursery_churn");
+console.log("checksum:" + checksum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/02_survivor_promotion.ts
+++ b/benchmarks/gc_ratchet/probes/02_survivor_promotion.ts
@@ -1,0 +1,49 @@
+// GC ratchet probe: survivor aging and promotion into old-gen.
+//
+// Keeps one allocation in eight reachable from a module-level array while the
+// rest cycle through a ring and die, so nursery survivors repeatedly clear the
+// two-bit aging gate (HAS_SURVIVED -> TENURED) and get evacuated into
+// OLD_ARENA. Post-collect `heapUsed` measures how compactly the surviving set
+// ends up stored: pinning a tenured object in place — the expected consequence
+// of dropping precise roots in favour of a conservative scan — shows up as
+// retained bytes that no longer shrink.
+
+declare function gc(): void;
+
+const ITERATIONS = 320000;
+const KEEP_EVERY = 8;
+const RING = 128;
+
+const live: { a: number; b: number }[] = [];
+const ring: ({ a: number; b: number } | null)[] = [];
+for (let i = 0; i < RING; i++) {
+  ring.push(null);
+}
+
+let checksum = 0;
+for (let i = 0; i < ITERATIONS; i++) {
+  const o = { a: i, b: i * 3 };
+  checksum = (checksum + o.a) | 0;
+  if (i % KEEP_EVERY === 0) {
+    live.push(o);
+  } else {
+    ring[i % RING] = o;
+  }
+}
+
+for (let i = 0; i < RING; i++) {
+  ring[i] = null;
+}
+for (let i = 0; i < live.length; i++) {
+  checksum = (checksum + live[i].b) | 0;
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:02_survivor_promotion");
+console.log("checksum:" + checksum);
+console.log("live:" + live.length);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/03_cross_gen_writes.ts
+++ b/benchmarks/gc_ratchet/probes/03_cross_gen_writes.ts
@@ -1,0 +1,44 @@
+// GC ratchet probe: old-to-young stores and the remembered set.
+//
+// Builds a long-lived table, ages it into old-gen with explicit collects, then
+// overwrites its slots with freshly allocated nursery objects. Every store is
+// an old->young edge the write barrier must record, and every overwritten slot
+// drops its previous target. Retained bytes after the final collect should
+// track the live table only; a barrier or root-scanning change that
+// over-retains the replaced generations shows up here first.
+
+declare function gc(): void;
+
+const TABLE_SIZE = 4096;
+const ROUNDS = 120;
+
+const table: { v: number; tag: number }[] = [];
+for (let i = 0; i < TABLE_SIZE; i++) {
+  table.push({ v: i, tag: 0 });
+}
+
+// Age the table into old-gen before the write storm.
+gc();
+gc();
+
+let checksum = 0;
+for (let round = 0; round < ROUNDS; round++) {
+  for (let i = 0; i < TABLE_SIZE; i++) {
+    const fresh = { v: round * TABLE_SIZE + i, tag: round };
+    table[i] = fresh;
+    checksum = (checksum + fresh.tag) | 0;
+  }
+}
+
+for (let i = 0; i < TABLE_SIZE; i++) {
+  checksum = (checksum + table[i].v) | 0;
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:03_cross_gen_writes");
+console.log("checksum:" + checksum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/04_dead_after_deep_stack.ts
+++ b/benchmarks/gc_ratchet/probes/04_dead_after_deep_stack.ts
@@ -1,0 +1,52 @@
+// GC ratchet probe: dead objects under a stack high-water mark.
+//
+// This is the specific case a conservative stack scan is expected to get wrong.
+// A deep recursion allocates in every frame and then unwinds completely; the
+// machine stack below the current stack pointer still holds the old frames' bit
+// patterns. Precise shadow-stack roots ignore that region entirely. A
+// conservative scan that reads it treats those stale words as roots and keeps
+// the whole recursion's garbage alive.
+//
+// Retained bytes here are the most sensitive signal in the suite for the
+// shadow-stack removal campaign. `sink` forces the per-frame batch onto the
+// heap so it cannot be scalar-replaced; only the last batch stays reachable
+// after the unwind, so everything else is unambiguously garbage.
+
+declare function gc(): void;
+
+const DEPTH = 700;
+const PER_FRAME = 48;
+const REPEATS = 40;
+
+let sink: { d: number; pad: number }[] | null = null;
+
+function descend(depth: number): number {
+  const scratch: { d: number; pad: number }[] = [];
+  for (let i = 0; i < PER_FRAME; i++) {
+    scratch.push({ d: depth, pad: i });
+  }
+  sink = scratch;
+  let local = scratch[PER_FRAME - 1].d;
+  if (depth > 0) {
+    local = (local + descend(depth - 1)) | 0;
+  }
+  return local;
+}
+
+let checksum = 0;
+for (let r = 0; r < REPEATS; r++) {
+  checksum = (checksum + descend(DEPTH)) | 0;
+}
+
+sink = null;
+
+// Everything allocated above is unreachable, but the frames that held it are
+// still resident on the machine stack as stale words.
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:04_dead_after_deep_stack");
+console.log("checksum:" + checksum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/05_closure_capture.ts
+++ b/benchmarks/gc_ratchet/probes/05_closure_capture.ts
@@ -1,0 +1,45 @@
+// GC ratchet probe: closure environments and captured cells.
+//
+// Closure conversion boxes captured locals into heap cells, and the
+// async-to-generator transform boxes every body local into a shared mutable
+// cell. Those cells are a distinct allocation family from plain objects. This
+// probe creates batches of closures over per-iteration bindings, invokes them,
+// parks the batch in a module-level slot so it cannot be optimised away, then
+// drops it so the environments become garbage.
+
+declare function gc(): void;
+
+const BATCHES = 700;
+const PER_BATCH = 512;
+
+let sink: (() => number)[] | null = null;
+
+function makeBatch(seed: number): number {
+  const fns: (() => number)[] = [];
+  for (let i = 0; i < PER_BATCH; i++) {
+    const captured = { base: seed + i, extra: i * 2 };
+    fns.push(() => (captured.base + captured.extra) | 0);
+  }
+  sink = fns;
+  let sum = 0;
+  for (let i = 0; i < fns.length; i++) {
+    sum = (sum + fns[i]()) | 0;
+  }
+  return sum;
+}
+
+let checksum = 0;
+for (let b = 0; b < BATCHES; b++) {
+  checksum = (checksum + makeBatch(b)) | 0;
+}
+
+sink = null;
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:05_closure_capture");
+console.log("checksum:" + checksum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/06_string_retention.ts
+++ b/benchmarks/gc_ratchet/probes/06_string_retention.ts
@@ -1,0 +1,52 @@
+// GC ratchet probe: heap strings.
+//
+// Heap strings are their own allocation family (STRING_TAG, separate scanner)
+// and their bytes are not required to be valid UTF-8. This probe builds and
+// discards a large volume of concatenated and sliced strings through a ring so
+// they genuinely reach the heap, keeping only a small digest alive. Post-collect
+// retention therefore reflects string reclamation rather than object
+// reclamation.
+
+declare function gc(): void;
+
+const ROUNDS = 3000;
+const PIECES = 96;
+const RING = 64;
+
+const ring: (string | null)[] = [];
+for (let i = 0; i < RING; i++) {
+  ring.push(null);
+}
+
+function buildStrings(round: number): number {
+  let acc = "";
+  let width = 0;
+  for (let i = 0; i < PIECES; i++) {
+    acc = acc + "seg" + ((round + i) & 255) + "|";
+    ring[i % RING] = acc;
+    if (acc.length > 512) {
+      const tail = acc.slice(acc.length - 128);
+      width = (width + tail.length) | 0;
+      acc = tail;
+    }
+  }
+  return (width + acc.length) | 0;
+}
+
+let checksum = 0;
+for (let r = 0; r < ROUNDS; r++) {
+  checksum = (checksum + buildStrings(r)) | 0;
+}
+
+for (let i = 0; i < RING; i++) {
+  ring[i] = null;
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:06_string_retention");
+console.log("checksum:" + checksum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/07_array_grow_evacuate.ts
+++ b/benchmarks/gc_ratchet/probes/07_array_grow_evacuate.ts
@@ -1,0 +1,55 @@
+// GC ratchet probe: array element storage growth and reallocation.
+//
+// A growing array repeatedly abandons its previous element storage, which is a
+// separate allocation from the array header. Evacuation has to rewrite the
+// header's pointer to the moved storage; per-object pinning would leave the old
+// storage in place and fragment the region. The probe grows many arrays past
+// several reallocation boundaries, keeps a small live sample, cycles the rest
+// through a ring so they are genuinely heap-allocated, then drops them.
+
+declare function gc(): void;
+
+const ARRAYS = 6000;
+const LENGTH = 640;
+const KEEP_EVERY = 64;
+const RING = 32;
+
+const survivors: number[][] = [];
+const ring: (number[] | null)[] = [];
+for (let i = 0; i < RING; i++) {
+  ring.push(null);
+}
+
+function grow(seed: number): number {
+  const a: number[] = [];
+  for (let i = 0; i < LENGTH; i++) {
+    a.push((seed + i) | 0);
+  }
+  if (seed % KEEP_EVERY === 0) {
+    survivors.push(a);
+  } else {
+    ring[seed % RING] = a;
+  }
+  return a[LENGTH - 1];
+}
+
+let checksum = 0;
+for (let i = 0; i < ARRAYS; i++) {
+  checksum = (checksum + grow(i)) | 0;
+}
+for (let i = 0; i < RING; i++) {
+  ring[i] = null;
+}
+for (let i = 0; i < survivors.length; i++) {
+  checksum = (checksum + survivors[i].length) | 0;
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:07_array_grow_evacuate");
+console.log("checksum:" + checksum);
+console.log("survivors:" + survivors.length);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/probes/08_map_set_sidetables.ts
+++ b/benchmarks/gc_ratchet/probes/08_map_set_sidetables.ts
@@ -1,0 +1,44 @@
+// GC ratchet probe: Map/Set side tables with object keys and values.
+//
+// Map and Set keep separately allocated storage the arena does not own, reached
+// through registered side-table scanners rather than the object walk. Object
+// keys make the entries participate in the reachability graph. The probe churns
+// a bounded working set through many generations of entries so most keys and
+// values die while the containers themselves stay live, which is the shape that
+// breaks if a scanner stops being registered or starts over-retaining.
+
+declare function gc(): void;
+
+const GENERATIONS = 1400;
+const WORKING_SET = 1024;
+
+const map = new Map<object, number>();
+const set = new Set<object>();
+
+let checksum = 0;
+for (let g = 0; g < GENERATIONS; g++) {
+  map.clear();
+  set.clear();
+  for (let i = 0; i < WORKING_SET; i++) {
+    const key = { g: g, i: i };
+    map.set(key, (g * WORKING_SET + i) | 0);
+    set.add(key);
+  }
+  map.forEach((value: number) => {
+    checksum = (checksum + value) | 0;
+  });
+  checksum = (checksum + set.size + map.size) | 0;
+}
+
+map.clear();
+set.clear();
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:08_map_set_sidetables");
+console.log("checksum:" + checksum);
+console.log("final_sizes:" + map.size + "," + set.size);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh
+++ b/benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Measure the GC ratchet on a quiet host: either re-pin the baseline, or check
+# against it with the memory and timing metrics gated.
+#
+# THIS IS NOT benchmarks/run_public_baseline.sh. That script produces the
+# maintainer-owned public Node/Bun evidence in
+# benchmarks/results/public-node-bun-v1.json and gates `lint`. This one produces
+# the internal Perry-vs-Perry GC ratchet in
+# benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json and gates the `gc-ratchet`
+# CI job. The quiet-host discipline below is copied from that script on purpose;
+# the artifacts are unrelated and must never be regenerated from one another.
+#
+# Usage:
+#   PERRY_BIN=/path/to/target/release/perry \
+#   PERRY_RUNTIME_DIR=/path/to/target/release \
+#     ./benchmarks/gc_ratchet/run_gc_ratchet_baseline.sh --check
+#
+#   ... --pin --notes "why this shift is intentional"
+#
+# --check  measure and compare against the pinned artifact under the
+#          `pinned_host` profile, which gates RSS and wall time as well as
+#          retention and the evacuation counters. Default.
+# --pin    overwrite the pinned artifact. Do this ONLY when a shift has been
+#          reviewed and accepted. Re-pinning to make a red gate go green defeats
+#          the entire point of the ratchet.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HERE="$ROOT/benchmarks/gc_ratchet"
+cd "$ROOT"
+
+MAX_CPU_ACTIVE="${GC_RATCHET_MAX_CPU_ACTIVE:-25.0}"
+QUIET_SECONDS="${GC_RATCHET_QUIET_SECONDS:-60}"
+REPEATS="${GC_RATCHET_REPEATS:-7}"
+MIN_FREE_GB="${GC_RATCHET_MIN_FREE_GB:-9}"
+OUT="$ROOT/.bench-results/gc-ratchet"
+ARTIFACT="$HERE/baseline/gc-ratchet-v1.json"
+MODE="check"
+NOTES=""
+RUN_SUITE=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) MODE="check"; shift ;;
+    --pin) MODE="pin"; shift ;;
+    --notes) NOTES="$2"; shift 2 ;;
+    --no-suite) RUN_SUITE=0; shift ;;
+    --out) OUT="$2"; shift 2 ;;
+    --artifact) ARTIFACT="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$OUT"
+fail() { echo "gc-ratchet: $*" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Preconditions. Every one of these has cost this project a wrong conclusion.
+# ---------------------------------------------------------------------------
+
+# A dirty tree means the recorded commit does not describe what was measured.
+[[ -z "$(git status --porcelain)" ]] || fail "working tree must be clean before measurement"
+
+# Build outputs are invisible to `git status`, so the binary under test has to
+# be named explicitly. An implicit search can silently pick up an archive from
+# another worktree that has nothing to do with this commit.
+[[ -n "${PERRY_BIN:-}" ]] || fail "set PERRY_BIN to the perry binary under test"
+[[ -x "${PERRY_BIN}" ]] || fail "PERRY_BIN=$PERRY_BIN is not executable"
+[[ -n "${PERRY_RUNTIME_DIR:-}" ]] || fail "set PERRY_RUNTIME_DIR to the directory holding libperry_{runtime,stdlib}.a"
+for lib in libperry_runtime.a libperry_stdlib.a; do
+  [[ -f "$PERRY_RUNTIME_DIR/$lib" ]] || fail \
+    "$PERRY_RUNTIME_DIR/$lib is missing. perry-runtime and perry-stdlib are rlib-only; the archives come from the perry-runtime-static / perry-stdlib-static wrapper crates. Build: cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static"
+done
+export PERRY_RUNTIME_DIR
+# Deterministic link: use the prebuilt full stdlib rather than letting the
+# auto-optimizer rebuild a workload-specific archive mid-measurement.
+export PERRY_NO_AUTO_OPTIMIZE=1
+
+# Measuring on a nearly full volume distorts everything downstream.
+free_gb=$(df -g "$ROOT" | awk 'NR==2 {print $4}')
+[[ "${free_gb:-0}" -ge "$MIN_FREE_GB" ]] || fail "only ${free_gb}GB free; refusing to measure below ${MIN_FREE_GB}GB"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  pmset -g batt | head -1 | grep -q "AC Power" || fail "macOS host must be connected to AC power"
+fi
+
+# The Node oracle is a correctness input, not a toolchain detail: a probe that
+# quietly stops allocating still exits 0 and reports a tiny retained heap.
+EXPECTED_NODE="v$(tr -d 'v \n' < "$ROOT/.node-version")"
+uname_s="$(uname -s | tr '[:upper:]' '[:lower:]')"
+NODE_BIN="${GC_RATCHET_NODE:-$HOME/node-${EXPECTED_NODE}-${uname_s}-$(uname -m)/bin/node}"
+[[ -x "$NODE_BIN" ]] || fail "pinned Node oracle not found at $NODE_BIN (expected $EXPECTED_NODE); set GC_RATCHET_NODE"
+actual_node="$("$NODE_BIN" --version)"
+[[ "$actual_node" == "$EXPECTED_NODE" ]] || fail "expected Node $EXPECTED_NODE, found $actual_node at $NODE_BIN"
+
+wait_for_quiet() {
+  echo "Waiting for CPU active <= $MAX_CPU_ACTIVE% for $QUIET_SECONDS consecutive seconds..."
+  python3 - "$MAX_CPU_ACTIVE" "$QUIET_SECONDS" <<'PY'
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+
+limit, required = float(sys.argv[1]), int(sys.argv[2])
+
+
+def cpu_active_percent():
+    system = platform.system()
+    if system == "Darwin":
+        output = subprocess.run(
+            ["top", "-l", "2", "-n", "0", "-s", "1"],
+            capture_output=True, text=True, timeout=20, check=True,
+        ).stdout
+        idle = re.findall(r"([0-9]+(?:[.,][0-9]+)?)% idle", output)
+        if not idle:
+            raise RuntimeError("could not read macOS CPU idle percentage")
+        return 100.0 - float(idle[-1].replace(",", "."))
+    if system == "Linux":
+        def counters():
+            with open("/proc/stat", encoding="utf-8") as handle:
+                values = [int(value) for value in handle.readline().split()[1:]]
+            return sum(values), values[3] + values[4]
+        total_before, idle_before = counters()
+        time.sleep(1)
+        total_after, idle_after = counters()
+        return 100.0 * (1.0 - (idle_after - idle_before) / (total_after - total_before))
+    cores = os.cpu_count() or 1
+    return min(100.0, os.getloadavg()[0] * 100.0 / cores)
+
+
+quiet_since = None
+deadline = time.monotonic() + 900
+while time.monotonic() < deadline:
+    active = cpu_active_percent()
+    now = time.monotonic()
+    if active > limit:
+        quiet_since = None
+    elif quiet_since is None:
+        quiet_since = now
+    if quiet_since is not None and now - quiet_since >= required:
+        print(f"Quiet host confirmed: cpu_active={active:.1f}%")
+        raise SystemExit(0)
+    time.sleep(4)
+raise SystemExit("host did not become CPU-quiet within 15 minutes; nothing was written")
+PY
+}
+
+echo "gc-ratchet ($MODE) at $(git rev-parse HEAD)"
+echo "  perry:   $PERRY_BIN"
+echo "  runtime: $PERRY_RUNTIME_DIR"
+echo "  node:    $NODE_BIN ($actual_node)"
+uptime
+
+wait_for_quiet
+
+echo "=== retention + GC counters (${REPEATS} repeats) ==="
+python3 "$HERE/gc_ratchet.py" measure \
+  --perry "$PERRY_BIN" \
+  --repeats "$REPEATS" \
+  --node "$NODE_BIN" \
+  --output "$OUT/measurement.json"
+
+if [[ "$MODE" == "check" ]]; then
+  python3 "$HERE/gc_ratchet.py" check \
+    --artifact "$ARTIFACT" \
+    --current "$OUT/measurement.json" \
+    --profile pinned_host
+  exit $?
+fi
+
+SUITE_ARG=()
+if [[ $RUN_SUITE -eq 1 ]]; then
+  wait_for_quiet
+  echo "=== benchmark suite (wall + RSS, recorded for the record) ==="
+  PATH="$(dirname "$NODE_BIN"):$PATH" PERRY_BIN="$PERRY_BIN" \
+    "$ROOT/benchmarks/compare.sh" --full --runs 5 --json-out "$OUT/suite.json" --warn-only
+  SUITE_ARG=(--suite "$OUT/suite.json")
+fi
+
+python3 "$HERE/gc_ratchet.py" assemble \
+  --measurement "$OUT/measurement.json" \
+  --tolerances "$HERE/tolerances.json" \
+  --perry "$PERRY_BIN" \
+  --commit "$(git rev-parse HEAD)" \
+  "${SUITE_ARG[@]}" \
+  --notes "$NOTES" \
+  --output "$ARTIFACT"
+
+python3 "$HERE/gc_ratchet.py" validate --artifact "$ARTIFACT"
+echo "gc-ratchet baseline written: $ARTIFACT"

--- a/benchmarks/gc_ratchet/tolerances.json
+++ b/benchmarks/gc_ratchet/tolerances.json
@@ -1,0 +1,195 @@
+{
+  "_readme": [
+    "Regression bands for the GC ratchet, one set per profile. Every band states",
+    "the run-to-run variance it was derived from. The measurements behind these",
+    "numbers are 3 independent sessions x 7 repeats (21 runs) per probe on the",
+    "pinned quiet host, plus 5 traced runs per probe for the GC counters; the",
+    "observed spreads are recorded in the artifact next to every number.",
+    "",
+    "allowance = max(|baseline| * pct/100, abs). direction 'increase' means only",
+    "growth is a regression; 'either' means any drift beyond the band is, which",
+    "is correct for the evacuation counters because they are a behavioural",
+    "fingerprint of the collector rather than a score.",
+    "",
+    "Profiles exist because the metric families do not share noise floors.",
+    "'shared_ci' runs on a GitHub-hosted runner, which is a different machine",
+    "class from the host the baseline was captured on: retention and GC counters",
+    "transfer because they are semantic, memory and time do not. 'pinned_host' is",
+    "for a maintainer re-running the suite on the same quiet box, where memory and",
+    "time are comparable and are gated."
+  ],
+
+  "shared_ci": {
+    "heap_used_bytes": {
+      "pct": 2.0,
+      "abs": 65536,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "Observed spread 0.000% over 21 runs on all 8 probes: bit-identical. The band is therefore pure anti-brittleness margin for incidental churn (a new runtime global, an extra interned string), not a noise allowance. The 64 KiB floor keeps the smallest probe (457,872 B retained) from being gated on sub-kilobyte drift while staying 16x below the smallest interesting regression, which is one falsely retained 1 MiB nursery block."
+    },
+    "heap_total_bytes": {
+      "pct": 2.0,
+      "abs": 1048576,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "Observed spread 0.000%. Arena capacity moves in 1 MiB block quanta, so any floor below one block turns this into a strict equality gate that a single extra block would trip. The floor tolerates exactly one extra block and fails at two."
+    },
+    "minor_cycles": {
+      "pct": 5.0,
+      "abs": 1,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000% over 5 traced runs per probe (baselines 14-104 cycles). One extra or missing collection is churn; two is a change in when the collector fires."
+    },
+    "step_cycles": {
+      "pct": 5.0,
+      "abs": 1,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000%. Same reasoning as minor_cycles; tracked separately because a change that splits or merges collection phases moves one without the other."
+    },
+    "copied_objects": {
+      "pct": 5.0,
+      "abs": 16,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000% (baselines 18k-43k). This is the metric that collapses if objects start being pinned instead of evacuated, which is the primary predicted effect of replacing precise roots with a conservative scan plus per-object pinning."
+    },
+    "copied_bytes": {
+      "pct": 5.0,
+      "abs": 65536,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000% (baselines 1.1 MB-24.4 MB). Pairs with copied_objects: a change in mean evacuated object size moves this without moving the count."
+    },
+    "promoted_objects": {
+      "pct": 5.0,
+      "abs": 16,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000%. Baselines range from 15 to 4,796, so on the smallest probe the 16-object floor dominates and this cell is effectively ungated; the other seven probes carry the signal. Stated rather than hidden."
+    },
+    "promoted_bytes": {
+      "pct": 5.0,
+      "abs": 65536,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000%. Rises when the collector starts tenuring garbage, which is how false retention from a conservative scan reaches old-gen and stops being reclaimable by a minor collection at all."
+    },
+    "freed_bytes": {
+      "pct": 5.0,
+      "abs": 1048576,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Observed spread 0.000% (baselines 29 MB-124 MB). A drop means the collector reclaimed less from the same allocation sequence, which is the definition of the regression this campaign risks. Floor is one arena block."
+    },
+    "rss_bytes": {
+      "pct": 15.0,
+      "abs": 8388608,
+      "direction": "increase",
+      "gating": false,
+      "rationale": "NOT GATED HERE. Observed spread on the pinned host is 0.408%, but a GitHub-hosted runner is a different machine class with a different allocator arena layout and a different baseline RSS, so a band tight enough to catch a real regression would fire on the host difference alone. Recorded and reported so a large shift is still visible; gated in the pinned_host profile instead."
+    },
+    "peak_rss_bytes": {
+      "pct": 15.0,
+      "abs": 8388608,
+      "direction": "increase",
+      "gating": false,
+      "rationale": "NOT GATED HERE, for the same reason as rss_bytes. Observed spread on the pinned host is 0.113%."
+    },
+    "wall_ms": {
+      "pct": 30.0,
+      "abs": 100,
+      "direction": "increase",
+      "gating": false,
+      "rationale": "EXCLUDED FROM THE SHARED-CI GATE. Wall time on a shared runner is dominated by neighbour noise; no band both survives that and catches a real GC slowdown. Rather than widen it until it cannot fire, it is marked non-gating and reported. The GC-work dimension is covered on this runner by the deterministic counters (minor_cycles, copied_objects, freed_bytes), which measure how much work the collector did without measuring how fast the machine was."
+    }
+  },
+
+  "pinned_host": {
+    "heap_used_bytes": {
+      "pct": 2.0,
+      "abs": 65536,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "heap_total_bytes": {
+      "pct": 2.0,
+      "abs": 1048576,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "minor_cycles": {
+      "pct": 5.0,
+      "abs": 1,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "step_cycles": {
+      "pct": 5.0,
+      "abs": 1,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "copied_objects": {
+      "pct": 5.0,
+      "abs": 16,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "copied_bytes": {
+      "pct": 5.0,
+      "abs": 65536,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "promoted_objects": {
+      "pct": 5.0,
+      "abs": 16,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "promoted_bytes": {
+      "pct": 5.0,
+      "abs": 65536,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "freed_bytes": {
+      "pct": 5.0,
+      "abs": 1048576,
+      "direction": "either",
+      "gating": true,
+      "rationale": "Same band as shared_ci; observed spread 0.000%."
+    },
+    "rss_bytes": {
+      "pct": 3.0,
+      "abs": 524288,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "GATED HERE. Worst cross-session spread of medians was 0.408% and worst within-session spread was 0.73%, so 3% is roughly 7x the observed noise and 4x the worst single-session spread. On the 23-38 MB baselines the percentage dominates the 512 KiB floor, which exists only so a future smaller probe is not gated on page-granularity jitter."
+    },
+    "peak_rss_bytes": {
+      "pct": 3.0,
+      "abs": 524288,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "GATED HERE. Worst cross-session spread of medians was 0.113%, worst within-session 0.72%. Same band as rss_bytes; peak is the number that decides whether a workload fits in memory."
+    },
+    "wall_ms": {
+      "pct": 10.0,
+      "abs": 15,
+      "direction": "increase",
+      "gating": true,
+      "rationale": "GATED HERE ONLY. Worst cross-session spread of medians-of-7 was 0.751% on an idle box (load 1.7-2.0); worst raw within-session spread was 5.3%, which the median-of-7 damps out. 10% is ~13x the cross-session figure and ~2x the worst raw spread, so it will not fire on scheduler jitter but will catch the tens-of-percent slowdown a whole-stack conservative scan would introduce. The 15 ms floor covers the fastest probe (126 ms)."
+    }
+  }
+}

--- a/changelog.d/7045-gc-perf-ratchet-baseline.md
+++ b/changelog.d/7045-gc-perf-ratchet-baseline.md
@@ -1,0 +1,54 @@
+**GC performance/RSS ratchet (Task 0 of the GC architecture campaign):** pin the
+current evacuating minor collector's observable behaviour and gate on it, before
+the shadow-stack-root removal work starts. Measurement and infrastructure only —
+no compiler or runtime behaviour changes.
+
+- **New artifact** `benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json`, captured
+  on the pinned quiet host (Apple M1, 8 cores, 8 GB, macOS 26.5.1) at load 1.19
+  with CPU-active confirmed at 5.9%, recording per-probe distributions, the host
+  and load average, toolchain versions, and SHA-256 content hashes of `perry`,
+  `libperry_runtime.a` and `libperry_stdlib.a`. **Distinct from the public
+  Node/Bun baseline** in `benchmarks/results/public-node-bun-v1.json`, which is
+  untouched: different directory, different workflow, different gate, and the
+  distinction is restated in the artifact, the README and every file header.
+- **Eight probes** (`benchmarks/gc_ratchet/probes/`) covering nursery churn with
+  a zero live set, survivor aging and promotion, old-to-young stores, dead
+  objects under a deep stack high-water mark, closure environments, heap strings,
+  array element-storage growth, and Map/Set side tables. Each probe's stdout is
+  diffed byte-for-byte against the Node pinned in `.node-version`; all eight
+  pass. Every probe parks its allocations in a heap container before dropping
+  them — an earlier draft allocated into non-escaping locals, LLVM scalar-
+  replaced them, and the probe ran in 10 ms with zero collections while looking
+  healthy.
+- **Four metric families, separated by noise floor.** Retention
+  (`heap_used_bytes`, `heap_total_bytes`, read after an explicit full `gc()`) and
+  the evacuating minor's own accounting (`minor_cycles`, `step_cycles`,
+  `copied_objects`, `copied_bytes`, `promoted_objects`, `promoted_bytes`,
+  `freed_bytes`, parsed from `PERRY_GC_DIAG=1` in a separate untimed pass) were
+  **bit-identical across 3 sessions × 7 repeats** on all 8 probes, so both are
+  gated everywhere. RSS (≤0.41% spread) and wall time (≤0.75% on medians) are
+  gated only in the `pinned_host` profile and explicitly marked non-gating in
+  `shared_ci`, because a GitHub runner is a different machine class — stated in
+  `tolerances.json` rather than hidden behind a band too wide to fire.
+- **Checker** `benchmarks/gc_ratchet/gc_ratchet.py` with `measure` / `assemble` /
+  `check` / `validate`. Integrity problems fail rather than skip: a missing or
+  extra probe, a probe whose output stops matching the Node oracle, fewer repeats
+  than the baseline, a platform mismatch, or a tampered summary. Evacuation
+  counters are gated two-sided, because a collector that copies *fewer* objects
+  has changed and must be re-pinned deliberately.
+- **CI** `.github/workflows/gc-ratchet.yml`, a standalone job with no
+  `continue-on-error` and no pipe swallowing the checker's exit status — the
+  shape `gc-stress` has, which let a regression sit through three merges. Not yet
+  promoted to a required status check; the promotion command is in the PR body,
+  to be run once the job has been green once.
+- **Validated end to end against a real collector change**, not just injected
+  JSON: under `PERRY_CONSERVATIVE_STACK_SCAN=full` — the mechanism the campaign
+  adopts — the gate exits 1 with 60 regression rows and retention up 364%–5371%,
+  while the control arm reproduces the baseline exactly and exits 0. That A/B
+  also surfaced a design bug, fixed here: the "probe ran no minor collection"
+  rule was in `measure`, so a collector that stopped running copying minors
+  produced a harness error blaming the probe instead of a regression; it now
+  lives in `validate_artifact`.
+- `tests/test_gc_ratchet.py` — 32 tests, one per failure mode, including a
+  parametric test that walks every gating metric in every profile and asserts
+  each independently turns the job red.

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -1,0 +1,380 @@
+"""Tests for the GC ratchet gate.
+
+The point of most of these is not that the checker *passes* on good input — a
+checker that always passes would satisfy that. The point is that it *fails* on
+each kind of bad input, one test per failure mode, including one parametric test
+that walks every gating metric in every profile and proves each can independently
+turn the job red. ``gc-stress`` was ``continue-on-error: true`` for long enough
+that a regression sat behind it through three merges; a gate nobody has watched
+fail is indistinguishable from that.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from benchmarks.gc_ratchet.gc_ratchet import (
+    ALL_METRICS,
+    DEFAULT_ARTIFACT,
+    GC_METRICS,
+    PROFILES,
+    RatchetError,
+    distribution,
+    evaluate,
+    parse_gc_diag,
+    parse_gcmetrics,
+    tolerances_from_json,
+    validate_artifact,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOLERANCES_PATH = REPO_ROOT / "benchmarks" / "gc_ratchet" / "tolerances.json"
+
+BASE_VALUES = {
+    "heap_used_bytes": 1_000_000.0,
+    "heap_total_bytes": 20_971_520.0,
+    "minor_cycles": 80.0,
+    "step_cycles": 80.0,
+    "copied_objects": 20_000.0,
+    "copied_bytes": 1_500_000.0,
+    "promoted_objects": 4_000.0,
+    "promoted_bytes": 500_000.0,
+    "freed_bytes": 100_000_000.0,
+    "rss_bytes": 30_000_000.0,
+    "peak_rss_bytes": 31_000_000.0,
+    "wall_ms": 200.0,
+}
+
+
+def _metrics(overrides=None):
+    values = dict(BASE_VALUES)
+    values.update(overrides or {})
+    return {metric: distribution([values[metric]] * 7) for metric in ALL_METRICS}
+
+
+def _probe(name="01_probe", overrides=None, correctness="pass"):
+    return {
+        name: {
+            "stdout": f"probe:{name}\nchecksum:1\n",
+            "correctness": {"status": correctness, "oracle_version": "v26.5.0", "reason": ""},
+            "metrics": _metrics(overrides),
+        }
+    }
+
+
+def _baseline(probes=None):
+    probes = probes if probes is not None else _probe()
+    return {
+        "schema_version": 1,
+        "kind": "gc-ratchet-baseline",
+        "artifact_id": "gc-ratchet-v1",
+        "commit": "deadbeef",
+        "generated_at": "2026-07-30T00:00:00+00:00",
+        "platform": "darwin-arm64",
+        "host": {"cpu_count": 8, "load_average": {"1m": 1.0}},
+        "run_config": {"repeats": 7, "warmup": 1, "traced_runs": 2, "probes": sorted(probes)},
+        "tolerances": json.loads(TOLERANCES_PATH.read_text(encoding="utf-8")),
+        "probes": probes,
+    }
+
+
+def _measurement(probes=None, platform="darwin-arm64", repeats=7):
+    probes = probes if probes is not None else _probe()
+    return {
+        "schema_version": 1,
+        "kind": "gc-ratchet-measurement",
+        "generated_at": "2026-07-30T01:00:00+00:00",
+        "platform": platform,
+        "host": {"cpu_count": 8, "load_average": {"1m": 1.0}},
+        "run_config": {"repeats": repeats, "warmup": 1, "traced_runs": 2, "probes": sorted(probes)},
+        "probes": probes,
+    }
+
+
+def _hard(failures):
+    return [failure for failure in failures if not failure.startswith("NOTE")]
+
+
+class ParsingTests(unittest.TestCase):
+    def test_parses_gcmetric_lines_and_ignores_noise(self):
+        stderr = (
+            "some unrelated warning\n"
+            "#gcmetric heap_used_bytes=1234\n"
+            "#gcmetric heap_total_bytes=20971520\n"
+            "#gcmetricmalformed=1\n"
+        )
+        self.assertEqual(
+            parse_gcmetrics(stderr),
+            {"heap_used_bytes": 1234, "heap_total_bytes": 20971520},
+        )
+
+    def test_parses_and_aggregates_copy_minor_accounting(self):
+        stderr = (
+            "[gc-copy-minor] eligible=true fallback=none\n"
+            "[gc-copy-minor] ran copied_objects=10 copied_bytes=100 "
+            "promoted_objects=1 promoted_bytes=8 freed_bytes=900\n"
+            "[gc-step] pre_in_use=1 post_in_use=2 sweep_freed=3\n"
+            "[gc-copy-minor] ran copied_objects=5 copied_bytes=50 "
+            "promoted_objects=0 promoted_bytes=0 freed_bytes=100\n"
+        )
+        parsed = parse_gc_diag(stderr)
+        self.assertEqual(parsed["minor_cycles"], 2)
+        self.assertEqual(parsed["step_cycles"], 1)
+        self.assertEqual(parsed["copied_objects"], 15)
+        self.assertEqual(parsed["copied_bytes"], 150)
+        self.assertEqual(parsed["freed_bytes"], 1000)
+
+    def test_eligible_lines_do_not_count_as_cycles(self):
+        # "[gc-copy-minor] eligible=..." is a decision trace, not a collection.
+        # Counting it would inflate minor_cycles and make the metric depend on
+        # how often the policy was *consulted* rather than how often it ran.
+        parsed = parse_gc_diag("[gc-copy-minor] eligible=true fallback=none\n")
+        self.assertEqual(parsed["minor_cycles"], 0)
+
+
+class ToleranceTests(unittest.TestCase):
+    def test_shipped_tolerances_parse_and_cover_every_metric(self):
+        profiles = tolerances_from_json(json.loads(TOLERANCES_PATH.read_text(encoding="utf-8")))
+        for profile in PROFILES:
+            self.assertEqual(set(profiles[profile]), set(ALL_METRICS))
+
+    def test_every_tolerance_states_a_rationale(self):
+        profiles = tolerances_from_json(json.loads(TOLERANCES_PATH.read_text(encoding="utf-8")))
+        for profile, entries in profiles.items():
+            for metric, tolerance in entries.items():
+                self.assertTrue(
+                    tolerance.rationale.strip(),
+                    f"{profile}.{metric} has no rationale",
+                )
+
+    def test_profile_with_nothing_gating_is_rejected(self):
+        payload = json.loads(TOLERANCES_PATH.read_text(encoding="utf-8"))
+        for entry in payload["shared_ci"].values():
+            entry["gating"] = False
+        with self.assertRaises(RatchetError) as caught:
+            tolerances_from_json(payload)
+        self.assertIn("could never fail", str(caught.exception))
+
+    def test_rationale_may_not_be_blank(self):
+        payload = json.loads(TOLERANCES_PATH.read_text(encoding="utf-8"))
+        payload["shared_ci"]["heap_used_bytes"]["rationale"] = "   "
+        with self.assertRaises(RatchetError):
+            tolerances_from_json(payload)
+
+    def test_gc_counters_are_two_sided(self):
+        profiles = tolerances_from_json(json.loads(TOLERANCES_PATH.read_text(encoding="utf-8")))
+        for profile in PROFILES:
+            for metric in GC_METRICS:
+                self.assertEqual(
+                    profiles[profile][metric].direction,
+                    "either",
+                    f"{profile}.{metric} must fail on drift in either direction",
+                )
+
+
+class GatePassTests(unittest.TestCase):
+    def test_identical_measurement_passes(self):
+        baseline = _baseline()
+        rows, failures = evaluate(baseline, _measurement(), profile="shared_ci")
+        self.assertEqual(_hard(failures), [])
+        self.assertTrue(rows)
+        self.assertTrue(all(row.status == "ok" for row in rows))
+
+    def test_change_inside_the_band_passes(self):
+        # heap_used_bytes allowance is max(2% of 1,000,000, 65,536) = 65,536.
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"heap_used_bytes": 1_065_536.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertEqual(_hard(failures), [])
+
+    def test_noisy_wall_time_does_not_fail_shared_ci(self):
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"wall_ms": 1_000_000.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertEqual(_hard(failures), [])
+
+    def test_memory_growth_does_not_fail_shared_ci(self):
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"peak_rss_bytes": 300_000_000.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertEqual(_hard(failures), [])
+
+
+class GateFailTests(unittest.TestCase):
+    def test_retention_regression_fails(self):
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"heap_used_bytes": 2_000_000.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("heap_used_bytes" in failure for failure in _hard(failures)))
+
+    def test_one_falsely_retained_nursery_block_fails(self):
+        # The smallest regression the campaign could plausibly introduce: a
+        # single 1 MiB nursery block kept alive by a stale stack word.
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"heap_used_bytes": 1_000_000.0 + 1_048_576}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("heap_used_bytes" in failure for failure in _hard(failures)))
+
+    def test_evacuation_collapse_fails_even_though_it_is_a_decrease(self):
+        # Pinning objects instead of evacuating them makes copied_objects fall.
+        # A one-sided "growth is bad" gate would wave this through.
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"copied_objects": 10.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("copied_objects" in failure for failure in _hard(failures)))
+
+    def test_reclaiming_less_fails(self):
+        baseline = _baseline()
+        current = _measurement(_probe(overrides={"freed_bytes": 50_000_000.0}))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("freed_bytes" in failure for failure in _hard(failures)))
+
+    def test_missing_probe_fails_instead_of_being_skipped(self):
+        baseline = _baseline()
+        current = _measurement({})
+        current["run_config"]["probes"] = []
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("missing" in failure for failure in _hard(failures)))
+
+    def test_extra_probe_fails(self):
+        baseline = _baseline()
+        probes = dict(_probe())
+        probes.update(_probe("02_new"))
+        _, failures = evaluate(baseline, _measurement(probes), profile="shared_ci")
+        self.assertTrue(any("02_new" in failure for failure in _hard(failures)))
+
+    def test_node_oracle_failure_fails(self):
+        baseline = _baseline()
+        current = _measurement(_probe(correctness="fail"))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("Node oracle" in failure for failure in _hard(failures)))
+
+    def test_changed_observable_output_fails(self):
+        baseline = _baseline()
+        probes = _probe()
+        probes["01_probe"]["stdout"] = "probe:01_probe\nchecksum:999\n"
+        _, failures = evaluate(baseline, _measurement(probes), profile="shared_ci")
+        self.assertTrue(any("observable output" in failure for failure in _hard(failures)))
+
+    def test_fewer_repeats_fails(self):
+        baseline = _baseline()
+        _, failures = evaluate(baseline, _measurement(repeats=3), profile="shared_ci")
+        self.assertTrue(any("repeats" in failure for failure in _hard(failures)))
+
+    def test_platform_mismatch_fails_by_default(self):
+        baseline = _baseline()
+        _, failures = evaluate(baseline, _measurement(platform="linux-x86_64"), profile="shared_ci")
+        self.assertTrue(any("platform mismatch" in failure for failure in _hard(failures)))
+
+    def test_platform_mismatch_can_be_downgraded_explicitly(self):
+        baseline = _baseline()
+        _, failures = evaluate(
+            baseline,
+            _measurement(platform="linux-x86_64"),
+            profile="shared_ci",
+            allow_platform_mismatch=True,
+        )
+        self.assertEqual(_hard(failures), [])
+        self.assertTrue(any(failure.startswith("NOTE") for failure in failures))
+
+    def test_pinned_host_profile_gates_memory_and_time(self):
+        baseline = _baseline()
+        current = _measurement(
+            _probe(overrides={"peak_rss_bytes": 40_000_000.0, "wall_ms": 400.0})
+        )
+        _, failures = evaluate(baseline, current, profile="pinned_host")
+        joined = " ".join(_hard(failures))
+        self.assertIn("peak_rss_bytes", joined)
+        self.assertIn("wall_ms", joined)
+
+    def test_every_gating_metric_can_independently_fail(self):
+        """Walk every gating metric in every profile and prove it turns red.
+
+        Without this, a band could quietly be set wide enough that the metric is
+        gating in name only, and nothing would ever notice.
+        """
+        payload = json.loads(TOLERANCES_PATH.read_text(encoding="utf-8"))
+        profiles = tolerances_from_json(payload)
+        for profile in PROFILES:
+            for metric, tolerance in profiles[profile].items():
+                if not tolerance.gating:
+                    continue
+                with self.subTest(profile=profile, metric=metric):
+                    base = BASE_VALUES[metric]
+                    breach = base + tolerance.allowance(base) * 1.5 + 1
+                    current = _measurement(_probe(overrides={metric: breach}))
+                    _, failures = evaluate(_baseline(), current, profile=profile)
+                    self.assertTrue(
+                        any(metric in failure for failure in _hard(failures)),
+                        f"{profile}.{metric} is marked gating but did not fail on a breach",
+                    )
+
+
+class ArtifactValidationTests(unittest.TestCase):
+    def test_pinned_artifact_is_valid(self):
+        self.assertTrue(
+            DEFAULT_ARTIFACT.exists(),
+            f"pinned baseline missing at {DEFAULT_ARTIFACT}",
+        )
+        validate_artifact(json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8")))
+
+    def test_pinned_artifact_records_provenance(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        self.assertRegex(artifact["commit"], r"^[0-9a-f]{40}$")
+        self.assertIn("load_average", artifact["host"])
+        self.assertIsNotNone(artifact["toolchain"]["rustc"])
+        binaries = artifact["toolchain"]["binaries"]
+        for key in ("perry", "libperry_runtime.a", "libperry_stdlib.a"):
+            self.assertRegex(binaries[key]["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_pinned_artifact_probes_all_ran_a_collection(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        for name, entry in artifact["probes"].items():
+            self.assertGreaterEqual(
+                entry["metrics"]["minor_cycles"]["median"],
+                1,
+                f"{name} pinned without exercising the collector",
+            )
+
+    def test_pinned_artifact_probes_match_the_node_oracle(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        for name, entry in artifact["probes"].items():
+            self.assertEqual(
+                entry["correctness"]["status"],
+                "pass",
+                f"{name} was pinned without a passing Node oracle diff",
+            )
+
+    def test_pinned_artifact_retention_is_deterministic(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        for name, entry in artifact["probes"].items():
+            for metric in ("heap_used_bytes", "heap_total_bytes"):
+                self.assertEqual(
+                    entry["metrics"][metric]["spread"],
+                    0,
+                    f"{name}.{metric} was not deterministic when pinned; "
+                    "it must not be in a gating family",
+                )
+
+    def test_tampered_summary_is_rejected(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        name = sorted(artifact["probes"])[0]
+        tampered = copy.deepcopy(artifact)
+        tampered["probes"][name]["metrics"]["heap_used_bytes"]["median"] = 1
+        with self.assertRaises(RatchetError):
+            validate_artifact(tampered)
+
+    def test_probe_without_a_collection_cannot_be_pinned(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        name = sorted(artifact["probes"])[0]
+        tampered = copy.deepcopy(artifact)
+        tampered["probes"][name]["metrics"]["minor_cycles"] = distribution([0, 0])
+        with self.assertRaises(RatchetError):
+            validate_artifact(tampered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this is

Task 0 of the GC architecture campaign: a pinned baseline of the current
evacuating minor collector, a checker that fails on regression against it, and a
CI job that runs the checker. Frozen *before* the shadow-stack-root removal work
starts, so that from here on the gate decides rather than argument.

No compiler or runtime behaviour changes. Measurement and infrastructure only.

**This is not the public benchmark baseline.** `benchmarks/run_public_baseline.sh`
→ `benchmarks/results/public-node-bun-v1.json` is maintainer-owned published
Node/Bun evidence that gates `lint`, and #7044 just fixed its build. This is an
internal Perry-vs-Perry GC ratchet in `benchmarks/gc_ratchet/` gating a new
`gc-ratchet` job. Nothing under `benchmarks/results/` or `public_baseline*` is
touched. The distinction is stated in a comparison table at the top of
`benchmarks/gc_ratchet/README.md`, in the header of every new file, and in a
`not_the_public_baseline` field inside the artifact itself, because these two
will otherwise be confused forever.

## Protocol

Measured on the pinned quiet host (`perry-macos.local`: Apple M1, 8 cores, 8 GB,
macOS 26.5.1), on AC power, in a dedicated worktree with an isolated
`CARGO_TARGET_DIR`, 16 GB free disk. Load average at capture: **1.19 / 1.48 /
2.14**, CPU-active confirmed at **5.9%**. Load is recorded inside the artifact
next to the numbers.

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`.
  The `-static` wrappers are not optional: `perry-runtime`/`perry-stdlib` are
  rlib-only, and building without them links a stale `.a` so both arms of an A/B
  behave identically. The package set is fixed and recorded so cargo feature
  unification cannot drift between runs.
- `PERRY_RUNTIME_DIR` named explicitly (never an implicit search),
  `PERRY_NO_AUTO_OPTIMIZE=1` for a deterministic link. The artifact records
  SHA-256 of `perry`, `libperry_runtime.a`, `libperry_stdlib.a` — content
  hashes, never mtimes — so a future run claiming different code but sharing a
  runtime hash is visibly vacuous.
- Quiet-host discipline copied from `run_public_baseline.sh`: clean tree, AC
  power, ≥9 GB free, pinned Node present at the exact version, CPU-active ≤25%
  for 60 consecutive seconds before each lane.
- Every probe's stdout is diffed byte-for-byte against Node 26.5.0 from
  `.node-version` (`~/node-v26.5.0-darwin-arm64/bin/node`, version asserted —
  the system node is a different patch). All 8 pass. Exit 0 is not correctness:
  a probe that silently stops allocating still exits 0 and reports a beautifully
  small retained heap.

## Measured variance

3 independent sessions × 7 repeats = 21 runs per probe, plus traced runs for the
GC counters. Worst spread across sessions over all 8 probes:

| Family | Metrics | Worst spread | Gated in shared CI | Gated on pinned host |
|---|---|---|---|---|
| retention | `heap_used_bytes`, `heap_total_bytes` | **0.000%** | yes | yes |
| GC accounting | `minor_cycles`, `step_cycles`, `copied_objects`, `copied_bytes`, `promoted_objects`, `promoted_bytes`, `freed_bytes` | **0.000%** | yes | yes |
| memory | `rss_bytes`, `peak_rss_bytes` | 0.41% / 0.11% | no | yes |
| timing | `wall_ms` | 0.75% (medians of 7) | **no** | yes |

Retention and the evacuation counters are bit-identical across every run of
every probe. They are semantic — a function of the allocation sequence and
collector policy, not of CPU speed, core count, or load — which is what makes
them gateable on a shared runner at all.

The GC counters come from `PERRY_GC_DIAG=1` in a separate untimed pass; enabling
the trace was verified not to move `heap_used_bytes`. The harness takes two
traced runs on **every** invocation and fails if they disagree, so it re-proves
the determinism it depends on each time it runs.

## Tolerances and why

Every band is in `benchmarks/gc_ratchet/tolerances.json` next to the variance it
was derived from; the loader rejects a tolerance with a blank rationale.

- `heap_used_bytes` — `max(2%, 64 KiB)`, one-sided. Observed noise is zero, so
  the band is anti-brittleness margin for incidental churn (a new runtime global,
  an extra interned string), not a noise allowance. It sits 16× below the
  smallest regression that matters — one falsely retained 1 MiB nursery block —
  and there is a test asserting exactly that case fails.
- `heap_total_bytes` — `max(2%, 1 MiB)`. Arena capacity moves in 1 MiB quanta, so
  a smaller floor would be a strict equality gate. Tolerates one extra block,
  fails at two.
- Evacuation counters — `max(5%, small floor)`, **two-sided**. A behavioural
  fingerprint, not a score: a collector that suddenly copies *fewer* objects has
  changed, plausibly because objects are now pinned, and must be re-pinned
  deliberately rather than silently congratulated.
- `rss_bytes` / `peak_rss_bytes` — `max(3%, 512 KiB)` one-sided on the pinned
  host, ≈7× the observed spread.
- `wall_ms` — `max(10%, 15 ms)` one-sided on the pinned host: ≈13× the 0.75%
  cross-session spread of medians and ≈2× the worst raw within-session spread,
  which the median-of-7 damps.

## What I excluded, and why

`wall_ms`, `rss_bytes` and `peak_rss_bytes` are **not gated in the `shared_ci`
profile**. They are marked `"gating": false` with the reason written in the
tolerances file, rather than being handed a band so wide it could never fire.

- Wall time on a GitHub-hosted runner is dominated by neighbour noise; no band
  both survives that and catches a real GC slowdown.
- RSS on a GitHub runner is a different machine class with a different baseline,
  so the comparison is not meaningful there at any band.

The GC-work dimension is not lost by that: `minor_cycles`, `copied_objects`,
`copied_bytes` and `freed_bytes` measure how much work the collector did without
measuring how fast the machine was, and they are gated everywhere. All four
families are gated in the `pinned_host` profile, run on the quiet box via
`run_gc_ratchet_baseline.sh --check`.

## The gate can fail — and was proven to, against a real collector change

`gc-stress` is `continue-on-error: true`, which is how a regression sat unnoticed
through three merges. `gc-ratchet` has no `continue-on-error`, no `|| true`, and
no pipe between the checker and the shell's exit status.

Failure is not only threshold breaches: a missing probe, an extra probe, a probe
whose stdout stops matching the Node oracle, fewer repeats than the baseline, a
platform mismatch, or a tampered artifact summary are all hard failures rather
than silent skips.

`tests/test_gc_ratchet.py` (32 tests) has one test per failure mode plus a
parametric test that walks **every gating metric in every profile**, injects a
breach, and asserts the checker turns red — so a band cannot quietly be widened
until a metric is gating in name only.

Unit tests only prove the checker reacts to edited JSON, though. To show the
*probes* are sensitive to what the campaign will actually do, the whole thing was
run end-to-end against `PERRY_CONSERVATIVE_STACK_SCAN=full` — the runtime's
existing escape hatch for the legacy conservative stack scan, i.e. the mechanism
being adopted. Control arm reproduced the baseline exactly on all eight probes
and exited 0. The conservative-scan arm exited 1 with 60 regression rows:

| Probe | `heap_used_bytes` baseline | conservative scan | Δ | `minor_cycles` |
|---|---:|---:|---:|---:|
| `01_nursery_churn` | 807,000 | 3,742,800 | +364% | 14 → 0 |
| `02_survivor_promotion` | 5,022,864 | 25,242,760 | +403% | 10 → 0 |
| `03_cross_gen_writes` | 705,320 | 6,494,536 | +821% | 22 → 0 |
| `04_dead_after_deep_stack` | 1,000,728 | 9,187,088 | +818% | 104 → 0 |
| `05_closure_capture` | 1,040,208 | 7,336,208 | +605% | 26 → 0 |
| `06_string_retention` | 746,056 | 4,746,240 | +536% | 64 → 0 |
| `07_array_grow_evacuate` | 1,816,232 | 99,362,360 | +5371% | 80 → 0 |
| `08_map_set_sidetables` | 457,872 | 6,754,560 | +1375% | 84 → 0 |

Sensitivity is orders of magnitude, not margin.

That A/B also found a design bug, fixed here: the "probe ran no minor collection"
rule was in `measure`, so a collector that stopped running copying minors
produced a *harness error blaming the probe* instead of a regression. It now
lives in `validate_artifact` (you may not **pin** such a probe), and `measure`
records `minor_cycles = 0` so the checker reports it as the regression it is.

## A note on the probes

Every probe parks its allocations in a heap container before dropping them, and
that is load-bearing. The first draft allocated into locals that never escaped;
LLVM scalar-replaced the objects away and the probe ran in 10 ms with zero
collections and 600 retained bytes — a benchmark that measured nothing while
looking perfectly healthy. Caught by checking `PERRY_GC_DIAG` cycle counts rather
than trusting the numbers.

## CI wiring — and what I deliberately did not do

`.github/workflows/gc-ratchet.yml`, job `gc-ratchet`, on `macos-14` (arm64,
matching the `darwin-arm64` platform key the baseline was captured under; the
checker refuses a platform mismatch rather than comparing incomparable numbers).
Runs on every PR, `push` to `main`, and `workflow_dispatch`. Harness unit tests
and artifact validation run first so a broken harness fails in seconds rather
than after a 20-minute compiler build. A path filter skips the build for changes
that cannot touch the collector while still reporting the check, which keeps it
viable as a required context.

Standalone job, not a step inside `lint`, deliberately: `lint` carries unrelated
red debt that gets admin-bypassed and this gate must not ride along with that.
Same reasoning already written into `changeset-gate`.

**I did not add `gc-ratchet` to the required status checks.** The current set is
`lint, cargo-test, parity, compile-smoke, api-docs-drift, security-audit,
conformance-smoke-complete`. Promoting a context that has never run green would
block every open PR immediately — the exact failure mode the repo is living
through right now with the stale public baseline blocking `lint`. Once this PR's
own `gc-ratchet` run is green, promotion is one command:

```
gh api -X PUT repos/PerryTS/perry/branches/main/protection/required_status_checks \
  -f 'contexts[]=lint' -f 'contexts[]=cargo-test' -f 'contexts[]=parity' \
  -f 'contexts[]=compile-smoke' -f 'contexts[]=api-docs-drift' \
  -f 'contexts[]=security-audit' -f 'contexts[]=conformance-smoke-complete' \
  -f 'contexts[]=gc-ratchet'
```

Until that is run the job fails loudly but does not block a merge. It is a
repo-settings change and a maintainer decision, so it is flagged rather than made
unilaterally.

## What I could not verify

- **Cross-host determinism of retention and the GC counters.** They are
  bit-identical across 21 runs on the pinned host, and they are semantic rather
  than timing-derived, but I had only one quiet machine. Whether a GitHub
  `macos-14` runner reproduces the same byte counts is answered by this PR's own
  first `gc-ratchet` run. If it diverges, the honest fix is to scope the
  retention gate to the pinned host and leave the GC counters gating in CI; the
  artifact and checker already carry the `platform` key needed for that, and the
  checker fails rather than silently comparing across platforms.
- **`gc-ratchet` wall-clock cost on a cold macOS runner.** Unmeasured. It reuses
  the existing `${{ runner.os }}-cargo-bench-` cache key so it should warm from
  `benchmark.yml`, but the first run will be slow.
- **Linux behaviour.** Not measured at all; measurement was scoped to the one
  quiet box.
- `benchmarks/baseline.json`, the pre-existing legacy suite gate, reports its own
  unrelated deltas under `--warn-only` during the suite lane. Untouched and not
  chased.
