### PR TITLE
feat(test): add affected-crate fast Rust runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,14 +37,23 @@ Platform-specific extras — only required if you're touching that backend:
 - **Linux UI** (`perry-ui-gtk4`): `libgtk-4-dev libadwaita-1-dev libpulse-dev pkg-config` (Xvfb for headless UI tests)
 - **Windows UI** (`perry-ui-windows`): MSVC (`ilammy/msvc-dev-cmd` or a `vcvars64.bat` session)
 
-Build and test the default (platform-independent) workspace:
+Build the default (platform-independent) workspace and run the affected crates'
+fast unit tests:
 
 ```bash
 cargo build --release
-cargo test --workspace \
-  --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos \
-  --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows
+./scripts/test_affected_crates.sh --base origin/main
 ```
+
+The runner includes committed, staged, and unstaged paths relative to the base
+revision; stage new files before running it because untracked paths are ignored.
+Use `--dry-run` to inspect its per-crate Cargo commands, or set
+`PERRY_TEST_BASE` to change the default base. It mirrors CI's
+`scripts/ci_test_scope.py` selection and unit-target filtering, including the
+single-threaded `perry-runtime` run. It deliberately skips integration tests
+under `crates/*/tests/`; CI runs those through its scoped and nightly jobs.
+Never replace it with `cargo test --workspace`: Perry's per-crate feature sets
+must remain isolated.
 
 For a faster inner loop, `cargo check -p perry` (correctness only) or
 `cargo build --profile perry-dev -p perry` (optimized local dev build). The

--- a/scripts/test_affected_crates.sh
+++ b/scripts/test_affected_crates.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE="${PERRY_TEST_BASE:-origin/main}"
+DRY_RUN=false
+
+usage() {
+  echo "Usage: $0 [--base REV] [--dry-run]"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "error: --base requires a revision" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for tool in git python3 cargo sort grep sed env; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: required tool not found: $tool" >&2; exit 127; }
+done
+
+cd "$ROOT"
+BASE_COMMIT="$(git rev-parse --verify --quiet --end-of-options "$BASE^{commit}")" || {
+  echo "error: invalid base revision: $BASE" >&2
+  exit 2
+}
+
+changed_files="$(git diff --name-only "$BASE_COMMIT" -- | LC_ALL=C sort -u)"
+scope="$(printf '%s\n' "$changed_files" | python3 scripts/ci_test_scope.py)"
+
+echo "Changed files since $BASE:"
+printf '%s\n' "$changed_files"
+echo "Packages in test scope:"
+printf '%s\n' "$scope"
+if [[ -z "$scope" ]]; then
+  echo "No crates affected by this diff -- nothing to test."
+  exit 0
+fi
+
+run() {
+  printf '+ '
+  printf '%q ' "$@"
+  printf '\n'
+  "$DRY_RUN" || "$@"
+}
+
+if printf '%s\n' "$scope" | grep -qx 'perry-runtime'; then
+  run env CARGO_BUILD_JOBS=1 RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime
+fi
+
+rest="$(printf '%s\n' "$scope" | sed '/^perry-runtime$/d' | python3 scripts/ci_test_scope.py --with-tests)"
+echo "Crates with unit tests in scope:"
+printf '%s\n' "$rest"
+while IFS= read -r package; do
+  [[ -n "$package" ]] || continue
+  if printf '%s\n' "$package" | python3 scripts/ci_test_scope.py --has-lib; then
+    run env CARGO_BUILD_JOBS=1 cargo test --lib --bins -p "$package"
+  else
+    run env CARGO_BUILD_JOBS=1 cargo test --bins -p "$package"
+  fi
+done <<< "$rest"

--- a/tests/test_affected_crates.sh
+++ b/tests/test_affected_crates.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat >"$TMP/bin/git" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  rev-parse) [[ "${FAKE_INVALID_BASE:-0}" != 1 ]] && printf '%s\n' deadbeef ;;
+  diff)
+    [[ " $* " != *' --diff-filter='* ]]
+    printf '%s\n' 'crates/perry-parser/src/with space.rs' 'crates/perry-runtime/src/deleted.rs'
+    ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$TMP/bin/python3" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+input="$(cat)"
+case " ${*:-} " in
+  *' --with-tests '*) [[ -z "$input" ]] || printf '%s\n' "$input" ;;
+  *' --has-lib '*) [[ "$input" == perry-parser ]] ;;
+  *)
+    grep -qx 'crates/perry-parser/src/with space.rs' <<< "$input"
+    grep -qx 'crates/perry-runtime/src/deleted.rs' <<< "$input"
+    if [[ "${FAKE_RUNTIME_ONLY:-0}" == 1 ]]; then
+      printf '%s\n' perry-runtime
+    else
+      printf '%s\n' perry-runtime perry perry-parser
+    fi
+    ;;
+esac
+SH
+
+cat >"$TMP/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+printf 'jobs=%s threads=%s argv=%s\n' \
+  "${CARGO_BUILD_JOBS:-}" "${RUST_TEST_THREADS:-}" "$*" >>"$FAKE_CARGO_LOG"
+SH
+chmod +x "$TMP/bin/"*
+
+PATH="$TMP/bin:/usr/bin:/bin" FAKE_CARGO_LOG="$TMP/cargo.log" \
+  "$ROOT/scripts/test_affected_crates.sh" --base 'base with space' --dry-run \
+  >"$TMP/dry-run.out"
+grep -Fq 'Changed files since base with space:' "$TMP/dry-run.out"
+grep -Fq 'env CARGO_BUILD_JOBS=1 RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime' "$TMP/dry-run.out"
+grep -Fq 'env CARGO_BUILD_JOBS=1 cargo test --bins -p perry' "$TMP/dry-run.out"
+grep -Fq 'env CARGO_BUILD_JOBS=1 cargo test --lib --bins -p perry-parser' "$TMP/dry-run.out"
+[[ ! -e "$TMP/cargo.log" ]]
+
+PATH="$TMP/bin:/usr/bin:/bin" FAKE_CARGO_LOG="$TMP/cargo.log" FAKE_RUNTIME_ONLY=1 \
+  "$ROOT/scripts/test_affected_crates.sh" --base HEAD --dry-run \
+  >"$TMP/runtime-only.out"
+grep -Fq 'cargo test --lib -p perry-runtime' "$TMP/runtime-only.out"
+[[ "$(grep -c '^+ ' "$TMP/runtime-only.out")" -eq 1 ]]
+
+PATH="$TMP/bin:/usr/bin:/bin" FAKE_CARGO_LOG="$TMP/cargo.log" \
+  "$ROOT/scripts/test_affected_crates.sh" --base HEAD >"$TMP/run.out"
+cat >"$TMP/expected.log" <<'EOF'
+jobs=1 threads=1 argv=test --lib -p perry-runtime
+jobs=1 threads= argv=test --bins -p perry
+jobs=1 threads= argv=test --lib --bins -p perry-parser
+EOF
+cmp "$TMP/expected.log" "$TMP/cargo.log"
+
+if PATH="$TMP/bin:/usr/bin:/bin" FAKE_INVALID_BASE=1 \
+  "$ROOT/scripts/test_affected_crates.sh" --base missing >"$TMP/invalid.out" 2>"$TMP/invalid.err"; then
+  echo "expected invalid base to fail" >&2
+  exit 1
+fi
+grep -Fq 'error: invalid base revision: missing' "$TMP/invalid.err"
+
+echo "affected crate runner: ok"


### PR DESCRIPTION
Closes #7053

## Summary

- add an opt-in local runner for Rust unit tests affected by tracked changes
- reuse CI's existing crate selection and target-mode logic
- preserve per-crate Cargo isolation and single-threaded runtime tests

## Changes

| File | Change |
|------|--------|
| `scripts/test_affected_crates.sh` | Select affected crates from a base revision and run their fast unit-test targets |
| `tests/test_affected_crates.sh` | Verify paths, target modes, ordering, environment constraints, dry-run behavior, and invalid bases with fake tools |
| `CONTRIBUTING.md` | Document usage and replace the known-broken workspace test command |

## Test plan

- [x] `bash -n scripts/test_affected_crates.sh tests/test_affected_crates.sh`
- [x] `shellcheck scripts/test_affected_crates.sh tests/test_affected_crates.sh`
- [x] `./tests/test_affected_crates.sh`
- [x] `CARGO_BUILD_JOBS=1 cargo test --lib --bins -p perry-ui-testkit` (5 passed)
- [x] representative real `--dry-run` against `origin/main`
- [x] `git diff --check origin/main...HEAD`

## Limitations

- runs unit-test targets only; integration suites remain covered by scoped/nightly CI
- ignores untracked files until they are staged
- requires the selected base revision to exist locally

## Checklist

- [x] Linked approved issue
- [x] Scripts pass ShellCheck
- [x] Documentation updated
- [x] Conventional commit format
- [x] No attribution trailers
- [x] Workspace version, CLAUDE.md, and CHANGELOG.md are unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to run targeted Rust tests for crates affected by changes.
  * Added dry-run support to preview test commands before execution.
  * Added configurable base-revision support for determining affected files.

* **Documentation**
  * Updated source-building guidance with targeted testing instructions and CI scope details.

* **Tests**
  * Added coverage for affected-crate detection, command generation, dry runs, and invalid revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->