### PR TITLE
docs(changelog): note the index_get.rs growth in the #7206 fragment

### DIFF
--- a/changelog.d/7206-stale-receiver-registers.md
+++ b/changelog.d/7206-stale-receiver-registers.md
@@ -106,3 +106,10 @@
   must report 2 uses and still exit `0`, `--max-stale 0` must exit `1`,
   `--max-stale 2` must exit `0`, and the control fixture must report zero.
   Reverting the default to `return 1 if total else 0` fails three of them.
+
+**File-size note.** `crates/perry-codegen/src/expr/index_get.rs` grew by 27 lines
+(2135 → 2162) to carry the receiver rooting. It was already 135 lines over the
+2000-line cap and unallowlisted before this change, and it is one of 16 files
+currently failing `scripts/check_file_size.sh` on `main` — so this neither
+introduced a new offender nor is it fixable by an allowlist entry. Decomposing
+that file is its own change.


### PR DESCRIPTION
`#7206`'s receiver rooting made a file that was already too big 27 lines bigger, and nothing recorded it. This adds a sentence to that PR's changelog fragment so the growth is attributable later.

`crates/perry-codegen/src/expr/index_get.rs` went from 2135 to 2162 lines. The cap is 2000.

<details>
<summary><b>Why this is a note and not a fix</b></summary>

The file was already 135 lines over the cap and unallowlisted before `#7206` existed, so this did not create the problem — it made an existing one slightly worse.

An allowlist entry would not help either. `scripts/check_file_size.sh` currently fails on `main` for **16** files, and `index_get.rs` is one of them; allowlisting a single file leaves the gate exactly as red as before. Actually decomposing the file is a real change with its own review surface, and folding it into a GC-rooting PR would have been the wrong call.

So the honest outcome is a record rather than a repair: when someone does split that file, the 27 lines have a name attached.

</details>

<details>
<summary><b>Validation</b></summary>

**Ran:** nothing to run — this edits one markdown file in `changelog.d/`.

**Verified:** the fragment is still unreleased (`changelog.d/7206-stale-receiver-registers.md` is present on `main`), so appending to it is the normal way to amend it before it folds into release notes at tag time.

**Note:** the file-size gate and `lint` are both red on `main` for unrelated pre-existing reasons. This PR does not change either.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog note documenting a file-size guideline exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->