### PR TITLE
fix(dotenv): register dotenv.parse so it stops compiling to a swallowed runtime throw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1277
+**Current Version:** 0.5.1278
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "base64",
@@ -5563,14 +5563,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "cc",
  "libc",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "log",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "base64",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5674,14 +5674,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "serde",
  "serde_json",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1277"
+version = "0.5.1278"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "clap",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "block2",
  "objc2",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "chrono",
  "cron",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5824,14 +5824,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5849,7 +5849,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bytes",
  "h2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bson",
  "futures-util",
@@ -5936,7 +5936,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6032,14 +6032,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "brotli",
  "flate2",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6125,7 +6125,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "base64",
@@ -6178,14 +6178,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6280,14 +6280,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6296,14 +6296,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "itoa",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6353,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "block2",
@@ -6369,7 +6369,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "block2",
@@ -6384,7 +6384,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1277"
+version = "0.5.1278"
 
 [[package]]
 name = "perry-ui-test"
@@ -6395,11 +6395,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1277"
+version = "0.5.1278"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "block2",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "block2",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "block2",
  "libc",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "base64",
  "libc",
@@ -6461,14 +6461,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "anyhow",
  "base64",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1277"
+version = "0.5.1278"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1277"
+version = "0.5.1278"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7199-dotenv-parse-manifest-wiring.md
+++ b/changelog.d/7199-dotenv-parse-manifest-wiring.md
@@ -1,0 +1,36 @@
+### Fixed
+
+- **`dotenv.parse` no longer compiles to a swallowed runtime throw.** The
+  native implementation (`js_dotenv_parse`) has shipped since the dotenv module
+  was added, and codegen already declared the extern — but the API manifest
+  only ever registered `dotenv.config`, and `NATIVE_MODULE_TABLE` only ever had
+  a `config` dispatch row. The #463 unimplemented-API gate therefore fired on
+  every `dotenv.parse(...)` call site and, under the default defer policy,
+  compiled it to a throw-on-reach runtime error.
+
+  This is a data-loss-shaped bug rather than a missing feature. Config loaders
+  wrap the parse in `try { … } catch {}` so a malformed `.env` isn't fatal
+  (Socket Firewall's `readConfigFile()` is exactly this shape), which means the
+  deferred throw landed in the `catch` and was **swallowed**: the program ran
+  as though the `.env` file did not exist, with no crash, no warning, and no
+  runtime notice. Every setting in the file was silently dropped.
+
+  Fixed by adding the two missing rows — a `dotenv.parse` dispatch row
+  (`args: &[NA_STR]`, `ret: NR_OBJ_FROM_JSON_STR`) and the matching
+  `parse(src: string): any` manifest entry — plus regenerated
+  `docs/api/perry.d.ts` / `docs/src/api/reference.md`.
+
+  The return kind carries the fix as much as the row does: `js_dotenv_parse`
+  returns a JSON *string*, so `NR_OBJ_FROM_JSON_STR` (the same kind
+  `jsonwebtoken.decode` uses) pipes it through `js_json_parse` and hands
+  TypeScript a real object. Wired as a plain `NR_STR` the call would have
+  compiled and appeared to work while `parsed.FOO` read `undefined` — a quieter
+  version of the same bug — so the regression test asserts the return kind, not
+  just the row's existence.
+
+  Both the default-import (`dotenv.parse(...)`) and named-import
+  (`import { parse } from 'dotenv'`) forms now route to the native code and
+  compile with zero deferred-site notices; empty input returns `{}`, not `null`.
+  Covered by `dotenv_parse_is_registered` (perry-api-manifest) and
+  `dotenv_parse_dispatches_to_native_impl_as_an_object` (perry-codegen), both
+  `src/` unit tests so they run in the per-PR `cargo-test` gate.

--- a/crates/perry-api-manifest/src/entries/part_1.rs
+++ b/crates/perry-api-manifest/src/entries/part_1.rs
@@ -1241,6 +1241,27 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
     method("nodemailer", "sendMail", true, None),
     method("nodemailer", "verify", true, None),
     method_sig("dotenv", "config", false, None, &[], TypeSpec::Any),
+    // `dotenv.parse(src)` — the native impl (`js_dotenv_parse`) has shipped
+    // since the module was added, but the manifest never registered the
+    // symbol, so the #463 gate compiled every call site to a deferred
+    // throw-on-reach error. Callers that wrap config loading in
+    // `try { … } catch {}` swallowed that throw and silently got no config
+    // at all, which is why this is registered as a data-loss fix, not a
+    // missing-feature one. The extern returns a JSON string; the dispatch
+    // row's `NR_OBJ_FROM_JSON_STR` pipes it through `js_json_parse` so the
+    // user-visible value is a real object.
+    method_sig(
+        "dotenv",
+        "parse",
+        false,
+        None,
+        &[ParamSpec::Named {
+            name: "src",
+            ty: TypeSpec::String,
+            optional: false,
+        }],
+        TypeSpec::Any,
+    ),
     method_sig(
         "nanoid",
         "nanoid",

--- a/crates/perry-api-manifest/src/lib.rs
+++ b/crates/perry-api-manifest/src/lib.rs
@@ -548,6 +548,48 @@ mod tests {
         assert_eq!(bare.is_some(), prefixed.is_some());
     }
 
+    /// `dotenv.parse` regression guard.
+    ///
+    /// `js_dotenv_parse` has always been implemented and declared to codegen,
+    /// but the manifest only ever registered `dotenv.config`. That gap made
+    /// the #463 unimplemented-API gate fire for every `dotenv.parse(...)`
+    /// call site, which under the default (defer) policy compiles to a
+    /// throw-on-reach runtime error rather than a build failure. Callers that
+    /// load config inside `try { … } catch {}` — the common shape — swallowed
+    /// the throw and silently ran with no configuration at all.
+    #[test]
+    fn dotenv_parse_is_registered() {
+        let entry = module_has_symbol("dotenv", "parse")
+            .expect("dotenv.parse must be in the manifest — see js_dotenv_parse");
+        assert!(
+            matches!(
+                entry.kind,
+                ApiKind::Method {
+                    has_receiver: false,
+                    class_filter: None
+                }
+            ),
+            "dotenv.parse must be a static module method, got {:?}",
+            entry.kind
+        );
+        assert_eq!(
+            entry.params.len(),
+            1,
+            "dotenv.parse takes exactly the source text"
+        );
+        assert!(
+            matches!(
+                entry.params[0],
+                ParamSpec::Named {
+                    ty: TypeSpec::String,
+                    ..
+                }
+            ),
+            "dotenv.parse's argument is the .env source string, got {:?}",
+            entry.params[0]
+        );
+    }
+
     #[test]
     fn buffer_inspect_max_bytes_is_manifest_property() {
         let entry = module_has_symbol("node:buffer", "INSPECT_MAX_BYTES")

--- a/crates/perry-codegen/src/lower_call/native_table/utils_crypto.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/utils_crypto.rs
@@ -131,6 +131,20 @@ pub(super) const UTILS_CRYPTO_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_F64,
     },
+    // `dotenv.parse(src)` → the JSON string `js_dotenv_parse` builds, piped
+    // through `js_json_parse` by NR_OBJ_FROM_JSON_STR so TypeScript sees a
+    // real object (`{ FOO: "bar" }`), not the encoded string. Without this
+    // row the symbol fell through the #463 gate to a deferred runtime throw
+    // even though the native implementation was already linked in.
+    NativeModSig {
+        module: "dotenv",
+        has_receiver: false,
+        method: "parse",
+        class_filter: None,
+        runtime: "js_dotenv_parse",
+        args: &[NA_STR],
+        ret: NR_OBJ_FROM_JSON_STR,
+    },
     // ========== nanoid ==========
     // js_nanoid_sized(NaN) → size=0 → falls back to js_nanoid() (21-char default),
     // so nanoid() and nanoid(N) both route through the same entry safely.
@@ -395,3 +409,38 @@ pub(super) const UTILS_CRYPTO_ROWS: &[NativeModSig] = &[
         ret: NR_VOID,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `dotenv.parse` must dispatch to the native implementation and return a
+    /// real object.
+    ///
+    /// `js_dotenv_parse` was declared to codegen and linked into every binary,
+    /// but had no dispatch row, so the #463 gate compiled each call site to a
+    /// deferred throw-on-reach error. `readConfigFile()`-shaped callers wrap
+    /// the call in `try { … } catch {}`, so the throw was swallowed and the
+    /// `.env` config silently never loaded.
+    ///
+    /// The return kind matters as much as the row: `js_dotenv_parse` hands back
+    /// a JSON *string*, so only `NR_OBJ_FROM_JSON_STR` (which pipes it through
+    /// `js_json_parse`) makes `dotenv.parse(src).FOO` read a property instead
+    /// of indexing a string.
+    #[test]
+    fn dotenv_parse_dispatches_to_native_impl_as_an_object() {
+        let row = UTILS_CRYPTO_ROWS
+            .iter()
+            .find(|r| r.module == "dotenv" && r.method == "parse")
+            .expect("dotenv.parse needs a dispatch row");
+        assert_eq!(row.runtime, "js_dotenv_parse");
+        assert!(!row.has_receiver);
+        assert_eq!(row.class_filter, None);
+        assert!(matches!(row.args, [NativeArgKind::StrPtr]));
+        assert!(
+            matches!(row.ret, NativeRetKind::ObjFromJsonStr),
+            "dotenv.parse must be JSON-decoded into an object, got {:?}",
+            row.ret
+        );
+    }
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2000 entries across 122 modules
+// Coverage: 2001 entries across 122 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -1428,6 +1428,8 @@ declare module "domain" {
 declare module "dotenv" {
   /** stdlib */
   export function config(...args: any[]): any;
+  /** stdlib */
+  export function parse(src: string): any;
 }
 
 declare module "ethers" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2923 entries across 124 modules.
+Total: 2924 entries across 124 modules.
 
 ## Modules
 
@@ -1203,6 +1203,7 @@ Total: 2923 entries across 124 modules.
 ### Methods
 
 - `config` — module
+- `parse` — module
 
 ## `ethers`
 


### PR DESCRIPTION
## Problem

`dotenv.parse(...)` compiles to a **deferred throw-on-reach runtime error**, even though the native implementation has always been there and linked into every binary.

`js_dotenv_parse` is defined and exported by both `crates/perry-stdlib/src/dotenv.rs` and the bundled well-known binding `crates/perry-ext-dotenv/src/lib.rs`, and it is declared to codegen in `runtime_decls/stdlib_ffi/utilities.rs`. What was missing was the last two links in the chain: the API manifest only ever registered `dotenv.config`, and `NATIVE_MODULE_TABLE` only ever had a `config` dispatch row. So the #463 unimplemented-API gate fired on every `dotenv.parse` call site and — under the default (defer) policy — compiled it to a value that throws only if reached.

Before:

```console
$ perry repro.ts -o repro && ./repro
notice: 1 ahead-of-time-unsupported site handled at runtime:
  - unimplemented API   repro.ts:3   → deferred runtime error (throws only if reached)
Error: dotenv.parse is not implemented in Perry (ahead-of-time) (repro.ts:3)
```

### Why this is a data-loss bug, not a missing feature

The usual shape for loading a config file is a `try`/`catch` around the parse, because a malformed `.env` is not supposed to be fatal. Socket Firewall's `readConfigFile()` is exactly that:

```ts
function readConfigFile(p: string) {
  try {
    return dotenv.parse(fs.readFileSync(p, 'utf8'))
  } catch {
    return {}
  }
}
```

The deferred throw lands inside that `catch`, so it is **swallowed**. The program does not crash, does not warn, and does not print a deferred-site notice at runtime — it simply runs as though the user had no `.env` file at all. Every setting in it is silently dropped. A user debugging "why is my config being ignored" has nothing to go on.

## Fix

Two rows, no new runtime code.

- `crates/perry-codegen/src/lower_call/native_table/utils_crypto.rs` — add the `dotenv.parse` dispatch row: `args: &[NA_STR]`, `ret: NR_OBJ_FROM_JSON_STR`.
- `crates/perry-api-manifest/src/entries/part_1.rs` — register `dotenv.parse(src: string): any`.
- `docs/api/perry.d.ts`, `docs/src/api/reference.md` — regenerated from the manifest.

The **return kind is the load-bearing detail**. `js_dotenv_parse` hands back a JSON *string*, not an object. `NR_OBJ_FROM_JSON_STR` is the existing return kind (used by `jsonwebtoken.decode`) that pipes the pointer through `js_json_parse`, so what TypeScript actually receives is a real object. With a plain `NR_STR` the call would have compiled and "worked" while returning the string `{"FOO":"bar"}`, and `parsed.FOO` would have read `undefined` — a quieter version of the same bug. The test asserts the return kind for that reason.

## Verification

End-to-end against a `perry-dev` build:

```ts
import dotenv from 'dotenv';
const parsed = dotenv.parse('FOO=bar\n# comment\nBAZ="qux"\nNUM=42\n');
console.log(typeof parsed);                            // object
console.log(parsed.FOO, parsed.BAZ, parsed.NUM);       // bar qux 42
console.log(Object.keys(parsed).sort().join(','));     // BAZ,FOO,NUM

function readConfigFile(text: string) {
  try { return dotenv.parse(text) as Record<string, string> } catch { return {} }
}
console.log(readConfigFile('API_TOKEN=secret\n').API_TOKEN);  // secret

import { parse } from 'dotenv';
console.log(parse('A=1\n').A);                         // 1
console.log(typeof dotenv.parse(''), Object.keys(dotenv.parse('')).length);  // object 0
```

Compiles with **zero** deferred-site notices and exits 0 with the output above. Both the default-import (`dotenv.parse`) and named-import (`import { parse }`) forms route through the new row. Empty input returns `{}`, not `null`.

## Tests

Both are `#[cfg(test)]` unit tests in `src/`, so they run in the per-PR `cargo-test` gate (`--lib --bins`) rather than only in the nightly integration tier.

- `perry-api-manifest` — `dotenv_parse_is_registered`: asserts the symbol exists, is a static module method, and takes one `String` parameter.
- `perry-codegen` — `dotenv_parse_dispatches_to_native_impl_as_an_object`: asserts the dispatch row points at `js_dotenv_parse`, takes `NA_STR`, and returns `NR_OBJ_FROM_JSON_STR`.

`cargo test --lib -p perry-api-manifest` (35 passed) and `cargo test --lib -p perry-codegen` (515 passed) are green, as is `cargo test -p perry-codegen --test manifest_consistency` (the #512 drift gate that keeps the two tables in sync).

## Note on the version bump

This is one of three independent PRs I am opening off the same `main`. Each bumps `[workspace.package] version` to `0.5.1278` per the CLAUDE.md flow, so whichever lands second and third will need the version line rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dotenv.parse(src)` to parse dotenv-formatted text into an object.
  * Supports both default and named imports.
  * Handles empty input and deferred notices correctly.
* **Documentation**
  * Updated API documentation and reference listings to include `dotenv.parse`.
* **Chores**
  * Updated the project version to 0.5.1278.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->