### PR TITLE
docs: the four ways a CI gate can be unable to fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,17 @@ Build outputs are invisible to `git status`, so a clean tree tells you nothing a
 - **`conformance-smoke` shards are flaky.** Before believing a red shard, re-run it and A/B the named tests against a pristine `main` build; several are already in `test-parity/known_failures.json`.
 - **Integration suites under `crates/*/tests/*.rs` do not run per-PR** (nightly/tag only) — a regression there can land green and sit red for days. Prefer putting acceptance coverage in `cargo-test`-visible unit tests (#5960).
 
+### ★ Four ways a gate can be unable to fail
+
+All four look fine on the Actions page. None can turn a merge red. When adding or reviewing a gate, check all four — each has bitten this repo, three of them within one week:
+
+1. **`continue-on-error: true`** — `gc-stress` carried it for months while being the only job covering GC correctness.
+2. **Not in branch protection's required contexts** — `gc-stress` again. This is why #6925's `PERRY_PTR_SHAPE_LOCALS=0` regression landed visibly red and survived three merges. A job that reports failure without blocking is documentation, not a gate.
+3. **`concurrency` with unconditional `cancel-in-progress`** — on a branch with a slow runner queue, every new merge cancels the previous run before it reaches a runner. `gc-ratchet` had three consecutive `main` runs cancelled, zero executed. Scope cancellation to `pull_request` and let `main` runs queue.
+4. **The gate runs but its subject never did** — the most dangerous, because the job is genuinely green. `PERRY_GC_FORCE_EVACUATE` was inert for every `gc()`-driven test (#6942/#6946); the matrix's `--pressure` knob disabled the very path it was measuring (#7024); its `moved=` counter summed two different collectors, so a cell could pass having run zero copying minors (#7025). **A gate must assert its subject was live**, not merely that nothing threw — e.g. `copied_objects > 0` before a green verdict.
+
+Corollary: a *new* gate has never been green, so promoting it to required immediately blocks every open PR. Run it once, then promote. Leaving that second step undone is how (2) happens.
+
 ### Known-weak areas (symptom is often not the bug)
 - **Async-to-generator transform, body locals.** It boxes every body local into a shared mutable cell typed `Any`. Two consequences seen in the wild: per-iteration `let`/`const` bindings collapse for closures created in a loop, and computed numeric-key calls (`arr[i](x)`) lose their type proof and silently resolve by *method name*, evaporating the call.
 - **Native base-class subclassing.** A native base's surface is installed at `super()` time and its parent edge lives in the class registry; keying any of that on a literal `extends` name loses it for fieldless classes, indirect subclasses, and class expressions.

--- a/changelog.d/7047-gate-cannot-fail-patterns.md
+++ b/changelog.d/7047-gate-cannot-fail-patterns.md
@@ -1,0 +1,12 @@
+Documented the four distinct ways a CI gate can be structurally unable to fail,
+in `CLAUDE.md`. All four look green-adjacent on the Actions page and none can turn
+a merge red: `continue-on-error: true`; absence from branch protection's required
+contexts; `concurrency` with unconditional `cancel-in-progress` on a slow-queue
+branch; and the subtlest — the gate runs and passes while its subject never
+actually executed.
+
+Each has bitten this repo, three of them inside one week. The fourth is the
+dangerous one because the job is genuinely green: `PERRY_GC_FORCE_EVACUATE` was
+inert for every `gc()`-driven test, and the GC matrix's `--pressure` knob disabled
+the very path it was measuring. The rule that follows is that a gate must assert
+its subject was live, not merely that nothing threw.


### PR DESCRIPTION
A `CLAUDE.md` addition under *"CI gates that surprise people"*. No code.

## Why

Four structurally different ways a gate can be unable to fail have now bitten this repo — **three of them inside one week**. They all look fine on the Actions page and none can turn a merge red, so each was found by accident rather than by anyone noticing the gate was toothless.

| | mechanism | where |
|---|---|---|
| 1 | `continue-on-error: true` | `gc-stress`, for months, while being the only job covering GC correctness |
| 2 | not in branch protection's required contexts | `gc-stress` again — why #6925's `PERRY_PTR_SHAPE_LOCALS=0` regression landed **visibly red** and survived three merges |
| 3 | `concurrency` + unconditional `cancel-in-progress` | `gc-ratchet` had three consecutive `main` runs cancelled, **zero executed**, because every new merge cancelled the previous one before it reached a runner on a 40-minute queue |
| 4 | the gate runs, but its **subject** never did | the dangerous one — the job is *genuinely green* |

(4) is worth stating separately because it is invisible to every review process we have. `PERRY_GC_FORCE_EVACUATE` was **inert** for every `gc()`-driven test — it is read only on the minor path while `gc()` runs a full mark-sweep (#6942/#6946). The GC matrix's `--pressure` knob **disabled the very path it was measuring** (#7024). Its `moved=` counter summed two different collectors, so a `requires=move` cell could pass having run **zero** copying minors (#7025).

The rule that follows: **a gate must assert its subject was live, not merely that nothing threw** — e.g. `copied_objects > 0` before a green verdict.

And a corollary for (2): a *new* gate has never been green, so promoting it to required immediately would block every open PR. Run it once, then promote. Leaving that second step undone is exactly how (2) happens — `gc-ratchet` is in that state right now.

## Scope

Documentation only. `CLAUDE.md` is 219 lines, well under the 2000-line cap.

Note `scripts/check_file_size.sh` exits 1 on this branch for **8 pre-existing files** unrelated to this change (`typed_abi.rs`, `index_get.rs`, `native_module.rs`, `array/generic.rs`, `layout_trace.rs`, `callable_export_check.rs`, `callable_exports.rs`, `constants.rs`) — that is one of the four stacked `lint` failures currently blocking every merge, and is not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on four common CI gate configurations that can incorrectly appear successful.
  * Documented the requirement to verify that a gate’s intended checks actually execute.
  * Added a rule to run new gates before making them required, helping ensure they are exercised in practice.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->