### PR TITLE
fix(ui): dispatch widget child methods natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,6 +6110,7 @@ dependencies = [
  "anyhow",
  "perry-api-manifest",
  "perry-diagnostics",
+ "perry-dispatch",
  "perry-parser",
  "perry-ui-model",
  "serde",

--- a/changelog.d/7069-widget-child-methods.md
+++ b/changelog.d/7069-widget-child-methods.md
@@ -1,0 +1,5 @@
+Fixed `Widget.addChild()` and `Widget.removeAllChildren()` on native targets.
+Widget handles returned by ordinary `perry/ui` factories, as well as parameters
+typed as `Widget`, now route these compatibility methods through the same native
+FFI operations as `widgetAddChild()` and `widgetClearChildren()` instead of
+falling through to a silent dynamic no-op.

--- a/crates/perry-dispatch/src/ui_instance_table.rs
+++ b/crates/perry-dispatch/src/ui_instance_table.rs
@@ -3,6 +3,19 @@
 use super::*;
 
 pub const PERRY_UI_INSTANCE_TABLE: &[MethodRow] = &[
+    // ---- Generic Widget compatibility methods ----
+    MethodRow {
+        method: "addChild",
+        runtime: "perry_ui_widget_add_child",
+        args: &[ArgKind::Widget],
+        ret: ReturnKind::Void,
+    },
+    MethodRow {
+        method: "removeAllChildren",
+        runtime: "perry_ui_widget_clear_children",
+        args: &[],
+        ret: ReturnKind::Void,
+    },
     // ---- Window instance methods ----
     MethodRow {
         method: "show",

--- a/crates/perry-dispatch/tests/dispatch_drift.rs
+++ b/crates/perry-dispatch/tests/dispatch_drift.rs
@@ -13,8 +13,8 @@
 //! row in the centralised tables resolves via the public lookup helper.
 
 use perry_dispatch::{
-    ui_method_to_runtime, PERRY_I18N_TABLE, PERRY_SYSTEM_TABLE, PERRY_UI_INSTANCE_TABLE,
-    PERRY_UI_TABLE,
+    perry_ui_instance_lookup, ui_method_to_runtime, PERRY_I18N_TABLE, PERRY_SYSTEM_TABLE,
+    PERRY_UI_INSTANCE_TABLE, PERRY_UI_TABLE,
 };
 
 #[test]
@@ -54,6 +54,18 @@ fn perry_ui_instance_table_is_resolvable_via_helper() {
             row.method
         );
     }
+}
+
+#[test]
+fn widget_compat_methods_use_native_abi_symbols() {
+    assert_eq!(
+        perry_ui_instance_lookup("addChild").map(|row| row.runtime),
+        Some("perry_ui_widget_add_child")
+    );
+    assert_eq!(
+        perry_ui_instance_lookup("removeAllChildren").map(|row| row.runtime),
+        Some("perry_ui_widget_clear_children")
+    );
 }
 
 #[test]

--- a/crates/perry-hir/Cargo.toml
+++ b/crates/perry-hir/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 perry-diagnostics.workspace = true
 perry-api-manifest.workspace = true
+perry-dispatch.workspace = true
 perry-ui-model.workspace = true
 # #1679: HIR lowering parses synthesized function-literal source for
 # const-foldable `new Function(...)` bodies, so the parser is a regular

--- a/crates/perry-hir/src/destructuring/var_decl/native_new.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/native_new.rs
@@ -365,19 +365,14 @@ pub(crate) fn register_native_from_new_and_calls(
                         .lookup_native_module(func_name)
                         .and_then(|(m, mm)| mm.map(|x| (m.to_string(), x.to_string())));
                     if let Some((module_name, method_name)) = mod_method {
-                        if module_name == "perry/ui" {
-                            match method_name.as_str() {
-                                "Canvas" | "State" | "Sheet" | "Toolbar" | "Window"
-                                | "LazyVStack" | "NavigationStack" | "Picker" | "Table"
-                                | "TabBar" => {
-                                    ctx.register_native_instance(
-                                        name.to_string(),
-                                        module_name.clone(),
-                                        method_name.clone(),
-                                    );
-                                }
-                                _ => {}
-                            }
+                        if module_name == "perry/ui"
+                            && crate::lower::perry_ui_factory_returns_handle(&method_name)
+                        {
+                            ctx.register_native_instance(
+                                name.to_string(),
+                                module_name.clone(),
+                                method_name.clone(),
+                            );
                         }
                         // perry/tui state(initial) — register the receiver as a
                         // "State" native instance so subsequent .get()/.set()

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -1697,7 +1697,8 @@ impl LoweringContext {
 pub(crate) fn perry_ui_handle_widget(name: &str) -> bool {
     matches!(
         name,
-        "Canvas"
+        "Widget"
+            | "Canvas"
             | "State"
             | "Sheet"
             | "Toolbar"
@@ -1708,4 +1709,18 @@ pub(crate) fn perry_ui_handle_widget(name: &str) -> bool {
             | "Table"
             | "TabBar"
     )
+}
+
+/// True when a named `perry/ui` function returns an opaque handle that can
+/// dispatch receiver methods through `PERRY_UI_INSTANCE_TABLE`.
+///
+/// Keep factory classification tied to the shared dispatch table rather than
+/// maintaining another constructor allowlist in HIR. `VStack`, `HStack`, and
+/// `Button` are the only exceptions: their overloaded argument shapes have
+/// dedicated native-codegen branches, so they intentionally have no generic
+/// dispatch-table rows.
+pub(crate) fn perry_ui_factory_returns_handle(name: &str) -> bool {
+    matches!(name, "VStack" | "HStack" | "Button")
+        || perry_dispatch::perry_ui_lookup(name)
+            .is_some_and(|row| row.ret == perry_dispatch::ReturnKind::Widget)
 }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -1715,12 +1715,12 @@ pub(crate) fn perry_ui_handle_widget(name: &str) -> bool {
 /// dispatch receiver methods through `PERRY_UI_INSTANCE_TABLE`.
 ///
 /// Keep factory classification tied to the shared dispatch table rather than
-/// maintaining another constructor allowlist in HIR. `VStack`, `HStack`, and
-/// `Button` are the only exceptions: their overloaded argument shapes have
-/// dedicated native-codegen branches, so they intentionally have no generic
-/// dispatch-table rows.
+/// maintaining another constructor allowlist in HIR. `VStack`, `HStack`,
+/// `Button`, `ForEach`, and `WebView` are the only exceptions: their overloaded,
+/// callback-driven, or option-bag argument shapes have dedicated native-codegen
+/// branches, so they intentionally have no generic dispatch-table rows.
 pub(crate) fn perry_ui_factory_returns_handle(name: &str) -> bool {
-    matches!(name, "VStack" | "HStack" | "Button")
+    matches!(name, "VStack" | "HStack" | "Button" | "ForEach" | "WebView")
         || perry_dispatch::perry_ui_lookup(name)
             .is_some_and(|row| row.ret == perry_dispatch::ReturnKind::Widget)
 }

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -36,6 +36,7 @@
 //   property access, assignment, and `new C()` constructor calls.
 pub(crate) mod builder_fold;
 mod context;
+pub(crate) use context::perry_ui_factory_returns_handle;
 pub(crate) mod expr_assign;
 mod expr_call;
 pub(crate) mod expr_function;

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -823,20 +823,16 @@ pub(crate) fn lower_module_decl(
                                         if let Some((module_name, Some(method_name))) =
                                             ctx.lookup_native_module(func_name)
                                         {
-                                            if module_name == "perry/ui" {
-                                                match method_name {
-                                                    "Canvas" | "State" | "Sheet" | "Toolbar"
-                                                    | "Window" | "LazyVStack"
-                                                    | "NavigationStack" | "Picker" | "Table"
-                                                    | "TabBar" => {
-                                                        ctx.register_native_instance(
-                                                            name.clone(),
-                                                            module_name.to_string(),
-                                                            method_name.to_string(),
-                                                        );
-                                                    }
-                                                    _ => {}
-                                                }
+                                            if module_name == "perry/ui"
+                                                && super::context::perry_ui_factory_returns_handle(
+                                                    method_name,
+                                                )
+                                            {
+                                                ctx.register_native_instance(
+                                                    name.clone(),
+                                                    module_name.to_string(),
+                                                    method_name.to_string(),
+                                                );
                                             }
                                         }
                                         // node:http server (issue #577) — named-import factory:

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -559,6 +559,20 @@ fn test_perry_ui_state_value_uses_native_getter() {
 /// native FFI dispatch as the canonical `widgetAddChild(parent, child)` free
 /// function, including for basic widget factories such as VStack and Text.
 #[test]
+fn test_perry_ui_widget_factory_handle_classification() {
+    for factory in ["VStack", "HStack", "Button", "ForEach", "Text", "WebView"] {
+        assert!(
+            super::perry_ui_factory_returns_handle(factory),
+            "{factory} should be classified as a Widget-returning factory"
+        );
+    }
+    assert!(!super::perry_ui_factory_returns_handle("showToast"));
+    assert!(!super::perry_ui_factory_returns_handle("widgetAddChild"));
+}
+
+/// #6642: native lowering must preserve the Widget compatibility methods on
+/// factory results and explicitly Widget-typed parameters.
+#[test]
 fn test_perry_ui_widget_add_child_uses_native_dispatch() {
     use crate::ir::{clear_current_module_source, Expr, Stmt};
 

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -555,6 +555,94 @@ fn test_perry_ui_state_value_uses_native_getter() {
     );
 }
 
+/// #6642: the Widget `.addChild()` compatibility method must use the same
+/// native FFI dispatch as the canonical `widgetAddChild(parent, child)` free
+/// function, including for basic widget factories such as VStack and Text.
+#[test]
+fn test_perry_ui_widget_add_child_uses_native_dispatch() {
+    use crate::ir::{clear_current_module_source, Expr, Stmt};
+
+    let source = r#"
+        import { VStack, Text, type Widget } from "perry/ui";
+
+        const parent = VStack(0, []);
+        const child = Text("hello");
+        parent.addChild(child);
+        parent.removeAllChildren();
+
+        function attach(target: Widget, item: Widget) {
+            target.addChild(item);
+        }
+    "#;
+    let module =
+        perry_parser::parse_typescript(source, "widget_add_child.ts").expect("source should parse");
+    let hir =
+        super::lower_module(&module, "test", "widget_add_child.ts").expect("source should lower");
+    clear_current_module_source();
+
+    let call = hir.init.iter().find_map(|stmt| match stmt {
+        Stmt::Expr(Expr::NativeMethodCall {
+            module,
+            class_name,
+            object,
+            method,
+            args,
+        }) if method == "addChild" => Some((module, class_name, object, args)),
+        _ => None,
+    });
+
+    assert!(
+        matches!(
+            call,
+            Some((module, Some(class_name), Some(_), args))
+                if module == "perry/ui" && class_name == "VStack" && args.len() == 1
+        ),
+        "Widget.addChild must lower as a perry/ui instance call, got: {:#?}",
+        hir.init
+    );
+
+    assert!(
+        hir.init.iter().any(|stmt| matches!(
+            stmt,
+            Stmt::Expr(Expr::NativeMethodCall {
+                module,
+                class_name: Some(class_name),
+                object: Some(_),
+                method,
+                args,
+            }) if module == "perry/ui"
+                && class_name == "VStack"
+                && method == "removeAllChildren"
+                && args.is_empty()
+        )),
+        "Widget.removeAllChildren must lower as a perry/ui instance call, got: {:#?}",
+        hir.init
+    );
+
+    let attach = hir
+        .functions
+        .iter()
+        .find(|function| function.name == "attach")
+        .expect("attach should lower");
+    assert!(
+        attach.body.iter().any(|stmt| matches!(
+            stmt,
+            Stmt::Expr(Expr::NativeMethodCall {
+                module,
+                class_name: Some(class_name),
+                object: Some(_),
+                method,
+                args,
+            }) if module == "perry/ui"
+                && class_name == "Widget"
+                && method == "addChild"
+                && args.len() == 1
+        )),
+        "Widget-typed parameters must use perry/ui instance dispatch, got: {:#?}",
+        attach.body
+    );
+}
+
 /// #6679: a NAMED class EXPRESSION's `.name` is its own explicit name
 /// (`Named` in `const B = class Named {}`), not the outer binding name. Per
 /// spec a named class expression is not an anonymous function definition, so

--- a/docs/src/ui/widgets.md
+++ b/docs/src/ui/widgets.md
@@ -5,10 +5,12 @@ Every example on this page is a real runnable program verified by CI
 (`scripts/run_doc_tests.sh`) — the snippet you read is the same source that's
 compiled and launched.
 
-The widget API is **free functions**, not methods. A widget is a 64-bit
-opaque handle; you pass it into helpers like `textSetFontSize(widget, 18)`
-rather than calling `widget.setFontSize(18)`. That's the only shape perry/ui
-supports — no fluent chain, no prototype methods.
+Most widget operations use **free functions**. A widget is a 64-bit opaque
+handle; pass it into helpers like `textSetFontSize(widget, 18)` rather than
+calling `widget.setFontSize(18)`. The small method surface declared by
+`WidgetMethods` is cross-backend too: it includes animations plus
+`parent.addChild(child)` and `parent.removeAllChildren()` compatibility aliases
+for `widgetAddChild` and `widgetClearChildren`.
 
 ## Text
 

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -11,6 +11,10 @@ declare const __canvasImage: unique symbol;
  * `perry_ui_widget_*` FFI entries.
  */
 export interface WidgetMethods {
+    /** Append a child widget. Equivalent to `widgetAddChild(this, child)`. */
+    addChild(child: Widget): void;
+    /** Remove every child widget. Equivalent to `widgetClearChildren(this)`. */
+    removeAllChildren(): void;
     /**
      * Animate the widget's opacity to `target` over `durationSecs` seconds.
      * The animation starts from the widget's current opacity.


### PR DESCRIPTION
Closes #6642

## Summary
- route `Widget.addChild()` and `Widget.removeAllChildren()` through the native perry/ui instance dispatch table
- recognize all widget-returning perry/ui factories, including the overload-specialized stack/button constructors, and `Widget`-typed parameters
- declare and document the cross-backend compatibility methods
- pin native ABI symbols and HIR lowering with regression tests

## Tests
- `cargo test --profile perry-dev -p perry-hir --lib -- --nocapture`
- `cargo test --profile perry-dev -p perry-codegen --lib -- --nocapture`
- `cargo test --profile perry-dev -p perry-dispatch --test dispatch_drift -- --nocapture`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Widget.addChild()` and `Widget.removeAllChildren()` for native widgets, factory-created widgets, and values typed as `Widget`, ensuring correct native child-management behavior.
- **Documentation**
  - Updated Widgets docs to clarify `parent.addChild(child)` and `parent.removeAllChildren()` compatibility with the standard widget child APIs.
- **Type Definitions**
  - Added `WidgetMethods.addChild(child: Widget): void` and `removeAllChildren(): void` to the public TypeScript declarations.
- **Tests**
  - Added acceptance and unit/regression coverage to verify the method-to-native behavior and lowering results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->