### PR TITLE
fix(node:test): support symbol keyed mock methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1408
+**Current Version:** 0.5.1409
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1408"
+version = "0.5.1409"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1408"
+version = "0.5.1409"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1408"
+version = "0.5.1409"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1408"
+version = "0.5.1409"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1408"
+version = "0.5.1409"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7102-node-test-mock-symbol.md
+++ b/changelog.d/7102-node-test-mock-symbol.md
@@ -1,0 +1,2 @@
+Added `node:test` mock method support for Symbol-keyed object methods, including
+Node-compatible call tracking and restore behavior.

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -299,6 +299,9 @@ fn parse_mock_timer_options(options: f64) -> (u32, f64) {
 #[derive(Clone)]
 enum MockRestoreTarget {
     None,
+    // Node 26.5 accepts Symbol method names, but its restore path only
+    // recognizes string names and falls through to the bare-function case.
+    ObjectSymbolMethod,
     ObjectProperty {
         target: f64,
         property: String,
@@ -631,7 +634,15 @@ fn take_mock_implementation(state: &mut MockState) -> f64 {
 }
 
 fn prepare_mock_state_restore(state: &mut MockState) -> MockRestoreTarget {
-    state.implementation = state.original;
+    // Node 26.5's restore path only recognizes string method names. A
+    // Symbol-keyed method falls through to the bare-function case, so the
+    // restored mock is left with no implementation and a later invocation
+    // throws instead of reaching the original method.
+    state.implementation = if matches!(state.restore, MockRestoreTarget::ObjectSymbolMethod) {
+        undefined_value()
+    } else {
+        state.original
+    };
     state.restore.clone()
 }
 
@@ -719,16 +730,37 @@ mod metadata_tests;
 extern "C" fn mock_function_invoke(closure: *const ClosureHeader, rest: f64) -> f64 {
     let id = closure_id(closure);
     let args = array_values(rest).unwrap_or_default();
-    let implementation = MOCK_STATES.with(|states| {
+    let (implementation, is_symbol_method) = MOCK_STATES.with(|states| {
         let mut states = states.borrow_mut();
         let Some(state) = states.iter_mut().find(|state| state.id == id) else {
-            return undefined_value();
+            return (undefined_value(), false);
         };
-        take_mock_implementation(state)
+        (
+            take_mock_implementation(state),
+            matches!(state.restore, MockRestoreTarget::ObjectSymbolMethod),
+        )
     });
 
     let this_value = crate::object::js_implicit_this_get();
     if JSValue::from_bits(implementation.to_bits()).is_undefined() {
+        if is_symbol_method {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let rest_handle = scope.root_nanbox_f64(rest);
+            let this_handle = scope.root_nanbox_f64(this_value);
+            let message_handle = scope.root_nanbox_f64(string_value("undefined is not a function"));
+            let error = crate::error::js_typeerror_new(raw_ptr_from_value(
+                message_handle.get_nanbox_f64(),
+            ) as *mut crate::StringHeader);
+            let error_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(error as i64));
+            record_mock_call(
+                id,
+                rest_handle.get_nanbox_f64(),
+                this_handle.get_nanbox_f64(),
+                undefined_value(),
+                error_handle.get_nanbox_f64(),
+            );
+            crate::exception::js_throw(error_handle.get_nanbox_f64());
+        }
         record_mock_call(id, rest, this_value, undefined_value(), undefined_value());
         return undefined_value();
     }
@@ -905,6 +937,35 @@ extern "C" fn mock_method_thunk(
             implementation.get_nanbox_f64(),
         );
     }
+    if unsafe { crate::symbol::js_is_symbol(property.get_nanbox_f64()) } != 0 {
+        object_target_addr(target.get_nanbox_f64());
+        let original = unsafe {
+            crate::symbol::js_object_get_symbol_property(
+                target.get_nanbox_f64(),
+                property.get_nanbox_f64(),
+            )
+        };
+        let implementation = if is_undefined_value(implementation.get_nanbox_f64()) {
+            original
+        } else {
+            implementation.get_nanbox_f64()
+        };
+        assert_callable_arg("implementation", implementation);
+        let function = scope.root_nanbox_f64(create_mock_function(
+            original,
+            implementation,
+            MockRestoreTarget::ObjectSymbolMethod,
+        ));
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(
+                target.get_nanbox_f64(),
+                property.get_nanbox_f64(),
+                function.get_nanbox_f64(),
+            );
+        }
+        return function.get_nanbox_f64();
+    }
+
     let property_name = property_name(property.get_nanbox_f64());
     let original = get_property_value(target.get_nanbox_f64(), &property_name);
     let implementation = if is_undefined_value(implementation.get_nanbox_f64()) {


### PR DESCRIPTION
Addresses `node-suite/test/mock-fn/symbol-method` in #6767.

`mock.method()` now accepts Symbol keys, reads and replaces the symbol-keyed implementation through Perry's symbol property side table, and reproduces Node 26.5's observable Symbol restore behavior. A failed invocation after restore is tracked and rethrown as `TypeError`, matching the oracle output.

Validation:

- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module test --filter symbol-method` (1/1, 100%)
- neighboring `inherited-method`, `method-receiver`, and `method-restore-chain` fixtures remain exact-parity passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mocking methods keyed by JavaScript Symbols through `node:test`.
  * Symbol-keyed mocks now support call tracking, restoration, and behavior consistent with Node.js.
  * Symbol methods can be mocked alongside regular object methods.

* **Bug Fixes**
  * Improved restoration of Symbol-keyed methods.
  * Restored methods now correctly return to an unavailable state and report an appropriate error when called without an implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->