### PR TITLE
style(gc): rustfmt triggers.rs missed by #7161's merge

### DIFF
--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -438,7 +438,10 @@ fn test_effective_arena_trigger_respects_armed_values() {
 fn test_moving_loop_minor_off_by_default_7154() {
     use super::super::policy::moving_loop_polls_enabled_from_env as enabled;
     // Default (unset) is non-evacuating.
-    assert!(!enabled(None), "moving-loop minor must be OFF by default (#7154)");
+    assert!(
+        !enabled(None),
+        "moving-loop minor must be OFF by default (#7154)"
+    );
     // Kill-switch values remain off.
     assert!(!enabled(Some("0")));
     assert!(!enabled(Some("off")));


### PR DESCRIPTION
One-file rustfmt fix: `5a06970b6` (#7161) landed a formatting violation in `gc/tests/triggers.rs:438` because its CI never ran (runner backlog). `cargo fmt --all -- --check` is red on main for every open PR because of it. No code change — rustfmt output only.