### PR TITLE
test(codegen): update scalar_replaced_slot_roots fixtures to #7088's frame enter

### DIFF
--- a/changelog.d/7185-scalar-replaced-slot-roots-fixtures.md
+++ b/changelog.d/7185-scalar-replaced-slot-roots-fixtures.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tests: `scalar_replaced_slot_roots` was red on `main` for a stale string, not a real regression**. Two helpers located the shadow frame push by grepping `call i64 @js_shadow_frame_push(i32 `, which #7088 replaced with `call ptr @js_shadow_frame_enter(i32 ` (same slot-count operand; the pop handle is now derived from `frame_top`). Both panicked at the lookup before reaching the assertions they exist for, so `scalar_replaced_object_field_holding_a_heap_value_is_bound` and `bind_is_hoisted_into_the_entry_block_ahead_of_the_storing_loop` failed while the #6968 rooting contract they guard was intact. Fixtures updated to the post-#7088 emission; every real assertion is unchanged and now actually executes (11/11 pass).

--- a/crates/perry-codegen/tests/scalar_replaced_slot_roots.rs
+++ b/crates/perry-codegen/tests/scalar_replaced_slot_roots.rs
@@ -188,8 +188,14 @@ fn enclosing_function<'a>(ir: &'a str, needle: &str) -> &'a str {
 }
 
 /// The slot count baked into this module-init function's frame push.
+///
+/// #7088 replaced the handle-returning `js_shadow_frame_push` with
+/// `js_shadow_frame_enter`, which returns the `ShadowStackState` pointer the
+/// inline slot stores address (the pop handle is derived from `frame_top`).
+/// The slot-count operand is unchanged, so only the callee name and its
+/// return type move.
 fn frame_slot_count(ir: &str) -> u32 {
-    let needle = "call i64 @js_shadow_frame_push(i32 ";
+    let needle = "call ptr @js_shadow_frame_enter(i32 ";
     let start = ir
         .find(needle)
         .map(|i| i + needle.len())
@@ -587,8 +593,9 @@ fn bind_is_hoisted_into_the_entry_block_ahead_of_the_storing_loop() {
     );
 
     let body = enclosing_function(&ir, "call void @js_shadow_slot_bind(");
+    // #7088: the push is `js_shadow_frame_enter` (returns the state pointer).
     let push = body
-        .find("call i64 @js_shadow_frame_push(")
+        .find("call ptr @js_shadow_frame_enter(")
         .unwrap_or_else(|| panic!("no frame push in the binding function:\n{body}"));
     let bind = body
         .find("call void @js_shadow_slot_bind(")


### PR DESCRIPTION
## What

`crates/perry-codegen/tests/scalar_replaced_slot_roots.rs` has two helpers that locate the shadow frame push by string:

```rust
let needle = "call i64 @js_shadow_frame_push(i32 ";
// ...
.find("call i64 @js_shadow_frame_push(")
```

#7088 replaced that emission with `call ptr @js_shadow_frame_enter(i32 N)` — same slot-count operand, but the callee returns the `ShadowStackState` pointer the inline slot stores address (the pop handle is derived from `frame_top`). Both lookups therefore missed and **panicked at the grep** — `expected a shadow frame push` / `no frame push in the binding function` — before reaching the assertions they exist for.

So `scalar_replaced_object_field_holding_a_heap_value_is_bound` and `bind_is_hoisted_into_the_entry_block_ahead_of_the_storing_loop` have been **red on `main`** while the #6968 rooting contract they guard is in fact intact: the `bind_calls(&ir) > 0` assertion in the first test passes, and the whole ordering claim in the second was simply never evaluated. That is the [#4 failure mode in CLAUDE.md's gate checklist](../blob/main/CLAUDE.md) inverted — a test that is red for a reason unrelated to its subject teaches people to ignore it.

## Fix

Point both at `call ptr @js_shadow_frame_enter(`. Nothing else changes — every real assertion (field alloca is bound; the frame grows *differentially*; the bind is hoisted into the entry block ahead of the storing loop and after the push) is untouched and now actually executes.

## Verification

```
cargo test -p perry-codegen --test scalar_replaced_slot_roots
test result: ok. 11 passed; 0 failed
```
(was: 9 passed, 2 failed on `main` @ `6406ed66e`)

## Not in scope

`cargo test -p perry-codegen --test loop_safepoint_purity` is also red on `main` (6/7), for a different and genuine reason: #7161 made the back-edge poll **opt-in**, so `emit_gc_loop_safepoint` emits nothing by default and every "…keeps the back edge poll" assertion fails. That needs a test-override hook for the `OnceLock`-cached gate (the codegen analogue of the runtime's `GC_MOVING_LOOP_POLLS_TEST_OVERRIDE`) rather than a fixture edit, and it belongs with #7161. Flagging it here so it is not mistaken for the same class of staleness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shadow-frame validation to align with the current runtime interface.
  * Restored successful execution of all 11 existing scalar replacement assertions.

* **Documentation**
  * Added a changelog entry describing the fixture and test updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->