### PR TITLE
chore: finalize #7185 maintainer landing metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1276
+**Current Version:** 0.5.1277
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "base64",
@@ -5563,14 +5563,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "cc",
  "libc",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "log",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "base64",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5674,14 +5674,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "serde",
  "serde_json",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1276"
+version = "0.5.1277"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "clap",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "block2",
  "objc2",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "chrono",
  "cron",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5824,14 +5824,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5849,7 +5849,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bytes",
  "h2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bson",
  "futures-util",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6032,14 +6032,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "brotli",
  "flate2",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6125,7 +6125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "base64",
@@ -6178,14 +6178,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6280,14 +6280,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6296,14 +6296,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "itoa",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6353,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "block2",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "block2",
@@ -6384,7 +6384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1276"
+version = "0.5.1277"
 
 [[package]]
 name = "perry-ui-test"
@@ -6395,11 +6395,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1276"
+version = "0.5.1277"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "block2",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "block2",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "block2",
  "libc",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "base64",
  "libc",
@@ -6461,14 +6461,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "anyhow",
  "base64",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1276"
+version = "0.5.1277"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1276"
+version = "0.5.1277"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7186-scalar-replaced-slot-roots-fixtures.md
+++ b/changelog.d/7186-scalar-replaced-slot-roots-fixtures.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **maintainer metadata and diagnostics for #7185**. Bumped the workspace patch version required for the already-landed fixture correction, removed ambiguous trailing spaces from its changelog code spans, and updated the remaining test comments and panic messages to name `js_shadow_frame_enter` consistently.

--- a/crates/perry-codegen/tests/scalar_replaced_slot_roots.rs
+++ b/crates/perry-codegen/tests/scalar_replaced_slot_roots.rs
@@ -200,7 +200,7 @@ fn frame_slot_count(ir: &str) -> u32 {
         .find(needle)
         .map(|i| i + needle.len())
         .unwrap_or_else(|| {
-            panic!("expected a shadow frame push in:\n{ir}");
+            panic!("expected a shadow frame enter in:\n{ir}");
         });
     let rest = &ir[start..];
     let end = rest.find(')').expect("malformed frame push");
@@ -547,7 +547,7 @@ fn every_store_into_a_hoisted_scalar_slot_shades_its_value() {
 }
 
 /// The bind must sit in the ENTRY block, ahead of the loop that stores through
-/// the slot — and after `js_shadow_frame_push`.
+/// the slot — and after `js_shadow_frame_enter`.
 ///
 /// This is the property the whole change exists for: a store inside a loop must
 /// not re-bind per iteration. It is also where the one real ordering hazard
@@ -596,7 +596,7 @@ fn bind_is_hoisted_into_the_entry_block_ahead_of_the_storing_loop() {
     // #7088: the push is `js_shadow_frame_enter` (returns the state pointer).
     let push = body
         .find("call ptr @js_shadow_frame_enter(")
-        .unwrap_or_else(|| panic!("no frame push in the binding function:\n{body}"));
+        .unwrap_or_else(|| panic!("no frame enter in the binding function:\n{body}"));
     let bind = body
         .find("call void @js_shadow_slot_bind(")
         .expect("bind was located by enclosing_function");


### PR DESCRIPTION
#7185 landed while this same-repository maintainer branch was being prepared. The contributor commit correctly omitted release metadata, so this follow-up supplies the required 0.5.1277 patch bump and keeps the remaining scalar-root comments and panic diagnostics consistent with `js_shadow_frame_enter`.

It also resolves the review wording nit without changing the already-landed fixture assertions.

Verification:
- `cargo test -p perry-codegen --test scalar_replaced_slot_roots` (11/11)
- `cargo fmt --all -- --check`
- `git diff --check`

Follow-up to #7185.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **0.5.1277**.
  - Synchronized the documented version information across project materials.

- **Bug Fixes**
  - Documented corrections related to fixture behavior, diagnostics, whitespace handling, test comments, and panic messages.

- **Tests**
  - Updated test expectations to align with the latest runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->