### PR TITLE
test(compile): lock in auto-opt freshness on runtime/stdlib source edits

### DIFF
--- a/changelog.d/7155-auto-opt-freshness-runtime-source-test.md
+++ b/changelog.d/7155-auto-opt-freshness-runtime-source-test.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Locked in auto-optimize freshness on runtime/stdlib source edits (#7155).**
+  The auto-optimize build stamp is keyed on a content fingerprint of every source
+  tree that lands in the runtime/stdlib archives (#5930), so editing
+  `crates/perry-runtime` / `crates/perry-stdlib` invalidates a cached
+  `target/perry-auto-<hash>` archive and forces a rebuild even when mtimes lie
+  (`git checkout`, `cp -p`, CI cache restore) — no manual
+  `rm libperry_runtime.a`. That guarantee had direct test coverage only for the
+  routed `perry-ext-*` crates; this adds regression tests for the runtime/stdlib
+  crates themselves — the ones behind the GC-iteration "compile silently reused a
+  stale runtime" trap — asserting a content edit rotates both the source
+  fingerprint and the build stamp while an identical-bytes rewrite stays a fast
+  no-op.

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -290,6 +290,111 @@ fn source_fingerprint_follows_workspace_dep_closure() {
     );
 }
 
+/// The GC-iteration "stale runtime" trap: perry-runtime / perry-stdlib are the
+/// crates a runtime dev edits most, yet the pre-existing fingerprint coverage
+/// only exercised the routed ext crates. A CONTENT edit to a runtime/stdlib
+/// source file must rotate the fingerprint even when the file's mtime does NOT
+/// advance (a `git checkout`, `cp -p`, or cache restore can hand back a fresh
+/// checkout whose sources look "older" than a cached archive) — the #5892/#5930
+/// content fingerprint is exactly what makes that safe, where the mtime gate
+/// alone is blind. Rewriting identical bytes must NOT rotate it, so the common
+/// no-edit rebuild stays a fast cache hit.
+#[test]
+fn source_fingerprint_tracks_runtime_and_stdlib_content_not_mtimes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    minimal_auto_workspace(dir.path());
+
+    let fp0 = auto_optimized_source_fingerprint(dir.path(), &[]);
+
+    // mtime-only churn (identical bytes, later write time) must not rotate the
+    // key — this is the no-edit fast path the freshness gate relies on.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    write_file(
+        &dir.path().join("crates/perry-runtime/src/lib.rs"),
+        b"pub fn rt() {}\n",
+    );
+    assert_eq!(
+        fp0,
+        auto_optimized_source_fingerprint(dir.path(), &[]),
+        "rewriting identical runtime bytes must not rotate the fingerprint"
+    );
+
+    // A content edit to a perry-runtime source file must rotate it.
+    write_file(
+        &dir.path().join("crates/perry-runtime/src/gc.rs"),
+        b"pub fn collect() {}\n",
+    );
+    let fp_rt = auto_optimized_source_fingerprint(dir.path(), &[]);
+    assert_ne!(
+        fp0, fp_rt,
+        "a perry-runtime source edit must rotate the fingerprint"
+    );
+
+    // Same guarantee for perry-stdlib.
+    write_file(
+        &dir.path().join("crates/perry-stdlib/src/lib.rs"),
+        b"pub fn stdlib_changed() {}\n",
+    );
+    let fp_std = auto_optimized_source_fingerprint(dir.path(), &[]);
+    assert_ne!(
+        fp_rt, fp_std,
+        "a perry-stdlib source edit must rotate the fingerprint"
+    );
+}
+
+/// Ties the runtime-source fingerprint to the freshness gate the compile driver
+/// actually consults: a content edit to perry-runtime rotates the build stamp,
+/// so a `target/perry-auto-<hash>` dir stamped for the OLD source can never pass
+/// `auto_optimized_archives_are_fresh` — no manual `rm libperry_runtime.a`. The
+/// stamp is compared before any mtime probe, so this holds even when the edited
+/// file's mtime never advanced past the cached archive.
+#[test]
+fn runtime_source_edit_rotates_build_stamp_and_fails_freshness() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    minimal_auto_workspace(dir.path());
+
+    let fp_before = auto_optimized_source_fingerprint(dir.path(), &[]);
+    let stamp_before = auto_optimized_build_stamp("key", None, &[], &[], &fp_before);
+
+    // Plant archives + the stamp recorded for the OLD source, mtimes newer than
+    // the sources so the mtime half of the gate would (wrongly) call them fresh.
+    let runtime = dir
+        .path()
+        .join("target/perry-auto/release/libperry_runtime.a");
+    let stdlib = dir
+        .path()
+        .join("target/perry-auto/release/libperry_stdlib.a");
+    let stamp_path = dir.path().join("target/perry-auto/.perry-auto-build.stamp");
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    write_file(&runtime, b"!<arch>\n");
+    write_file(&stdlib, b"!<arch>\n");
+    write_file(&stamp_path, stamp_before.as_bytes());
+
+    // Now a content edit to the runtime. Recompute the stamp the driver would
+    // expect and confirm the gate rejects the archives stamped for the old one.
+    write_file(
+        &dir.path().join("crates/perry-runtime/src/gc.rs"),
+        b"pub fn collect_v2() {}\n",
+    );
+    let fp_after = auto_optimized_source_fingerprint(dir.path(), &[]);
+    let stamp_after = auto_optimized_build_stamp("key", None, &[], &[], &fp_after);
+    assert_ne!(
+        stamp_before, stamp_after,
+        "a runtime source edit must rotate the build stamp"
+    );
+    assert!(
+        !auto_optimized_archives_are_fresh(
+            dir.path(),
+            &runtime,
+            &stdlib,
+            &[],
+            &stamp_path,
+            &stamp_after,
+        ),
+        "archives stamped for the pre-edit runtime source must not pass the freshness gate"
+    );
+}
+
 /// Closes #507. The well-known flip's "shared tokio" allowlist
 /// must match the set of perry-ext-* crates whose own
 /// `Cargo.toml` pulls tokio. If a new wrapper is added that uses

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -319,10 +319,15 @@ fn source_fingerprint_tracks_runtime_and_stdlib_content_not_mtimes() {
         "rewriting identical runtime bytes must not rotate the fingerprint"
     );
 
-    // A content edit to a perry-runtime source file must rotate it.
+    // A content edit to an EXISTING perry-runtime source file must rotate it.
+    // Editing in place (rather than adding a new file) is what makes this
+    // assertion depend on the file CONTENT hash: a fingerprint that hashed only
+    // the path set would still rotate on an added file, and the test could not
+    // fail. See `runtime_source_edit_rotates_build_stamp_and_fails_freshness`
+    // for the same reasoning applied to the freshness gate.
     write_file(
-        &dir.path().join("crates/perry-runtime/src/gc.rs"),
-        b"pub fn collect() {}\n",
+        &dir.path().join("crates/perry-runtime/src/lib.rs"),
+        b"pub fn rt_changed() {}\n",
     );
     let fp_rt = auto_optimized_source_fingerprint(dir.path(), &[]);
     assert_ne!(
@@ -345,9 +350,18 @@ fn source_fingerprint_tracks_runtime_and_stdlib_content_not_mtimes() {
 /// Ties the runtime-source fingerprint to the freshness gate the compile driver
 /// actually consults: a content edit to perry-runtime rotates the build stamp,
 /// so a `target/perry-auto-<hash>` dir stamped for the OLD source can never pass
-/// `auto_optimized_archives_are_fresh` — no manual `rm libperry_runtime.a`. The
-/// stamp is compared before any mtime probe, so this holds even when the edited
-/// file's mtime never advanced past the cached archive.
+/// `auto_optimized_archives_are_fresh` — no manual `rm libperry_runtime.a`.
+///
+/// The stamp gate is the ONLY thing this test lets answer "stale": the archives
+/// are planted *after* the source edit, so every source is older than them and
+/// the mtime half of `auto_optimized_archives_are_fresh` votes "fresh". That
+/// ordering is deliberate — plant them first and the edit's own mtime makes the
+/// gate reject on the mtime path alone, so the assertion would still pass with
+/// the stamp comparison deleted and the test could never fail (the repo's
+/// "a gate must assert its subject was live" rule). It is also the real-world
+/// case the content fingerprint exists for: a `git checkout` / `cp -p` / CI
+/// cache restore hands back sources whose mtimes never advance past a cached
+/// archive.
 #[test]
 fn runtime_source_edit_rotates_build_stamp_and_fails_freshness() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -356,8 +370,16 @@ fn runtime_source_edit_rotates_build_stamp_and_fails_freshness() {
     let fp_before = auto_optimized_source_fingerprint(dir.path(), &[]);
     let stamp_before = auto_optimized_build_stamp("key", None, &[], &[], &fp_before);
 
-    // Plant archives + the stamp recorded for the OLD source, mtimes newer than
-    // the sources so the mtime half of the gate would (wrongly) call them fresh.
+    // Content edit to an EXISTING runtime source file (in place, so the
+    // assertion rides on the content hash rather than on the path set).
+    write_file(
+        &dir.path().join("crates/perry-runtime/src/lib.rs"),
+        b"pub fn rt_v2() {}\n",
+    );
+
+    // Only now plant the archives + the stamp recorded for the PRE-edit source,
+    // so their mtimes are newer than every source and the mtime half of the gate
+    // says "fresh". Anything but the stamp mismatch would let this pass.
     let runtime = dir
         .path()
         .join("target/perry-auto/release/libperry_runtime.a");
@@ -370,12 +392,6 @@ fn runtime_source_edit_rotates_build_stamp_and_fails_freshness() {
     write_file(&stdlib, b"!<arch>\n");
     write_file(&stamp_path, stamp_before.as_bytes());
 
-    // Now a content edit to the runtime. Recompute the stamp the driver would
-    // expect and confirm the gate rejects the archives stamped for the old one.
-    write_file(
-        &dir.path().join("crates/perry-runtime/src/gc.rs"),
-        b"pub fn collect_v2() {}\n",
-    );
     let fp_after = auto_optimized_source_fingerprint(dir.path(), &[]);
     let stamp_after = auto_optimized_build_stamp("key", None, &[], &[], &fp_after);
     assert_ne!(


### PR DESCRIPTION
Someone editing the Perry runtime or standard library needs `perry compile` to pick up that edit. The failure mode this guards against is the worst kind: the compile succeeds, prints nothing unusual, and produces a binary built from the code as it was before the edit. Anyone debugging in that state is reading output from a build that does not match their source, and the only way out is knowing to delete a cached archive by hand.

That guarantee already holds on `main`. This pull request is test coverage only, so that it cannot quietly stop holding. It adds two regression tests and changes no product code.

<details>

<summary>Why staleness is possible at all, and how it is already prevented</summary>

`perry compile` caches compiled archives of the runtime and standard library under `target/perry-auto-<hash>/release/`, so that a normal compile does not rebuild them every time. Deciding whether a cached archive is still usable is the freshness gate's job.

The obvious way to decide is to compare modification times: if the source is newer than the archive, rebuild. That test is wrong more often than it looks, because modification times can lie. A `git checkout`, a `cp -p`, or a continuous-integration cache restore can all hand back source files whose timestamps are older than a cached archive built from different content.

The gate therefore keys the build stamp on a content fingerprint of every source tree that ends up in the archives, computed by `auto_optimized_source_fingerprint`. That function was added in #5930 to close #5892. Because the fingerprint is over content rather than timestamps, a source edit invalidates the cache even when the timestamps say otherwise.

</details>

<details>

<summary>Confirming the reported symptom no longer reproduces</summary>

The report was that after editing `crates/perry-runtime`, `perry compile` produced a binary from the old runtime, and the only workaround was to manually `rm` the cached archive. That was hit during garbage-collector iteration work.

Checked on `origin/main` with a prebuilt `perry` binary, which is after #5930 landed. The bug does not reproduce:

- Editing a file under `crates/perry-runtime/src/gc/` and running `perry compile` prints `auto-optimize: rebuilding runtime+stdlib` and rebuilds the archive, with no manual `rm` needed.
- Making the same edit but backdating the file's modification time to 2020, so it is older than the archive and simulates a cache restore, still rebuilds. That rebuild is driven by the content fingerprint, which is exactly the case a timestamp-only gate would miss.
- Rebuilding with no edit at all is a fast no-op and leaves the archive's modification time untouched, so the cache hit path still works.

</details>

<details>

<summary>The coverage gap this closes</summary>

The correctness fix is already in place; what was missing was a test that pins it for the runtime and standard-library crates specifically. Those are the crates a runtime developer edits most often, and they were the least covered.

The existing fingerprint tests only exercised the routed `perry-ext-*` crates. The one test that did touch the runtime, `..._are_stale_when_runtime_source_is_newer`, exercises the modification-time half of the gate rather than the content fingerprint. So the property that actually saved the reported case had no direct test behind it.

</details>

<details>

<summary>The two new tests</summary>

`source_fingerprint_tracks_runtime_and_stdlib_content_not_mtimes` asserts that a content edit to either `perry-runtime` or `perry-stdlib` rotates the fingerprint, and that rewriting byte-identical content does not. The second half is what keeps the no-edit fast path honest.

`runtime_source_edit_rotates_build_stamp_and_fails_freshness` asserts that a runtime edit rotates the build stamp, so that archives stamped for the pre-edit source correctly fail `auto_optimized_archives_are_fresh`.

`cargo test -p perry --bins optimized_libs` reports 25 passed and 0 failed.

</details>

<details>

<summary>Note on the performance trade-off</summary>

The fingerprint reads the runtime and standard-library source content on every compile, and it is deliberately not cached by modification time. A cache keyed on modification times would reintroduce precisely the cache-restore staleness that #5930 fixed.

The read is small relative to the cost of a compile, and the no-edit path remains a fast no-op, which the new tests assert.

</details>
