### PR TITLE
fix(ci): restore Windows documentation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2091,20 +2091,22 @@ jobs:
           #   cmd_xcompile_blocking: "./scripts/run_doc_tests.sh --verbose --xcompile-only --xcompile-only-target=web --xcompile-only-target=wasm --xcompile-only-target=ios-simulator"
           #   cmd_xcompile_advisory: "./scripts/run_doc_tests.sh --verbose --xcompile-only"
           #   gallery_advisory: false
-          # windows-2022 doc-tests for perry-ui-windows temporarily disabled:
-          # 30+ doc-test snippets COMPILE_FAIL on the Windows runner with
-          # perry exit 1 (mix of platform-banner gaps and #463-unimplemented
-          # node:* surface). Tracked separately; re-enable once the snippet
-          # set + perry-ui-windows compile paths are reconciled. macOS
-          # doc-tests still gate the release.
-          # - os: windows-2022
-          #   ui_backend: perry-ui-windows
-          #   shell: pwsh
-          #   cmd_exclude_gallery: "./scripts/run_doc_tests.ps1 --verbose --skip-xcompile --filter-exclude ui/gallery.ts"
-          #   cmd_gallery: "./scripts/run_doc_tests.ps1 --verbose --skip-xcompile --filter ui/gallery.ts"
-          #   cmd_xcompile_blocking: "./scripts/run_doc_tests.ps1 --verbose --xcompile-only --xcompile-only-target=web --xcompile-only-target=wasm --xcompile-only-target=ios-simulator"
-          #   cmd_xcompile_advisory: "./scripts/run_doc_tests.ps1 --verbose --xcompile-only"
-          #   gallery_advisory: false
+          # Re-enabled for #6624. The old 30+ COMPILE_FAIL cluster was mostly
+          # one staticlib-boundary link gap: WinHTTP + SHCreateMemStream import
+          # metadata did not reach Perry's final MSVC link. The compiler now
+          # supplies winhttp.lib + shlwapi.lib explicitly, while later API
+          # work closed the stale #463/WebView failures from that run.
+          - os: windows-2022
+            ui_backend: perry-ui-windows
+            shell: pwsh
+            # The well-known HTTP aggregate remains excluded on every host
+            # while its no-auto ext-archive routing issue is tracked.
+            cmd_exclude_gallery: "./scripts/run_doc_tests.ps1 --verbose --skip-xcompile --filter-exclude ui/gallery.ts --filter-exclude stdlib/http/snippets.ts"
+            cmd_gallery: "./scripts/run_doc_tests.ps1 --verbose --skip-xcompile --filter ui/gallery.ts"
+            cmd_xcompile_blocking: "./scripts/run_doc_tests.ps1 --verbose --xcompile-only --xcompile-only-target=web --xcompile-only-target=wasm"
+            cmd_xcompile_advisory: "./scripts/run_doc_tests.ps1 --verbose --xcompile-only"
+            # Baseline captured from run #24735151417 (900x788).
+            gallery_advisory: false
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2035,9 +2035,8 @@ jobs:
   # demand. PR authors and maintainers can both apply labels.
   # ---------------------------------------------------------------------------
   doc-tests:
-    # Release-publish decoupling (see `parity` above): aspirational extended
-    # suite, informational only — does not block package publishing.
-    continue-on-error: true
+    # Blocking host runs and the portable cross-compile subset gate the job.
+    # Known platform-tail failures remain advisory at their individual steps.
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_extended_tests) ||

--- a/changelog.d/7083-windows-doc-tests.md
+++ b/changelog.d/7083-windows-doc-tests.md
@@ -1,0 +1,1 @@
+fix(ci): restore Windows documentation tests and preserve required UI system libraries across static linking

--- a/crates/perry/src/commands/compile/link/windows_link.rs
+++ b/crates/perry/src/commands/compile/link/windows_link.rs
@@ -36,6 +36,12 @@ pub(super) fn add_system_libs(cmd: &mut Command) {
         .arg("msimg32.lib")
         .arg("kernel32.lib")
         .arg("shell32.lib")
+        // shlwapi.lib exports SHCreateMemStream, used by the Windows Image
+        // widget to hand downloaded bytes to GDI+. Like WinHTTP below, the
+        // windows-rs #[link] metadata is lost through perry-ui-windows's
+        // staticlib boundary; omitting this import library made every UI
+        // doc-test fail with LNK2019.
+        .arg("shlwapi.lib")
         .arg("ole32.lib")
         .arg("comctl32.lib")
         .arg("advapi32.lib")
@@ -67,6 +73,23 @@ pub(super) fn add_system_libs(cmd: &mut Command) {
         // through perry-ui-windows's `staticlib` crate-type to perry's final
         // link line. Closes #732.
         .arg("winhttp.lib");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_widget_system_imports_survive_the_staticlib_boundary() {
+        let mut command = Command::new("link.exe");
+        add_system_libs(&mut command);
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.iter().any(|arg| arg == "shlwapi.lib"));
+        assert!(args.iter().any(|arg| arg == "winhttp.lib"));
+    }
 }
 
 /// Embed the comctl32 v6 application manifest into a UI executable so common

--- a/scripts/run_doc_tests.ps1
+++ b/scripts/run_doc_tests.ps1
@@ -17,9 +17,19 @@ cargo build --release `
     -p perry `
     -p perry-runtime `
     -p perry-stdlib `
+    -p perry-runtime-static `
+    -p perry-stdlib-static `
     -p perry-ui-windows `
     -p perry-doc-tests
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Host doc-tests can reuse the full prebuilt runtime/stdlib archives above.
+# This mirrors run_doc_tests.sh and avoids a feature-specialized Cargo rebuild
+# for each of ~90 examples. Cross-compile runs must leave auto-optimization on
+# because it is what produces target-specific archives.
+if ($Args -notcontains '--xcompile-only') {
+    $env:PERRY_NO_AUTO_OPTIMIZE = '1'
+}
 
 $ReportDir = Join-Path $RepoRoot 'docs\examples\_reports'
 New-Item -ItemType Directory -Force -Path $ReportDir | Out-Null


### PR DESCRIPTION
Closes #6624

## Summary
- restore the Windows documentation-test matrix entry
- link `shlwapi.lib` explicitly across the `perry-ui-windows` staticlib boundary
- prebuild the static runtime/stdlib wrappers and reuse them for host doc tests
- keep web/wasm cross-compilation in the blocking Windows pass

## Validation
- `cargo test -p perry image_widget_system_imports_survive_the_staticlib_boundary`
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint .github/workflows/test.yml` (only pre-existing shellcheck findings)

The PR will be labeled `run-extended-tests` so the restored Windows matrix runs before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Windows documentation test coverage in CI.
  * Fixed Windows static-link builds by preserving required system libraries.
  * Improved documentation test setup for host and cross-compilation scenarios.

* **Tests**
  * Added validation to ensure required Windows networking and shell libraries are included during linking.
  * Limited blocking cross-compilation checks to supported web and WebAssembly targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->