### PR TITLE
build: share compiler cache across ephemeral worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1265
+**Current Version:** 0.5.1266
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "base64",
@@ -5563,14 +5563,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "cc",
  "libc",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "log",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "base64",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5674,14 +5674,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "serde",
  "serde_json",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1265"
+version = "0.5.1266"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "clap",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "block2",
  "objc2",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "chrono",
  "cron",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5824,14 +5824,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5849,7 +5849,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bytes",
  "h2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5915,7 +5915,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bson",
  "futures-util",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6031,14 +6031,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6047,7 +6047,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "brotli",
  "flate2",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "base64",
@@ -6177,14 +6177,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6279,14 +6279,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6295,14 +6295,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "itoa",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6352,7 +6352,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "block2",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "block2",
@@ -6383,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1265"
+version = "0.5.1266"
 
 [[package]]
 name = "perry-ui-test"
@@ -6394,11 +6394,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1265"
+version = "0.5.1266"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "block2",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "block2",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "block2",
  "libc",
@@ -6443,7 +6443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "base64",
  "libc",
@@ -6460,14 +6460,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "anyhow",
  "base64",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1265"
+version = "0.5.1266"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1265"
+version = "0.5.1266"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7048-cargo-cache.md
+++ b/changelog.d/7048-cargo-cache.md
@@ -1,0 +1,1 @@
+Added an opt-in cached Cargo wrapper for ephemeral worktrees. It keeps compiler objects outside the repository, disables incompatible incremental compilation only for wrapped commands, and leaves ordinary long-lived development builds unchanged.

--- a/docs/src/contributing/building.md
+++ b/docs/src/contributing/building.md
@@ -57,6 +57,30 @@ Perry has three build profiles, each tuned for a different job (#5422):
 After a `--timings` build, `scripts/cargo_timing_summary.py` prints the slowest
 units so build-time regressions are visible.
 
+### Compiler cache for ephemeral worktrees
+
+Short-lived worktrees and coding agents can opt into a compiler cache shared
+outside the repository. Install `sccache` in your user environment, then run
+Cargo through the wrapper:
+
+```bash
+./scripts/cargo_cached.sh check -p perry
+
+# Slim, optimized developer CLI
+./scripts/cargo_cached.sh build --profile perry-dev -p perry \
+  --no-default-features --features dev-cli
+```
+
+The wrapper disables Cargo incremental compilation because `sccache` cannot
+cache incremental artifacts. It stores compiler objects under
+`${XDG_CACHE_HOME:-$HOME/.cache}/perry/sccache` by default, not in the worktree;
+set `SCCACHE_DIR` or `SCCACHE_CACHE_SIZE` to override its `12G` cache policy.
+It does not install or configure `sccache` globally.
+
+In a long-lived worktree, use ordinary `cargo` commands instead so the local
+incremental cache remains available. Cache benefit depends on the compiler,
+flags, dependencies, and how much prior work the cache can reuse.
+
 ## Build Specific Crates
 
 ```bash

--- a/scripts/cargo_cached.sh
+++ b/scripts/cargo_cached.sh
@@ -12,6 +12,10 @@ command -v sccache >/dev/null 2>&1 || {
 
 export RUSTC_WRAPPER=sccache
 export CARGO_INCREMENTAL=0
+if [ -z "${SCCACHE_DIR:-}" ] && [ -z "${XDG_CACHE_HOME:-}" ] && [ -z "${HOME:-}" ]; then
+  echo 'cargo_cached: HOME is not set and SCCACHE_DIR/XDG_CACHE_HOME are unset' >&2
+  exit 1
+fi
 export SCCACHE_DIR="${SCCACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/perry/sccache}"
 export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-12G}"
 

--- a/scripts/cargo_cached.sh
+++ b/scripts/cargo_cached.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v cargo >/dev/null 2>&1 || {
+  echo 'cargo_cached: cargo not found in PATH' >&2
+  exit 127
+}
+command -v sccache >/dev/null 2>&1 || {
+  echo 'cargo_cached: sccache not found in PATH' >&2
+  exit 127
+}
+
+export RUSTC_WRAPPER=sccache
+export CARGO_INCREMENTAL=0
+export SCCACHE_DIR="${SCCACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/perry/sccache}"
+export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-12G}"
+
+mkdir -p -- "$SCCACHE_DIR"
+exec cargo "$@"

--- a/tests/test_cargo_cached.sh
+++ b/tests/test_cargo_cached.sh
@@ -98,4 +98,14 @@ set -e
 test "$MISSING_STATUS" -eq 127
 test "$MISSING_OUTPUT" = 'cargo_cached: cargo not found in PATH'
 
+set +e
+MISSING_OUTPUT="$(
+  unset HOME XDG_CACHE_HOME SCCACHE_DIR
+  PATH="$FAKE_BIN:/usr/bin:/bin" "$WRAPPER" check 2>&1
+)"
+MISSING_STATUS=$?
+set -e
+test "$MISSING_STATUS" -eq 1
+test "$MISSING_OUTPUT" = 'cargo_cached: HOME is not set and SCCACHE_DIR/XDG_CACHE_HOME are unset'
+
 echo 'cargo cached wrapper: ok'

--- a/tests/test_cargo_cached.sh
+++ b/tests/test_cargo_cached.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$ROOT/scripts/cargo_cached.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN" "$TMP_DIR/home"
+
+cat >"$FAKE_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'RUSTC_WRAPPER=%s\n' "$RUSTC_WRAPPER"
+  printf 'CARGO_INCREMENTAL=%s\n' "$CARGO_INCREMENTAL"
+  printf 'SCCACHE_DIR=%s\n' "$SCCACHE_DIR"
+  printf 'SCCACHE_CACHE_SIZE=%s\n' "$SCCACHE_CACHE_SIZE"
+  printf 'argc=%s\n' "$#"
+  i=0
+  for arg in "$@"; do
+    printf 'arg%s=%s\n' "$i" "$arg"
+    i=$((i + 1))
+  done
+} >"$CAPTURE"
+EOF
+
+cat >"$FAKE_BIN/sccache" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/cargo" "$FAKE_BIN/sccache"
+
+assert_line() {
+  grep -Fx -- "$2" "$1" >/dev/null || {
+    printf 'missing line %s in %s\n' "$2" "$1" >&2
+    exit 1
+  }
+}
+
+DEFAULT_CAPTURE="$TMP_DIR/default.txt"
+(
+  unset XDG_CACHE_HOME SCCACHE_DIR SCCACHE_CACHE_SIZE
+  export HOME="$TMP_DIR/home" PATH="$FAKE_BIN:/usr/bin:/bin" CAPTURE="$DEFAULT_CAPTURE"
+  "$WRAPPER" build --package "perry cli"
+)
+
+DEFAULT_CACHE="$TMP_DIR/home/.cache/perry/sccache"
+assert_line "$DEFAULT_CAPTURE" 'RUSTC_WRAPPER=sccache'
+assert_line "$DEFAULT_CAPTURE" 'CARGO_INCREMENTAL=0'
+assert_line "$DEFAULT_CAPTURE" "SCCACHE_DIR=$DEFAULT_CACHE"
+assert_line "$DEFAULT_CAPTURE" 'SCCACHE_CACHE_SIZE=12G'
+assert_line "$DEFAULT_CAPTURE" 'argc=3'
+assert_line "$DEFAULT_CAPTURE" 'arg0=build'
+assert_line "$DEFAULT_CAPTURE" 'arg1=--package'
+assert_line "$DEFAULT_CAPTURE" 'arg2=perry cli'
+test -d "$DEFAULT_CACHE"
+case "$DEFAULT_CACHE" in
+  "$ROOT"/*) echo "default cache must be outside the repository" >&2; exit 1 ;;
+esac
+
+XDG_CAPTURE="$TMP_DIR/xdg.txt"
+XDG_CACHE="$TMP_DIR/xdg/perry/sccache"
+HOME="$TMP_DIR/home" XDG_CACHE_HOME="$TMP_DIR/xdg" \
+  PATH="$FAKE_BIN:/usr/bin:/bin" CAPTURE="$XDG_CAPTURE" \
+  "$WRAPPER" check
+assert_line "$XDG_CAPTURE" "SCCACHE_DIR=$XDG_CACHE"
+test -d "$XDG_CACHE"
+
+OVERRIDE_CAPTURE="$TMP_DIR/override.txt"
+OVERRIDE_CACHE="$TMP_DIR/custom-cache"
+HOME="$TMP_DIR/home" PATH="$FAKE_BIN:/usr/bin:/bin" CAPTURE="$OVERRIDE_CAPTURE" \
+  SCCACHE_DIR="$OVERRIDE_CACHE" SCCACHE_CACHE_SIZE=3G \
+  "$WRAPPER" check -p perry
+assert_line "$OVERRIDE_CAPTURE" "SCCACHE_DIR=$OVERRIDE_CACHE"
+assert_line "$OVERRIDE_CAPTURE" 'SCCACHE_CACHE_SIZE=3G'
+test -d "$OVERRIDE_CACHE"
+
+CARGO_ONLY="$TMP_DIR/cargo-only"
+mkdir -p "$CARGO_ONLY"
+cp "$FAKE_BIN/cargo" "$CARGO_ONLY/cargo"
+ln -s "$(command -v bash)" "$CARGO_ONLY/bash"
+set +e
+MISSING_OUTPUT="$(PATH="$CARGO_ONLY" "$WRAPPER" check 2>&1)"
+MISSING_STATUS=$?
+set -e
+test "$MISSING_STATUS" -eq 127
+test "$MISSING_OUTPUT" = 'cargo_cached: sccache not found in PATH'
+
+CACHE_ONLY="$TMP_DIR/cache-only"
+mkdir -p "$CACHE_ONLY"
+cp "$FAKE_BIN/sccache" "$CACHE_ONLY/sccache"
+ln -s "$(command -v bash)" "$CACHE_ONLY/bash"
+set +e
+MISSING_OUTPUT="$(PATH="$CACHE_ONLY" "$WRAPPER" check 2>&1)"
+MISSING_STATUS=$?
+set -e
+test "$MISSING_STATUS" -eq 127
+test "$MISSING_OUTPUT" = 'cargo_cached: cargo not found in PATH'
+
+echo 'cargo cached wrapper: ok'


### PR DESCRIPTION
Closes #7047

## Summary

- add an opt-in Cargo wrapper for sharing compiler objects across ephemeral worktrees
- keep Cargo/sccache installation and cache storage owned by the developer environment
- document when to use cached builds versus ordinary incremental Cargo

## Why

Short-lived worktrees lose local `target/` reuse and repeatedly compile unchanged Rust inputs. A repository-wide wrapper or shared `CARGO_TARGET_DIR` would impose policy on every contributor and risk Perry's per-crate feature/link isolation, so this change provides only an explicit wrapper.

## Changes

| File | Change |
|------|--------|
| `scripts/cargo_cached.sh` | Configure sccache for one Cargo invocation and forward arguments unchanged |
| `tests/test_cargo_cached.sh` | Validate defaults, overrides, argument forwarding, external cache storage, and missing tools with fake executables |
| `docs/src/contributing/building.md` | Explain ephemeral-worktree use and the long-lived incremental alternative |

## Validation

- [x] `shellcheck scripts/cargo_cached.sh tests/test_cargo_cached.sh`
- [x] `bash -n scripts/cargo_cached.sh tests/test_cargo_cached.sh`
- [x] `./tests/test_cargo_cached.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] Controlled `cargo check -p perry` benchmark with a clean temporary target and cache

| Mode | Wall time |
|------|-----------|
| No sccache | 32.80s |
| Cold sccache | 31.09s |
| Warm sccache | 21.11s |

The warm run served 400/400 cacheable compiler requests from cache (338 Rust, 49 C/C++, 13 assembler), with zero misses. Results are environment-specific and are not presented as a fixed speedup.

`./scripts/pre-tag-check.sh --quick` was also run. Its change-focused checks pass; it reports existing `origin/main` baseline drift in workspace architecture, benchmark freshness, file-size, GC-store, and address-classification audits. This PR does not touch any reported file or baseline.

## Checklist

- [x] Linked approved issue
- [x] Scripts pass ShellCheck
- [x] Documentation updated
- [x] Conventional commit format
- [x] No attribution trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Cargo wrapper using `sccache` for faster builds in ephemeral worktrees.
  * Supports configurable cache locations and sizes with sensible defaults.
  * Automatically disables incompatible incremental compilation for cached runs.
  * Provides a clear error when no cache location can be determined.
* **Documentation**
  * Added guidance, example commands, and environment-variable configuration for the cached wrapper.
* **Tests**
  * Added coverage for cache configuration and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->