### PR TITLE
fix: enforce clang 15 minimum for LLVM codegen

### DIFF
--- a/changelog.d/6352-clang-minimum-version.md
+++ b/changelog.d/6352-clang-minimum-version.md
@@ -1,0 +1,1 @@
+Fixed `perry doctor` and LLVM compilation accepting clang 14 even though Perry's opaque-pointer IR requires clang 15 or newer. Perry now prefers a supported versioned clang binary when the unversioned `clang` on `PATH` is too old, reports old installations clearly in text and JSON output, and fails before surfacing a raw LLVM parse error.

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -266,26 +266,9 @@ fn build_clang_compile_plan(
 /// resulting `.o`, and clean up both on success. On failure the temp files
 /// are left behind for debugging — the caller can `grep /tmp/perry_llvm_*`.
 pub fn compile_ll_to_object(ll_text: &str, target_triple: Option<&str>) -> Result<Vec<u8>> {
-    let tmp_dir = env::temp_dir();
-    let pid = std::process::id();
-    // Per-call unique counter — strictly monotonic, no collisions across
-    // rayon workers in the same process. We still mix in the wall-clock
-    // nanos for cross-process distinctness (two `perry` invocations can
-    // share /tmp), but the counter is what guarantees in-process safety.
-    let counter = TEMP_NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let wall_nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let ll_path = tmp_dir.join(format!("perry_llvm_{}_{}_{}.ll", pid, wall_nonce, counter));
-    let obj_path = tmp_dir.join(format!("perry_llvm_{}_{}_{}.o", pid, wall_nonce, counter));
-
-    {
-        let mut f = fs::File::create(&ll_path)
-            .with_context(|| format!("Failed to create temp .ll file at {}", ll_path.display()))?;
-        f.write_all(ll_text.as_bytes())?;
-    }
-
+    // Validate the toolchain before creating the potentially large `.ll`
+    // scratch file. Unsupported clang releases should fail without leaving
+    // an artifact that was never passed to the compiler.
     let clang = find_clang().context(if cfg!(windows) {
         "clang not found. Install LLVM with one of:\n\
          \n\
@@ -307,6 +290,26 @@ pub fn compile_ll_to_object(ll_text: &str, target_triple: Option<&str>) -> Resul
          PERRY_LLVM_CLANG to the path of clang. Run `perry doctor` to verify the install."
     })?;
     ensure_supported_clang(&clang)?;
+
+    let tmp_dir = env::temp_dir();
+    let pid = std::process::id();
+    // Per-call unique counter — strictly monotonic, no collisions across
+    // rayon workers in the same process. We still mix in the wall-clock
+    // nanos for cross-process distinctness (two `perry` invocations can
+    // share /tmp), but the counter is what guarantees in-process safety.
+    let counter = TEMP_NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let wall_nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let ll_path = tmp_dir.join(format!("perry_llvm_{}_{}_{}.ll", pid, wall_nonce, counter));
+    let obj_path = tmp_dir.join(format!("perry_llvm_{}_{}_{}.o", pid, wall_nonce, counter));
+
+    {
+        let mut f = fs::File::create(&ll_path)
+            .with_context(|| format!("Failed to create temp .ll file at {}", ll_path.display()))?;
+        f.write_all(ll_text.as_bytes())?;
+    }
 
     let plan = build_clang_compile_plan(
         clang.clone(),
@@ -660,12 +663,25 @@ pub const MINIMUM_CLANG_MAJOR: u32 = 15;
 /// accepting wrappers that write their version banner to stderr.
 pub fn clang_version_output(clang: &Path) -> Option<String> {
     let output = Command::new(clang).arg("--version").output().ok()?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if !stdout.is_empty() {
-        return Some(stdout);
+    select_clang_version_output(
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn select_clang_version_output(stdout: &str, stderr: &str) -> Option<String> {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+    if parse_clang_major_version(stdout).is_some() {
+        return Some(stdout.to_string());
     }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    (!stderr.is_empty()).then_some(stderr)
+    if parse_clang_major_version(stderr).is_some() {
+        return Some(stderr.to_string());
+    }
+    if !stdout.is_empty() {
+        return Some(stdout.to_string());
+    }
+    (!stderr.is_empty()).then(|| stderr.to_string())
 }
 
 /// Parse the major release from standard clang version banners, including
@@ -1098,6 +1114,22 @@ mod tests {
             Some(18)
         );
         assert_eq!(parse_clang_major_version("not a clang banner"), None);
+    }
+
+    #[test]
+    fn version_banner_on_stderr_wins_over_stdout_wrapper_noise() {
+        let selected = select_clang_version_output(
+            "wrapper: selecting system toolchain",
+            "Ubuntu clang version 14.0.0-1ubuntu1.1",
+        );
+        assert_eq!(
+            selected.as_deref(),
+            Some("Ubuntu clang version 14.0.0-1ubuntu1.1")
+        );
+        assert_eq!(
+            select_clang_version_output("clang version 18.1.8", "warning").as_deref(),
+            Some("clang version 18.1.8")
+        );
     }
 
     #[test]

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -14,7 +14,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 
 /// Cached result of the pre-flight clang probe — evaluated once per process.
 /// `Some(default_triple)` if the probe succeeded, `None` if it failed.
@@ -306,6 +306,7 @@ pub fn compile_ll_to_object(ll_text: &str, target_triple: Option<&str>) -> Resul
          (e.g. `apt install clang`, `dnf install clang`, `pacman -S clang`) or set \
          PERRY_LLVM_CLANG to the path of clang. Run `perry doctor` to verify the install."
     })?;
+    ensure_supported_clang(&clang)?;
 
     let plan = build_clang_compile_plan(
         clang.clone(),
@@ -651,6 +652,88 @@ fn build_clang_failure_hint(stderr: &str, clang_version: &str, requested_triple:
     lines.join("\n")
 }
 
+/// Oldest clang release that accepts Perry's opaque-pointer LLVM IR without
+/// an opt-in flag.
+pub const MINIMUM_CLANG_MAJOR: u32 = 15;
+
+/// Return the complete `clang --version` output, preferring stdout but
+/// accepting wrappers that write their version banner to stderr.
+pub fn clang_version_output(clang: &Path) -> Option<String> {
+    let output = Command::new(clang).arg("--version").output().ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return Some(stdout);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    (!stderr.is_empty()).then_some(stderr)
+}
+
+/// Parse the major release from standard clang version banners, including
+/// distro-prefixed and Apple clang variants.
+pub fn parse_clang_major_version(version_output: &str) -> Option<u32> {
+    version_output.lines().find_map(|line| {
+        let marker = "clang version ";
+        let start = line.find(marker)? + marker.len();
+        let digits: String = line[start..]
+            .chars()
+            .take_while(|ch| ch.is_ascii_digit())
+            .collect();
+        if digits.is_empty() {
+            None
+        } else {
+            digits.parse().ok()
+        }
+    })
+}
+
+fn clang_major_version(clang: &Path) -> Option<u32> {
+    clang_version_output(clang).and_then(|output| parse_clang_major_version(&output))
+}
+
+fn ensure_supported_clang(clang: &Path) -> Result<()> {
+    ensure_supported_clang_major(clang, clang_major_version(clang))
+}
+
+fn ensure_supported_clang_major(clang: &Path, major: Option<u32>) -> Result<()> {
+    let Some(major) = major else {
+        // Some toolchain wrappers do not expose a conventional version
+        // banner. Let the real compilation attempt decide whether they work.
+        return Ok(());
+    };
+    if major < MINIMUM_CLANG_MAJOR {
+        bail!(
+            "clang at `{}` is too old ({} < {}). Perry emits opaque-pointer LLVM IR, \
+             which requires clang {} or newer. Install clang-{}+ and put it first on \
+             PATH, or set PERRY_LLVM_CLANG to a supported clang binary.",
+            clang.display(),
+            major,
+            MINIMUM_CLANG_MAJOR,
+            MINIMUM_CLANG_MAJOR,
+            MINIMUM_CLANG_MAJOR,
+        );
+    }
+    Ok(())
+}
+
+fn select_clang_candidate_with<F>(
+    candidates: impl IntoIterator<Item = PathBuf>,
+    mut version_probe: F,
+) -> Option<PathBuf>
+where
+    F: FnMut(&Path) -> Option<u32>,
+{
+    let mut fallback = None;
+    for candidate in candidates {
+        if fallback.is_none() {
+            fallback = Some(candidate.clone());
+        }
+        if version_probe(&candidate).is_some_and(|major| major >= MINIMUM_CLANG_MAJOR) {
+            return Some(candidate);
+        }
+    }
+    fallback
+}
+
 pub fn find_clang() -> Option<PathBuf> {
     // Honor explicit override first — useful on systems with multiple clang
     // installs (e.g. Homebrew LLVM vs Xcode).
@@ -660,21 +743,42 @@ pub fn find_clang() -> Option<PathBuf> {
             return Some(candidate);
         }
     }
-    // Check PATH (with .exe extension handling on Windows).
-    if which("clang") {
-        return Some(PathBuf::from("clang"));
+
+    let mut candidates = Vec::new();
+    // Keep the ordinary PATH spelling first when it is already supported.
+    // If it points to clang 14 (Ubuntu 22.04), candidate selection continues
+    // through versioned Debian/Ubuntu binaries before falling back to it.
+    if let Some(candidate) = which_path("clang") {
+        candidates.push(candidate);
     }
+    for major in (MINIMUM_CLANG_MAJOR..=40).rev() {
+        if let Some(candidate) = which_path(&format!("clang-{major}")) {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    // Keep old versioned-only installations discoverable so doctor/compiler
+    // can report "too old" instead of the misleading "clang not found".
+    for major in (3..MINIMUM_CLANG_MAJOR).rev() {
+        if let Some(candidate) = which_path(&format!("clang-{major}")) {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+
     // Check well-known install locations.
     #[cfg(windows)]
     {
         // Standalone LLVM installer (llvm.org)
         let standalone = PathBuf::from(r"C:\Program Files\LLVM\bin\clang.exe");
         if standalone.exists() {
-            return Some(standalone);
+            candidates.push(standalone);
         }
         // MSVC Build Tools bundled clang (via "C++ Clang Compiler" component)
         if let Some(path) = find_msvc_bundled_clang() {
-            return Some(path);
+            candidates.push(path);
         }
     }
     #[cfg(not(windows))]
@@ -690,11 +794,24 @@ pub fn find_clang() -> Option<PathBuf> {
         ] {
             let candidate = PathBuf::from(prefix).join("clang");
             if candidate.exists() && is_executable(&candidate) {
-                return Some(candidate);
+                candidates.push(candidate);
+            }
+        }
+        for major in (MINIMUM_CLANG_MAJOR..=40).rev() {
+            let candidate = PathBuf::from(format!("/usr/lib/llvm-{major}/bin/clang"));
+            if candidate.exists() && is_executable(&candidate) && !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+        for major in (3..MINIMUM_CLANG_MAJOR).rev() {
+            let candidate = PathBuf::from(format!("/usr/lib/llvm-{major}/bin/clang"));
+            if candidate.exists() && is_executable(&candidate) && !candidates.contains(&candidate) {
+                candidates.push(candidate);
             }
         }
     }
-    None
+
+    select_clang_candidate_with(candidates, clang_major_version)
 }
 
 /// Search for clang.exe bundled with Visual Studio Build Tools / Community.
@@ -750,26 +867,26 @@ fn find_msvc_bundled_clang() -> Option<PathBuf> {
     None
 }
 
-fn which(name: &str) -> bool {
+fn which_path(name: &str) -> Option<PathBuf> {
     let path_var = match env::var_os("PATH") {
         Some(p) => p,
-        None => return false,
+        None => return None,
     };
     for dir in env::split_paths(&path_var) {
         let candidate = dir.join(name);
         if candidate.exists() && is_executable(&candidate) {
-            return true;
+            return Some(candidate);
         }
         // On Windows, executables have .exe extension
         #[cfg(windows)]
         {
             let with_exe = dir.join(format!("{}.exe", name));
             if with_exe.exists() && is_executable(&with_exe) {
-                return true;
+                return Some(with_exe);
             }
         }
     }
-    false
+    None
 }
 
 #[cfg(unix)]
@@ -811,8 +928,8 @@ fn find_llvm_tool(tool: &str) -> Option<PathBuf> {
             return Some(candidate);
         }
     }
-    if which(tool) {
-        return Some(PathBuf::from(tool));
+    if let Some(path) = which_path(tool) {
+        return Some(path);
     }
     None
 }
@@ -964,6 +1081,62 @@ mod tests {
 
     fn version_block(target_line: &str) -> String {
         format!("clang version 18.0.0\n{}\nThread model: posix", target_line)
+    }
+
+    #[test]
+    fn parses_common_clang_version_banners() {
+        assert_eq!(
+            parse_clang_major_version("Ubuntu clang version 14.0.0-1ubuntu1.1"),
+            Some(14)
+        );
+        assert_eq!(
+            parse_clang_major_version("Apple clang version 17.0.0 (clang-1700.0.13.5)"),
+            Some(17)
+        );
+        assert_eq!(
+            parse_clang_major_version("Debian clang version 18.1.8\nTarget: x86_64-linux-gnu"),
+            Some(18)
+        );
+        assert_eq!(parse_clang_major_version("not a clang banner"), None);
+    }
+
+    #[test]
+    fn prefers_supported_versioned_clang_over_old_path_default() {
+        let candidates = vec![
+            PathBuf::from("/usr/bin/clang"),
+            PathBuf::from("/usr/bin/clang-18"),
+            PathBuf::from("/usr/bin/clang-15"),
+        ];
+        let selected =
+            select_clang_candidate_with(candidates, |path| match path.file_name()?.to_str()? {
+                "clang" => Some(14),
+                "clang-18" => Some(18),
+                "clang-15" => Some(15),
+                _ => None,
+            });
+        assert_eq!(selected, Some(PathBuf::from("/usr/bin/clang-18")));
+    }
+
+    #[test]
+    fn retains_first_candidate_to_report_an_old_only_install() {
+        let candidates = vec![
+            PathBuf::from("/usr/bin/clang"),
+            PathBuf::from("/usr/bin/clang-14"),
+        ];
+        let selected = select_clang_candidate_with(candidates, |_| Some(14));
+        assert_eq!(selected, Some(PathBuf::from("/usr/bin/clang")));
+    }
+
+    #[test]
+    fn old_clang_preflight_explains_the_opaque_pointer_requirement() {
+        let error = ensure_supported_clang_major(Path::new("/usr/bin/clang"), Some(14))
+            .expect_err("clang 14 must be rejected");
+        let message = error.to_string();
+        assert!(message.contains("too old (14 < 15)"));
+        assert!(message.contains("opaque-pointer LLVM IR"));
+        assert!(message.contains("PERRY_LLVM_CLANG"));
+        assert!(ensure_supported_clang_major(Path::new("/usr/bin/clang-15"), Some(15)).is_ok());
+        assert!(ensure_supported_clang_major(Path::new("/toolchain-wrapper"), None).is_ok());
     }
 
     #[test]

--- a/crates/perry/src/commands/doctor.rs
+++ b/crates/perry/src/commands/doctor.rs
@@ -71,20 +71,8 @@ fn check_perry_version() -> CheckResult {
 fn check_clang() -> CheckResult {
     match perry_codegen::linker::find_clang() {
         Some(path) => {
-            let version = Command::new(&path)
-                .arg("--version")
-                .output()
-                .ok()
-                .and_then(|out| {
-                    let s = String::from_utf8_lossy(&out.stdout).to_string();
-                    s.lines().next().map(|l| l.to_string())
-                })
-                .unwrap_or_else(|| path.display().to_string());
-            CheckResult {
-                name: "clang (LLVM codegen)".to_string(),
-                status: CheckStatus::Ok,
-                details: Some(version),
-            }
+            let version_output = perry_codegen::linker::clang_version_output(&path);
+            classify_clang(&path, version_output.as_deref())
         }
         None => {
             let hint = if cfg!(windows) {
@@ -100,6 +88,46 @@ fn check_clang() -> CheckResult {
                 details: Some(hint.to_string()),
             }
         }
+    }
+}
+
+fn classify_clang(path: &std::path::Path, version_output: Option<&str>) -> CheckResult {
+    let version = version_output
+        .and_then(|output| output.lines().next())
+        .unwrap_or("unknown clang version");
+    let major = version_output.and_then(perry_codegen::linker::parse_clang_major_version);
+    if let Some(major) = major {
+        if major < perry_codegen::linker::MINIMUM_CLANG_MAJOR {
+            return CheckResult {
+                name: "clang (LLVM codegen)".to_string(),
+                status: CheckStatus::Error,
+                details: Some(format!(
+                    "{} at {} is too old ({} < {}); install clang-{}+ or set \
+                     PERRY_LLVM_CLANG to a supported binary",
+                    version,
+                    path.display(),
+                    major,
+                    perry_codegen::linker::MINIMUM_CLANG_MAJOR,
+                    perry_codegen::linker::MINIMUM_CLANG_MAJOR,
+                )),
+            };
+        }
+    }
+    if major.is_none() {
+        return CheckResult {
+            name: "clang (LLVM codegen)".to_string(),
+            status: CheckStatus::Warning,
+            details: Some(format!(
+                "could not determine the version of {} (Perry requires clang {}+)",
+                path.display(),
+                perry_codegen::linker::MINIMUM_CLANG_MAJOR,
+            )),
+        };
+    }
+    CheckResult {
+        name: "clang (LLVM codegen)".to_string(),
+        status: CheckStatus::Ok,
+        details: Some(format!("{} ({})", version, path.display())),
     }
 }
 
@@ -359,8 +387,12 @@ pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()
         check_compat_reports(),
     ];
 
-    let mut has_errors = false;
-    let mut has_warnings = false;
+    let has_errors = checks
+        .iter()
+        .any(|check| matches!(check.status, CheckStatus::Error));
+    let has_warnings = checks
+        .iter()
+        .any(|check| matches!(check.status, CheckStatus::Warning));
 
     match format {
         OutputFormat::Text => {
@@ -374,14 +406,8 @@ pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()
                 let (emoji, color_fn): (_, fn(&str) -> console::StyledObject<&str>) =
                     match check.status {
                         CheckStatus::Ok => (CHECK, |s| style(s).green()),
-                        CheckStatus::Warning => {
-                            has_warnings = true;
-                            (WARN, |s| style(s).yellow())
-                        }
-                        CheckStatus::Error => {
-                            has_errors = true;
-                            (CROSS, |s| style(s).red())
-                        }
+                        CheckStatus::Warning => (WARN, |s| style(s).yellow()),
+                        CheckStatus::Error => (CROSS, |s| style(s).red()),
                     };
 
                 let status_str = match check.status {
@@ -451,4 +477,36 @@ pub fn run(args: DoctorArgs, format: OutputFormat, use_color: bool) -> Result<()
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_clang, CheckStatus};
+    use std::path::Path;
+
+    #[test]
+    fn clang_14_is_a_doctor_error() {
+        let result = classify_clang(
+            Path::new("/usr/bin/clang"),
+            Some("Ubuntu clang version 14.0.0-1ubuntu1.1"),
+        );
+        assert!(matches!(result.status, CheckStatus::Error));
+        let details = result
+            .details
+            .expect("old clang should explain the failure");
+        assert!(details.contains("too old (14 < 15)"));
+        assert!(details.contains("PERRY_LLVM_CLANG"));
+    }
+
+    #[test]
+    fn clang_15_is_accepted_and_unknown_wrappers_warn() {
+        let supported = classify_clang(
+            Path::new("/usr/bin/clang-15"),
+            Some("Debian clang version 15.0.6"),
+        );
+        assert!(matches!(supported.status, CheckStatus::Ok));
+
+        let unknown = classify_clang(Path::new("/opt/toolchain/clang"), Some("custom wrapper"));
+        assert!(matches!(unknown.status, CheckStatus::Warning));
+    }
 }


### PR DESCRIPTION
## Summary

Make clang discovery, `perry doctor`, and LLVM compilation enforce the documented clang 15 minimum instead of accepting Ubuntu 22.04's clang 14 and failing later on opaque-pointer IR.

## Changes

- parse Apple, Debian, and Ubuntu clang version banners from stdout or stderr
- prefer a supported `clang-15+` binary when unversioned `clang` is too old, while retaining old-only installs for a precise diagnostic
- report clang 14 as an error in `perry doctor` text and JSON output
- reject clang 14 before invoking it on generated LLVM IR
- compute doctor failure state independently of output format so JSON returns `success: false` and exits nonzero
- add unit coverage for version parsing, candidate selection, compiler preflight, and doctor classification

## Related issue

Fixes #6352

## Test plan

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] `cargo test -p perry-codegen --lib linker::tests` (19 passed)
- [x] `cargo test -p perry --bin perry commands::doctor::tests` (2 passed)
- [x] `cargo check -p perry`
- [x] Controlled fake-toolchain checks: clang 14 doctor exits 1 with JSON `success: false`; clang 15 is preferred over unversioned clang 14; compilation rejects clang 14 before invoking it
- [x] (if user-facing) Added `#[test]` coverage in both affected crates
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` (the clang 15 requirement and Ubuntu 22.04 instructions already exist in the installation/build docs)
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform (not applicable)

## Screenshots / output

```text
clang 14: status=error, success=false, exit=1
Ubuntu clang version 14.0.0-1ubuntu1.1 ... is too old (14 < 15)

clang 14 + clang-15 on PATH: status=ok, success=true, exit=0
Ubuntu clang version 15.0.7 (.../clang-15)

compile with clang 14:
clang ... is too old (14 < 15). Perry emits opaque-pointer LLVM IR, which requires clang 15 or newer.
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clang detection and selection for LLVM compilation, preferring supported versioned clang over outdated unversioned installs.
  * `perry doctor` now evaluates clang versions more accurately and clearly distinguishes accepted versions from too-old ones.
  * Unsupported clang versions are reported consistently in both human-readable output and JSON.
  * Compilation now fails early with an actionable error when clang is below the minimum supported version.
  * Expanded discovery for clang across common Linux and Windows install locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->