### PR TITLE
fix(test): support mock accessor option overloads

### DIFF
--- a/changelog.d/7097-node-test-mock-accessor-options.md
+++ b/changelog.d/7097-node-test-mock-accessor-options.md
@@ -1,0 +1,1 @@
+fix(test): support Node-compatible option overloads for mock methods, getters, and setters

--- a/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
@@ -425,7 +425,7 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         method: "method",
         class_filter: None,
         runtime: "js_node_test_mock_method",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -434,7 +434,7 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         method: "getter",
         class_filter: None,
         runtime: "js_node_test_mock_getter",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -443,7 +443,7 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         method: "setter",
         class_filter: None,
         runtime: "js_node_test_mock_setter",
-        args: &[NA_F64, NA_F64, NA_F64],
+        args: &[NA_F64, NA_F64, NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -537,3 +537,19 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         ret: NR_F64,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::NODE_CORE_MODULE_SEA_TLS_TEST_ROWS;
+
+    #[test]
+    fn node_test_mock_accessor_calls_keep_the_options_argument() {
+        for method in ["method", "getter", "setter"] {
+            let sig = NODE_CORE_MODULE_SEA_TLS_TEST_ROWS
+                .iter()
+                .find(|sig| sig.module == "test" && sig.method == method)
+                .unwrap_or_else(|| panic!("missing node:test mock.{method} signature"));
+            assert_eq!(sig.args.len(), 4, "mock.{method} must forward options");
+        }
+    }
+}

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -498,6 +498,89 @@ fn accessor_function_value(bits: u64) -> f64 {
     }
 }
 
+#[derive(Clone, Copy)]
+struct MockMethodOptions {
+    getter: bool,
+    setter: bool,
+}
+
+fn is_non_null_object(value: f64) -> bool {
+    let js = JSValue::from_bits(value.to_bits());
+    js.is_pointer() && !is_callable_value(value)
+}
+
+fn mock_option_bool(options: f64, name: &str, default: bool) -> bool {
+    let Some(value) = object_property(options, name.as_bytes()) else {
+        return default;
+    };
+    match value.to_bits() {
+        crate::value::TAG_TRUE => true,
+        crate::value::TAG_FALSE => false,
+        crate::value::TAG_UNDEFINED => default,
+        _ => throw_invalid_arg_type(&format!("options.{name}"), "boolean", value),
+    }
+}
+
+fn parse_mock_method_options(
+    options: f64,
+    default_getter: bool,
+    default_setter: bool,
+) -> MockMethodOptions {
+    if is_undefined_value(options) {
+        return MockMethodOptions {
+            getter: default_getter,
+            setter: default_setter,
+        };
+    }
+    if !is_non_null_object(options) {
+        throw_invalid_arg_type("options", "object", options);
+    }
+    MockMethodOptions {
+        getter: mock_option_bool(options, "getter", default_getter),
+        setter: mock_option_bool(options, "setter", default_setter),
+    }
+}
+
+fn normalize_mock_method_args(implementation: f64, options: f64) -> (f64, f64) {
+    if is_non_null_object(implementation) {
+        (undefined_value(), implementation)
+    } else {
+        (implementation, options)
+    }
+}
+
+fn throw_invalid_mock_option_value(arg: &str, value: f64, reason: &str) -> ! {
+    crate::validators::throw_invalid_arg_value(
+        arg,
+        reason,
+        &crate::fs::validate::describe_received(value),
+    );
+}
+
+fn validate_mock_accessor_options(options: MockMethodOptions, kind: &str) {
+    if kind == "getter" && !options.getter {
+        throw_invalid_mock_option_value(
+            "options.getter",
+            f64::from_bits(crate::value::TAG_FALSE),
+            "cannot be false",
+        );
+    }
+    if kind == "setter" && !options.setter {
+        throw_invalid_mock_option_value(
+            "options.setter",
+            f64::from_bits(crate::value::TAG_FALSE),
+            "cannot be false",
+        );
+    }
+    if options.getter && options.setter {
+        throw_invalid_mock_option_value(
+            "options.setter",
+            f64::from_bits(crate::value::TAG_TRUE),
+            "cannot be used with 'options.getter'",
+        );
+    }
+}
+
 fn install_accessor_mock(target: f64, property: &str, accessor: crate::object::AccessorDescriptor) {
     let raw = object_target_addr(target);
     let key = js_string_from_bytes(property.as_ptr(), property.len() as u32);
@@ -852,7 +935,17 @@ extern "C" fn mock_method_thunk(
     target: f64,
     property: f64,
     implementation: f64,
+    options: f64,
 ) -> f64 {
+    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let options = parse_mock_method_options(options, false, false);
+    validate_mock_accessor_options(options, "method");
+    if options.getter {
+        return create_getter_mock(target, property, implementation);
+    }
+    if options.setter {
+        return create_setter_mock(target, property, implementation);
+    }
     let property = property_name(property);
     let original = get_property_value(target, &property);
     let implementation = if is_undefined_value(implementation) {
@@ -874,12 +967,7 @@ extern "C" fn mock_method_thunk(
     function
 }
 
-extern "C" fn mock_getter_thunk(
-    _closure: *const ClosureHeader,
-    target: f64,
-    property: f64,
-    implementation: f64,
-) -> f64 {
+fn create_getter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     let property = property_name(property);
     let raw = object_target_addr(target);
     let original_accessor = crate::object::get_accessor_descriptor(raw, &property);
@@ -919,12 +1007,20 @@ extern "C" fn mock_getter_thunk(
     function
 }
 
-extern "C" fn mock_setter_thunk(
+extern "C" fn mock_getter_thunk(
     _closure: *const ClosureHeader,
     target: f64,
     property: f64,
     implementation: f64,
+    options: f64,
 ) -> f64 {
+    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let options = parse_mock_method_options(options, true, false);
+    validate_mock_accessor_options(options, "getter");
+    create_getter_mock(target, property, implementation)
+}
+
+fn create_setter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     let property = property_name(property);
     let raw = object_target_addr(target);
     let original_accessor = crate::object::get_accessor_descriptor(raw, &property);
@@ -962,6 +1058,19 @@ extern "C" fn mock_setter_thunk(
         },
     );
     function
+}
+
+extern "C" fn mock_setter_thunk(
+    _closure: *const ClosureHeader,
+    target: f64,
+    property: f64,
+    implementation: f64,
+    options: f64,
+) -> f64 {
+    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let options = parse_mock_method_options(options, false, true);
+    validate_mock_accessor_options(options, "setter");
+    create_setter_mock(target, property, implementation)
 }
 
 extern "C" fn mock_property_thunk(
@@ -1042,17 +1151,17 @@ fn mock_object_value() -> f64 {
         set_field(
             mock,
             "method",
-            closure_value(mock_method_thunk as *const u8, 3),
+            closure_value(mock_method_thunk as *const u8, 4),
         );
         set_field(
             mock,
             "getter",
-            closure_value(mock_getter_thunk as *const u8, 3),
+            closure_value(mock_getter_thunk as *const u8, 4),
         );
         set_field(
             mock,
             "setter",
-            closure_value(mock_setter_thunk as *const u8, 3),
+            closure_value(mock_setter_thunk as *const u8, 4),
         );
         set_field(
             mock,
@@ -1475,18 +1584,33 @@ pub extern "C" fn js_node_test_mock_fn(
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_test_mock_method(target: f64, property: f64, implementation: f64) -> f64 {
-    mock_method_thunk(std::ptr::null(), target, property, implementation)
+pub extern "C" fn js_node_test_mock_method(
+    target: f64,
+    property: f64,
+    implementation: f64,
+    options: f64,
+) -> f64 {
+    mock_method_thunk(std::ptr::null(), target, property, implementation, options)
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_test_mock_getter(target: f64, property: f64, implementation: f64) -> f64 {
-    mock_getter_thunk(std::ptr::null(), target, property, implementation)
+pub extern "C" fn js_node_test_mock_getter(
+    target: f64,
+    property: f64,
+    implementation: f64,
+    options: f64,
+) -> f64 {
+    mock_getter_thunk(std::ptr::null(), target, property, implementation, options)
 }
 
 #[no_mangle]
-pub extern "C" fn js_node_test_mock_setter(target: f64, property: f64, implementation: f64) -> f64 {
-    mock_setter_thunk(std::ptr::null(), target, property, implementation)
+pub extern "C" fn js_node_test_mock_setter(
+    target: f64,
+    property: f64,
+    implementation: f64,
+    options: f64,
+) -> f64 {
+    mock_setter_thunk(std::ptr::null(), target, property, implementation, options)
 }
 
 #[no_mangle]
@@ -1601,6 +1725,49 @@ pub(crate) fn scan_test_module_roots_mut(visitor: &mut crate::gc::RuntimeRootVis
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options_with_bool(name: &str, value: bool) -> f64 {
+        let options = js_object_alloc(0, 1);
+        set_field(
+            options,
+            name,
+            f64::from_bits(if value {
+                crate::value::TAG_TRUE
+            } else {
+                crate::value::TAG_FALSE
+            }),
+        );
+        boxed_ptr(options)
+    }
+
+    #[test]
+    fn mock_method_accepts_options_in_the_implementation_slot() {
+        let options = options_with_bool("getter", true);
+        let (implementation, normalized_options) =
+            normalize_mock_method_args(options, undefined_value());
+
+        assert!(is_undefined_value(implementation));
+        assert_eq!(normalized_options.to_bits(), options.to_bits());
+        let parsed = parse_mock_method_options(normalized_options, false, false);
+        assert!(parsed.getter);
+        assert!(!parsed.setter);
+    }
+
+    #[test]
+    fn mock_getter_and_setter_defaults_preserve_the_accessor_kind() {
+        let getter = parse_mock_method_options(undefined_value(), true, false);
+        assert!(getter.getter);
+        assert!(!getter.setter);
+
+        let setter = parse_mock_method_options(undefined_value(), false, true);
+        assert!(!setter.getter);
+        assert!(setter.setter);
+    }
 }
 
 fn reporter_with_kind(kind: i32, source: f64) -> f64 {

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -535,10 +535,11 @@ fn parse_mock_method_options(
     if !is_non_null_object(options) {
         throw_invalid_arg_type("options", "object", options);
     }
-    MockMethodOptions {
-        getter: mock_option_bool(options, "getter", default_getter),
-        setter: mock_option_bool(options, "setter", default_setter),
-    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let options = scope.root_nanbox_f64(options);
+    let getter = mock_option_bool(options.get_nanbox_f64(), "getter", default_getter);
+    let setter = mock_option_bool(options.get_nanbox_f64(), "setter", default_setter);
+    MockMethodOptions { getter, setter }
 }
 
 fn normalize_mock_method_args(implementation: f64, options: f64) -> (f64, f64) {
@@ -937,33 +938,48 @@ extern "C" fn mock_method_thunk(
     implementation: f64,
     options: f64,
 ) -> f64 {
-    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let property = scope.root_nanbox_f64(property);
+    let implementation = scope.root_nanbox_f64(implementation);
+    let options = scope.root_nanbox_f64(options);
+    let (implementation, options) =
+        normalize_mock_method_args(implementation.get_nanbox_f64(), options.get_nanbox_f64());
+    let implementation = scope.root_nanbox_f64(implementation);
     let options = parse_mock_method_options(options, false, false);
     validate_mock_accessor_options(options, "method");
     if options.getter {
-        return create_getter_mock(target, property, implementation);
+        return create_getter_mock(
+            target.get_nanbox_f64(),
+            property.get_nanbox_f64(),
+            implementation.get_nanbox_f64(),
+        );
     }
     if options.setter {
-        return create_setter_mock(target, property, implementation);
+        return create_setter_mock(
+            target.get_nanbox_f64(),
+            property.get_nanbox_f64(),
+            implementation.get_nanbox_f64(),
+        );
     }
-    let property = property_name(property);
-    let original = get_property_value(target, &property);
-    let implementation = if is_undefined_value(implementation) {
+    let property_name = property_name(property.get_nanbox_f64());
+    let original = get_property_value(target.get_nanbox_f64(), &property_name);
+    let implementation = if is_undefined_value(implementation.get_nanbox_f64()) {
         original
     } else {
-        implementation
+        implementation.get_nanbox_f64()
     };
     assert_callable_arg("implementation", implementation);
     let function = create_mock_function(
         original,
         implementation,
         MockRestoreTarget::ObjectProperty {
-            target,
-            property: property.clone(),
+            target: target.get_nanbox_f64(),
+            property: property_name.clone(),
             original,
         },
     );
-    set_property_value(target, &property, function);
+    set_property_value(target.get_nanbox_f64(), &property_name, function);
     function
 }
 
@@ -1014,10 +1030,21 @@ extern "C" fn mock_getter_thunk(
     implementation: f64,
     options: f64,
 ) -> f64 {
-    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let property = scope.root_nanbox_f64(property);
+    let implementation = scope.root_nanbox_f64(implementation);
+    let options = scope.root_nanbox_f64(options);
+    let (implementation, options) =
+        normalize_mock_method_args(implementation.get_nanbox_f64(), options.get_nanbox_f64());
+    let implementation = scope.root_nanbox_f64(implementation);
     let options = parse_mock_method_options(options, true, false);
     validate_mock_accessor_options(options, "getter");
-    create_getter_mock(target, property, implementation)
+    create_getter_mock(
+        target.get_nanbox_f64(),
+        property.get_nanbox_f64(),
+        implementation.get_nanbox_f64(),
+    )
 }
 
 fn create_setter_mock(target: f64, property: f64, implementation: f64) -> f64 {
@@ -1067,10 +1094,21 @@ extern "C" fn mock_setter_thunk(
     implementation: f64,
     options: f64,
 ) -> f64 {
-    let (implementation, options) = normalize_mock_method_args(implementation, options);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let property = scope.root_nanbox_f64(property);
+    let implementation = scope.root_nanbox_f64(implementation);
+    let options = scope.root_nanbox_f64(options);
+    let (implementation, options) =
+        normalize_mock_method_args(implementation.get_nanbox_f64(), options.get_nanbox_f64());
+    let implementation = scope.root_nanbox_f64(implementation);
     let options = parse_mock_method_options(options, false, true);
     validate_mock_accessor_options(options, "setter");
-    create_setter_mock(target, property, implementation)
+    create_setter_mock(
+        target.get_nanbox_f64(),
+        property.get_nanbox_f64(),
+        implementation.get_nanbox_f64(),
+    )
 }
 
 extern "C" fn mock_property_thunk(
@@ -1728,47 +1766,8 @@ pub(crate) fn scan_test_module_roots_mut(visitor: &mut crate::gc::RuntimeRootVis
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn options_with_bool(name: &str, value: bool) -> f64 {
-        let options = js_object_alloc(0, 1);
-        set_field(
-            options,
-            name,
-            f64::from_bits(if value {
-                crate::value::TAG_TRUE
-            } else {
-                crate::value::TAG_FALSE
-            }),
-        );
-        boxed_ptr(options)
-    }
-
-    #[test]
-    fn mock_method_accepts_options_in_the_implementation_slot() {
-        let options = options_with_bool("getter", true);
-        let (implementation, normalized_options) =
-            normalize_mock_method_args(options, undefined_value());
-
-        assert!(is_undefined_value(implementation));
-        assert_eq!(normalized_options.to_bits(), options.to_bits());
-        let parsed = parse_mock_method_options(normalized_options, false, false);
-        assert!(parsed.getter);
-        assert!(!parsed.setter);
-    }
-
-    #[test]
-    fn mock_getter_and_setter_defaults_preserve_the_accessor_kind() {
-        let getter = parse_mock_method_options(undefined_value(), true, false);
-        assert!(getter.getter);
-        assert!(!getter.setter);
-
-        let setter = parse_mock_method_options(undefined_value(), false, true);
-        assert!(!setter.getter);
-        assert!(setter.setter);
-    }
-}
+#[path = "test_unit_tests.rs"]
+mod tests;
 
 fn reporter_with_kind(kind: i32, source: f64) -> f64 {
     if JSValue::from_bits(source.to_bits()).is_undefined() {

--- a/crates/perry-runtime/src/node_submodules/test_unit_tests.rs
+++ b/crates/perry-runtime/src/node_submodules/test_unit_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+fn options_with_value(name: &str, value: f64) -> f64 {
+    let options = js_object_alloc(0, 1);
+    set_field(options, name, value);
+    boxed_ptr(options)
+}
+
+fn options_with_bool(name: &str, value: bool) -> f64 {
+    options_with_value(
+        name,
+        f64::from_bits(if value {
+            crate::value::TAG_TRUE
+        } else {
+            crate::value::TAG_FALSE
+        }),
+    )
+}
+
+fn caught_error_code(f: impl FnOnce() -> f64) -> &'static str {
+    let error = catch_js(f).expect_err("operation should throw");
+    let error = raw_ptr_from_value(error) as *mut crate::error::ErrorHeader;
+    crate::node_submodules::error_code_for_message(crate::error::js_error_get_message(error))
+        .expect("error should have a registered Node code")
+}
+
+extern "C" fn allocating_true_option(_closure: *const ClosureHeader) -> f64 {
+    let _ = js_object_alloc(0, 0);
+    f64::from_bits(crate::value::TAG_TRUE)
+}
+
+#[test]
+fn mock_method_accepts_options_in_the_implementation_slot() {
+    let options = options_with_bool("getter", true);
+    let (implementation, normalized_options) =
+        normalize_mock_method_args(options, undefined_value());
+
+    assert!(is_undefined_value(implementation));
+    assert_eq!(normalized_options.to_bits(), options.to_bits());
+    let parsed = parse_mock_method_options(normalized_options, false, false);
+    assert!(parsed.getter);
+    assert!(!parsed.setter);
+}
+
+#[test]
+fn mock_getter_and_setter_defaults_preserve_the_accessor_kind() {
+    let getter = parse_mock_method_options(undefined_value(), true, false);
+    assert!(getter.getter);
+    assert!(!getter.setter);
+
+    let setter = parse_mock_method_options(undefined_value(), false, true);
+    assert!(!setter.getter);
+    assert!(setter.setter);
+}
+
+#[test]
+fn mock_method_options_survive_an_allocating_getter() {
+    let options = js_object_alloc(0, 2);
+    install_accessor_mock(
+        boxed_ptr(options),
+        "getter",
+        crate::object::AccessorDescriptor {
+            get: closure_value(allocating_true_option as *const u8, 0).to_bits(),
+            set: 0,
+        },
+    );
+    set_field(options, "setter", f64::from_bits(crate::value::TAG_FALSE));
+
+    let parsed = parse_mock_method_options(boxed_ptr(options), false, false);
+    assert!(parsed.getter);
+    assert!(!parsed.setter);
+}
+
+#[test]
+fn mock_accessor_options_reject_invalid_flags() {
+    let getter_false = options_with_bool("getter", false);
+    assert_eq!(
+        caught_error_code(|| {
+            let options = parse_mock_method_options(getter_false, true, false);
+            validate_mock_accessor_options(options, "getter");
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_VALUE"
+    );
+
+    let setter_false = options_with_bool("setter", false);
+    assert_eq!(
+        caught_error_code(|| {
+            let options = parse_mock_method_options(setter_false, false, true);
+            validate_mock_accessor_options(options, "setter");
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_VALUE"
+    );
+
+    let both = js_object_alloc(0, 2);
+    set_field(both, "getter", f64::from_bits(crate::value::TAG_TRUE));
+    set_field(both, "setter", f64::from_bits(crate::value::TAG_TRUE));
+    assert_eq!(
+        caught_error_code(|| {
+            let options = parse_mock_method_options(boxed_ptr(both), false, false);
+            validate_mock_accessor_options(options, "method");
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_VALUE"
+    );
+
+    let non_boolean = options_with_value("getter", 1.0);
+    assert_eq!(
+        caught_error_code(|| {
+            let _ = parse_mock_method_options(non_boolean, false, false);
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_TYPE"
+    );
+}


### PR DESCRIPTION
## Summary
- forward the fourth `options` argument through native `mock.method`, `mock.getter`, and `mock.setter` calls
- support Node's overload where an options object occupies the implementation slot
- validate `getter`/`setter` booleans and mutually exclusive accessor modes with Node-compatible error codes
- keep method/getter/setter arities and overload defaults covered by unit tests

This clears two more failures in #6767: `mock-fn/accessor-options` and `mock-fn/method-options-validation`.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perry-runtime -p perry-codegen`
- `cargo test -p perry-codegen node_test_mock_accessor_calls_keep_the_options_argument -- --nocapture`
- `cargo test -p perry-runtime mock_method_accepts_options_in_the_implementation_slot -- --nocapture`
- `cargo test -p perry-runtime mock_getter_and_setter_defaults_preserve_the_accessor_kind -- --nocapture`
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/mock-fn/accessor-options` (1/1 pass, 100%)
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/mock-fn/method-options-validation` (1/1 pass, 100%)
- `git diff --check`

`./scripts/check_file_size.sh` still reports 12 pre-existing over-limit files not touched by this PR. The changed runtime file remains below the cap (1,943 lines).

Refs #6767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Node-compatible options when mocking methods, getters, and setters.
  * Accessor mocks now honor configuration options consistently, including default behavior.

* **Bug Fixes**
  * Improved mock argument handling and validation for accessor options.
  * Invalid option values now produce the expected errors.

* **Tests**
  * Added coverage for option handling, accessor defaults, error cases, and four-argument mock signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->