### PR TITLE
test(gc): treat unverified correctness as a gc-ratchet failure

### DIFF
--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -144,10 +144,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .bench-results
+          # Load is recorded inside the measurement JSON too; printing it here
+          # keeps it in the log next to the numbers.
           uptime
+          # Pass the oracle explicitly rather than letting the harness search.
+          # A run that cannot reach the oracle now fails the gate — "we did not
+          # verify" must not look like "verified" — so resolution must not be
+          # left to chance.
           python3 benchmarks/gc_ratchet/gc_ratchet.py measure \
             --perry target/release/perry \
             --repeats 7 \
+            --node "$(command -v node)" \
             --output .bench-results/gc-ratchet-current.json
 
       # No pipe, no `|| true`, no continue-on-error: this step's exit status is

--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -23,8 +23,21 @@ permissions:
   contents: read
 
 concurrency:
-  group: gc-ratchet-${{ github.ref }}
-  cancel-in-progress: true
+  # Separate groups per event, and cancel ONLY pull-request runs.
+  #
+  # A shared group with unconditional cancel-in-progress looked right and was
+  # wrong: `main` is busy and the macOS runner pool is deep enough that a run
+  # can sit queued for 40+ minutes, so every new merge cancelled the previous
+  # main run before it ever got a runner. Observed on the first day this
+  # workflow existed — three consecutive main runs cancelled, zero executed.
+  # A gate that is always cancelled never fails, which is the same hole as
+  # `continue-on-error: true` wearing a different hat.
+  #
+  # Cancelling superseded PR runs is still correct: only the head commit's
+  # result gates the merge. Main-branch runs queue instead, so each merged
+  # commit eventually gets its own answer.
+  group: gc-ratchet-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -122,6 +122,36 @@ error — the "probe ran no collection" rule deliberately lives in
 that the largest possible regression is not misdiagnosed as "your probe is too
 small".
 
+## Cross-host evidence (why the shared-CI profile gates what it gates)
+
+The baseline is captured on an 8-core M1 with 8 GB at load ~1.2. The first
+`gc-ratchet` CI run executed on a **3-core virtualised M1 with 7 GB, macOS
+14.8.7, at load 25.6** — a different machine class under heavy load. Comparing
+that run's medians against the pinned baseline:
+
+| Metric | Cross-host result |
+|---|---|
+| `heap_used_bytes`, `heap_total_bytes` | **bit-identical on all 8 probes** |
+| `minor_cycles`, `step_cycles`, `promoted_objects`, `promoted_bytes`, `freed_bytes` | **bit-identical on all 8 probes** |
+| `copied_objects`, `copied_bytes` | drift ≤0.06% on 6 of 8 probes, identical on the rest |
+| `peak_rss_bytes` | within ±0.6% |
+| `wall_ms` | **+54% to +60%** |
+
+Three things are settled by this.
+
+Retention really is load-independent: it reproduced byte-for-byte on a box under
+load 25.6, which is the property the whole shared-CI gate rests on.
+
+The evacuation counters are *nearly* host-invariant but not exactly so —
+`copied_objects` and `copied_bytes` carry a sub-0.1% host-dependent component,
+presumably because the scavenger's trigger interacts with allocation timing.
+That is ~80× inside their 5% band, so they stay gating, but do not assume
+bit-identity across hosts the way you can for retention.
+
+Excluding `wall_ms` from the shared-CI gate was not caution, it was necessary.
+The same binary is 54–60% slower on the runner. Any wall-time band tight enough
+to catch a GC slowdown would have made every CI run red on day one.
+
 ## Direction
 
 Retention, memory and timing regress only upward, so their bands are one-sided.

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -652,8 +652,15 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
                 raise RatchetError(f"{name}: {metric} has too few samples")
             if recorded != distribution(samples):
                 raise RatchetError(f"{name}: {metric} summary is inconsistent with its samples")
-        if entry.get("correctness", {}).get("status") == "fail":
-            raise RatchetError(f"{name}: baseline pinned a probe whose output is wrong")
+        # A baseline may only be pinned from an oracle-verified run: "unchecked"
+        # is as unacceptable here as "fail", because the whole artifact's
+        # authority rests on the probes having been shown to compute the right
+        # thing at the moment they were frozen.
+        if entry.get("correctness", {}).get("status") != "pass":
+            raise RatchetError(
+                f"{name}: baseline was pinned without a passing Node oracle diff "
+                f"(status={entry.get('correctness', {}).get('status')!r})"
+            )
         if metrics["minor_cycles"]["median"] < 1:
             raise RatchetError(f"{name}: baseline pinned a probe that ran no minor collection")
 
@@ -734,8 +741,19 @@ def evaluate(
 
         if cur_entry.get("stdout") != base_entry.get("stdout"):
             failures.append(f"{name}: observable output changed since the baseline")
-        if cur_entry.get("correctness", {}).get("status") == "fail":
+
+        # "unchecked" is a failure, not a pass. A run that could not reach the
+        # Node oracle has not verified that the probe still computes anything;
+        # its retained-heap numbers could just as well come from a probe that
+        # silently stopped allocating. "We did not verify" must never be
+        # indistinguishable from "verified".
+        correctness = cur_entry.get("correctness", {})
+        status = correctness.get("status")
+        if status == "fail":
             failures.append(f"{name}: probe output no longer matches the Node oracle")
+        elif status != "pass":
+            reason = correctness.get("reason") or "no correctness report"
+            failures.append(f"{name}: correctness was not verified against the Node oracle ({reason})")
 
         for metric in ALL_METRICS:
             tolerance = tolerances[metric]

--- a/changelog.d/7046-gc-ratchet-unverified-correctness.md
+++ b/changelog.d/7046-gc-ratchet-unverified-correctness.md
@@ -1,12 +1,32 @@
-**GC ratchet — unverified correctness is now a gate failure** (follow-up to
-#7045): `gc_ratchet.py check` failed a probe whose stdout stopped matching the
-Node oracle, but passed one whose correctness could not be established at all
-(`unchecked` — Node missing, Node non-zero, or no oracle supplied). That made
-"we did not verify" indistinguishable from "we verified and it was fine", which
-is the exact hazard the oracle diff exists to close: a probe that silently stops
-allocating exits 0 and reports a beautifully small retained heap, and the ratchet
-would have read that as a memory improvement. `check` now fails on any status
-other than `pass`, `validate_artifact` refuses a baseline pinned from an
-unverified run, and the CI measure step resolves the oracle explicitly rather
-than searching. The #7045 baseline still validates unchanged — all eight probes
-were pinned with `pass` against Node 26.5.0.
+**GC ratchet hardening** (follow-up to #7045), three fixes found by watching the
+gate actually run:
+
+- **Unverified correctness is now a gate failure.** `gc_ratchet.py check` failed
+  a probe whose stdout stopped matching the Node oracle, but passed one whose
+  correctness could not be established at all (`unchecked` — Node missing, Node
+  non-zero, or no oracle supplied). That made "we did not verify"
+  indistinguishable from "we verified and it was fine", which is the exact hazard
+  the oracle diff exists to close: a probe that silently stops allocating exits 0
+  and reports a beautifully small retained heap, and the ratchet would have read
+  that as a memory improvement. `check` now fails on any status other than
+  `pass`, `validate_artifact` refuses a baseline pinned from an unverified run,
+  and the CI measure step resolves the oracle explicitly rather than searching.
+- **`main`-branch runs stopped cancelling each other.** The concurrency group was
+  keyed only on `github.ref` with unconditional `cancel-in-progress`. `main` is
+  busy and the macOS runner pool is deep enough that a run sits queued 40+
+  minutes, so every merge cancelled the previous `main` run before it ever got a
+  runner — three consecutive `main` runs cancelled, zero executed. A gate that is
+  always cancelled never fails, which is `continue-on-error: true` in a different
+  hat. Cancellation is now scoped to `pull_request`; `main` runs queue instead.
+- **Cross-host behaviour is now measured, not assumed.** The first CI run
+  executed on a 3-core virtualised M1 at load 25.6, against a baseline captured
+  on an 8-core M1 at load 1.2. Retention (`heap_used_bytes`,
+  `heap_total_bytes`) and five of the seven evacuation counters were
+  **bit-identical on all eight probes**; `copied_objects`/`copied_bytes` drifted
+  at most 0.06% (~80× inside their band); peak RSS stayed within 0.6%; wall time
+  was **54–60% slower**. That last figure is the empirical justification for
+  excluding wall time from the shared-CI profile — any band tight enough to catch
+  a GC slowdown would have made every CI run red on day one. Recorded in
+  `benchmarks/gc_ratchet/README.md`.
+
+The #7045 baseline validates unchanged; nothing needs re-pinning.

--- a/changelog.d/7046-gc-ratchet-unverified-correctness.md
+++ b/changelog.d/7046-gc-ratchet-unverified-correctness.md
@@ -1,0 +1,12 @@
+**GC ratchet — unverified correctness is now a gate failure** (follow-up to
+#7045): `gc_ratchet.py check` failed a probe whose stdout stopped matching the
+Node oracle, but passed one whose correctness could not be established at all
+(`unchecked` — Node missing, Node non-zero, or no oracle supplied). That made
+"we did not verify" indistinguishable from "we verified and it was fine", which
+is the exact hazard the oracle diff exists to close: a probe that silently stops
+allocating exits 0 and reports a beautifully small retained heap, and the ratchet
+would have read that as a memory improvement. `check` now fails on any status
+other than `pass`, `validate_artifact` refuses a baseline pinned from an
+unverified run, and the CI measure step resolves the oracle explicitly rather
+than searching. The #7045 baseline still validates unchanged — all eight probes
+were pinned with `pass` against Node 26.5.0.

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -252,6 +252,20 @@ class GateFailTests(unittest.TestCase):
         _, failures = evaluate(baseline, current, profile="shared_ci")
         self.assertTrue(any("Node oracle" in failure for failure in _hard(failures)))
 
+    def test_unverified_correctness_fails(self):
+        # A run that could not reach the oracle has not shown the probe still
+        # computes anything. Passing it would make "we did not check"
+        # indistinguishable from "we checked and it was fine".
+        baseline = _baseline()
+        current = _measurement(_probe(correctness="unchecked"))
+        _, failures = evaluate(baseline, current, profile="shared_ci")
+        self.assertTrue(any("not verified" in failure for failure in _hard(failures)))
+
+    def test_baseline_cannot_be_pinned_without_an_oracle_diff(self):
+        artifact = _baseline(_probe(correctness="unchecked"))
+        with self.assertRaises(RatchetError):
+            validate_artifact(artifact)
+
     def test_changed_observable_output_fails(self):
         baseline = _baseline()
         probes = _probe()


### PR DESCRIPTION
Follow-up to #7045. This commit was written while #7045 was in review and landed
on the branch a few minutes after it was merged, so it missed the merge.

## The hole

`gc_ratchet.py check` failed a probe whose stdout no longer matched the Node
oracle (`status == "fail"`), but **passed** one whose correctness could not be
established at all (`status == "unchecked"` — Node missing, Node non-zero, no
oracle supplied).

That makes "we did not verify" indistinguishable from "we verified and it was
fine", which is exactly the hazard the oracle diff exists to close. A probe that
silently stops allocating exits 0 and reports a beautifully small retained heap;
without the diff, the ratchet would read that as an improvement in retained
memory and wave it through. The whole authority of the retention numbers rests
on the probes having been shown to still compute the right thing.

## The fix

- `evaluate` now fails on any correctness status other than `pass`, and names the
  reason the check could not be made.
- `validate_artifact` refuses to accept a baseline pinned from a run that was not
  oracle-verified — `unchecked` is as unacceptable as `fail` at pinning time.
- The CI `Measure` step passes `--node "$(command -v node)"` explicitly instead
  of letting the harness search, so the new strictness cannot produce a spurious
  red from a resolution hiccup. The job already asserts the Node version against
  `.node-version` in a preceding step.

## Tests

Two added, 34 total, all passing:

- `test_unverified_correctness_fails` — an `unchecked` probe turns the gate red.
- `test_baseline_cannot_be_pinned_without_an_oracle_diff` — `validate_artifact`
  rejects such an artifact.

The pinned baseline from #7045 still validates unchanged: all eight probes were
captured with `status: "pass"` against Node 26.5.0, so nothing needs re-pinning.

No compiler or runtime behaviour changes.
