### PR TITLE
fix(lru-cache): dispatch `cache.size` property read to js_lru_cache_size

### DIFF
--- a/changelog.d/7156-lru-cache-size-property-getter.md
+++ b/changelog.d/7156-lru-cache-size-property-getter.md
@@ -1,0 +1,11 @@
+Fixed `LRUCache#size` read as a property (`cache.size`) returning `undefined`.
+A handle-backed native instance's zero-arg data getters are dispatched as 0-arg
+`NativeMethodCall`s only when `is_native_dispatch_member` recognizes the
+`(module, class, property)` triple; `lru-cache` had no arm, so a bare `cache.size`
+fell through to the inverted default (a plain `PropertyGet`) and the runtime's
+handle-property lookup — which has no `size` handler for the compact lru-cache
+handle — returned `undefined`. The method-call form `cache.size()` was unaffected
+because it routes through the call-expression path to the existing
+`js_lru_cache_size` dispatch row. Added the `"lru-cache" => prop == "size"` arm so
+the property read now dispatches to `js_lru_cache_size`, mirroring the `blob`
+(`size`/`type`/…) and `__disposable__` (`disposed`) getter arms.

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -125,6 +125,18 @@ pub(crate) fn is_native_dispatch_member(module: &str, class: &str, prop: &str) -
         // behind a compact native handle. Bare reads must invoke the FFI
         // getters; methods still travel through the call-expression path.
         "readline" => matches!(prop, "line" | "terminal"),
+        // lru-cache: `.size` is the one native DATA GETTER whose value comes
+        // from the FFI helper `js_lru_cache_size`, so a bare read must dispatch
+        // as a 0-arg `NativeMethodCall` through the `lru-cache` NativeModSig row
+        // (see `lower_call/native_table/node_misc.rs`). Without this arm the read
+        // fell to the inverted default (a plain `PropertyGet`) and the runtime's
+        // handle-property lookup — which has no `size` handler for the compact
+        // lru-cache handle — returned `undefined`. Every other member
+        // (`get`/`set`/`has`/`delete`/`clear`/`peek`) is a METHOD: a method CALL
+        // arrives via the call-expression path, and a bare method-VALUE read must
+        // stay a plain PropertyGet, never a 0-arg invoking dispatch. Mirrors the
+        // `blob` (`size`/`type`/…) and `__disposable__` (`disposed`) getter arms.
+        "lru-cache" => prop == "size",
         // #6364 — DisposableStack / AsyncDisposableStack: `disposed` is the
         // only native data getter (its value comes from the FFI helper
         // `js_disposable_stack_disposed`), so a bare read must dispatch as a
@@ -599,5 +611,20 @@ mod tests {
         assert!(is_native_dispatch_member("perry/ui", "State", "value"));
         assert!(!is_native_dispatch_member("perry/ui", "State", "custom"));
         assert!(!is_native_dispatch_member("perry/ui", "Canvas", "value"));
+    }
+
+    #[test]
+    fn lru_cache_dispatches_only_the_size_getter() {
+        // `cache.size` (bare property read) must dispatch as a 0-arg
+        // NativeMethodCall → `js_lru_cache_size`, not fall through to a plain
+        // PropertyGet (which read `undefined`). Regression for the handle-backed
+        // property-getter dispatch gap.
+        assert!(is_native_dispatch_member("lru-cache", "LRUCache", "size"));
+        // Methods stay method-VALUE reads (plain PropertyGet); their CALL form
+        // arrives via the call-expression path, so they must NOT dispatch here.
+        assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "get"));
+        assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "set"));
+        assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "has"));
+        assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "clear"));
     }
 }


### PR DESCRIPTION
Reading the number of entries in an `lru-cache` the normal way, as the property `cache.size`, returns `undefined` instead of a number. Any program that checks its cache size, logs it, or branches on it gets the wrong answer silently, with no error raised. Calling it as a method, `cache.size()`, has always worked, so the bug looks arbitrary from the outside: the same value is reachable one way and not the other.

This adds the one missing entry that makes the property form dispatch to the same native function the method form already reaches. No code generation changes are needed, and no other cache member changes behavior.

<details>

<summary>How a native property read is compiled</summary>

Some Perry objects are backed by a compact native handle rather than by an ordinary JavaScript object, and `lru-cache` is one of them. When the compiler sees a bare member read on one of those objects, such as `cache.size` with no call parentheses, it has to decide between two lowerings.

It can emit a zero-argument `NativeMethodCall`, which is the getter form and invokes the native function behind the property. Or it can emit a plain `PropertyGet`, which just looks the name up on the object. That decision is made in `crates/perry-hir/src/lower/expr_member.rs`, and it emits the getter form only when `is_native_dispatch_member(module, class, property)` returns `true`. Everything else falls through to the plain `PropertyGet` default.

The distinction matters because both lowerings are correct for different members. A getter such as `size` holds a value that only the native side knows. A method such as `get` needs to stay a plain `PropertyGet` when read without parentheses, because `const fn = cache.get` should hand back the function itself, not invoke it.

</details>

<details>

<summary>Root cause</summary>

`is_native_dispatch_member`, in `crates/perry-hir/src/lower/expr_member/native_dispatch.rs`, had no arm for `"lru-cache"` at all. A bare `cache.size` therefore reached the catch-all `_ => false` and lowered to a plain `PropertyGet`.

That `PropertyGet` reached the runtime's handle-property lookup, and that lookup has no `size` handler for the compact `lru-cache` handle, so it returned `undefined`. Nothing further down the chain was broken: the `js_lru_cache_size` extern exists and the `lru-cache` `size` dispatch row is correct, declared as `has_receiver: true, args: &[], ret: NR_F64`. The value simply was never asked for.

`cache.size()` was unaffected because a call expression takes a different route entirely. The call-expression path in `local_natives.rs` and `lower_call` rewrites it to `NativeMethodCall { module: "lru-cache", method: "size" }`, which code generation already routes to `js_lru_cache_size` through the native dispatch table.

</details>

<details>

<summary>The change</summary>

The `"lru-cache" => prop == "size"` arm is added to `is_native_dispatch_member`, mirroring the handle-backed getter arms that already exist for `blob` (`size`, `type`, and others), `readline` (`line` and `terminal`), `__disposable__` (`disposed`), and `perry/ui` `State` (`value`).

`size` is the only `lru-cache` getter the runtime and native table expose, so the arm is deliberately narrow. The other members (`get`, `set`, `has`, `delete`, `clear`, and `peek`) stay as method-value reads that lower to a plain `PropertyGet`, and their call forms keep dispatching through the call-expression path as before.

No code generation change is required. Once the getter lowers to a `NativeMethodCall`, the existing `lru-cache` `size` dispatch row handles it.

</details>

<details>

<summary>Verification runs</summary>

A new regression unit test, `lru_cache_dispatches_only_the_size_getter` in `native_dispatch.rs`, asserts that `size` dispatches and that the methods do not.

Running `--print-hir` over `new LRUCache({max:10}); …; cache.size` now shows `NativeMethodCall { module: "lru-cache", method: "size", args: [] }` where it previously showed a plain `PropertyGet`.

Compiling and running `new LRUCache(...); cache.set(...); cache.size` prints `2`, where it previously printed `undefined`. The full `test-files/test_parity_lru_cache.ts` fixture now prints correct `size:` values of `3`, `3`, `2`, and `0`.

`cargo test -p perry-hir native_dispatch` is green. `cargo test -p perry-codegen` shows no new failures; its three `manifest_consistency` failures relating to `iovalkey`, `dotenv`, `nanoid` and others already exist on `main` and are unrelated to this change.

</details>

<details>

<summary>How this relates to #7136</summary>

The faithful `lru-cache` rewrite in #7136 is not on `main` yet, and the two changes do not conflict. This one is on the code-generation pipeline side and is independent: it corrects how the property getter is dispatched, not how the cache stores its values.

Until #7136 lands, `cache.size` reports the current runtime's entry count. Once it lands, `cache.size` will report the faithful entry count. The dispatch fix is correct in both cases.

</details>
