### PR TITLE
fix(windows-ui): enforce codegen FFI signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6387,6 +6387,9 @@ version = "0.5.1265"
 [[package]]
 name = "perry-ui-test"
 version = "0.1.0"
+dependencies = [
+ "perry-dispatch",
+]
 
 [[package]]
 name = "perry-ui-testkit"

--- a/changelog.d/7078-windows-ffi-signature-check.md
+++ b/changelog.d/7078-windows-ffi-signature-check.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cross-check Windows UI FFI signatures against native codegen in CI and align 21 stale argument or return shapes that could silently read the wrong Win64 registers.

--- a/crates/perry-dispatch/src/ui_table/part_a.rs
+++ b/crates/perry-dispatch/src/ui_table/part_a.rs
@@ -644,7 +644,7 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
     MethodRow {
         method: "webviewSetEphemeral",
         runtime: "perry_ui_webview_set_ephemeral",
-        args: &[ArgKind::Widget, ArgKind::F64],
+        args: &[ArgKind::Widget, ArgKind::I64Raw],
         ret: ReturnKind::Void,
     },
     MethodRow {
@@ -922,7 +922,7 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
     MethodRow {
         method: "widgetAddChildAt",
         runtime: "perry_ui_widget_add_child_at",
-        args: &[ArgKind::Widget, ArgKind::Widget, ArgKind::I64Raw],
+        args: &[ArgKind::Widget, ArgKind::Widget, ArgKind::F64],
         ret: ReturnKind::Void,
     },
     MethodRow {
@@ -984,7 +984,7 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
         method: "comboboxGetValue",
         runtime: "perry_ui_combobox_get_value",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
     // ---- TreeView (issue #480) ----
     MethodRow {
@@ -1021,7 +1021,7 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
         method: "treeViewGetSelectedId",
         runtime: "perry_ui_tree_view_get_selected_id",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
     // ---- Calendar (issue #481) ----
     MethodRow {
@@ -1045,7 +1045,7 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
         method: "calendarGetSelectedDate",
         runtime: "perry_ui_calendar_get_selected_date",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
     // ---- DatePicker (issue #4772) ----
     MethodRow {
@@ -1069,6 +1069,6 @@ pub(crate) const PERRY_UI_TABLE_PART_A: &[MethodRow] = &[
         method: "datePickerGetSelectedDate",
         runtime: "perry_ui_date_picker_get_selected_date",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
 ];

--- a/crates/perry-dispatch/src/ui_table/part_b.rs
+++ b/crates/perry-dispatch/src/ui_table/part_b.rs
@@ -157,7 +157,7 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
         method: "richTextGetString",
         runtime: "perry_ui_rich_text_get_string",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
     MethodRow {
         method: "richTextSetHtml",
@@ -169,7 +169,7 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
         method: "richTextGetHtml",
         runtime: "perry_ui_rich_text_get_html",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::Str,
+        ret: ReturnKind::F64,
     },
     MethodRow {
         method: "richTextToggleBold",
@@ -301,7 +301,7 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
     MethodRow {
         method: "stackSetDetachesHidden",
         runtime: "perry_ui_stack_set_detaches_hidden",
-        args: &[ArgKind::Widget, ArgKind::F64],
+        args: &[ArgKind::Widget, ArgKind::I64Raw],
         ret: ReturnKind::Void,
     },
     // ---- Additional constructors ----
@@ -375,7 +375,7 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
         method: "pickerGetSelected",
         runtime: "perry_ui_picker_get_selected",
         args: &[ArgKind::Widget],
-        ret: ReturnKind::F64,
+        ret: ReturnKind::I64AsF64,
     },
     MethodRow {
         method: "pickerSetSelected",
@@ -654,7 +654,7 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
         method: "pollOpenFile",
         runtime: "perry_ui_poll_open_file",
         args: &[],
-        ret: ReturnKind::F64,
+        ret: ReturnKind::Str,
     },
     // ---- Keyboard shortcuts ----
     // `modifiers` is a bitfield: 1=Cmd, 2=Shift, 4=Option, 8=Control.

--- a/crates/perry-ui-test/Cargo.toml
+++ b/crates/perry-ui-test/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 workspace = true
 
 [dev-dependencies]
+perry-dispatch.workspace = true

--- a/crates/perry-ui-test/tests/ffi_parity.rs
+++ b/crates/perry-ui-test/tests/ffi_parity.rs
@@ -1,5 +1,5 @@
 use perry_ui_test::{Support, FEATURES};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -52,6 +52,202 @@ fn extract_native_crate_symbols(src_dir: &Path) -> HashSet<String> {
     let mut symbols = HashSet::new();
     visit(src_dir, &mut symbols);
     symbols
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AbiSignature {
+    args: Vec<AbiType>,
+    ret: AbiType,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AbiType {
+    I64,
+    F64,
+    Void,
+    Other(String),
+}
+
+impl std::fmt::Display for AbiType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::I64 => f.write_str("i64"),
+            Self::F64 => f.write_str("f64"),
+            Self::Void => f.write_str("void"),
+            Self::Other(ty) => f.write_str(ty),
+        }
+    }
+}
+
+impl std::fmt::Display for AbiSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let args = self
+            .args
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "({args}) -> {}", self.ret)
+    }
+}
+
+fn parse_abi_type(source: &str) -> AbiType {
+    let compact: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+    match compact.as_str() {
+        "" | "()" => AbiType::Void,
+        "i64" => AbiType::I64,
+        "f64" => AbiType::F64,
+        _ => AbiType::Other(compact),
+    }
+}
+
+fn split_top_level(source: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0usize;
+    for (offset, ch) in source.char_indices() {
+        match ch {
+            '(' | '[' | '<' => depth += 1,
+            ')' | ']' | '>' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(&source[start..offset]);
+                start = offset + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    parts.push(&source[start..]);
+    parts
+}
+
+/// Parse linker-visible Rust FFI definitions from one source file.
+///
+/// This deliberately reads the declared Rust types rather than a built
+/// library's symbol table: object formats preserve symbol names, but not the
+/// parameter register classes whose drift is dangerous on Win64.
+fn extract_ffi_signatures(source: &str) -> Vec<(String, AbiSignature)> {
+    const PREFIX: &str = "pub extern \"C\" fn ";
+    let mut signatures = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(relative_start) = source[cursor..].find(PREFIX) {
+        let prefix_start = cursor + relative_start;
+        let line_start = source[..prefix_start]
+            .rfind('\n')
+            .map_or(0, |newline| newline + 1);
+        if !source[line_start..prefix_start].trim().is_empty() {
+            // Ignore examples and prose such as
+            // `// pub extern "C" fn perry_ui_...`.
+            cursor = prefix_start + PREFIX.len();
+            continue;
+        }
+
+        let name_start = prefix_start + PREFIX.len();
+        let Some(relative_open) = source[name_start..].find('(') else {
+            break;
+        };
+        let open = name_start + relative_open;
+        let name = source[name_start..open].trim();
+        if !name.starts_with("perry_ui_") && !name.starts_with("perry_system_") {
+            cursor = open + 1;
+            continue;
+        }
+
+        let mut depth = 0usize;
+        let mut close = None;
+        for (relative, ch) in source[open..].char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + relative);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close = close.unwrap_or_else(|| panic!("unclosed FFI parameter list for {name}"));
+        let params = &source[open + 1..close];
+        let args = split_top_level(params)
+            .into_iter()
+            .filter(|param| !param.trim().is_empty())
+            .map(|param| {
+                let (_, ty) = param
+                    .split_once(':')
+                    .unwrap_or_else(|| panic!("missing parameter type in {name}: {param}"));
+                parse_abi_type(ty)
+            })
+            .collect();
+
+        let after_params = &source[close + 1..];
+        let signature_end = after_params
+            .find('{')
+            .unwrap_or_else(|| panic!("missing function body for {name}"));
+        let return_source = after_params[..signature_end].trim();
+        let ret = return_source
+            .strip_prefix("->")
+            .map(parse_abi_type)
+            .unwrap_or(AbiType::Void);
+        signatures.push((name.to_string(), AbiSignature { args, ret }));
+        cursor = close + 1;
+    }
+
+    signatures
+}
+
+fn extract_native_crate_signatures(src_dir: &Path) -> HashMap<String, AbiSignature> {
+    fn visit(path: &Path, signatures: &mut HashMap<String, AbiSignature>) {
+        if path.is_dir() {
+            let Ok(entries) = fs::read_dir(path) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                visit(&entry.path(), signatures);
+            }
+            return;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            return;
+        }
+
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        for (name, signature) in extract_ffi_signatures(&source) {
+            if let Some(previous) = signatures.insert(name.clone(), signature.clone()) {
+                assert_eq!(
+                    previous, signature,
+                    "conflicting definitions of {name} include different ABI signatures"
+                );
+            }
+        }
+    }
+
+    let mut signatures = HashMap::new();
+    visit(src_dir, &mut signatures);
+    signatures
+}
+
+fn codegen_signature(row: &perry_dispatch::MethodRow, has_receiver: bool) -> AbiSignature {
+    use perry_dispatch::{ArgKind, ReturnKind};
+
+    let mut args = Vec::with_capacity(row.args.len() + usize::from(has_receiver));
+    if has_receiver {
+        args.push(AbiType::I64);
+    }
+    args.extend(row.args.iter().map(|kind| match kind {
+        ArgKind::Widget | ArgKind::Str | ArgKind::I64Raw => AbiType::I64,
+        ArgKind::F64 | ArgKind::Closure => AbiType::F64,
+    }));
+    let ret = match row.ret {
+        ReturnKind::Widget | ReturnKind::Promise | ReturnKind::Str | ReturnKind::I64AsF64 => {
+            AbiType::I64
+        }
+        ReturnKind::F64 => AbiType::F64,
+        ReturnKind::Void => AbiType::Void,
+    };
+    AbiSignature { args, ret }
 }
 
 /// Extract `perry_ui_*` / `perry_system_*` symbols from web runtime JS.
@@ -133,6 +329,30 @@ fn check_platform(
     }
 }
 
+#[test]
+fn ffi_signature_parser_ignores_comments_and_handles_multiline_definitions() {
+    let source = r#"
+// pub extern "C" fn perry_ui_not_a_definition(value: i64) -> i64 {
+#[no_mangle]
+pub extern "C" fn perry_ui_real(
+    widget: i64,
+    callback: f64,
+) -> i64 {
+    0
+}
+"#;
+    assert_eq!(
+        extract_ffi_signatures(source),
+        vec![(
+            "perry_ui_real".to_string(),
+            AbiSignature {
+                args: vec![AbiType::I64, AbiType::F64],
+                ret: AbiType::I64,
+            }
+        )]
+    );
+}
+
 // ── Platform Tests ───────────────────────────────────────────────────────────
 
 macro_rules! native_platform_test {
@@ -151,6 +371,63 @@ native_platform_test!(test_ios, "iOS", "../perry-ui-ios/src", ios);
 native_platform_test!(test_android, "Android", "../perry-ui-android/src", android);
 native_platform_test!(test_gtk4, "GTK4", "../perry-ui-gtk4/src", gtk4);
 native_platform_test!(test_windows, "Windows", "../perry-ui-windows/src", windows);
+
+/// Every Windows UI export that native codegen can call must use the exact
+/// integer/floating-point ABI shape declared in `perry-dispatch`.
+///
+/// This is stricter than symbol parity. In the Win64 calling convention,
+/// changing an argument from `i64` to `f64` (or moving a callback to a
+/// different position) changes which positional register the callee reads
+/// while leaving the linker-visible symbol unchanged.
+#[test]
+fn test_windows_codegen_ffi_signatures() {
+    use perry_dispatch::{PERRY_UI_INSTANCE_TABLE, PERRY_UI_TABLE};
+
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let native = extract_native_crate_signatures(&manifest_dir.join("../perry-ui-windows/src"));
+    let mut expected: BTreeMap<&str, AbiSignature> = BTreeMap::new();
+
+    for (table, has_receiver) in [(PERRY_UI_TABLE, false), (PERRY_UI_INSTANCE_TABLE, true)] {
+        for row in table {
+            let signature = codegen_signature(row, has_receiver);
+            if let Some(previous) = expected.insert(row.runtime, signature.clone()) {
+                assert_eq!(
+                    previous, signature,
+                    "codegen tables declare conflicting ABI signatures for {}",
+                    row.runtime
+                );
+            }
+        }
+    }
+
+    let mut mismatches = Vec::new();
+    let mut checked = 0usize;
+    for (name, expected_signature) in expected {
+        let Some(native_signature) = native.get(name) else {
+            // Platform-unsupported dispatch rows are allowed to have no
+            // Windows export; symbol parity separately checks every feature
+            // marked Supported or Stub.
+            continue;
+        };
+        checked += 1;
+        if native_signature != &expected_signature {
+            mismatches.push(format!(
+                "  {name}: codegen {expected_signature}, Windows {native_signature}"
+            ));
+        }
+    }
+
+    assert!(
+        checked > 250,
+        "unexpectedly checked only {checked} UI exports"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "Windows UI exports disagree with native codegen on {} ABI signature(s):\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+}
 
 #[test]
 fn test_web() {

--- a/crates/perry-ui-windows/src/ffi/clipboard_dialog.rs
+++ b/crates/perry-ui-windows/src/ffi/clipboard_dialog.rs
@@ -119,7 +119,7 @@ pub extern "C" fn perry_ui_blur_widget(handle: i64) {
     kb::blur_widget(handle);
 }
 #[no_mangle]
-pub extern "C" fn perry_ui_is_key_down(code: f64) -> i32 {
+pub extern "C" fn perry_ui_is_key_down(code: f64) -> i64 {
     let raw = code as i32;
     if !(0..=u16::MAX as i32).contains(&raw) {
         return 0;
@@ -131,8 +131,8 @@ pub extern "C" fn perry_ui_is_key_down(code: f64) -> i32 {
     }
 }
 #[no_mangle]
-pub extern "C" fn perry_ui_current_modifiers() -> i32 {
-    kb::current_modifiers() as i32
+pub extern "C" fn perry_ui_current_modifiers() -> i64 {
+    kb::current_modifiers() as i64
 }
 
 /// Get the icon for an application at the given path. Returns a widget handle or 0.

--- a/crates/perry-ui-windows/src/ffi/image_sheet_toolbar_tab.rs
+++ b/crates/perry-ui-windows/src/ffi/image_sheet_toolbar_tab.rs
@@ -89,7 +89,7 @@ pub extern "C" fn perry_ui_toolbar_add_item(
 
 /// Attach a toolbar to the current window.
 #[no_mangle]
-pub extern "C" fn perry_ui_toolbar_attach(toolbar_handle: i64) {
+pub extern "C" fn perry_ui_toolbar_attach(toolbar_handle: i64, _window_handle: i64) {
     toolbar::attach(toolbar_handle);
 }
 
@@ -103,7 +103,7 @@ pub extern "C" fn perry_ui_tabbar_create(_on_change: f64) -> i64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_tabbar_add_tab(_handle: i64, _label_ptr: i64) {}
+pub extern "C" fn perry_ui_tabbar_add_tab(_handle: i64, _label_ptr: i64, _content: i64) {}
 
 #[no_mangle]
 pub extern "C" fn perry_ui_tabbar_set_selected(_handle: i64, _index: i64) {}

--- a/crates/perry-ui-windows/src/ffi/splitview_app_textarea.rs
+++ b/crates/perry-ui-windows/src/ffi/splitview_app_textarea.rs
@@ -26,7 +26,7 @@ pub extern "C" fn perry_ui_vbox_add_child(_handle: i64, _child: i64) {}
 pub extern "C" fn perry_ui_vbox_finalize(_handle: i64) {}
 
 #[no_mangle]
-pub extern "C" fn perry_ui_frame_split_create() -> i64 {
+pub extern "C" fn perry_ui_frame_split_create(_divider_position: f64) -> i64 {
     0
 }
 
@@ -75,7 +75,7 @@ pub extern "C" fn perry_ui_poll_open_file() -> i64 {
 // =============================================================================
 
 #[no_mangle]
-pub extern "C" fn perry_ui_textarea_create(on_change: f64) -> i64 {
+pub extern "C" fn perry_ui_textarea_create(_placeholder_ptr: i64, on_change: f64) -> i64 {
     widgets::textarea::create(on_change)
 }
 

--- a/crates/perry-ui-windows/src/ffi/table_tree_combo_picker.rs
+++ b/crates/perry-ui-windows/src/ffi/table_tree_combo_picker.rs
@@ -25,10 +25,8 @@ pub extern "C" fn perry_ui_table_set_filter_text(h: i64, t: i64) {
     widgets::table::set_filter_text(h, t as *const u8);
 }
 #[no_mangle]
-pub extern "C" fn perry_ui_table_get_filter_text(h: i64) -> f64 {
-    let ptr = widgets::table::get_filter_text(h);
-    // Wrap as NaN-boxed STRING_TAG (top16 = 0x7FFF, lower 48 = pointer).
-    f64::from_bits(0x7FFF_0000_0000_0000_u64 | (ptr as u64 & 0x0000_FFFF_FFFF_FFFF))
+pub extern "C" fn perry_ui_table_get_filter_text(h: i64) -> i64 {
+    widgets::table::get_filter_text(h)
 }
 
 /// TreeView (#480) — real Win32 impl via SysTreeView32 + TVN_SELCHANGEDW.

--- a/crates/perry-ui-windows/src/ffi/textfield_scroll.rs
+++ b/crates/perry-ui-windows/src/ffi/textfield_scroll.rs
@@ -27,10 +27,10 @@ pub extern "C" fn perry_ui_scrollview_set_child(scroll_handle: i64, child_handle
     widgets::scrollview::set_child(scroll_handle, child_handle);
 }
 
-/// Scroll to make a child visible.
+/// Scroll to a content offset. Windows ScrollView is vertical-only.
 #[no_mangle]
-pub extern "C" fn perry_ui_scrollview_scroll_to(scroll_handle: i64, child_handle: i64) {
-    widgets::scrollview::scroll_to(scroll_handle, child_handle);
+pub extern "C" fn perry_ui_scrollview_scroll_to(scroll_handle: i64, _x: f64, y: f64) {
+    widgets::scrollview::set_offset(scroll_handle, y);
 }
 
 /// Get scroll offset.
@@ -41,8 +41,8 @@ pub extern "C" fn perry_ui_scrollview_get_offset(scroll_handle: i64) -> f64 {
 
 /// Set scroll offset.
 #[no_mangle]
-pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, offset: f64) {
-    widgets::scrollview::set_offset(scroll_handle, offset);
+pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, _x: f64, y: f64) {
+    widgets::scrollview::set_offset(scroll_handle, y);
 }
 
 // =============================================================================
@@ -50,7 +50,7 @@ pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, offset: f64
 // =============================================================================
 
 #[no_mangle]
-pub extern "C" fn perry_ui_text_set_wraps(_handle: i64, _wraps: i64) {}
+pub extern "C" fn perry_ui_text_set_wraps(_handle: i64, _max_width: f64) {}
 
 #[no_mangle]
 pub extern "C" fn perry_ui_textfield_get_string(handle: i64) -> i64 {


### PR DESCRIPTION
Fixes #6618.

Adds a CI parity test that compares every Windows `perry_ui_*` Rust export reachable from the shared native dispatch tables against the exact argument and return ABI shape codegen emits. This checks register classes and arity, not just symbol presence, and covers receiver-based methods as well as free functions.

The guard exposed 21 existing mismatches. This PR aligns them by:
- fixing Windows wrapper arities for TextArea, FrameSplit, ScrollView, Toolbar, and TabBar;
- correcting Windows integer and raw-string return shapes;
- correcting shared dispatch kinds for NaN-boxed string returns, numeric picker results, integer flags, and f64 child indices.

Validation:
- `cargo test -p perry-ui-test`
- `cargo test -p perry-dispatch`
- `cargo test -p perry-codegen --lib`
- `cargo check -p perry-codegen`
- `cargo check --tests --target x86_64-pc-windows-msvc -p perry-ui-windows` (cross-checked with Zig C wrappers)
- `cargo fmt --all -- --check`
- `git diff --check`