### PR TITLE
feat(windows): add executable metadata and signing

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -697,6 +697,61 @@ jobs:
         run: |
           cargo install xwin --locked --version 0.9.0 --root xwin-install --target ${{ matrix.target }}
 
+      # Optional Authenticode signing. Configure a base64-encoded PFX and its
+      # password to enable this; repositories without a certificate continue
+      # to publish the VERSIONINFO-bearing unsigned binary.
+      - name: Sign perry.exe with Authenticode (when configured)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          WINDOWS_CODE_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_CODE_SIGNING_PFX_BASE64 }}
+          WINDOWS_CODE_SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PFX_PASSWORD }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:WINDOWS_CODE_SIGNING_PFX_BASE64) {
+            Write-Host 'WINDOWS_CODE_SIGNING_PFX_BASE64 is not configured; leaving perry.exe unsigned.'
+            exit 0
+          }
+          if (-not $env:WINDOWS_CODE_SIGNING_PFX_PASSWORD) {
+            throw 'WINDOWS_CODE_SIGNING_PFX_BASE64 is configured but WINDOWS_CODE_SIGNING_PFX_PASSWORD is missing.'
+          }
+
+          $binary = "target/${{ matrix.target }}/dist/perry.exe"
+          $certificate = Join-Path $env:RUNNER_TEMP 'perry-code-signing.pfx'
+          try {
+            $certificateBytes = [Convert]::FromBase64String($env:WINDOWS_CODE_SIGNING_PFX_BASE64)
+            [IO.File]::WriteAllBytes($certificate, $certificateBytes)
+
+            $signtoolCommand = Get-Command signtool.exe -ErrorAction SilentlyContinue
+            if ($signtoolCommand) {
+              $signtool = $signtoolCommand.Source
+            } else {
+              $kitsBin = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin'
+              $signtool = Get-ChildItem "$kitsBin\*\x64\signtool.exe" |
+                Sort-Object { [version]$_.Directory.Parent.Name } -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+            if (-not $signtool) {
+              throw 'signtool.exe was not found in PATH or the Windows 10 SDK.'
+            }
+
+            & $signtool sign /fd SHA256 /tr https://timestamp.digicert.com /td SHA256 `
+              /d 'Perry native TypeScript compiler' /f $certificate `
+              /p $env:WINDOWS_CODE_SIGNING_PFX_PASSWORD $binary
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool sign failed with exit code $LASTEXITCODE"
+            }
+
+            & $signtool verify /pa /v $binary
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool verify failed with exit code $LASTEXITCODE"
+            }
+          } finally {
+            if (Test-Path $certificate) {
+              Remove-Item -Force $certificate
+            }
+          }
+
       - name: Package release archive (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -824,6 +824,31 @@ jobs:
       - name: Build compiler + runtime + Windows UI crates (perry-dev)
         run: cargo build --profile perry-dev -p perry -p perry-runtime -p perry-stdlib -p perry-ui-windows -p perry-ui-windows-winui
 
+      - name: Verify perry.exe VERSIONINFO resource
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $binary = 'target/perry-dev/perry.exe'
+          $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
+          $expectedVersion = ($metadata.packages | Where-Object name -eq 'perry').version
+          $version = (Get-Item $binary).VersionInfo
+
+          $expectedFields = @{
+            CompanyName      = 'PerryTS'
+            FileDescription  = 'Perry native TypeScript compiler'
+            OriginalFilename = 'perry.exe'
+            ProductName      = 'Perry'
+          }
+          foreach ($field in $expectedFields.Keys) {
+            if ($version.$field -ne $expectedFields[$field]) {
+              throw "$field missing or incorrect in ${binary}: '$($version.$field)'"
+            }
+          }
+          if (-not $version.FileVersion.StartsWith($expectedVersion) -or
+              -not $version.ProductVersion.StartsWith($expectedVersion)) {
+            throw "VERSIONINFO does not match Cargo version $expectedVersion (file=$($version.FileVersion), product=$($version.ProductVersion))"
+          }
+
   # ---------------------------------------------------------------------------
   # GC write-barrier stress (optional / non-blocking)
   #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5556,6 +5556,7 @@ dependencies = [
  "url",
  "walkdir",
  "windows-sys 0.61.2",
+ "winresource",
  "zip",
  "zstd",
 ]
@@ -10447,6 +10448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/changelog.d/7084-windows-version-signing.md
+++ b/changelog.d/7084-windows-version-signing.md
@@ -1,0 +1,1 @@
+feat(windows): embed version metadata in perry.exe and support optional Authenticode signing for releases

--- a/crates/perry/Cargo.toml
+++ b/crates/perry/Cargo.toml
@@ -5,6 +5,13 @@ edition.workspace = true
 license.workspace = true
 description = "Native TypeScript compiler - CLI driver"
 
+[package.metadata.winresource]
+CompanyName = "PerryTS"
+FileDescription = "Perry native TypeScript compiler"
+LegalCopyright = "Copyright © PerryTS contributors"
+OriginalFilename = "perry.exe"
+ProductName = "Perry"
+
 [lints]
 workspace = true
 
@@ -156,3 +163,6 @@ all-codegen-backends = [
 [dev-dependencies]
 tempfile.workspace = true
 swc_common.workspace = true
+
+[build-dependencies]
+winresource = "0.1.31"

--- a/crates/perry/build.rs
+++ b/crates/perry/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    if std::env::var_os("CARGO_CFG_TARGET_OS").as_deref() != Some(std::ffi::OsStr::new("windows")) {
+        return;
+    }
+
+    // Windows Explorer reads these fields from the executable's VERSIONINFO
+    // resource. `WindowsResource::new` takes the file/product version from
+    // CARGO_PKG_VERSION and the descriptive fields from Cargo.toml.
+    winresource::WindowsResource::new()
+        .compile()
+        .expect("failed to compile perry.exe VERSIONINFO resource");
+}


### PR DESCRIPTION
Closes #6625

## Summary
- embed a Windows `VERSIONINFO` resource in `perry.exe`, with the numeric/string version sourced from Cargo metadata
- verify the resource fields in the required Windows build job
- optionally Authenticode-sign and RFC 3161 timestamp release binaries when the repository PFX secrets are configured
- verify the resulting Authenticode signature before packaging

## Release configuration
Set `WINDOWS_CODE_SIGNING_PFX_BASE64` to a base64-encoded PFX and `WINDOWS_CODE_SIGNING_PFX_PASSWORD` to its password. Without those secrets, release packaging remains intentionally unsigned and logs that signing was skipped.

## Validation
- `cargo check -p perry --bin perry`
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint .github/workflows/test.yml .github/workflows/release-packages.yml` (only pre-existing shellcheck findings)

The Windows CI job performs the authoritative PE resource check.