### PR TITLE
test(gc): scope the #7114 IR assertions to the function under test

### DIFF
--- a/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
+++ b/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
@@ -460,6 +460,34 @@ fn allocating_numeric() -> Expr {
     }
 }
 
+/// The IR of ONE generated function, sliced out of the module.
+///
+/// `ir_for` / `ir_for_new` return the **whole module**, and an assertion about
+/// instruction ORDER over a whole module is satisfiable by an unrelated
+/// function's IR: `ir.find("call i64 @js_object_alloc(")` answers with whichever
+/// function happens to come first in the file, not with the operand under test.
+/// A test that passes that way has proved nothing, which is exactly what it was
+/// written to rule out (raised on #7116).
+///
+/// Every ordering assertion in the #7114 section goes through here, and pairs
+/// the ordering with an exact *count* of the operand-specific opcode inside the
+/// slice — order plus count is what makes "this is the operand I meant" a
+/// property of the test rather than of the module layout.
+fn function_ir<'a>(ir: &'a str, define_prefix: &str) -> &'a str {
+    let start = ir
+        .find(define_prefix)
+        .unwrap_or_else(|| panic!("no `{define_prefix}` in module IR:\n{ir}"));
+    let body = &ir[start..];
+    let end = body.find("\n}\n").map(|e| e + 2).unwrap_or(body.len());
+    &body[..end]
+}
+
+/// The function a `module_with_init` / `module_with_new` statement lowers into.
+/// Module-level `init` statements are emitted into the entry module's `@main`.
+fn init_ir(ir: &str) -> &str {
+    function_ir(ir, "define i32 @main(")
+}
+
 /// `"acc:" + <allocating numeric>` — the reported shape.
 ///
 /// The invariant: **no operand register may outlive a collection point.** The
@@ -477,15 +505,37 @@ fn string_literal_concat_operand_is_re_derived_below_the_allocating_sibling() {
         })],
     );
 
-    let concat = ir
-        .find("call i64 @js_string_concat_value(")
-        .unwrap_or_else(|| panic!("expected the fused string+value concat:\n{ir}"));
-    let alloc = ir[..concat]
+    // Scoped to @main, so nothing below can be satisfied by another function's
+    // IR, and count-anchored, so "the concat" and "the sibling's allocation"
+    // are unambiguous rather than "whichever matched first".
+    let f = init_ir(&ir);
+    let handle = "load double, ptr @concat_reload_ts_.str.";
+    assert_eq!(
+        f.matches("call i64 @js_string_concat_value(").count(),
+        1,
+        "exactly one fused string+value concat in @main:\n{f}"
+    );
+    assert_eq!(
+        f.matches("call i64 @js_object_alloc(").count(),
+        1,
+        "exactly one allocating sibling in @main:\n{f}"
+    );
+    assert_eq!(
+        f.matches(handle).count(),
+        2,
+        "the literal's handle must be loaded TWICE in @main: once where the \
+         operand is lowered, and once re-derived below the collection point. \
+         One load is the #7114 bug; three means something else is re-lowering \
+         it:\n{f}"
+    );
+
+    let concat = f.find("call i64 @js_string_concat_value(").unwrap();
+    let alloc = f[..concat]
         .rfind("call i64 @js_object_alloc(")
-        .unwrap_or_else(|| panic!("the sibling operand must allocate:\n{ir}"));
-    let handle_load = ir[..concat]
-        .rfind("load double, ptr @concat_reload_ts_.str.")
-        .unwrap_or_else(|| panic!("the literal must come from its handle global:\n{ir}"));
+        .unwrap_or_else(|| panic!("the sibling must allocate before the concat:\n{f}"));
+    let handle_load = f[..concat]
+        .rfind(handle)
+        .unwrap_or_else(|| panic!("the literal must come from its handle global:\n{f}"));
 
     assert!(
         handle_load > alloc,
@@ -494,11 +544,11 @@ fn string_literal_concat_operand_is_re_derived_below_the_allocating_sibling() {
          below is what made `console.log(\"acc:\" + run(1e7))` print an empty \
          line — the handle global is a registered root that an evacuating \
          cycle REWRITES, and the pre-call register keeps the pre-move \
-         address:\n{ir}"
+         address:\n{f}"
     );
 
     assert_eq!(
-        ir.matches("call i32 @js_gc_temp_root_push").count(),
+        f.matches("call i32 @js_gc_temp_root_push").count(),
         0,
         "and it must cost no runtime call. A registered root already has \
          liveness; all it was missing is the re-derivation, which is the load \
@@ -527,16 +577,17 @@ fn string_literal_concat_operand_is_not_re_derived_when_nothing_collects() {
         })],
     );
 
+    let f = init_ir(&ir);
     assert_eq!(
-        ir.matches("load double, ptr @concat_noreload_ts_.str.")
+        f.matches("load double, ptr @concat_noreload_ts_.str.")
             .count(),
         1,
         "a comparison over two immediates runs no user code and allocates \
-         nothing, so the literal must be loaded exactly once:\n{ir}"
+         nothing, so the literal must be loaded exactly once:\n{f}"
     );
     assert!(
-        !ir.contains("call i32 @js_gc_temp_root_push"),
-        "and no rooting at all:\n{ir}"
+        !f.contains("call i32 @js_gc_temp_root_push"),
+        "and no rooting at all:\n{f}"
     );
 }
 
@@ -553,16 +604,26 @@ fn string_literal_array_element_is_re_derived_below_an_allocating_element() {
         ]))],
     );
 
+    let f = init_ir(&ir);
     let handle_pat = "load double, ptr @array_reload_ts_.str.";
-    let loads: Vec<usize> = ir.match_indices(handle_pat).map(|(i, _)| i).collect();
-    let element_alloc = ir
-        .find("call i64 @js_object_alloc(")
-        .unwrap_or_else(|| panic!("element 1 must allocate:\n{ir}"));
+    assert_eq!(
+        f.matches("call i64 @js_object_alloc(").count(),
+        1,
+        "exactly one allocating element in @main:\n{f}"
+    );
+    assert_eq!(
+        f.matches(handle_pat).count(),
+        2,
+        "element 0's handle must be loaded twice in @main: the original \
+         lowering and the re-derivation below element 1's allocation:\n{f}"
+    );
 
+    let loads: Vec<usize> = f.match_indices(handle_pat).map(|(i, _)| i).collect();
+    let element_alloc = f.find("call i64 @js_object_alloc(").unwrap();
     assert!(
-        loads.iter().any(|&l| l > element_alloc),
-        "#7114: element 0's handle must be re-derived below element 1's \
-         allocation before it is stored into the array:\n{ir}"
+        loads[0] < element_alloc && loads[1] > element_alloc,
+        "#7114: one load above element 1's allocation and one below it, so the \
+         value stored into the array is the post-relocation address:\n{f}"
     );
 }
 
@@ -593,20 +654,33 @@ fn wtf8_literal_operand_is_rooted_not_merely_reused() {
         })],
     );
 
-    let push = ir
-        .find("call i32 @js_gc_temp_root_push")
-        .unwrap_or_else(|| panic!("a WTF-8 literal operand must be ROOTED:\n{ir}"));
-    let alloc = ir
-        .find("call i64 @js_object_alloc(")
-        .unwrap_or_else(|| panic!("the sibling operand must allocate:\n{ir}"));
-    let get = ir
-        .find("call i64 @js_gc_temp_root_get")
-        .unwrap_or_else(|| panic!("and re-read after it:\n{ir}"));
+    let f = init_ir(&ir);
+    assert_eq!(
+        f.matches("call i32 @js_gc_temp_root_push").count(),
+        1,
+        "exactly one temp root in @main — the WTF-8 operand's. Zero means it \
+         was suppressed without a compensating re-derivation (#7114 for \
+         lone-surrogate literals); more than one means this assertion is no \
+         longer about the operand it names:\n{f}"
+    );
+    assert_eq!(
+        f.matches("call i64 @js_gc_temp_root_get").count(),
+        1,
+        "and exactly one re-read of it:\n{f}"
+    );
+    assert_eq!(
+        f.matches("call i64 @js_object_alloc(").count(),
+        1,
+        "exactly one allocating sibling in @main:\n{f}"
+    );
 
+    let push = f.find("call i32 @js_gc_temp_root_push").unwrap();
+    let alloc = f.find("call i64 @js_object_alloc(").unwrap();
+    let get = f.find("call i64 @js_gc_temp_root_get").unwrap();
     assert!(
         push < alloc && alloc < get,
         "order must be push -> allocating sibling -> re-read. Anything else \
          means the WTF-8 literal is being carried across the collection point \
-         in a register, which is #7114 for lone-surrogate literals:\n{ir}"
+         in a register, which is #7114 for lone-surrogate literals:\n{f}"
     );
 }

--- a/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
+++ b/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
@@ -488,6 +488,51 @@ fn init_ir(ir: &str) -> &str {
     function_ir(ir, "define i32 @main(")
 }
 
+/// The scoping itself, made falsifiable.
+///
+/// Everything below rests on `init_ir` genuinely narrowing the search. If it
+/// silently returned the whole module the ordering assertions would go back to
+/// being satisfiable by an unrelated function's IR and nothing else in this file
+/// would notice — so the narrowing is asserted directly: the slice is one
+/// function, strictly smaller than the module, and it does NOT reach
+/// `__perry_init_strings_*`, which is the other function in these modules that
+/// touches the same handle globals.
+#[test]
+fn init_ir_slices_only_the_function_under_test() {
+    let ir = ir_for(
+        "scope_check.ts",
+        vec![Stmt::Expr(Expr::Binary {
+            op: perry_hir::BinaryOp::Add,
+            left: Box::new(Expr::String("acc:".to_string())),
+            right: Box::new(allocating_numeric()),
+        })],
+    );
+    let f = init_ir(&ir);
+
+    assert!(
+        f.starts_with("define i32 @main("),
+        "the slice must begin at the function it names:\n{f}"
+    );
+    assert_eq!(
+        f.matches("\ndefine ").count(),
+        0,
+        "and end before the next one — exactly one function in the slice:\n{f}"
+    );
+    assert!(
+        f.len() < ir.len(),
+        "a slice the size of the module is not a slice"
+    );
+    assert!(
+        ir.contains("define void @__perry_init_strings_"),
+        "precondition: the module really does contain another function that \
+         touches the same handle globals, otherwise this test proves nothing"
+    );
+    assert!(
+        !f.contains("__perry_init_strings_scope_check_ts_chunk"),
+        "and the slice must not reach it (#7116):\n{f}"
+    );
+}
+
 /// `"acc:" + <allocating numeric>` — the reported shape.
 ///
 /// The invariant: **no operand register may outlive a collection point.** The


### PR DESCRIPTION
Follow-up to #7116 (merged as `57f9dc31b`). Addresses the CodeRabbit finding that
was submitted at 05:03:58 — one minute after the last commit — and so was never
looked at before the merge.

**Test-only. No codegen change:** `git diff 57f9dc31b HEAD -- 'crates/*/src'` is
empty.

## The finding, and why it is not trivial

> `ir_for` returns the complete module IR. The three `.find()` calls select the
> first matching operation in that module. If another generated function emits
> one of these calls, the test can pass without proving that the
> `Expr::WtfString` operand is rooted and re-read after its allocating sibling.

CodeRabbit labelled it *Trivial*. For a test whose entire job is proving that a
value is re-derived **below a collection point**, an assertion satisfiable by
some other function's IR is precisely the wrong test. It applied to more than
the WTF-8 case: every ordering assertion added in #7114 searched whole-module IR.

## What changed

- `function_ir` / `init_ir` slice one `define` out of the module. Module-level
  `init` statements lower into the entry module's `@main`, so that is the slice.
- All four #7114 assertions are scoped to that slice **and** pinned to an exact
  *count* of the operand-specific opcode inside it — order plus count makes
  "this is the operand I meant" a property of the test rather than of module
  layout. The concat and array tests now assert **exactly two** loads of that
  literal's own handle global: one where the operand is lowered, one re-derived
  below the collection point. One load is the #7114 bug; three would mean
  something else is re-lowering it.
- The narrowing itself is falsifiable: `init_ir_slices_only_the_function_under_test`
  asserts the slice is one function, strictly smaller than the module, and does
  not reach `__perry_init_strings_*` — the other function in these modules that
  touches the same handle globals.

## Sabotage, four directions

Host: `perry@perry-macos.local` (Apple M1, 8 cores), `--release`. Every arm below
was run against the **scoped** assertions, so this is evidence that scoping did
not weaken them.

| sabotage | result |
|---|---|
| revert the #7114 fix (`temp_root.rs` + `new.rs` to `ff85fd483`) | `concat` and `array_element` **FAIL**; other 10 pass |
| re-derive **unconditionally** (drop the `collects` window) | the **gate** `..._not_re_derived_when_nothing_collects` **FAILS**; other 11 pass |
| **half**-close the literal asymmetry (`WtfString` suppressed in `operand_needs_root` only) | `wtf8_..._rooted_not_merely_reused` **FAILS**; other 11 pass |
| **un-scope** `init_ir` (return the whole module) | `init_ir_slices_only_the_function_under_test` **FAILS**; other 11 pass |

Clean run: **12/12 pass.**

The fourth row is worth reading honestly: with `init_ir` un-scoped, the other
eleven tests still passed. In *these* single-statement modules the unscoped
`.find()` happened to land on the right function, so the flaw was latent
fragility rather than a live false pass — which is exactly why it needed a gate
rather than an argument. It has one now.

## Gates

Because `crates/*/src` is byte-identical to merged `main`, the #7116 matrix and
`gc-ratchet` results carry unchanged; both are restated here with the identity
proof, plus a fresh single-arm ratchet on merged `main`.

- **codegen contract suite:** 12/12 (see sabotage table)
- **GC x repsel matrix** `--arms all --pressure 8` (on `57f9dc31b`'s compiler):
  `PASS=379 UNVER=100 XFAIL=1 FAIL=0` over 480 cells, byte-exact vs
  `node v26.5.1` on 479/480. The `#7114` corpus row is PASS on all 20 arms and
  **live** on the moving ones (`evac_minor`: 66 cycles / 1 506 487 scavenged;
  `default`: 50 cycles / 1 121 856 scavenged).
- **gc-ratchet** — see below.

### gc-ratchet — run locally, pinned-host profile

CI is not the gate (runner pool hours deep; `GC Ratchet` has been cancelled on
consecutive `main` commits without reaching a runner), so this was run on the
machine the baseline is pinned to — `perry-macos.fritz.box`, Apple M1, 8 cores,
which is the exact host recorded in `benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json`.

**1. Current gate, on merged `main`'s compiler** (`run_gc_ratchet_baseline.sh --check`,
`pinned_host` profile, quiet host confirmed at `cpu_active=5.4%`):

```
gc-ratchet: OK
```

96 gated rows `ok`/`improvement`, **0 regressions**; `correctness=pass` against
`node v26.5.1` on all 8 probes; `heap_used_bytes` and `heap_total_bytes` 0.00%
drift on every probe. The one non-zero semantic drift against the *pinned
baseline* is `07_array_grow_evacuate.copied_objects` 18 294 → 18 290 (−0.02%,
band 5%), which is the documented sub-0.1% host-dependent component of the
evacuation counters — and it is not from #7114, because the base-vs-fix A/B
below has that counter bit-identical.

**2. Base-vs-fix A/B isolating #7114** (`ff85fd483` vs `ff85fd483`+#7114, both
arms `--check`, **exit 0 for both**):

| | result |
|---|---|
| gated (retention + GC accounting) | **72/72 medians bit-identical** over 8 probes x 9 metrics |
| ungated `wall_ms` | 8/8 probes differ, −0.66% … +0.62% |
| ungated `rss_bytes` | 5/8 probes differ, −0.49% … +0.23% |
| correctness vs `node v26.5.1` | pass on all 8 probes, both arms |

The ungated spread is the load-bearing half. Bit-identical gated counters are
also exactly what a **vacuous** A/B looks like when a stale `.a` makes both arms
the same binary, so a nonzero ungated spread on every row is the evidence that
the two binaries genuinely differed. Independently confirmed by fingerprint:
`perry` sha256 `2df0831b…` (base) vs `86d9575a…` (fix), with
`libperry_runtime.a` byte-identical at `143b184c…` — correct, since #7114 is a
codegen-only change, so the archive *should* be identical and the differing
artifact *should* be `perry` itself.

**Why the A/B was not re-run for this PR:** it would be vacuous by construction.
This PR changes only a test file, so both arms would be the same compiler. The
A/B above is the correct isolation of the #7114 change, and
`git diff 57f9dc31b HEAD -- 'crates/*/src'` being empty is what licenses
carrying it forward.

### Gap parity suite (partial, informational)

`./run_parity_tests.sh --filter test_gap_` on merged `main`'s compiler, stopped
at **166/438** to free the host for the ratchet (the ratchet needs a quiet host
and the suite was pacing at ~4 hours). Three failures, **none attributable to
#7114**:

| test | status |
|---|---|
| `test_gap_2159_defineproperty_class_prototype` | in `test-parity/known_failures.json` |
| `test_gap_2514_settracesigint` | in `test-parity/known_failures.json` |
| `test_gap_6301_event_target_subclass` | **not** triaged — verified byte-identical output on pristine `ff85fd483`, so pre-existing. It is the native-base-subclassing weak area; a `known_failures.json` provenance gap (#797). |
