### PR TITLE
fix(node:test): implement property mock contexts

### DIFF
--- a/changelog.d/7100-node-test-mock-property.md
+++ b/changelog.d/7100-node-test-mock-property.md
@@ -1,0 +1,1 @@
+Implemented Node-compatible `node:test` property mock contexts with access tracking, replacement scheduling, and restoration.

--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -122,6 +122,39 @@ pub(crate) fn lower_native_method_call(
         }
     }
 
+    // `MockTracker.property(object, name[, value])` must distinguish an
+    // omitted third argument from an explicitly supplied `undefined`.
+    // Generic native-table lowering pads both shapes to the same three f64
+    // values, so pass the source argument-presence bit through a dedicated
+    // ABI. Node uses omission to select the original property value while
+    // explicit `undefined` is a real replacement value.
+    if matches!(module, "test" | "node:test") && object.is_none() && method == "property" {
+        let mut lowered = Vec::with_capacity(args.len());
+        for arg in args {
+            lowered.push(lower_expr(ctx, arg)?);
+        }
+        let undefined = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+        let target = lowered.first().unwrap_or(&undefined);
+        let property = lowered.get(1).unwrap_or(&undefined);
+        let value = lowered.get(2).unwrap_or(&undefined);
+        let value_present = if args.len() > 2 { "1" } else { "0" };
+        ctx.pending_declares.push((
+            "js_node_test_mock_property_with_presence".to_string(),
+            DOUBLE,
+            vec![DOUBLE, DOUBLE, DOUBLE, I32],
+        ));
+        return Ok(ctx.block().call(
+            DOUBLE,
+            "js_node_test_mock_property_with_presence",
+            &[
+                (DOUBLE, target),
+                (DOUBLE, property),
+                (DOUBLE, value),
+                (I32, value_present),
+            ],
+        ));
+    }
+
     // Generic native module dispatch (receiver-less): fastify, mysql2,
     // ws, pg, ioredis, mongodb, better-sqlite3, etc. These were in the
     // old Cranelift codegen's dispatch table but lost in the v0.5.0

--- a/crates/perry-codegen/tests/node_test_mock_property_presence.rs
+++ b/crates/perry-codegen/tests/node_test_mock_property_presence.rs
@@ -1,0 +1,131 @@
+//! `node:test` property mocks preserve omitted-vs-explicit-undefined at the
+//! native ABI boundary.
+
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
+
+fn ir_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        nextjs_path_init_modules: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_ffi_aliases: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        namespace_member_origin_names: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations: false,
+        module_source: None,
+        debug_source_line_offset: 0,
+    }
+}
+
+fn mock_property_call(args: Vec<Expr>) -> Stmt {
+    Stmt::Expr(Expr::NativeMethodCall {
+        module: "test".to_string(),
+        class_name: None,
+        object: None,
+        method: "property".to_string(),
+        args,
+    })
+}
+
+fn fixture_module() -> Module {
+    let target = || Expr::Object(vec![("value".to_string(), Expr::Integer(5))]);
+    Module {
+        name: "node_test_mock_property_presence.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: Vec::new(),
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        script_global_functions: Vec::new(),
+        references_global_this: false,
+        annexb_global_undefined_names: Vec::new(),
+        init: vec![
+            mock_property_call(vec![target(), Expr::String("value".to_string())]),
+            mock_property_call(vec![
+                target(),
+                Expr::String("value".to_string()),
+                Expr::Undefined,
+            ]),
+        ],
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        class_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+#[test]
+fn property_mock_abi_carries_source_argument_presence() {
+    let ir = String::from_utf8(compile_module(&fixture_module(), ir_opts()).unwrap()).unwrap();
+    let calls = ir
+        .lines()
+        .filter(|line| line.contains("call double @js_node_test_mock_property_with_presence"))
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2, "expected two property-mock calls:\n{ir}");
+    assert!(
+        calls[0].contains("i32 0"),
+        "omitted value must carry presence=false:\n{}",
+        calls[0]
+    );
+    assert!(
+        calls[1].contains("i32 1"),
+        "explicit undefined must carry presence=true:\n{}",
+        calls[1]
+    );
+}

--- a/crates/perry-codegen/tests/node_test_mock_property_presence.rs
+++ b/crates/perry-codegen/tests/node_test_mock_property_presence.rs
@@ -119,12 +119,12 @@ fn property_mock_abi_carries_source_argument_presence() {
         .collect::<Vec<_>>();
     assert_eq!(calls.len(), 2, "expected two property-mock calls:\n{ir}");
     assert!(
-        calls[0].contains("i32 0"),
+        calls[0].contains("i32 0)"),
         "omitted value must carry presence=false:\n{}",
         calls[0]
     );
     assert!(
-        calls[1].contains("i32 1"),
+        calls[1].contains("i32 1)"),
         "explicit undefined must carry presence=true:\n{}",
         calls[1]
     );

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -17,6 +17,9 @@ use crate::object::{js_object_alloc, js_object_set_field_by_name};
 use crate::string::js_string_from_bytes;
 use crate::value::{JSValue, POINTER_MASK, TAG_UNDEFINED};
 
+#[path = "test_property.rs"]
+mod property_mock;
+
 const REPORTER_SPEC: i32 = 0;
 const REPORTER_TAP: i32 = 1;
 const REPORTER_DOT: i32 = 2;
@@ -713,25 +716,6 @@ fn create_mock_function(original: f64, implementation: f64, restore: MockRestore
     function.get_nanbox_f64()
 }
 
-fn create_restore_context(restore: MockRestoreTarget) -> f64 {
-    let id = next_mock_id();
-    let calls = boxed_ptr(crate::array::js_array_alloc(0));
-    let context = mock_context_object(id, calls, false);
-    MOCK_STATES.with(|states| {
-        states.borrow_mut().push(MockState {
-            id,
-            original: undefined_value(),
-            implementation: undefined_value(),
-            once: Vec::new(),
-            calls,
-            context,
-            function: undefined_value(),
-            restore,
-        });
-    });
-    context
-}
-
 fn reset_mock_state_calls(state: &mut MockState) {
     state.calls = boxed_ptr(crate::array::js_array_alloc(0));
     update_mock_context_calls(state.context, state.calls);
@@ -1144,22 +1128,6 @@ extern "C" fn mock_setter_thunk(
     )
 }
 
-extern "C" fn mock_property_thunk(
-    _closure: *const ClosureHeader,
-    target: f64,
-    property: f64,
-    value: f64,
-) -> f64 {
-    let property = property_name(property);
-    let original = get_property_value(target, &property);
-    set_property_value(target, &property, value);
-    create_restore_context(MockRestoreTarget::ObjectProperty {
-        target,
-        property,
-        original,
-    })
-}
-
 extern "C" fn mock_reset_thunk(_closure: *const ClosureHeader) -> f64 {
     MOCK_STATES.with(|states| {
         for state in states.borrow_mut().iter_mut() {
@@ -1168,6 +1136,7 @@ extern "C" fn mock_reset_thunk(_closure: *const ClosureHeader) -> f64 {
             reset_mock_state_calls(state);
         }
     });
+    property_mock::restore_all();
     undefined_value()
 }
 
@@ -1182,6 +1151,7 @@ extern "C" fn mock_restore_all_thunk(_closure: *const ClosureHeader) -> f64 {
     for id in ids {
         restore_mock_state(id);
     }
+    property_mock::restore_all();
     undefined_value()
 }
 
@@ -1234,11 +1204,7 @@ fn mock_object_value() -> f64 {
             "setter",
             closure_value(mock_setter_thunk as *const u8, 4),
         );
-        set_field(
-            mock,
-            "property",
-            closure_value(mock_property_thunk as *const u8, 3),
-        );
+        set_field(mock, "property", property_mock::tracker_property_value());
         set_field(
             mock,
             "reset",
@@ -1691,7 +1657,17 @@ pub extern "C" fn js_node_test_mock_setter(
 
 #[no_mangle]
 pub extern "C" fn js_node_test_mock_property(target: f64, property: f64, value: f64) -> f64 {
-    mock_property_thunk(std::ptr::null(), target, property, value)
+    property_mock::create(target, property, true, value)
+}
+
+#[no_mangle]
+pub extern "C" fn js_node_test_mock_property_with_presence(
+    target: f64,
+    property: f64,
+    value: f64,
+    value_present: i32,
+) -> f64 {
+    property_mock::create(target, property, value_present != 0, value)
 }
 
 #[no_mangle]
@@ -1810,6 +1786,7 @@ pub(crate) fn scan_test_module_roots_mut(visitor: &mut crate::gc::RuntimeRootVis
             }
         }
     });
+    property_mock::scan_roots_mut(visitor);
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/node_submodules/test_property.rs
+++ b/crates/perry-runtime/src/node_submodules/test_property.rs
@@ -1,0 +1,598 @@
+//! `MockTracker.property()` and `MockPropertyContext` support.
+
+use std::cell::RefCell;
+
+use super::*;
+
+#[derive(Clone, Copy)]
+struct OnceValue {
+    access_index: u64,
+    value: f64,
+}
+
+struct MockPropertyState {
+    id: i64,
+    target: f64,
+    property: String,
+    original_value: f64,
+    original_accessor: Option<crate::object::AccessorDescriptor>,
+    original_attrs: Option<crate::object::PropertyAttrs>,
+    writable: bool,
+    value: f64,
+    accesses: f64,
+    access_count: u64,
+    once: Vec<OnceValue>,
+    context: f64,
+}
+
+thread_local! {
+    static PROPERTY_STATES: RefCell<Vec<MockPropertyState>> = const { RefCell::new(Vec::new()) };
+}
+
+fn set_object_field(object: f64, name: &str, value: f64) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let object = scope.root_nanbox_f64(object);
+    let value = scope.root_nanbox_f64(value);
+    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let raw = raw_ptr_from_value(object.get_nanbox_f64());
+    js_object_set_field_by_name(
+        raw as *mut crate::object::ObjectHeader,
+        key,
+        value.get_nanbox_f64(),
+    );
+}
+
+fn property_context_object(id: i64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let context = scope.root_nanbox_f64(boxed_ptr(js_object_alloc(0, 6)));
+    set_object_field(
+        context.get_nanbox_f64(),
+        "accessCount",
+        closure_value_with_id(mock_property_access_count as *const u8, 0, id),
+    );
+    set_object_field(
+        context.get_nanbox_f64(),
+        "resetAccesses",
+        closure_value_with_id(mock_property_reset_accesses as *const u8, 0, id),
+    );
+    set_object_field(
+        context.get_nanbox_f64(),
+        "mockImplementation",
+        closure_value_with_id(mock_property_implementation as *const u8, 1, id),
+    );
+    set_object_field(
+        context.get_nanbox_f64(),
+        "mockImplementationOnce",
+        rest_closure_value_with_id(mock_property_implementation_once as *const u8, 1, id),
+    );
+    set_object_field(
+        context.get_nanbox_f64(),
+        "restore",
+        closure_value_with_id(mock_property_restore as *const u8, 0, id),
+    );
+
+    let accesses_getter = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_accesses as *const u8,
+        0,
+        id,
+    ));
+    let key = scope.root_nanbox_f64(string_value("accesses"));
+    let raw = raw_ptr_from_value(context.get_nanbox_f64());
+    unsafe {
+        crate::object::ensure_key_in_keys_array(
+            raw as *mut crate::object::ObjectHeader,
+            raw_ptr_from_value(key.get_nanbox_f64()) as *mut crate::StringHeader,
+        );
+    }
+    crate::object::set_accessor_descriptor(
+        raw,
+        "accesses".to_string(),
+        crate::object::AccessorDescriptor {
+            get: accesses_getter.get_nanbox_f64().to_bits(),
+            set: 0,
+        },
+    );
+    crate::object::set_property_attrs(
+        raw,
+        "accesses".to_string(),
+        crate::object::PropertyAttrs::new(false, false, true),
+    );
+    context.get_nanbox_f64()
+}
+
+fn install_property_accessor(
+    target: f64,
+    property: &str,
+    getter: f64,
+    setter: f64,
+    original_attrs: Option<crate::object::PropertyAttrs>,
+) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let getter = scope.root_nanbox_f64(getter);
+    let setter = scope.root_nanbox_f64(setter);
+    let key = scope.root_nanbox_f64(string_value(property));
+    let raw = raw_ptr_from_value(target.get_nanbox_f64());
+    unsafe {
+        crate::object::ensure_key_in_keys_array(
+            raw as *mut crate::object::ObjectHeader,
+            raw_ptr_from_value(key.get_nanbox_f64()) as *mut crate::StringHeader,
+        );
+    }
+    crate::object::set_accessor_descriptor(
+        raw,
+        property.to_string(),
+        crate::object::AccessorDescriptor {
+            get: getter.get_nanbox_f64().to_bits(),
+            set: setter.get_nanbox_f64().to_bits(),
+        },
+    );
+    let attrs = original_attrs.unwrap_or(crate::object::PropertyAttrs::new(true, true, true));
+    crate::object::set_property_attrs(
+        raw,
+        property.to_string(),
+        crate::object::PropertyAttrs::new(true, attrs.enumerable(), attrs.configurable()),
+    );
+}
+
+fn restore_property_state(id: i64) {
+    let restore = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| {
+                (
+                    state.target,
+                    state.property.clone(),
+                    state.original_value,
+                    state.original_accessor,
+                    state.original_attrs,
+                )
+            })
+    });
+    let Some((target, property, original_value, original_accessor, original_attrs)) = restore
+    else {
+        return;
+    };
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let original_value = scope.root_nanbox_f64(original_value);
+    let raw = raw_ptr_from_value(target.get_nanbox_f64());
+    if let Some(accessor) = original_accessor {
+        crate::object::set_accessor_descriptor(raw, property.clone(), accessor);
+    } else {
+        crate::object::clear_accessor_descriptor(raw, &property);
+        set_object_field(
+            target.get_nanbox_f64(),
+            &property,
+            original_value.get_nanbox_f64(),
+        );
+    }
+    let raw = raw_ptr_from_value(target.get_nanbox_f64());
+    if let Some(attrs) = original_attrs {
+        crate::object::set_property_attrs(raw, property, attrs);
+    } else {
+        crate::object::clear_property_attrs(raw, &property);
+    }
+}
+
+fn validate_on_access(value: f64, minimum: u64) -> u64 {
+    let js = JSValue::from_bits(value.to_bits());
+    if js.is_undefined() || js.is_null() {
+        return minimum;
+    }
+    if !crate::fs::validate::is_numeric(js) {
+        throw_invalid_arg_type("onAccess", "number", value);
+    }
+    let number = crate::builtins::js_number_coerce(value);
+    const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+    if !number.is_finite()
+        || number.fract() != 0.0
+        || number < minimum as f64
+        || number > MAX_SAFE_INTEGER
+    {
+        let message = format!(
+            "The value of \"onAccess\" is out of range. It must be an integer >= {minimum}."
+        );
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_OUT_OF_RANGE");
+    }
+    number as u64
+}
+
+fn record_property_access(id: i64, access_type: &str, fallback: f64) -> f64 {
+    let (value, accesses) = PROPERTY_STATES.with(|states| {
+        let mut states = states.borrow_mut();
+        let Some(state) = states.iter_mut().find(|state| state.id == id) else {
+            return (fallback, undefined_value());
+        };
+        let value = state
+            .once
+            .iter()
+            .position(|once| once.access_index == state.access_count)
+            .map(|index| state.once.remove(index).value)
+            .unwrap_or(fallback);
+        (value, state.accesses)
+    });
+    if !is_array_value(accesses) {
+        return value;
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value = scope.root_nanbox_f64(value);
+    let accesses = scope.root_nanbox_f64(accesses);
+    let access_type = scope.root_nanbox_f64(string_value(access_type));
+    let stack_message = scope.root_nanbox_f64(string_value("Error"));
+    let stack = crate::error::js_error_new_with_message(raw_ptr_from_value(
+        stack_message.get_nanbox_f64(),
+    ) as *mut crate::StringHeader);
+    let stack = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(stack as i64));
+    let record = scope.root_nanbox_f64(boxed_ptr(js_object_alloc(0, 3)));
+    set_object_field(
+        record.get_nanbox_f64(),
+        "type",
+        access_type.get_nanbox_f64(),
+    );
+    set_object_field(record.get_nanbox_f64(), "value", value.get_nanbox_f64());
+    set_object_field(record.get_nanbox_f64(), "stack", stack.get_nanbox_f64());
+
+    let accesses_ptr =
+        raw_ptr_from_value(accesses.get_nanbox_f64()) as *mut crate::array::ArrayHeader;
+    let accesses_ptr = crate::array::js_array_push_f64(accesses_ptr, record.get_nanbox_f64());
+    let accesses_value = boxed_ptr(accesses_ptr);
+    PROPERTY_STATES.with(|states| {
+        if let Some(state) = states.borrow_mut().iter_mut().find(|state| state.id == id) {
+            state.accesses = accesses_value;
+            state.access_count += 1;
+        }
+    });
+    value.get_nanbox_f64()
+}
+
+extern "C" fn mock_property_get(closure: *const ClosureHeader) -> f64 {
+    let id = closure_id(closure);
+    let value = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| state.value)
+            .unwrap_or_else(undefined_value)
+    });
+    record_property_access(id, "get", value)
+}
+
+extern "C" fn mock_property_set(closure: *const ClosureHeader, value: f64) -> f64 {
+    let id = closure_id(closure);
+    let (writable, property) = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| (state.writable, state.property.clone()))
+            .unwrap_or((true, String::new()))
+    });
+    if !writable {
+        let message = format!("The argument 'propertyName' {property} cannot be set");
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+    }
+    let value = record_property_access(id, "set", value);
+    PROPERTY_STATES.with(|states| {
+        if let Some(state) = states.borrow_mut().iter_mut().find(|state| state.id == id) {
+            state.value = value;
+        }
+    });
+    undefined_value()
+}
+
+extern "C" fn mock_property_access_count(closure: *const ClosureHeader) -> f64 {
+    let id = closure_id(closure);
+    PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| state.access_count as f64)
+            .unwrap_or(0.0)
+    })
+}
+
+extern "C" fn mock_property_accesses(closure: *const ClosureHeader) -> f64 {
+    let id = closure_id(closure);
+    let accesses = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| state.accesses)
+            .unwrap_or_else(undefined_value)
+    });
+    if !is_array_value(accesses) {
+        return boxed_ptr(crate::array::js_array_alloc(0));
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let accesses = scope.root_nanbox_f64(accesses);
+    let ptr = raw_ptr_from_value(accesses.get_nanbox_f64()) as *const crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(ptr);
+    boxed_ptr(crate::array::js_array_slice(ptr, 0, len as i32))
+}
+
+extern "C" fn mock_property_reset_accesses(closure: *const ClosureHeader) -> f64 {
+    let id = closure_id(closure);
+    let accesses = boxed_ptr(crate::array::js_array_alloc(0));
+    PROPERTY_STATES.with(|states| {
+        if let Some(state) = states.borrow_mut().iter_mut().find(|state| state.id == id) {
+            state.accesses = accesses;
+            state.access_count = 0;
+        }
+    });
+    undefined_value()
+}
+
+extern "C" fn mock_property_implementation(closure: *const ClosureHeader, value: f64) -> f64 {
+    mock_property_set(closure, value)
+}
+
+extern "C" fn mock_property_implementation_once(
+    closure: *const ClosureHeader,
+    value: f64,
+    rest: f64,
+) -> f64 {
+    let id = closure_id(closure);
+    let next_access = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .find(|state| state.id == id)
+            .map(|state| state.access_count)
+            .unwrap_or(0)
+    });
+    let on_access = array_values(rest)
+        .and_then(|values| values.first().copied())
+        .unwrap_or_else(undefined_value);
+    let access_index = validate_on_access(on_access, next_access);
+    PROPERTY_STATES.with(|states| {
+        if let Some(state) = states.borrow_mut().iter_mut().find(|state| state.id == id) {
+            if let Some(existing) = state
+                .once
+                .iter_mut()
+                .find(|once| once.access_index == access_index)
+            {
+                existing.value = value;
+            } else {
+                state.once.push(OnceValue {
+                    access_index,
+                    value,
+                });
+            }
+        }
+    });
+    undefined_value()
+}
+
+extern "C" fn mock_property_restore(closure: *const ClosureHeader) -> f64 {
+    restore_property_state(closure_id(closure));
+    undefined_value()
+}
+
+extern "C" fn mock_property_proxy_get(
+    closure: *const ClosureHeader,
+    target: f64,
+    key: f64,
+    receiver: f64,
+) -> f64 {
+    if value_to_string(key).as_deref() == Some("mock") {
+        let id = closure_id(closure);
+        return PROPERTY_STATES.with(|states| {
+            states
+                .borrow()
+                .iter()
+                .find(|state| state.id == id)
+                .map(|state| state.context)
+                .unwrap_or_else(undefined_value)
+        });
+    }
+    crate::proxy::js_reflect_get(target, key, receiver)
+}
+
+extern "C" fn tracker_property_thunk(
+    _closure: *const ClosureHeader,
+    target: f64,
+    property: f64,
+    rest: f64,
+) -> f64 {
+    let values = array_values(rest).unwrap_or_default();
+    let value_present = !values.is_empty();
+    let value = values.first().copied().unwrap_or_else(undefined_value);
+    create(target, property, value_present, value)
+}
+
+pub(super) fn tracker_property_value() -> f64 {
+    let value = rest_closure_value_with_id(tracker_property_thunk as *const u8, 2, 0);
+    let raw = raw_ptr_from_value(value);
+    crate::object::set_builtin_closure_length(raw, 3);
+    value
+}
+
+pub(super) fn create(target: f64, property: f64, value_present: bool, value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
+    let property_value = scope.root_nanbox_f64(property);
+    let value = scope.root_nanbox_f64(value);
+    object_target_addr(target.get_nanbox_f64());
+    let property = property_name(property_value.get_nanbox_f64());
+    let key = scope.root_nanbox_f64(string_value(&property));
+    if crate::value::js_is_truthy(crate::object::js_object_has_own(
+        target.get_nanbox_f64(),
+        key.get_nanbox_f64(),
+    )) == 0
+    {
+        let message =
+            format!("The argument 'propertyName' {property} is not a property of the object");
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+    }
+
+    let original_value =
+        scope.root_nanbox_f64(get_property_value(target.get_nanbox_f64(), &property));
+    let raw = raw_ptr_from_value(target.get_nanbox_f64());
+    let original_accessor = crate::object::get_accessor_descriptor(raw, &property);
+    let original_attrs = crate::object::get_property_attrs(raw, &property);
+    let attrs = original_attrs.unwrap_or(crate::object::PropertyAttrs::new(true, true, true));
+    if !attrs.configurable() {
+        let message = format!("Cannot redefine property: {property}");
+        crate::fs::validate::throw_type_error_with_code(&message, "ERR_INVALID_ARG_VALUE");
+    }
+    let writable = original_accessor.is_none() && attrs.writable();
+    let mocked_value = scope.root_nanbox_f64(if value_present {
+        value.get_nanbox_f64()
+    } else {
+        original_value.get_nanbox_f64()
+    });
+
+    let id = next_mock_id();
+    let accesses = scope.root_nanbox_f64(boxed_ptr(crate::array::js_array_alloc(0)));
+    let context = scope.root_nanbox_f64(property_context_object(id));
+    let getter =
+        scope.root_nanbox_f64(closure_value_with_id(mock_property_get as *const u8, 0, id));
+    let setter =
+        scope.root_nanbox_f64(closure_value_with_id(mock_property_set as *const u8, 1, id));
+
+    PROPERTY_STATES.with(|states| {
+        states.borrow_mut().push(MockPropertyState {
+            id,
+            target: target.get_nanbox_f64(),
+            property: property.clone(),
+            original_value: original_value.get_nanbox_f64(),
+            original_accessor,
+            original_attrs,
+            writable,
+            value: mocked_value.get_nanbox_f64(),
+            accesses: accesses.get_nanbox_f64(),
+            access_count: 0,
+            once: Vec::new(),
+            context: context.get_nanbox_f64(),
+        });
+    });
+    install_property_accessor(
+        target.get_nanbox_f64(),
+        &property,
+        getter.get_nanbox_f64(),
+        setter.get_nanbox_f64(),
+        original_attrs,
+    );
+
+    let handler = scope.root_nanbox_f64(boxed_ptr(js_object_alloc(0, 1)));
+    let get_trap = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_proxy_get as *const u8,
+        3,
+        id,
+    ));
+    set_object_field(handler.get_nanbox_f64(), "get", get_trap.get_nanbox_f64());
+    crate::proxy::js_proxy_new(target.get_nanbox_f64(), handler.get_nanbox_f64())
+}
+
+pub(super) fn restore_all() {
+    let ids = PROPERTY_STATES.with(|states| {
+        states
+            .borrow()
+            .iter()
+            .map(|state| state.id)
+            .collect::<Vec<_>>()
+    });
+    for id in ids {
+        restore_property_state(id);
+    }
+}
+
+pub(super) fn scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    PROPERTY_STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.target);
+            visitor.visit_nanbox_f64_slot(&mut state.original_value);
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+            visitor.visit_nanbox_f64_slot(&mut state.accesses);
+            visitor.visit_nanbox_f64_slot(&mut state.context);
+            for once in state.once.iter_mut() {
+                visitor.visit_nanbox_f64_slot(&mut once.value);
+            }
+            if let Some(accessor) = state.original_accessor.as_mut() {
+                for bits in [&mut accessor.get, &mut accessor.set] {
+                    if *bits != 0 {
+                        let mut value = f64::from_bits(*bits);
+                        visitor.visit_nanbox_f64_slot(&mut value);
+                        *bits = value.to_bits();
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object_with_value(value: f64) -> f64 {
+        let object = boxed_ptr(js_object_alloc(0, 1));
+        set_object_field(object, "value", value);
+        object
+    }
+
+    fn proxy_context(proxy: f64) -> f64 {
+        crate::proxy::js_proxy_get(proxy, string_value("mock"))
+    }
+
+    #[test]
+    fn omitted_value_spies_while_explicit_undefined_replaces() {
+        let target = object_with_value(5.0);
+        let proxy = create(target, string_value("value"), false, undefined_value());
+        assert_eq!(get_property_value(target, "value"), 5.0);
+        let context = proxy_context(proxy);
+        let count = object_property(context, b"accessCount").expect("accessCount");
+        assert_eq!(
+            js_closure_call0(raw_ptr_from_value(count) as *const ClosureHeader),
+            1.0
+        );
+        restore_all();
+        assert_eq!(get_property_value(target, "value"), 5.0);
+
+        let target = object_with_value(5.0);
+        create(target, string_value("value"), true, undefined_value());
+        assert!(is_undefined_value(get_property_value(target, "value")));
+        restore_all();
+        assert_eq!(get_property_value(target, "value"), 5.0);
+    }
+
+    #[test]
+    fn property_context_tracks_and_schedules_accesses() {
+        let target = object_with_value(1.0);
+        let proxy = create(target, string_value("value"), true, 2.0);
+        let context = proxy_context(proxy);
+        let implementation =
+            object_property(context, b"mockImplementation").expect("mockImplementation");
+        js_closure_call1(
+            raw_ptr_from_value(implementation) as *const ClosureHeader,
+            9.0,
+        );
+        let once =
+            object_property(context, b"mockImplementationOnce").expect("mockImplementationOnce");
+        crate::closure::js_closure_call2(
+            raw_ptr_from_value(once) as *const ClosureHeader,
+            4.0,
+            1.0,
+        );
+
+        assert_eq!(get_property_value(target, "value"), 4.0);
+        assert_eq!(get_property_value(target, "value"), 9.0);
+        let count = object_property(context, b"accessCount").expect("accessCount");
+        assert_eq!(
+            js_closure_call0(raw_ptr_from_value(count) as *const ClosureHeader),
+            3.0
+        );
+        let accesses = object_property(context, b"accesses").expect("accesses");
+        assert_eq!(array_values(accesses).expect("access array").len(), 3);
+        restore_all();
+        assert_eq!(get_property_value(target, "value"), 1.0);
+    }
+}

--- a/crates/perry-runtime/src/node_submodules/test_property.rs
+++ b/crates/perry-runtime/src/node_submodules/test_property.rs
@@ -45,30 +45,55 @@ fn set_object_field(object: f64, name: &str, value: f64) {
 fn property_context_object(id: i64) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let context = scope.root_nanbox_f64(boxed_ptr(js_object_alloc(0, 6)));
+    let access_count = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_access_count as *const u8,
+        0,
+        id,
+    ));
     set_object_field(
         context.get_nanbox_f64(),
         "accessCount",
-        closure_value_with_id(mock_property_access_count as *const u8, 0, id),
+        access_count.get_nanbox_f64(),
     );
+    let reset_accesses = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_reset_accesses as *const u8,
+        0,
+        id,
+    ));
     set_object_field(
         context.get_nanbox_f64(),
         "resetAccesses",
-        closure_value_with_id(mock_property_reset_accesses as *const u8, 0, id),
+        reset_accesses.get_nanbox_f64(),
     );
+    let mock_implementation = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_implementation as *const u8,
+        1,
+        id,
+    ));
     set_object_field(
         context.get_nanbox_f64(),
         "mockImplementation",
-        closure_value_with_id(mock_property_implementation as *const u8, 1, id),
+        mock_implementation.get_nanbox_f64(),
     );
+    let mock_implementation_once = scope.root_nanbox_f64(rest_closure_value_with_id(
+        mock_property_implementation_once as *const u8,
+        1,
+        id,
+    ));
     set_object_field(
         context.get_nanbox_f64(),
         "mockImplementationOnce",
-        rest_closure_value_with_id(mock_property_implementation_once as *const u8, 1, id),
+        mock_implementation_once.get_nanbox_f64(),
     );
+    let restore = scope.root_nanbox_f64(closure_value_with_id(
+        mock_property_restore as *const u8,
+        0,
+        id,
+    ));
     set_object_field(
         context.get_nanbox_f64(),
         "restore",
-        closure_value_with_id(mock_property_restore as *const u8, 0, id),
+        restore.get_nanbox_f64(),
     );
 
     let accesses_getter = scope.root_nanbox_f64(closure_value_with_id(
@@ -202,21 +227,23 @@ fn validate_on_access(value: f64, minimum: u64) -> u64 {
 }
 
 fn record_property_access(id: i64, access_type: &str, fallback: f64) -> f64 {
-    let (value, accesses) = PROPERTY_STATES.with(|states| {
-        let mut states = states.borrow_mut();
-        let Some(state) = states.iter_mut().find(|state| state.id == id) else {
-            return (fallback, undefined_value());
+    let (value, accesses, scheduled_index) = PROPERTY_STATES.with(|states| {
+        let states = states.borrow();
+        let Some(state) = states.iter().find(|state| state.id == id) else {
+            return (fallback, undefined_value(), None);
         };
-        let value = state
+        let scheduled = state
             .once
             .iter()
-            .position(|once| once.access_index == state.access_count)
-            .map(|index| state.once.remove(index).value)
-            .unwrap_or(fallback);
-        (value, state.accesses)
+            .find(|once| once.access_index == state.access_count);
+        (
+            scheduled.map(|once| once.value).unwrap_or(fallback),
+            state.accesses,
+            scheduled.map(|once| once.access_index),
+        )
     });
     if !is_array_value(accesses) {
-        return value;
+        return fallback;
     }
 
     let scope = crate::gc::RuntimeHandleScope::new();
@@ -244,6 +271,15 @@ fn record_property_access(id: i64, access_type: &str, fallback: f64) -> f64 {
     PROPERTY_STATES.with(|states| {
         if let Some(state) = states.borrow_mut().iter_mut().find(|state| state.id == id) {
             state.accesses = accesses_value;
+            if let Some(access_index) = scheduled_index {
+                if let Some(index) = state
+                    .once
+                    .iter()
+                    .position(|once| once.access_index == access_index)
+                {
+                    state.once.remove(index);
+                }
+            }
             state.access_count += 1;
         }
     });


### PR DESCRIPTION
## Summary

- implement `MockTracker.property()` with tracked getter/setter accessors and a proxy-backed `mock` context
- support access history, access counts, reset, restore, replacement values, and indexed one-shot values
- preserve the semantic difference between an omitted replacement and explicit `undefined` through a compiler/runtime presence bit
- integrate property mocks with tracker reset and restore-all behavior

Refs #6767

## Parity fixtures fixed

- `node-suite/test/mock-fn/property-access-records`
- `node-suite/test/mock-fn/property-context`
- `node-suite/test/mock-fn/property-no-value`
- `node-suite/test/mock-fn/property-on-access`
- `node-suite/test/mock-fn/property-undefined`

All five pass exact Node parity; the pre-existing `node-suite/test/mock-fn/basic` fixture also remains green.

## Verification

- `cargo check -p perry-codegen -p perry-runtime`
- `cargo test -p perry-codegen --test node_test_mock_property_presence -- --nocapture`
- `cargo test -p perry-runtime node_submodules::test::property_mock::tests -- --nocapture`
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/mock-fn/property-` (5/5, 100%)
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/mock-fn/basic` (1/1, 100%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `node:test` property mocks, including getter/setter interception and access tracking.
  * Added persistent and one-time mock implementations.
  * Added mock context restoration, bulk reset, and proxy support.
  * Property mocks now distinguish omitted values from explicitly provided `undefined`.
* **Bug Fixes**
  * Improved validation for property names, configurability, writability, and access handlers.
  * Fixed property mock restoration and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->