### PR TITLE
test(repsel): make "no analysis ran" a visible, gated state

### DIFF
--- a/benchmarks/repsel_census/README.md
+++ b/benchmarks/repsel_census/README.md
@@ -58,6 +58,22 @@ Three separate mechanisms, in increasing order of paranoia:
    had an `Analysis` variant, a `Ptr<NumArray>` target-rep string, and no
    `select()` call site anywhere in the tree.
 
+4. **An analysis-reach check**: a corpus workload whose *candidate* total is
+   zero across every analysis fails the run, unless it is named in
+   `ZERO_CANDIDATE_ALLOWLIST` (in the script, not the baseline) with a reason.
+
+   Mechanisms 1–3 are all about promotion counts, and promotion counts cannot
+   see this. "Considered and denied" names a rule you can argue with; "zero
+   candidates" names nothing — and the two produce an identical census table.
+   When #7104 landed, **8 of the 18 real workloads were in the second state**,
+   every one because its hot loop is at module top level and
+   `codegen/entry.rs` excludes module-init contexts from canonical selection
+   before any per-value rule runs (#7109). Nothing in the census could have
+   told the difference; the follow-up records those as denials so it can.
+
+   Only `suite_01_startup` is allowlisted: it is a lone `console.log`, with no
+   bindings for any analysis to consider.
+
 Sabotage-verified in both directions. Each of `PERRY_PTR_SHAPE_LOCALS=0`,
 `PERRY_PTR_NUMARRAY_LOCALS=0`, `PERRY_CANONICAL_I32_LOCALS=0`,
 `PERRY_CANONICAL_STR_LOCALS=0` and `PERRY_INT_VALUED_LOCALS=0` turns the census
@@ -95,3 +111,20 @@ masked-window / buffer-view `TaPtr` *region* machinery
 (`stmt/masked_window_region.rs`). It is region-shaped rather than a per-value
 promotion and has no `opt_report` analysis, so the census makes no claim about
 it. `spec-abi-taptr-slot` covers `TaPtr` only in its parameter form.
+
+### What a zero in the `candidates` column still cannot tell you
+
+The analysis-reach check above is per *workload*, not per *analysis*. A single
+analysis can still read zero candidates on a workload for either reason,
+because `--opt-report` records inside the per-value rules — a value filtered
+out before it becomes a candidate produces no entry:
+
+- `Ptr<NumArray>` admits only `number[]` / `Int32Array`-typed bindings, and
+  bails for the whole module on a prototype barrier. `11_prime_sieve`'s
+  `boolean[]` sieve is correctly not a candidate, and correctly invisible.
+- `Ptr<Shape>` gates provenance before the containment walk that records.
+- A function whose call sites were all inlined away never reaches the
+  spec-ABI decision loop at all (`14_closure`).
+
+Tracked as #7112 and #7111. Until those land, read a per-analysis zero as
+"either nothing of this shape, or a pre-filter", never as a denial.

--- a/benchmarks/repsel_census/baseline.json
+++ b/benchmarks/repsel_census/baseline.json
@@ -18,7 +18,7 @@
       "candidates": {
         "ptr-shape": 1,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 1,
         "int-valued-ta": 0,
         "spec-abi": 1
       }
@@ -40,7 +40,7 @@
       "candidates": {
         "ptr-shape": 1,
         "ptr-numarray": 1,
-        "canonical-slot": 2,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 2
       }
@@ -62,7 +62,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 4,
+        "canonical-slot": 6,
         "int-valued-ta": 0,
         "spec-abi": 3
       }
@@ -84,7 +84,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 1,
+        "canonical-slot": 3,
         "int-valued-ta": 1,
         "spec-abi": 0
       }
@@ -106,7 +106,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 2,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 1
       }
@@ -128,7 +128,7 @@
       "candidates": {
         "ptr-shape": 5,
         "ptr-numarray": 0,
-        "canonical-slot": 3,
+        "canonical-slot": 5,
         "int-valued-ta": 0,
         "spec-abi": 3
       }
@@ -172,7 +172,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -194,7 +194,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 1,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -216,7 +216,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 1,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -238,7 +238,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 1,
         "int-valued-ta": 0,
         "spec-abi": 1
       }
@@ -260,7 +260,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -282,7 +282,7 @@
       "candidates": {
         "ptr-shape": 1,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -304,7 +304,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -326,7 +326,7 @@
       "candidates": {
         "ptr-shape": 1,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -348,7 +348,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 1,
-        "canonical-slot": 0,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -370,7 +370,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 4,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -392,7 +392,7 @@
       "candidates": {
         "ptr-shape": 1,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -414,7 +414,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 2,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -436,7 +436,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 3,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -458,7 +458,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 0,
+        "canonical-slot": 7,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
@@ -480,7 +480,7 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 0,
-        "canonical-slot": 3,
+        "canonical-slot": 7,
         "int-valued-ta": 0,
         "spec-abi": 1
       }
@@ -502,11 +502,11 @@
       "candidates": {
         "ptr-shape": 0,
         "ptr-numarray": 1,
-        "canonical-slot": 0,
+        "canonical-slot": 5,
         "int-valued-ta": 0,
         "spec-abi": 0
       }
     }
   ],
-  "generated_at": "2026-07-31T02:23:42.048018Z"
+  "generated_at": "2026-07-31T03:14:57.355324Z"
 }

--- a/changelog.d/7113-repsel-zero-candidate-visibility.md
+++ b/changelog.d/7113-repsel-zero-candidate-visibility.md
@@ -1,0 +1,57 @@
+### `--opt-report` / repsel census: "no analysis ran" is now a visible, gated state
+
+The promotion census (#7104) recorded that **8 of its 18 real workloads produced
+zero representation-selection candidates** — no analysis considered a single
+value in them. That is a stronger and more basic statement than "promotion is
+low": a denial names a rule you can argue with, while zero candidates names
+nothing, and both render as the identical census table.
+
+It is **one root cause, not eight**. `codegen/entry.rs` excludes module-init and
+program-entry bodies from canonical (i32/u32/Str) selection wholesale, and that
+decision is taken at `FnCtx` construction — before any per-value rule runs — so
+a top-level local recorded neither a selection nor a denial. Nine of the
+seventeen `benchmarks/suite` workloads put their entire hot loop at module top
+level. The control is `16_matrix_multiply`: its 3 canonical-i32 promotions are
+`matmul::i/j/k`, inside the function; its two *top-level* loops over the same
+arrays promote nothing.
+
+Changes, none of which alter which values get promoted:
+
+- `FnCtx::repsel_context_denial` carries *why* a context forbids canonical
+  selection (`module_init_context`, `async_body`, `generator_body`,
+  `was_plain_async_body`), and the `Stmt::Let` site records it as a denial.
+  Deliberately `None` when only the `PERRY_CANONICAL_*` env gate is off — those
+  are bisection knobs, and their arms must not grow entries the default build
+  lacks.
+- Every proven-integer local that stayed boxed now names the first failing rule
+  from an ordered table (`CanonicalI32Denial::verdict`), so a local with two
+  problems names the more actionable one. `02_loop_overhead`'s `i` and `sum`
+  report `not_index_used_or_bounded`; its `ITERATIONS` reports
+  `module_init_context`.
+- The census gains `check_analysis_reach`: a corpus workload whose candidate
+  total is zero across every analysis fails, unless named in
+  `ZERO_CANDIDATE_ALLOWLIST` — held in the script, not the regenerable
+  baseline, so `--update` cannot widen it. Only `suite_01_startup` is
+  allowlisted (a lone `console.log`, no bindings).
+
+Workloads reached by no analysis: **8 → 1**. Canonical-slot candidates across
+the corpus: **15 → 71**. Promotion floors are unchanged.
+
+Verified byte-neutral: baseline vs patched compiler emit identical object files
+on 15 suite workloads with the report off and 6 with it on. Verified falsifiable:
+the census exits 1 against the pre-change compiler (7 workloads flagged
+`UNREACHED BY EVERY ANALYSIS`) and 0 after, and the shipped-baseline unit test
+fails against the pre-fix baseline. The existing `PERRY_PTR_SHAPE_LOCALS=0` CI
+sabotage arm still goes red for its own reason, not the new one.
+
+Per-workload findings filed separately: #7109 (module-init exclusion — the real
+promotion gap, `08_string_concat`'s `result` and `11_prime_sieve`'s `i`/`j` are
+fully eligible and waiting on it), #7110 (canonical-i32 needs index-use or a
+proven i32 bound, so a bare accumulator never promotes anywhere), #7111 (a
+function whose call sites were all inlined away never reaches the spec-ABI
+decision loop), #7112 (`Ptr<Shape>` / `Ptr<NumArray>` candidate pre-filters
+record nothing).
+
+Not a regression in any of them: `01_startup` genuinely has nothing to promote,
+and `11_prime_sieve`'s `boolean[]` sieve is correctly refused by
+`Ptr<NumArray>`'s numeric-element-type rule.

--- a/crates/perry-codegen/src/codegen/closure.rs
+++ b/crates/perry-codegen/src/codegen/closure.rs
@@ -771,12 +771,21 @@ pub(super) fn compile_closure(
         && !is_async
         && !cross_module.async_step_closures.contains(&func_id)
         && !cross_module.local_generator_funcs.contains(&func_id);
-    let repsel_closure_refs = if repsel_allows || repsel_str_allows {
+    // #7106: report the structural context exclusion at the `Stmt::Let` site.
+    // The closure gate spells its generator/async-step reasons differently from
+    // the body gate, so map them onto the same rule names by hand.
+    let repsel_context_denial = crate::expr::body_context_denial(
+        is_async,
+        cross_module.local_generator_funcs.contains(&func_id),
+        cross_module.async_step_closures.contains(&func_id),
+    );
+    let report_denial = crate::expr::report_context_denial(repsel_context_denial);
+    let repsel_closure_refs = if repsel_allows || repsel_str_allows || report_denial {
         crate::expr::collect_closure_referenced_locals(body)
     } else {
         std::collections::HashSet::new()
     };
-    let repsel_str_ineligible = if repsel_str_allows {
+    let repsel_str_ineligible = if repsel_str_allows || report_denial {
         crate::expr::collect_canonical_str_ineligible_locals(body)
     } else {
         std::collections::HashSet::new()
@@ -938,6 +947,7 @@ pub(super) fn compile_closure(
         i32_counter_slots: HashMap::new(),
         local_slot_reps: HashMap::new(),
         repsel_context_allows_canonical_i32: repsel_allows,
+        repsel_context_denial,
         repsel_closure_ref_locals: repsel_closure_refs,
         repsel_context_allows_canonical_str: repsel_str_allows,
         repsel_str_ineligible_locals: repsel_str_ineligible,

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -669,6 +669,25 @@ pub(super) fn compile_module_entry(
             &cross_module.compile_time_constants,
             &cross_module.module_dispatch,
         );
+        // #7106: the two screens the `Stmt::Let` denial consults, so the
+        // module-init denial count excludes locals a PERMITTING context would
+        // have rejected anyway (closure-captured; string-ineligible). Both sets
+        // are read exclusively behind the `repsel_context_allows_*` flags,
+        // which are `false` here, so populating them changes no emitted byte —
+        // and they are only collected when the report is on, so an ordinary
+        // build does no extra walking.
+        let (repsel_report_closure_refs, repsel_report_str_ineligible) =
+            if crate::opt_report::enabled() {
+                (
+                    crate::expr::collect_closure_referenced_locals(&hir.init),
+                    crate::expr::collect_canonical_str_ineligible_locals(&hir.init),
+                )
+            } else {
+                (
+                    std::collections::HashSet::new(),
+                    std::collections::HashSet::new(),
+                )
+            };
         let mut init_local_types: HashMap<u32, perry_hir::types::Type> = HashMap::new();
         crate::boxed_vars::collect_let_types_in_stmts(&hir.init, &mut init_local_types);
         let mut ctx = FnCtx {
@@ -774,10 +793,19 @@ pub(super) fn compile_module_entry(
             // Representation-selection Phase 1: module-init contexts keep the
             // boxed/parallel-shadow model (top-level locals interleave with
             // import/init machinery; the win lives in function bodies).
+            //
+            // #7106: that exclusion used to be invisible. It is taken here,
+            // before any per-value rule runs, so a program whose whole hot loop
+            // sits at module top level recorded neither a selection nor a
+            // denial — the report simply showed no candidates, which reads
+            // identically to "this program has no values worth promoting".
+            // Naming the rule makes the `Stmt::Let` site emit one denial per
+            // would-be-eligible top-level local instead.
             repsel_context_allows_canonical_i32: false,
-            repsel_closure_ref_locals: std::collections::HashSet::new(),
+            repsel_context_denial: Some(crate::expr::MODULE_INIT_CONTEXT),
+            repsel_closure_ref_locals: repsel_report_closure_refs,
             repsel_context_allows_canonical_str: false,
-            repsel_str_ineligible_locals: std::collections::HashSet::new(),
+            repsel_str_ineligible_locals: repsel_report_str_ineligible,
             spec_abi_functions: &cross_module.spec_abi_functions,
             spec_ta_bindings: &cross_module.spec_ta_bindings,
             spec_ta_ready: std::collections::HashSet::new(),
@@ -1299,6 +1327,25 @@ pub(super) fn compile_module_entry(
             &cross_module.compile_time_constants,
             &cross_module.module_dispatch,
         );
+        // #7106: the two screens the `Stmt::Let` denial consults, so the
+        // module-init denial count excludes locals a PERMITTING context would
+        // have rejected anyway (closure-captured; string-ineligible). Both sets
+        // are read exclusively behind the `repsel_context_allows_*` flags,
+        // which are `false` here, so populating them changes no emitted byte —
+        // and they are only collected when the report is on, so an ordinary
+        // build does no extra walking.
+        let (repsel_report_closure_refs, repsel_report_str_ineligible) =
+            if crate::opt_report::enabled() {
+                (
+                    crate::expr::collect_closure_referenced_locals(&hir.init),
+                    crate::expr::collect_canonical_str_ineligible_locals(&hir.init),
+                )
+            } else {
+                (
+                    std::collections::HashSet::new(),
+                    std::collections::HashSet::new(),
+                )
+            };
         let mut ctx = FnCtx {
             func: init_fn,
             module_slug: crate::expr::native_region_slug(strings.module_prefix()),
@@ -1402,10 +1449,19 @@ pub(super) fn compile_module_entry(
             // Representation-selection Phase 1: module-init contexts keep the
             // boxed/parallel-shadow model (top-level locals interleave with
             // import/init machinery; the win lives in function bodies).
+            //
+            // #7106: that exclusion used to be invisible. It is taken here,
+            // before any per-value rule runs, so a program whose whole hot loop
+            // sits at module top level recorded neither a selection nor a
+            // denial — the report simply showed no candidates, which reads
+            // identically to "this program has no values worth promoting".
+            // Naming the rule makes the `Stmt::Let` site emit one denial per
+            // would-be-eligible top-level local instead.
             repsel_context_allows_canonical_i32: false,
-            repsel_closure_ref_locals: std::collections::HashSet::new(),
+            repsel_context_denial: Some(crate::expr::MODULE_INIT_CONTEXT),
+            repsel_closure_ref_locals: repsel_report_closure_refs,
             repsel_context_allows_canonical_str: false,
-            repsel_str_ineligible_locals: std::collections::HashSet::new(),
+            repsel_str_ineligible_locals: repsel_report_str_ineligible,
             spec_abi_functions: &cross_module.spec_abi_functions,
             spec_ta_bindings: &cross_module.spec_ta_bindings,
             spec_ta_ready: std::collections::HashSet::new(),

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -657,12 +657,18 @@ pub(super) fn compile_function(
         && !f.is_async
         && !f.is_generator
         && !f.was_plain_async;
-    let repsel_closure_refs = if repsel_allows || repsel_str_allows {
+    // #7106: when the context forbids selection for a STRUCTURAL reason, the
+    // `Stmt::Let` site still reports one denial per would-be-eligible local, so
+    // "async bodies are excluded" is a counted rule rather than a silent zero.
+    let repsel_context_denial =
+        crate::expr::body_context_denial(f.is_async, f.is_generator, f.was_plain_async);
+    let report_denial = crate::expr::report_context_denial(repsel_context_denial);
+    let repsel_closure_refs = if repsel_allows || repsel_str_allows || report_denial {
         crate::expr::collect_closure_referenced_locals(&f.body)
     } else {
         std::collections::HashSet::new()
     };
-    let repsel_str_ineligible = if repsel_str_allows {
+    let repsel_str_ineligible = if repsel_str_allows || report_denial {
         crate::expr::collect_canonical_str_ineligible_locals(&f.body)
     } else {
         std::collections::HashSet::new()
@@ -774,6 +780,7 @@ pub(super) fn compile_function(
             .collect(),
         i32_counter_slots: spec_i32_param_slots,
         repsel_context_allows_canonical_i32: repsel_allows,
+        repsel_context_denial,
         repsel_closure_ref_locals: repsel_closure_refs,
         repsel_context_allows_canonical_str: repsel_str_allows,
         repsel_str_ineligible_locals: repsel_str_ineligible,

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -400,12 +400,19 @@ pub(super) fn compile_method(
         && !method.is_async
         && !method.is_generator
         && !method.was_plain_async;
-    let repsel_closure_refs = if repsel_allows || repsel_str_allows {
+    // #7106: report the structural context exclusion at the `Stmt::Let` site.
+    let repsel_context_denial = crate::expr::body_context_denial(
+        method.is_async,
+        method.is_generator,
+        method.was_plain_async,
+    );
+    let report_denial = crate::expr::report_context_denial(repsel_context_denial);
+    let repsel_closure_refs = if repsel_allows || repsel_str_allows || report_denial {
         crate::expr::collect_closure_referenced_locals(&method.body)
     } else {
         std::collections::HashSet::new()
     };
-    let repsel_str_ineligible = if repsel_str_allows {
+    let repsel_str_ineligible = if repsel_str_allows || report_denial {
         crate::expr::collect_canonical_str_ineligible_locals(&method.body)
     } else {
         std::collections::HashSet::new()
@@ -517,6 +524,7 @@ pub(super) fn compile_method(
         i32_counter_slots: HashMap::new(),
         local_slot_reps: HashMap::new(),
         repsel_context_allows_canonical_i32: repsel_allows,
+        repsel_context_denial,
         repsel_closure_ref_locals: repsel_closure_refs,
         repsel_context_allows_canonical_str: repsel_str_allows,
         repsel_str_ineligible_locals: repsel_str_ineligible,
@@ -1446,12 +1454,16 @@ pub(super) fn compile_static_method(
         && !f.is_async
         && !f.is_generator
         && !f.was_plain_async;
-    let repsel_closure_refs = if repsel_allows || repsel_str_allows {
+    // #7106: report the structural context exclusion at the `Stmt::Let` site.
+    let repsel_context_denial =
+        crate::expr::body_context_denial(f.is_async, f.is_generator, f.was_plain_async);
+    let report_denial = crate::expr::report_context_denial(repsel_context_denial);
+    let repsel_closure_refs = if repsel_allows || repsel_str_allows || report_denial {
         crate::expr::collect_closure_referenced_locals(&f.body)
     } else {
         std::collections::HashSet::new()
     };
-    let repsel_str_ineligible = if repsel_str_allows {
+    let repsel_str_ineligible = if repsel_str_allows || report_denial {
         crate::expr::collect_canonical_str_ineligible_locals(&f.body)
     } else {
         std::collections::HashSet::new()
@@ -1567,6 +1579,7 @@ pub(super) fn compile_static_method(
         i32_counter_slots: HashMap::new(),
         local_slot_reps: HashMap::new(),
         repsel_context_allows_canonical_i32: repsel_allows,
+        repsel_context_denial,
         repsel_closure_ref_locals: repsel_closure_refs,
         repsel_context_allows_canonical_str: repsel_str_allows,
         repsel_str_ineligible_locals: repsel_str_ineligible,

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -137,10 +137,12 @@ mod shadow_slot;
 mod slot_rep;
 pub(crate) mod temp_root;
 pub(crate) use slot_rep::{
-    canonical_i32_locals_enabled, canonical_local_i32_slot, canonical_str_locals_enabled,
-    collect_canonical_str_ineligible_locals, collect_closure_referenced_locals,
+    body_context_denial, canonical_i32_locals_enabled, canonical_local_i32_slot,
+    canonical_str_locals_enabled, collect_canonical_str_ineligible_locals,
+    collect_closure_referenced_locals, deny_canonical_context, deny_canonical_i32,
     load_canonical_local_boxed, local_is_canonical_str, local_rep_is_canonical_i32,
-    note_canonical_local, store_canonical_local_from_double, SlotRep,
+    note_canonical_local, report_context_denial, store_canonical_local_from_double,
+    CanonicalI32Denial, SlotRep, MODULE_INIT_CONTEXT,
 };
 
 pub(crate) use dispatch::{lower_expr, lower_math_operand};
@@ -800,6 +802,24 @@ pub(crate) struct FnCtx<'a> {
     /// init. Checked at the `Stmt::Let` eligibility site together with the
     /// `PERRY_CANONICAL_I32_LOCALS` env gate.
     pub repsel_context_allows_canonical_i32: bool,
+
+    /// Why this context forbids canonical (i32/u32/Str) selection, for
+    /// `--opt-report` (#6952) and the promotion census (#7106); `None` when it
+    /// permits it.
+    ///
+    /// The two `repsel_context_allows_*` flags are taken *before* any per-value
+    /// rule runs, so a suppressed context recorded nothing at all — neither a
+    /// selection nor a denial. In the report that is indistinguishable from "the
+    /// program has no candidate values", which is exactly the ambiguity the
+    /// census exists to remove, one stage upstream. Carrying the reason lets the
+    /// `Stmt::Let` site record a denial for every local that WOULD have been
+    /// eligible, so "module init is excluded" is a named rule with a count
+    /// instead of a silent zero.
+    ///
+    /// Deliberately `None` when the only thing that is off is the
+    /// `PERRY_CANONICAL_{I32,STR}_LOCALS` env gate: that is a bisection knob,
+    /// and its arms must not grow report entries the default build lacks.
+    pub repsel_context_denial: Option<&'static str>,
 
     /// Representation-selection Phase 5a (`collectors/proven_this.rs`): when
     /// this body is a proven-`this` method clone, the `Ptr<Shape>` proof

--- a/crates/perry-codegen/src/expr/slot_rep.rs
+++ b/crates/perry-codegen/src/expr/slot_rep.rs
@@ -106,6 +106,48 @@ pub(crate) enum SlotRep {
     Str,
 }
 
+/// The `repsel_context_denial` rule for a module-init / program-entry body.
+///
+/// Both entry contexts (`codegen/entry.rs`) exclude canonical selection
+/// wholesale, so every top-level local stays boxed no matter what the per-value
+/// rules would have said. Naming the rule is what turns that from an invisible
+/// zero into a counted denial (#7106).
+pub(crate) const MODULE_INIT_CONTEXT: &str = "module_init_context";
+
+/// Why an ordinary body context forbids canonical (i32/u32/Str) selection, or
+/// `None` when it permits it.
+///
+/// Structural reasons only — the `PERRY_CANONICAL_{I32,STR}_LOCALS` env gates
+/// are deliberately NOT reported here. Those are bisection knobs, and their
+/// `=0` arms must produce the same report entries as the default build minus
+/// the selections, not a new class of denial the default build never emits.
+pub(crate) fn body_context_denial(
+    is_async: bool,
+    is_generator: bool,
+    was_plain_async: bool,
+) -> Option<&'static str> {
+    if is_async {
+        Some("async_body")
+    } else if is_generator {
+        Some("generator_body")
+    } else if was_plain_async {
+        Some("was_plain_async_body")
+    } else {
+        None
+    }
+}
+
+/// Whether the context-denial screens (`repsel_closure_ref_locals`,
+/// `repsel_str_ineligible_locals`) should be collected even though the context
+/// forbids selection: only when `--opt-report` is on AND there is a structural
+/// reason to report. The screens are read exclusively behind the
+/// `repsel_context_allows_*` flags, so populating them in a denied context
+/// changes no emitted byte — it only makes the denial count exact, by not
+/// counting locals a permitting context would have rejected anyway.
+pub(crate) fn report_context_denial(denial: Option<&'static str>) -> bool {
+    denial.is_some() && crate::opt_report::enabled()
+}
+
 /// `PERRY_CANONICAL_I32_LOCALS` gate. Enabled by default; `=0`/`off`/`false`
 /// disables canonical-i32 storage selection, reverting eligible locals to the
 /// parallel-shadow model. Mirrors `int_valued_ta_locals::enabled` and is keyed
@@ -172,6 +214,199 @@ pub(crate) fn note_canonical_local(ctx: &FnCtx<'_>, id: u32, name: &str, rep: Sl
         "repsel: canonical-{rep:?} local '{name}' (id {id}) in {} [{}] (total {n})",
         ctx.source_function, ctx.module_slug
     );
+}
+
+/// The `--opt-report` denial for a local that satisfied every VALUE-level rule
+/// of a canonical (i32/u32/Str) selection and lost only because the enclosing
+/// context forbids the representation wholesale (#7106).
+///
+/// Counterpart to [`note_canonical_local`]: that records the wins, this records
+/// the class of loss the report was previously blind to. A context gate is
+/// taken before any per-value rule runs, so such a local used to produce no
+/// entry at all — and an absent entry reads exactly like "this program had
+/// nothing to promote". Eight of the eighteen census workloads (#7106) sat in
+/// that state, every one of them because their hot loop is at module top level.
+///
+/// `loop_depth` is the number of loops open at the declaration, which is 0 for
+/// a `for` counter (the target is pushed after its `Let` lowers) and ≥1 only
+/// for a local declared inside a loop body. Reported as-is; it is context in
+/// the JSON, never gated on.
+/// Which value-level canonical-i32 rules a proven-integer local failed, in the
+/// order the report should prefer to name them (#7106).
+///
+/// Every field is a rule the `Stmt::Let` eligibility conjunction already
+/// evaluates; this only carries the individual verdicts out so the report can
+/// say *which* one lost, instead of dropping the whole judgement on the floor.
+pub(crate) struct CanonicalI32Denial {
+    pub bigint: bool,
+    pub init_out_of_range: bool,
+    pub boxed_var: bool,
+    pub module_global: bool,
+    pub closure_referenced: bool,
+    pub array_row_alias: bool,
+    pub not_index_used_or_bounded: bool,
+    pub context: Option<&'static str>,
+}
+
+impl CanonicalI32Denial {
+    /// `(rule, reason, tier, issue)` for the first failing rule, or `None` when
+    /// nothing failed — which can only happen if a caller invokes this for a
+    /// local that was in fact selected, so the report stays silent rather than
+    /// inventing a denial.
+    fn verdict(
+        &self,
+    ) -> Option<(
+        &'static str,
+        &'static str,
+        crate::opt_report::Tier,
+        Option<&'static str>,
+    )> {
+        use crate::opt_report::Tier;
+        if self.bigint {
+            return Some((
+                "declared_bigint",
+                "declared `bigint`; canonical i32 storage would lose the value",
+                Tier::InherentlyPolymorphic,
+                None,
+            ));
+        }
+        if self.init_out_of_range {
+            return Some((
+                "init_outside_i32",
+                "the initializer is an integer literal outside the i32 range",
+                Tier::InherentlyPolymorphic,
+                None,
+            ));
+        }
+        if self.boxed_var {
+            return Some((
+                "boxed_var",
+                "captured by reference into a boxed cell, so its storage is not \
+                 the local slot",
+                Tier::Fixable,
+                None,
+            ));
+        }
+        if self.module_global {
+            return Some((
+                "module_global",
+                "a module-level binding, held in an `@perry_global_*` NaN-boxed \
+                 LLVM global rather than a local slot",
+                Tier::CompilerLimitation,
+                Some(MODULE_GLOBAL_ISSUE),
+            ));
+        }
+        if self.closure_referenced {
+            return Some((
+                "closure_referenced",
+                "referenced from a nested closure; the capture machinery reads \
+                 the boxed double slot",
+                Tier::Fixable,
+                None,
+            ));
+        }
+        if self.array_row_alias {
+            return Some((
+                "array_row_alias",
+                "aliases a flat-const array row, so it is array-valued rather \
+                 than scalar",
+                Tier::CompilerLimitation,
+                None,
+            ));
+        }
+        if self.not_index_used_or_bounded {
+            return Some((
+                "not_index_used_or_bounded",
+                "proven integer-valued, but never used as an array index and \
+                 not provably i32-bounded, so nothing pins its range to 32 bits \
+                 — a bare accumulator or counter lands here",
+                Tier::CompilerLimitation,
+                Some(NOT_BOUNDED_ISSUE),
+            ));
+        }
+        // Everything value-level passed; only the context gate is left.
+        self.context.map(|rule| {
+            let (reason, issue) = context_rule_text(rule);
+            (rule, reason, Tier::CompilerLimitation, Some(issue))
+        })
+    }
+}
+
+/// Record why a proven-integer local did not get canonical-i32 storage.
+pub(crate) fn deny_canonical_i32(ctx: &FnCtx<'_>, id: u32, name: &str, denial: CanonicalI32Denial) {
+    if !crate::opt_report::enabled() {
+        return;
+    }
+    let Some((rule, reason, tier, issue)) = denial.verdict() else {
+        return;
+    };
+    crate::opt_report::deny(crate::opt_report::Denial {
+        position: crate::opt_report::Position::Local,
+        name,
+        local_id: Some(id),
+        analysis: crate::opt_report::Analysis::CanonicalSlot,
+        rule,
+        reason,
+        tier,
+        issue,
+        loop_depth: u32::try_from(ctx.loop_targets.len()).unwrap_or(u32::MAX),
+        detail: Some(String::from("would have selected I32/U32")),
+        byte_offset: None,
+    });
+}
+
+/// Tracking issue for "a module-level binding can never take a canonical slot".
+const MODULE_GLOBAL_ISSUE: &str = "#7109";
+/// Tracking issue for the index-use / i32-bound precondition.
+const NOT_BOUNDED_ISSUE: &str = "#7110";
+
+/// `(reason, issue)` for a context-level denial rule.
+fn context_rule_text(rule: &str) -> (&'static str, &'static str) {
+    match rule {
+        MODULE_INIT_CONTEXT => (
+            "module-init / program-entry bodies are excluded from canonical \
+             storage selection wholesale (codegen/entry.rs), so no per-value \
+             rule ran for this local",
+            "#7109",
+        ),
+        "async_body" | "was_plain_async_body" => (
+            "async bodies route every body local through a shared mutable cell \
+             (the async-to-generator transform), which the canonical model must \
+             not touch",
+            "#6328",
+        ),
+        _ => (
+            "generator bodies route every body local through a shared mutable \
+             cell, which the canonical model must not touch",
+            "#6328",
+        ),
+    }
+}
+
+pub(crate) fn deny_canonical_context(
+    ctx: &FnCtx<'_>,
+    id: u32,
+    name: &str,
+    rule: &'static str,
+    rep: SlotRep,
+) {
+    if !crate::opt_report::enabled() {
+        return;
+    }
+    let (reason, issue) = context_rule_text(rule);
+    crate::opt_report::deny(crate::opt_report::Denial {
+        position: crate::opt_report::Position::Local,
+        name,
+        local_id: Some(id),
+        analysis: crate::opt_report::Analysis::CanonicalSlot,
+        rule,
+        reason,
+        tier: crate::opt_report::Tier::CompilerLimitation,
+        issue: Some(issue),
+        loop_depth: u32::try_from(ctx.loop_targets.len()).unwrap_or(u32::MAX),
+        detail: Some(format!("would have selected {rep:?}")),
+        byte_offset: None,
+    });
 }
 
 /// Rep + i32 slot for a canonical-i32 local; `None` when the local's slot
@@ -545,4 +780,132 @@ pub(crate) fn collect_closure_referenced_locals(stmts: &[perry_hir::Stmt]) -> Ha
         }
     }
     out
+}
+
+#[cfg(test)]
+mod repsel_denial_tests {
+    use super::*;
+
+    /// Nothing failed at all: a caller that asks about a SELECTED local must
+    /// not get a denial invented for it.
+    fn passing() -> CanonicalI32Denial {
+        CanonicalI32Denial {
+            bigint: false,
+            init_out_of_range: false,
+            boxed_var: false,
+            module_global: false,
+            closure_referenced: false,
+            array_row_alias: false,
+            not_index_used_or_bounded: false,
+            context: None,
+        }
+    }
+
+    #[test]
+    fn a_local_that_failed_nothing_produces_no_denial() {
+        assert!(passing().verdict().is_none());
+    }
+
+    #[test]
+    fn the_context_gate_is_reported_when_every_value_rule_passed() {
+        let d = CanonicalI32Denial {
+            context: Some(MODULE_INIT_CONTEXT),
+            ..passing()
+        };
+        let (rule, _, _, issue) = d.verdict().expect("a context denial");
+        assert_eq!(rule, MODULE_INIT_CONTEXT);
+        assert_eq!(issue, Some("#7109"));
+    }
+
+    /// The regression this exists to prevent: a top-level loop counter that is
+    /// index-used and otherwise fully eligible must name the CONTEXT, not fall
+    /// silently out of the report. This is `11_prime_sieve`'s `i`/`j`.
+    #[test]
+    fn an_index_used_top_level_counter_names_the_module_init_rule() {
+        let d = CanonicalI32Denial {
+            not_index_used_or_bounded: false,
+            context: Some(MODULE_INIT_CONTEXT),
+            ..passing()
+        };
+        assert_eq!(d.verdict().map(|v| v.0), Some(MODULE_INIT_CONTEXT));
+    }
+
+    /// A bare accumulator at module top level fails BOTH rules. The
+    /// value-level one is the more actionable, so it wins. This is
+    /// `02_loop_overhead`'s `i`.
+    #[test]
+    fn a_value_rule_outranks_the_context_rule() {
+        let d = CanonicalI32Denial {
+            not_index_used_or_bounded: true,
+            context: Some(MODULE_INIT_CONTEXT),
+            ..passing()
+        };
+        let (rule, _, tier, issue) = d.verdict().expect("a value-level denial");
+        assert_eq!(rule, "not_index_used_or_bounded");
+        assert_eq!(tier, crate::opt_report::Tier::CompilerLimitation);
+        assert_eq!(issue, Some("#7110"));
+    }
+
+    /// Precedence is total and ordered: with every rule failing at once, the
+    /// most actionable one is named.
+    #[test]
+    fn precedence_is_stable_when_several_rules_fail() {
+        let all = CanonicalI32Denial {
+            bigint: true,
+            init_out_of_range: true,
+            boxed_var: true,
+            module_global: true,
+            closure_referenced: true,
+            array_row_alias: true,
+            not_index_used_or_bounded: true,
+            context: Some(MODULE_INIT_CONTEXT),
+        };
+        assert_eq!(all.verdict().map(|v| v.0), Some("declared_bigint"));
+
+        let order = [
+            ("declared_bigint", "init_outside_i32"),
+            ("init_outside_i32", "boxed_var"),
+            ("boxed_var", "module_global"),
+            ("module_global", "closure_referenced"),
+            ("closure_referenced", "array_row_alias"),
+            ("array_row_alias", "not_index_used_or_bounded"),
+        ];
+        let mut d = all;
+        for (named, next) in order {
+            assert_eq!(d.verdict().map(|v| v.0), Some(named));
+            match named {
+                "declared_bigint" => d.bigint = false,
+                "init_outside_i32" => d.init_out_of_range = false,
+                "boxed_var" => d.boxed_var = false,
+                "module_global" => d.module_global = false,
+                "closure_referenced" => d.closure_referenced = false,
+                "array_row_alias" => d.array_row_alias = false,
+                _ => unreachable!(),
+            }
+            assert_eq!(d.verdict().map(|v| v.0), Some(next));
+        }
+    }
+
+    /// Body-context reasons map onto stable rule names; a permitting context
+    /// yields `None` so no denial is recorded for an ordinary sync body.
+    #[test]
+    fn body_contexts_map_to_stable_rule_names() {
+        assert_eq!(body_context_denial(false, false, false), None);
+        assert_eq!(body_context_denial(true, false, false), Some("async_body"));
+        assert_eq!(
+            body_context_denial(false, true, false),
+            Some("generator_body")
+        );
+        assert_eq!(
+            body_context_denial(false, false, true),
+            Some("was_plain_async_body")
+        );
+    }
+
+    /// The screens are only collected when there is a structural reason AND
+    /// the report is on — an ordinary build must do no extra walking.
+    #[test]
+    fn screens_are_not_collected_without_a_structural_reason() {
+        assert!(!report_context_denial(None));
+    }
 }

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -1249,16 +1249,56 @@ pub(crate) fn lower_let(
     // flag-off model stays exactly the pre-phase one.
     let canonical_safe_local =
         i32_safe_local || ctx.native_facts.int_valued_ta_locals().contains(&id);
-    let canonical_i32 = (ctx.integer_locals.contains(&id) || is_unsigned_i32_local)
+    // Split into the VALUE-level proof and the CONTEXT gate so a context-level
+    // exclusion can be reported (#7106). `canonical_i32` is the conjunction, so
+    // selection behaviour is unchanged.
+    let canonical_i32_value_eligible = (ctx.integer_locals.contains(&id) || is_unsigned_i32_local)
         && canonical_safe_local
         && init_in_i32_range
         && !matches!(refined_ty, perry_hir::types::Type::BigInt)
         && !ctx.boxed_vars.contains(&id)
         && !ctx.module_globals.contains_key(&id)
         && !ctx.i32_counter_slots.contains_key(&id)
-        && ctx.repsel_context_allows_canonical_i32
         && !ctx.repsel_closure_ref_locals.contains(&id)
         && !ctx.array_row_aliases.contains_key(&id);
+    let canonical_i32 = canonical_i32_value_eligible && ctx.repsel_context_allows_canonical_i32;
+    // #7106: name the rule for every PROVEN-INTEGER local that stayed boxed.
+    //
+    // A local that satisfied every value-level rule and lost only to the
+    // context used to produce no report entry at all, which is
+    // indistinguishable from "no candidate existed" — the exact ambiguity the
+    // promotion census was built to remove, one stage upstream. So did a local
+    // that failed a value-level rule: the analysis had a proof obligation and a
+    // verdict, and the report threw the verdict away.
+    //
+    // Scoped to `integer_locals ∪ unsigned_i32_locals` — locals Perry has
+    // already PROVEN integer-valued — so this reports near-misses, not every
+    // binding in the program.
+    if !canonical_i32
+        && (ctx.integer_locals.contains(&id) || is_unsigned_i32_local)
+        && !ctx.i32_counter_slots.contains_key(&id)
+        && crate::expr::canonical_i32_locals_enabled()
+        && crate::opt_report::enabled()
+    {
+        crate::expr::deny_canonical_i32(
+            ctx,
+            id,
+            name,
+            crate::expr::CanonicalI32Denial {
+                // Ordered most- to least-actionable; the FIRST failing rule is
+                // the one reported, so a local with two problems names the one
+                // worth fixing first.
+                bigint: matches!(refined_ty, perry_hir::types::Type::BigInt),
+                init_out_of_range: !init_in_i32_range,
+                boxed_var: ctx.boxed_vars.contains(&id),
+                module_global: ctx.module_globals.contains_key(&id),
+                closure_referenced: ctx.repsel_closure_ref_locals.contains(&id),
+                array_row_alias: ctx.array_row_aliases.contains_key(&id),
+                not_index_used_or_bounded: !canonical_safe_local,
+                context: ctx.repsel_context_denial,
+            },
+        );
+    }
     if canonical_i32 {
         let rep = if is_unsigned_i32_local {
             crate::expr::SlotRep::U32
@@ -1322,17 +1362,23 @@ pub(crate) fn lower_let(
     // (`+=` self-append, `.length`, `===`/`<`, `charCodeAt`-family), which
     // tag-dispatch on the slot bits inline instead of routing operands
     // through `js_get_string_pointer_unified`. See `expr/slot_rep.rs`.
-    let canonical_str = ctx.repsel_context_allows_canonical_str
-        && matches!(
-            refined_ty,
-            perry_hir::types::Type::String | perry_hir::types::Type::StringLiteral(_)
-        )
-        && !ctx.local_slot_reps.contains_key(&id)
+    // Value-level proof and context gate split, as for canonical-i32 (#7106).
+    let canonical_str_value_eligible = matches!(
+        refined_ty,
+        perry_hir::types::Type::String | perry_hir::types::Type::StringLiteral(_)
+    ) && !ctx.local_slot_reps.contains_key(&id)
         && !ctx.boxed_vars.contains(&id)
         && !ctx.module_globals.contains_key(&id)
         && !ctx.repsel_closure_ref_locals.contains(&id)
         && !ctx.repsel_str_ineligible_locals.contains(&id)
         && !ctx.i32_counter_slots.contains_key(&id);
+    let canonical_str = canonical_str_value_eligible && ctx.repsel_context_allows_canonical_str;
+    if canonical_str_value_eligible && !canonical_str && crate::expr::canonical_str_locals_enabled()
+    {
+        if let Some(rule) = ctx.repsel_context_denial {
+            crate::expr::deny_canonical_context(ctx, id, name, rule, crate::expr::SlotRep::Str);
+        }
+    }
     if canonical_str {
         ctx.local_slot_reps.insert(id, crate::expr::SlotRep::Str);
         crate::expr::note_canonical_local(ctx, id, name, crate::expr::SlotRep::Str);

--- a/scripts/compiler_output_harness/repsel_census.py
+++ b/scripts/compiler_output_harness/repsel_census.py
@@ -140,6 +140,28 @@ LIVENESS_FLOORS: dict[str, dict[str, int]] = {
     "fixture_spec_abi_taptr": {"spec-abi-entry": 1, "spec-abi-taptr-slot": 1},
 }
 
+#: Workloads allowed to produce **zero candidates** — no analysis considered any
+#: value in them. Held in code for the same reason as [`LIVENESS_FLOORS`]: it is
+#: an assertion about the compiler, and `--update` must not be able to widen it.
+#:
+#: A promotion count of zero is a fact about the corpus. Zero *candidates* is a
+#: fact about the compiler: it says no analysis reached the program at all, so
+#: there is no rule to point at and nothing to argue with. Before #7106's
+#: follow-up, **8 of the 18 real workloads were in that state** — every one
+#: because its hot loop is at module top level, which `codegen/entry.rs`
+#: excludes from canonical selection before any per-value rule runs. The
+#: promotion counts were identical either way, which is exactly why the census
+#: alone could not see it.
+#:
+#: An entry here must name a program that genuinely has nothing to analyse.
+ZERO_CANDIDATE_ALLOWLIST: dict[str, str] = {
+    "suite_01_startup": (
+        'a single `console.log("started")` — the program declares no bindings '
+        "at all, so there is legitimately nothing for any representation "
+        "analysis to consider"
+    ),
+}
+
 
 # ── Report -> census ───────────────────────────────────────────────────────
 
@@ -420,6 +442,39 @@ def check_instrument_liveness(observed: dict[str, dict[str, Any]]) -> list[str]:
     ]
 
 
+def check_analysis_reach(observed: dict[str, dict[str, Any]]) -> list[str]:
+    """Every corpus workload must be REACHED by at least one analysis.
+
+    The census counts promotions, so it can say "this workload promoted
+    nothing". It cannot, on its own, say whether that is because every rule
+    considered the values and said no, or because no rule ever ran. A denial
+    names a rule and can be argued with; zero candidates names nothing.
+
+    That distinction is not academic: it is how the module-init exclusion in
+    `codegen/entry.rs` stayed invisible through #7034 and #7104. Both readings
+    produce the identical promotion table.
+
+    So: a workload whose candidate total is zero across every analysis fails,
+    unless it is in [`ZERO_CANDIDATE_ALLOWLIST`] with a stated reason.
+    """
+    failures: list[str] = []
+    for name, entry in sorted(observed.items()):
+        candidates = entry.get("candidates", {})
+        if sum(int(v) for v in candidates.values()) > 0:
+            continue
+        if name in ZERO_CANDIDATE_ALLOWLIST:
+            continue
+        failures.append(
+            f"{name}: zero candidates across every analysis — no representation "
+            "analysis considered a single value in this workload. That is not "
+            '"considered and denied", it is "never looked at", and it is the '
+            "state the census cannot distinguish from an honest zero. Either "
+            "an analysis regressed, or the workload genuinely has nothing to "
+            "analyse and belongs in ZERO_CANDIDATE_ALLOWLIST with a reason."
+        )
+    return failures
+
+
 # ── Rendering ──────────────────────────────────────────────────────────────
 
 
@@ -544,6 +599,7 @@ def census(args: argparse.Namespace) -> int:
         improvements += imp
     liveness = check_liveness_fixtures(observed) if not partial else []
     dead = check_instrument_liveness(observed) if not partial else []
+    unreached = check_analysis_reach(observed) if not partial else []
 
     if partial:
         print(
@@ -561,6 +617,7 @@ def census(args: argparse.Namespace) -> int:
     for label, problems in (
         ("REGRESSION", regressions),
         ("DEAD INSTRUMENT", liveness + dead),
+        ("UNREACHED BY EVERY ANALYSIS", unreached),
     ):
         if not problems:
             continue

--- a/tests/test_repsel_census.py
+++ b/tests/test_repsel_census.py
@@ -211,6 +211,64 @@ class Verdicts(unittest.TestCase):
         self.assertTrue(all("did not run" in f for f in failures))
 
 
+class AnalysisReach(unittest.TestCase):
+    """`check_analysis_reach` — "never looked at" is not "considered and denied".
+
+    A promotion count of zero is a fact about the corpus. Zero *candidates* is a
+    fact about the compiler, and the two produce an identical census table.
+    """
+
+    @staticmethod
+    def _entry(**candidates: int) -> dict:
+        full = {analysis: 0 for analysis in CENSUS.EXPECTED_ANALYSES}
+        full.update(candidates)
+        return {"counts": {key: 0 for key in CENSUS.CENSUS_KEYS}, "candidates": full}
+
+    def test_a_workload_no_analysis_reached_fails(self):
+        problems = CENSUS.check_analysis_reach({"suite_02_loop_overhead": self._entry()})
+        self.assertEqual(len(problems), 1)
+        self.assertIn("suite_02_loop_overhead", problems[0])
+        self.assertIn("zero candidates", problems[0])
+
+    def test_one_candidate_is_enough_to_be_reached(self):
+        """Even an all-DENIED workload passes: a denial names a rule."""
+        observed = {"suite_02_loop_overhead": self._entry(**{"canonical-slot": 1})}
+        self.assertFalse(CENSUS.check_analysis_reach(observed))
+
+    def test_promoting_nothing_is_not_by_itself_a_failure(self):
+        """The point of the gate is reach, not promotion."""
+        entry = self._entry(**{"ptr-shape": 4})
+        self.assertEqual(sum(entry["counts"].values()), 0)
+        self.assertFalse(CENSUS.check_analysis_reach({"batch": entry}))
+
+    def test_the_allowlist_excuses_only_what_it_names(self):
+        observed = {
+            name: self._entry() for name in ("suite_01_startup", "suite_15_mandelbrot")
+        }
+        problems = CENSUS.check_analysis_reach(observed)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("suite_15_mandelbrot", problems[0])
+
+    def test_every_allowlisted_workload_states_a_reason(self):
+        for name, reason in CENSUS.ZERO_CANDIDATE_ALLOWLIST.items():
+            self.assertTrue(reason.strip(), f"{name} is allowlisted with no reason")
+
+    def test_the_allowlist_lives_in_code_not_the_regenerable_baseline(self):
+        """`--update` must not be able to widen it — same rule as LIVENESS_FLOORS."""
+        baseline = json.loads((REPO_ROOT / "benchmarks/repsel_census/baseline.json").read_text())
+        for workload in baseline["workloads"]:
+            self.assertNotIn("zero_candidates_ok", workload)
+
+    def test_the_shipped_baseline_has_no_unexplained_zero_candidate_workload(self):
+        """The state this gate exists to prevent must not be in the baseline."""
+        baseline = json.loads((REPO_ROOT / "benchmarks/repsel_census/baseline.json").read_text())
+        observed = {
+            w["name"]: {"counts": {}, "candidates": w["candidates"]}
+            for w in baseline["workloads"]
+        }
+        self.assertFalse(CENSUS.check_analysis_reach(observed))
+
+
 class Baseline(unittest.TestCase):
     def test_the_shipped_baseline_loads_and_covers_every_fixture(self):
         data = CENSUS.load_baseline(CENSUS.DEFAULT_BASELINE)


### PR DESCRIPTION
## What this is

#7104's census recorded, as data it did not diagnose:

> Eight of the eighteen real workloads produce **zero candidates** — no
> representation analysis even considered a value in them.

This diagnoses that, fixes the reporting hole that made it unreadable, and
gates it so it cannot come back silently. **It is one root cause, not eight.**

Promotion counts do not move. Every emitted object file is byte-identical.

## The answer, per workload

The eight are `01_startup`, `02_loop_overhead`, `06_math_intensive`,
`08_string_concat`, `11_prime_sieve`, `13_factorial`, `14_closure`,
`15_mandelbrot`. (The brief that prompted this listed nine, adding
`05_fibonacci` — that one has 1 candidate, denied `i64_specialized`. It was
never in the zero-candidate class.)

| workload | verdict | mechanism |
| --- | --- | --- |
| `01_startup` | **(a) nothing to promote** | one `console.log("started")`, zero bindings. The only honest zero in the set. |
| `02_loop_overhead` | **(b) ×2** | `i`, `sum`: `let_stmt.rs:1224` `i32_safe_local` — never index-used, not provably i32-bounded (#7110). `ITERATIONS`: `entry.rs:804` module-init exclusion (#7109). |
| `06_math_intensive` | **(b) ×2** | same two rules. `result` is an f64 accumulator; there is no unboxed-f64 rep to want. |
| `08_string_concat` | **(b)** | `result` is a fully eligible canonical-`Str` local — `+=` self-append in a loop, Phase 3a's motivating pattern — blocked only by `entry.rs:806` (#7109). |
| `11_prime_sieve` | **(a) + (b)** | `sieve` is `boolean[]`; `ptr_numarray.rs:352-364` admits only `Number`/`Int32` elements, so it is correctly not a `Ptr<NumArray>` candidate. `i`/`j` **are** index-used and fully eligible, blocked only by module-init (#7109). |
| `13_factorial` | **(b) ×2** | same as `02`. |
| `14_closure` | **(a) + (b)** | `compute(x)` declares no locals, and its call sites are inlined away, so it never reaches the spec-ABI decision loop (`codegen/mod.rs:2221`, #7111) — the right answer is "moot". The counter is `02`'s case. |
| `15_mandelbrot` | **(b) ×2** | `px`/`py`/`iter`/`totalIter` fail `i32_safe_local`; `WIDTH`/`HEIGHT`/`MAX_ITER` blocked by module-init. `x`/`y`/`cx`/`cy` are f64 — no rep exists. |

**No (c).** Nothing here is a bug. Every one is a deliberate precondition,
two of them stricter than the workloads need, and all of them invisible.

### Where the brief was wrong, plainly

- `11_prime_sieve` does **not** have a numeric array. `boolean[]` is correctly
  refused, and that is a good answer.
- `02_loop_overhead` being "definitionally a loop counter" is not sufficient:
  a bare counter is refused **in a function body too**. Wrapping it in a
  function changes nothing. Verified.
- `15_mandelbrot` is float-heavy, and there is no unboxed-f64 representation
  for it to select. Its integer counters are the `02` case.

## The mechanism, and why nothing could see it

`--opt-report` records at `select()` / `deny()` sites **inside** the per-value
rules. Both `repsel_context_allows_canonical_{i32,str}` are decided at
`FnCtx` construction, before any rule runs — and `codegen/entry.rs:804,1460`
hard-codes them `false` for module-init and program-entry bodies:

```rust
// module-init contexts keep the boxed/parallel-shadow model (top-level
// locals interleave with import/init machinery; the win lives in
// function bodies).
repsel_context_allows_canonical_i32: false,
```

So a top-level local recorded **neither a selection nor a denial**. In the
report that is indistinguishable from "this program has no candidate values" —
the exact ambiguity the census exists to remove, one stage upstream.

That premise ("the win lives in function bodies") does not hold for the corpus
Perry is measured on: **9 of the 17 suite benchmarks put their entire hot loop
at module top level.** `16_matrix_multiply` is the control — its 3 canonical-i32
promotions are `matmul::i/j/k`, inside the function; its two *top-level* loops
over the same arrays promote nothing.

Reduced to two programs with a byte-identical loop:

```ts
// in a function: canonical-slot SELECTED, rep I32
function f(a: number[], size: number): number {
    let sum = 0;
    for (let i = 0; i < size; i++) { sum = sum + a[i]; }
    return sum;
}

// at module top level: ZERO entries. Not selected, not denied.
for (let i = 0; i < arr.length; i++) { sum = sum + arr[i]; }
```

Putting the top-level loop in a bare block (so the counter is not a module
global) changes nothing. The gate is the context.

## What this PR changes

**Nothing about which values get promoted.** Three reporting changes and a gate.

1. `FnCtx::repsel_context_denial: Option<&'static str>` carries *why* a context
   forbids canonical selection (`module_init_context`, `async_body`,
   `generator_body`, `was_plain_async_body`). Deliberately `None` when only the
   `PERRY_CANONICAL_*` env gate is off — those are bisection knobs and their
   arms must not grow entries the default build lacks.

2. The `Stmt::Let` site records a denial for every proven-integer local that
   stayed boxed, naming the **first** failing rule from an ordered table
   (`CanonicalI32Denial::verdict`), so a local with two problems names the more
   actionable one. Scoped to `integer_locals ∪ unsigned_i32_locals` — locals
   already proven integer-valued — so this reports near-misses, not every
   binding in the program.

3. The two module-init `FnCtx`s populate `repsel_closure_ref_locals` /
   `repsel_str_ineligible_locals` **when the report is on**, so the denial count
   excludes locals a permitting context would have rejected anyway. Both sets
   are read exclusively behind the `repsel_context_allows_*` flags, which are
   `false` there — so this changes no emitted byte, and an ordinary build does
   no extra walking.

4. `check_analysis_reach` in the census: a corpus workload whose candidate total
   is zero across every analysis fails, unless named in
   `ZERO_CANDIDATE_ALLOWLIST` **in the script, not the regenerable baseline** —
   same reasoning as `LIVENESS_FLOORS`, so `--update` cannot widen it. Only
   `suite_01_startup` is allowlisted, with its reason.

## Before / after

Promotion counts (the gated floors) are **identical** — 23 rows, no change.
What moves is `candidates`:

| workload | canonical-slot candidates |
| --- | --- |
| `suite_01_startup` | 0 → 0 |
| `suite_02_loop_overhead` | 0 → **3** |
| `suite_05_fibonacci` | 0 → **1** |
| `suite_06_math_intensive` | 0 → **2** |
| `suite_08_string_concat` | 0 → **3** |
| `suite_11_prime_sieve` | 0 → **4** |
| `suite_13_factorial` | 0 → **2** |
| `suite_14_closure` | 0 → **3** |
| `suite_15_mandelbrot` | 0 → **7** |
| `suite_16_matrix_multiply` | 3 → **7** |
| `batch` | 3 → **5** |
| TOTAL (all 23) | 15 → **71** |

`ptr-shape` (9), `ptr-numarray` (5), `int-valued-ta` (1) and `spec-abi` (12)
candidate totals are unchanged — those analyses still have the same blindness,
tracked as #7112 / #7111.

**Workloads reached by no analysis at all: 8 → 1**, and the one is
`01_startup`, which has no bindings.

`02_loop_overhead` now reads:

```
canonical-slot denied module_init ITERATIONS  module_init_context
canonical-slot denied module_init i           not_index_used_or_bounded
canonical-slot denied module_init sum         not_index_used_or_bounded
```

## Verification

**No emitted byte changes.** `main@2416b7341` compiler vs patched, over the
full 23-source census corpus, comparing the emitted object:

- report **off**: **23/23 byte-identical**
- report **on**: **23/23 byte-identical**

(Object, not linked binary: macOS `ld` embeds a UUID, so two identical default
builds already differ — #7104 recorded the same caveat.)

**This test does not pass against the unfixed compiler.** Checked by running
the new gate against the pre-change binary, exit codes read from the harness
itself, not a wrapper:

| arm | verdict |
| --- | --- |
| patched compiler, `census --gate` | **exit 0**, "Census OK." |
| **pre-change compiler**, `census --gate` | **exit 1** — 7 workloads flagged `UNREACHED BY EVERY ANALYSIS` (+ `01_startup` allowlisted = the 8) |
| `tests.test_repsel_census` on the pre-fix `baseline.json` | **FAILS** — `test_the_shipped_baseline_has_no_unexplained_zero_candidate_workload` |
| `tests.test_repsel_census` as shipped | 28 pass |
| `cargo test -p perry-codegen --lib` | 333 pass (incl. #7107's 16) |
| `census-self-test` | OK |
| 14 programs vs Node **26.5.1** (pinned) | all match, and match `main`'s compiler |

**The existing CI sabotage arm is unaffected**: `PERRY_PTR_SHAPE_LOCALS=0`
still exits 1 *and* still reports `fixture_ptr_shape: ptr-shape promoted 0`, so
it still goes red for the reason that proves its subject was live — not for the
new one.

## Filed, not fixed here

One issue per mechanism, per this project's preference for granular issues:

- **#7109** — module-init bodies excluded from canonical i32+Str selection.
  The real promotion gap. Not a one-line flip: module init interleaves with
  import/global-init machinery and has its own shadow-frame bookkeeping, so it
  needs the audit function bodies got. `08_string_concat`'s `result` and
  `11_prime_sieve`'s `i`/`j` are fully eligible and waiting on it.
- **#7110** — canonical-i32 needs index-use or a proven i32 bound, so a bare
  accumulator never promotes *anywhere*. The precondition is not a range proof;
  it is a "this set already behaved this way" compatibility bound (see the
  audit note in `expr/slot_rep.rs`), so widening it needs a real range argument.
- **#7111** — a function whose call sites were all inlined away never enters
  the spec-ABI decision loop, so the report cannot say "moot". Cheap: one
  `else` arm at `codegen/mod.rs:2221`.
- **#7112** — `Ptr<Shape>` / `Ptr<NumArray>` candidate pre-filters record
  nothing, so a per-analysis zero still cannot be read.

## Not measured

Stated rather than estimated:

- **No wall-clock numbers.** The build host was at load average 70–124 for
  most of this work. Candidate and promotion counts are static and
  load-insensitive; timings taken there would not be. What #7109 and #7110 are
  *worth* in runtime terms is therefore unquantified.
- Whether lifting the module-init exclusion is **safe** is not established —
  only that it is what blocks these workloads.
- `check_file_size.sh` is red on `main` with 15 pre-existing violations (none
  in this diff), and `main`'s Tests workflow has been failing since at least
  2026-07-28. Unrelated to this change; flagged because it will show up on this
  PR too.

## Rebased onto #7107

Rebased from `3f1a0853a` onto `2416b7341` (#7107, return-shape facts).
`benchmarks/repsel_census/baseline.json` was the only conflicting file, and it
was **regenerated, not hand-merged** — it is generated data, and a textual merge
would match neither compiler.

Relative to `main`'s baseline, the regenerated file changes **only
`canonical-slot` candidates**. Verified explicitly:

| invariant | result |
| --- | --- |
| `batch` `ptr-shape` **floor** still 2 (#7107's ratchet) | **2 → 2**, preserved |
| `batch` `ptr-shape` **candidates** still 5 (#7107) | **5 → 5**, preserved |
| any floor changed by the regenerate | **none** — zero floor deltas corpus-wide |
| `ptr-shape` / `ptr-numarray` / `int-valued-ta` / `spec-abi` candidates | unchanged |
| `LIVENESS_FLOORS` widened | no — byte-identical to `main`; every fixture floor still meets its minimum |
| `ZERO_CANDIDATE_ALLOWLIST` widened | no — still exactly `suite_01_startup` |
| workloads with zero candidates in the shipped baseline | 1 (`suite_01_startup`) |

Both live in the script rather than the regenerable baseline precisely so
`--update` cannot widen them, and that held.

Tracked by #7106. Related: #7034, #7107, #6952.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved representation-selection diagnostics by identifying why eligible values or contexts are excluded.
  - Added visibility into module initialization, asynchronous, generator, and transformed-async scenarios.

- **Bug Fixes**
  - Census checks now detect workloads that receive no candidates across any analysis, while supporting documented exceptions.
  - Clarified the difference between zero candidates and zero promotions.

- **Tests**
  - Added coverage for diagnostic precedence, analysis reachability, allowlisted cases, and regression safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->