### PR TITLE
fix(windows-ui): theme client controls in dark mode

### DIFF
--- a/changelog.d/7070-windows-dark-controls.md
+++ b/changelog.d/7070-windows-dark-controls.md
@@ -1,0 +1,5 @@
+Fixed Windows dark mode applying only to the title bar. Standard and
+owner-drawn child controls, container client areas, toolbars, and the command
+palette now use matching dark colors and update when the system theme changes,
+while explicit Perry foreground and background styles continue to take
+precedence.

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -1285,6 +1285,11 @@ unsafe extern "system" fn wnd_proc(
             }
             LRESULT(0)
         }
+        WM_SETTINGCHANGE | WM_THEMECHANGED => {
+            crate::theme::refresh_window_tree(hwnd);
+            crate::dwm::apply_titlebar_theme(hwnd);
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
         WM_PAINT => {
             // Main window has no content to paint — just validate the region
             let mut ps = PAINTSTRUCT::default();
@@ -1345,6 +1350,9 @@ unsafe extern "system" fn wnd_proc(
             if let Some(result) = crate::widgets::text::handle_ctlcolor(hdc, child_hwnd) {
                 return result;
             }
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
@@ -1352,6 +1360,9 @@ unsafe extern "system" fn wnd_proc(
             let child_hwnd = HWND(lparam.0 as *mut _);
             if let Some(brush) = crate::widgets::textfield::handle_ctlcoloredit(hdc, child_hwnd) {
                 return LRESULT(brush);
+            }
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
+                return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -1377,6 +1388,9 @@ unsafe extern "system" fn wnd_proc(
                 } else {
                     break;
                 }
+            }
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -1421,7 +1435,7 @@ unsafe extern "system" fn wnd_proc(
                     return LRESULT(1);
                 }
             }
-            DefWindowProcW(hwnd, msg, wparam, lparam)
+            crate::theme::erase_background(hwnd, HDC(wparam.0 as *mut _))
         }
         WM_DESTROY => {
             crate::app::handle_terminate();

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -1389,7 +1389,7 @@ unsafe extern "system" fn wnd_proc(
                     break;
                 }
             }
-            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -150,6 +150,8 @@ pub mod menu;
 pub mod sheet;
 pub mod state;
 pub mod system;
+#[cfg(target_os = "windows")]
+pub mod theme;
 pub mod toolbar;
 pub mod tray;
 pub mod widgets;

--- a/crates/perry-ui-windows/src/theme.rs
+++ b/crates/perry-ui-windows/src/theme.rs
@@ -149,9 +149,10 @@ pub unsafe fn handle_container_message(
         return Some(erase_background(hwnd, hdc));
     }
 
-    let editable = msg == 0x0133 || msg == WM_CTLCOLORLISTBOX; // WM_CTLCOLOREDIT / LISTBOX
-    let color_message =
-        matches!(msg, WM_CTLCOLORSTATIC | WM_CTLCOLORBTN | WM_CTLCOLORLISTBOX) || editable;
+    let control_surface_message =
+        msg == 0x0133 || matches!(msg, WM_CTLCOLORBTN | WM_CTLCOLORLISTBOX); // EDIT / BTN / LISTBOX
+    let color_message = matches!(msg, WM_CTLCOLORSTATIC | WM_CTLCOLORBTN | WM_CTLCOLORLISTBOX)
+        || control_surface_message;
     let forwarded = matches!(msg, WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM) || color_message;
     if !forwarded {
         return None;
@@ -167,14 +168,14 @@ pub unsafe fn handle_container_message(
     }
 
     if color_message {
-        return handle_control_color(HDC(wparam.0 as *mut _), editable);
+        return handle_control_color(HDC(wparam.0 as *mut _), control_surface_message);
     }
     None
 }
 
 /// Default fallback for `WM_CTLCOLORSTATIC` / `BTN` / `EDIT` after a widget's
 /// explicit foreground/background styling has had the first chance to answer.
-pub fn handle_control_color(hdc: HDC, editable: bool) -> Option<LRESULT> {
+pub fn handle_control_color(hdc: HDC, control_surface: bool) -> Option<LRESULT> {
     if !is_dark_mode() {
         return None;
     }
@@ -182,14 +183,14 @@ pub fn handle_control_color(hdc: HDC, editable: bool) -> Option<LRESULT> {
         SetTextColor(hdc, text_color());
         SetBkColor(
             hdc,
-            if editable {
+            if control_surface {
                 control_background_color()
             } else {
                 COLORREF(DARK_BACKGROUND)
             },
         );
     }
-    let brush = if editable {
+    let brush = if control_surface {
         control_brush()
     } else {
         background_brush()

--- a/crates/perry-ui-windows/src/theme.rs
+++ b/crates/perry-ui-windows/src/theme.rs
@@ -1,0 +1,235 @@
+//! Win32 client-area and child-control light/dark theming (#6612).
+//!
+//! DWM owns only the non-client frame. Standard controls need an explicit
+//! uxtheme class, while owner/custom-drawn controls need matching GDI colors.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
+
+use windows::core::{BOOL, PCWSTR};
+use windows::Win32::Foundation::{COLORREF, HWND, LPARAM, LRESULT, RECT, WPARAM};
+use windows::Win32::Graphics::Gdi::{
+    CreateSolidBrush, DeleteObject, FillRect, GetSysColor, GetSysColorBrush, InvalidateRect,
+    SetBkColor, SetTextColor, COLOR_WINDOW, COLOR_WINDOWTEXT, HBRUSH, HDC,
+};
+use windows::Win32::UI::Controls::SetWindowTheme;
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumChildWindows, GetClientRect, GetParent, SendMessageW, WM_COMMAND, WM_CONTEXTMENU,
+    WM_CTLCOLORBTN, WM_CTLCOLORLISTBOX, WM_CTLCOLORSTATIC, WM_DRAWITEM, WM_ERASEBKGND,
+};
+
+const MODE_UNKNOWN: u8 = 0;
+const MODE_LIGHT: u8 = 1;
+const MODE_DARK: u8 = 2;
+
+/// COLORREF is `0x00BBGGRR`.
+const DARK_BACKGROUND: u32 = 0x0020_2020;
+const DARK_CONTROL_BACKGROUND: u32 = 0x002B_2B2B;
+const DARK_TEXT: u32 = 0x00F0_F0F0;
+
+static CACHED_MODE: AtomicU8 = AtomicU8::new(MODE_UNKNOWN);
+static DARK_BACKGROUND_BRUSH: OnceLock<usize> = OnceLock::new();
+static DARK_CONTROL_BRUSH: OnceLock<usize> = OnceLock::new();
+
+fn wide(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+fn detect_dark_mode() -> bool {
+    crate::system::is_dark_mode() != 0
+}
+
+/// Return the cached app-theme state, probing the registry on first use.
+pub fn is_dark_mode() -> bool {
+    match CACHED_MODE.load(Ordering::Relaxed) {
+        MODE_DARK => true,
+        MODE_LIGHT => false,
+        _ => refresh_mode(),
+    }
+}
+
+/// Re-read the Windows app theme. Called for `WM_SETTINGCHANGE` /
+/// `WM_THEMECHANGED` so an already-running Perry app follows the OS setting.
+pub fn refresh_mode() -> bool {
+    let dark = detect_dark_mode();
+    CACHED_MODE.store(if dark { MODE_DARK } else { MODE_LIGHT }, Ordering::Relaxed);
+    dark
+}
+
+fn permanent_brush(slot: &OnceLock<usize>, color: u32) -> HBRUSH {
+    let raw = *slot.get_or_init(|| unsafe { CreateSolidBrush(COLORREF(color)).0 as usize });
+    HBRUSH(raw as *mut _)
+}
+
+/// Default client/container background brush for the current app theme.
+pub fn background_brush() -> HBRUSH {
+    if is_dark_mode() {
+        permanent_brush(&DARK_BACKGROUND_BRUSH, DARK_BACKGROUND)
+    } else {
+        unsafe { GetSysColorBrush(COLOR_WINDOW) }
+    }
+}
+
+/// Default control surface brush (`EDIT`, `BUTTON`, list-like controls).
+pub fn control_brush() -> HBRUSH {
+    if is_dark_mode() {
+        permanent_brush(&DARK_CONTROL_BRUSH, DARK_CONTROL_BACKGROUND)
+    } else {
+        unsafe { GetSysColorBrush(COLOR_WINDOW) }
+    }
+}
+
+pub fn text_color() -> COLORREF {
+    if is_dark_mode() {
+        COLORREF(DARK_TEXT)
+    } else {
+        COLORREF(unsafe { GetSysColor(COLOR_WINDOWTEXT) })
+    }
+}
+
+pub fn control_background_color() -> COLORREF {
+    if is_dark_mode() {
+        COLORREF(DARK_CONTROL_BACKGROUND)
+    } else {
+        COLORREF(unsafe { GetSysColor(COLOR_WINDOW) })
+    }
+}
+
+/// Ask uxtheme to render a standard child control in the current app theme.
+///
+/// `DarkMode_Explorer` is the theme class used by modern Win32 apps;
+/// unsupported Windows versions simply ignore the request.
+pub fn apply_control_theme(hwnd: HWND) {
+    let class = wide(if is_dark_mode() {
+        "DarkMode_Explorer"
+    } else {
+        "Explorer"
+    });
+    unsafe {
+        let _ = SetWindowTheme(hwnd, PCWSTR(class.as_ptr()), PCWSTR::null());
+        let _ = InvalidateRect(Some(hwnd), None, true);
+    }
+}
+
+/// Forward control notifications through lightweight Perry containers.
+///
+/// Win32 sends `WM_CTLCOLOR*`, `WM_COMMAND`, and `WM_DRAWITEM` only to a
+/// control's immediate parent. Form/NavStack/ZStack therefore need to relay
+/// them until the top-level Perry window can apply widget-specific styling.
+pub unsafe fn handle_container_message(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> Option<LRESULT> {
+    if msg == WM_ERASEBKGND {
+        let parent = unsafe { GetParent(hwnd) }.ok()?;
+        let is_app_root = crate::app::get_main_hwnd() == Some(parent)
+            || crate::window::is_perry_window_hwnd(parent.0 as isize);
+        if !is_app_root {
+            return None;
+        }
+
+        let hdc = HDC(wparam.0 as *mut _);
+        let mut rect = RECT::default();
+        unsafe {
+            let _ = GetClientRect(hwnd, &mut rect);
+        }
+        if crate::widgets::paint_gradient(hwnd, hdc, &rect) {
+            return Some(LRESULT(1));
+        }
+        if let Some(color) = crate::widgets::get_hwnd_bg_color(hwnd) {
+            unsafe {
+                let brush = CreateSolidBrush(COLORREF(color));
+                FillRect(hdc, &rect, brush);
+                let _ = DeleteObject(brush.into());
+            }
+            return Some(LRESULT(1));
+        }
+        return Some(erase_background(hwnd, hdc));
+    }
+
+    let editable = msg == 0x0133 || msg == WM_CTLCOLORLISTBOX; // WM_CTLCOLOREDIT / LISTBOX
+    let color_message =
+        matches!(msg, WM_CTLCOLORSTATIC | WM_CTLCOLORBTN | WM_CTLCOLORLISTBOX) || editable;
+    let forwarded = matches!(msg, WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM) || color_message;
+    if !forwarded {
+        return None;
+    }
+
+    if let Ok(parent) = unsafe { GetParent(hwnd) } {
+        if !parent.0.is_null() {
+            let result = unsafe { SendMessageW(parent, msg, Some(wparam), Some(lparam)) };
+            if result.0 != 0 || !color_message {
+                return Some(result);
+            }
+        }
+    }
+
+    if color_message {
+        return handle_control_color(HDC(wparam.0 as *mut _), editable);
+    }
+    None
+}
+
+/// Default fallback for `WM_CTLCOLORSTATIC` / `BTN` / `EDIT` after a widget's
+/// explicit foreground/background styling has had the first chance to answer.
+pub fn handle_control_color(hdc: HDC, editable: bool) -> Option<LRESULT> {
+    if !is_dark_mode() {
+        return None;
+    }
+    unsafe {
+        SetTextColor(hdc, text_color());
+        SetBkColor(
+            hdc,
+            if editable {
+                control_background_color()
+            } else {
+                COLORREF(DARK_BACKGROUND)
+            },
+        );
+    }
+    let brush = if editable {
+        control_brush()
+    } else {
+        background_brush()
+    };
+    Some(LRESULT(brush.0 as isize))
+}
+
+/// Fill a window's client area with the theme's default background.
+pub fn erase_background(hwnd: HWND, hdc: HDC) -> LRESULT {
+    unsafe {
+        let mut rect = RECT::default();
+        let _ = GetClientRect(hwnd, &mut rect);
+        FillRect(hdc, &rect, background_brush());
+    }
+    LRESULT(1)
+}
+
+unsafe extern "system" fn refresh_child(hwnd: HWND, _lparam: LPARAM) -> BOOL {
+    apply_control_theme(hwnd);
+    BOOL(1)
+}
+
+/// Re-theme an existing top-level window and every descendant control.
+pub fn refresh_window_tree(hwnd: HWND) {
+    refresh_mode();
+    apply_control_theme(hwnd);
+    unsafe {
+        let _ = EnumChildWindows(Some(hwnd), Some(refresh_child), LPARAM(0));
+        let _ = InvalidateRect(Some(hwnd), None, true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dark_palette_uses_colorref_byte_order() {
+        assert_eq!(DARK_BACKGROUND, 0x0020_2020);
+        assert_eq!(DARK_CONTROL_BACKGROUND, 0x002B_2B2B);
+        assert_eq!(DARK_TEXT, 0x00F0_F0F0);
+    }
+}

--- a/crates/perry-ui-windows/src/theme.rs
+++ b/crates/perry-ui-windows/src/theme.rs
@@ -173,8 +173,9 @@ pub unsafe fn handle_container_message(
     None
 }
 
-/// Default fallback for `WM_CTLCOLORSTATIC` / `BTN` / `EDIT` after a widget's
-/// explicit foreground/background styling has had the first chance to answer.
+/// Default fallback for `WM_CTLCOLORSTATIC` / `BTN` / `EDIT` / `LISTBOX` after
+/// a widget's explicit foreground/background styling has had the first chance
+/// to answer.
 pub fn handle_control_color(hdc: HDC, control_surface: bool) -> Option<LRESULT> {
     if !is_dark_mode() {
         return None;

--- a/crates/perry-ui-windows/src/toolbar.rs
+++ b/crates/perry-ui-windows/src/toolbar.rs
@@ -47,6 +47,11 @@ unsafe extern "system" fn toolbar_default_wnd_proc(
     wparam: windows::Win32::Foundation::WPARAM,
     lparam: windows::Win32::Foundation::LPARAM,
 ) -> windows::Win32::Foundation::LRESULT {
+    if let Some(result) =
+        unsafe { crate::theme::handle_container_message(hwnd, msg, wparam, lparam) }
+    {
+        return result;
+    }
     windows::Win32::UI::WindowsAndMessaging::DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 
@@ -100,6 +105,7 @@ pub fn create() -> i64 {
                 None,
             )
             .unwrap();
+            crate::theme::apply_control_theme(hwnd);
 
             TOOLBAR_HWNDS.with(|t| t.borrow_mut().insert(id, hwnd));
         }
@@ -149,7 +155,7 @@ pub fn add_item(toolbar_handle: i64, label_ptr: *const u8, icon_ptr: *const u8, 
                     let x = ((item_count - 1) * 80) as i32;
                     let label_wide = to_wide(&label);
                     let btn_class = to_wide("BUTTON");
-                    let _btn = CreateWindowExW(
+                    if let Ok(btn) = CreateWindowExW(
                         WINDOW_EX_STYLE::default(),
                         PCWSTR(btn_class.as_ptr()),
                         PCWSTR(label_wide.as_ptr()),
@@ -162,7 +168,9 @@ pub fn add_item(toolbar_handle: i64, label_ptr: *const u8, icon_ptr: *const u8, 
                         None,
                         Some(HINSTANCE::from(hinstance)),
                         None,
-                    );
+                    ) {
+                        crate::theme::apply_control_theme(btn);
+                    }
                 }
             }
         });

--- a/crates/perry-ui-windows/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-windows/src/widgets/bottom_nav.rs
@@ -181,6 +181,7 @@ pub fn add_item(handle: i64, icon_ptr: *const u8, label_ptr: *const u8) {
                 None,
             );
             let Ok(btn) = btn else { return };
+            crate::theme::apply_control_theme(btn);
 
             NAVS.with(|n| {
                 let mut navs = n.borrow_mut();

--- a/crates/perry-ui-windows/src/widgets/button.rs
+++ b/crates/perry-ui-windows/src/widgets/button.rs
@@ -292,8 +292,9 @@ pub fn handle_draw_item(lparam: LPARAM) -> bool {
     };
 
     let text_color = BUTTON_TEXT_COLORS.with(|c| c.borrow().get(&handle).copied());
-    // Default: dark charcoal text for buttons without explicit color
-    let text_color = text_color.unwrap_or(0x00333333);
+    let text_color = text_color
+        .map(COLORREF)
+        .unwrap_or_else(crate::theme::text_color);
 
     unsafe {
         let hdc = dis.hDC;
@@ -322,10 +323,12 @@ pub fn handle_draw_item(lparam: LPARAM) -> bool {
                 FillRect(hdc, &rect, brush);
             }
             let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
+        } else if crate::theme::is_dark_mode() {
+            FillRect(hdc, &rect, crate::theme::control_brush());
         }
 
         // Draw centered text
-        SetTextColor(hdc, COLORREF(text_color));
+        SetTextColor(hdc, text_color);
         SetBkMode(hdc, TRANSPARENT);
 
         let hfont = windows::Win32::Graphics::Gdi::HFONT(

--- a/crates/perry-ui-windows/src/widgets/command_palette.rs
+++ b/crates/perry-ui-windows/src/widgets/command_palette.rs
@@ -21,7 +21,7 @@ use windows::core::PCWSTR;
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::*;
 #[cfg(target_os = "windows")]
-use windows::Win32::Graphics::Gdi::{COLOR_WINDOW, HBRUSH};
+use windows::Win32::Graphics::Gdi::{COLOR_WINDOW, HBRUSH, HDC};
 #[cfg(target_os = "windows")]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 #[cfg(target_os = "windows")]
@@ -254,6 +254,7 @@ pub fn show() {
                 None,
             )
             .unwrap();
+            crate::theme::refresh_window_tree(popup);
 
             POPUP.with(|p| *p.borrow_mut() = Some((popup, edit, list)));
             QUERY.with(|q| q.borrow_mut().clear());
@@ -314,7 +315,17 @@ unsafe extern "system" fn palette_wnd_proc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
+    if let Some(result) =
+        unsafe { crate::theme::handle_container_message(hwnd, msg, wparam, lparam) }
+    {
+        return result;
+    }
     match msg {
+        WM_SETTINGCHANGE | WM_THEMECHANGED => {
+            crate::theme::refresh_window_tree(hwnd);
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
+        WM_ERASEBKGND => crate::theme::erase_background(hwnd, HDC(wparam.0 as *mut _)),
         WM_COMMAND => {
             let control_id = (wparam.0 & 0xFFFF) as u16;
             let notify = ((wparam.0 >> 16) & 0xFFFF) as u16;

--- a/crates/perry-ui-windows/src/widgets/form.rs
+++ b/crates/perry-ui-windows/src/widgets/form.rs
@@ -56,6 +56,11 @@ unsafe extern "system" fn form_wnd_proc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
+    if let Some(result) =
+        unsafe { crate::theme::handle_container_message(hwnd, msg, wparam, lparam) }
+    {
+        return result;
+    }
     DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 

--- a/crates/perry-ui-windows/src/widgets/hstack.rs
+++ b/crates/perry-ui-windows/src/widgets/hstack.rs
@@ -57,8 +57,8 @@ unsafe extern "system" fn container_wnd_proc(
                     return result;
                 }
             }
-            if let Some(color) = super::get_hwnd_bg_color(hwnd)
-                .or_else(|| super::find_ancestor_hwnd_bg_color(hwnd))
+            if let Some(color) =
+                super::get_hwnd_bg_color(hwnd).or_else(|| super::find_ancestor_hwnd_bg_color(hwnd))
             {
                 let hdc = HDC(wparam.0 as *mut _);
                 unsafe {
@@ -68,7 +68,7 @@ unsafe extern "system" fn container_wnd_proc(
                 return LRESULT(brush.0 as isize);
             }
             let hdc = HDC(wparam.0 as *mut _);
-            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+            if let Some(result) = crate::theme::handle_control_color(hdc, msg == WM_CTLCOLORBTN) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
@@ -79,7 +79,7 @@ unsafe extern "system" fn container_wnd_proc(
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
-        x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
+        x if x == 0x0133 /* WM_CTLCOLOREDIT */ || x == WM_CTLCOLORLISTBOX => {
             if let Ok(parent) = GetParent(hwnd) {
                 let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
                 if result.0 != 0 {
@@ -105,7 +105,8 @@ unsafe extern "system" fn container_wnd_proc(
                 // WM_PAINT — check if gradient exists before BeginPaint
                 let mut rect = RECT::default();
                 let _ = GetClientRect(hwnd, &mut rect);
-                let has_gradient = crate::widgets::GRADIENT_MAP.lock()
+                let has_gradient = crate::widgets::GRADIENT_MAP
+                    .lock()
                     .map(|map| map.iter().any(|(k, _)| *k == hwnd.0 as isize))
                     .unwrap_or(false);
                 if has_gradient {
@@ -117,8 +118,8 @@ unsafe extern "system" fn container_wnd_proc(
                 }
             }
             // Fall through to solid color fill
-            let color = super::get_hwnd_bg_color(hwnd)
-                .or_else(|| super::find_ancestor_hwnd_bg_color(hwnd));
+            let color =
+                super::get_hwnd_bg_color(hwnd).or_else(|| super::find_ancestor_hwnd_bg_color(hwnd));
             if let Some(color) = color {
                 let brush = windows::Win32::Graphics::Gdi::CreateSolidBrush(COLORREF(color));
                 if msg == WM_ERASEBKGND {

--- a/crates/perry-ui-windows/src/widgets/hstack.rs
+++ b/crates/perry-ui-windows/src/widgets/hstack.rs
@@ -67,6 +67,10 @@ unsafe extern "system" fn container_wnd_proc(
                 let brush = unsafe { CreateSolidBrush(COLORREF(color)) };
                 return LRESULT(brush.0 as isize);
             }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM => {
@@ -77,7 +81,14 @@ unsafe extern "system" fn container_wnd_proc(
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                if result.0 != 0 {
+                    return result;
+                }
+            }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
+                return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -127,6 +138,12 @@ unsafe extern "system" fn container_wnd_proc(
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
+            }
+            if msg == WM_ERASEBKGND {
+                return crate::theme::erase_background(
+                    hwnd,
+                    windows::Win32::Graphics::Gdi::HDC(wparam.0 as *mut _),
+                );
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }

--- a/crates/perry-ui-windows/src/widgets/mod.rs
+++ b/crates/perry-ui-windows/src/widgets/mod.rs
@@ -266,6 +266,7 @@ pub fn alloc_control_id() -> u16 {
 /// Register a widget entry and return its 1-based handle.
 #[cfg(target_os = "windows")]
 pub fn register_widget(hwnd: HWND, kind: WidgetKind, control_id: u16) -> i64 {
+    crate::theme::apply_control_theme(hwnd);
     let handle = WIDGETS.with(|w| {
         let mut widgets = w.borrow_mut();
         widgets.push(WidgetEntry {
@@ -324,6 +325,7 @@ pub fn register_widget_with_layout(
     spacing: f64,
     insets: (f64, f64, f64, f64),
 ) -> i64 {
+    crate::theme::apply_control_theme(hwnd);
     let control_id = alloc_control_id();
     let handle = WIDGETS.with(|w| {
         let mut widgets = w.borrow_mut();

--- a/crates/perry-ui-windows/src/widgets/navstack.rs
+++ b/crates/perry-ui-windows/src/widgets/navstack.rs
@@ -59,6 +59,11 @@ unsafe extern "system" fn navstack_wnd_proc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
+    if let Some(result) =
+        unsafe { crate::theme::handle_container_message(hwnd, msg, wparam, lparam) }
+    {
+        return result;
+    }
     DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 

--- a/crates/perry-ui-windows/src/widgets/scrollview.rs
+++ b/crates/perry-ui-windows/src/widgets/scrollview.rs
@@ -151,12 +151,12 @@ unsafe extern "system" fn scroll_wnd_proc(
                 }
             }
             let hdc = HDC(wparam.0 as *mut _);
-            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+            if let Some(result) = crate::theme::handle_control_color(hdc, msg == WM_CTLCOLORBTN) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
-        x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
+        x if x == 0x0133 /* WM_CTLCOLOREDIT */ || x == WM_CTLCOLORLISTBOX => {
             if let Ok(parent) = GetParent(hwnd) {
                 let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
                 if result.0 != 0 {

--- a/crates/perry-ui-windows/src/widgets/scrollview.rs
+++ b/crates/perry-ui-windows/src/widgets/scrollview.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::*;
 #[cfg(target_os = "windows")]
-use windows::Win32::Graphics::Gdi::{FillRect, HBRUSH};
+use windows::Win32::Graphics::Gdi::{FillRect, HBRUSH, HDC};
 #[cfg(target_os = "windows")]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 #[cfg(target_os = "windows")]
@@ -145,7 +145,27 @@ unsafe extern "system" fn scroll_wnd_proc(
         }
         WM_COMMAND | WM_CTLCOLORSTATIC | WM_CTLCOLORBTN | WM_CONTEXTMENU | WM_DRAWITEM => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                if result.0 != 0 || !matches!(msg, WM_CTLCOLORSTATIC | WM_CTLCOLORBTN) {
+                    return result;
+                }
+            }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
+        x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
+            if let Ok(parent) = GetParent(hwnd) {
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                if result.0 != 0 {
+                    return result;
+                }
+            }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
+                return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -173,6 +193,12 @@ unsafe extern "system" fn scroll_wnd_proc(
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
+            }
+            if msg == WM_ERASEBKGND {
+                return crate::theme::erase_background(
+                    hwnd,
+                    windows::Win32::Graphics::Gdi::HDC(wparam.0 as *mut _),
+                );
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }

--- a/crates/perry-ui-windows/src/widgets/text.rs
+++ b/crates/perry-ui-windows/src/widgets/text.rs
@@ -438,14 +438,18 @@ pub fn handle_ctlcolor(hdc: HDC, child_hwnd: HWND) -> Option<LRESULT> {
     // Find the nearest ancestor brush for background
     let ancestor_brush = find_ancestor_brush(child_hwnd);
 
-    let null_brush = LRESULT(unsafe { GetStockObject(NULL_BRUSH) }.0 as isize);
-
     // With WS_CLIPCHILDREN on parent VStack/HStack, the parent doesn't paint
     // under child controls. Return the ancestor brush so the Text control fills
     // its own background with the correct color.
     let bg_brush = ancestor_brush
         .map(|b| LRESULT(b.0 as isize))
-        .unwrap_or(null_brush);
+        .unwrap_or_else(|| {
+            if crate::theme::is_dark_mode() {
+                LRESULT(crate::theme::background_brush().0 as isize)
+            } else {
+                LRESULT(unsafe { GetStockObject(NULL_BRUSH) }.0 as isize)
+            }
+        });
 
     TEXT_STYLES.with(|styles| {
         let styles = styles.borrow();
@@ -467,7 +471,7 @@ pub fn handle_ctlcolor(hdc: HDC, child_hwnd: HWND) -> Option<LRESULT> {
                 }
                 Some(bg_brush)
             } else {
-                None
+                crate::theme::handle_control_color(hdc, false)
             }
         }
     })

--- a/crates/perry-ui-windows/src/widgets/vstack.rs
+++ b/crates/perry-ui-windows/src/widgets/vstack.rs
@@ -78,6 +78,10 @@ unsafe extern "system" fn container_wnd_proc(
                 let brush = unsafe { CreateSolidBrush(COLORREF(color)) };
                 return LRESULT(brush.0 as isize);
             }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM => {
@@ -88,7 +92,14 @@ unsafe extern "system" fn container_wnd_proc(
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
+                if result.0 != 0 {
+                    return result;
+                }
+            }
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
+                return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -138,6 +149,12 @@ unsafe extern "system" fn container_wnd_proc(
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
+            }
+            if msg == WM_ERASEBKGND {
+                return crate::theme::erase_background(
+                    hwnd,
+                    windows::Win32::Graphics::Gdi::HDC(wparam.0 as *mut _),
+                );
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }

--- a/crates/perry-ui-windows/src/widgets/vstack.rs
+++ b/crates/perry-ui-windows/src/widgets/vstack.rs
@@ -68,8 +68,8 @@ unsafe extern "system" fn container_wnd_proc(
                 }
             }
             // Fallback: find our own bg or ancestor bg and return that brush
-            if let Some(color) = super::get_hwnd_bg_color(hwnd)
-                .or_else(|| super::find_ancestor_hwnd_bg_color(hwnd))
+            if let Some(color) =
+                super::get_hwnd_bg_color(hwnd).or_else(|| super::find_ancestor_hwnd_bg_color(hwnd))
             {
                 let hdc = HDC(wparam.0 as *mut _);
                 unsafe {
@@ -79,7 +79,7 @@ unsafe extern "system" fn container_wnd_proc(
                 return LRESULT(brush.0 as isize);
             }
             let hdc = HDC(wparam.0 as *mut _);
-            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+            if let Some(result) = crate::theme::handle_control_color(hdc, msg == WM_CTLCOLORBTN) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
@@ -90,7 +90,7 @@ unsafe extern "system" fn container_wnd_proc(
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
-        x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
+        x if x == 0x0133 /* WM_CTLCOLOREDIT */ || x == WM_CTLCOLORLISTBOX => {
             if let Ok(parent) = GetParent(hwnd) {
                 let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
                 if result.0 != 0 {
@@ -116,7 +116,8 @@ unsafe extern "system" fn container_wnd_proc(
                 // WM_PAINT — check if gradient exists before BeginPaint
                 let mut rect = RECT::default();
                 let _ = GetClientRect(hwnd, &mut rect);
-                let has_gradient = crate::widgets::GRADIENT_MAP.lock()
+                let has_gradient = crate::widgets::GRADIENT_MAP
+                    .lock()
                     .map(|map| map.iter().any(|(k, _)| *k == hwnd.0 as isize))
                     .unwrap_or(false);
                 if has_gradient {
@@ -128,8 +129,8 @@ unsafe extern "system" fn container_wnd_proc(
                 }
             }
             // Fall through to solid color fill
-            let color = super::get_hwnd_bg_color(hwnd)
-                .or_else(|| super::find_ancestor_hwnd_bg_color(hwnd));
+            let color =
+                super::get_hwnd_bg_color(hwnd).or_else(|| super::find_ancestor_hwnd_bg_color(hwnd));
             if let Some(color) = color {
                 let brush = windows::Win32::Graphics::Gdi::CreateSolidBrush(COLORREF(color));
                 if msg == WM_ERASEBKGND {

--- a/crates/perry-ui-windows/src/widgets/zstack.rs
+++ b/crates/perry-ui-windows/src/widgets/zstack.rs
@@ -47,6 +47,11 @@ unsafe extern "system" fn zstack_wnd_proc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
+    if let Some(result) =
+        unsafe { crate::theme::handle_container_message(hwnd, msg, wparam, lparam) }
+    {
+        return result;
+    }
     DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 

--- a/crates/perry-ui-windows/src/window.rs
+++ b/crates/perry-ui-windows/src/window.rs
@@ -115,9 +115,31 @@ unsafe extern "system" fn window_default_wnd_proc(
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         WM_CTLCOLORBTN => {
-            use windows::Win32::Graphics::Gdi::HDC;
+            use windows::Win32::Graphics::Gdi::{SetBkColor, SetBkMode, HDC, TRANSPARENT};
             let hdc = HDC(wparam.0 as *mut _);
-            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+            let mut walk = HWND(lparam.0 as *mut _);
+            for _ in 0..10 {
+                if let Ok(parent_hwnd) = GetParent(walk) {
+                    if parent_hwnd.0.is_null() {
+                        break;
+                    }
+                    let parent_handle = crate::widgets::find_handle_by_hwnd(parent_hwnd);
+                    if parent_handle > 0 {
+                        if let (Some(color), Some(brush)) = (
+                            crate::widgets::get_bg_color(parent_handle),
+                            crate::widgets::get_bg_brush(parent_handle),
+                        ) {
+                            SetBkColor(hdc, COLORREF(color));
+                            SetBkMode(hdc, TRANSPARENT);
+                            return LRESULT(brush.0 as isize);
+                        }
+                    }
+                    walk = parent_hwnd;
+                } else {
+                    break;
+                }
+            }
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)

--- a/crates/perry-ui-windows/src/window.rs
+++ b/crates/perry-ui-windows/src/window.rs
@@ -79,6 +79,11 @@ unsafe extern "system" fn window_default_wnd_proc(
             }
             LRESULT(0)
         }
+        WM_SETTINGCHANGE | WM_THEMECHANGED => {
+            crate::theme::refresh_window_tree(hwnd);
+            crate::dwm::apply_titlebar_theme(hwnd);
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
         WM_COMMAND => {
             let control_id = (wparam.0 & 0xFFFF) as u16;
             let notify_code = ((wparam.0 >> 16) & 0xFFFF) as u16;
@@ -92,16 +97,52 @@ unsafe extern "system" fn window_default_wnd_proc(
             if let Some(result) = crate::widgets::text::handle_ctlcolor(hdc, child_hwnd) {
                 return result;
             }
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
             use windows::Win32::Graphics::Gdi::HDC;
             let hdc = HDC(wparam.0 as *mut _);
             let child_hwnd = HWND(lparam.0 as *mut _);
-            if let Some(result) = crate::widgets::text::handle_ctlcolor(hdc, child_hwnd) {
+            if let Some(brush) = crate::widgets::textfield::handle_ctlcoloredit(hdc, child_hwnd) {
+                return LRESULT(brush);
+            }
+            if let Some(result) = crate::theme::handle_control_color(hdc, true) {
                 return result;
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
+        WM_CTLCOLORBTN => {
+            use windows::Win32::Graphics::Gdi::HDC;
+            let hdc = HDC(wparam.0 as *mut _);
+            if let Some(result) = crate::theme::handle_control_color(hdc, false) {
+                return result;
+            }
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
+        WM_DRAWITEM => {
+            if crate::widgets::button::handle_draw_item(lparam) {
+                return LRESULT(1);
+            }
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        }
+        WM_ERASEBKGND => {
+            use windows::Win32::Graphics::Gdi::HDC;
+            let window_id = HWND_TO_WINDOW.with(|m| m.borrow().get(&(hwnd.0 as isize)).copied());
+            if let Some(wid) = window_id {
+                if let Some(root) = WINDOW_ROOTS.with(|m| m.borrow().get(&wid).copied()) {
+                    if let Some(brush) = crate::widgets::get_bg_brush(root) {
+                        let hdc = HDC(wparam.0 as *mut _);
+                        let mut rect = RECT::default();
+                        let _ = GetClientRect(hwnd, &mut rect);
+                        windows::Win32::Graphics::Gdi::FillRect(hdc, &rect, brush);
+                        return LRESULT(1);
+                    }
+                }
+            }
+            crate::theme::erase_background(hwnd, HDC(wparam.0 as *mut _))
         }
         _ => DefWindowProcW(hwnd, msg, wparam, lparam),
     }


### PR DESCRIPTION
Closes #6612

## Summary
- apply the active Windows theme class to registered and internal child controls
- paint dark client/control brushes for STATIC, BUTTON, EDIT, and LISTBOX messages while preserving explicit Perry colors
- propagate theme changes through main, secondary, container, toolbar, and command-palette HWND trees

## Validation
- `cargo fmt --all -- --check`
- `cargo check --target x86_64-pc-windows-msvc -p perry-ui-windows` (cross-checked from macOS with Zig providing the native C toolchain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Windows dark mode styling beyond the title bar to client areas, toolbars, forms/containers, owner-drawn controls, navigation layouts, and the command palette.
  * Theme colors now refresh automatically when the system theme changes.

* **Bug Fixes**
  * Improved theme-aware background erasing and control-color handling across Windows widgets, including buttons, edit/listbox cases, and nested container paths.
  * Owner-drawn buttons now use theme text color and correctly fill themed button backgrounds when no explicit colors are set.
  * Toolbar and navigation buttons apply theming immediately after successful control creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->