### PR TITLE
style(gc): rustfmt triggers.rs to unblock lint on main

### DIFF
--- a/changelog.d/7180-fmt-lint-unblock.md
+++ b/changelog.d/7180-fmt-lint-unblock.md
@@ -1,0 +1,1 @@
+**`lint` unblocked on `main`.** #7161 landed with a `rustfmt` violation in `crates/perry-runtime/src/gc/tests/triggers.rs`, which fails `cargo fmt --all -- --check` — the `lint` job every PR must pass. Pure formatting, no behaviour change.

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -438,7 +438,10 @@ fn test_effective_arena_trigger_respects_armed_values() {
 fn test_moving_loop_minor_off_by_default_7154() {
     use super::super::policy::moving_loop_polls_enabled_from_env as enabled;
     // Default (unset) is non-evacuating.
-    assert!(!enabled(None), "moving-loop minor must be OFF by default (#7154)");
+    assert!(
+        !enabled(None),
+        "moving-loop minor must be OFF by default (#7154)"
+    );
     // Kill-switch values remain off.
     assert!(!enabled(Some("0")));
     assert!(!enabled(Some("off")));


### PR DESCRIPTION
## Summary

`lint` is red on `main`. #7161 landed with a `rustfmt` violation in the test it added, so `cargo fmt --all -- --check` fails — and that job is required for every PR, so **every open PR is blocked** until this lands.

```
Diff in crates/perry-runtime/src/gc/tests/triggers.rs:438:
 fn test_moving_loop_minor_off_by_default_7154() {
-    assert!(!enabled(None), "moving-loop minor must be OFF by default (#7154)");
+    assert!(
+        !enabled(None),
+        "moving-loop minor must be OFF by default (#7154)"
+    );
```

Reproduced against `origin/main` itself (`5a06970b6`), not against a branch:

```
git show origin/main:crates/perry-runtime/src/gc/tests/triggers.rs > /tmp/t.rs
rustfmt --edition 2021 --check /tmp/t.rs   # emits the diff above
```

Formatting only — the applied change is exactly `rustfmt`'s output, no behaviour change and no other file touched. Found while rebasing #7179 onto the merged #7161.

Refs #7161.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unblocked lint checks by correcting a formatting violation.
  * No runtime behavior or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->