### PR TITLE
fix(gc): keep live array elements traced and initialize unused array capacity

### DIFF
--- a/changelog.d/gc-pointer-free-mask-invariant.md
+++ b/changelog.d/gc-pointer-free-mask-invariant.md
@@ -1,0 +1,7 @@
+fix(gc): two moving-collector soundness hardenings for arrays.
+
+1. `layout_note_slot` now restores `SIDE_MASK` state whenever it records a pointer into an array's existing element mask. Previously a stale `POINTER_FREE` state could linger with a populated mask (e.g. after an array was truncated to a numeric/empty prefix), and `heap_payload_slot_selection` treats `POINTER_FREE` as "no pointers" — skipping the whole payload without consulting the mask. The evacuating young-gen minor then dropped live within-length pointer elements, later read as a garbage pointer (`TypeError: value is not a function`). Same class as #6831.
+
+2. `js_array_alloc` / `js_array_grow` now HOLE-initialize the `[length, capacity)` slack instead of leaving it as raw arena bytes. Uninitialized slack could hold stale pointer-shaped bits that any beyond-`length` scan/trace would follow into freed/relocated memory; HOLE is a non-pointer sentinel (matching `js_array_alloc_with_length`).
+
+Verified with `PERRY_GC_FROMSPACE_SCAN`: within-length stale array→young edges drop 202→0; uninitialized-slack false-positive edges drop from ~4000/cycle to ~0. `cargo test -p perry-runtime` array/layout suites green.

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -47,6 +47,13 @@ pub extern "C" fn js_array_alloc(capacity: u32) -> *mut ArrayHeader {
         // Initialize header
         (*ptr).length = 0;
         (*ptr).capacity = actual_capacity;
+        // EXPERIMENT (#sfw-registry slack): HOLE-initialize the whole capacity so
+        // the unused [length, capacity) slack never holds stale arena bits that
+        // the whole-heap from-space scan misreads as live from-space pointers.
+        let elements_ptr = (ptr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;
+        for i in 0..actual_capacity as usize {
+            std::ptr::write(elements_ptr.add(i), crate::value::TAG_HOLE);
+        }
         set_array_numeric_layout(ptr, NumericArrayLayout::RawF64);
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
     }

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -47,9 +47,9 @@ pub extern "C" fn js_array_alloc(capacity: u32) -> *mut ArrayHeader {
         // Initialize header
         (*ptr).length = 0;
         (*ptr).capacity = actual_capacity;
-        // EXPERIMENT (#sfw-registry slack): HOLE-initialize the whole capacity so
-        // the unused [length, capacity) slack never holds stale arena bits that
-        // the whole-heap from-space scan misreads as live from-space pointers.
+        // HOLE-initialize the whole capacity so the unused [length, capacity)
+        // slack never holds stale arena bits that the whole-heap from-space
+        // scan misreads as live from-space pointers.
         let elements_ptr = (ptr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;
         for i in 0..actual_capacity as usize {
             std::ptr::write(elements_ptr.add(i), crate::value::TAG_HOLE);

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -91,9 +91,9 @@ pub extern "C" fn js_array_grow(arr: *mut ArrayHeader, min_capacity: u32) -> *mu
         ptr::copy_nonoverlapping(arr as *const u8, new_ptr as *mut u8, old_size);
 
         (*new_ptr).capacity = new_capacity;
-        // EXPERIMENT (#sfw-registry slack): HOLE-initialize the newly added
-        // [old_capacity, new_capacity) slack so it never holds stale arena bits
-        // the whole-heap from-space scan misreads as live from-space pointers.
+        // HOLE-initialize the newly added [old_capacity, new_capacity) slack
+        // so it never holds stale arena bits the whole-heap from-space scan
+        // misreads as live from-space pointers.
         {
             let new_elems =
                 (new_ptr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -91,6 +91,16 @@ pub extern "C" fn js_array_grow(arr: *mut ArrayHeader, min_capacity: u32) -> *mu
         ptr::copy_nonoverlapping(arr as *const u8, new_ptr as *mut u8, old_size);
 
         (*new_ptr).capacity = new_capacity;
+        // EXPERIMENT (#sfw-registry slack): HOLE-initialize the newly added
+        // [old_capacity, new_capacity) slack so it never holds stale arena bits
+        // the whole-heap from-space scan misreads as live from-space pointers.
+        {
+            let new_elems =
+                (new_ptr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;
+            for i in old_capacity as usize..new_capacity as usize {
+                ptr::write(new_elems.add(i), crate::value::TAG_HOLE);
+            }
+        }
         let old_header =
             (arr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
         let new_header =

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -748,6 +748,20 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
             if pointer {
                 if let Some(mask) = masks.get_mut(&parent_user) {
                     mask.set_slot(slot_index);
+                    // A non-empty pointer mask MUST be reflected by SIDE_MASK
+                    // state: `heap_payload_slot_selection` treats POINTER_FREE
+                    // as "no pointers" and skips the WHOLE payload without ever
+                    // consulting the mask. If a stale POINTER_FREE lingers here
+                    // (an array truncated to a numeric/empty prefix flips to
+                    // POINTER_FREE while its element mask is retained), recording
+                    // a pointer would leave every masked element untraced — the
+                    // evacuating minor then reclaims/relocates the child out from
+                    // under the live slot, later read+called as a garbage pointer
+                    // ("value is not a function"). Recording a pointer proves the
+                    // object is not pointer-free, so restore SIDE_MASK.
+                    if (*header)._reserved & GC_LAYOUT_STATE_MASK != GC_LAYOUT_SIDE_MASK {
+                        set_layout_state(header, GC_LAYOUT_SIDE_MASK);
+                    }
                 } else if (*header)._reserved & GC_LAYOUT_STATE_MASK == GC_LAYOUT_POINTER_FREE {
                     let mut mask = LayoutSlotMask::Inline(0);
                     mask.set_slot(slot_index);

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -261,8 +261,8 @@ fn test_layout_mask_small_mixed_array_scans_exact_pointer_slot() {
 
 #[test]
 fn test_pointer_store_restores_side_mask_from_stale_pointer_free() {
-    // #sfw-registry regression: an array can end up in POINTER_FREE layout
-    // state while still carrying a populated element pointer-mask (e.g. after a
+    // Regression: an array can end up in POINTER_FREE layout state while
+    // still carrying a populated element pointer-mask (e.g. after a
     // numeric-layout rebuild observed a short/empty prefix while the mask
     // lingered). `heap_payload_slot_selection` short-circuits POINTER_FREE and
     // skips the WHOLE payload without consulting the mask, so the evacuating

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -260,6 +260,77 @@ fn test_layout_mask_small_mixed_array_scans_exact_pointer_slot() {
 }
 
 #[test]
+fn test_pointer_store_restores_side_mask_from_stale_pointer_free() {
+    // #sfw-registry regression: an array can end up in POINTER_FREE layout
+    // state while still carrying a populated element pointer-mask (e.g. after a
+    // numeric-layout rebuild observed a short/empty prefix while the mask
+    // lingered). `heap_payload_slot_selection` short-circuits POINTER_FREE and
+    // skips the WHOLE payload without consulting the mask, so the evacuating
+    // minor would drop live pointer elements. `layout_note_slot` must restore
+    // SIDE_MASK whenever it records a pointer into an existing mask.
+    clear_marks();
+    clear_mark_seeds();
+
+    let child0 = crate::string::js_string_from_bytes(b"c0".as_ptr(), 2) as *mut u8;
+    let child1 = crate::string::js_string_from_bytes(b"c1".as_ptr(), 2) as *mut u8;
+    let child0_h = unsafe { header_from_user_ptr(child0) };
+    let child1_h = unsafe { header_from_user_ptr(child1) };
+
+    let arr = crate::array::js_array_alloc_with_length(2);
+    // Store a pointer at index 0 -> SIDE_MASK + mask{0}.
+    crate::array::js_array_set_f64(
+        arr,
+        0,
+        f64::from_bits(STRING_TAG | (child0 as u64 & POINTER_MASK)),
+    );
+    assert_eq!(test_layout_pointer_slot_count(arr as usize, 2), Some(1));
+
+    // Reproduce the stale-state hazard: force POINTER_FREE while the mask{0}
+    // entry is still present (`set_layout_state` only touches the state bits).
+    let arr_header = unsafe { header_from_user_ptr(arr as *mut u8) };
+    unsafe {
+        set_layout_state(arr_header, GC_LAYOUT_POINTER_FREE);
+    }
+
+    // Store a pointer at index 1 through the normal array store path.
+    crate::array::js_array_set_f64(
+        arr,
+        1,
+        f64::from_bits(STRING_TAG | (child1 as u64 & POINTER_MASK)),
+    );
+
+    // The fix: recording a pointer must have restored SIDE_MASK, so the mask is
+    // consulted and BOTH pointer slots are visible to the tracer.
+    unsafe {
+        assert_eq!(
+            (*arr_header)._reserved & GC_LAYOUT_STATE_MASK,
+            GC_LAYOUT_SIDE_MASK,
+            "recording a pointer into an existing mask must restore SIDE_MASK"
+        );
+    }
+    assert_eq!(test_layout_pointer_slot_count(arr as usize, 2), Some(2));
+
+    let valid_ptrs = build_valid_pointer_set();
+    let mut worklist = Vec::new();
+    unsafe {
+        trace_array(arr as *mut u8, &valid_ptrs, &mut worklist);
+        assert_ne!(
+            (*child0_h).gc_flags & GC_FLAG_MARKED,
+            0,
+            "index 0 pointer must be traced"
+        );
+        assert_ne!(
+            (*child1_h).gc_flags & GC_FLAG_MARKED,
+            0,
+            "index 1 pointer (stored under stale POINTER_FREE) must be traced"
+        );
+    }
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+#[test]
 fn test_layout_mask_heap_conversion_keeps_sparse_words_zeroed() {
     clear_marks();
     clear_mark_seeds();


### PR DESCRIPTION
Two ways the garbage collector can mishandle arrays, both fixed here. The first one loses data: an array holding object references can have those references silently dropped during a collection, and the next read of that element gets whatever now sits at that address. In practice the program dies later with `TypeError: value is not a function`, at a place that has nothing to do with the array. The second one reads memory that was never written: the unused slack at the end of an array was left as raw uninitialized bytes, which the collector could mistake for pointers and follow.

Both were found while investigating a crash in a downstream command-line application. Each fix stands on its own, is independently correct, and is tested. Neither one fixes that crash; its root cause is a separate bug, described at the bottom.

<details>

<summary>Background: how the collector decides what to scan in an array</summary>

Perry's collector is generational and moving. Newly allocated objects live in a young generation, and a minor collection walks only that generation, copying whatever is still reachable somewhere else and reclaiming the rest. Copying is what makes a missed reference fatal rather than merely wasteful: an object that the collector never visits does not get its new address recorded, so any reference to it becomes a pointer to memory that has been reused.

To avoid scanning every slot of every array, each object carries a layout state describing where its pointers are. `POINTER_FREE` means the payload holds no pointers at all, so the collector can skip it entirely. `SIDE_MASK` means the object has a side table, a bitmask marking which element indices hold pointers, and the collector should consult that mask. Those two states are the ones that matter below.

</details>

<details>

<summary>Fix 1: recording a pointer restores the SIDE_MASK layout state</summary>

An array could end up in the `POINTER_FREE` layout state while still carrying a populated element pointer mask. One way to get there is a numeric-layout rebuild that observed a short or empty prefix and set `POINTER_FREE`, while the previously populated mask lingered behind it.

The two disagree, and the code that reads them does not notice. `heap_payload_slot_selection` short-circuits on `POINTER_FREE` and skips the entire payload without ever consulting the mask. So the evacuating young-generation minor collection dropped live pointer elements that sit within the array's `length`, and a later read of one of those elements returned a garbage pointer, which surfaces as `TypeError: value is not a function`.

The fix is to close the disagreement at the point it is created. `layout_note_slot` now restores `SIDE_MASK` whenever it records a pointer into an array's existing element mask, because recording a pointer is itself proof that the object is not pointer-free.

This is the same class of bug as #6831.

The diagnostic scan `PERRY_GC_FROMSPACE_SCAN` counts stale references from an old object into the young generation. Within-length stale array-to-young edges go from 202 to 0 with this fix. The regression test is `test_pointer_store_restores_side_mask_from_stale_pointer_free`.

</details>

<details>

<summary>Fix 2: initializing the unused capacity of an array</summary>

An array allocates room for more elements than it currently holds, so that appending does not reallocate every time. The region between `length` and `capacity` is slack, and it was being left as raw arena bytes, meaning whatever the allocator happened to hand back.

Raw bytes can look like a pointer by coincidence. Any scan or trace that reads beyond `length` follows those bits as if they were a live reference, which segfaults if the address it lands on has been evacuated. Short of a crash, it floods `PERRY_GC_FROMSPACE_SCAN` with false positives, roughly 4000 per collection cycle.

`js_array_alloc` and `js_array_grow` now HOLE-initialize the `[length, capacity)` slack. HOLE is a non-pointer sentinel value, so the slack can no longer be mistaken for a reference. This matches what `js_array_alloc_with_length` already did, and it is the same class as issue #323.

Uninitialized-slack false-positive edges go from roughly 4000 per cycle to roughly 0.

</details>

<details>

<summary>Test runs</summary>

`cargo test -p perry-runtime` passes the array suite 73 to 0 and the layout suite 78 to 0, rebased on `origin/main`.

The `gc::tests::teardown::map_set_*` failures are pre-existing and order-dependent, and are unrelated to this change.

</details>

<details>

<summary>The crash this does not fix</summary>

The `value is not a function` crash that prompted this investigation has a separate root cause, and it is not addressed here.

There, the evacuating minor collection drops an old object's `field[1]` reference to a shared young function across a collection-cycle boundary. That is a remembered-set snapshot drop, in the same area as #5029, rather than an array-layout problem. The remembered set is the collector's record of which old objects point into the young generation, and an edge missing from it means the minor collection never scans that reference at all.

The full hand-off, with evidence and the exact next diagnostic step, is pinned at PerryTS/perry#7154.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array memory handling during allocation and growth, preventing stale values in unused capacity.
  * Strengthened garbage collection tracking when arrays receive new pointer values, helping ensure referenced objects remain available.
  * Improved reliability when scanning and processing arrays with mixed value types.

* **Tests**
  * Added regression coverage for array pointer tracking and memory layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->