### PR TITLE
fix(compile): close Ajv CJS source and hoist gaps

### DIFF
--- a/changelog.d/7068-cjs-ajv-source-routing.md
+++ b/changelog.d/7068-cjs-ajv-source-routing.md
@@ -1,0 +1,7 @@
+Fixed two CommonJS compilation gaps exposed by Ajv and
+fast-json-stringify. Packages whose TypeScript sources combine ESM declarations
+with a top-level `module.exports` epilogue now stay on their published
+JavaScript graph instead of mixing emitted CommonJS and source-only modules.
+Hoisted CommonJS classes can also call safe module-level function declarations
+that appear later in the file without losing the binding; helpers that capture
+wrapper-local state remain inside the wrapper with their dependent classes.

--- a/crates/perry/src/commands/compile/cjs_wrap/detect.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/detect.rs
@@ -359,6 +359,76 @@ pub fn has_top_level_esm(source: &str) -> bool {
     false
 }
 
+/// Returns true when a depth-zero statement assigns `module.exports`.
+///
+/// The input must already have comments and string/template contents masked by
+/// [`strip_comments_and_strings`]. This is deliberately narrower than
+/// [`is_commonjs`]: callers use it to distinguish a real top-level CommonJS
+/// epilogue from Rollup-style ESM that merely contains `module.exports` inside
+/// a nested factory.
+pub(in crate::commands::compile) fn has_top_level_module_exports_assignment(source: &str) -> bool {
+    fn is_ident_start(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphabetic()
+    }
+    fn is_ident_byte(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+    }
+    fn skip_space(bytes: &[u8], mut i: usize) -> usize {
+        while bytes
+            .get(i)
+            .is_some_and(|b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+        {
+            i += 1;
+        }
+        i
+    }
+
+    let bytes = source.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' | b']' | b'}' => {
+                depth -= 1;
+                i += 1;
+            }
+            b if is_ident_start(b) => {
+                let start = i;
+                i += 1;
+                while i < bytes.len() && is_ident_byte(bytes[i]) {
+                    i += 1;
+                }
+                if depth != 0 || &bytes[start..i] != b"module" {
+                    continue;
+                }
+                let mut cursor = skip_space(bytes, i);
+                if bytes.get(cursor) != Some(&b'.') {
+                    continue;
+                }
+                cursor = skip_space(bytes, cursor + 1);
+                let exports_end = cursor + b"exports".len();
+                if bytes.get(cursor..exports_end) != Some(b"exports")
+                    || bytes.get(exports_end).is_some_and(|b| is_ident_byte(*b))
+                {
+                    continue;
+                }
+                cursor = skip_space(bytes, exports_end);
+                if bytes.get(cursor) == Some(&b'=')
+                    && !matches!(bytes.get(cursor + 1), Some(b'=' | b'>'))
+                {
+                    return true;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
+
 /// Returns true if `line` starts with `keyword` followed by a character
 /// that can legally begin an `import`/`export` statement's continuation:
 /// space, `{`, `*` (export only), `"`, `'`, or `(` (dynamic import). We

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -266,6 +266,42 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
             iife_locals.push(injected.to_string());
         }
     }
+    // #6585: function declarations are IIFE-local too. Ajv declares
+    // `function addNames(...)` after several classes whose getters call it.
+    // Hoisting those classes out of the CJS IIFE severed the function binding,
+    // so the getters fell through to a global read and threw
+    // `ReferenceError: addNames is not defined`.
+    //
+    // Preserve class identity whenever possible: a capture-free helper can be
+    // duplicated at module scope (the original stays in the IIFE), allowing
+    // the class to keep using the established hoist path. A helper that reads
+    // any IIFE binding, sibling helper, or class cannot be duplicated safely;
+    // add only those unsafe names to `iife_locals`, which keeps their dependent
+    // classes inside the wrapper.
+    let function_decls = collect_top_level_function_decls(source);
+    let function_names: Vec<String> = function_decls.iter().map(|f| f.name.clone()).collect();
+    let class_names = top_level_class_names(source);
+    let exported_names = super::extract_exports::extract_exports_from_source(source);
+    let mut unsafe_function_names = Vec::new();
+    for decl in &function_decls {
+        let mut blockers = iife_locals.clone();
+        blockers.extend(class_names.iter().cloned());
+        blockers.extend(
+            function_names
+                .iter()
+                .filter(|name| *name != &decl.name)
+                .cloned(),
+        );
+        let unsafe_to_duplicate = class_body_references_any(&decl.block_text, &blockers)
+            || super::extract_requires::identifier_is_reassigned(source, &decl.name)
+            || exported_names.contains(&decl.name);
+        if unsafe_to_duplicate {
+            unsafe_function_names.push(decl.name.clone());
+            if !iife_locals.contains(&decl.name) {
+                iife_locals.push(decl.name.clone());
+            }
+        }
+    }
 
     let mut i = 0usize;
     while i < bytes.len() {
@@ -438,6 +474,12 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
     let mut kept: Vec<bool> = candidates.iter().map(|c| c.references_iife_local).collect();
     loop {
         let mut changed = false;
+        let kept_names: Vec<String> = candidates
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| kept[*idx])
+            .map(|(_, cand)| cand.name.clone())
+            .collect();
         for idx in 0..candidates.len() {
             if kept[idx] {
                 continue;
@@ -456,20 +498,38 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
                     }
                 }
             }
+            // A class can depend on a kept sibling without extending it
+            // (`CodeGen.run()` does `new ParentNode()`). Once one class must
+            // stay in the IIFE, keep every class whose body references it,
+            // iterating to a fixpoint for longer dependency chains.
+            if !kept[idx] && class_body_references_any(candidates[idx].block_text, &kept_names) {
+                kept[idx] = true;
+                changed = true;
+            }
         }
         if !changed {
             break;
         }
     }
 
-    let mut hoisted_blocks: Vec<&str> = Vec::new();
+    let mut hoisted_blocks: Vec<String> = function_decls
+        .iter()
+        .filter(|decl| !unsafe_function_names.contains(&decl.name))
+        .filter(|decl| {
+            candidates.iter().enumerate().any(|(idx, cand)| {
+                !kept[idx]
+                    && class_body_references_any(cand.block_text, std::slice::from_ref(&decl.name))
+            })
+        })
+        .map(|decl| decl.block_text.clone())
+        .collect();
     let mut hoisted_names: Vec<String> = Vec::new();
     let mut elided: Vec<(usize, usize)> = Vec::new();
     for (idx, cand) in candidates.iter().enumerate() {
         if kept[idx] {
             continue;
         }
-        hoisted_blocks.push(cand.block_text);
+        hoisted_blocks.push(cand.block_text.to_string());
         hoisted_names.push(cand.name.clone());
         elided.push((cand.line_start, cand.end));
     }
@@ -817,6 +877,136 @@ fn collect_top_level_let_const_var_names(source: &str) -> Vec<String> {
     }
 
     names
+}
+
+struct TopLevelFunctionDecl {
+    name: String,
+    block_text: String,
+}
+
+/// Collect depth-zero function declarations from a CommonJS source, including
+/// their exact source blocks. The comment/string/regex masker preserves byte
+/// positions, letting this scan balance braces without mistaking literal
+/// contents for code.
+fn collect_top_level_function_decls(source: &str) -> Vec<TopLevelFunctionDecl> {
+    fn is_ident_byte(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+    }
+    fn skip_horizontal_space(bytes: &[u8], mut i: usize) -> usize {
+        while bytes.get(i).is_some_and(|b| matches!(b, b' ' | b'\t')) {
+            i += 1;
+        }
+        i
+    }
+
+    let stripped = super::detect::strip_comments_and_strings(source);
+    let bytes = stripped.as_bytes();
+    let mut decls = Vec::new();
+    let mut depth: i32 = 0;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let at_line_start = i == 0 || bytes[i - 1] == b'\n';
+        match bytes[i] {
+            b'{' => {
+                depth += 1;
+                i += 1;
+                continue;
+            }
+            b'}' => {
+                depth -= 1;
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+        if !at_line_start || depth != 0 {
+            i += 1;
+            continue;
+        }
+
+        let mut cursor = skip_horizontal_space(bytes, i);
+        if bytes.get(cursor..cursor + 5) == Some(b"async")
+            && bytes
+                .get(cursor + 5)
+                .is_some_and(|b| matches!(b, b' ' | b'\t'))
+        {
+            cursor = skip_horizontal_space(bytes, cursor + 5);
+        }
+        if bytes.get(cursor..cursor + 8) != Some(b"function")
+            || bytes.get(cursor + 8).is_some_and(|b| is_ident_byte(*b))
+        {
+            i += 1;
+            continue;
+        }
+        cursor = skip_horizontal_space(bytes, cursor + 8);
+        if bytes.get(cursor) == Some(&b'*') {
+            cursor = skip_horizontal_space(bytes, cursor + 1);
+        }
+        let start = cursor;
+        while bytes.get(cursor).is_some_and(|b| is_ident_byte(*b)) {
+            cursor += 1;
+        }
+        if cursor == start {
+            i += 1;
+            continue;
+        }
+        let name = String::from_utf8_lossy(&bytes[start..cursor]).into_owned();
+
+        // Find the body opener, ignoring braces in destructured/default
+        // parameters while the parameter list is still open.
+        let mut paren_depth: i32 = 0;
+        let mut body_start = None;
+        while cursor < bytes.len() {
+            match bytes[cursor] {
+                b'(' | b'[' => paren_depth += 1,
+                b')' | b']' => paren_depth -= 1,
+                b'{' if paren_depth == 0 => {
+                    body_start = Some(cursor);
+                    break;
+                }
+                _ => {}
+            }
+            cursor += 1;
+        }
+        let Some(body_start) = body_start else {
+            i += 1;
+            continue;
+        };
+
+        let mut body_depth: i32 = 0;
+        let mut end = body_start;
+        while end < bytes.len() {
+            match bytes[end] {
+                b'{' => body_depth += 1,
+                b'}' => {
+                    body_depth -= 1;
+                    if body_depth == 0 {
+                        end += 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            end += 1;
+        }
+        if body_depth != 0 || end <= body_start {
+            i += 1;
+            continue;
+        }
+
+        if !name.is_empty()
+            && !decls
+                .iter()
+                .any(|decl: &TopLevelFunctionDecl| decl.name == name)
+        {
+            decls.push(TopLevelFunctionDecl {
+                name,
+                block_text: source[i..end].to_string(),
+            });
+        }
+        i = end;
+    }
+    decls
 }
 
 /// Issue #4933 — collect the names of every **top-level** `class <Name>`

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -294,6 +294,12 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
         );
         let unsafe_to_duplicate = class_body_references_any(&decl.block_text, &blockers)
             || super::extract_requires::identifier_is_reassigned(source, &decl.name)
+            || identifier_used_as_value_outside(
+                source,
+                &decl.name,
+                decl.source_start,
+                decl.source_end,
+            )
             || exported_names.contains(&decl.name);
         if unsafe_to_duplicate {
             unsafe_function_names.push(decl.name.clone());
@@ -882,6 +888,8 @@ fn collect_top_level_let_const_var_names(source: &str) -> Vec<String> {
 struct TopLevelFunctionDecl {
     name: String,
     block_text: String,
+    source_start: usize,
+    source_end: usize,
 }
 
 /// Collect depth-zero function declarations from a CommonJS source, including
@@ -1002,11 +1010,76 @@ fn collect_top_level_function_decls(source: &str) -> Vec<TopLevelFunctionDecl> {
             decls.push(TopLevelFunctionDecl {
                 name,
                 block_text: source[i..end].to_string(),
+                source_start: i,
+                source_end: end,
             });
         }
         i = end;
     }
     decls
+}
+
+/// Returns true when a function declaration's binding is used as a value
+/// elsewhere in the module rather than only called directly.
+///
+/// Duplicating a capture-free helper is safe for `helper(...)` calls, but not
+/// when the IIFE mutates the original function object (`helper.cache = ...`),
+/// aliases it (`const cb = helper`), compares its identity, or passes it to
+/// another function. In those cases a module-scope duplicate would diverge
+/// from the original. Member property names such as `obj.helper()` are
+/// unrelated bindings and are ignored.
+fn identifier_used_as_value_outside(
+    source: &str,
+    name: &str,
+    excluded_start: usize,
+    excluded_end: usize,
+) -> bool {
+    fn is_ident_byte(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+    }
+
+    let stripped = super::detect::strip_comments_and_strings(source);
+    let bytes = stripped.as_bytes();
+    let name_bytes = name.as_bytes();
+    let mut i = 0usize;
+    while i + name_bytes.len() <= bytes.len() {
+        if i >= excluded_start && i < excluded_end && excluded_end <= bytes.len() {
+            i = excluded_end;
+            continue;
+        }
+        if &bytes[i..i + name_bytes.len()] != name_bytes {
+            i += 1;
+            continue;
+        }
+
+        let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+        let after = i + name_bytes.len();
+        let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+        if !before_ok || !after_ok {
+            i = after;
+            continue;
+        }
+
+        let mut before = i;
+        while before > 0 && bytes[before - 1].is_ascii_whitespace() {
+            before -= 1;
+        }
+        // `obj.helper` / `obj?.helper` names a property, not this binding.
+        if before > 0 && bytes[before - 1] == b'.' {
+            i = after;
+            continue;
+        }
+
+        let mut cursor = after;
+        while bytes.get(cursor).is_some_and(|b| b.is_ascii_whitespace()) {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'(') {
+            return true;
+        }
+        i = cursor + 1;
+    }
+    false
 }
 
 /// Issue #4933 — collect the names of every **top-level** `class <Name>`

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -278,7 +278,8 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
     // any IIFE binding, sibling helper, or class cannot be duplicated safely;
     // add only those unsafe names to `iife_locals`, which keeps their dependent
     // classes inside the wrapper.
-    let function_decls = collect_top_level_function_decls(source);
+    let stripped_source = super::detect::strip_comments_and_strings(source);
+    let function_decls = collect_top_level_function_decls(source, &stripped_source);
     let function_names: Vec<String> = function_decls.iter().map(|f| f.name.clone()).collect();
     let class_names = top_level_class_names(source);
     let exported_names = super::extract_exports::extract_exports_from_source(source);
@@ -295,7 +296,7 @@ pub fn extract_top_level_class_decls(source: &str) -> (String, Vec<String>, Stri
         let unsafe_to_duplicate = class_body_references_any(&decl.block_text, &blockers)
             || super::extract_requires::identifier_is_reassigned(source, &decl.name)
             || identifier_used_as_value_outside(
-                source,
+                &stripped_source,
                 &decl.name,
                 decl.source_start,
                 decl.source_end,
@@ -896,7 +897,10 @@ struct TopLevelFunctionDecl {
 /// their exact source blocks. The comment/string/regex masker preserves byte
 /// positions, letting this scan balance braces without mistaking literal
 /// contents for code.
-fn collect_top_level_function_decls(source: &str) -> Vec<TopLevelFunctionDecl> {
+fn collect_top_level_function_decls(
+    source: &str,
+    stripped_source: &str,
+) -> Vec<TopLevelFunctionDecl> {
     fn is_ident_byte(b: u8) -> bool {
         b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
     }
@@ -907,8 +911,7 @@ fn collect_top_level_function_decls(source: &str) -> Vec<TopLevelFunctionDecl> {
         i
     }
 
-    let stripped = super::detect::strip_comments_and_strings(source);
-    let bytes = stripped.as_bytes();
+    let bytes = stripped_source.as_bytes();
     let mut decls = Vec::new();
     let mut depth: i32 = 0;
     let mut i = 0usize;
@@ -1029,7 +1032,7 @@ fn collect_top_level_function_decls(source: &str) -> Vec<TopLevelFunctionDecl> {
 /// from the original. Member property names such as `obj.helper()` are
 /// unrelated bindings and are ignored.
 fn identifier_used_as_value_outside(
-    source: &str,
+    stripped_source: &str,
     name: &str,
     excluded_start: usize,
     excluded_end: usize,
@@ -1038,8 +1041,7 @@ fn identifier_used_as_value_outside(
         b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
     }
 
-    let stripped = super::detect::strip_comments_and_strings(source);
-    let bytes = stripped.as_bytes();
+    let bytes = stripped_source.as_bytes();
     let name_bytes = name.as_bytes();
     let mut i = 0usize;
     while i + name_bytes.len() <= bytes.len() {

--- a/crates/perry/src/commands/compile/cjs_wrap/issue_6585_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/issue_6585_tests.rs
@@ -58,3 +58,22 @@ exports.Formatter = Formatter;
     assert!(rest.contains("class Formatter"));
     assert!(rest.contains("function format"));
 }
+
+#[test]
+fn class_stays_wrapped_when_later_function_object_is_decorated() {
+    let src = r#"class CodeGen {
+  run() { return addNames({}).cache.size; }
+}
+function addNames(names) { return names; }
+addNames.cache = new Map();
+exports.CodeGen = CodeGen;
+"#;
+    let (blocks, names, rest) = extract_top_level_class_decls(src);
+    assert!(
+        blocks.is_empty(),
+        "decorated helper and dependent class must remain wrapped:\n{blocks}"
+    );
+    assert!(names.is_empty());
+    assert!(rest.contains("class CodeGen"));
+    assert!(rest.contains("addNames.cache = new Map()"));
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/issue_6585_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/issue_6585_tests.rs
@@ -1,0 +1,60 @@
+use super::detect::{has_top_level_module_exports_assignment, strip_comments_and_strings};
+use super::hoist_classes::extract_top_level_class_decls;
+
+#[test]
+fn top_level_module_exports_assignment_excludes_nested_factories() {
+    let direct =
+        strip_comments_and_strings("export default Ajv;\nmodule.exports = exports = Ajv;\n");
+    assert!(has_top_level_module_exports_assignment(&direct));
+
+    let nested = strip_comments_and_strings(
+        "export function helper() {\n  module.exports = factory();\n}\n",
+    );
+    assert!(!has_top_level_module_exports_assignment(&nested));
+
+    let read_only = strip_comments_and_strings("export const current = module.exports;\n");
+    assert!(!has_top_level_module_exports_assignment(&read_only));
+}
+
+#[test]
+fn class_hoist_surfaces_later_function_binding() {
+    let src = r#"class ParentNode {
+  get names() { return addNames({}, this.from); }
+}
+class CodeGen {
+  run() { return new ParentNode().names; }
+}
+function addNames(names, from) { return names; }
+exports.CodeGen = CodeGen;
+"#;
+    let (blocks, names, rest) = extract_top_level_class_decls(src);
+    assert!(
+        blocks.starts_with("function addNames"),
+        "capture-free helper must be surfaced before classes:\n{blocks}"
+    );
+    assert!(blocks.contains("class ParentNode"));
+    assert!(blocks.contains("class CodeGen"));
+    assert_eq!(names, ["ParentNode", "CodeGen"]);
+    assert!(!rest.contains("class ParentNode"));
+    assert!(!rest.contains("class CodeGen"));
+    assert!(rest.contains("function addNames"));
+}
+
+#[test]
+fn class_stays_wrapped_when_later_function_captures_local() {
+    let src = r#"const prefix = "local:";
+class Formatter {
+  run(value) { return format(value); }
+}
+function format(value) { return prefix + value; }
+exports.Formatter = Formatter;
+"#;
+    let (blocks, names, rest) = extract_top_level_class_decls(src);
+    assert!(
+        blocks.is_empty(),
+        "capturing helper and dependent class must remain wrapped:\n{blocks}"
+    );
+    assert!(names.is_empty());
+    assert!(rest.contains("class Formatter"));
+    assert!(rest.contains("function format"));
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -42,6 +42,9 @@ mod extract_requires;
 mod hoist_classes;
 mod wrap;
 
+#[cfg(test)]
+mod issue_6585_tests;
+
 // Cross-sibling helpers — siblings reach for these via `use super::*;`.
 use detect::is_js_reserved_word;
 use extract_exports::{

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -32,6 +32,7 @@ use perry_hir::ModuleKind;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use super::CompilationContext;
 #[cfg(test)]
@@ -750,12 +751,27 @@ fn original_source_via_map(entry: &Path) -> Option<PathBuf> {
 /// declarations inside an IIFE. Node loads the emitted JS entry, so keep that
 /// entry instead of following its source map for this narrow shape (#6586).
 fn is_hybrid_cjs_emit_input(path: &Path) -> bool {
-    let Ok(source) = fs::read_to_string(path) else {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, bool>>> = OnceLock::new();
+
+    let Ok(path) = fs::canonicalize(path) else {
+        return false;
+    };
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(cached) = cache.lock().expect("hybrid source cache").get(&path) {
+        return *cached;
+    }
+
+    let Ok(source) = fs::read_to_string(&path) else {
         return false;
     };
     let stripped = super::cjs_wrap::detect::strip_comments_and_strings(&source);
-    super::cjs_wrap::detect::has_top_level_esm(&stripped)
-        && super::cjs_wrap::detect::has_top_level_module_exports_assignment(&stripped)
+    let hybrid = super::cjs_wrap::detect::has_top_level_esm(&stripped)
+        && super::cjs_wrap::detect::has_top_level_module_exports_assignment(&stripped);
+    cache
+        .lock()
+        .expect("hybrid source cache")
+        .insert(path, hybrid);
+    hybrid
 }
 
 /// If a package's root TypeScript source is a hybrid CJS-emit input, keep the

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -742,12 +742,54 @@ fn original_source_via_map(entry: &Path) -> Option<PathBuf> {
     original_source_from_map_file(&append_map_extension(entry))
 }
 
+/// A published CommonJS package can ship the TypeScript input to its CJS emit.
+/// Some such inputs are intentionally hybrid: normal ESM declarations for
+/// TypeScript plus a top-level `module.exports = ...` interop epilogue. The
+/// source is not a directly executable module in Perry: ESM classification
+/// leaves `module` unbound, while CJS wrapping would move its `export`
+/// declarations inside an IIFE. Node loads the emitted JS entry, so keep that
+/// entry instead of following its source map for this narrow shape (#6586).
+fn is_hybrid_cjs_emit_input(path: &Path) -> bool {
+    let Ok(source) = fs::read_to_string(path) else {
+        return false;
+    };
+    let stripped = super::cjs_wrap::detect::strip_comments_and_strings(&source);
+    super::cjs_wrap::detect::has_top_level_esm(&stripped)
+        && super::cjs_wrap::detect::has_top_level_module_exports_assignment(&stripped)
+}
+
+/// If a package's root TypeScript source is a hybrid CJS-emit input, keep the
+/// entire package graph on its published JavaScript. Mixing a `dist` root with
+/// source-mapped TypeScript subpaths creates duplicate module identities and
+/// reintroduces source-only semantics that Node never executes (Ajv's
+/// `dist/ajv.js` plus `lib/compile/codegen/index.ts` was the #6585/#6586
+/// combination).
+fn package_entry_requires_cjs_emit(package_dir: &Path) -> bool {
+    if let Some(entry) = resolve_package_entry(package_dir, None) {
+        if is_js_file(&entry) {
+            if original_source_via_map(&entry).is_some_and(|src| is_hybrid_cjs_emit_input(&src)) {
+                return true;
+            }
+        } else if is_hybrid_cjs_emit_input(&entry) {
+            return true;
+        }
+    }
+
+    let src_index = package_dir.join("src").join("index");
+    resolve_with_extensions(&src_index)
+        .is_some_and(|src| !is_js_file(&src) && is_hybrid_cjs_emit_input(&src))
+}
+
 /// Resolve package entry preferring TypeScript source over compiled JS output.
 /// Used for compile_packages where we want to compile from TS source, not bundled JS.
 pub(super) fn resolve_package_source_entry(
     package_dir: &Path,
     subpath: Option<&str>,
 ) -> Option<PathBuf> {
+    if package_entry_requires_cjs_emit(package_dir) {
+        return None;
+    }
+
     let normal_entry = resolve_package_entry(package_dir, subpath);
 
     // #2569 step 5: the most authoritative pointer to a package's original
@@ -759,7 +801,9 @@ pub(super) fn resolve_package_source_entry(
     if let Some(entry) = normal_entry.as_ref() {
         if is_js_file(entry) {
             if let Some(original) = original_source_via_map(entry) {
-                return Some(original);
+                if !is_hybrid_cjs_emit_input(&original) {
+                    return Some(original);
+                }
             }
         }
     }
@@ -768,7 +812,7 @@ pub(super) fn resolve_package_source_entry(
     if let Some(sub) = subpath {
         let src_path = package_dir.join("src").join(sub);
         if let Some(resolved) = resolve_with_extensions(&src_path) {
-            if !is_js_file(&resolved) {
+            if !is_js_file(&resolved) && !is_hybrid_cjs_emit_input(&resolved) {
                 return Some(resolved);
             }
         }
@@ -777,7 +821,7 @@ pub(super) fn resolve_package_source_entry(
     // Try src/index.ts (most common TS source entry)
     let src_index = package_dir.join("src").join("index");
     if let Some(resolved) = resolve_with_extensions(&src_index) {
-        if !is_js_file(&resolved) {
+        if !is_js_file(&resolved) && !is_hybrid_cjs_emit_input(&resolved) {
             return Some(resolved);
         }
     }
@@ -787,7 +831,7 @@ pub(super) fn resolve_package_source_entry(
     if is_js_file(&normal_entry) {
         // Try .ts equivalent of the .js entry
         let ts_path = normal_entry.with_extension("ts");
-        if ts_path.exists() {
+        if ts_path.exists() && !is_hybrid_cjs_emit_input(&ts_path) {
             return Some(ts_path);
         }
         // Check src/ directory mirror of lib/ or dist/ path
@@ -801,7 +845,7 @@ pub(super) fn resolve_package_source_entry(
                 };
                 if let Ok(rest) = stripped {
                     let src_equiv = package_dir.join("src").join(rest).with_extension("ts");
-                    if src_equiv.exists() {
+                    if src_equiv.exists() && !is_hybrid_cjs_emit_input(&src_equiv) {
                         return Some(src_equiv);
                     }
                 }

--- a/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
+++ b/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
@@ -99,6 +99,121 @@ fn source_map_redirects_when_no_declaration_map() {
 }
 
 #[test]
+fn hybrid_cjs_emit_input_keeps_published_javascript_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let package_dir = write_dist_package(dir.path());
+    let original = package_dir.join("internal/entry.ts");
+    fs::create_dir_all(original.parent().expect("source parent")).expect("mkdir source parent");
+    fs::write(
+        &original,
+        "class Ajv {}\nmodule.exports = exports = Ajv\nexport default Ajv\n",
+    )
+    .expect("write hybrid source");
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../internal/entry.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(resolve_package_source_entry(&package_dir, None), None);
+}
+
+#[test]
+fn hybrid_src_index_convention_keeps_published_javascript_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let package_dir = write_dist_package(dir.path());
+    fs::create_dir_all(package_dir.join("src")).expect("mkdir src");
+    fs::write(
+        package_dir.join("src/index.ts"),
+        "const plugin = () => {}\nmodule.exports = exports = plugin\nexport default plugin\n",
+    )
+    .expect("write hybrid source");
+
+    assert_eq!(resolve_package_source_entry(&package_dir, None), None);
+}
+
+#[test]
+fn hybrid_package_root_keeps_subpaths_on_published_javascript() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let package_dir = write_dist_package(dir.path());
+    let root_source = write_source(&package_dir, "internal/root.ts");
+    fs::write(
+        &root_source,
+        "class Ajv {}\nmodule.exports = exports = Ajv\nexport default Ajv\n",
+    )
+    .expect("write hybrid root");
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../internal/root.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write root map");
+
+    fs::write(package_dir.join("dist/helper.js"), "exports.helper = 1;\n").expect("helper js");
+    write_source(&package_dir, "internal/helper.ts");
+    fs::write(
+        package_dir.join("dist/helper.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "helper.js",
+            "sources": ["../internal/helper.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write helper map");
+
+    assert_eq!(
+        resolve_package_source_entry(&package_dir, Some("dist/helper")),
+        None
+    );
+}
+
+#[test]
+fn nested_cjs_factory_does_not_defeat_esm_source_redirect() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let package_dir = write_dist_package(dir.path());
+    let original = package_dir.join("internal/entry.ts");
+    fs::create_dir_all(original.parent().expect("source parent")).expect("mkdir source parent");
+    fs::write(
+        &original,
+        "export function helper() {\n  module.exports = factory()\n}\n",
+    )
+    .expect("write esm source");
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../internal/entry.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(
+        resolved_source(&package_dir),
+        Some(original.canonicalize().expect("canonical source"))
+    );
+}
+
+#[test]
 fn source_root_is_prepended_to_map_sources() {
     let dir = tempfile::tempdir().expect("tempdir");
     let package_dir = write_dist_package(dir.path());

--- a/crates/perry/tests/issue_6559_real_libs_e2e.rs
+++ b/crates/perry/tests/issue_6559_real_libs_e2e.rs
@@ -3,15 +3,13 @@
 //! with their runtime `new Function` codegen evaluated by the dyn-eval
 //! interpreter.
 //!
-//! STATUS: find-my-way is now un-ignored and green (#6587: `x instanceof C`
-//! with a `null`/`undefined` LHS no longer throws — see
-//! `perry-runtime/src/object/instanceof.rs`). ajv and fast-json-stringify
-//! remain `#[ignore]`d on PRE-EXISTING perry CJS-compilation gaps at module
-//! load / library init, BEFORE any runtime-generated code runs (per-test
-//! reasons on the #[ignore] attributes). The interpreter itself is proven
-//! end-to-end against the captured generated-code shapes of these exact
-//! library versions in issue_6559_dyn_function_interpreter.rs (always-on,
-//! green). Un-ignore each remaining test as its CJS wall falls.
+//! STATUS: fast-json-stringify and find-my-way are un-ignored and green
+//! (#6586 and #6587 respectively). Ajv gets past the former CJS source-routing
+//! and `addNames` hoisting walls (#6586 / #6585), but remains `#[ignore]`d on
+//! the later generated-validator scope gap described on its attribute. The
+//! interpreter itself is proven end-to-end against the captured generated-code
+//! shapes of these exact library versions in
+//! issue_6559_dyn_function_interpreter.rs (always-on, green).
 //!
 //! Each test provisions its own tempdir project via `npm install` (pinned
 //! majors matching the versions the shapes were captured from). When npm or
@@ -194,11 +192,10 @@ fn compile_and_run(root: &Path, fixture: &str) -> (String, String) {
 /// a format (email via ajv-formats), pattern, enum, uniqueItems — compiled
 /// validators built by `new Function(self, scope, code)` at runtime.
 #[test]
-#[ignore = "blocked on a PRE-EXISTING perry CJS-compilation gap, not the #6559 interpreter: \
-ajv's dist/compile/codegen/index.js class methods call the module-level `addNames` declared \
-later in the file, which compiles to `ReferenceError: addNames is not defined` at runtime \
-(ajv imports + instantiates fine; ajv.compile() hits it before any generated code runs). \
-Run with PERRY_REQUIRE_NPM_E2E=1 -- --ignored once the CJS forward-reference hoisting gap is fixed."]
+#[ignore = "the #6586 hybrid-source routing and #6585 addNames hoisting walls are fixed; \
+ajv.compile() now reaches runtime-generated validator compilation and throws the later \
+`Error: CodeGen: ref must be passed in value` scope-binding gap. Keep this under #6559 \
+until that dynamic-code path is fixed."]
 fn real_ajv_compiled_validator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
@@ -279,9 +276,6 @@ console.log("errors:", summary.join(";"));
 /// strings, numbers, booleans and a date-time — the serializer is generated
 /// by `new Function(validator, serializer, code)` at runtime.
 #[test]
-#[ignore = "blocked on a PRE-EXISTING perry CJS-compilation gap, not the #6559 interpreter: \
-the compiled fast-json-stringify module tree throws `ReferenceError: module is not defined` \
-at load. Run with PERRY_REQUIRE_NPM_E2E=1 -- --ignored once the CJS wrapping gap is fixed."]
 fn real_fast_json_stringify_serializer() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();

--- a/crates/perry/tests/issue_6585_cjs_class_forward_function.rs
+++ b/crates/perry/tests/issue_6585_cjs_class_forward_function.rs
@@ -1,0 +1,104 @@
+//! Regression for #6585: a class method in a CommonJS module can call a
+//! module-scoped function declaration that appears later in source order.
+//! Ajv's `dist/compile/codegen/index.js` uses this exact shape for `addNames`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn cjs_class_method_sees_later_function_declaration() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let package = root.join("node_modules").join("fake-ajv-codegen");
+    std::fs::create_dir_all(&package).expect("mkdir package");
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "issue-6585",
+  "private": true,
+  "perry": {
+    "compilePackages": ["fake-ajv-codegen"],
+    "allow": { "compilePackages": ["fake-ajv-codegen"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+    std::fs::write(
+        package.join("package.json"),
+        r#"{ "name": "fake-ajv-codegen", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write package.json");
+    std::fs::write(
+        package.join("index.js"),
+        r#""use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CodeGen = void 0;
+
+class ParentNode {
+  constructor(nodes) {
+    this.nodes = nodes;
+  }
+  get names() {
+    return this.nodes.reduce((names, node) => addNames(names, node.names), {});
+  }
+}
+
+class CodeGen {
+  run() {
+    return new ParentNode([{ names: { alpha: 1 } }, { names: { alpha: 2, beta: 4 } }]).names;
+  }
+}
+exports.CodeGen = CodeGen;
+
+function addNames(names, from) {
+  for (const name in from) names[name] = (names[name] || 0) + (from[name] || 0);
+  return names;
+}
+"#,
+    )
+    .expect("write CJS package");
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"import { CodeGen } from "fake-ajv-codegen";
+console.log(JSON.stringify(new CodeGen().run()));
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\ncompile stdout:\n{}\nruntime stdout:\n{}\nruntime stderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "{\"alpha\":3,\"beta\":4}\n"
+    );
+}


### PR DESCRIPTION
## Summary

- keep hybrid TypeScript inputs with top-level ESM plus a CommonJS `module.exports` epilogue on their published JavaScript package graph
- preserve hoisted CommonJS class access to safe later function declarations, while keeping capturing helpers and their dependent classes wrapped
- unignore the real fast-json-stringify npm end-to-end test; update the Ajv test to document the later #6559 dynamic-code scope gap it now reaches

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --profile perry-dev -p perry --bin perry commands::compile::cjs_wrap::tests -- --nocapture` (100 passed before test-only module split)
- `cargo test --profile perry-dev -p perry --bin perry commands::compile::cjs_wrap::issue_6585_tests -- --nocapture` (3 passed)
- `cargo test --profile perry-dev -p perry --bin perry commands::compile::resolve::declaration_map_source_tests -- --nocapture` (10 passed)
- `cargo test --profile perry-dev -p perry --test issue_6585_cjs_class_forward_function -- --nocapture`
- `cargo test --profile perry-dev -p perry --test issue_6586_namespace_cjs_default_import -- --nocapture`
- `PERRY_REQUIRE_NPM_E2E=1 cargo test --profile perry-dev -p perry --test issue_6559_real_libs_e2e real_fast_json_stringify_serializer -- --exact --nocapture`

Closes #6585
Closes #6586
Refs #6559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation for packages mixing ESM declarations with top-level CommonJS `module.exports`.
  * Fixed CommonJS class hoisting/wrapping so class methods safely resolve later helper declarations.
  * Corrected wrapping behavior when helpers are mutated via property/decorator-style assignments.
* **Tests**
  * Added regression coverage for hybrid CommonJS/ESM emit resolution and forward-reference function handling.
  * Re-enabled the `fast-json-stringify` serializer end-to-end test (when available).
  * Updated E2E expectations around `ajv` test skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->