### PR TITLE
fix(node:test): align mock timer advancement

### DIFF
--- a/changelog.d/7103-node-test-mock-timers.md
+++ b/changelog.d/7103-node-test-mock-timers.md
@@ -1,0 +1,2 @@
+Aligned `node:test` mock timer defaults and `runAll()` advancement with Node.js,
+including epoch-zero initialization and one-millisecond default ticks.

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -332,7 +332,11 @@ extern "C" fn mock_timers_enable(_closure: *const ClosureHeader, options: f64) -
 }
 
 extern "C" fn mock_timers_tick(_closure: *const ClosureHeader, ms: f64) -> f64 {
-    let delay = validate_mock_timer_number("time", ms);
+    let delay = if is_undefined_value(ms) {
+        1.0
+    } else {
+        validate_mock_timer_number("time", ms)
+    };
     crate::timer::js_mock_timers_tick(delay);
     undefined_value()
 }
@@ -372,7 +376,7 @@ fn validate_mock_timer_number(arg: &str, value: f64) -> f64 {
 
 fn parse_mock_timer_options(options: f64) -> (u32, f64) {
     let mut apis_value = options;
-    let mut now = crate::timer::js_mock_timers_real_now_ms();
+    let mut now = 0.0;
     let js = JSValue::from_bits(options.to_bits());
     if js.is_undefined() {
         return (crate::timer::MOCK_TIMERS_ALL_APIS, now);

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -662,37 +662,25 @@ pub fn js_mock_timers_tick(ms: f64) {
 
 pub fn js_mock_timers_run_all() {
     ensure_mock_timers_enabled();
-    const RUN_LIMIT: usize = 100_000;
-    for _ in 0..RUN_LIMIT {
-        let next_due = {
-            let state = MOCK_TIMERS.lock().unwrap();
-            state
-                .callbacks
-                .iter()
-                .filter(|timer| !timer.cleared)
-                .map(|timer| timer.due_ms)
-                .chain(
-                    state
-                        .intervals
-                        .iter()
-                        .filter(|timer| !timer.cleared)
-                        .map(|timer| timer.next_ms),
-                )
-                .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-        };
-        let Some(target) = next_due else {
-            return;
-        };
+    let longest_due = {
+        let state = MOCK_TIMERS.lock().unwrap();
+        state
+            .callbacks
+            .iter()
+            .filter(|timer| !timer.cleared)
+            .map(|timer| timer.due_ms)
+            .chain(
+                state
+                    .intervals
+                    .iter()
+                    .filter(|timer| !timer.cleared)
+                    .map(|timer| timer.next_ms),
+            )
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    };
+    if let Some(target) = longest_due {
         mock_timers_advance_to(target);
-        let has_more = {
-            let state = MOCK_TIMERS.lock().unwrap();
-            state.callbacks.iter().any(|timer| !timer.cleared)
-        };
-        if !has_more {
-            return;
-        }
     }
-    throw_mock_timer_invalid_state("Invalid state: MockTimers runAll() reached the timer limit");
 }
 
 fn schedule_mock_callback_timer(


### PR DESCRIPTION
Addresses the remaining mock-timer failures tracked in #6767:

- `node-suite/test/mock-timers/default-epoch`
- `node-suite/test/mock-timers/default-tick`
- `node-suite/test/mock-timers/run-all-nested`

Mock timers now default to epoch zero, omitted `tick()` arguments advance one millisecond, and `runAll()` advances to the longest timer present at entry instead of recursively draining timers scheduled beyond that horizon.

Validation:

- `cargo check -p perry-runtime`
- `./run_parity_tests.sh --suite node-suite --module test --filter node-suite/test/mock-timers/` (13/13 runnable fixtures, 100%; the existing validation fixture is skipped because Node exits nonzero)