### PR TITLE
fix(worker_threads): preserve structured clone values

### DIFF
--- a/changelog.d/7091-worker-structured-clone.md
+++ b/changelog.d/7091-worker-structured-clone.md
@@ -1,0 +1,1 @@
+Fixed worker-thread message channels preserving typed arrays and ArrayBuffers, recursively rejecting uncloneable values, and reporting branded structured-clone errors.

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -53,14 +53,14 @@ const MAX_TRY_DEPTH: usize = 1024;
 /// B (its stack frame doesn't exist there) — so the buffers, the depth
 /// counter, the current exception, and the finally-flag all have to
 /// live in TLS once `perry/thread` workers can run user code that
-/// throws. Previously all five were process-wide `static mut`s and would
+/// throws. Previously this state was process-wide `static mut` data and would
 /// corrupt under any concurrent throw.
-// arm64_32 fix: the three per-depth arrays are HEAP-allocated (`Box<[..]>`)
+// arm64_32 fix: the per-depth arrays are HEAP-allocated (`Box<[..]>`)
 // instead of stored inline in TLS. At MAX_TRY_DEPTH=1024 they are ~280KB of
 // initialized thread-local data (`jump_buffers` alone is 1024 * 256B = 256KB),
 // which overflows ld64's 64KB `__thread_data` cap for arm64_32 (and the ILP32
-// TLS layout generally). Boxing leaves only three fat pointers + scalars inline
-// in TLS; the arrays live on the heap. `[T]` indexing on `Box<[T]>` is
+// TLS layout generally). Boxing leaves only fat pointers + scalars inline in
+// TLS; the arrays live on the heap. `[T]` indexing on `Box<[T]>` is
 // unchanged, so the accessors below need no edits. (Mirrors the
 // TRANSITION_CACHE / VTABLE_IC / INTERN_TABLE boxing.)
 struct ExceptionState {
@@ -81,6 +81,10 @@ struct ExceptionState {
     /// `call_method_depth_*`). Indexed by try-depth, in lockstep with
     /// `jump_buffers`.
     call_method_depths: Box<[u32]>,
+    /// Recorded-prototype lookup stack depth. A getter can throw while
+    /// `resolve_inherited_field` is recursively walking; longjmp skips its
+    /// guard drops, so restore the stack to this try-entry savepoint.
+    prototype_resolution_depths: Box<[usize]>,
     /// #6559: dyn-eval interpreter state (rooted-stack length + interpreter
     /// call depth, packed) captured when each `try` was pushed. A throw
     /// `longjmp`s past interpreter Rust frames without running their
@@ -104,6 +108,7 @@ impl ExceptionState {
             shadow_savepoints: vec![ShadowSavepoint::EMPTY; MAX_TRY_DEPTH].into_boxed_slice(),
             runtime_handle_savepoints: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
             call_method_depths: vec![0u32; MAX_TRY_DEPTH].into_boxed_slice(),
+            prototype_resolution_depths: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
             #[cfg(feature = "dyn-eval")]
             dyn_eval_savepoints: vec![0u64; MAX_TRY_DEPTH].into_boxed_slice(),
             try_depth: 0,
@@ -142,6 +147,8 @@ pub extern "C" fn js_try_push() -> *mut i32 {
         // this `try` can restore it — `longjmp` skips the `CallMethodDepthGuard`
         // `Drop`s of the method frames it unwinds (#5591).
         (*s).call_method_depths[depth] = crate::object::call_method_depth_savepoint();
+        (*s).prototype_resolution_depths[depth] =
+            crate::object::prototype_chain::resolution_stack_savepoint();
         // #6559: capture the dyn-eval interpreter's rooted-stack length +
         // call depth, so a caught throw restores interpreter state exactly
         // like the shadow stack.
@@ -250,6 +257,9 @@ pub extern "C" fn js_throw(value: f64) -> ! {
         // per caught throw and eventually wedges every method call into the
         // depth-guard fallback (#5591).
         crate::object::call_method_depth_restore((*s).call_method_depths[depth]);
+        crate::object::prototype_chain::resolution_stack_restore(
+            (*s).prototype_resolution_depths[depth],
+        );
         // #6559: restore the dyn-eval interpreter's rooted stack + call depth
         // (interpreter Rust frames unwound by this longjmp never run their
         // truncate/decrement epilogues).
@@ -449,6 +459,9 @@ pub(crate) fn test_unwind_innermost_shadow_restore() {
         let depth = (*s).try_depth - 1;
         shadow_stack_restore((*s).shadow_savepoints[depth]);
         runtime_handle_stack_restore((*s).runtime_handle_savepoints[depth]);
+        crate::object::prototype_chain::resolution_stack_restore(
+            (*s).prototype_resolution_depths[depth],
+        );
     });
 }
 

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -459,6 +459,12 @@ pub fn gc_init() {
     // stale address against a forwarding-resolved receiver, which defeats its
     // own self-recursion guard and drives the mutator into unbounded recursion.
     gc_register_mutable_root_scanner(crate::array::scan_prototype_addr_cache_roots_mut);
+    // #6763: inherited-property resolution retains an owner while an accessor
+    // or Proxy trap can re-enter after moving GC. Rewrite that temporary
+    // identity so malformed prototype cycles remain bounded.
+    gc_register_mutable_root_scanner(
+        crate::object::prototype_chain::scan_prototype_resolution_stack_roots_mut,
+    );
     gc_register_mutable_root_scanner(crate::map::scan_map_iterator_array_roots_mut);
     gc_register_mutable_root_scanner(crate::set::scan_set_iterator_array_roots_mut);
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -327,6 +327,55 @@ fn test_runtime_root_visitor_marks_and_rewrites_nanbox_slot() {
 }
 
 #[test]
+fn test_prototype_resolution_stack_rewrites_owner_for_gc_reentry() {
+    let base_depth = crate::object::prototype_chain::resolution_stack_savepoint();
+    let nursery_owner = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    let valid_ptrs = build_valid_pointer_set();
+    let relocated_owner = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
+    unsafe {
+        set_forwarding_address(
+            header_from_user_ptr(nursery_owner) as *mut GcHeader,
+            relocated_owner,
+        );
+    }
+
+    assert!(
+        crate::object::prototype_chain::test_resolution_stack_enter_and_forget(
+            nursery_owner as usize,
+        )
+    );
+    crate::object::prototype_chain::scan_prototype_resolution_stack_roots_mut(
+        &mut RuntimeRootVisitor::for_rewrite(&valid_ptrs),
+    );
+    let reentry_was_blocked =
+        !crate::object::prototype_chain::test_resolution_stack_enter_and_forget(
+            relocated_owner as usize,
+        );
+    crate::object::prototype_chain::resolution_stack_restore(base_depth);
+
+    assert!(
+        reentry_was_blocked,
+        "a post-GC reentrant lookup must match the rewritten active-owner slot"
+    );
+}
+
+#[test]
+fn test_prototype_resolution_stack_scanner_is_registered() {
+    crate::gc::gc_init();
+    let registered = crate::gc::roots::MUTABLE_ROOT_SCANNERS.with(|scanners| {
+        scanners.borrow().iter().any(|entry| {
+            entry.scanner as usize
+                == crate::object::prototype_chain::scan_prototype_resolution_stack_roots_mut
+                    as MutableRootScanner as usize
+        })
+    });
+    assert!(
+        registered,
+        "the active prototype-resolution identities must be visible to moving GC"
+    );
+}
+
+#[test]
 fn test_implicit_this_root_scanner_marks_and_rewrites() {
     // Regression for #1813. The implicit-`this` cell holds the NaN-boxed
     // receiver across a dynamically-dispatched non-arrow method body. Under a

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -541,6 +541,34 @@ pub extern "C" fn js_object_get_field_by_name(
                         }
                         _ => {}
                     }
+
+                    // A typed array reached through an `any`-typed value uses
+                    // this generic property getter instead of codegen's typed
+                    // method path. Resolve inherited methods/accessors through
+                    // the instance's actual prototype, preserving custom
+                    // `Reflect.construct` prototypes before the intrinsic
+                    // per-kind prototype fallback. Without this,
+                    // structured-cloned views had the right brand and bytes
+                    // but reads such as `cloned.join` returned `undefined`.
+                    let proto = match super::super::prototype_chain::object_static_prototype(addr) {
+                        Some(crate::value::TAG_NULL) => None,
+                        Some(bits) => Some(f64::from_bits(bits)),
+                        None => Some(crate::object::builtin_prototype_value(
+                            crate::typedarray::name_for_kind(kind),
+                        )),
+                    };
+                    if let Some(proto) = proto {
+                        let proto_value = JSValue::from_bits(proto.to_bits());
+                        if proto_value.is_pointer() {
+                            let inherited = super::super::js_object_get_field_by_name(
+                                proto_value.as_pointer::<ObjectHeader>(),
+                                key,
+                            );
+                            if !inherited.is_undefined() {
+                                return inherited;
+                            }
+                        }
+                    }
                 } else {
                     let buf = addr as *const crate::buffer::BufferHeader;
                     match key_bytes {
@@ -579,6 +607,28 @@ pub extern "C" fn js_object_get_field_by_name(
                             return JSValue::from_bits(ctor.to_bits());
                         }
                         _ => {}
+                    }
+
+                    // Buffer-backed Uint8Arrays share the intrinsic
+                    // Uint8Array prototype. Like the TypedArrayHeader branch
+                    // above, this is required when the receiver's static type
+                    // has been erased (for example by structured clone).
+                    let proto = match super::super::prototype_chain::object_static_prototype(addr) {
+                        Some(crate::value::TAG_NULL) => None,
+                        Some(bits) => Some(f64::from_bits(bits)),
+                        None => Some(crate::object::builtin_prototype_value("Uint8Array")),
+                    };
+                    if let Some(proto) = proto {
+                        let proto_value = JSValue::from_bits(proto.to_bits());
+                        if proto_value.is_pointer() {
+                            let inherited = super::super::js_object_get_field_by_name(
+                                proto_value.as_pointer::<ObjectHeader>(),
+                                key,
+                            );
+                            if !inherited.is_undefined() {
+                                return inherited;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -513,10 +513,12 @@ pub extern "C" fn js_object_get_field_by_name(
                                 super::super::prototype_chain::object_static_prototype(addr)
                             {
                                 if proto_bits != crate::value::TAG_NULL {
-                                    let proto = JSValue::from_bits(proto_bits);
-                                    if proto.is_pointer() {
-                                        let p = proto.as_pointer::<ObjectHeader>();
-                                        return super::super::js_object_get_field_by_name(p, key);
+                                    if let Some(inherited) =
+                                        super::super::prototype_chain::resolve_inherited_field(
+                                            addr, key,
+                                        )
+                                    {
+                                        return inherited;
                                     }
                                 }
                             }
@@ -550,22 +552,28 @@ pub extern "C" fn js_object_get_field_by_name(
                     // per-kind prototype fallback. Without this,
                     // structured-cloned views had the right brand and bytes
                     // but reads such as `cloned.join` returned `undefined`.
-                    let proto = match super::super::prototype_chain::object_static_prototype(addr) {
-                        Some(crate::value::TAG_NULL) => None,
-                        Some(bits) => Some(f64::from_bits(bits)),
-                        None => Some(crate::object::builtin_prototype_value(
-                            crate::typedarray::name_for_kind(kind),
-                        )),
-                    };
-                    if let Some(proto) = proto {
-                        let proto_value = JSValue::from_bits(proto.to_bits());
-                        if proto_value.is_pointer() {
-                            let inherited = super::super::js_object_get_field_by_name(
-                                proto_value.as_pointer::<ObjectHeader>(),
-                                key,
-                            );
-                            if !inherited.is_undefined() {
+                    match super::super::prototype_chain::object_static_prototype(addr) {
+                        Some(crate::value::TAG_NULL) => {}
+                        Some(_) => {
+                            if let Some(inherited) =
+                                super::super::prototype_chain::resolve_inherited_field(addr, key)
+                            {
                                 return inherited;
+                            }
+                        }
+                        None => {
+                            let proto = crate::object::builtin_prototype_value(
+                                crate::typedarray::name_for_kind(kind),
+                            );
+                            let proto_value = JSValue::from_bits(proto.to_bits());
+                            if proto_value.is_pointer() {
+                                let inherited = super::super::js_object_get_field_by_name(
+                                    proto_value.as_pointer::<ObjectHeader>(),
+                                    key,
+                                );
+                                if !inherited.is_undefined() {
+                                    return inherited;
+                                }
                             }
                         }
                     }
@@ -613,20 +621,26 @@ pub extern "C" fn js_object_get_field_by_name(
                     // Uint8Array prototype. Like the TypedArrayHeader branch
                     // above, this is required when the receiver's static type
                     // has been erased (for example by structured clone).
-                    let proto = match super::super::prototype_chain::object_static_prototype(addr) {
-                        Some(crate::value::TAG_NULL) => None,
-                        Some(bits) => Some(f64::from_bits(bits)),
-                        None => Some(crate::object::builtin_prototype_value("Uint8Array")),
-                    };
-                    if let Some(proto) = proto {
-                        let proto_value = JSValue::from_bits(proto.to_bits());
-                        if proto_value.is_pointer() {
-                            let inherited = super::super::js_object_get_field_by_name(
-                                proto_value.as_pointer::<ObjectHeader>(),
-                                key,
-                            );
-                            if !inherited.is_undefined() {
+                    match super::super::prototype_chain::object_static_prototype(addr) {
+                        Some(crate::value::TAG_NULL) => {}
+                        Some(_) => {
+                            if let Some(inherited) =
+                                super::super::prototype_chain::resolve_inherited_field(addr, key)
+                            {
                                 return inherited;
+                            }
+                        }
+                        None => {
+                            let proto = crate::object::builtin_prototype_value("Uint8Array");
+                            let proto_value = JSValue::from_bits(proto.to_bits());
+                            if proto_value.is_pointer() {
+                                let inherited = super::super::js_object_get_field_by_name(
+                                    proto_value.as_pointer::<ObjectHeader>(),
+                                    key,
+                                );
+                                if !inherited.is_undefined() {
+                                    return inherited;
+                                }
                             }
                         }
                     }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -565,15 +565,14 @@ pub extern "C" fn js_object_get_field_by_name(
                             let proto = crate::object::builtin_prototype_value(
                                 crate::typedarray::name_for_kind(kind),
                             );
-                            let proto_value = JSValue::from_bits(proto.to_bits());
-                            if proto_value.is_pointer() {
-                                let inherited = super::super::js_object_get_field_by_name(
-                                    proto_value.as_pointer::<ObjectHeader>(),
+                            if let Some(inherited) = super::super::prototype_chain::
+                                resolve_inherited_field_from_prototype(
+                                    addr,
+                                    proto.to_bits(),
                                     key,
-                                );
-                                if !inherited.is_undefined() {
-                                    return inherited;
-                                }
+                                )
+                            {
+                                return inherited;
                             }
                         }
                     }
@@ -632,15 +631,14 @@ pub extern "C" fn js_object_get_field_by_name(
                         }
                         None => {
                             let proto = crate::object::builtin_prototype_value("Uint8Array");
-                            let proto_value = JSValue::from_bits(proto.to_bits());
-                            if proto_value.is_pointer() {
-                                let inherited = super::super::js_object_get_field_by_name(
-                                    proto_value.as_pointer::<ObjectHeader>(),
+                            if let Some(inherited) = super::super::prototype_chain::
+                                resolve_inherited_field_from_prototype(
+                                    addr,
+                                    proto.to_bits(),
                                     key,
-                                );
-                                if !inherited.is_undefined() {
-                                    return inherited;
-                                }
+                                )
+                            {
+                                return inherited;
                             }
                         }
                     }

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -48,8 +48,10 @@ thread_local! {
     /// Owners currently walking a recorded prototype chain. Although
     /// `Object.setPrototypeOf` normally rejects cycles, residual/native owners
     /// and custom-construction links can still expose a malformed chain. Keep
-    /// recursive property lookup bounded and stop on a repeated owner.
-    static PROTOTYPE_RESOLUTION_STACK: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+    /// recursive property lookup bounded and stop on a repeated owner. These
+    /// are NaN-boxed root slots, not raw addresses: an accessor or Proxy trap
+    /// can collect and move an owner before re-entering property resolution.
+    static PROTOTYPE_RESOLUTION_STACK: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
 }
 const MAX_PROTOTYPE_RESOLUTION_DEPTH: usize = 64;
 
@@ -57,12 +59,14 @@ struct PrototypeResolutionGuard;
 
 impl PrototypeResolutionGuard {
     fn enter(owner: usize) -> Option<Self> {
+        let owner_bits = crate::value::js_nanbox_pointer(owner as i64).to_bits();
         PROTOTYPE_RESOLUTION_STACK.with(|stack| {
             let mut stack = stack.borrow_mut();
-            if stack.len() >= MAX_PROTOTYPE_RESOLUTION_DEPTH || stack.contains(&owner) {
+            if stack.len() >= MAX_PROTOTYPE_RESOLUTION_DEPTH || stack.contains(&owner_bits) {
                 return None;
             }
-            stack.push(owner);
+            crate::gc::runtime_write_barrier_root_nanbox(owner_bits);
+            stack.push(owner_bits);
             Some(Self)
         })
     }
@@ -82,6 +86,30 @@ pub(crate) fn resolution_stack_savepoint() -> usize {
 
 pub(crate) fn resolution_stack_restore(depth: usize) {
     PROTOTYPE_RESOLUTION_STACK.with(|stack| stack.borrow_mut().truncate(depth));
+}
+
+/// GC scanner for owners held across recursive inherited-property resolution.
+///
+/// Getters and Proxy traps may collect before re-entering this resolver. The
+/// scanner both keeps each active owner alive and rewrites its stack slot after
+/// evacuation so the repeated-owner check remains an identity check.
+pub(crate) fn scan_prototype_resolution_stack_roots_mut(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+) {
+    PROTOTYPE_RESOLUTION_STACK.with(|stack| {
+        for owner_bits in stack.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_u64_slot(owner_bits);
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_resolution_stack_enter_and_forget(owner: usize) -> bool {
+    let Some(guard) = PrototypeResolutionGuard::enter(owner) else {
+        return false;
+    };
+    std::mem::forget(guard);
+    true
 }
 
 /// Latched true by the first recorded `Object.setPrototypeOf`. Lets hot
@@ -364,8 +392,20 @@ pub(crate) fn resolve_inherited_field(
     obj_ptr: usize,
     key: *const crate::StringHeader,
 ) -> Option<crate::value::JSValue> {
-    let _guard = PrototypeResolutionGuard::enter(obj_ptr)?;
     let proto_bits = object_static_prototype(obj_ptr)?;
+    resolve_inherited_field_from_prototype(obj_ptr, proto_bits, key)
+}
+
+/// Resolve an inherited property through a known prototype while retaining
+/// `obj_ptr` as the receiver for accessors and Proxy traps. Intrinsic
+/// TypedArray prototypes are not recorded in `object_static_prototype`, so
+/// their erased-type fallback passes the builtin prototype here directly.
+pub(crate) fn resolve_inherited_field_from_prototype(
+    obj_ptr: usize,
+    proto_bits: u64,
+    key: *const crate::StringHeader,
+) -> Option<crate::value::JSValue> {
+    let _guard = PrototypeResolutionGuard::enter(obj_ptr)?;
     if proto_bits == TAG_NULL {
         return None;
     }

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -437,9 +437,11 @@ pub(crate) fn resolve_inherited_field_from_prototype(
             let key_val = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
             let receiver =
                 f64::from_bits(crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits());
+            let scope = crate::gc::RuntimeHandleScope::new();
             let previous_this = super::js_implicit_this_set(receiver);
+            let previous_this_handle = scope.root_nanbox_f64(previous_this);
             let v = crate::proxy::js_proxy_get(proto_val, key_val);
-            super::js_implicit_this_set(previous_this);
+            super::js_implicit_this_set(previous_this_handle.get_nanbox_f64());
             if v.to_bits() == crate::value::TAG_UNDEFINED {
                 return None;
             }
@@ -456,14 +458,19 @@ pub(crate) fn resolve_inherited_field_from_prototype(
     // properties; otherwise prototype accessors would observe the prototype
     // object instead of the instance.
     let receiver = f64::from_bits(crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits());
+    let scope = crate::gc::RuntimeHandleScope::new();
     let previous_this = super::js_implicit_this_set(receiver);
+    let previous_this_handle = scope.root_nanbox_f64(previous_this);
     // The recursive `get_field(proto, key)` re-derives the accessor receiver
     // from `proto`; stash the real instance so an inherited getter binds `this`
     // to it, not to the prototype.
     let prev_override = super::field_get_set::accessor_receiver_override_begin(receiver);
+    let prev_override_handle = prev_override.map(|value| scope.root_nanbox_f64(value));
     let v = super::js_object_get_field_by_name(proto, key);
-    super::field_get_set::accessor_receiver_override_end(prev_override);
-    super::js_implicit_this_set(previous_this);
+    super::field_get_set::accessor_receiver_override_end(
+        prev_override_handle.map(|handle| handle.get_nanbox_f64()),
+    );
+    super::js_implicit_this_set(previous_this_handle.get_nanbox_f64());
     if v.bits() == 0x7FFC_0000_0000_0001 {
         // undefined — treat as "not present" so callers fall back cleanly.
         None

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -25,6 +25,7 @@
 //! `TAG_NULL`, so a recorded-null entry is distinguishable from "no entry
 //! recorded" (default prototype); in the meta record, 0 means unset.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -43,6 +44,46 @@ pub(crate) fn array_static_proto_recorded() -> bool {
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 
 static OBJECT_PROTOTYPES: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
+thread_local! {
+    /// Owners currently walking a recorded prototype chain. Although
+    /// `Object.setPrototypeOf` normally rejects cycles, residual/native owners
+    /// and custom-construction links can still expose a malformed chain. Keep
+    /// recursive property lookup bounded and stop on a repeated owner.
+    static PROTOTYPE_RESOLUTION_STACK: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+const MAX_PROTOTYPE_RESOLUTION_DEPTH: usize = 64;
+
+struct PrototypeResolutionGuard;
+
+impl PrototypeResolutionGuard {
+    fn enter(owner: usize) -> Option<Self> {
+        PROTOTYPE_RESOLUTION_STACK.with(|stack| {
+            let mut stack = stack.borrow_mut();
+            if stack.len() >= MAX_PROTOTYPE_RESOLUTION_DEPTH || stack.contains(&owner) {
+                return None;
+            }
+            stack.push(owner);
+            Some(Self)
+        })
+    }
+}
+
+impl Drop for PrototypeResolutionGuard {
+    fn drop(&mut self) {
+        PROTOTYPE_RESOLUTION_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+pub(crate) fn resolution_stack_savepoint() -> usize {
+    PROTOTYPE_RESOLUTION_STACK.with(|stack| stack.borrow().len())
+}
+
+pub(crate) fn resolution_stack_restore(depth: usize) {
+    PROTOTYPE_RESOLUTION_STACK.with(|stack| stack.borrow_mut().truncate(depth));
+}
+
 /// Latched true by the first recorded `Object.setPrototypeOf`. Lets hot
 /// per-object probes (e.g. JSON.stringify's `toJSON` fast-negative check,
 /// #6009) skip the map mutex entirely in processes that never re-prototype
@@ -323,6 +364,7 @@ pub(crate) fn resolve_inherited_field(
     obj_ptr: usize,
     key: *const crate::StringHeader,
 ) -> Option<crate::value::JSValue> {
+    let _guard = PrototypeResolutionGuard::enter(obj_ptr)?;
     let proto_bits = object_static_prototype(obj_ptr)?;
     if proto_bits == TAG_NULL {
         return None;
@@ -387,5 +429,45 @@ pub(crate) fn resolve_inherited_field(
         None
     } else {
         Some(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherited_lookup_stops_on_recorded_prototype_cycle() {
+        let first = crate::object::js_object_alloc(0, 0);
+        let second = crate::object::js_object_alloc(0, 0);
+        object_set_static_prototype(
+            first as usize,
+            crate::value::js_nanbox_pointer(second as i64).to_bits(),
+        );
+        object_set_static_prototype(
+            second as usize,
+            crate::value::js_nanbox_pointer(first as i64).to_bits(),
+        );
+        let missing = crate::string::js_string_from_bytes(b"missing".as_ptr(), 7);
+        assert!(resolve_inherited_field(first as usize, missing).is_none());
+        assert!(PROTOTYPE_RESOLUTION_STACK.with(|stack| stack.borrow().is_empty()));
+    }
+
+    #[test]
+    fn exception_unwind_restores_resolution_stack_savepoint() {
+        let base_depth = resolution_stack_savepoint();
+        let _jump_buffer = crate::exception::js_try_push();
+        let first = PrototypeResolutionGuard::enter(usize::MAX - 1).unwrap();
+        let second = PrototypeResolutionGuard::enter(usize::MAX).unwrap();
+        assert_eq!(resolution_stack_savepoint(), base_depth + 2);
+
+        // A real longjmp skips these drops. Forget the guards to model that
+        // behavior, then replay js_throw's savepoint restoration.
+        std::mem::forget(first);
+        std::mem::forget(second);
+        crate::exception::test_unwind_innermost_shadow_restore();
+        crate::exception::js_try_end();
+
+        assert_eq!(resolution_stack_savepoint(), base_depth);
     }
 }

--- a/crates/perry-runtime/src/typedarray/access.rs
+++ b/crates/perry-runtime/src/typedarray/access.rs
@@ -43,6 +43,52 @@ pub extern "C" fn js_typed_array_get(ta: *const TypedArrayHeader, index: i32) ->
     }
 }
 
+/// Read the exact raw lane bits of a BigInt64Array/BigUint64Array element.
+///
+/// Cross-crate structured-clone snapshots use this instead of
+/// `js_typed_array_get`, whose JS-facing result is a freshly allocated
+/// NaN-boxed BigInt pointer. Returning the stored lane avoids retaining a
+/// transient heap pointer and preserves all 64 bits.
+pub fn bigint_lane_bits(ta: *const TypedArrayHeader, index: i32) -> Option<u64> {
+    let ta = clean_ta_ptr(ta);
+    if ta.is_null() || index < 0 {
+        return None;
+    }
+    unsafe {
+        if crate::native_arena::is_native_typed_view(ta) {
+            crate::native_arena::validate_view_alive(
+                crate::native_arena::native_view_from_typed_array(ta),
+            );
+        }
+        if index as u32 >= (*ta).length || !matches!((*ta).kind, KIND_BIGINT64 | KIND_BIGUINT64) {
+            return None;
+        }
+        let slot = data_ptr(ta).add(index as usize * (*ta).elem_size as usize);
+        Some(*(slot as *const u64))
+    }
+}
+
+/// Restore one exact raw BigInt64Array/BigUint64Array lane.
+pub fn set_bigint_lane_bits(ta: *mut TypedArrayHeader, index: i32, bits: u64) -> bool {
+    let ta = clean_ta_ptr(ta) as *mut TypedArrayHeader;
+    if ta.is_null() || index < 0 {
+        return false;
+    }
+    unsafe {
+        if crate::native_arena::is_native_typed_view(ta as *const TypedArrayHeader) {
+            crate::native_arena::validate_view_alive(
+                crate::native_arena::native_view_from_typed_array(ta as *const TypedArrayHeader),
+            );
+        }
+        if index as u32 >= (*ta).length || !matches!((*ta).kind, KIND_BIGINT64 | KIND_BIGUINT64) {
+            return false;
+        }
+        let slot = data_ptr(ta).add(index as usize * (*ta).elem_size as usize);
+        *(slot as *mut u64) = bits;
+        true
+    }
+}
+
 /// Cold fallback for the codegen inline **checked i32** typed-array element read
 /// (integer-kind receivers reached through an erased / typed parameter — e.g.
 /// `function f(S: Int32Array){ return S[i] | 0 }`). The inline path serves the

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -32,9 +32,9 @@ mod transform;
 // such item by name to keep those paths resolving. Inherent/no-path-referenced
 // items need no re-export.
 pub use access::{
-    js_typed_array_at, js_typed_array_copy_within, js_typed_array_get,
+    bigint_lane_bits, js_typed_array_at, js_typed_array_copy_within, js_typed_array_get,
     js_typed_array_index_get_dynamic, js_typed_array_length, js_typed_array_set,
-    js_typed_array_set_from, js_uint8array_get, js_uint8array_set,
+    js_typed_array_set_from, js_uint8array_get, js_uint8array_set, set_bigint_lane_bits,
 };
 pub(crate) use construct::typed_array_from_source_raw_values;
 pub use construct::{js_typed_array_new, js_typed_array_new_empty, js_typed_array_new_from_array};
@@ -1119,6 +1119,17 @@ mod tests {
             assert_eq!(check(KIND_INT32, 1e21), -559939584.0);
             assert_eq!(check(KIND_UINT32, -1.0), 4294967295.0);
             assert_eq!(check(KIND_INT8, 1e21), 0.0);
+        }
+    }
+
+    #[test]
+    fn bigint_lane_snapshot_helpers_preserve_all_64_bits() {
+        for kind in [KIND_BIGINT64, KIND_BIGUINT64] {
+            let typed = typed_array_alloc(kind, 2);
+            assert!(set_bigint_lane_bits(typed, 0, u64::MAX));
+            assert!(set_bigint_lane_bits(typed, 1, 9_007_199_254_740_993));
+            assert_eq!(bigint_lane_bits(typed, 0), Some(u64::MAX));
+            assert_eq!(bigint_lane_bits(typed, 1), Some(9_007_199_254_740_993));
         }
     }
 }

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -515,6 +515,7 @@ extern "C" fn worker_threads_channels_microtask(_closure: *const ClosureHeader) 
 enum SerializedMessage {
     Json(String),
     ArrayBuffer(Vec<u8>),
+    BigIntTypedArray { kind: u8, lanes: Vec<u64> },
     TypedArray { kind: u8, elements: Vec<f64> },
 }
 
@@ -544,6 +545,17 @@ fn serialize_message(value: f64) -> SerializedMessage {
     if let Some(kind) = perry_runtime::typedarray::lookup_typed_array_kind(raw) {
         let typed = raw as *const perry_runtime::typedarray::TypedArrayHeader;
         let len = perry_runtime::typedarray::js_typed_array_length(typed).max(0);
+        if matches!(
+            kind,
+            perry_runtime::typedarray::KIND_BIGINT64 | perry_runtime::typedarray::KIND_BIGUINT64
+        ) {
+            let lanes = (0..len)
+                .map(|index| {
+                    perry_runtime::typedarray::bigint_lane_bits(typed, index).unwrap_or_default()
+                })
+                .collect();
+            return SerializedMessage::BigIntTypedArray { kind, lanes };
+        }
         let elements = (0..len)
             .map(|index| perry_runtime::typedarray::js_typed_array_get(typed, index))
             .collect();
@@ -564,6 +576,16 @@ fn deserialize_message(msg: &SerializedMessage) -> f64 {
                 perry_runtime::buffer::js_buffer_set(buffer, index as i32, *value as i32);
             }
             f64::from_bits(JSValue::pointer(buffer as *const u8).bits())
+        }
+        SerializedMessage::BigIntTypedArray { kind, lanes } => {
+            let typed = perry_runtime::typedarray::js_typed_array_new_empty(
+                *kind as i32,
+                lanes.len() as i32,
+            );
+            for (index, bits) in lanes.iter().enumerate() {
+                perry_runtime::typedarray::set_bigint_lane_bits(typed, index as i32, *bits);
+            }
+            f64::from_bits(JSValue::pointer(typed as *const u8).bits())
         }
         SerializedMessage::TypedArray { kind, elements } => {
             if *kind == perry_runtime::typedarray::KIND_UINT8 {
@@ -610,6 +632,7 @@ fn message_value_is_uncloneable(value: f64, visited: &mut HashSet<usize>) -> boo
     }
     if raw < 0x10000
         || perry_runtime::buffer::is_registered_buffer(raw)
+        || perry_runtime::typedarray::lookup_typed_array_kind(raw).is_some()
         || perry_runtime::set::is_registered_set(raw)
         || perry_runtime::shared_sab::is_shared_sab(raw)
     {

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -109,8 +109,8 @@ struct MessagePortState {
     peer: u64,
     /// NaN-boxed MessagePort object value, used as MessageEvent target.
     object_bits: u64,
-    /// Queue of delivered messages as JSON strings (oldest first).
-    inbox: VecDeque<String>,
+    /// Queue of delivered structured-clone snapshots (oldest first).
+    inbox: VecDeque<SerializedMessage>,
     /// `message` event listener (NaN-boxed closure value bits), if registered.
     message_cb: Option<u64>,
     /// `close` event listener (NaN-boxed closure value bits), if registered.
@@ -136,8 +136,8 @@ struct BroadcastChannelState {
     name: String,
     /// NaN-boxed BroadcastChannel object value, used as MessageEvent target.
     object_bits: u64,
-    /// Queue of delivered messages as JSON strings (oldest first).
-    inbox: VecDeque<String>,
+    /// Queue of delivered structured-clone snapshots (oldest first).
+    inbox: VecDeque<SerializedMessage>,
     /// `message` listeners registered through addEventListener().
     message_event_cbs: Vec<u64>,
     /// Whether `close()` has detached this BroadcastChannel.
@@ -508,19 +508,146 @@ extern "C" fn worker_threads_channels_microtask(_closure: *const ClosureHeader) 
     js_undefined()
 }
 
-/// JSON-serialize a JSValue into a String (structured-clone-like deep copy).
-fn serialize_message(value: f64) -> String {
-    let str_ptr = unsafe { js_json_stringify(value, 0) };
-    string_header_to_string(str_ptr).unwrap_or_else(|| "undefined".to_string())
+/// Same-agent message snapshot. JSON remains the fallback for ordinary
+/// values; typed arrays retain their element kind and are reconstructed as a
+/// fresh typed array rather than degrading to a plain JSON object (#6763).
+#[derive(Clone)]
+enum SerializedMessage {
+    Json(String),
+    ArrayBuffer(Vec<u8>),
+    TypedArray { kind: u8, elements: Vec<f64> },
 }
 
-/// JSON-deserialize a stored message string back into a JSValue.
-fn deserialize_message(msg: &str) -> f64 {
-    if msg == "undefined" || msg.is_empty() {
-        return js_undefined();
+fn serialize_message(value: f64) -> SerializedMessage {
+    let raw = perry_runtime::value::js_nanbox_get_pointer(value) as usize;
+    // Perry's Uint8Array constructor is BufferHeader-backed rather than a
+    // TypedArrayHeader, so preserve that branded representation too.
+    if perry_runtime::buffer::is_uint8array_buffer(raw) {
+        let buffer = raw as *const perry_runtime::buffer::BufferHeader;
+        let len = perry_runtime::buffer::js_buffer_length(buffer).max(0);
+        let elements = (0..len)
+            .map(|index| perry_runtime::buffer::js_buffer_get(buffer, index) as f64)
+            .collect();
+        return SerializedMessage::TypedArray {
+            kind: perry_runtime::typedarray::KIND_UINT8,
+            elements,
+        };
     }
-    let str_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    f64::from_bits(unsafe { js_json_parse(str_ptr) })
+    if perry_runtime::buffer::is_array_buffer(raw) {
+        let buffer = raw as *const perry_runtime::buffer::BufferHeader;
+        let len = perry_runtime::buffer::js_buffer_length(buffer).max(0);
+        let bytes = (0..len)
+            .map(|index| perry_runtime::buffer::js_buffer_get(buffer, index) as u8)
+            .collect();
+        return SerializedMessage::ArrayBuffer(bytes);
+    }
+    if let Some(kind) = perry_runtime::typedarray::lookup_typed_array_kind(raw) {
+        let typed = raw as *const perry_runtime::typedarray::TypedArrayHeader;
+        let len = perry_runtime::typedarray::js_typed_array_length(typed).max(0);
+        let elements = (0..len)
+            .map(|index| perry_runtime::typedarray::js_typed_array_get(typed, index))
+            .collect();
+        return SerializedMessage::TypedArray { kind, elements };
+    }
+
+    let str_ptr = unsafe { js_json_stringify(value, 0) };
+    SerializedMessage::Json(
+        string_header_to_string(str_ptr).unwrap_or_else(|| "undefined".to_string()),
+    )
+}
+
+fn deserialize_message(msg: &SerializedMessage) -> f64 {
+    match msg {
+        SerializedMessage::ArrayBuffer(bytes) => {
+            let buffer = perry_runtime::buffer::js_array_buffer_new(bytes.len() as i32);
+            for (index, value) in bytes.iter().enumerate() {
+                perry_runtime::buffer::js_buffer_set(buffer, index as i32, *value as i32);
+            }
+            f64::from_bits(JSValue::pointer(buffer as *const u8).bits())
+        }
+        SerializedMessage::TypedArray { kind, elements } => {
+            if *kind == perry_runtime::typedarray::KIND_UINT8 {
+                let buffer = perry_runtime::buffer::js_uint8array_alloc(elements.len() as i32);
+                for (index, value) in elements.iter().enumerate() {
+                    perry_runtime::buffer::js_buffer_set(buffer, index as i32, *value as i32);
+                }
+                return f64::from_bits(JSValue::pointer(buffer as *const u8).bits());
+            }
+            let typed = perry_runtime::typedarray::js_typed_array_new_empty(
+                *kind as i32,
+                elements.len() as i32,
+            );
+            for (index, value) in elements.iter().enumerate() {
+                perry_runtime::typedarray::js_typed_array_set(typed, index as i32, *value);
+            }
+            f64::from_bits(JSValue::pointer(typed as *const u8).bits())
+        }
+        SerializedMessage::Json(json) => {
+            if json == "undefined" || json.is_empty() {
+                return js_undefined();
+            }
+            let str_ptr = js_string_from_bytes(json.as_ptr(), json.len() as u32);
+            f64::from_bits(unsafe { js_json_parse(str_ptr) })
+        }
+    }
+}
+
+/// Reject functions, symbols, marked values, and MessagePorts anywhere in a
+/// submitted message graph. The visited set makes cyclic graphs terminate;
+/// JSON remains the ordinary-object snapshot fallback.
+fn message_value_is_uncloneable(value: f64, visited: &mut HashSet<usize>) -> bool {
+    let js = JSValue::from_bits(value.to_bits());
+    if !js.is_pointer() {
+        return false;
+    }
+    let raw = perry_runtime::value::js_nanbox_get_pointer(value) as usize;
+    // Node deliberately ignores markAsUncloneable(ArrayBuffer): backing
+    // stores remain cloneable (and transferable) even when marked.
+    if UNCLONEABLE_OBJECTS.with(|set| set.borrow().contains(&value.to_bits()))
+        && !perry_runtime::buffer::is_array_buffer(raw)
+    {
+        return true;
+    }
+    if raw < 0x10000
+        || perry_runtime::buffer::is_registered_buffer(raw)
+        || perry_runtime::set::is_registered_set(raw)
+        || perry_runtime::shared_sab::is_shared_sab(raw)
+    {
+        return false;
+    }
+    if perry_runtime::closure::is_closure_ptr(raw)
+        || perry_runtime::symbol::is_registered_symbol(raw)
+        || port_id_from_object(value).is_some()
+    {
+        return true;
+    }
+    if !visited.insert(raw) {
+        return false;
+    }
+
+    if let Some(array) = array_ptr_from_value(value) {
+        let len = perry_runtime::array::js_array_length(array);
+        return (0..len).any(|index| {
+            message_value_is_uncloneable(
+                perry_runtime::array::js_array_get_f64(array, index),
+                visited,
+            )
+        });
+    }
+    let Some(object) = object_ptr_from_value(value) else {
+        return false;
+    };
+    let field_count = unsafe {
+        if (*object).keys_array.is_null() {
+            (*object).field_count
+        } else {
+            perry_runtime::array::js_array_length((*object).keys_array)
+        }
+    };
+    (0..field_count).any(|index| {
+        let field = perry_runtime::object::js_object_get_field(object, index);
+        message_value_is_uncloneable(f64::from_bits(field.bits()), visited)
+    })
 }
 
 fn call_callback0(callback_bits: u64, this_bits: u64) {
@@ -680,8 +807,9 @@ extern "C" fn port_post_message(closure: *const ClosureHeader, value: f64, _tran
     if port_id == PARENT_PORT_HANDLE as u64 && CURRENT_WORKER_ID.with(|id| id.get()) != 0 {
         return js_worker_threads_post_message(value);
     }
-    // Reject values flagged uncloneable (#3159). Match Node's DataCloneError.
-    if UNCLONEABLE_OBJECTS.with(|set| set.borrow().contains(&value.to_bits())) {
+    // Validate the full submitted graph: a marked object nested inside an
+    // otherwise cloneable container rejects the whole message.
+    if message_value_is_uncloneable(value, &mut HashSet::new()) {
         throw_data_clone_error("object could not be cloned.");
     }
     let serialized = serialize_message(value);
@@ -854,9 +982,17 @@ extern "C" fn port_close(closure: *const ClosureHeader) -> f64 {
 /// worker_threads DataCloneError: matches Node's message for postMessage
 /// rejections of marked-uncloneable / marked-untransferable values (#3159).
 fn throw_data_clone_error(detail: &str) -> ! {
-    let msg = format!("DataCloneError: {detail}");
-    let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-    let err = perry_runtime::error::js_error_new_with_message(msg_ptr);
+    throw_dom_exception("DataCloneError", detail)
+}
+
+fn throw_invalid_state_error(detail: &str) -> ! {
+    throw_dom_exception("InvalidStateError", detail)
+}
+
+fn throw_dom_exception(name: &str, detail: &str) -> ! {
+    let message = string_value(detail);
+    let name = string_value(name);
+    let err = perry_runtime::event_target::js_dom_exception_new(message, name);
     perry_runtime::exception::js_throw(f64::from_bits(JSValue::pointer(err as *const u8).bits()))
 }
 
@@ -1227,10 +1363,6 @@ pub extern "C" fn js_worker_threads_message_channel_new() -> f64 {
 
 extern "C" fn broadcast_post_message(closure: *const ClosureHeader, value: f64) -> f64 {
     let channel_id = port_id_from_closure(closure);
-    if UNCLONEABLE_OBJECTS.with(|set| set.borrow().contains(&value.to_bits())) {
-        throw_data_clone_error("object could not be cloned.");
-    }
-    let serialized = serialize_message(value);
     let channel_name = BROADCAST_CHANNELS.with(|channels| {
         channels
             .borrow()
@@ -1238,8 +1370,12 @@ extern "C" fn broadcast_post_message(closure: *const ClosureHeader, value: f64) 
             .and_then(|state| (!state.closed).then(|| state.name.clone()))
     });
     let Some(channel_name) = channel_name else {
-        return js_undefined();
+        throw_invalid_state_error("BroadcastChannel is closed");
     };
+    if message_value_is_uncloneable(value, &mut HashSet::new()) {
+        throw_data_clone_error("object could not be cloned.");
+    }
+    let serialized = serialize_message(value);
     BROADCAST_CHANNELS.with(|channels| {
         for (id, state) in channels.borrow_mut().iter_mut() {
             if *id != channel_id && !state.closed && state.name == channel_name {

--- a/crates/perry-stdlib/src/worker_threads/channel_pump.rs
+++ b/crates/perry-stdlib/src/worker_threads/channel_pump.rs
@@ -7,7 +7,7 @@
 
 use super::{
     call_callback0, call_callback1, deserialize_message, event_object, object_event_handler,
-    BROADCAST_CHANNELS, MESSAGE_PORTS,
+    SerializedMessage, BROADCAST_CHANNELS, MESSAGE_PORTS,
 };
 
 /// Drain queued MessageChannel inboxes, dispatching to `message` listeners and
@@ -25,7 +25,7 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
         raw_cb: Option<u64>,
         event_cbs: Vec<u64>,
         handler_cb: Option<u64>,
-        msg: String,
+        msg: SerializedMessage,
     }
 
     loop {
@@ -87,7 +87,7 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
         target_bits: u64,
         event_cbs: Vec<u64>,
         handler_cb: Option<u64>,
-        msg: String,
+        msg: SerializedMessage,
     }
 
     loop {

--- a/crates/perry/tests/issue_6763_broadcast_clone.rs
+++ b/crates/perry/tests/issue_6763_broadcast_clone.rs
@@ -1,0 +1,122 @@
+//! Focused worker_threads structured-clone regressions from the #6763 parity
+//! umbrella. These assertions keep the already-fixed increments in the normal
+//! integration suite instead of relying only on the full Node differential run.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn broadcast_and_port_clone_preserve_binary_values_and_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+import {
+  BroadcastChannel,
+  markAsUncloneable,
+  MessageChannel,
+  receiveMessageOnPort,
+} from "node:worker_threads";
+
+function outcome(fn: () => void): string {
+  try {
+    fn();
+    return "ok";
+  } catch (error: any) {
+    return `${error?.name} ${error?.code ?? ""}`;
+  }
+}
+
+const sender = new BroadcastChannel("clone");
+const receiver = new BroadcastChannel("clone");
+const view = new Uint8Array([3, 1, 4]);
+sender.postMessage(view);
+view[0] = 9;
+const broadcastPacket = receiveMessageOnPort(receiver);
+const cloned = broadcastPacket?.message;
+console.log(
+  "typed",
+  cloned instanceof Uint8Array,
+  cloned.join(","),
+  view.join(","),
+);
+
+const channel = new MessageChannel();
+console.log(
+  "broadcast-port",
+  outcome(() => sender.postMessage({ port: channel.port1 })),
+);
+sender.close();
+console.log("closed", outcome(() => sender.postMessage("late")));
+receiver.close();
+
+const root = { value: 1 };
+markAsUncloneable(root);
+console.log("marked-root", outcome(() => channel.port1.postMessage(root)));
+const nested = { value: 2 };
+markAsUncloneable(nested);
+console.log(
+  "marked-nested",
+  outcome(() => channel.port1.postMessage({ nested })),
+);
+
+const buffer = new ArrayBuffer(4);
+markAsUncloneable(buffer);
+console.log("arraybuffer-post", outcome(() => channel.port1.postMessage(buffer)));
+const portPacket = receiveMessageOnPort(channel.port2);
+console.log(
+  "arraybuffer-clone",
+  portPacket?.message instanceof ArrayBuffer,
+  portPacket?.message?.byteLength,
+  buffer.byteLength,
+);
+channel.port1.close();
+channel.port2.close();
+"#,
+    )
+    .expect("write fixture");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "typed true 3,1,4 9,1,4\n",
+            "broadcast-port DataCloneError 25\n",
+            "closed InvalidStateError 11\n",
+            "marked-root DataCloneError 25\n",
+            "marked-nested DataCloneError 25\n",
+            "arraybuffer-post ok\n",
+            "arraybuffer-clone true 4 4\n",
+        )
+    );
+}

--- a/crates/perry/tests/issue_6763_broadcast_clone.rs
+++ b/crates/perry/tests/issue_6763_broadcast_clone.rs
@@ -46,6 +46,14 @@ console.log(
   cloned.join(","),
   view.join(","),
 );
+Object.defineProperty(Uint8Array.prototype, "__cloneReceiver", {
+  configurable: true,
+  get() {
+    return this === cloned;
+  },
+});
+console.log("typed-getter-this", cloned.__cloneReceiver);
+delete (Uint8Array.prototype as any).__cloneReceiver;
 
 const ints = new Int32Array([-1, 2147483647]);
 sender.postMessage(ints);
@@ -58,6 +66,14 @@ console.log(
   clonedInts.join(","),
   ints.join(","),
 );
+Object.defineProperty(Int32Array.prototype, "__cloneReceiver", {
+  configurable: true,
+  get() {
+    return this === clonedInts;
+  },
+});
+console.log("int32-getter-this", clonedInts.__cloneReceiver);
+delete (Int32Array.prototype as any).__cloneReceiver;
 
 const bigs = new BigUint64Array([
   18446744073709551615n,
@@ -138,7 +154,9 @@ channel.port2.close();
         String::from_utf8_lossy(&run.stdout),
         concat!(
             "typed true 3,1,4 9,1,4\n",
+            "typed-getter-this true\n",
             "int32 true -1,2147483647 7,2147483647\n",
+            "int32-getter-this true\n",
             "biguint64 true 18446744073709551615,9007199254740993 ",
             "1,9007199254740993\n",
             "broadcast-port DataCloneError 25\n",

--- a/crates/perry/tests/issue_6763_broadcast_clone.rs
+++ b/crates/perry/tests/issue_6763_broadcast_clone.rs
@@ -47,6 +47,33 @@ console.log(
   view.join(","),
 );
 
+const ints = new Int32Array([-1, 2147483647]);
+sender.postMessage(ints);
+ints[0] = 7;
+const intsPacket = receiveMessageOnPort(receiver);
+const clonedInts = intsPacket?.message;
+console.log(
+  "int32",
+  clonedInts instanceof Int32Array,
+  clonedInts.join(","),
+  ints.join(","),
+);
+
+const bigs = new BigUint64Array([
+  18446744073709551615n,
+  9007199254740993n,
+]);
+sender.postMessage(bigs);
+bigs[0] = 1n;
+const bigsPacket = receiveMessageOnPort(receiver);
+const clonedBigs = bigsPacket?.message;
+console.log(
+  "biguint64",
+  clonedBigs instanceof BigUint64Array,
+  clonedBigs.join(","),
+  bigs.join(","),
+);
+
 const channel = new MessageChannel();
 console.log(
   "broadcast-port",
@@ -111,6 +138,9 @@ channel.port2.close();
         String::from_utf8_lossy(&run.stdout),
         concat!(
             "typed true 3,1,4 9,1,4\n",
+            "int32 true -1,2147483647 7,2147483647\n",
+            "biguint64 true 18446744073709551615,9007199254740993 ",
+            "1,9007199254740993\n",
             "broadcast-port DataCloneError 25\n",
             "closed InvalidStateError 11\n",
             "marked-root DataCloneError 25\n",


### PR DESCRIPTION
## Summary

- replace the JSON-only MessagePort/BroadcastChannel queue with typed snapshots for top-level TypedArrays and ArrayBuffers
- recursively reject uncloneable values (including nested marked objects, functions, symbols, and MessagePorts) while preserving Node's ArrayBuffer marker exception
- throw branded `DataCloneError`/`InvalidStateError` DOMExceptions and validate a closed BroadcastChannel before cloneability
- resolve typed-array prototype methods when a cloned value reaches the dynamic property path

This is a focused increment on the worker_threads parity umbrella; it does not close the remaining constructor, EventTarget, transfer-list, or nested structured-clone gaps.

Refs #6763

## Verification

- `cargo check -p perry-runtime -p perry-stdlib`
- `cargo test -p perry --test issue_6763_broadcast_clone -- --nocapture`
- Node/Perry byte parity:
  - `worker_threads/broadcast-channel/close-and-clone.ts`
  - `worker_threads/broadcast-channel/error-precedence.ts`
  - `worker_threads/transfer-markers/uncloneable-post.ts`
- full BroadcastChannel folder audit: 7/16 currently pass; remaining mismatches are outside this clone-focused increment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved same-agent `worker_threads` structured cloning to preserve `ArrayBuffer`/typed-array contents and bigint typed-array identity.
  * Message posting now rejects uncloneable values with a `DataCloneError`.
  * Fixed inherited property resolution for custom typed-array prototypes (including buffer-backed `Uint8Array`) and improved prototype-cycle handling.
  * Sending to a closed `BroadcastChannel` now throws `InvalidStateError`.
* **Tests**
  * Expanded structured-clone integration coverage for typed-array observable identity and error names/codes.
  * Added typed-array bigint lane snapshot and GC prototype-resolution root scanning regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->