### PR TITLE
docs: record the measured #7109 timing in the #7121 changelog fragment

### DIFF
--- a/changelog.d/7121-module-init-repsel.md
+++ b/changelog.d/7121-module-init-repsel.md
@@ -77,6 +77,13 @@ dispatch whose hot arm derives both handles with a bare
 write-barrier count are unchanged (9 and 3 in both arms) — canonical `Str` is
 tagged-at-rest and does not move storage.
 
+Measured after the fact (#7123): that loop scaled to 3 000 000 iterations, timed
+by the program's own `Date.now()` delta over 20 interleaved pairs on an M1 under
+load, goes **74 ms → 69 ms (−6.8 %)**, distributions 72–79 ms vs 68–72 ms. It is
+the only timing claim attached to this change, and it is confined to the idiom
+the change targets — the other 29 of 39 workloads compile to a byte-identical
+object.
+
 ## Also
 
 `note_canonical_local` reported a hard-coded `RegionKind::Function` to


### PR DESCRIPTION
Follow-up to #7121 (#7109). Documentation only — six lines in the changelog
fragment, no code.

#7121 shipped with **no timing claim**, because the host was at load 15–80 all
session and `08_string_concat` at its committed 100 000 iterations runs in under
10 ms — below the resolution of its own `Date.now()` delta. Saying "we did not
measure" was the right call then; the measurement has since been made and
belongs in the release notes rather than in a PR comment.

## The measurement

`08_string_concat`'s loop, unchanged in shape, scaled to 3 000 000 iterations so
the in-program timer has something to resolve, and timed by that timer (process
startup excluded). 20 **interleaved** pairs — alternating the two binaries
rather than running 20 of one then 20 of the other, so a drift in host load
cannot be attributed to the change.

```ts
const ITERATIONS = 3000000;
let result = "";
const start = Date.now();
for (let i = 0; i < ITERATIONS; i++) {
    result = result + "x";
}
console.log("elapsed_ms:" + (Date.now() - start));
```

| arm | median | min | distribution |
|---|---|---|---|
| `4d3ddc9a3` (base) | 74 ms | 72 ms | 72–79 ms |
| with #7109 | **69 ms** | 68 ms | 68–72 ms |

**−6.8 % median, −5.6 % minimum.** The distributions are essentially disjoint,
which is what makes this reportable at load ≈26 — the intra-arm spread is ~9 %
of the median but the arms do not interleave.

The mechanism is visible in the IR and was already in #7121: the top-level
`result = result + "x"` went from two `js_get_string_pointer_unified` calls per
iteration to Phase 3a's four-arm tag dispatch whose hot arm derives both handles
with a bare `and i64 …, 0xFFFF_FFFF_FFFF`.

## Why it is stated narrowly

**29 of the 39 workloads in #7121's object A/B compile to a byte-identical
`.o`.** #7109 converted 321 `module_init_context` denials into selections, but
most of those are canonical-i32 promotions that `-O3` was already achieving —
under the parallel-shadow model every `LocalGet` of such a local already read
the i32 slot, so the double slot was dead code.

So this is a number about **the top-level `+=` self-append idiom**, which is the
one lowering that changes and survives optimization. It is deliberately not
presented as "#7109 is worth −6.8 %".

## Verification

Both binaries built from the same runtime archives (`libperry_runtime.a` /
`libperry_stdlib.a` unchanged between the two commits — #7109 touches
`perry-codegen` only), `PERRY_NO_AUTO_OPTIMIZE=1`, `--no-cache`, and the two
linked binaries confirmed to differ by hash before timing, so this is not an
A/B of one binary against itself.

No code, no test, and no gate changes. `changelog.d/` fragments are folded into
the release notes at tag time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reported a measured improvement for a targeted module initialization scenario, reducing runtime from 74 ms to 69 ms in a 3,000,000-iteration benchmark.
  * Documented timing ranges and noted that 29 of 39 tested workloads produce byte-identical results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->