### PR TITLE
fix(diagnostics): name the missing member (and the compilePackages fix) when a bundled npm shim is incomplete

### DIFF
--- a/changelog.d/7204-loud-shim-member-diagnostic.md
+++ b/changelog.d/7204-loud-shim-member-diagnostic.md
@@ -1,0 +1,43 @@
+### Fixed
+
+- **An unimplemented member of a bundled npm shim now names itself, and names
+  the fix.** When Perry serves a natively-shimmed npm package and the program
+  calls a member the shim doesn't implement, the #463 gate defers to a
+  throw-on-reach runtime error and records the site for the end-of-compile
+  notice. That notice printed only `unimplemented API   <file:line>` — neither
+  the module nor the member — so a reader had no way to tell what had gone
+  missing, and a caller that swallows the throw (a `try { … } catch {}` around
+  config loading, any defensive wrapper) made the notice the *only* evidence
+  the program was broken.
+
+  The case that motivated this: `lodash` is in `NATIVE_MODULES`, so Perry
+  serves it from `perry-stdlib`'s shim rather than the installed package, and
+  that shim implements arrays/strings/math but no object helpers at all — no
+  `omit`, `pick`, `get`, `set`, `has`, `merge`, `defaults`. Unlike a
+  `perry-ext-*` well-known binding it emits no "serving X from the bundled
+  native binding" note either, so nothing in the build said a substitution had
+  happened. Socket Firewall's `_.omit(headers, ['host'])` runs on every proxied
+  registry request.
+
+  `DeferredEvalSite` now carries `detail` (the dotted symbol) and `remedy` (the
+  actionable fix). The notice grows a symbol column, and both the notice and
+  the deferred runtime error carry the `perry.compilePackages` escape hatch:
+
+  ```
+    - unimplemented API   lodash.omit   app.ts:6   → deferred runtime error (throws only if reached)
+    `lodash` is served by Perry's bundled native shim, which implements only part of the
+    package's API. To compile the real npm source instead, add it to `perry.compilePackages`
+    in package.json: { "perry": { "compilePackages": ["lodash"] } }
+  ```
+
+  The remedy is offered only where it can actually be taken: Node builtins
+  (`fs.bogus`, `node:fs.bogus`, `process.binding`), Perry-owned surfaces
+  (`perry/gc.notReal`), deeper namespaces (`crypto.subtle.digest`), and
+  unshimmed modules get the named symbol but no `compilePackages` line, since
+  there is no npm source to compile instead. Multiple missing members of the
+  same package share one remedy block.
+
+  No change to what compiles. Covered by
+  `shimmed_npm_member_carries_the_compile_packages_remedy` and
+  `remedy_is_scoped_to_bundled_npm_shims` (both `src/` unit tests, so they run
+  in the per-PR `cargo-test` gate).

--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -397,6 +397,20 @@ pub struct DeferredEvalSite {
     pub kind: String,
     /// `file:line` of the site.
     pub location: String,
+    /// What, specifically, was degraded — for an unimplemented-API site the
+    /// dotted symbol (`lodash.omit`). `None` for surfaces where the kind
+    /// label already says everything there is to say (`eval(...)`).
+    ///
+    /// Without this the notice read `unimplemented API   src/app.ts:3`, which
+    /// names neither the module nor the member. A user whose build printed
+    /// that line had no way to tell which call went missing short of running
+    /// the program and reaching the throw — and a caller that swallows the
+    /// throw never even gets that.
+    pub detail: Option<String>,
+    /// A concrete, copy-pasteable fix for this site, when one exists. Today
+    /// this is the `perry.compilePackages` escape hatch for a member Perry's
+    /// bundled npm shim doesn't implement.
+    pub remedy: Option<String>,
 }
 
 /// Set strict-eval mode for the current compile thread. `true` restores the
@@ -456,8 +470,65 @@ pub fn location_string(source_file_path: &str, byte_offset: u32) -> String {
 /// Build the descriptive message a *deferred* unimplemented-API site throws at
 /// runtime when it is actually reached (#5245). `api` is the dotted display
 /// label (e.g. `process.binding`); `location` is `file:line`.
+///
+/// When `api` names a member of a *bundled npm shim* the message also carries
+/// the fix, because in that case the missing member is not a Perry-wide
+/// limitation the user has to wait on — the real package is one
+/// `perry.compilePackages` entry away. See [`shimmed_package_remedy`].
 pub fn unimplemented_runtime_error_message(api: &str, location: &str) -> String {
-    format!("{api} is not implemented in Perry (ahead-of-time) ({location})")
+    let base = format!("{api} is not implemented in Perry (ahead-of-time) ({location})");
+    match shimmed_package_remedy(api) {
+        Some(remedy) => format!("{base}. {remedy}"),
+        None => base,
+    }
+}
+
+/// The npm package name behind a dotted API label, when that label names a
+/// member of a package Perry serves from a **bundled native shim**.
+///
+/// Returns `None` for Node builtins (`fs.cp` — there is no npm source to
+/// compile instead), for Perry-owned modules (`perry/gc`), and for anything
+/// that isn't in `NATIVE_MODULES`.
+///
+/// The module is the label minus its last dotted segment, so `lodash.omit` →
+/// `lodash` and `decimal.js.foo` → `decimal.js`. A deeper label like
+/// `crypto.subtle.digest` yields `crypto.subtle`, which is not a native module
+/// name, so it correctly falls through to `None`.
+pub fn shimmed_package_module(api: &str) -> Option<&str> {
+    let (module, _member) = api.rsplit_once('.')?;
+    // The gate sites pass whichever spelling the user imported, so normalize
+    // before the builtin check — `is_node_builtin_module` expects a stripped
+    // name and `node:fs.bogus` would otherwise sail past it.
+    let module = module.strip_prefix("node:").unwrap_or(module);
+    if crate::ir::is_node_builtin_module(module) {
+        return None;
+    }
+    // Perry-owned surfaces (`perry`, `perry/thread`, `perry/gc`) have no npm
+    // package behind them — pointing at `compilePackages` would be nonsense.
+    if module == "perry" || module.starts_with("perry/") {
+        return None;
+    }
+    crate::ir::is_native_module(module).then_some(module)
+}
+
+/// The `perry.compilePackages` remedy sentence for an unimplemented member of
+/// a bundled npm shim, or `None` when no such remedy applies.
+///
+/// This is the actionable half of the #463 diagnostic. Perry decides on the
+/// user's behalf to serve a natively-shimmed npm package from its own partial
+/// implementation instead of the installed source; when that implementation is
+/// missing the member the program actually calls, the resulting failure is a
+/// consequence of *Perry's* substitution, and the user can undo it. Saying so
+/// at the point of failure is the difference between a 30-second fix and an
+/// afternoon.
+pub fn shimmed_package_remedy(api: &str) -> Option<String> {
+    let module = shimmed_package_module(api)?;
+    Some(format!(
+        "`{module}` is served by Perry's bundled native shim, which implements only part of \
+         the package's API. To compile the real npm source instead, add it to \
+         `perry.compilePackages` in package.json: {{ \"perry\": {{ \"compilePackages\": \
+         [\"{module}\"] }} }}"
+    ))
 }
 
 /// The single decision point every unimplemented-API gate (#463 sites in
@@ -496,9 +567,23 @@ pub fn check_unimplemented_api(
     }
 
     // Default (defer) mode or the `PERRY_ALLOW_UNIMPLEMENTED` override: record
-    // the site for the visible end-of-compile notice and defer.
-    record_deferred_aot_site(UNIMPLEMENTED_API_KIND, location);
+    // the site for the visible end-of-compile notice and defer. The API name
+    // and the shim remedy ride along so the notice can name what broke and
+    // how to fix it — pre-#7204 it printed only `unimplemented API <file:line>`.
+    record_deferred_unimplemented_api(location, api);
     UnimplementedDecision::DeferToRuntimeError(runtime_msg)
+}
+
+/// Record an unimplemented-API site with the detail the notice needs to be
+/// actionable: the dotted symbol, and the `perry.compilePackages` remedy when
+/// the module is a bundled npm shim.
+pub fn record_deferred_unimplemented_api(location: impl Into<String>, api: &str) {
+    push_deferred_site(DeferredEvalSite {
+        kind: UNIMPLEMENTED_API_KIND.to_string(),
+        location: location.into(),
+        detail: Some(api.to_string()),
+        remedy: shimmed_package_remedy(api),
+    });
 }
 
 /// Record a deferred ahead-of-time-unsupported site for the end-of-compile
@@ -509,10 +594,19 @@ pub fn check_unimplemented_api(
 /// `kind` is the display label of the surface (e.g. `import(...)`); `location`
 /// is `file:line`.
 pub fn record_deferred_aot_site(kind: impl Into<String>, location: impl Into<String>) {
-    let site = DeferredEvalSite {
+    push_deferred_site(DeferredEvalSite {
         kind: kind.into(),
         location: location.into(),
-    };
+        detail: None,
+        remedy: None,
+    });
+}
+
+/// Shared idempotent insert for every `record_deferred_*` entry point.
+/// `detail`/`remedy` are a deterministic function of `(kind, location)`, so
+/// full-struct equality dedupes exactly as the historical `(kind, location)`
+/// comparison did.
+fn push_deferred_site(site: DeferredEvalSite) {
     if let Ok(mut v) = EVAL_DEFERRED_SITES.lock() {
         if !v.contains(&site) {
             v.push(site);
@@ -942,6 +1036,95 @@ mod tests {
         let mine: Vec<_> = sites.iter().filter(|s| s.location == loc).collect();
         assert_eq!(mine.len(), 1, "exactly one recorded site for {loc}");
         assert_eq!(mine[0].kind, UNIMPLEMENTED_API_KIND);
+        // #7204: the recorded site must name the symbol. The notice used to
+        // print only `unimplemented API   <file:line>`, which told a reader
+        // nothing about what had gone missing.
+        assert_eq!(mine[0].detail.as_deref(), Some("process.binding"));
+    }
+
+    /// A member of a **bundled npm shim** carries the `perry.compilePackages`
+    /// remedy — in the recorded notice site AND in the message the deferred
+    /// site throws.
+    ///
+    /// This is the actionable half of #7204. `lodash` is in `NATIVE_MODULES`,
+    /// so Perry serves it from its own partial shim instead of the installed
+    /// package; when the shim is missing the member the program calls, the
+    /// user's fix is one `compilePackages` entry, and nothing in the old
+    /// diagnostic said so. `_.omit(headers, ['host'])` — a real Socket
+    /// Firewall call on every proxied request — is exactly this shape.
+    #[test]
+    fn shimmed_npm_member_carries_the_compile_packages_remedy() {
+        let _sink_guard = lock_eval_sink();
+        set_unimplemented_strict_mode(false);
+        let loc = "/app/shim_remedy_fixture.ts:3";
+        let decision = check_unimplemented_api(
+            "`lodash.omit` is not implemented (#463)",
+            "lodash.omit",
+            loc,
+            0,
+        );
+        match decision {
+            UnimplementedDecision::DeferToRuntimeError(msg) => {
+                assert!(msg.contains("lodash.omit"), "msg: {msg}");
+                assert!(msg.contains("perry.compilePackages"), "msg: {msg}");
+                assert!(msg.contains("bundled native shim"), "msg: {msg}");
+            }
+            other => panic!("expected defer, got {other:?}"),
+        }
+        let sites = take_deferred_eval_sites();
+        let mine: Vec<_> = sites.iter().filter(|s| s.location == loc).collect();
+        assert_eq!(mine.len(), 1, "exactly one recorded site for {loc}");
+        assert_eq!(mine[0].detail.as_deref(), Some("lodash.omit"));
+        let remedy = mine[0]
+            .remedy
+            .as_deref()
+            .expect("a shimmed npm member must carry a remedy");
+        assert!(remedy.contains("compilePackages"), "remedy: {remedy}");
+        assert!(remedy.contains("\"lodash\""), "remedy: {remedy}");
+    }
+
+    /// The remedy applies to bundled npm shims ONLY.
+    ///
+    /// A Node builtin has no npm source to compile instead, and neither does a
+    /// Perry-owned module, so suggesting `compilePackages` for either would
+    /// send the user chasing a fix that cannot exist. Deep labels
+    /// (`crypto.subtle.digest`) resolve to a module name that isn't in
+    /// `NATIVE_MODULES` and fall through the same way.
+    #[test]
+    fn remedy_is_scoped_to_bundled_npm_shims() {
+        assert_eq!(shimmed_package_module("lodash.omit"), Some("lodash"));
+        assert_eq!(
+            shimmed_package_module("dayjs.businessDaysAdd"),
+            Some("dayjs")
+        );
+
+        for api in [
+            // Node builtins — nothing to compile from npm.
+            "fs.bogus",
+            "process.binding",
+            "crypto.hmacSha256",
+            // `node:`-prefixed spelling of the same.
+            "node:fs.bogus",
+            // Perry-owned surfaces.
+            "perry.notReal",
+            "perry/gc.notReal",
+            // Deeper namespaces, and modules Perry doesn't shim at all.
+            "crypto.subtle.digest",
+            "some-random-package.thing",
+            // No dot at all.
+            "bareword",
+        ] {
+            assert_eq!(
+                shimmed_package_module(api),
+                None,
+                "{api} must not offer a compilePackages remedy"
+            );
+            assert_eq!(shimmed_package_remedy(api), None, "{api}");
+            assert!(
+                !unimplemented_runtime_error_message(api, "f.ts:1").contains("compilePackages"),
+                "{api}"
+            );
+        }
     }
 
     /// Strict-unimplemented mode: an unimplemented-API site is refused (the

--- a/crates/perry/src/commands/compile/helpers.rs
+++ b/crates/perry/src/commands/compile/helpers.rs
@@ -215,19 +215,46 @@ pub(crate) fn print_deferred_eval_notice(format: OutputFormat) {
     // error that throws only if reached.
     let kind_width = sites.iter().map(|s| s.kind.len()).max().unwrap_or(0);
     let loc_width = sites.iter().map(|s| s.location.len()).max().unwrap_or(0);
+    // #7204: the symbol column. An `unimplemented API` line used to name only
+    // a file and a line number, so a shimmed-module member that silently went
+    // missing (`lodash.omit`, served by Perry's partial lodash shim) produced
+    // a notice a reader could not act on — and if the call site swallowed the
+    // deferred throw, the notice was the ONLY evidence the program was broken.
+    let detail_width = sites
+        .iter()
+        .filter_map(|s| s.detail.as_ref())
+        .map(|d| d.len())
+        .max()
+        .unwrap_or(0);
     for s in &sites {
         let disposition = if s.kind.contains("eval") || s.kind.contains("Function") {
             "runtime interpreter (#6559)"
         } else {
             "deferred runtime error (throws only if reached)"
         };
+        let detail = s.detail.as_deref().unwrap_or("");
         eprintln!(
-            "  - {:<kw$}   {:<lw$}   → {disposition}",
+            "  - {:<kw$}   {:<dw$}   {:<lw$}   → {disposition}",
             s.kind,
+            detail,
             s.location,
             kw = kind_width,
+            dw = detail_width,
             lw = loc_width,
         );
+    }
+    // One remedy block per distinct package, not per site — a program calling
+    // four missing lodash helpers needs the `compilePackages` line once.
+    let mut shown: Vec<&str> = Vec::new();
+    for s in &sites {
+        let Some(remedy) = s.remedy.as_deref() else {
+            continue;
+        };
+        if shown.contains(&remedy) {
+            continue;
+        }
+        shown.push(remedy);
+        eprintln!("  {y}{remedy}{r}");
     }
     eprintln!(
         "  Pass {b}--strict-eval{r}/{b}--strict-dynamic-import{r} (or set {b}perry.strict = true{r}) to make these a compile-time error instead."


### PR DESCRIPTION
## Problem

When Perry serves a natively-shimmed npm package and the program calls a member the shim doesn't implement, the failure is close to invisible.

`lodash` is in `NATIVE_MODULES`, so Perry serves it from `crates/perry-stdlib/src/lodash.rs` instead of the installed package — and that shim implements arrays, strings and math but **no object helpers at all**: no `omit`, `pick`, `get`, `set`, `has`, `merge`, `defaults`. Unlike a `perry-ext-*` well-known binding, lodash produces no "serving X from the bundled native binding" note, so nothing in the build says a substitution happened.

Here is what a user saw before this PR:

```console
$ perry app.ts -o app        # exit 0
notice: 2 ahead-of-time-unsupported sites handled at runtime:
  - unimplemented API   app.ts:6    → deferred runtime error (throws only if reached)
  - unimplemented API   app.ts:7    → deferred runtime error (throws only if reached)
```

That notice names **neither the module nor the member**. It says two things somewhere in the program are degraded and leaves the reader to find them. And if the call site swallows the throw — a `try { … } catch {}` around config loading, a defensive wrapper — the notice is the *only* evidence the program is broken at all.

This is not hypothetical. Socket Firewall's `_.omit(headers, ['host'])` runs on every proxied registry request, and the round of debugging that produced this PR was spent on exactly this diagnostic gap.

## Fix

Make the diagnostic name the thing and name the fix. Two small changes, no behavior change to what compiles.

**1. The recorded site carries what broke.** `DeferredEvalSite` gains `detail` (the dotted symbol) and `remedy` (the actionable fix). The notice grows a symbol column:

```console
notice: 3 ahead-of-time-unsupported sites handled at runtime:
  - unimplemented API   fs.notARealFsFunction   shim.ts:11   → deferred runtime error (throws only if reached)
  - unimplemented API   lodash.omit             shim.ts:6    → deferred runtime error (throws only if reached)
  - unimplemented API   lodash.pick             shim.ts:7    → deferred runtime error (throws only if reached)
  `lodash` is served by Perry's bundled native shim, which implements only part of the package's API. To compile the real npm source instead, add it to `perry.compilePackages` in package.json: { "perry": { "compilePackages": ["lodash"] } }
  Pass --strict-eval/--strict-dynamic-import (or set perry.strict = true) to make these a compile-time error instead.
```

**2. The deferred throw carries the same fix**, so a user who only sees the runtime error still gets it:

```
Error: lodash.omit is not implemented in Perry (ahead-of-time) (app.ts:6). `lodash` is served by
Perry's bundled native shim, which implements only part of the package's API. To compile the real
npm source instead, add it to `perry.compilePackages` in package.json:
{ "perry": { "compilePackages": ["lodash"] } }
```

### Scoping — where the remedy does and does not apply

The `compilePackages` suggestion is offered **only** for bundled npm shims, because only there does a real npm source exist to compile instead. `shimmed_package_module` returns `None` for:

- Node builtins (`fs.bogus`, `process.binding`, `crypto.hmacSha256`), in either spelling — `node:fs.bogus` normalizes first, which a test caught;
- Perry-owned surfaces (`perry.notReal`, `perry/gc.notReal`);
- deeper namespaces (`crypto.subtle.digest`) and modules Perry doesn't shim.

Note in the sample above that `fs.notARealFsFunction` is named but gets no remedy line, while the two lodash sites share **one** remedy block rather than repeating it per site.

## Tests

`#[cfg(test)]` unit tests in `src/`, so they run in the per-PR `cargo-test` gate (`--lib --bins`), not only the nightly integration tier.

- `shimmed_npm_member_carries_the_compile_packages_remedy` — the deferred message and the recorded site both name `lodash.omit` and carry the remedy.
- `remedy_is_scoped_to_bundled_npm_shims` — a table of nine labels that must **not** offer a remedy.
- `unimplemented_defers_by_default_and_records_site` — extended to assert `detail` is populated.

`cargo test --lib -p perry-hir` (271 passed) and `cargo test --bins -p perry` (880 passed) are green. Clippy is clean on both touched files.

## What this PR is not

This is the diagnostic half of the problem. Two follow-ups I did **not** do here, deliberately:

**Implementing the lodash object helpers.** `omit`/`pick`/`merge`/`defaults`/`get`/`set`/`has` in the native shim is the real fix for lodash specifically, and it is a substantially bigger change (lodash's `omit`/`pick`/`get`/`set` all take path arguments — `'a.b[0].c'` — so a faithful port needs `stringToPath` plus `baseGet`/`baseSet`/`baseUnset`, and a half-path implementation would be worse than none). Worth its own PR.

**Refusing at compile time instead of deferring.** I think there is a good argument that an unimplemented member of a *bundled npm shim* should be a hard `#463` error rather than a deferred throw: the defer policy exists because a site may be tree-shaken away, but here Perry chose the substitution on the user's behalf and the user can undo it in one line. Node builtins would keep deferring — there is no alternative source for them.

I stopped short of that flip because I could not measure its blast radius in this session. It would turn every previously-compiling program that touches any unimplemented shim member into a build failure, and validating that needs the gap suite, the parity suite, and the integration tier. Landing an unvalidated default flip is how the repo has been bitten before. Happy to open it as a follow-up if maintainers want it — this PR makes the deferred case legible either way, and it is a strictly smaller step in the same direction.

## Note on the version bump

One of several independent PRs off the same `main`; each bumps `[workspace.package] version` to `0.5.1278`, so whichever lands later needs the version line rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for unimplemented members in bundled npm shims.
  * Error messages now identify the affected module and member.
  * Added actionable guidance to compile the full package when applicable.
  * End-of-compile notices now present details and recommendations more clearly, while avoiding irrelevant guidance for unsupported modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->