### PR TITLE
fix(runtime): make Windows process.env case-insensitive

### DIFF
--- a/changelog.d/7081-windows-env-case-insensitive.md
+++ b/changelog.d/7081-windows-env-case-insensitive.md
@@ -1,0 +1,1 @@
+fix(runtime): make Windows `process.env` key access case-insensitive while preserving enumerated key casing

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -34,6 +34,9 @@ pub extern "C" fn js_object_delete_field(
     if obj.is_null() || key.is_null() {
         return 1;
     }
+    if let Some(result) = crate::process::process_env_delete_field(obj, key) {
+        return result;
+    }
     // A delete can rewrite key→slot mappings in place (same keys_array
     // address), so cached (keys_array, key)→index plans must be flushed
     // (`object::prop_plan` read-plan cache).

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -39,6 +39,13 @@ pub extern "C" fn js_object_get_field_by_name(
     if key.is_null() {
         return JSValue::undefined();
     }
+    // `process.env` is a live OS-backed exotic object. Direct reads are
+    // codegen-specialized, but an alias (`const env = process.env; env.X`)
+    // reaches this generic path. On Windows the OS lookup also supplies the
+    // required case-insensitivity (`env.Path === env.PATH`).
+    if let Some(value) = crate::process::process_env_get_field(obj, key) {
+        return value;
+    }
     // #2846: the receiver may be a Proxy value that arrived through a generic
     // property read (e.g. `rec.proxy.a` where `rec = Proxy.revocable(...)`).
     // Proxies are encoded as small fake pointers; deref-ing one as an

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -926,6 +926,16 @@ unsafe fn object_string_key_has_property(
     let nanbox_false = f64::from_bits(0x7FFC_0000_0000_0003u64); // TAG_FALSE
     let nanbox_true = f64::from_bits(0x7FFC_0000_0000_0004u64); // TAG_TRUE
 
+    let env_key = crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+    if let Some(present) = crate::process::process_env_has_field(obj_ptr, env_key) {
+        if present {
+            return nanbox_true;
+        }
+        // An absent environment key can still be inherited from
+        // Object.prototype (`"toString" in process.env`), so only the positive
+        // OS-backed result is terminal here.
+    }
+
     // `class X extends Request/Response` instances forward native members
     // (`body`/`method`/…) through their stashed fetch handle. Gated: programs
     // that never construct a fetch subclass skip the per-call key alloc +

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -422,6 +422,12 @@ pub extern "C" fn js_object_set_field_by_name(
     key: *const crate::StringHeader,
     value: f64,
 ) {
+    // Aliased `process.env` writes must update the OS environment, not only the
+    // materialized object's field bag. The helper declines internal cache
+    // mirror writes so those can proceed through the ordinary setter below.
+    if crate::process::process_env_set_field(obj, key, value) {
+        return;
+    }
     // #5135: the receiver may be a Proxy id arriving with its NaN-box tag
     // already masked off (the `obj.prop++` / `PropertyUpdate` codegen path
     // hands us the bare pointer band, not the full POINTER_TAG value). A Proxy

--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -237,6 +237,9 @@ pub(crate) unsafe fn own_key_present(
     if obj.is_null() || (obj as usize) < 0x10000 || (obj as usize) & 0x7 != 0 || key.is_null() {
         return false;
     }
+    if let Some(present) = crate::process::process_env_has_field(obj, key) {
+        return present;
+    }
     // Only a genuine `GC_TYPE_OBJECT` carries a `keys_array` at ObjectHeader
     // offset 16. A non-object receiver that still cleared the alignment/range
     // guard above — most importantly a real `Map`/`Set`, whose 16-byte header

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -136,6 +136,9 @@ pub(crate) fn obj_value_has_own_key(value: f64, key: f64) -> bool {
         if key_str.is_null() {
             return false;
         }
+        if let Some(present) = crate::process::process_env_has_field(obj, key_str) {
+            return present;
+        }
         let keys = (*obj).keys_array;
         if keys.is_null() || (keys as usize) < 0x10000 {
             return false;

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -15,6 +15,7 @@ mod credentials;
 mod env_misc;
 pub(crate) use env_misc::{
     exit_after_current_thread_collection_teardown, format_out_of_range_number,
+    process_env_delete_field, process_env_get_field, process_env_has_field, process_env_set_field,
 };
 mod finalization;
 pub(crate) mod ipc;

--- a/crates/perry-runtime/src/process/env_misc.rs
+++ b/crates/perry-runtime/src/process/env_misc.rs
@@ -12,6 +12,8 @@ use crate::closure::{
 };
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+#[cfg(windows)]
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static PROCESS_UNCAUGHT_CAPTURE_CALLBACK_SET: AtomicBool = AtomicBool::new(false);
@@ -755,18 +757,9 @@ pub extern "C" fn js_process_constrained_memory() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_getenv(name_ptr: *const StringHeader) -> *mut StringHeader {
     unsafe {
-        if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
-            return std::ptr::null_mut();
-        }
-
-        let len = (*name_ptr).byte_len as usize;
-        let data_ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-
-        // Convert to Rust string
-        let name_bytes = std::slice::from_raw_parts(data_ptr, len);
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => return std::ptr::null_mut(),
+        let name = match env_name_from_header(name_ptr) {
+            Some(name) => name,
+            None => return std::ptr::null_mut(),
         };
 
         match std::env::var(name) {
@@ -901,15 +894,9 @@ static KEEP_PROCESS_PENDING_EXIT_CODE: extern "C" fn() -> i32 = js_process_pendi
 pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
     use crate::value::js_jsvalue_to_string;
     unsafe {
-        if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
-            return;
-        }
-        let len = (*name_ptr).byte_len as usize;
-        let data_ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-        let name_bytes = std::slice::from_raw_parts(data_ptr, len);
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => return,
+        let name = match env_name_from_header(name_ptr) {
+            Some(name) => name,
+            None => return,
         };
         if !env_name_is_settable(name) {
             return;
@@ -935,6 +922,11 @@ pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
             Ok(s) => s,
             Err(_) => return,
         };
+        // Windows treats names case-insensitively but preserves one spelling
+        // in the environment block. Keep the materialized object's first-seen
+        // spelling instead of appending an enumerable alias such as both
+        // `Path` and `PATH`.
+        let cache_name = env_cache_name_for_set(name);
         std::env::set_var(name, v_str);
         // Keep the cached `process.env` object in step so enumeration
         // (`Object.keys(process.env)`, `for…in`, spread) sees the new key —
@@ -943,10 +935,12 @@ pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
         if cached != 0.0 {
             let obj = crate::value::js_nanbox_get_pointer(cached) as *mut crate::ObjectHeader;
             if !obj.is_null() {
-                let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                let key = js_string_from_bytes(cache_name.as_ptr(), cache_name.len() as u32);
                 let val = js_string_from_bytes(v_str.as_ptr(), v_str.len() as u32);
                 let val_f64 = f64::from_bits(JSValue::string_ptr(val).bits());
-                crate::object::js_object_set_field_by_name(obj, key, val_f64);
+                with_env_cache_mutation(|| {
+                    crate::object::js_object_set_field_by_name(obj, key, val_f64);
+                });
             }
         }
     }
@@ -1040,17 +1034,26 @@ static KEEP_JS_MODULE_RESOLVE_LOOKUP_PATHS: extern "C" fn(f64, f64) -> f64 =
 #[no_mangle]
 pub extern "C" fn js_removeenv(name_ptr: *const StringHeader) {
     unsafe {
-        if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
+        let name = match env_name_from_header(name_ptr) {
+            Some(name) => name,
+            None => return,
+        };
+        if !env_name_is_settable(name) {
             return;
         }
-        let len = (*name_ptr).byte_len as usize;
-        let data_ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-        let name_bytes = std::slice::from_raw_parts(data_ptr, len);
-        let name = match std::str::from_utf8(name_bytes) {
-            Ok(s) => s,
-            Err(_) => return,
-        };
+        let cache_name = env_cache_name_for_remove(name);
         std::env::remove_var(name);
+
+        let cached = CACHED_ENV.with(|c| c.get());
+        if cached != 0.0 {
+            let obj = crate::value::js_nanbox_get_pointer(cached) as *mut crate::ObjectHeader;
+            if !obj.is_null() {
+                let key = js_string_from_bytes(cache_name.as_ptr(), cache_name.len() as u32);
+                with_env_cache_mutation(|| {
+                    crate::object::js_object_delete_field(obj, key);
+                });
+            }
+        }
     }
 }
 
@@ -1071,6 +1074,87 @@ pub extern "C" fn js_process_env() -> f64 {
 
 thread_local! {
     static CACHED_ENV: std::cell::Cell<f64> = const { std::cell::Cell::new(0.0) };
+    /// Prevent the cached object's internal mirror update from re-entering the
+    /// `process.env` object hooks and calling `set_var` / `remove_var` again.
+    static ENV_CACHE_MUTATION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(windows)]
+thread_local! {
+    /// Folded Windows name -> first spelling exposed through Object.keys().
+    static ENV_KEY_CASING: std::cell::RefCell<HashMap<String, String>> =
+        std::cell::RefCell::new(HashMap::new());
+}
+
+unsafe fn env_name_from_header<'a>(name_ptr: *const StringHeader) -> Option<&'a str> {
+    if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
+        return None;
+    }
+    let len = unsafe { (*name_ptr).byte_len as usize };
+    let data_ptr = unsafe { (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>()) };
+    std::str::from_utf8(unsafe { std::slice::from_raw_parts(data_ptr, len) }).ok()
+}
+
+fn with_env_cache_mutation<R>(f: impl FnOnce() -> R) -> R {
+    ENV_CACHE_MUTATION.with(|active| {
+        let previous = active.replace(true);
+        let result = f();
+        active.set(previous);
+        result
+    })
+}
+
+fn env_cache_mutation_active() -> bool {
+    ENV_CACHE_MUTATION.with(|active| active.get())
+}
+
+#[cfg(any(windows, test))]
+fn windows_env_key_identity(name: &str) -> String {
+    name.to_uppercase()
+}
+
+#[cfg(windows)]
+fn existing_windows_env_name(name: &str) -> Option<String> {
+    let identity = windows_env_key_identity(name);
+    std::env::vars()
+        .find(|(candidate, _)| windows_env_key_identity(candidate) == identity)
+        .map(|(candidate, _)| candidate)
+}
+
+#[cfg(windows)]
+fn env_cache_name_for_set(name: &str) -> String {
+    let identity = windows_env_key_identity(name);
+    ENV_KEY_CASING.with(|casing| {
+        let mut casing = casing.borrow_mut();
+        if let Some(existing) = casing.get(&identity) {
+            return existing.clone();
+        }
+        let display = existing_windows_env_name(name).unwrap_or_else(|| name.to_string());
+        casing.insert(identity, display.clone());
+        display
+    })
+}
+
+#[cfg(not(windows))]
+fn env_cache_name_for_set(name: &str) -> String {
+    name.to_string()
+}
+
+#[cfg(windows)]
+fn env_cache_name_for_remove(name: &str) -> String {
+    let identity = windows_env_key_identity(name);
+    ENV_KEY_CASING.with(|casing| {
+        casing
+            .borrow_mut()
+            .remove(&identity)
+            .or_else(|| existing_windows_env_name(name))
+            .unwrap_or_else(|| name.to_string())
+    })
+}
+
+#[cfg(not(windows))]
+fn env_cache_name_for_remove(name: &str) -> String {
+    name.to_string()
 }
 
 /// Is `value` the live `process.env` object? Writes to it must reach the real
@@ -1095,7 +1179,74 @@ pub fn is_process_env_ptr(addr: usize) -> bool {
     if cached == 0.0 {
         return false;
     }
+    let addr = if (addr as u64) >> 48 == 0x7FFD {
+        addr & crate::value::POINTER_MASK as usize
+    } else {
+        addr
+    };
     crate::value::js_nanbox_get_pointer(cached) as usize == addr
+}
+
+/// Intercept a generic property read on an aliased `process.env` object.
+///
+/// Direct `process.env.KEY` reads are lowered to `js_getenv_value`, but reads
+/// through `const env = process.env` use the ordinary object getter. Routing
+/// both through the OS is what supplies Windows' case-insensitive semantics.
+pub(crate) fn process_env_get_field(
+    obj: *const crate::ObjectHeader,
+    key: *const StringHeader,
+) -> Option<JSValue> {
+    if !is_process_env_ptr(obj as usize) {
+        return None;
+    }
+    let value = js_getenv(key);
+    if value.is_null() {
+        // Node's environment interceptor declines an absent key so inherited
+        // Object.prototype properties (for example `env.toString`) can still
+        // resolve through the ordinary path.
+        None
+    } else {
+        Some(JSValue::string_ptr(value))
+    }
+}
+
+/// Intercept a generic property write on an aliased `process.env` object.
+pub(crate) fn process_env_set_field(
+    obj: *mut crate::ObjectHeader,
+    key: *const StringHeader,
+    value: f64,
+) -> bool {
+    if env_cache_mutation_active() || !is_process_env_ptr(obj as usize) {
+        return false;
+    }
+    js_setenv(key, value);
+    true
+}
+
+/// Intercept a generic property delete on an aliased `process.env` object.
+pub(crate) fn process_env_delete_field(
+    obj: *mut crate::ObjectHeader,
+    key: *const StringHeader,
+) -> Option<i32> {
+    if env_cache_mutation_active() || !is_process_env_ptr(obj as usize) {
+        return None;
+    }
+    js_removeenv(key);
+    Some(1)
+}
+
+/// Query an environment key without consulting the case-sensitive materialized
+/// object. `std::env` delegates to the case-insensitive OS environment block on
+/// Windows and remains byte/case-sensitive on Unix.
+pub(crate) fn process_env_has_field(
+    obj: *const crate::ObjectHeader,
+    key: *const StringHeader,
+) -> Option<bool> {
+    if !is_process_env_ptr(obj as usize) {
+        return None;
+    }
+    let name = unsafe { env_name_from_header(key) };
+    Some(name.is_some_and(|name| std::env::var_os(name).is_some()))
 }
 
 /// `std::env::set_var` PANICS — and, being called from an `extern "C"` frame,
@@ -1121,6 +1272,13 @@ fn js_process_env_impl() -> f64 {
     let alloc_limit = std::cmp::max(vars.len() as u32, crate::object::INLINE_SLOT_FLOOR as u32);
     let obj = crate::object::js_object_alloc(0, alloc_limit);
     for (k, v) in &vars {
+        #[cfg(windows)]
+        ENV_KEY_CASING.with(|casing| {
+            casing
+                .borrow_mut()
+                .entry(windows_env_key_identity(k))
+                .or_insert_with(|| k.clone());
+        });
         let key = js_string_from_bytes(k.as_ptr(), k.len() as u32);
         let val = js_string_from_bytes(v.as_ptr(), v.len() as u32);
         let val_f64 = f64::from_bits(JSValue::string_ptr(val).bits());
@@ -1794,3 +1952,58 @@ static KEEP_JS_PROCESS_REF: extern "C" fn(f64) -> f64 = js_process_ref;
 #[cfg(feature = "keepalive-anchors")]
 #[used]
 static KEEP_JS_PROCESS_UNREF: extern "C" fn(f64) -> f64 = js_process_unref;
+
+#[cfg(test)]
+mod env_object_tests {
+    use super::*;
+
+    const TEST_KEY: &str = "PERRY_ENV_ALIAS_RUNTIME_TEST_6622";
+
+    #[test]
+    fn windows_key_identity_is_case_insensitive() {
+        assert_eq!(windows_env_key_identity("Path"), "PATH");
+        assert_eq!(
+            windows_env_key_identity("perry_Mixed_Case"),
+            windows_env_key_identity("PERRY_mIXED_cASE")
+        );
+    }
+
+    #[test]
+    fn aliased_env_object_routes_get_set_has_and_delete_to_the_os() {
+        std::env::remove_var(TEST_KEY);
+
+        let env = js_process_env();
+        let obj = crate::value::js_nanbox_get_pointer(env) as *mut crate::ObjectHeader;
+        assert!(!obj.is_null());
+
+        let set_key = js_string_from_bytes(TEST_KEY.as_ptr(), TEST_KEY.len() as u32);
+        let value = "through-alias";
+        let value_ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
+        let value_boxed = f64::from_bits(JSValue::string_ptr(value_ptr).bits());
+        crate::object::js_object_set_field_by_name(obj, set_key, value_boxed);
+
+        let lookup_name = if cfg!(windows) {
+            TEST_KEY.to_ascii_lowercase()
+        } else {
+            TEST_KEY.to_string()
+        };
+        let lookup_key = js_string_from_bytes(lookup_name.as_ptr(), lookup_name.len() as u32);
+        let got = crate::object::js_object_get_field_by_name(obj, lookup_key);
+        assert_eq!(read_js_string_lossy(f64::from_bits(got.bits())), value);
+
+        let key_boxed = f64::from_bits(JSValue::string_ptr(lookup_key).bits());
+        assert_ne!(
+            crate::value::js_is_truthy(crate::object::js_object_has_property(env, key_boxed)),
+            0
+        );
+        assert_ne!(
+            crate::value::js_is_truthy(crate::object::js_object_has_own(env, key_boxed)),
+            0
+        );
+
+        assert_eq!(crate::object::js_object_delete_field(obj, lookup_key), 1);
+        assert!(std::env::var_os(TEST_KEY).is_none());
+        let got = crate::object::js_object_get_field_by_name(obj, set_key);
+        assert!(got.is_undefined());
+    }
+}

--- a/crates/perry-runtime/src/process/env_misc.rs
+++ b/crates/perry-runtime/src/process/env_misc.rs
@@ -762,7 +762,7 @@ pub extern "C" fn js_getenv(name_ptr: *const StringHeader) -> *mut StringHeader 
             None => return std::ptr::null_mut(),
         };
 
-        match std::env::var(name) {
+        match std::env::var(&name) {
             Ok(value) => {
                 // Create a JS string from the value
                 let bytes = value.as_bytes();
@@ -898,7 +898,7 @@ pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
             Some(name) => name,
             None => return,
         };
-        if !env_name_is_settable(name) {
+        if !env_name_is_settable(&name) {
             return;
         }
 
@@ -926,8 +926,8 @@ pub extern "C" fn js_setenv(name_ptr: *const StringHeader, value: f64) {
         // in the environment block. Keep the materialized object's first-seen
         // spelling instead of appending an enumerable alias such as both
         // `Path` and `PATH`.
-        let cache_name = env_cache_name_for_set(name);
-        std::env::set_var(name, v_str);
+        let cache_name = env_cache_name_for_set(&name);
+        std::env::set_var(&name, v_str);
         // Keep the cached `process.env` object in step so enumeration
         // (`Object.keys(process.env)`, `for…in`, spread) sees the new key —
         // reads go through `js_getenv`, but enumeration walks this object.
@@ -1038,11 +1038,11 @@ pub extern "C" fn js_removeenv(name_ptr: *const StringHeader) {
             Some(name) => name,
             None => return,
         };
-        if !env_name_is_settable(name) {
+        if !env_name_is_settable(&name) {
             return;
         }
-        let cache_name = env_cache_name_for_remove(name);
-        std::env::remove_var(name);
+        let cache_name = env_cache_name_for_remove(&name);
+        std::env::remove_var(&name);
 
         let cached = CACHED_ENV.with(|c| c.get());
         if cached != 0.0 {
@@ -1086,21 +1086,35 @@ thread_local! {
         std::cell::RefCell::new(HashMap::new());
 }
 
-unsafe fn env_name_from_header<'a>(name_ptr: *const StringHeader) -> Option<&'a str> {
+unsafe fn env_name_from_header(name_ptr: *const StringHeader) -> Option<String> {
     if name_ptr.is_null() || (name_ptr as usize) < 0x1000 {
         return None;
     }
     let len = unsafe { (*name_ptr).byte_len as usize };
     let data_ptr = unsafe { (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>()) };
-    std::str::from_utf8(unsafe { std::slice::from_raw_parts(data_ptr, len) }).ok()
+    std::str::from_utf8(unsafe { std::slice::from_raw_parts(data_ptr, len) })
+        .ok()
+        .map(str::to_owned)
+}
+
+struct EnvCacheMutationGuard<'a> {
+    active: &'a std::cell::Cell<bool>,
+    previous: bool,
+}
+
+impl Drop for EnvCacheMutationGuard<'_> {
+    fn drop(&mut self) {
+        self.active.set(self.previous);
+    }
 }
 
 fn with_env_cache_mutation<R>(f: impl FnOnce() -> R) -> R {
     ENV_CACHE_MUTATION.with(|active| {
-        let previous = active.replace(true);
-        let result = f();
-        active.set(previous);
-        result
+        let _guard = EnvCacheMutationGuard {
+            active,
+            previous: active.replace(true),
+        };
+        f()
     })
 }
 
@@ -1966,6 +1980,16 @@ mod env_object_tests {
             windows_env_key_identity("perry_Mixed_Case"),
             windows_env_key_identity("PERRY_mIXED_cASE")
         );
+    }
+
+    #[test]
+    fn env_cache_mutation_flag_is_restored_after_unwind() {
+        assert!(!env_cache_mutation_active());
+        let result = std::panic::catch_unwind(|| {
+            with_env_cache_mutation(|| panic!("simulated JS exception"));
+        });
+        assert!(result.is_err());
+        assert!(!env_cache_mutation_active());
     }
 
     #[test]

--- a/test-parity/node-suite/process/env/windows-case-insensitive.ts
+++ b/test-parity/node-suite/process/env/windows-case-insensitive.ts
@@ -1,0 +1,40 @@
+import process from "node:process";
+
+const env = process.env;
+const original = "Perry_Case_Insensitive_6622";
+const upper = original.toUpperCase();
+const lower = original.toLowerCase();
+
+if (process.platform === "win32") {
+  delete env[lower];
+  env[original] = "first";
+  console.log("case get:", env[upper] === "first");
+  console.log("case has:", upper in env, Object.hasOwn(env, lower));
+  console.log(
+    "one enumerated spelling:",
+    Object.keys(env).filter((key) => key.toUpperCase() === upper).length === 1,
+  );
+
+  env[upper] = "second";
+  console.log(
+    "case set:",
+    env[lower] === "second",
+    Object.keys(env).includes(original),
+  );
+  delete env[lower];
+  console.log(
+    "case delete:",
+    env[upper] === undefined,
+    !(upper in env),
+    !Object.hasOwn(env, original),
+    !Object.keys(env).some((key) => key.toUpperCase() === upper),
+  );
+} else {
+  // Keep the fixture's output stable on Unix, where environment names remain
+  // case-sensitive.
+  console.log("case get:", true);
+  console.log("case has:", true, true);
+  console.log("one enumerated spelling:", true);
+  console.log("case set:", true, true);
+  console.log("case delete:", true, true, true, true);
+}

--- a/test-parity/node-suite/process/env/write.ts
+++ b/test-parity/node-suite/process/env/write.ts
@@ -6,8 +6,24 @@ process.env.PERRY_NUM = 42 as any;
 console.log("coerced:", process.env.PERRY_NUM, typeof process.env.PERRY_NUM);
 const computedKey = "PERRY_COMPUTED";
 process.env[computedKey] = true as any;
-console.log("computed:", process.env[computedKey], typeof process.env[computedKey]);
+console.log(
+  "computed:",
+  process.env[computedKey],
+  typeof process.env[computedKey],
+);
 delete process.env.PERRY_RT;
 console.log("after delete:", process.env.PERRY_RT);
 delete process.env[computedKey];
 console.log("after computed delete:", process.env[computedKey]);
+
+const envAlias = process.env;
+envAlias.PERRY_ALIAS = "via alias";
+console.log(
+  "alias set/get/has:",
+  process.env.PERRY_ALIAS,
+  "PERRY_ALIAS" in envAlias,
+  Object.hasOwn(envAlias, "PERRY_ALIAS"),
+);
+console.log("alias prototype:", typeof envAlias.toString);
+delete envAlias.PERRY_ALIAS;
+console.log("alias delete:", process.env.PERRY_ALIAS);


### PR DESCRIPTION
Fixes #6622

## Summary
- route generic/aliased `process.env` get, set, membership, own-key, and delete operations through the live OS environment
- preserve the first-seen Windows key spelling for enumeration while resolving names case-insensitively
- keep the materialized environment object synchronized and retain normal prototype fallback
- add alias and Windows case-insensitivity parity coverage plus focused runtime tests

## Validation
- `cargo test -p perry-runtime process::env_misc::env_object_tests`
- `cargo check --tests --no-default-features --features full,regex-engine,diagnostics --target x86_64-pc-windows-msvc -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module process --filter process/env/write`
- `./run_parity_tests.sh --suite node-suite --module process --filter windows-case-insensitive`
- `cargo fmt --all -- --check`
- `deno fmt --check test-parity/node-suite/process/env/write.ts test-parity/node-suite/process/env/windows-case-insensitive.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows `process.env` access to be case-insensitive.
  * Preserved the original environment-variable casing during enumeration.
  * Improved consistency for reading, writing, checking, and deleting environment variables through aliases.

* **Tests**
  * Added coverage for Windows casing behavior and aliased `process.env` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->