### PR TITLE
ci(compiler-output-regression): restore the native-region-proof gate that is red on main

### DIFF
--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -407,7 +407,10 @@ allowed_missed_reason_kinds = [
 [workloads.h1_native_rep_equivalence.runtime_budgets]
 allocations_traced = 0
 gc_collections_traced = 0
-# Includes root barrier setup now counted by the static analyzer.
+# Heap write barriers only. The inline shadow-stack root-shading barriers
+# added by #7088 (one per rooted Buffer local: src, dst, same) are counted
+# under root_shading_barriers_static, not here; they are gated behind
+# incremental marking and never fire in this workload (write_barriers_traced=0).
 write_barriers_static = 1
 write_barriers_traced = 0
 boxed_number_allocations_static = 0
@@ -445,7 +448,10 @@ no_conversions = true
 
 [[workloads.h1_native_rep_equivalence.named_regions.selectors]]
 function_contains = "main"
-label_any = ["for.body.2"]
+# for.body.2 -> for.body.14 after #7088: the inline shadow-slot stores add
+# ss.* blocks ahead of the module-init loops, shifting the deterministic
+# per-function block counter by 12 (2/6/10 -> 14/18/22).
+label_any = ["for.body.14"]
 counter_min = { load_i8 = 1, store_i8 = 1 }
 
 [[workloads.h1_native_rep_equivalence.named_regions]]
@@ -457,7 +463,8 @@ no_conversions = true
 
 [[workloads.h1_native_rep_equivalence.named_regions.selectors]]
 function_contains = "main"
-label_any = ["for.body.6"]
+# for.body.6 -> for.body.18 after #7088 (see direct_bounded).
+label_any = ["for.body.18"]
 counter_min = { load_i8 = 1, store_i8 = 1 }
 
 [[workloads.h1_native_rep_equivalence.named_regions]]
@@ -469,7 +476,8 @@ no_conversions = true
 
 [[workloads.h1_native_rep_equivalence.named_regions.selectors]]
 function_contains = "main"
-label_any = ["for.body.10"]
+# for.body.10 -> for.body.22 after #7088 (see direct_bounded).
+label_any = ["for.body.22"]
 counter_min = { load_i8 = 1, store_i8 = 1 }
 
 [[workloads.h1_native_rep_equivalence.named_regions]]

--- a/changelog.d/7136-native-region-proof-inline-root-barrier.md
+++ b/changelog.d/7136-native-region-proof-inline-root-barrier.md
@@ -1,0 +1,32 @@
+**ci(compiler-output-regression):** the `native-region-proof` gate accounts for
+#7088's inline shadow-slot root barrier, restoring green on `main`.
+
+#7088 moved the per-store shadow-stack root store — and its
+incremental-mark root-shading barrier — from a `js_shadow_slot_bind` /
+`js_shadow_slot_set` runtime call to inline IR. That barrier was always
+emitted; it just lived *inside* the runtime function, invisible to the
+harness's static call counter. Inlining made the `js_write_barrier_root_nanbox`
+call site visible, so `write_barriers_static` jumped (e.g. h1_native_rep_equivalence
+0→3, one per rooted Buffer local) and every affected `native-region-proof`
+workload tripped its heap-barrier budget. The same inline lowering inserts
+`ss.*` blocks ahead of the module-init loops, shifting the deterministic
+per-function block counter by 12 and blanking the `direct_bounded` /
+`local_cast` / `helper_index` region labels (`for.body.2/6/10` → `14/18/22`).
+
+Neither is a real regression: the root-shading barrier is gated behind
+`PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT`, never fires in these workloads
+(`write_barriers_traced` stays 0), and #7088 proves it observationally
+identical to the call it replaced. The barriers sit in guarded `ss.barrier`
+blocks at root-bind sites, never inside the native loops, which still carry
+raw `load i8`/`store i8` with alias metadata and no runtime calls.
+
+- `structural_counters` now scores `write_barriers_static` on the
+  optimizer-controlled *heap* barriers (`js_write_barrier`,
+  `js_write_barrier_slot`) only. The shadow-stack root-shading barriers
+  (`js_write_barrier_root_nanbox`, `js_write_barrier_root_heap_word`) are
+  reported under a new `root_shading_barriers_static` field — still visible,
+  no longer inflating the heap-barrier budget. Real regressions stay caught:
+  heap barriers are still counted, and a root barrier that actually *fires*
+  is caught by the `write_barriers_traced` budget.
+- `h1_native_rep_equivalence`'s region selectors follow the renumbered loop
+  bodies (`for.body.14/18/22`).

--- a/scripts/compiler_output_harness/analyzers.py
+++ b/scripts/compiler_output_harness/analyzers.py
@@ -221,9 +221,23 @@ def structural_counters(ir_before: str, ir_after: str, assembly: str) -> dict[st
             "ptrtoint": ir_after.count(" ptrtoint "),
             "runtime_calls": runtime_calls,
             "boxed_number_allocations": after_calls.get("js_boxed_number_new", 0),
+            # Heap write barriers — the perf-relevant, optimizer-controlled
+            # barriers this gate exists to catch. Counted statically because a
+            # native region that stores a GC pointer into a heap object needs
+            # one; the proof budgets bound how many.
             "write_barriers": after_calls.get("js_write_barrier", 0)
-            + after_calls.get("js_write_barrier_slot", 0)
-            + after_calls.get("js_write_barrier_root_nanbox", 0)
+            + after_calls.get("js_write_barrier_slot", 0),
+            # GC shadow-stack root-shading barriers (#7088). Before #7088 these
+            # lived inside the `js_shadow_slot_bind` / `js_shadow_slot_set`
+            # runtime calls and were invisible to this static IR counter; #7088
+            # emits the shadow-slot store — and its barrier — inline, so the
+            # call site is now visible here. Each is emitted once per rooted
+            # pointer-capable local (a structural constant, not an optimizer
+            # choice) and is gated behind PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT,
+            # so it never fires unless incremental marking is live — meaning it
+            # is caught, if it ever regresses at runtime, by write_barriers_traced.
+            # Tracked separately so it does not inflate the heap-barrier budget.
+            "root_shading_barriers": after_calls.get("js_write_barrier_root_nanbox", 0)
             + after_calls.get("js_write_barrier_root_heap_word", 0),
             "buffer_slow_path_calls": sum(
                 count
@@ -445,6 +459,7 @@ def runtime_counter_summary(
         "allocations_traced": traced_allocations,
         "gc_collections_traced": gc_collections,
         "write_barriers_static": int(after.get("write_barriers", 0) or 0),
+        "root_shading_barriers_static": int(after.get("root_shading_barriers", 0) or 0),
         "write_barriers_traced": traced_write_barriers,
         "boxed_number_allocations_static": int(
             after.get("boxed_number_allocations", 0) or 0

--- a/tests/test_compiler_output_regression.py
+++ b/tests/test_compiler_output_regression.py
@@ -80,21 +80,21 @@ main:
 H1_MIN_IR = """
 define i32 @main() {
 entry:
-  br label %for.body.2
-for.body.2:
+  br label %for.body.14
+for.body.14:
   %i = load i32, ptr %slot
   store i32 %i, ptr %slot
   %ok = icmp slt i32 %i, %n
   %p0 = getelementptr i8, ptr %src, i32 %i
   %b = load i8, ptr %p0
   store i8 %b, ptr %p0
-  br label %for.body.6
-for.body.6:
+  br label %for.body.18
+for.body.18:
   %p1 = getelementptr i8, ptr %src, i32 %i
   %b1 = load i8, ptr %p1
   store i8 %b1, ptr %p1
-  br label %for.body.10
-for.body.10:
+  br label %for.body.22
+for.body.22:
   %p2 = getelementptr i8, ptr %src, i32 %i
   %b2 = load i8, ptr %p2
   store i8 %b2, ptr %p2
@@ -1556,7 +1556,11 @@ idxset.bounded_numeric_merge.5:
         self.assertEqual(summary["gc_collections_traced"], 2)
         self.assertEqual(summary["allocations_traced"], 4)
         self.assertEqual(summary["write_barriers_traced"], 3)
-        self.assertEqual(summary["write_barriers_static"], 4)
+        # write_barriers_static counts only heap barriers (js_write_barrier +
+        # js_write_barrier_slot); the inline shadow-stack root-shading barriers
+        # (#7088) are tracked separately so they do not inflate the budget.
+        self.assertEqual(summary["write_barriers_static"], 2)
+        self.assertEqual(summary["root_shading_barriers_static"], 2)
         self.assertEqual(summary["boxed_number_allocations_static"], 1)
         self.assertEqual(summary["buffer_slow_path_accesses_static"], 2)
         self.assertEqual(summary["array_slow_path_accesses_static"], 2)


### PR DESCRIPTION
The `compiler-output-regression` merge gate is failing on a clean checkout of `origin/main`. Because it is a required check, that failure blocks every open pull request in the repository, whatever the pull request actually changes. Nothing is wrong with the compiler. The gate is counting something it was never meant to count, because a recent change moved that thing somewhere the gate could see it.

Some background on what the gate measures. Its `native-region-proof` suite proves two properties of the generated code: that hot native loops contain no runtime calls, and that the compiler emits no more write barriers than a per-workload budget allows. A write barrier is a short piece of code the compiler inserts next to a pointer store so the garbage collector learns that a new reference exists. The suite counts barriers by scanning the generated intermediate representation for barrier call sites, so it is sensitive to where a barrier physically sits, not to whether that barrier ever runs.

This change splits that one count into two. `write_barriers_static` now counts only the heap write barriers the optimizer controls (`js_write_barrier` and `js_write_barrier_slot`), which are the barriers this gate exists to police. The garbage collector's shadow-stack root-shading barriers (`js_write_barrier_root_nanbox` and `js_write_barrier_root_heap_word`) move to a new `root_shading_barriers_static` field, which is reported but does not gate. The `h1_native_rep_equivalence` workload's region selectors are also pointed at the loop-body labels the compiler emits today. No compiler code changes here, only the Python harness and its TOML fixtures.

<details>
<summary>Bisecting the red gate to one commit</summary>

Running `git bisect` with `h1_native_rep_equivalence` as the probe pins the flip to `91f1e7c82`, `perf(gc): emit the shadow-slot root store inline (#7088)`, authored by Ralph Küpper. The immediate parent of that commit gates green and `91f1e7c82` itself gates red.

The shadow stack is a side list of pointers that the garbage collector walks to find values held in local variables. Before #7088, binding a local into that list went through the `js_shadow_slot_bind` and `js_shadow_slot_set` runtime functions, and the incremental-mark root-shading barrier lived inside those functions. #7088 emits the shadow-slot store, and its barrier, as inline intermediate representation instead.

</details>

<details>
<summary>Why the static barrier count jumped</summary>

The root-shading barrier was always being emitted. Before #7088 it lived inside a runtime function, so the harness's static call counter, which only scans the caller's intermediate representation, never saw it. Inlining exposed the `js_write_barrier_root_nanbox` call site directly in the workload's own code, and the static count went up accordingly.

For `h1_native_rep_equivalence` the count went from 0 to 3, one barrier for each rooted `Buffer` local (`src`, `dst`, and `same`). `h1_buffer_alias_negative` rose to 46 and `scalar_replacement_literals` rose to 22. Each of those exceeded the workload's heap-barrier budget, so the gate failed.

</details>

<details>
<summary>Why the region labels went blank</summary>

The `native-region-proof` suite selects the loop bodies it wants to inspect by exact basic-block label, and those labels are numbered by a deterministic per-function counter. The inline lowering from #7088 inserts a run of new blocks (`ss.slow`, `chk_top`, `chk_len`, `store`, `done`, and `barrier`) ahead of the module-initialization loops, which shifts that counter by 12.

The result is that the `direct_bounded`, `local_cast`, and `helper_index` regions moved from `for.body.2`, `for.body.6`, and `for.body.10` to `for.body.14`, `for.body.18`, and `for.body.22`. The exact-label selectors stopped matching anything, so the suite reported `labels=[]` for those regions.

</details>

<details>
<summary>Evidence that the output change is intended, not a regression</summary>

The root-shading barriers sit in guarded `ss.barrier` blocks behind `PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT`, and they never fire in these workloads. The runtime counter `write_barriers_traced` stays at 0 throughout.

Every `js_write_barrier_root_nanbox` call is at a root-bind site, never inside a native loop. The native loops still carry raw `load i8` and `store i8` instructions annotated with `!alias.scope` and `!noalias`, with no runtime calls at all. This was verified in the after-optimization intermediate representation for both `h1_native_rep_equivalence` and `h1_buffer_alias_negative`; the latter carries 46 root barriers and zero heap `js_write_barrier` or `js_write_barrier_slot` calls.

#7088's own changelog states that the inline barrier is "observationally identical, not a weaker barrier" than the call it replaced. Setting `PERRY_INLINE_SHADOW_SLOT=0`, the built-in revert switch, makes the affected workloads gate green again, which confirms the entire delta comes from #7088's inline lowering.

Real regressions are still caught after this change. Heap barriers are still counted against the budget, and a root barrier that actually fires is caught by the `write_barriers_traced` budget of 0. The change is monotonic: static counts can only go down, so nothing that passes today can start failing.

</details>

<details>
<summary>Verification runs</summary>

`python3 -m unittest tests.test_compiler_output_regression tests.test_native_abi_evidence_report` reports 87 passing, and the `write_barriers_static` split is now pinned by an assertion in that suite.

On the `native-region-proof` gate, `h1_native_rep_equivalence` and `scalar_replacement_literals`, the two workloads free of local-environment noise, both gate green. The region labels resolve to `for.body.14`, `for.body.18`, and `for.body.22`, and the measured `write_barriers_static` is 0.

Running the full suite locally, HEAD plus this fix now matches the #7088 parent commit, which is the last known continuous-integration-green point. The only residual failures are pre-existing local macOS, clang 16, arm64 noise: an undeclared `@llvm.smax.i32` intrinsic and a clang loop-safepoint placement difference. Both fail identically on the green parent commit and neither occurs on the Ubuntu x86-64 runner. No `write_barriers_static`, `labels=[]`, or root-barrier failures remain.

`cargo test -p perry-codegen --lib` reports 406 passing.

</details>

One unrelated red gate is worth flagging so it is not mistaken for fallout from this change. On a clean `origin/main`, `cargo test -p perry-codegen`'s `manifest_consistency` integration test already fails, caused by drift between `API_MANIFEST` and `NATIVE_MODULE_TABLE` in `crates/perry-api-manifest/src/entries.rs`.
