### PR TITLE
fix(test): preserve node:test import aliases

### DIFF
--- a/changelog.d/7096-node-test-import-aliases.md
+++ b/changelog.d/7096-node-test-import-aliases.md
@@ -1,0 +1,1 @@
+fix(test): preserve Node-compatible identity across `node:test` default and callable alias imports

--- a/crates/perry-codegen/src/nm_install.rs
+++ b/crates/perry-codegen/src/nm_install.rs
@@ -48,6 +48,11 @@ pub(crate) fn nm_install_symbol(name: &str) -> Option<&'static str> {
         "sea" => Some("js_nm_install_sea"),
         "sqlite" => Some("js_nm_install_sqlite"),
         "stream" => Some("js_nm_install_stream"),
+        // `node:test` is exposed as a top-level core module in HIR, but its
+        // callable exports live in the submodule registry. Value reads such as
+        // the default import must arm that registry before asking the generic
+        // native-module property dispatcher for `default` / `test`.
+        "test" => Some("js_node_submod_install_test"),
         "timers" => Some("js_nm_install_timers"),
         "tls" => Some("js_nm_install_tls"),
         "tty" => Some("js_nm_install_tty"),
@@ -164,6 +169,18 @@ pub(crate) const NM_SUBMOD_INSTALL_SYMBOLS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::nm_install_symbol;
+
+    #[test]
+    fn top_level_test_module_installs_its_submodule_registry() {
+        assert_eq!(
+            nm_install_symbol("test"),
+            Some("js_node_submod_install_test")
+        );
+        assert_eq!(
+            nm_install_symbol("node:test"),
+            Some("js_node_submod_install_test")
+        );
+    }
 
     #[test]
     fn path_slash_submodules_install_the_path_dispatch_bucket() {

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1145,8 +1145,13 @@ fn ensure_export_singleton(
     submod: &'static SubmoduleSpec,
     export: &'static ExportSpec,
 ) -> *mut ClosureHeader {
-    let key_name = if submod.key == "test" && matches!(export.name, "default" | "test") {
-        find_export(submod, "test")
+    let key_name = if submod.key == "test" {
+        let canonical = match export.name {
+            "default" | "test" | "it" => "test",
+            "suite" | "describe" => "suite",
+            _ => export.name,
+        };
+        find_export(submod, canonical)
             .map(|canonical| canonical.name)
             .unwrap_or(export.name)
     } else {
@@ -1198,17 +1203,16 @@ fn ensure_export_singleton(
             allocated_handle.get_raw_mut_ptr::<ClosureHeader>() as usize,
         );
         allocated_handle.get_raw_mut_ptr()
-    } else {
-        allocated
-    };
-    if submod.key == "test"
+    } else if submod.key == "test"
         && matches!(
             export.name,
             "default" | "test" | "suite" | "describe" | "it"
         )
     {
-        test::decorate_test_export(allocated);
-    }
+        test::decorate_test_export(allocated, key_name == "test")
+    } else {
+        allocated
+    };
     EXPORT_SINGLETONS.with(|m| {
         m.borrow_mut().insert(key, allocated);
     });

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -1128,7 +1128,7 @@ fn test_context_value(name: &str) -> f64 {
     let ctx = js_object_alloc(0, 8);
     let test_fn = closure_value(thunk_test as *const u8, 3);
     let test_fn_ptr = raw_ptr_from_value(test_fn);
-    let test_fn = if test_fn_ptr >= 0x10000 {
+    let test_fn = if crate::value::addr_class::is_plausible_heap_addr(test_fn_ptr) {
         boxed_ptr(decorate_test_export(
             test_fn_ptr as *mut ClosureHeader,
             false,

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -1128,9 +1128,14 @@ fn test_context_value(name: &str) -> f64 {
     let ctx = js_object_alloc(0, 8);
     let test_fn = closure_value(thunk_test as *const u8, 3);
     let test_fn_ptr = raw_ptr_from_value(test_fn);
-    if test_fn_ptr >= 0x10000 {
-        decorate_test_export(test_fn_ptr as *mut ClosureHeader);
-    }
+    let test_fn = if test_fn_ptr >= 0x10000 {
+        boxed_ptr(decorate_test_export(
+            test_fn_ptr as *mut ClosureHeader,
+            false,
+        ))
+    } else {
+        test_fn
+    };
     set_field(ctx, "name", string_value(name));
     set_field(ctx, "assert", boxed_ptr(assert));
     set_field(ctx, "mock", mock_object_value());
@@ -1539,23 +1544,32 @@ pub extern "C" fn js_node_test_mock_timers_reset() -> f64 {
     mock_timers_reset(std::ptr::null())
 }
 
-pub(crate) fn decorate_test_export(closure: *mut ClosureHeader) {
-    let owner = closure as usize;
-    crate::closure::closure_set_dynamic_prop(
-        owner,
-        "skip",
-        closure_value(thunk_test_skip as *const u8, 3),
-    );
-    crate::closure::closure_set_dynamic_prop(
-        owner,
-        "todo",
-        closure_value(thunk_test_todo as *const u8, 3),
-    );
-    crate::closure::closure_set_dynamic_prop(
-        owner,
-        "only",
-        closure_value(thunk_test_only as *const u8, 3),
-    );
+pub(crate) fn decorate_test_export(
+    closure: *mut ClosureHeader,
+    include_test_alias: bool,
+) -> *mut ClosureHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let closure_handle = scope.root_raw_mut_ptr(closure);
+    if include_test_alias {
+        crate::closure::closure_set_dynamic_prop(
+            closure_handle.get_raw_mut_ptr::<ClosureHeader>() as usize,
+            "test",
+            boxed_ptr(closure_handle.get_raw_mut_ptr::<ClosureHeader>()),
+        );
+    }
+    for (name, func) in [
+        ("skip", thunk_test_skip as *const u8),
+        ("todo", thunk_test_todo as *const u8),
+        ("only", thunk_test_only as *const u8),
+    ] {
+        let method = scope.root_nanbox_f64(closure_value(func, 3));
+        crate::closure::closure_set_dynamic_prop(
+            closure_handle.get_raw_mut_ptr::<ClosureHeader>() as usize,
+            name,
+            method.get_nanbox_f64(),
+        );
+    }
+    closure_handle.get_raw_mut_ptr()
 }
 
 pub(crate) fn test_special_export_value(name: &str) -> Option<f64> {

--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -404,6 +404,77 @@ fn stream_promises_default_export_exposes_namespace() {
 }
 
 #[test]
+fn test_default_and_named_exports_share_the_self_alias() {
+    let default = unsafe {
+        js_node_submodule_export_as_function(
+            b"test".as_ptr(),
+            "test".len() as u32,
+            b"default".as_ptr(),
+            "default".len() as u32,
+        )
+    };
+    let named = unsafe {
+        js_node_submodule_export_as_function(
+            b"test".as_ptr(),
+            "test".len() as u32,
+            b"test".as_ptr(),
+            "test".len() as u32,
+        )
+    };
+    let it = unsafe {
+        js_node_submodule_export_as_function(
+            b"test".as_ptr(),
+            "test".len() as u32,
+            b"it".as_ptr(),
+            "it".len() as u32,
+        )
+    };
+    let suite = unsafe {
+        js_node_submodule_export_as_function(
+            b"test".as_ptr(),
+            "test".len() as u32,
+            b"suite".as_ptr(),
+            "suite".len() as u32,
+        )
+    };
+    let describe = unsafe {
+        js_node_submodule_export_as_function(
+            b"test".as_ptr(),
+            "test".len() as u32,
+            b"describe".as_ptr(),
+            "describe".len() as u32,
+        )
+    };
+
+    assert_eq!(default.to_bits(), named.to_bits());
+    assert_eq!(it.to_bits(), named.to_bits());
+    assert_eq!(describe.to_bits(), suite.to_bits());
+    let closure = crate::value::js_nanbox_get_pointer(default) as usize;
+    assert_eq!(
+        crate::closure::closure_get_dynamic_prop(closure, "test").to_bits(),
+        default.to_bits()
+    );
+
+    let module_default = unsafe {
+        crate::object::js_native_module_property_by_name(
+            b"test".as_ptr(),
+            "test".len(),
+            b"default".as_ptr(),
+            "default".len(),
+        )
+    };
+    assert_eq!(module_default.to_bits(), default.to_bits());
+    let key = js_string_from_bytes(b"test".as_ptr(), "test".len() as u32);
+    let property =
+        crate::object::js_object_get_field_by_name_f64(closure as *const ObjectHeader, key);
+    assert_eq!(property.to_bits(), default.to_bits());
+    let mut cache = [0, 0];
+    let property =
+        crate::object::js_object_get_field_ic_miss(closure as *const ObjectHeader, key, &mut cache);
+    assert_eq!(property.to_bits(), default.to_bits());
+}
+
+#[test]
 fn namespace_member_missing_export_returns_undefined() {
     let value = unsafe {
         js_node_submodule_namespace_member(


### PR DESCRIPTION
## Summary
- install the `node:test` submodule registry before top-level default/native value reads in production builds
- share callable singletons for Node's `default`/`test`/`it` and `suite`/`describe` aliases
- expose the `test.test === test` self alias and root callable decoration across allocations

The missing installer was masked in unit tests because `cfg(test)` auto-installs every submodule. Production codegen therefore returned the legacy native-module sentinel for the default import, and member access observed `undefined`.

This clears the first two failures listed in #6767: `imports/aliases` and `imports/module-shape`.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo test -p perry-codegen top_level_test_module_installs_its_submodule_registry -- --nocapture`
- `cargo test -p perry-runtime test_default_and_named_exports_share_the_self_alias -- --nocapture`
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/imports/aliases` (1/1 pass, 100%)
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/imports/module-shape` (1/1 pass, 100%)
- production LLVM trace contains `js_node_submod_install_test()` before `js_native_module_property_by_name`

Refs #6767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Node’s `node:test` module, including default and alias imports.
  * Ensured default, named (`test`), and callable (`it`) exports resolve to the same underlying test API.
  * Improved consistency between `suite` and `describe` exports and how they’re decorated.
  * Preserved expected test properties such as `skip`, `todo`, and `only`.
  * Added internal coverage to validate export identity and dynamic property behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->