### PR TITLE
test(repsel): promotion census with a ratcheted, falsifiable floor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1138,7 +1138,7 @@ jobs:
           path: target/compiler-output-regression/
 
   # ---------------------------------------------------------------------------
-  # Representation-selection promotion census (#7035)
+  # Representation-selection promotion census (#7106)
   #
   # Counts, per workload and PER REPRESENTATION, how many values got each
   # unboxed representation, and compares each count against a ratcheted floor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1138,6 +1138,124 @@ jobs:
           path: target/compiler-output-regression/
 
   # ---------------------------------------------------------------------------
+  # Representation-selection promotion census (#7035)
+  #
+  # Counts, per workload and PER REPRESENTATION, how many values got each
+  # unboxed representation, and compares each count against a ratcheted floor
+  # (benchmarks/repsel_census/baseline.json).
+  #
+  # Why this job exists: #7034 discovered by hand-instrumenting the compiler
+  # that `Ptr<Shape>` promotes NOTHING on `batch.ts` — the object-heavy
+  # workload it exists for — and that only 3 of 17 suite benchmarks promote a
+  # single shape local each. Nothing in CI could have told anyone that.
+  #
+  # Why it can fail (CLAUDE.md, "Four ways a gate can be unable to fail"):
+  # floors alone would not be enough, because the honest floor for
+  # `Ptr<Shape>` on real code is zero today and a zero floor can never go red.
+  # The corpus therefore includes hand-written liveness fixtures whose
+  # minimums live in `scripts/compiler_output_harness/repsel_census.py`, NOT in
+  # the regenerable baseline, plus a corpus-wide assertion that no census key
+  # reads zero everywhere. Verified by sabotage in both directions: each of
+  # PERRY_PTR_SHAPE_LOCALS / PERRY_PTR_NUMARRAY_LOCALS /
+  # PERRY_CANONICAL_I32_LOCALS / PERRY_CANONICAL_STR_LOCALS /
+  # PERRY_INT_VALUED_LOCALS set to 0 turns this job red; the default build is
+  # green.
+  #
+  # DELIBERATELY NOT a required status check on its first landing — a gate
+  # that has never been green would block every open PR. Promoting it is a
+  # follow-up, and CLAUDE.md failure mode (2) is what happens if that
+  # follow-up is skipped.
+  # ---------------------------------------------------------------------------
+  repsel-census:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "false"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      SCCACHE_CACHE_SIZE: "12G"
+      CARGO_INCREMENTAL: "0"
+      # The census only needs codegen (`--no-link`), never a linked binary, so
+      # it cannot be fooled by a stale libperry_runtime.a. Auto-optimize is off
+      # because it rebuilds runtime libs the census never links.
+      PERRY_NO_AUTO_OPTIMIZE: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Cache sccache objects
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.sccache
+          key: sccache-${{ runner.os }}-perry-${{ github.job }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-perry-
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Verdict logic first, cheaply: if the census can't tell a regression
+      # from a pass, the compile-based run below is not worth the minutes.
+      - name: Census verdict self-test
+        run: |
+          python3 scripts/compiler_output_regression.py census-self-test
+          python3 -m unittest tests.test_repsel_census
+
+      - name: Build compiler
+        run: cargo build -p perry
+
+      - name: Promotion census
+        run: |
+          python3 scripts/compiler_output_regression.py census \
+            --perry target/debug/perry \
+            --keep-reports target/repsel-census/reports \
+            --gate
+
+      # Prove the gate's subject was live: with `Ptr<Shape>` selection
+      # disabled the census MUST go red. A census that reports zero and exits
+      # green is worth nothing, and this step is what stops that from being
+      # possible. `!` because a green run here is the failure.
+      - name: Sabotage check (the gate must be able to fail)
+        run: |
+          set +e
+          out="$(python3 scripts/compiler_output_regression.py census \
+            --perry target/debug/perry \
+            --env PERRY_PTR_SHAPE_LOCALS=0 \
+            --gate 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "$out"
+          # Exit 1 is the gate's verdict; exit 2 is a harness error (a compile
+          # that fell over, a schema mismatch). Only the former proves the
+          # census observed the sabotage, so insist on the code AND the reason.
+          if [ "$status" -ne 1 ]; then
+            echo "::error::Sabotage run exited $status, expected 1 (a gate verdict)."
+            echo "::error::Exit 0 means the census cannot see Ptr<Shape> promotion at all."
+            exit 1
+          fi
+          if ! printf '%s' "$out" | grep -q "fixture_ptr_shape: ptr-shape promoted 0"; then
+            echo "::error::Sabotage run failed for some reason OTHER than the"
+            echo "::error::ptr-shape fixture losing its promotion. The gate is red,"
+            echo "::error::but not for the reason that proves its subject was live."
+            exit 1
+          fi
+          echo "Census correctly went red with PERRY_PTR_SHAPE_LOCALS=0."
+
+      - name: Upload census reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: repsel-census
+          path: target/repsel-census/
+
+  # ---------------------------------------------------------------------------
   # Native ABI evidence packet
   #
   # Full material-performance packet for the type-lowering gate. This is heavier

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ tests/test-*
 !tests/test_perf_frontier_report.py
 !tests/test_test262_focused_report.py
 !tests/test_npm_sweep.py
+!tests/test_repsel_census.py
 !tests/test_perf_frontier_gate_smoke.sh
 !tests/*/
 bench_*

--- a/benchmarks/repsel_census/README.md
+++ b/benchmarks/repsel_census/README.md
@@ -1,4 +1,4 @@
-# Representation-selection promotion census (#7035)
+# Representation-selection promotion census (#7106)
 
 How many values actually get each of Perry's unboxed representations, per
 workload, with a ratcheted floor so a drop turns a build red.
@@ -54,7 +54,7 @@ Three separate mechanisms, in increasing order of paranoia:
 3. **A corpus-wide instrument check**: a census key that reads zero in *every*
    workload fails the run. A counter that is zero because nothing promoted and
    one that is zero because nobody increments it look identical; this
-   distinguishes them. `Ptr<NumArray>` was in the second state until #7035 — it
+   distinguishes them. `Ptr<NumArray>` was in the second state until #7106 — it
    had an `Analysis` variant, a `Ptr<NumArray>` target-rep string, and no
    `select()` call site anywhere in the tree.
 

--- a/benchmarks/repsel_census/README.md
+++ b/benchmarks/repsel_census/README.md
@@ -1,0 +1,97 @@
+# Representation-selection promotion census (#7035)
+
+How many values actually get each of Perry's unboxed representations, per
+workload, with a ratcheted floor so a drop turns a build red.
+
+```bash
+# Count promotions across the corpus and check the floors.
+python3 scripts/compiler_output_regression.py census --gate
+
+# Report only, no verdict.
+python3 scripts/compiler_output_regression.py census
+
+# Re-record the floors after an intentional change.
+python3 scripts/compiler_output_regression.py census --update
+
+# Verdict logic only (no compiler needed).
+python3 scripts/compiler_output_regression.py census-self-test
+```
+
+## Why this exists
+
+Perry's performance story rests on six unboxed representations. Until #7034,
+nobody knew how many values any of them promoted on real code, because nothing
+reported it — an agent had to hand-instrument the compiler to find out that
+`Ptr<Shape>` promotes **nothing at all** on `benchmarks/app-patterns/kernels/batch.ts`,
+the object/property-heavy program that representation exists for.
+Independently confirmed at the time: `PERRY_PTR_SHAPE_LOCALS=0` and the default
+produced a byte-identical binary.
+
+The census makes that a standing, visible, gated number instead of a discovery.
+
+## How it cannot quietly pass
+
+Read CLAUDE.md, "★ Four ways a gate can be unable to fail". The fourth applies
+here most directly: *the gate runs but its subject never did*. A census that
+faithfully prints `Ptr<Shape>: 0` and exits green is worth nothing.
+
+Three separate mechanisms, in increasing order of paranoia:
+
+1. **Per-workload, per-representation floors** in `baseline.json`. A count
+   below its floor is a regression. Counts are recorded per representation,
+   never aggregated — the interesting signal is `Ptr<Shape>` being 0 *while*
+   canonical `Str` is nonzero, and one total hides exactly that.
+
+2. **Liveness fixtures** in `fixtures/`. Floors alone are not enough: the
+   honest floor for `Ptr<Shape>` on real code is zero today, and a zero floor
+   can never fail. Each fixture is written to satisfy one representation's
+   proof obligations in full, and its minimum lives in `LIVENESS_FLOORS` in
+   `scripts/compiler_output_harness/repsel_census.py` — **in code, not in the
+   regenerable baseline**, so that re-running `--update` after a breakage
+   cannot write the fixture down to zero and leave a permanently-green gate.
+   `--update` refuses to do it.
+
+3. **A corpus-wide instrument check**: a census key that reads zero in *every*
+   workload fails the run. A counter that is zero because nothing promoted and
+   one that is zero because nobody increments it look identical; this
+   distinguishes them. `Ptr<NumArray>` was in the second state until #7035 — it
+   had an `Analysis` variant, a `Ptr<NumArray>` target-rep string, and no
+   `select()` call site anywhere in the tree.
+
+Sabotage-verified in both directions. Each of `PERRY_PTR_SHAPE_LOCALS=0`,
+`PERRY_PTR_NUMARRAY_LOCALS=0`, `PERRY_CANONICAL_I32_LOCALS=0`,
+`PERRY_CANONICAL_STR_LOCALS=0` and `PERRY_INT_VALUED_LOCALS=0` turns the census
+red; the default build is green. CI re-runs the first of those on every job so
+the property is checked, not just claimed once.
+
+## Editing the fixtures
+
+Don't tidy them. Every one is written against a specific collector's rules and
+most of the obvious cleanups disqualify the very local under test — passing a
+`Ptr<Shape>` local to a function is an escape (rule 2), wrapping a canonical-i32
+local in a loop moves it to the parallel-shadow model, adding a bounds check to
+`fixture_int_valued_ta` moves its locals to the ordinary integer-local path.
+Each file says which edits would silently take it to zero.
+
+If a fixture legitimately stops exercising its representation, change the
+fixture *and* say so in the PR. Lowering `LIVENESS_FLOORS` instead is how this
+gate would end up unable to fail.
+
+## Coverage
+
+Instrumented (counted by `--opt-report`, #6952):
+
+| Census key | Representation | Source of truth |
+| --- | --- | --- |
+| `ptr-shape` | `Ptr<Shape>` | `collectors/ptr_shape.rs` |
+| `ptr-numarray` | `Ptr<NumArray>` | `collectors/ptr_numarray.rs` |
+| `canonical-i32` / `canonical-u32` / `canonical-str` | canonical slot reps | `expr/slot_rep.rs` |
+| `int-valued-ta` | int-valued locals | `collectors/int_valued_ta_locals.rs` |
+| `spec-abi-entry` | specialized ABI entries | `codegen/typed_abi.rs` |
+| `spec-abi-taptr-slot` | `TaPtr` parameter slots | `collectors/spec_abi_sites.rs` |
+
+**Not** instrumented, stated plainly rather than reported as a zero: the
+masked-window / buffer-view `TaPtr` *region* machinery
+(`stmt/masked_window_region.rs`). It is region-shaped rather than a per-value
+promotion and has no `opt_report` analysis, so the census makes no claim about
+it. `spec-abi-taptr-slot` covers `TaPtr` only in its parameter form.

--- a/benchmarks/repsel_census/baseline.json
+++ b/benchmarks/repsel_census/baseline.json
@@ -1,0 +1,512 @@
+{
+  "schema_version": 1,
+  "workloads": [
+    {
+      "name": "fixture_ptr_shape",
+      "role": "liveness",
+      "source": "benchmarks/repsel_census/fixtures/fixture_ptr_shape.ts",
+      "floors": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 1,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 1
+      }
+    },
+    {
+      "name": "fixture_ptr_numarray",
+      "role": "liveness",
+      "source": "benchmarks/repsel_census/fixtures/fixture_ptr_numarray.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-i32": 2,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 1,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 1,
+        "ptr-numarray": 1,
+        "canonical-slot": 2,
+        "int-valued-ta": 0,
+        "spec-abi": 2
+      }
+    },
+    {
+      "name": "fixture_canonical_slots",
+      "role": "liveness",
+      "source": "benchmarks/repsel_census/fixtures/fixture_canonical_slots.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 2,
+        "canonical-u32": 1,
+        "canonical-str": 1,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 3,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 4,
+        "int-valued-ta": 0,
+        "spec-abi": 3
+      }
+    },
+    {
+      "name": "fixture_int_valued_ta",
+      "role": "liveness",
+      "source": "benchmarks/repsel_census/fixtures/fixture_int_valued_ta.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 1,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 1,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 1,
+        "int-valued-ta": 1,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "fixture_spec_abi_taptr",
+      "role": "liveness",
+      "source": "benchmarks/repsel_census/fixtures/fixture_spec_abi_taptr.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 2,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 1,
+        "spec-abi-taptr-slot": 2
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 2,
+        "int-valued-ta": 0,
+        "spec-abi": 1
+      }
+    },
+    {
+      "name": "batch",
+      "role": "corpus",
+      "source": "benchmarks/app-patterns/kernels/batch.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 3,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 4,
+        "ptr-numarray": 0,
+        "canonical-slot": 3,
+        "int-valued-ta": 0,
+        "spec-abi": 3
+      }
+    },
+    {
+      "name": "suite_01_startup",
+      "role": "corpus",
+      "source": "benchmarks/suite/01_startup.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_02_loop_overhead",
+      "role": "corpus",
+      "source": "benchmarks/suite/02_loop_overhead.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_03_array_write",
+      "role": "corpus",
+      "source": "benchmarks/suite/03_array_write.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_04_array_read",
+      "role": "corpus",
+      "source": "benchmarks/suite/04_array_read.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_05_fibonacci",
+      "role": "corpus",
+      "source": "benchmarks/suite/05_fibonacci.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 1
+      }
+    },
+    {
+      "name": "suite_06_math_intensive",
+      "role": "corpus",
+      "source": "benchmarks/suite/06_math_intensive.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_07_object_create",
+      "role": "corpus",
+      "source": "benchmarks/suite/07_object_create.ts",
+      "floors": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_08_string_concat",
+      "role": "corpus",
+      "source": "benchmarks/suite/08_string_concat.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_09_method_calls",
+      "role": "corpus",
+      "source": "benchmarks/suite/09_method_calls.ts",
+      "floors": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_10_nested_loops",
+      "role": "corpus",
+      "source": "benchmarks/suite/10_nested_loops.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_11_prime_sieve",
+      "role": "corpus",
+      "source": "benchmarks/suite/11_prime_sieve.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_12_binary_trees",
+      "role": "corpus",
+      "source": "benchmarks/suite/12_binary_trees.ts",
+      "floors": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 1,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_13_factorial",
+      "role": "corpus",
+      "source": "benchmarks/suite/13_factorial.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_14_closure",
+      "role": "corpus",
+      "source": "benchmarks/suite/14_closure.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_15_mandelbrot",
+      "role": "corpus",
+      "source": "benchmarks/suite/15_mandelbrot.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    },
+    {
+      "name": "suite_16_matrix_multiply",
+      "role": "corpus",
+      "source": "benchmarks/suite/16_matrix_multiply.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-i32": 3,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 0,
+        "canonical-slot": 3,
+        "int-valued-ta": 0,
+        "spec-abi": 1
+      }
+    },
+    {
+      "name": "suite_17_loop_data_dependent",
+      "role": "corpus",
+      "source": "benchmarks/suite/17_loop_data_dependent.ts",
+      "floors": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-i32": 0,
+        "canonical-u32": 0,
+        "canonical-str": 0,
+        "int-valued-ta": 0,
+        "spec-abi-entry": 0,
+        "spec-abi-taptr-slot": 0
+      },
+      "candidates": {
+        "ptr-shape": 0,
+        "ptr-numarray": 1,
+        "canonical-slot": 0,
+        "int-valued-ta": 0,
+        "spec-abi": 0
+      }
+    }
+  ],
+  "generated_at": "2026-07-31T01:39:37.595749Z"
+}

--- a/benchmarks/repsel_census/fixtures/fixture_canonical_slots.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_canonical_slots.ts
@@ -1,0 +1,48 @@
+// Liveness fixture for the three canonical-slot census keys (#7035):
+// `canonical-i32`, `canonical-u32` and `canonical-str`.
+//
+// These are the reps `expr/slot_rep.rs` selects. Splitting them into three
+// census keys rather than one `canonical-slot` aggregate is deliberate: on
+// `batch.ts` the ONLY promotion in the whole program is a canonical `Str`
+// local, and an aggregate would have shown "canonical-slot: 1" while hiding
+// that I32 and U32 promoted nothing there.
+//
+// Requirements: plain synchronous function bodies (async / generator bodies
+// route locals through the async-to-generator shared cells and are excluded),
+// no closure capture of the candidate locals.
+
+function i32Mixer(seed: number): number {
+  // Canonical i32: STRAIGHT-LINE locals seeded from an i32 literal and only
+  // ever bitwise-updated. Straight-line on purpose — a loop-CARRIED
+  // accumulator and a loop counter both route through the parallel-shadow
+  // `i32_counter_slots` model instead of selecting the canonical rep, so
+  // wrapping this in a `for` would take the fixture to zero without any
+  // representation actually regressing.
+  let h = 2166136261 | 0;
+  const k = 16777619 | 0;
+  h = h ^ (seed | 0);
+  h = (h << 5) ^ k;
+  h = h ^ (h >> 7);
+  return h | 0;
+}
+
+function u32Mixer(seed: number): number {
+  // Canonical u32: `>>> 0` keeps the value observable as unsigned above 2^31.
+  let u = (0x9e3779b9 ^ (seed | 0)) >>> 0;
+  for (let i = 0; i < 16; i++) {
+    u = (u ^ (u << 13)) >>> 0;
+    u = (u ^ (u >>> 17)) >>> 0;
+  }
+  return u >>> 0;
+}
+
+function strBuilder(n: number): number {
+  // Canonical Str: a string local whose every write is a string.
+  let s = "seed";
+  for (let i = 0; i < n; i++) {
+    s = s + "x";
+  }
+  return s.length;
+}
+
+console.log("canonical:" + (i32Mixer(8) + u32Mixer(8) + strBuilder(8)));

--- a/benchmarks/repsel_census/fixtures/fixture_canonical_slots.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_canonical_slots.ts
@@ -1,4 +1,4 @@
-// Liveness fixture for the three canonical-slot census keys (#7035):
+// Liveness fixture for the three canonical-slot census keys (#7106):
 // `canonical-i32`, `canonical-u32` and `canonical-str`.
 //
 // These are the reps `expr/slot_rep.rs` selects. Splitting them into three

--- a/benchmarks/repsel_census/fixtures/fixture_int_valued_ta.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_int_valued_ta.ts
@@ -1,0 +1,41 @@
+// Liveness fixture for the `int-valued-ta` census key (#7035).
+//
+// `collectors/int_valued_ta_locals.rs` admits a local as native-i32 even when
+// one of its writes is a POSSIBLY-OUT-OF-BOUNDS int typed-array read — the
+// bcryptjs `_encipher` Feistel-accumulator shape the collector was written
+// for. Soundness rests on a whole-function observation constraint, so the
+// fixture reproduces it exactly:
+//
+//   rule 1 (writes)       — every write is an int-TA element read, a bitwise
+//                           op, or `Math.imul`; never `*`, never a plain-array
+//                           read, never a float/Uint32 TA
+//   rule 2 (observations) — every use is a direct bitwise operand or a store
+//                           into an int-kind typed array; never an array index,
+//                           an additive operand, a comparison, a call argument,
+//                           a `return`, or a `console.log`
+//
+// `off` is a parameter, so `lr[off]` is NOT provably in bounds — that is the
+// whole point. Adding `if (off < lr.length)` would move these locals to the
+// ordinary `integer_locals` path and take this fixture to zero.
+
+function encipher(lr: Int32Array, off: number, P: Int32Array): void {
+  let l = lr[off];
+  let r = lr[off + 1];
+  l = l ^ P[0];
+  r = r ^ l;
+  r = r ^ P[1];
+  l = l ^ Math.imul(r, 3);
+  l = l ^ (r >>> 8);
+  r = r ^ (l << 3);
+  lr[off] = r;
+  lr[off + 1] = l;
+}
+
+const state = new Int32Array(8);
+const box = new Int32Array(4);
+state[0] = 11;
+state[1] = 22;
+box[0] = 0x243f6a88;
+box[1] = 0x85a308d3;
+encipher(state, 0, box);
+console.log("int_valued_ta:" + state[0]);

--- a/benchmarks/repsel_census/fixtures/fixture_int_valued_ta.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_int_valued_ta.ts
@@ -1,4 +1,4 @@
-// Liveness fixture for the `int-valued-ta` census key (#7035).
+// Liveness fixture for the `int-valued-ta` census key (#7106).
 //
 // `collectors/int_valued_ta_locals.rs` admits a local as native-i32 even when
 // one of its writes is a POSSIBLY-OUT-OF-BOUNDS int typed-array read — the

--- a/benchmarks/repsel_census/fixtures/fixture_ptr_numarray.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_ptr_numarray.ts
@@ -1,0 +1,46 @@
+// Liveness fixture for the `Ptr<NumArray>` census key (#7035).
+//
+// Written to satisfy `collectors/ptr_numarray.rs` in full so a zero count
+// means the counter is dead, not that the corpus is uninteresting. This one
+// matters more than most: before #7035 `opt_report` had a `PtrNumArray`
+// analysis variant and a `Ptr<NumArray>` target-rep string, but there was no
+// `select()` call site for it anywhere in the tree. Its `selected` tally was a
+// number that could not be incremented.
+//
+// Proof obligations satisfied:
+//   provenance  — `new Array(<static n>)` (HolesOK) and `[]` (Dense), one Let each
+//   containment — element reads, numeric element writes, `.length`, numeric
+//                 `push`, and a bare `return` only; never passed, captured,
+//                 logged, reassigned or aliased
+//   density     — no `pop`/`shift`/`splice`/`unshift`/`copyWithin`
+//   in-bounds   — loop indices bounded by a compile-time-constant length
+//   module-wide — no shape barrier, no `Array.prototype[i] = …` anywhere
+//
+// Do not add `console.log(buf)` or pass either array to a helper: a bare
+// reference is an escape and disqualifies the local outright.
+
+function preallocated(): number {
+  const buf = new Array(64);
+  for (let i = 0; i < 64; i++) {
+    buf[i] = i * 2;
+  }
+  let total = 0;
+  for (let i = 0; i < 64; i++) {
+    total = total + buf[i];
+  }
+  return total;
+}
+
+function grownFromEmpty(n: number): number {
+  const acc: number[] = [];
+  for (let i = 0; i < n; i++) {
+    acc.push(i + 0.5);
+  }
+  let total = 0;
+  for (let i = 0; i < acc.length; i++) {
+    total = total + acc[i];
+  }
+  return total;
+}
+
+console.log("ptr_numarray:" + (preallocated() + grownFromEmpty(8)));

--- a/benchmarks/repsel_census/fixtures/fixture_ptr_numarray.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_ptr_numarray.ts
@@ -1,8 +1,8 @@
-// Liveness fixture for the `Ptr<NumArray>` census key (#7035).
+// Liveness fixture for the `Ptr<NumArray>` census key (#7106).
 //
 // Written to satisfy `collectors/ptr_numarray.rs` in full so a zero count
 // means the counter is dead, not that the corpus is uninteresting. This one
-// matters more than most: before #7035 `opt_report` had a `PtrNumArray`
+// matters more than most: before #7106 `opt_report` had a `PtrNumArray`
 // analysis variant and a `Ptr<NumArray>` target-rep string, but there was no
 // `select()` call site for it anywhere in the tree. Its `selected` tally was a
 // number that could not be incremented.

--- a/benchmarks/repsel_census/fixtures/fixture_ptr_shape.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_ptr_shape.ts
@@ -1,4 +1,4 @@
-// Liveness fixture for the `Ptr<Shape>` census key (#7035).
+// Liveness fixture for the `Ptr<Shape>` census key (#7106).
 //
 // This file exists to make one assertion checkable: that the census can
 // observe a `Ptr<Shape>` promotion AT ALL. A census key that reads zero

--- a/benchmarks/repsel_census/fixtures/fixture_ptr_shape.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_ptr_shape.ts
@@ -1,0 +1,45 @@
+// Liveness fixture for the `Ptr<Shape>` census key (#7035).
+//
+// This file exists to make one assertion checkable: that the census can
+// observe a `Ptr<Shape>` promotion AT ALL. A census key that reads zero
+// because nothing was promoted and one that reads zero because nobody
+// increments the counter look identical in a report; this program is written
+// to satisfy every rule in `collectors/ptr_shape.rs`, so if its count is zero
+// the instrument is broken, not the corpus.
+//
+// Rules satisfied, in the collector's own numbering:
+//   1. provenance   — `let p = new Point(...)`, exactly one `Let`, init is `new`
+//   2. containment  — `p` is only ever field-read/written and method-called;
+//                     never reassigned, captured, passed, returned or aliased
+//   3. this-flow    — `Point`'s constructor and methods only touch `this.<field>`
+//   4. dispatch     — no own-property write can shadow `norm2`
+//   5. module-wide  — no defineProperty / delete / setPrototypeOf / Proxy /
+//                     mutating Reflect anywhere in this module
+//
+// Do not "tidy" this file. Passing `p` to a function, returning it, or storing
+// it in an array all disqualify it (rule 2) and would silently take the
+// fixture to zero.
+
+class Point {
+  x: number;
+  y: number;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+  norm2(): number {
+    return this.x * this.x + this.y * this.y;
+  }
+}
+
+function shapeProven(n: number): number {
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    const p = new Point(i, i + 1);
+    p.x = p.x + 1;
+    total = total + p.norm2();
+  }
+  return total;
+}
+
+console.log("ptr_shape:" + shapeProven(4));

--- a/benchmarks/repsel_census/fixtures/fixture_spec_abi_taptr.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_spec_abi_taptr.ts
@@ -1,0 +1,38 @@
+// Liveness fixture for the `spec-abi-entry` and `spec-abi-taptr-slot` census
+// keys (#7035).
+//
+// `TaPtr` is one of the six unboxed representations, but unlike the others it
+// is a *parameter* rep rather than a local rep: it lives inside a specialized
+// entry's rep tuple (`SpecParamRep::label()` spells it `ta<kind>` /
+// `ta<kind>x<len>`). The census counts those slots by parsing the tuple, so
+// this fixture keeps both keys honest.
+//
+// What `collectors/spec_abi_sites.rs` needs:
+//   - a module binding whose SINGLE top-level `let`/`const` init is
+//     `new Int32Array(<integer literal>)` — a non-view construction form
+//   - that binding never reassigned anywhere in the module and never
+//     referenced inside a closure body
+//   - a DIRECT call to a user function passing it, in a LATER top-level
+//     statement than the binding (structural dominance)
+//   - integer-literal / numeric-literal args for the I32 / F64 slots
+//
+// Reassigning `TABLE`, or reading it inside an arrow function, drops the
+// judgment to `Boxed` and takes both keys to zero.
+
+const TABLE = new Int32Array(256);
+const SCRATCH = new Int32Array(16);
+
+function mix(table: Int32Array, scratch: Int32Array, seed: number, scale: number): number {
+  let acc = seed | 0;
+  for (let i = 0; i < 16; i++) {
+    acc = acc ^ table[i & 255];
+    scratch[i & 15] = acc;
+  }
+  return acc * scale;
+}
+
+for (let i = 0; i < 256; i++) {
+  TABLE[i] = i * 7;
+}
+
+console.log("spec_abi_taptr:" + mix(TABLE, SCRATCH, 17, 1.5));

--- a/benchmarks/repsel_census/fixtures/fixture_spec_abi_taptr.ts
+++ b/benchmarks/repsel_census/fixtures/fixture_spec_abi_taptr.ts
@@ -1,5 +1,5 @@
 // Liveness fixture for the `spec-abi-entry` and `spec-abi-taptr-slot` census
-// keys (#7035).
+// keys (#7106).
 //
 // `TaPtr` is one of the six unboxed representations, but unlike the others it
 // is a *parameter* rep rather than a local rep: it lives inside a specialized

--- a/changelog.d/7104-repsel-promotion-census.md
+++ b/changelog.d/7104-repsel-promotion-census.md
@@ -2,7 +2,7 @@ Added a representation-selection **promotion census**: a per-workload,
 per-representation count of how many values actually get each unboxed
 representation, gated against a ratcheted baseline
 (`python3 scripts/compiler_output_regression.py census --gate`, new
-non-required `repsel-census` CI job). #7034 had to hand-instrument the compiler
+non-required `repsel-census` CI job, #7106). #7034 had to hand-instrument the compiler
 to discover that `Ptr<Shape>` promotes **nothing at all** on `batch.ts` — the
 object-heavy workload it exists for — and that only 3 of 17 suite benchmarks
 promote a single shape local each; nothing in CI could have surfaced that.

--- a/changelog.d/7104-repsel-promotion-census.md
+++ b/changelog.d/7104-repsel-promotion-census.md
@@ -1,0 +1,42 @@
+Added a representation-selection **promotion census**: a per-workload,
+per-representation count of how many values actually get each unboxed
+representation, gated against a ratcheted baseline
+(`python3 scripts/compiler_output_regression.py census --gate`, new
+non-required `repsel-census` CI job). #7034 had to hand-instrument the compiler
+to discover that `Ptr<Shape>` promotes **nothing at all** on `batch.ts` — the
+object-heavy workload it exists for — and that only 3 of 17 suite benchmarks
+promote a single shape local each; nothing in CI could have surfaced that.
+
+Two counters could not previously have been incremented at all, so their zeros
+were indistinguishable from a dead instrument. `Ptr<NumArray>` had an
+`opt_report::Analysis` variant, a `Ptr<NumArray>` target-rep string and denial
+recording, but **no `select()` call site anywhere in the tree**; int-valued
+locals (`collectors/int_valued_ta_locals.rs`) had no analysis variant. Both now
+record at the single site where a candidate becomes a fact. `--opt-report=json`
+additionally enumerates `Analysis::ALL`, so an analysis with no entries renders
+an explicit `0` rather than an absent key, and `PtrNumArray` gets an explicit
+serde rename — it was serialized `ptr-num-array` in `Entry::analysis` while the
+summary row said `ptr-numarray`, one analysis under two names in one document.
+Every recording site stays behind `opt_report::enabled()`, so no emitted byte
+changes.
+
+The gate is falsifiable by construction, because per-workload floors alone are
+not: the honest floor for `Ptr<Shape>` on real code is zero today, and a zero
+floor can never go red. The corpus therefore carries hand-written **liveness
+fixtures** whose minimums live in `LIVENESS_FLOORS` in the script rather than in
+the regenerable baseline (`--update` refuses to write below them), plus a
+corpus-wide assertion that no census key reads zero everywhere. Verified by
+sabotage in both directions: each of `PERRY_PTR_SHAPE_LOCALS=0`,
+`PERRY_PTR_NUMARRAY_LOCALS=0`, `PERRY_CANONICAL_I32_LOCALS=0`,
+`PERRY_CANONICAL_STR_LOCALS=0` and `PERRY_INT_VALUED_LOCALS=0` turns the census
+red, as does reverting the new `Ptr<NumArray>` `select()` (i.e. the pre-change
+compiler), while the unmodified build is green. CI re-runs the first arm on
+every job and asserts the exit code *and* the reason string, so "red for an
+unrelated reason" does not count as proof that the gate's subject was live.
+
+Current numbers across 18 real workloads: `Ptr<Shape>` promotes in 3,
+`Ptr<NumArray>` in 4, canonical `I32` in 2, and canonical `U32`, canonical
+`Str`, int-valued, specialized-ABI entries and `TaPtr` parameter slots in **none**
+outside the fixtures. The masked-window/buffer-view `TaPtr` *region* machinery
+has no `opt_report` analysis and is documented as unmeasured rather than
+reported as a zero.

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -378,7 +378,7 @@ pub(crate) fn collect_type_facts(
             binding_types,
             spec_ta_lens,
         );
-        // `--opt-report` (#6952) / promotion census (#7035): the win column
+        // `--opt-report` (#6952) / promotion census (#7106): the win column
         // for this analysis, recorded at the ONE site where a candidate
         // actually becomes a fact, so the report can never claim a promotion
         // the codegen did not take (or miss one it did). Both name walks are

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -378,12 +378,38 @@ pub(crate) fn collect_type_facts(
             binding_types,
             spec_ta_lens,
         );
+        // `--opt-report` (#6952) / promotion census (#7035): the win column
+        // for this analysis, recorded at the ONE site where a candidate
+        // actually becomes a fact, so the report can never claim a promotion
+        // the codegen did not take (or miss one it did). Both name walks are
+        // skipped entirely when the report is off.
+        let (names, depths) = if crate::opt_report::enabled() {
+            (
+                super::ptr_shape_report::local_names(stmts),
+                super::ptr_shape_report::loop_depths(stmts),
+            )
+        } else {
+            (HashMap::new(), HashMap::new())
+        };
         for id in extra {
             if !boxed_vars.contains(&id) && !module_globals.contains_key(&id) {
                 integer_locals.insert(id);
                 // Retained as its own fact for repsel Phase 1 eligibility —
                 // see `RepresentationFacts::int_valued_ta_locals`.
                 int_valued_ta_locals.insert(id);
+                if crate::opt_report::enabled() {
+                    let fallback = format!("<local {id}>");
+                    let name = names.get(&id).map(String::as_str).unwrap_or(&fallback);
+                    crate::opt_report::select(
+                        crate::opt_report::Position::Local,
+                        name,
+                        Some(id),
+                        crate::opt_report::Analysis::IntValuedTa,
+                        "IntValued",
+                        depths.get(&id).copied().unwrap_or(0),
+                        None,
+                    );
+                }
             }
         }
     }

--- a/crates/perry-codegen/src/collectors/ptr_numarray.rs
+++ b/crates/perry-codegen/src/collectors/ptr_numarray.rs
@@ -100,6 +100,7 @@ use perry_hir::types::Type as HirType;
 use perry_hir::{BinaryOp, Expr, LogicalOp, Stmt, UnaryOp};
 
 use super::ModuleDispatchFacts;
+use crate::opt_report;
 
 /// `PERRY_PTR_NUMARRAY_LOCALS` gate. Enabled by default; `=0`/`off`/`false`
 /// disables numeric-array pointer-local selection (every access keeps the
@@ -164,7 +165,37 @@ pub(crate) fn expr_is_numarray_prototype_index_barrier(expr: &Expr) -> bool {
 
 /// Compile-time visibility: one stderr line per proven local, plus a
 /// process-wide running count. Only under `PERRY_REPSEL_DEBUG=1`.
-fn note_num_array_local(id: u32, fact: &NumArrayLocal) {
+///
+/// Also feeds the `--opt-report` win column (#6952), exactly like
+/// [`super::ptr_shape::note_ptr_shape_local`] does. Until #7035 this analysis
+/// recorded **denials only**: `opt_report` had a `PtrNumArray` variant and a
+/// `Ptr<NumArray>` target-rep string, but no `select` call site anywhere in
+/// the tree — so its `selected` tally was a counter that could not be
+/// incremented, and "`Ptr<NumArray>`: 0 promoted" was indistinguishable from
+/// "the instrument is dead". That is CLAUDE.md's failure mode (4): the gate
+/// runs but its subject never did.
+fn note_num_array_local(
+    id: u32,
+    fact: &NumArrayLocal,
+    names: &HashMap<u32, String>,
+    depths: &HashMap<u32, u32>,
+) {
+    if opt_report::enabled() {
+        let fallback = format!("<local {id}>");
+        let name = names.get(&id).map(String::as_str).unwrap_or(&fallback);
+        opt_report::select(
+            opt_report::Position::Local,
+            name,
+            Some(id),
+            opt_report::Analysis::PtrNumArray,
+            "Ptr<NumArray>",
+            depths.get(&id).copied().unwrap_or(0),
+            Some(format!(
+                "{:?} density, proven initial length {}",
+                fact.density, fact.proven_initial_length
+            )),
+        );
+    }
     if !repsel_debug_enabled() {
         return;
     }
@@ -226,12 +257,24 @@ pub(crate) fn collect_num_array_locals(
         disqualified,
         ..
     } = walk;
+    // `--opt-report` (#6952): binding names and loop depths for the win
+    // column. Both walks are pure overhead when the report is off, so they
+    // are only built when it is on — the returned facts are identical either
+    // way.
+    let (names, depths) = if opt_report::enabled() {
+        (
+            super::ptr_shape_report::local_names(stmts),
+            super::ptr_shape_report::loop_depths(stmts),
+        )
+    } else {
+        (HashMap::new(), HashMap::new())
+    };
     let mut out = HashMap::new();
     for (id, fact) in candidates {
         if disqualified.contains(&id) || let_counts.get(&id).copied().unwrap_or(0) != 1 {
             continue;
         }
-        note_num_array_local(id, &fact);
+        note_num_array_local(id, &fact, &names, &depths);
         out.insert(id, fact);
     }
     out

--- a/crates/perry-codegen/src/collectors/ptr_numarray.rs
+++ b/crates/perry-codegen/src/collectors/ptr_numarray.rs
@@ -167,7 +167,7 @@ pub(crate) fn expr_is_numarray_prototype_index_barrier(expr: &Expr) -> bool {
 /// process-wide running count. Only under `PERRY_REPSEL_DEBUG=1`.
 ///
 /// Also feeds the `--opt-report` win column (#6952), exactly like
-/// [`super::ptr_shape::note_ptr_shape_local`] does. Until #7035 this analysis
+/// [`super::ptr_shape::note_ptr_shape_local`] does. Until #7106 this analysis
 /// recorded **denials only**: `opt_report` had a `PtrNumArray` variant and a
 /// `Ptr<NumArray>` target-rep string, but no `select` call site anywhere in
 /// the tree — so its `selected` tally was a counter that could not be

--- a/crates/perry-codegen/src/opt_report/mod.rs
+++ b/crates/perry-codegen/src/opt_report/mod.rs
@@ -189,20 +189,47 @@ pub enum Analysis {
     /// `collectors/ptr_shape.rs` — shape-proven object locals (RFC Phase 3b).
     PtrShape,
     /// `collectors/ptr_numarray.rs` — `number[]` locals (RFC Phase 4a.3).
+    ///
+    /// The explicit rename keeps the serialized spelling identical to
+    /// [`Analysis::as_str`]. Without it serde's kebab-case derive spells this
+    /// variant `ptr-num-array` in `Entry::analysis` while the summary row says
+    /// `ptr-numarray`, so one analysis appears under two names in a single
+    /// JSON document and a consumer keying on either sees half the data.
+    #[serde(rename = "ptr-numarray")]
     PtrNumArray,
     /// `expr/slot_rep.rs` — canonical i32/u32/Str locals (RFC Phase 1 / 3a).
     CanonicalSlot,
+    /// `collectors/int_valued_ta_locals.rs` — locals held native-i32 despite a
+    /// possibly-out-of-bounds int typed-array read (RFC Phase 2, wrap-i32).
+    IntValuedTa,
     /// `codegen/typed_abi.rs` — specialized-ABI / typed-clone entries
     /// (RFC Phase 2).
     SpecAbi,
 }
 
 impl Analysis {
+    /// Every representation analysis that records into this report, in a
+    /// stable order.
+    ///
+    /// The JSON summary and the promotion census (#7035) enumerate *this*
+    /// list rather than the analyses that happen to appear in a build's
+    /// entries. An analysis with no entries at all must render as an explicit
+    /// `0`, never as an absent key: "missing" and "zero" look identical to a
+    /// consumer, and the entire point of this report is that zero is visible.
+    pub const ALL: [Analysis; 5] = [
+        Analysis::PtrShape,
+        Analysis::PtrNumArray,
+        Analysis::CanonicalSlot,
+        Analysis::IntValuedTa,
+        Analysis::SpecAbi,
+    ];
+
     pub fn as_str(self) -> &'static str {
         match self {
             Analysis::PtrShape => "ptr-shape",
             Analysis::PtrNumArray => "ptr-numarray",
             Analysis::CanonicalSlot => "canonical-slot",
+            Analysis::IntValuedTa => "int-valued-ta",
             Analysis::SpecAbi => "spec-abi",
         }
     }
@@ -214,6 +241,7 @@ impl Analysis {
             Analysis::PtrShape => "Ptr<Shape>",
             Analysis::PtrNumArray => "Ptr<NumArray>",
             Analysis::CanonicalSlot => "I32/U32/Str",
+            Analysis::IntValuedTa => "IntValued",
             Analysis::SpecAbi => "specialized ABI",
         }
     }
@@ -225,6 +253,7 @@ impl Analysis {
             Analysis::PtrShape => "collectors/ptr_shape.rs",
             Analysis::PtrNumArray => "collectors/ptr_numarray.rs",
             Analysis::CanonicalSlot => "expr/slot_rep.rs",
+            Analysis::IntValuedTa => "collectors/int_valued_ta_locals.rs",
             Analysis::SpecAbi => "codegen/typed_abi.rs",
         }
     }
@@ -734,6 +763,22 @@ mod tests {
     #[test]
     fn deeper_loops_outrank_shallower_ones() {
         assert!(entry("f", 3, None).rank() < entry("f", 1, None).rank());
+    }
+
+    /// One analysis, one spelling. The summary rows use [`Analysis::as_str`]
+    /// and the per-entry `analysis` field uses serde; a consumer that keys on
+    /// the serde spelling (the census does, to split canonical-slot into its
+    /// three reps) must find the same string in both places.
+    #[test]
+    fn serialized_analysis_matches_as_str() {
+        for analysis in Analysis::ALL {
+            let serialized = serde_json::to_string(&analysis).unwrap();
+            assert_eq!(
+                serialized.trim_matches('"'),
+                analysis.as_str(),
+                "serde and as_str disagree for {analysis:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry-codegen/src/opt_report/mod.rs
+++ b/crates/perry-codegen/src/opt_report/mod.rs
@@ -211,7 +211,7 @@ impl Analysis {
     /// Every representation analysis that records into this report, in a
     /// stable order.
     ///
-    /// The JSON summary and the promotion census (#7035) enumerate *this*
+    /// The JSON summary and the promotion census (#7106) enumerate *this*
     /// list rather than the analyses that happen to appear in a build's
     /// entries. An analysis with no entries at all must render as an explicit
     /// `0`, never as an absent key: "missing" and "zero" look identical to a

--- a/crates/perry-codegen/src/opt_report/render.rs
+++ b/crates/perry-codegen/src/opt_report/render.rs
@@ -266,7 +266,7 @@ pub fn render_json(entries: &[Entry]) -> String {
             // entries: an analysis that recorded nothing must appear with an
             // explicit `0`. A consumer cannot tell an absent key from a zero
             // one, and "zero promotions" is precisely the fact this report
-            // exists to make visible (#7034 §0; census #7035).
+            // exists to make visible (#7034 §0; census #7106).
             by_analysis: Analysis::ALL
                 .iter()
                 .map(|a| {
@@ -419,7 +419,7 @@ mod tests {
         assert_eq!(ptr_shape["target_rep"], "Ptr<Shape>");
     }
 
-    /// #7035: a census consumer must be able to read "this representation
+    /// #7106: a census consumer must be able to read "this representation
     /// promoted nothing" straight off the JSON. An analysis with no entries at
     /// all therefore has to render as an explicit zero row, because an absent
     /// key and a zero key are indistinguishable downstream — and "absent" is

--- a/crates/perry-codegen/src/opt_report/render.rs
+++ b/crates/perry-codegen/src/opt_report/render.rs
@@ -262,14 +262,22 @@ pub fn render_json(entries: &[Entry]) -> String {
         summary: JsonSummary {
             selected: tallies.values().map(|t| t.selected).sum(),
             denied: tallies.values().map(|t| t.denied).sum(),
-            by_analysis: tallies
+            // Enumerate `Analysis::ALL`, not the analyses that happen to have
+            // entries: an analysis that recorded nothing must appear with an
+            // explicit `0`. A consumer cannot tell an absent key from a zero
+            // one, and "zero promotions" is precisely the fact this report
+            // exists to make visible (#7034 §0; census #7035).
+            by_analysis: Analysis::ALL
                 .iter()
-                .map(|(a, t)| JsonAnalysis {
-                    analysis: a.as_str(),
-                    target_rep: a.target_rep(),
-                    rule_source: a.rule_source(),
-                    selected: t.selected,
-                    denied: t.denied,
+                .map(|a| {
+                    let t = tallies.get(a).cloned().unwrap_or_default();
+                    JsonAnalysis {
+                        analysis: a.as_str(),
+                        target_rep: a.target_rep(),
+                        rule_source: a.rule_source(),
+                        selected: t.selected,
+                        denied: t.denied,
+                    }
                 })
                 .collect(),
         },
@@ -409,6 +417,52 @@ mod tests {
         assert_eq!(ptr_shape["selected"], 0);
         assert_eq!(ptr_shape["denied"], 1);
         assert_eq!(ptr_shape["target_rep"], "Ptr<Shape>");
+    }
+
+    /// #7035: a census consumer must be able to read "this representation
+    /// promoted nothing" straight off the JSON. An analysis with no entries at
+    /// all therefore has to render as an explicit zero row, because an absent
+    /// key and a zero key are indistinguishable downstream — and "absent" is
+    /// exactly what a dead instrument produces.
+    #[test]
+    fn json_lists_every_analysis_even_with_no_entries() {
+        let entries = vec![selected(Analysis::CanonicalSlot, "i", "I32")];
+        let json: serde_json::Value = serde_json::from_str(&render_json(&entries)).unwrap();
+        let rows = json["summary"]["by_analysis"].as_array().unwrap();
+        assert_eq!(
+            rows.len(),
+            Analysis::ALL.len(),
+            "every analysis must have a row; got:\n{rows:#?}"
+        );
+        for analysis in Analysis::ALL {
+            let row = rows
+                .iter()
+                .find(|r| r["analysis"] == analysis.as_str())
+                .unwrap_or_else(|| panic!("{} row missing", analysis.as_str()));
+            assert_eq!(row["target_rep"], analysis.target_rep());
+        }
+        let numarray = rows
+            .iter()
+            .find(|r| r["analysis"] == "ptr-numarray")
+            .unwrap();
+        assert_eq!(numarray["selected"], 0);
+        assert_eq!(numarray["denied"], 0);
+    }
+
+    /// Every analysis must render a distinct `analysis` key: the census keys
+    /// its per-representation counts off this string, so a duplicate would
+    /// silently merge two representations into one number — the aggregate
+    /// that #7034 warns hides the interesting signal.
+    #[test]
+    fn analysis_keys_are_distinct() {
+        let mut seen = std::collections::HashSet::new();
+        for analysis in Analysis::ALL {
+            assert!(
+                seen.insert(analysis.as_str()),
+                "duplicate analysis key {}",
+                analysis.as_str()
+            );
+        }
     }
 
     /// The per-element column must be visible in text — it is the honest

--- a/scripts/compiler_output_harness/cli.py
+++ b/scripts/compiler_output_harness/cli.py
@@ -5,6 +5,8 @@ import sys
 
 from .capture import capture, capture_suite, verify_existing
 from .common import DEFAULT_BENCHMARK_RUNS, HarnessError
+from .repsel_census import census
+from .repsel_census import self_test as census_self_test
 from .spec import WORKLOADS
 
 
@@ -92,6 +94,40 @@ def build_parser() -> argparse.ArgumentParser:
     verify_p.add_argument("--gate", action="store_true")
     verify_p.add_argument("--print-summary", action="store_true")
     verify_p.set_defaults(func=verify_existing)
+
+    # Representation-selection promotion census (#7035). Shares this harness's
+    # process plumbing but not its workload spec: the census corpus is chosen
+    # for representation coverage, whereas `workloads.toml` is tuned for
+    # vectorization and IR-shape gates.
+    census_p = sub.add_parser(
+        "census",
+        help="count how many values got each unboxed representation, against a ratcheted floor",
+    )
+    census_p.add_argument("--perry")
+    census_p.add_argument("--baseline")
+    census_p.add_argument(
+        "--workload",
+        action="append",
+        help="restrict to named workload(s); disables the corpus-wide liveness assertions",
+    )
+    census_p.add_argument(
+        "--env",
+        action="append",
+        metavar="KEY=VALUE",
+        help="extra environment for the compiler (used to sabotage a representation on purpose)",
+    )
+    census_p.add_argument("--keep-reports", help="write each raw --opt-report JSON to this dir")
+    census_p.add_argument("--compile-timeout", type=int, default=300)
+    census_p.add_argument(
+        "--update", action="store_true", help="rewrite the baseline floors from observation"
+    )
+    census_p.add_argument("--gate", action="store_true", help="exit nonzero on a regression")
+    census_p.set_defaults(func=census)
+
+    census_self_p = sub.add_parser(
+        "census-self-test", help="check the census verdict logic without compiling"
+    )
+    census_self_p.set_defaults(func=census_self_test)
 
     return parser
 

--- a/scripts/compiler_output_harness/cli.py
+++ b/scripts/compiler_output_harness/cli.py
@@ -95,7 +95,7 @@ def build_parser() -> argparse.ArgumentParser:
     verify_p.add_argument("--print-summary", action="store_true")
     verify_p.set_defaults(func=verify_existing)
 
-    # Representation-selection promotion census (#7035). Shares this harness's
+    # Representation-selection promotion census (#7106). Shares this harness's
     # process plumbing but not its workload spec: the census corpus is chosen
     # for representation coverage, whereas `workloads.toml` is tuned for
     # vectorization and IR-shape gates.

--- a/scripts/compiler_output_harness/repsel_census.py
+++ b/scripts/compiler_output_harness/repsel_census.py
@@ -257,13 +257,20 @@ def compile_and_census(
             "--no-link",
             "--no-cache",
         ]
-        result = run_command(
-            cmd,
-            cwd=tmpdir,
-            env=env,
-            timeout=timeout,
-            check=True,
-        )
+        try:
+            result = run_command(
+                cmd,
+                cwd=tmpdir,
+                env=env,
+                timeout=timeout,
+                check=True,
+            )
+        except OSError as exc:
+            # A missing/unusable compiler must exit 2 (harness error), NOT 1
+            # (gate verdict). CI's sabotage step asserts on exit 1 plus the
+            # reason string precisely so a broken toolchain can never be
+            # mistaken for "the census correctly went red".
+            raise HarnessError(f"could not run the compiler {perry[0]!r}: {exc}") from exc
     payload = _extract_json(result.stderr)
     if keep_report is not None:
         keep_report.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/compiler_output_harness/repsel_census.py
+++ b/scripts/compiler_output_harness/repsel_census.py
@@ -1,4 +1,4 @@
-"""Representation-selection promotion census (#7035).
+"""Representation-selection promotion census (#7106).
 
 Perry's performance story rests on six unboxed representations. Until #7034
 nobody knew how many values each one actually promotes on real code, because
@@ -396,7 +396,7 @@ def check_instrument_liveness(observed: dict[str, dict[str, Any]]) -> list[str]:
     """No census key may read zero across the ENTIRE corpus.
 
     A key that is zero everywhere is indistinguishable from a counter nobody
-    increments — which is literally what `Ptr<NumArray>` was before #7035: an
+    increments — which is literally what `Ptr<NumArray>` was before #7106: an
     `Analysis` variant with a `target_rep` string and no `select()` call site
     anywhere in the tree.
     """
@@ -519,7 +519,7 @@ def census(args: argparse.Namespace) -> int:
     if args.update:
         return _update(baseline, baseline_path, observed, workloads)
 
-    print("Representation-selection promotion census (#7035)")
+    print("Representation-selection promotion census (#7106)")
     print("=================================================\n")
     print(render_table(baseline, observed))
     print("\nPromotion coverage on non-fixture workloads")

--- a/scripts/compiler_output_harness/repsel_census.py
+++ b/scripts/compiler_output_harness/repsel_census.py
@@ -1,0 +1,685 @@
+"""Representation-selection promotion census (#7035).
+
+Perry's performance story rests on six unboxed representations. Until #7034
+nobody knew how many values each one actually promotes on real code, because
+nothing reported it: an agent had to hand-instrument the compiler to discover
+that `Ptr<Shape>` promotes **nothing at all** on `batch.ts` — the
+object/property-heavy program the representation exists for. Independently
+confirmed: `PERRY_PTR_SHAPE_LOCALS=0` and the default produce a byte-identical
+binary.
+
+This module turns that into a standing, gated measurement. It runs
+`perry compile --opt-report=json --no-link` over a corpus, extracts a
+**per-representation** count of promotions per workload, and compares each
+count against a ratcheted floor.
+
+## Why the counts are per representation, never aggregated
+
+The interesting signal in #7034 is that `Ptr<Shape>` is 0 *while* canonical
+`Str` is nonzero. One aggregate number hides exactly that. So the census keys
+on the representation, splitting `canonical-slot` into its three reps
+(`I32`/`U32`/`Str`) and counting `TaPtr` parameter slots inside specialized-ABI
+entries.
+
+## Why a floor and not a diff
+
+CLAUDE.md, "Four ways a gate can be unable to fail", case 4: *the gate runs but
+its subject never did*. A census that faithfully reports `Ptr<Shape>: 0` and
+exits green is worth nothing — that is the state the project is in today. So:
+
+1. Every workload carries a **floor** per representation. A count below its
+   floor is red. `--update` rewrites floors from observation.
+2. Floors alone are not enough, because today's honest floor for
+   `Ptr<Shape>` on real code *is* zero, and a zero floor can never fail. So
+   the corpus includes **liveness fixtures**: hand-written programs that must
+   promote a specific representation. Their minimums live in
+   [`LIVENESS_FLOORS`] — **in this file, not in the baseline JSON** — so that
+   re-running `--update` after a breakage cannot silently write them down to
+   zero and leave a permanently-green gate behind.
+3. A representation whose census key is nonzero *nowhere* in the corpus fails
+   the run outright ([`check_instrument_liveness`]). A counter that is zero
+   because nothing was promoted and a counter that is zero because nobody
+   increments it look identical in a report; this distinguishes them.
+
+Point 2 is what makes the gate falsifiable in both directions:
+`PERRY_PTR_SHAPE_LOCALS=0` takes the `ptr_shape` fixture to zero and the run
+goes red, while the default build is green.
+
+## What this census can and cannot see
+
+It counts what `--opt-report` (#6952) records, which is the set of analyses in
+`perry_codegen::opt_report::Analysis::ALL`. Two things are deliberately out of
+scope and are **not** silently reported as zero:
+
+- The masked-window / buffer-view `TaPtr` *region* machinery
+  (`stmt/masked_window_region.rs`) is region-shaped rather than a per-value
+  promotion, and has no `opt_report` analysis. `spec-abi-taptr-slot` covers
+  `TaPtr` only in its specialized-ABI *parameter* form.
+- Denials are recorded as context (`candidates`) but never gated: the count of
+  values a rule rejected is a property of the corpus, not of the compiler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+from .capture import resolve_perry
+from .common import HarnessError, REPO_ROOT, run_command, utc_now
+
+
+DEFAULT_BASELINE = REPO_ROOT / "benchmarks/repsel_census/baseline.json"
+
+BASELINE_SCHEMA_VERSION = 1
+
+#: The `--opt-report` JSON schema this census understands. A bump upstream must
+#: be a loud failure here, not a silently-empty census.
+SUPPORTED_REPORT_SCHEMA = 1
+
+#: Every analysis the report is expected to enumerate. Kept in lockstep with
+#: `perry_codegen::opt_report::Analysis::ALL`; a missing row means the compiler
+#: stopped emitting explicit zeros and the census can no longer tell "zero"
+#: from "absent".
+EXPECTED_ANALYSES = (
+    "ptr-shape",
+    "ptr-numarray",
+    "canonical-slot",
+    "int-valued-ta",
+    "spec-abi",
+)
+
+#: Census keys, one per representation, in report order.
+CENSUS_KEYS: tuple[str, ...] = (
+    "ptr-shape",
+    "ptr-numarray",
+    "canonical-i32",
+    "canonical-u32",
+    "canonical-str",
+    "int-valued-ta",
+    "spec-abi-entry",
+    "spec-abi-taptr-slot",
+)
+
+#: `SlotRep` debug spelling -> census key, for the `canonical-slot` analysis.
+CANONICAL_REPS = {
+    "I32": "canonical-i32",
+    "U32": "canonical-u32",
+    "Str": "canonical-str",
+}
+
+#: `SpecParamRep::label()` spelling for a `TaPtr` slot: `ta<kind>` or
+#: `ta<kind>x<len>`.
+TAPTR_LABEL = re.compile(r"^ta\d+(?:x-?\d+)?$")
+
+#: Liveness minimums for the hand-written fixtures, **held in code on purpose**.
+#:
+#: The baseline JSON is regenerable from observation; these are not. If a
+#: change breaks a representation and someone re-runs `--update`, the baseline
+#: floors follow the breakage down to zero — and a zero floor can never fail
+#: again. These minimums are the backstop: `--update` refuses to write a
+#: fixture floor below them, and `--gate` checks them independently of the
+#: baseline file.
+#:
+#: Each entry says: *this program, compiled by this compiler, must promote at
+#: least this many values of this representation.* That is the assertion that
+#: the instrument is alive, separate from any claim about real-world code.
+LIVENESS_FLOORS: dict[str, dict[str, int]] = {
+    "fixture_ptr_shape": {"ptr-shape": 1},
+    "fixture_ptr_numarray": {"ptr-numarray": 1},
+    "fixture_canonical_slots": {
+        "canonical-i32": 1,
+        "canonical-u32": 1,
+        "canonical-str": 1,
+    },
+    "fixture_int_valued_ta": {"int-valued-ta": 1},
+    "fixture_spec_abi_taptr": {"spec-abi-entry": 1, "spec-abi-taptr-slot": 1},
+}
+
+
+# ── Report -> census ───────────────────────────────────────────────────────
+
+
+def census_from_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Reduce one `--opt-report=json` payload to per-representation counts.
+
+    Pure and total: every key in [`CENSUS_KEYS`] is present in the result even
+    when it is zero. Raises rather than guessing when the payload does not look
+    like the schema this census was written against — a census that quietly
+    degrades to all-zeros is the exact failure this exists to prevent.
+    """
+    schema = report.get("schema_version")
+    if schema != SUPPORTED_REPORT_SCHEMA:
+        raise HarnessError(
+            f"--opt-report schema_version {schema!r} is not the supported "
+            f"{SUPPORTED_REPORT_SCHEMA}; the census must be updated deliberately "
+            "rather than silently reporting zeros"
+        )
+
+    rows = report.get("summary", {}).get("by_analysis")
+    if not isinstance(rows, list):
+        raise HarnessError("--opt-report JSON has no summary.by_analysis list")
+    by_analysis = {row["analysis"]: row for row in rows if isinstance(row, dict)}
+    missing = [a for a in EXPECTED_ANALYSES if a not in by_analysis]
+    if missing:
+        raise HarnessError(
+            "--opt-report omitted analyses "
+            f"{missing} from summary.by_analysis. Every analysis must render an "
+            "explicit row (perry_codegen::opt_report::Analysis::ALL) — an absent "
+            "key and a zero key are indistinguishable to this census."
+        )
+
+    entries = report.get("entries")
+    if not isinstance(entries, list):
+        raise HarnessError("--opt-report JSON has no entries list")
+
+    counts = {key: 0 for key in CENSUS_KEYS}
+    counts["ptr-shape"] = int(by_analysis["ptr-shape"]["selected"])
+    counts["ptr-numarray"] = int(by_analysis["ptr-numarray"]["selected"])
+    counts["int-valued-ta"] = int(by_analysis["int-valued-ta"]["selected"])
+    counts["spec-abi-entry"] = int(by_analysis["spec-abi"]["selected"])
+
+    unknown_canonical: set[str] = set()
+    for entry in entries:
+        if entry.get("outcome") != "selected":
+            continue
+        analysis = entry.get("analysis")
+        rep = entry.get("rep") or ""
+        if analysis == "canonical-slot":
+            key = CANONICAL_REPS.get(rep)
+            if key is None:
+                unknown_canonical.add(rep)
+                continue
+            counts[key] += 1
+        elif analysis == "spec-abi":
+            counts["spec-abi-taptr-slot"] += sum(
+                1 for label in rep.split(",") if TAPTR_LABEL.match(label.strip())
+            )
+    if unknown_canonical:
+        raise HarnessError(
+            f"canonical-slot reported unknown representation(s) {sorted(unknown_canonical)}; "
+            "a new SlotRep variant needs a census key in CANONICAL_REPS, otherwise "
+            "its promotions vanish from the census"
+        )
+
+    canonical_total = sum(counts[k] for k in CANONICAL_REPS.values())
+    reported = int(by_analysis["canonical-slot"]["selected"])
+    if canonical_total != reported:
+        raise HarnessError(
+            f"canonical-slot tally disagrees with its entries: summary says "
+            f"{reported} selected, entries account for {canonical_total}"
+        )
+
+    candidates = {
+        row: int(by_analysis[row]["selected"]) + int(by_analysis[row]["denied"])
+        for row in EXPECTED_ANALYSES
+    }
+    return {"counts": counts, "candidates": candidates}
+
+
+# ── Running the compiler ───────────────────────────────────────────────────
+
+
+def compile_and_census(
+    perry: list[str],
+    source: Path,
+    *,
+    timeout: int,
+    extra_env: dict[str, str] | None = None,
+    keep_report: Path | None = None,
+) -> dict[str, Any]:
+    """Compile `source` with `--opt-report=json --no-link` and reduce it.
+
+    `--no-link` on purpose: the report is produced during codegen, so the
+    census never needs `libperry_runtime.a` and cannot be fooled by a stale
+    one. `--no-cache` is redundant (`--opt-report` forces it) but stated so the
+    intent survives a change upstream.
+    """
+    if not source.exists():
+        raise HarnessError(f"census source not found: {source}")
+    env = dict(os.environ)
+    env.pop("PERRY_OPT_REPORT", None)
+    env["PERRY_NO_AUTO_OPTIMIZE"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    with tempfile.TemporaryDirectory(prefix="repsel-census-") as tmp:
+        tmpdir = Path(tmp)
+        cmd = perry + [
+            "compile",
+            str(source),
+            "-o",
+            str(tmpdir / "census.o"),
+            "--opt-report=json",
+            "--no-link",
+            "--no-cache",
+        ]
+        result = run_command(
+            cmd,
+            cwd=tmpdir,
+            env=env,
+            timeout=timeout,
+            check=True,
+        )
+    payload = _extract_json(result.stderr)
+    if keep_report is not None:
+        keep_report.parent.mkdir(parents=True, exist_ok=True)
+        keep_report.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    census = census_from_report(payload)
+    census["source"] = str(source.relative_to(REPO_ROOT))
+    return census
+
+
+def _extract_json(stderr: str) -> dict[str, Any]:
+    """Pull the report object out of the compiler's stderr.
+
+    The report is written to stderr so it cannot contaminate a `--format json`
+    stdout payload; other diagnostics share that stream, so locate the object
+    rather than parsing the whole buffer.
+    """
+    start = stderr.find('{\n  "schema_version"')
+    if start < 0:
+        start = stderr.find('{"schema_version"')
+    if start < 0:
+        raise HarnessError(
+            "no --opt-report JSON object found on the compiler's stderr. "
+            "Either codegen ran for no module (an object-cache hit that "
+            "--opt-report failed to suppress) or the flag was not honoured.\n"
+            f"stderr tail:\n{stderr[-2000:]}"
+        )
+    decoder = json.JSONDecoder()
+    try:
+        payload, _ = decoder.raw_decode(stderr[start:])
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise HarnessError(f"could not decode the --opt-report JSON: {exc}") from exc
+    return payload
+
+
+# ── Baseline ───────────────────────────────────────────────────────────────
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise HarnessError(
+            f"census baseline not found: {path}. Generate one with\n"
+            "  python3 scripts/compiler_output_regression.py census --update"
+        )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if int(data.get("schema_version", 0)) != BASELINE_SCHEMA_VERSION:
+        raise HarnessError(
+            f"census baseline schema_version must be {BASELINE_SCHEMA_VERSION}"
+        )
+    workloads = data.get("workloads")
+    if not isinstance(workloads, list) or not workloads:
+        raise HarnessError("census baseline must list workloads")
+    seen: set[str] = set()
+    for workload in workloads:
+        name = workload.get("name")
+        if not name:
+            raise HarnessError("every census workload needs a name")
+        if name in seen:
+            raise HarnessError(f"duplicate census workload {name!r}")
+        seen.add(name)
+        if not workload.get("source"):
+            raise HarnessError(f"census workload {name!r} needs a source")
+        floors = workload.get("floors")
+        if not isinstance(floors, dict):
+            raise HarnessError(f"census workload {name!r} needs a floors table")
+        unknown = set(floors) - set(CENSUS_KEYS)
+        if unknown:
+            raise HarnessError(
+                f"census workload {name!r} has unknown floor key(s) {sorted(unknown)}"
+            )
+    missing_fixtures = set(LIVENESS_FLOORS) - seen
+    if missing_fixtures:
+        raise HarnessError(
+            f"census baseline is missing liveness fixture(s) {sorted(missing_fixtures)}. "
+            "The fixtures are what prove the census can observe a promotion at all; "
+            "dropping one from the baseline silently disarms the gate."
+        )
+    return data
+
+
+# ── Verdicts ───────────────────────────────────────────────────────────────
+
+
+def check_workload(
+    name: str, floors: dict[str, int], counts: dict[str, int]
+) -> tuple[list[str], list[str]]:
+    """Return `(regressions, improvements)` for one workload."""
+    regressions: list[str] = []
+    improvements: list[str] = []
+    for key in CENSUS_KEYS:
+        floor = int(floors.get(key, 0))
+        observed = int(counts.get(key, 0))
+        if observed < floor:
+            regressions.append(
+                f"{name}: {key} promoted {observed}, floor is {floor} "
+                f"(-{floor - observed})"
+            )
+        elif observed > floor:
+            improvements.append(
+                f"{name}: {key} promoted {observed}, floor is {floor} (+{observed - floor})"
+            )
+    return regressions, improvements
+
+
+def check_liveness_fixtures(observed: dict[str, dict[str, Any]]) -> list[str]:
+    """Every fixture must promote what it was written to promote.
+
+    Independent of the baseline file on purpose — see [`LIVENESS_FLOORS`].
+    """
+    failures: list[str] = []
+    for name, minimums in LIVENESS_FLOORS.items():
+        if name not in observed:
+            failures.append(
+                f"liveness fixture {name!r} did not run; the census cannot claim "
+                "to observe promotions it never measured"
+            )
+            continue
+        counts = observed[name]["counts"]
+        for key, minimum in minimums.items():
+            if int(counts.get(key, 0)) < minimum:
+                failures.append(
+                    f"liveness fixture {name!r} promoted {counts.get(key, 0)} "
+                    f"{key} value(s); it is written to promote at least {minimum}. "
+                    "Either the representation stopped firing or the census counter "
+                    "for it is dead."
+                )
+    return failures
+
+
+def check_instrument_liveness(observed: dict[str, dict[str, Any]]) -> list[str]:
+    """No census key may read zero across the ENTIRE corpus.
+
+    A key that is zero everywhere is indistinguishable from a counter nobody
+    increments — which is literally what `Ptr<NumArray>` was before #7035: an
+    `Analysis` variant with a `target_rep` string and no `select()` call site
+    anywhere in the tree.
+    """
+    totals = {key: 0 for key in CENSUS_KEYS}
+    for entry in observed.values():
+        for key in CENSUS_KEYS:
+            totals[key] += int(entry["counts"].get(key, 0))
+    return [
+        f"census key {key!r} is zero across every workload in the corpus. "
+        "That is either a dead counter or a representation that no longer "
+        "fires anywhere; both are regressions."
+        for key in CENSUS_KEYS
+        if totals[key] == 0
+    ]
+
+
+# ── Rendering ──────────────────────────────────────────────────────────────
+
+
+def render_table(
+    baseline: dict[str, Any], observed: dict[str, dict[str, Any]]
+) -> str:
+    head = ["workload"] + list(CENSUS_KEYS)
+    rows = [head]
+    for workload in baseline["workloads"]:
+        name = workload["name"]
+        if name not in observed:
+            continue
+        counts = observed[name]["counts"]
+        floors = workload.get("floors", {})
+        cells = [name]
+        for key in CENSUS_KEYS:
+            got = int(counts.get(key, 0))
+            floor = int(floors.get(key, 0))
+            cells.append(str(got) if got == floor else f"{got} (floor {floor})")
+        rows.append(cells)
+    totals = ["TOTAL"] + [
+        str(sum(int(e["counts"].get(key, 0)) for e in observed.values()))
+        for key in CENSUS_KEYS
+    ]
+    rows.append(totals)
+    widths = [max(len(row[i]) for row in rows) for i in range(len(head))]
+    lines = []
+    for index, row in enumerate(rows):
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip())
+        if index == 0:
+            lines.append("  ".join("-" * w for w in widths))
+    return "\n".join(lines)
+
+
+def render_zero_report(
+    baseline: dict[str, Any], observed: dict[str, dict[str, Any]]
+) -> str:
+    """State plainly which representations promote nothing on real code.
+
+    This is the #7034 finding, printed on every run so it stops being something
+    a person has to rediscover by hand-instrumenting the compiler.
+    """
+    real = [
+        workload["name"]
+        for workload in baseline["workloads"]
+        if workload.get("role") != "liveness" and workload["name"] in observed
+    ]
+    lines = []
+    for key in CENSUS_KEYS:
+        promoting = [n for n in real if int(observed[n]["counts"].get(key, 0)) > 0]
+        lines.append(
+            f"  {key:<22} promotes in {len(promoting)}/{len(real)} non-fixture workload(s)"
+            + (f": {', '.join(promoting)}" if promoting else "")
+        )
+    return "\n".join(lines)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _resolve_source(rel: str) -> Path:
+    path = Path(rel)
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _selected_workloads(
+    baseline: dict[str, Any], only: Iterable[str] | None
+) -> list[dict[str, Any]]:
+    workloads = baseline["workloads"]
+    if not only:
+        return workloads
+    wanted = set(only)
+    picked = [w for w in workloads if w["name"] in wanted]
+    unknown = wanted - {w["name"] for w in picked}
+    if unknown:
+        raise HarnessError(f"unknown census workload(s): {sorted(unknown)}")
+    return picked
+
+
+def census(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.baseline) if args.baseline else DEFAULT_BASELINE
+    baseline = load_baseline(baseline_path)
+    perry = resolve_perry(args.perry)
+    workloads = _selected_workloads(baseline, args.workload)
+    keep_dir = Path(args.keep_reports).resolve() if args.keep_reports else None
+
+    extra_env: dict[str, str] = {}
+    for pair in args.env or []:
+        key, _, value = pair.partition("=")
+        extra_env[key] = value
+
+    observed: dict[str, dict[str, Any]] = {}
+    for workload in workloads:
+        name = workload["name"]
+        source = _resolve_source(workload["source"])
+        observed[name] = compile_and_census(
+            perry,
+            source,
+            timeout=args.compile_timeout,
+            extra_env=extra_env,
+            keep_report=(keep_dir / f"{name}.json") if keep_dir else None,
+        )
+
+    if args.update:
+        return _update(baseline, baseline_path, observed, workloads)
+
+    print("Representation-selection promotion census (#7035)")
+    print("=================================================\n")
+    print(render_table(baseline, observed))
+    print("\nPromotion coverage on non-fixture workloads")
+    print("------------------------------------------")
+    print(render_zero_report(baseline, observed))
+    print()
+
+    partial = len(workloads) != len(baseline["workloads"])
+    regressions: list[str] = []
+    improvements: list[str] = []
+    for workload in workloads:
+        name = workload["name"]
+        reg, imp = check_workload(name, workload.get("floors", {}), observed[name]["counts"])
+        regressions += reg
+        improvements += imp
+    liveness = check_liveness_fixtures(observed) if not partial else []
+    dead = check_instrument_liveness(observed) if not partial else []
+
+    if partial:
+        print(
+            "NOTE: --workload was given, so the corpus-wide liveness assertions were\n"
+            "      skipped. This run cannot be used as a gate.\n"
+        )
+
+    if improvements:
+        print("Improvements (advisory — re-run with --update to ratchet):")
+        for line in improvements:
+            print(f"  {line}")
+        print()
+
+    failed = False
+    for label, problems in (
+        ("REGRESSION", regressions),
+        ("DEAD INSTRUMENT", liveness + dead),
+    ):
+        if not problems:
+            continue
+        failed = True
+        print(f"{label}:")
+        for line in problems:
+            print(f"  {line}")
+        print()
+
+    if failed and args.gate:
+        print(
+            "Census FAILED. If the drop is intentional, say so explicitly by\n"
+            "re-running with --update and justifying the new floors in the PR —\n"
+            "but note that LIVENESS_FLOORS in scripts/compiler_output_harness/\n"
+            "repsel_census.py cannot be lowered that way, by design."
+        )
+        return 1
+    if failed:
+        print("(--gate not passed; reporting only)")
+        return 0
+    print("Census OK.")
+    return 0
+
+
+def _update(
+    baseline: dict[str, Any],
+    path: Path,
+    observed: dict[str, dict[str, Any]],
+    workloads: list[dict[str, Any]],
+) -> int:
+    for workload in workloads:
+        name = workload["name"]
+        counts = observed[name]["counts"]
+        minimums = LIVENESS_FLOORS.get(name, {})
+        below = {
+            key: (counts.get(key, 0), minimum)
+            for key, minimum in minimums.items()
+            if int(counts.get(key, 0)) < minimum
+        }
+        if below:
+            detail = ", ".join(
+                f"{key}: observed {got}, minimum {want}" for key, (got, want) in below.items()
+            )
+            raise HarnessError(
+                f"refusing to write a baseline for liveness fixture {name!r}: {detail}.\n"
+                "LIVENESS_FLOORS is the backstop that stops a broken build from being\n"
+                "re-baselined into a permanently-green gate. Fix the compiler (or the\n"
+                "fixture, if the source genuinely no longer exercises the rep) instead."
+            )
+        workload["floors"] = {key: int(counts.get(key, 0)) for key in CENSUS_KEYS}
+        workload["candidates"] = observed[name]["candidates"]
+    baseline["generated_at"] = utc_now()
+    path.write_text(json.dumps(baseline, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {path.relative_to(REPO_ROOT)} ({len(workloads)} workload(s)).")
+    return 0
+
+
+# ── Self-test ──────────────────────────────────────────────────────────────
+
+
+def self_test(_args: argparse.Namespace) -> int:
+    """Prove the verdict logic can go red, without compiling anything.
+
+    Deliberately asserts the *failing* direction first: a gate whose only test
+    is that it passes on a good tree is a gate nobody has watched fail.
+    """
+    report = {
+        "schema_version": 1,
+        "summary": {
+            "selected": 3,
+            "denied": 1,
+            "by_analysis": [
+                {"analysis": a, "target_rep": a, "rule_source": "x", "selected": s, "denied": d}
+                for a, s, d in (
+                    ("ptr-shape", 0, 1),
+                    ("ptr-numarray", 1, 0),
+                    ("canonical-slot", 2, 0),
+                    ("int-valued-ta", 0, 0),
+                    ("spec-abi", 0, 0),
+                )
+            ],
+        },
+        "entries": [
+            {"analysis": "canonical-slot", "outcome": "selected", "rep": "I32"},
+            {"analysis": "canonical-slot", "outcome": "selected", "rep": "Str"},
+            {"analysis": "ptr-numarray", "outcome": "selected", "rep": "Ptr<NumArray>"},
+            {"analysis": "ptr-shape", "outcome": "denied", "rep": "Boxed"},
+        ],
+    }
+    result = census_from_report(report)
+    counts = result["counts"]
+    assert counts["ptr-shape"] == 0, counts
+    assert counts["canonical-i32"] == 1, counts
+    assert counts["canonical-str"] == 1, counts
+    assert counts["canonical-u32"] == 0, counts
+    assert counts["ptr-numarray"] == 1, counts
+    assert set(counts) == set(CENSUS_KEYS), counts
+
+    regressions, improvements = check_workload("w", {"ptr-shape": 1}, counts)
+    assert regressions, "a count below its floor must be a regression"
+    regressions, improvements = check_workload("w", {"canonical-i32": 0}, counts)
+    assert not regressions and improvements, "a count above its floor is an improvement"
+
+    dead = check_instrument_liveness({"w": {"counts": counts}})
+    assert any("ptr-shape" in d for d in dead), dead
+
+    failures = check_liveness_fixtures({"fixture_ptr_shape": {"counts": counts}})
+    assert any("fixture_ptr_shape" in f for f in failures), failures
+
+    for broken, why in (
+        ({"schema_version": 99}, "schema drift"),
+        (
+            {
+                "schema_version": 1,
+                "summary": {"by_analysis": [{"analysis": "ptr-shape", "selected": 0, "denied": 0}]},
+                "entries": [],
+            },
+            "missing analyses",
+        ),
+    ):
+        try:
+            census_from_report(broken)
+        except HarnessError:
+            pass
+        else:  # pragma: no cover - the assertion IS the test
+            raise AssertionError(f"census_from_report accepted {why}")
+
+    print("repsel census self-test OK")
+    return 0

--- a/scripts/compiler_output_regression.py
+++ b/scripts/compiler_output_regression.py
@@ -55,6 +55,16 @@ from compiler_output_harness.common import (
     utc_now,
     write_text,
 )
+from compiler_output_harness.repsel_census import (
+    CENSUS_KEYS,
+    LIVENESS_FLOORS,
+    census,
+    census_from_report,
+    check_instrument_liveness,
+    check_liveness_fixtures,
+    check_workload,
+    load_baseline,
+)
 from compiler_output_harness.spec import (
     DEFAULT_SPEC_PATH,
     SPEC,

--- a/tests/test_repsel_census.py
+++ b/tests/test_repsel_census.py
@@ -1,4 +1,4 @@
-"""Unit tests for the representation-selection promotion census (#7035).
+"""Unit tests for the representation-selection promotion census (#7106).
 
 The census is a gate, so most of these tests assert the FAILING direction.
 CLAUDE.md's "Four ways a gate can be unable to fail" is the design brief: a

--- a/tests/test_repsel_census.py
+++ b/tests/test_repsel_census.py
@@ -1,0 +1,295 @@
+"""Unit tests for the representation-selection promotion census (#7035).
+
+The census is a gate, so most of these tests assert the FAILING direction.
+CLAUDE.md's "Four ways a gate can be unable to fail" is the design brief: a
+census that reports `Ptr<Shape>: 0` and exits green is exactly the state the
+project was already in, so the tests that matter are the ones that show the
+verdict logic going red.
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+if sys.version_info < (3, 11):
+    print("SKIP: Python 3.11+ is required for stdlib TOML parsing")
+    raise SystemExit(0)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "compiler_output_regression.py"
+
+SPEC = importlib.util.spec_from_file_location("compiler_output_regression", SCRIPT_PATH)
+assert SPEC is not None
+HARNESS = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = HARNESS
+SPEC.loader.exec_module(HARNESS)
+
+from compiler_output_harness import repsel_census as CENSUS
+from compiler_output_harness.common import HarnessError
+
+
+def report(
+    *,
+    selected: dict[str, int] | None = None,
+    denied: dict[str, int] | None = None,
+    entries: list[dict] | None = None,
+    schema_version: int = 1,
+) -> dict:
+    selected = selected or {}
+    denied = denied or {}
+    return {
+        "schema_version": schema_version,
+        "summary": {
+            "selected": sum(selected.values()),
+            "denied": sum(denied.values()),
+            "by_analysis": [
+                {
+                    "analysis": analysis,
+                    "target_rep": analysis,
+                    "rule_source": "x.rs",
+                    "selected": selected.get(analysis, 0),
+                    "denied": denied.get(analysis, 0),
+                }
+                for analysis in CENSUS.EXPECTED_ANALYSES
+            ],
+        },
+        "entries": entries or [],
+    }
+
+
+def win(analysis: str, rep: str) -> dict:
+    return {"analysis": analysis, "outcome": "selected", "rep": rep}
+
+
+class CensusExtraction(unittest.TestCase):
+    def test_every_key_is_present_even_when_zero(self):
+        counts = CENSUS.census_from_report(report())["counts"]
+        self.assertEqual(set(counts), set(CENSUS.CENSUS_KEYS))
+        self.assertTrue(all(v == 0 for v in counts.values()), counts)
+
+    def test_canonical_slot_is_split_per_representation(self):
+        """The #7034 signal is `Ptr<Shape>` 0 WHILE `Str` is nonzero.
+
+        One aggregate `canonical-slot` number would hide it, so the census
+        keys on the rep, not the analysis.
+        """
+        payload = report(
+            selected={"canonical-slot": 4},
+            entries=[
+                win("canonical-slot", "I32"),
+                win("canonical-slot", "I32"),
+                win("canonical-slot", "U32"),
+                win("canonical-slot", "Str"),
+            ],
+        )
+        counts = CENSUS.census_from_report(payload)["counts"]
+        self.assertEqual(counts["canonical-i32"], 2)
+        self.assertEqual(counts["canonical-u32"], 1)
+        self.assertEqual(counts["canonical-str"], 1)
+        self.assertEqual(counts["ptr-shape"], 0)
+
+    def test_taptr_slots_are_counted_inside_spec_abi_tuples(self):
+        payload = report(
+            selected={"spec-abi": 2},
+            entries=[
+                win("spec-abi", "ta4x256,ta4x16,i32,f64"),
+                win("spec-abi", "i32"),
+            ],
+        )
+        counts = CENSUS.census_from_report(payload)["counts"]
+        self.assertEqual(counts["spec-abi-entry"], 2)
+        self.assertEqual(counts["spec-abi-taptr-slot"], 2)
+
+    def test_denials_are_not_counted_as_promotions(self):
+        payload = report(
+            denied={"ptr-shape": 3},
+            entries=[{"analysis": "ptr-shape", "outcome": "denied", "rep": "Boxed"}],
+        )
+        result = CENSUS.census_from_report(payload)
+        self.assertEqual(result["counts"]["ptr-shape"], 0)
+        self.assertEqual(result["candidates"]["ptr-shape"], 3)
+
+    def test_schema_drift_is_loud(self):
+        with self.assertRaises(HarnessError):
+            CENSUS.census_from_report(report(schema_version=2))
+
+    def test_a_missing_analysis_row_is_an_error_not_a_zero(self):
+        """An absent key and a zero key are indistinguishable downstream.
+
+        The compiler is required to enumerate `Analysis::ALL`; if it stops,
+        the census must say so rather than quietly report zeros for whatever
+        vanished.
+        """
+        payload = report()
+        payload["summary"]["by_analysis"] = [
+            row
+            for row in payload["summary"]["by_analysis"]
+            if row["analysis"] != "ptr-numarray"
+        ]
+        with self.assertRaises(HarnessError) as ctx:
+            CENSUS.census_from_report(payload)
+        self.assertIn("ptr-numarray", str(ctx.exception))
+
+    def test_an_unknown_canonical_rep_is_an_error_not_a_silent_drop(self):
+        """A new `SlotRep` variant must not vanish from the census.
+
+        Without this, adding a seventh representation would show up as
+        "nothing changed" — the census would count its promotions into no key
+        at all.
+        """
+        payload = report(
+            selected={"canonical-slot": 1},
+            entries=[win("canonical-slot", "F64Unboxed")],
+        )
+        with self.assertRaises(HarnessError) as ctx:
+            CENSUS.census_from_report(payload)
+        self.assertIn("F64Unboxed", str(ctx.exception))
+
+    def test_summary_and_entries_must_agree(self):
+        payload = report(
+            selected={"canonical-slot": 5},
+            entries=[win("canonical-slot", "I32")],
+        )
+        with self.assertRaises(HarnessError):
+            CENSUS.census_from_report(payload)
+
+
+class Verdicts(unittest.TestCase):
+    def test_a_count_below_its_floor_is_a_regression(self):
+        counts = {key: 0 for key in CENSUS.CENSUS_KEYS}
+        regressions, improvements = CENSUS.check_workload("w", {"ptr-shape": 2}, counts)
+        self.assertEqual(len(regressions), 1)
+        self.assertIn("floor is 2", regressions[0])
+        self.assertFalse(improvements)
+
+    def test_a_count_above_its_floor_is_an_advisory_not_a_failure(self):
+        counts = {key: 0 for key in CENSUS.CENSUS_KEYS}
+        counts["ptr-shape"] = 3
+        regressions, improvements = CENSUS.check_workload("w", {"ptr-shape": 1}, counts)
+        self.assertFalse(regressions)
+        self.assertEqual(len(improvements), 1)
+
+    def test_a_zero_floor_alone_cannot_fail(self):
+        """The reason liveness fixtures exist, stated as a test.
+
+        `Ptr<Shape>` on `batch.ts` is honestly zero today, so its floor is
+        zero, so that row can never go red. A gate built only from floors
+        would therefore be unable to detect the representation dying.
+        """
+        counts = {key: 0 for key in CENSUS.CENSUS_KEYS}
+        regressions, _ = CENSUS.check_workload("batch", {"ptr-shape": 0}, counts)
+        self.assertFalse(regressions)
+
+    def test_a_key_that_is_zero_corpus_wide_fails(self):
+        counts = {key: 1 for key in CENSUS.CENSUS_KEYS}
+        counts["ptr-shape"] = 0
+        problems = CENSUS.check_instrument_liveness({"w": {"counts": counts}})
+        self.assertEqual(len(problems), 1)
+        self.assertIn("ptr-shape", problems[0])
+
+    def test_liveness_fixtures_fail_when_their_representation_stops_firing(self):
+        observed = {
+            name: {"counts": {key: minimum for key, minimum in minimums.items()}}
+            for name, minimums in CENSUS.LIVENESS_FLOORS.items()
+        }
+        self.assertFalse(CENSUS.check_liveness_fixtures(observed))
+        observed["fixture_ptr_shape"]["counts"]["ptr-shape"] = 0
+        failures = CENSUS.check_liveness_fixtures(observed)
+        self.assertEqual(len(failures), 1)
+        self.assertIn("fixture_ptr_shape", failures[0])
+
+    def test_a_fixture_that_never_ran_fails(self):
+        """Silence is not success — CLAUDE.md failure mode (4)."""
+        failures = CENSUS.check_liveness_fixtures({})
+        self.assertEqual(len(failures), len(CENSUS.LIVENESS_FLOORS))
+        self.assertTrue(all("did not run" in f for f in failures))
+
+
+class Baseline(unittest.TestCase):
+    def test_the_shipped_baseline_loads_and_covers_every_fixture(self):
+        data = CENSUS.load_baseline(CENSUS.DEFAULT_BASELINE)
+        names = {w["name"] for w in data["workloads"]}
+        for fixture in CENSUS.LIVENESS_FLOORS:
+            self.assertIn(fixture, names)
+
+    def test_the_shipped_baseline_records_the_fixture_minimums(self):
+        """The committed floors must already be at or above LIVENESS_FLOORS.
+
+        If they are not, the fixture is not actually promoting what it claims
+        and the liveness assertion is decorative.
+        """
+        data = CENSUS.load_baseline(CENSUS.DEFAULT_BASELINE)
+        by_name = {w["name"]: w for w in data["workloads"]}
+        for fixture, minimums in CENSUS.LIVENESS_FLOORS.items():
+            floors = by_name[fixture]["floors"]
+            for key, minimum in minimums.items():
+                self.assertGreaterEqual(
+                    int(floors.get(key, 0)),
+                    minimum,
+                    f"{fixture}.{key} baseline floor is below its liveness minimum",
+                )
+
+    def test_every_baseline_source_exists(self):
+        data = CENSUS.load_baseline(CENSUS.DEFAULT_BASELINE)
+        for workload in data["workloads"]:
+            self.assertTrue(
+                (REPO_ROOT / workload["source"]).exists(),
+                f"{workload['name']} source is missing: {workload['source']}",
+            )
+
+    def test_dropping_a_fixture_from_the_baseline_is_rejected(self):
+        """Deleting a liveness row would silently disarm the gate."""
+        data = json.loads(CENSUS.DEFAULT_BASELINE.read_text(encoding="utf-8"))
+        data["workloads"] = [
+            w for w in data["workloads"] if w["name"] != "fixture_ptr_shape"
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "baseline.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(HarnessError) as ctx:
+                CENSUS.load_baseline(path)
+        self.assertIn("fixture_ptr_shape", str(ctx.exception))
+
+    def test_unknown_floor_keys_are_rejected(self):
+        data = {
+            "schema_version": 1,
+            "workloads": [
+                {"name": name, "source": "x.ts", "floors": {}}
+                for name in CENSUS.LIVENESS_FLOORS
+            ],
+        }
+        data["workloads"][0]["floors"] = {"ptr-shpae": 1}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "baseline.json"
+            path.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(HarnessError):
+                CENSUS.load_baseline(path)
+
+
+class ReportExtraction(unittest.TestCase):
+    def test_json_is_located_amid_other_stderr_noise(self):
+        payload = json.dumps(report(), indent=2)
+        stderr = f"warning: something\n{payload}\nlinking...\n"
+        self.assertEqual(
+            CENSUS._extract_json(stderr)["schema_version"],
+            CENSUS.SUPPORTED_REPORT_SCHEMA,
+        )
+
+    def test_a_missing_report_is_an_error_not_an_empty_census(self):
+        """An object-cache hit produces no report.
+
+        Treating that as "zero promotions" would make the gate green for the
+        wrong reason on every cached build.
+        """
+        with self.assertRaises(HarnessError):
+            CENSUS._extract_json("nothing here\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this is

A **per-workload, per-representation census** of how many values actually get
each of Perry's unboxed representations, recorded as a **ratcheted baseline**
so a drop turns a build red.

#7034 discovered — by an agent hand-instrumenting the compiler — that
`Ptr<Shape>` promotes **nothing at all** on `batch.ts`, the object-heavy
workload that representation exists for, and that only 3 of 17 suite
benchmarks promote a single shape local each. Nothing in CI could have told
anyone that. This makes it a standing number.

Built on `--opt-report` (#6952) rather than a new analysis — the report already
knows which values were selected and denied and why. What it needed was (a) two
missing counters, (b) explicit zeros, and (c) a gate.

## The current numbers

Measured on this branch, `--profile perry-dev`, macOS arm64. `--no-link`, so no
runtime archive is involved.

```
workload                      ptr-shape  ptr-numarray  canonical-i32  canonical-u32  canonical-str  int-valued-ta  spec-abi-entry  spec-abi-taptr-slot
----------------------------  ---------  ------------  -------------  -------------  -------------  -------------  --------------  -------------------
fixture_ptr_shape             1          0             0              0              0              0              1               0
fixture_ptr_numarray          0          1             2              0              0              0              1               0
fixture_canonical_slots       0          0             2              1              1              0              3               0
fixture_int_valued_ta         0          0             1              0              0              1              0               0
fixture_spec_abi_taptr        0          0             2              0              0              0              1               2
batch                         0          0             3              0              0              0              0               0
suite_01_startup              0          0             0              0              0              0              0               0
suite_02_loop_overhead        0          0             0              0              0              0              0               0
suite_03_array_write          0          1             0              0              0              0              0               0
suite_04_array_read           0          1             0              0              0              0              0               0
suite_05_fibonacci            0          0             0              0              0              0              0               0
suite_06_math_intensive       0          0             0              0              0              0              0               0
suite_07_object_create        1          0             0              0              0              0              0               0
suite_08_string_concat        0          0             0              0              0              0              0               0
suite_09_method_calls         1          0             0              0              0              0              0               0
suite_10_nested_loops         0          1             0              0              0              0              0               0
suite_11_prime_sieve          0          0             0              0              0              0              0               0
suite_12_binary_trees         1          0             0              0              0              0              0               0
suite_13_factorial            0          0             0              0              0              0              0               0
suite_14_closure              0          0             0              0              0              0              0               0
suite_15_mandelbrot           0          0             0              0              0              0              0               0
suite_16_matrix_multiply      0          0             3              0              0              0              0               0
suite_17_loop_data_dependent  0          1             0              0              0              0              0               0
TOTAL                         4          5             13             1              1              1              6               2
```

Coverage across the 18 non-fixture workloads:

| representation | promotes in |
| --- | --- |
| `Ptr<Shape>` | 3/18 — `07_object_create`, `09_method_calls`, `12_binary_trees` (one local each) |
| `Ptr<NumArray>` | 4/18 — `03_array_write`, `04_array_read`, `10_nested_loops`, `17_loop_data_dependent` |
| canonical `I32` | 2/18 — `batch` (3), `16_matrix_multiply` (3) |
| canonical `U32` | **0/18** |
| canonical `Str` | **0/18** |
| int-valued | **0/18** |
| spec-ABI entry | **0/18** |
| `TaPtr` slot | **0/18** |

`Ptr<Shape>` on `batch.ts` reads **0** — the #7034 headline, reproduced.

### Re-checking #7034's byte-identical oracle (a small correction)

#7034 established `Ptr<Shape>` = 0 on `batch.ts` by observing that
`PERRY_PTR_SHAPE_LOCALS=0` and the default produced a byte-identical binary.
Re-run here on `--profile perry-dev`, macOS arm64, comparing the emitted object
(the linked binary is not byte-reproducible on this host — macOS `ld` embeds a
UUID, and two *identical* default builds already differ):

- default vs default: **byte-identical** — codegen itself is deterministic, so
  the comparison is meaningful.
- default vs `PERRY_PTR_SHAPE_LOCALS=0`: **25 of 65,816 bytes differ.**
  Every one is an offset constant shifted by exactly 1 (`mov x19, #0x31` →
  `#0x30`, `add x0, x8, #0x45` → `#0x44`, …), consistent with a one-byte shift
  in an embedded data region. Global symbol tables are identical; no
  instruction is added, removed, or changed in kind.

So the substance of the oracle holds — the knob changes no emitted code shape
on `batch.ts` — but "byte-identical" is not literally true on this tree, and it
should not be leaned on going forward: #6984 records that the Phase 3b kill
switch does not disable Phase 5a, so `=0` has a second effect independent of
shape-local promotion.

The zero itself does not rest on that oracle. `PERRY_REPSEL_DEBUG=1` prints
**zero** `ptr-shape` lines for `batch.ts` in both arms, and the census's four
`Ptr<Shape>` candidates there are all recorded as denied with their rule.

### A second finding: the analyses barely run at all

Denominators, from the same run (`selected` / `denied` per workload):

| workload | candidates | selected | denied |
| --- | ---: | ---: | ---: |
| `batch` | 10 | 3 | 7 |
| `suite_16_matrix_multiply` | 4 | 3 | 1 |
| `suite_03/04/07/09/10/12/17` | 1 each | 1 each | 0 |
| `suite_05_fibonacci` | 1 | 0 | 1 |
| `suite_01/02/06/08/11/13/14/15` | **0** | 0 | 0 |

Eight of the eighteen real workloads produce **zero candidates** — no
representation analysis even considered a value in them. That is a stronger
statement than "promotion is low", and it is not something #7034's
promotion-count framing surfaces. Recorded here as data, not diagnosed.

`batch.ts`'s seven denials, for the record: three `Ptr<Shape>` rule-2
(containment) — `buildRows::row`, `summarize::s`, `totalsRow::acc`; one
`Ptr<Shape>` rule-1 (provenance) on an unbound object literal in a closure; and
three `spec_tuple_unproven` spec-ABI entries. Every one is tiered
`compiler-limitation`, none `fixable`.

Four of the eight representations promote nothing anywhere outside the
hand-written fixtures.

**One discrepancy against #7034, reported rather than smoothed over.** #7034
records `batch.ts` producing one `PERRY_REPSEL_DEBUG` line, a canonical-`Str`
local. On this tree `batch.ts` produces **three** lines, all canonical-`I32`
(`buildRows::i`, `summarize::b`, `totalsRow::i`), and zero `Str`. The census
agrees with `PERRY_REPSEL_DEBUG` exactly, so the counter is not wrong; either
the earlier reading was taken on a different tree state or on a different file.
The load-bearing half of #7034 — `Ptr<Shape>` = 0 on `batch.ts` — reproduces.

## Two counters that could not have been incremented

- **`Ptr<NumArray>`** had an `Analysis` variant, a `Ptr<NumArray>` target-rep
  string, and denial recording — but **no `select()` call site anywhere in the
  tree**. Its `selected` tally was structurally always zero, which is
  indistinguishable in a report from "the representation promoted nothing".
  CLAUDE.md failure mode (4), in the report the census is built on.
- **int-valued locals** (`collectors/int_valued_ta_locals.rs`) had no analysis
  variant at all.

Both now record at the single site where a candidate becomes a fact. Also:

- `render_json` enumerates `Analysis::ALL`, so an analysis with no entries
  renders an explicit `0` instead of an absent key. Absent and zero are
  indistinguishable downstream, and absent is what a dead instrument produces.
- `PtrNumArray` gets an explicit `#[serde(rename = "ptr-numarray")]`. It was
  serialized `ptr-num-array` in `Entry::analysis` while the summary row said
  `ptr-numarray` — one analysis under two names in a single JSON document.

None of this changes an emitted byte: every recording site is behind
`opt_report::enabled()`, which is off unless `PERRY_OPT_REPORT` is set.

## Why this gate can fail

Per CLAUDE.md, "★ Four ways a gate can be unable to fail". Floors alone would
not be enough here — the honest floor for `Ptr<Shape>` on real code **is** zero
today, so that row could never go red. Three mechanisms:

1. **Per-representation floors** in `benchmarks/repsel_census/baseline.json`.
   Never aggregated: the signal is `Ptr<Shape>` = 0 *while* `Str` ≠ 0, and one
   total hides exactly that.
2. **Liveness fixtures** (`benchmarks/repsel_census/fixtures/`), each written
   against one collector's proof obligations. Their minimums live in
   `LIVENESS_FLOORS` **in the script, not in the regenerable baseline** — so
   re-running `--update` after a breakage cannot write them down to zero and
   leave a permanently-green gate. `--update` refuses.
3. **A corpus-wide instrument check**: a census key that reads zero in *every*
   workload fails the run.

### Sabotage evidence

| sabotage | verdict |
| --- | --- |
| `PERRY_PTR_SHAPE_LOCALS=0` | RED — fixture + `suite_07/09/12` lose their promotion; exit 1 |
| `PERRY_PTR_NUMARRAY_LOCALS=0` | RED — fixture + 4 suite workloads |
| `PERRY_CANONICAL_I32_LOCALS=0` | RED — 7 workloads including `batch` (3 → 0) |
| `PERRY_CANONICAL_STR_LOCALS=0` | RED — `fixture_canonical_slots` |
| `PERRY_INT_VALUED_LOCALS=0` | RED — `fixture_int_valued_ta` |
| **new `select()` for `Ptr<NumArray>` reverted** (i.e. the pre-change compiler) | **RED** |
| unmodified build | GREEN, exit 0 |

That last row is the one that matters: **this test does not pass against the
unfixed compiler.** Verified by deleting the new call site, rebuilding, and
re-running.

CI re-runs the `PERRY_PTR_SHAPE_LOCALS=0` arm on every job and asserts both the
exit code *and* the reason string, so "red for an unrelated reason" does not
count as proof of liveness.

## Not required, on purpose

`repsel-census` lands as a **non-required** status check. A gate that has never
been green would block every open PR the moment it is promoted. Promoting it to
required after it has run on `main` for a few days is a deliberate follow-up —
and CLAUDE.md failure mode (2) is exactly what happens if that step is skipped.

## What is not measured

Stated plainly rather than estimated:

- The masked-window / buffer-view **`TaPtr` region** machinery
  (`stmt/masked_window_region.rs`) is region-shaped rather than a per-value
  promotion and has no `opt_report` analysis. The census makes **no claim**
  about it — it is not reported as a zero. `spec-abi-taptr-slot` covers `TaPtr`
  only in its specialized-ABI parameter form.
- Denial counts are recorded as context (`candidates`) but never gated: how
  many values a rule rejected is a property of the corpus, not the compiler.
- `--opt-report` de-duplicates entries on `(module, function, name, position,
  analysis, rule)`. Two distinct locals with the same name in the same function
  collapse to one. Not observed in this corpus; noted because it bounds the
  counts from above.
- Corpus is 18 real workloads (`batch.ts` + `benchmarks/suite/NN_*.ts`) plus 5
  fixtures. Whole runtime, `perry-stdlib` and compiled npm packages are out of
  scope for this pass.

## Try it

```bash
python3 scripts/compiler_output_regression.py census --gate
python3 scripts/compiler_output_regression.py census --env PERRY_PTR_SHAPE_LOCALS=0 --gate  # red
python3 scripts/compiler_output_regression.py census-self-test
python3 -m unittest tests.test_repsel_census
```

Tracked by #7106. Related: #7034, #6952. Not addressed here: #7036 (source spans), #6984
(`PERRY_PTR_SHAPE_LOCALS=0` vs Phase 5a).
