### PR TITLE
fix(gc): a Symbol-typed local is a GC-heap reference, and gets a shadow slot (#7236)

### DIFF
--- a/.github/workflows/gc-root-dominance.yml
+++ b/.github/workflows/gc-root-dominance.yml
@@ -28,9 +28,17 @@ name: GC Root Dominance
 #      corollary in CLAUDE.md warns about.
 #
 #      **ACTION REQUIRED, and it is not something this workflow can do to
-#      itself**: with the allowlist below the job is green on `main`, so a
-#      repo admin must add `gc-root-dominance` to branch protection's required
-#      contexts. Until that happens this file is documentation, not a gate.
+#      itself**: a repo admin must add `gc-root-dominance` to branch
+#      protection's required contexts. Until that happens this file is
+#      documentation, not a gate.
+#
+#      Both conditions #7198 named are met as of #7236: the dominance check is
+#      green with an EMPTY allowlist, and `--unrooted-allocas --moving-only` --
+#      which was 98 before #7235 and 2 after -- now reads 0 and is a step
+#      below. Promote after this job's first green run on `main` WITH that
+#      step, not before: a gate that has never been green in its current shape
+#      blocks every open PR the day it becomes required, which is the corollary
+#      that produced this whole paragraph.
 #      See docs/src/internals/gc-rooting-invariant.md, "Promoting this gate".
 #   3. `concurrency` cancels pull-request runs only, never `main` runs;
 #   4. the subject is ASSERTED live, not assumed, at three levels.
@@ -179,6 +187,38 @@ jobs:
             --min-files 90 --min-binds 1500 --min-funcs 1200 \
             --allowlist scripts/gc_root_dominance_allowlist.json \
             --seeded-violations 40 \
+            -v
+
+      # ★ The OTHER mode, and until #7236 it had never been at zero.
+      #
+      # `--unrooted-allocas` asks a different question from the step above: not
+      # "is the root store late" but "is there a root store AT ALL". #7235 split
+      # its heap-source predicate by movability and got the count from 98 to 2,
+      # and both residuals were one bug -- `Type::Symbol` classified as an
+      # immediate, so a `Symbol` local got no shadow slot. That is now fixed and
+      # the corpus reads 0, which is the condition #7198 named for promoting
+      # this job to a required context.
+      #
+      # A number that is the acceptance criterion for a promotion and is checked
+      # by nothing will regress silently -- CLAUDE.md hazard 4, applied to the
+      # measurement rather than to the job. So it is a step. It shares the
+      # corpus, the exemptions and the allowlist file with the step above, and
+      # carries the same liveness floors: "0 violations" over a corpus that did
+      # not compile means nothing.
+      #
+      # If this arm ever goes red for a hazard that is real but deliberately
+      # deferred, the answer is an entry in gc_root_dominance_allowlist.json
+      # with an issue number, NOT deleting the step -- rule 1 in that file
+      # (an entry matching nothing fails the build) is what makes the tolerance
+      # temporary.
+      - name: Check that every GC value in an alloca has a root store
+        run: |
+          set -euo pipefail
+          python3 scripts/gc_root_dominance_check.py ir-corpus \
+            --unrooted-allocas \
+            --moving-only \
+            --min-files 90 --min-binds 1500 --min-funcs 1200 \
+            --allowlist scripts/gc_root_dominance_allowlist.json \
             -v
 
       - name: Upload the IR corpus on failure

--- a/changelog.d/7243-symbol-local-shadow-slot.md
+++ b/changelog.d/7243-symbol-local-shadow-slot.md
@@ -1,0 +1,59 @@
+Fixed `collectors/pointer_locals.rs` classifying **`Type::Symbol` as a
+non-pointer**, so a `Symbol`-typed local got no shadow-stack slot and lived in a
+plain `alloca` — invisible to the precise root walk (#7236). `alloc_symbol` is
+`gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)` and `js_symbol_new`
+returns it `POINTER_TAG`-boxed; nothing else holds a fresh symbol, so the malloc
+sweep inside the copying minor frees one that is still live.
+
+**The drift had already happened, one variant wide, inside one crate.**
+`typed_shape::type_is_pointer_bearing` — an exhaustive match, and the function
+that lays out the GC's own inline-field pointer masks — already answered `true`
+for `Symbol` while `is_definitely_non_pointer_type` answered "non-pointer", so a
+`Symbol` local was simultaneously not-a-pointer (no slot) and pointer-bearing
+(scanned as one). That is verbatim what the doc comment over
+`is_definitely_non_pointer_type` predicted would cost a use-after-move. There
+was a third copy in `expr/shadow_slot.rs` carrying the same entry — a separate
+hazard, since a `true` there suppresses `temp_root`'s protection of a symbol
+operand held across an allocating call — and a fourth in
+`lower_call/closure_analysis.rs` that correctly did not. All three now route to
+one exhaustive definition, so a new `Type` variant is a compile error rather
+than a silent "not a pointer". The full 21-variant audit found `Symbol` to be
+the only misclassification; the other six non-pointers are NaN-boxed immediates
+with no allocator.
+
+**The failure is a premature FREE, not a stale address**, and the correction
+matters because it dictates the witness. `gc_malloc` is the SYSTEM allocator
+with a `GcHeader` in front, not an arena allocation, so the copying minor cannot
+relocate a symbol — under #7235's taxonomy a `Symbol` local is RECLAIMABLE and
+not MOVABLE (#7230's class, not #7019's). `SYMBOL_POINTERS` does not save it
+either: `scan_symbol_pointer_metadata_roots_mut` uses
+`visit_metadata_usize_slot`, which rewrites without marking, exactly as
+`alloc_symbol`'s own comment says ("kept alive … or **not at all**"). Two
+consequences are baked into the new witness: the pressure must be **symbols**,
+because `copied_minor_malloc_sweep_due` gates the malloc sweep on a
+`MallocCount` trigger while object churn reaches the *arena* trigger (object
+churn reproduced 1 failure in 80 probes, and 0 on four of five repeats of
+another shape); and identity probes report nothing, because `js_symbol_equals`
+falls back to comparing `id` off the freed header and `js_is_symbol` to reading
+`magic`.
+
+New witness `test-files/test_gap_gc_symbol_local_rooting.ts`, registered in
+`test-parity/gc_repsel_corpus.txt`: `A 30 B 20` at `f8f1e7188` on the
+`loop_polls` arm (3/3 identical) **and on the shipped default** (2/2), `A 0 B 0`
+after, byte-exact against node 26.5.1.
+
+`gc_root_dominance_check.py --unrooted-allocas --moving-only` over a freshly
+generated 118-source / 136-module corpus: **4 → 0** (the two #7236 hits in
+`test_gap_class_forward_capture_6523` plus the new witness's two). That was 98
+before #7235 and 2 after, and 0 is the condition #7198 named for promoting
+`gc-root-dominance` to a required context. **The mode is now a step in that
+job** rather than a number living in issue bodies — verified able to fail (exit
+1 at `f8f1e7188`, exit 0 after) and sharing the corpus, exemptions, allowlist
+and liveness floors with the existing dominance step. The promotion itself
+remains a repo-admin action; `docs/src/internals/gc-rooting-invariant.md` now
+carries the exact steps.
+
+The representation-selection promotion census
+(`compiler_output_regression.py census --gate`) is **byte-identical** across all
+18 workloads before and after, so no promotion floor moved and no ratchet was
+taken.

--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -184,26 +184,23 @@ impl HirTypeFacts for PointerAnalysisFacts<'_> {
 /// Types that can NEVER hold a heap pointer, and therefore cost a local its
 /// shadow-stack slot in [`collect_pointer_typed_locals`].
 ///
-/// **This is the single definition.** It used to be a nested `fn` inside
-/// `collect_pointer_typed_locals`; it is module-level and `pub(crate)` because
-/// anything that decides a value may be treated as a rooted pointer has to
-/// agree with the pass that actually assigns the root slot. A second copy
-/// drifting by one `Type` variant would mean a value this collector left
-/// unrooted while another pass treated it as a live, movable pointer — a
-/// use-after-move under the evacuating minor (#7019), not a cosmetic
-/// inconsistency. `collectors/ptr_shape_returns.rs` (#7034 §4) is the current
-/// second caller.
+/// **Exactly the negation of [`crate::typed_shape::type_is_pointer_bearing`],
+/// by construction rather than by review.** This used to be a second hand-
+/// maintained `matches!` list, and it had already drifted from that one by a
+/// single variant: `Type::Symbol`. `typed_shape` said pointer (correctly —
+/// `js_symbol_new` NaN-boxes a movable `gc_malloc`), this said non-pointer, so
+/// a `Symbol`-typed local got no shadow-stack slot and sat in a plain `alloca`
+/// across every collection point in its scope (#7236). That is precisely the
+/// failure the previous comment here predicted: "a second copy drifting by one
+/// `Type` variant … a use-after-move under the evacuating minor (#7019), not a
+/// cosmetic inconsistency."
+///
+/// So there is now one copy, it is exhaustive, and a new `Type` variant is a
+/// compile error over there instead of a silent "not a pointer" here.
+/// `collectors/ptr_shape_returns.rs` (#7034 §4) is the second caller of this
+/// negation and inherits the answer.
 pub(crate) fn is_definitely_non_pointer_type(ty: &Type) -> bool {
-    matches!(
-        ty,
-        Type::Number
-            | Type::Int32
-            | Type::Boolean
-            | Type::Null
-            | Type::Void
-            | Type::Never
-            | Type::Symbol
-    ) || matches!(ty, Type::Union(variants) if variants.iter().all(is_definitely_non_pointer_type))
+    !crate::typed_shape::type_is_pointer_bearing(ty)
 }
 
 pub fn collect_pointer_typed_locals(
@@ -212,39 +209,18 @@ pub fn collect_pointer_typed_locals(
     flat_const_ids: &HashSet<u32>,
 ) -> std::collections::HashMap<u32, u32> {
     use perry_hir::Stmt;
+    /// Does this local need a shadow-stack slot?
+    ///
+    /// The third copy of the pointer question, now routed to the one
+    /// definition (#7236). It was the exact complement of
+    /// [`is_definitely_non_pointer_type`] over every `Type` variant *except*
+    /// `Symbol`, which neither of them claimed — so a `Symbol` local was
+    /// simultaneously "not a pointer" (no slot here) and "pointer-bearing"
+    /// (`typed_shape`, which lays out the GC's own field masks). The
+    /// per-variant rationale that used to live here moved to
+    /// `type_is_pointer_bearing`'s doc comment with it.
     fn is_ptr_typed(ty: &Type) -> bool {
-        matches!(
-            ty,
-            Type::String
-                // A string-LITERAL type (`"foo"`, or a `"a" | "b"` discriminant
-                // union member) is a heap String at runtime — it needs a root
-                // slot exactly like `Type::String`, or the moving-GC precise scan
-                // reaps a live string → silent corruption.
-                | Type::StringLiteral(_)
-                | Type::Array(_)
-                | Type::Tuple(_)
-                | Type::Object(_)
-                | Type::Named(_)
-                // An unresolved generic type parameter (`T`) can bind to any
-                // heap type; treat it as a pointer (fail-safe).
-                | Type::TypeVar(_)
-                | Type::Promise(_)
-                | Type::Function(_)
-                // A generic instantiation (`Map<K,V>`, `Set<T>`, `WeakMap`,
-                // `Box<T>`, `Array<T>`, a user generic class, …) is always a
-                // heap-reference type. Without this, a `Map`/`Set`-typed local
-                // got NO shadow-stack slot, so the PRECISE moving-GC root scan
-                // never saw it — the object was reaped as dead while still live
-                // (crash: "grown Map must retain its side-allocation owner
-                // record"). The non-moving default GC hid this via its
-                // conservative C-stack scan. Treating a rare non-pointer generic
-                // value as a root is harmless: the GC decode rejects any slot
-                // value that isn't a live heap pointer.
-                | Type::Generic { .. }
-                | Type::BigInt
-                | Type::Any
-                | Type::Unknown
-        ) || matches!(ty, Type::Union(variants) if variants.iter().any(is_ptr_typed))
+        crate::typed_shape::type_is_pointer_bearing(ty)
     }
 
     fn expr_value_type(
@@ -1164,5 +1140,122 @@ mod tests {
         let slots = collect_pointer_typed_locals(&[], &stmts, &HashSet::new());
         assert!(!slots.contains_key(&1));
         assert!(slots.contains_key(&2));
+    }
+
+    /// Every `Type` variant, with the answer pinned.
+    ///
+    /// #7236: `is_definitely_non_pointer_type` and `typed_shape`'s
+    /// `type_is_pointer_bearing` are two names for one question, and they had
+    /// drifted by exactly one variant — `Symbol` — which is how a
+    /// `POINTER_TAG`-boxed, `gc_malloc`'d, MOVABLE object came to be classified
+    /// as an immediate. They are now the same function, so this test is about
+    /// the ANSWERS: it enumerates the enum and fails if any classification
+    /// flips. `type_is_pointer_bearing`'s exhaustive `match` covers the other
+    /// half (a new variant is a compile error, not a silent "non-pointer").
+    #[test]
+    fn every_type_variant_has_its_pointer_classification_pinned() {
+        // The six immediates: a raw f64, INT32_TAG, TAG_TRUE/TAG_FALSE,
+        // TAG_NULL, TAG_UNDEFINED, and the uninhabited type. No allocator
+        // produces any of them, so there is nothing for the collector to see.
+        let non_pointers = [
+            Type::Number,
+            Type::Int32,
+            Type::Boolean,
+            Type::Null,
+            Type::Void,
+            Type::Never,
+        ];
+        // Everything else is, or can be, a heap reference. `Symbol` is in this
+        // list and not the one above: that IS #7236.
+        let pointers = [
+            Type::Symbol,
+            Type::String,
+            Type::StringLiteral("foo".to_string()),
+            Type::BigInt,
+            Type::Array(Box::new(Type::Number)),
+            Type::Tuple(vec![Type::Number]),
+            Type::Object(Default::default()),
+            Type::Function(FunctionType {
+                params: Vec::new(),
+                return_type: Box::new(Type::Any),
+                is_async: false,
+                is_generator: false,
+            }),
+            Type::Promise(Box::new(Type::Number)),
+            Type::Named("C".to_string()),
+            Type::Generic {
+                base: "Map".to_string(),
+                type_args: vec![Type::String, Type::Number],
+            },
+            Type::TypeVar("T".to_string()),
+            Type::Any,
+            Type::Unknown,
+        ];
+        for ty in &non_pointers {
+            assert!(
+                is_definitely_non_pointer_type(ty),
+                "{ty:?} must be a non-pointer"
+            );
+            assert!(!crate::typed_shape::type_is_pointer_bearing(ty));
+        }
+        for ty in &pointers {
+            assert!(
+                !is_definitely_non_pointer_type(ty),
+                "{ty:?} must be pointer-possible — a local of this type needs a \
+                 shadow-stack slot or the precise moving-GC root scan cannot see it"
+            );
+            assert!(crate::typed_shape::type_is_pointer_bearing(ty));
+        }
+        // A union is a non-pointer only when EVERY member is.
+        assert!(is_definitely_non_pointer_type(&Type::Union(vec![
+            Type::Number,
+            Type::Boolean
+        ])));
+        assert!(!is_definitely_non_pointer_type(&Type::Union(vec![
+            Type::Number,
+            Type::Symbol
+        ])));
+    }
+
+    /// #7236's reproducer, at the collector: `const s = Symbol("x")` must get a
+    /// slot. `alloc_symbol` is `gc_malloc(_, GC_TYPE_STRING)` and
+    /// `GC_TYPE_STRING` is `movable: true`, so without a slot the local sits in
+    /// a plain `alloca` across every collection point in its scope — exactly
+    /// what `gc_root_dominance_check.py --unrooted-allocas --moving-only`
+    /// reported twice on `test_gap_class_forward_capture_6523`.
+    #[test]
+    fn a_symbol_typed_local_gets_a_shadow_slot() {
+        let stmts = vec![Stmt::Let {
+            id: 1,
+            name: "s".to_string(),
+            ty: Type::Symbol,
+            mutable: false,
+            init: Some(Expr::SymbolNew(Some(Box::new(Expr::String(
+                "x".to_string(),
+            ))))),
+        }];
+        let slots = collect_pointer_typed_locals(&[], &stmts, &HashSet::new());
+        assert!(slots.contains_key(&1), "Symbol local must be shadow-rooted");
+    }
+
+    /// The other half, and the sharper one: the declared type is `any`, so the
+    /// slot survives only if the write-refinement fixpoint ALSO agrees that
+    /// `Symbol` is a pointer. `is_definitely_non_pointer_type` is what that
+    /// loop consults (`all_non_pointer`), so a fix applied to `is_ptr_typed`
+    /// alone would hand out the slot and then take it away again.
+    #[test]
+    fn an_inferred_symbol_local_keeps_its_shadow_slot() {
+        let stmts = vec![Stmt::Let {
+            id: 1,
+            name: "s".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::SymbolNew(None)),
+        }];
+        let slots = collect_pointer_typed_locals(&[], &stmts, &HashSet::new());
+        assert!(
+            slots.contains_key(&1),
+            "a local refined to Symbol must keep its shadow slot"
+        );
     }
 }

--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -188,12 +188,16 @@ impl HirTypeFacts for PointerAnalysisFacts<'_> {
 /// by construction rather than by review.** This used to be a second hand-
 /// maintained `matches!` list, and it had already drifted from that one by a
 /// single variant: `Type::Symbol`. `typed_shape` said pointer (correctly —
-/// `js_symbol_new` NaN-boxes a movable `gc_malloc`), this said non-pointer, so
-/// a `Symbol`-typed local got no shadow-stack slot and sat in a plain `alloca`
-/// across every collection point in its scope (#7236). That is precisely the
-/// failure the previous comment here predicted: "a second copy drifting by one
-/// `Type` variant … a use-after-move under the evacuating minor (#7019), not a
-/// cosmetic inconsistency."
+/// `js_symbol_new` NaN-boxes a `gc_malloc`'d `SymbolHeader` that a malloc
+/// sweep inside the copying minor frees when nothing marks it), this said
+/// non-pointer, so a `Symbol`-typed local got no shadow-stack slot and sat in a
+/// plain `alloca` across every collection point in its scope (#7236). That is
+/// precisely the failure the previous comment here predicted: "a second copy
+/// drifting by one `Type` variant … a use-after-move under the evacuating
+/// minor (#7019), not a cosmetic inconsistency." The realised failure turned
+/// out to be the sibling one — a premature free rather than a stale address,
+/// because `gc_malloc` is outside the arena — which is the distinction #7235
+/// drew between RECLAIMABLE and MOVABLE and the reason it drew it.
 ///
 /// So there is now one copy, it is exhaustive, and a new `Type` variant is a
 /// compile error over there instead of a silent "not a pointer" here.
@@ -1147,8 +1151,9 @@ mod tests {
     /// #7236: `is_definitely_non_pointer_type` and `typed_shape`'s
     /// `type_is_pointer_bearing` are two names for one question, and they had
     /// drifted by exactly one variant — `Symbol` — which is how a
-    /// `POINTER_TAG`-boxed, `gc_malloc`'d, MOVABLE object came to be classified
-    /// as an immediate. They are now the same function, so this test is about
+    /// `POINTER_TAG`-boxed, `gc_malloc`'d, collector-freed object came to be
+    /// classified as an immediate. They are now the same function, so this test
+    /// is about
     /// the ANSWERS: it enumerates the enum and fails if any classification
     /// flips. `type_is_pointer_bearing`'s exhaustive `match` covers the other
     /// half (a new variant is a compile error, not a silent "non-pointer").
@@ -1218,11 +1223,13 @@ mod tests {
     }
 
     /// #7236's reproducer, at the collector: `const s = Symbol("x")` must get a
-    /// slot. `alloc_symbol` is `gc_malloc(_, GC_TYPE_STRING)` and
-    /// `GC_TYPE_STRING` is `movable: true`, so without a slot the local sits in
-    /// a plain `alloca` across every collection point in its scope — exactly
-    /// what `gc_root_dominance_check.py --unrooted-allocas --moving-only`
-    /// reported twice on `test_gap_class_forward_capture_6523`.
+    /// slot. `alloc_symbol` is `gc_malloc(_, GC_TYPE_STRING)`, and a fresh
+    /// symbol is reachable from nothing else (`SYMBOL_POINTERS` is visited
+    /// metadata-only), so without a slot the local sits in a plain `alloca`
+    /// across every collection point in its scope and the malloc sweep inside
+    /// the copying minor frees it while it is live — exactly what
+    /// `gc_root_dominance_check.py --unrooted-allocas --moving-only` reported
+    /// twice on `test_gap_class_forward_capture_6523`.
     #[test]
     fn a_symbol_typed_local_gets_a_shadow_slot() {
         let stmts = vec![Stmt::Let {

--- a/crates/perry-codegen/src/expr/shadow_slot.rs
+++ b/crates/perry-codegen/src/expr/shadow_slot.rs
@@ -44,19 +44,28 @@ pub(crate) fn expr_is_known_non_pointer_shadow_value(ctx: &FnCtx<'_>, expr: &Exp
         Expr::LocalGet(id) => {
             // A reserved shadow slot means the local is pointer-possible even
             // if its initializer refined `local_types` to a scalar.
+            //
+            // #7236: this list also carried `HirType::Symbol`, and it is a
+            // SEPARATE hazard from the missing shadow slot — a `true` here
+            // suppresses `temp_root`'s argument/operand rooting, so
+            // `obj[s] = alloc()` with `s: symbol` left the movable symbol
+            // unrooted across the allocating call even once the local itself
+            // had a slot. `lower_call/closure_analysis.rs`'s
+            // `local_is_inert_primitive` never listed `Symbol`; this copy and
+            // `collectors/pointer_locals.rs` were the two that did.
+            //
+            // Derived from the one definition rather than restated, but kept
+            // NON-`Union` on purpose: `type_is_pointer_bearing` answers `false`
+            // for an all-scalar union (`number | undefined`), which would
+            // WIDEN this suppression to locals it never covered. That is a
+            // plausible optimisation and an unmeasured one; it is not this
+            // change. The guard makes the arm exactly the old list minus
+            // `Symbol`.
             !ctx.shadow_slot_map.contains_key(id)
-                && matches!(
-                    ctx.local_types.get(id),
-                    Some(
-                        HirType::Number
-                            | HirType::Int32
-                            | HirType::Boolean
-                            | HirType::Null
-                            | HirType::Void
-                            | HirType::Never
-                            | HirType::Symbol
-                    )
-                )
+                && ctx.local_types.get(id).is_some_and(|ty| {
+                    !matches!(ty, HirType::Union(_))
+                        && !crate::typed_shape::type_is_pointer_bearing(ty)
+                })
         }
         Expr::Compare { .. } | Expr::Void(_) => true,
         Expr::Unary { .. } => true,

--- a/crates/perry-codegen/src/typed_shape.rs
+++ b/crates/perry-codegen/src/typed_shape.rs
@@ -20,11 +20,20 @@ use perry_hir::types::Type;
 ///
 /// * `Symbol` — **a pointer.** `js_symbol_new` returns `POINTER_TAG`-boxed
 ///   storage from `alloc_symbol`, which is
-///   `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`, and
-///   `GC_TYPE_STRING`'s type-info entry is `movable: true`. It was listed as a
-///   non-pointer by `is_definitely_non_pointer_type` (#7236) while this
-///   function already answered `true` — the exact one-variant drift the doc
-///   comment over there warned about, which is why there is now one copy.
+///   `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`. Note *which* way
+///   it is dangerous: `gc_malloc` is the SYSTEM allocator with a `GcHeader` in
+///   front, not an arena allocation, so the copying minor cannot relocate a
+///   symbol — it can `dealloc` it (`sweep_malloc_objects`, reached from the
+///   copying minor whenever `copied_minor_malloc_sweep_due`). Under #7235's
+///   taxonomy a symbol is RECLAIMABLE and not MOVABLE, and nothing else holds a
+///   fresh one: `alloc_symbol`'s own comment says it is kept alive "through the
+///   SYMBOL_REGISTRY … or NOT AT ALL", and `SYMBOL_POINTERS` is visited with
+///   `visit_metadata_usize_slot`, which rewrites without marking. So an
+///   unrooted `Symbol` local is a premature FREE (#7230's class), not a stale
+///   address. It was listed as a non-pointer by
+///   `is_definitely_non_pointer_type` (#7236) while this function already
+///   answered `true` — the exact one-variant drift the doc comment over there
+///   warned about, which is why there is now one copy.
 /// * `StringLiteral` — a string-LITERAL type (`"foo"`, or a `"a" | "b"`
 ///   discriminant union member) is an ordinary heap `String` at runtime.
 /// * `TypeVar` — an unresolved generic type parameter (`T`) can bind to any

--- a/crates/perry-codegen/src/typed_shape.rs
+++ b/crates/perry-codegen/src/typed_shape.rs
@@ -1,5 +1,50 @@
 use perry_hir::types::Type;
 
+/// ★ Can a value of this type be a heap reference the collector must see?
+///
+/// **This is the single definition of "pointer" for the whole codegen crate**,
+/// and every consumer of that question routes here:
+/// [`crate::collectors::pointer_locals::is_definitely_non_pointer_type`] (which
+/// is its exact negation, and through it the shadow-slot assignment pass and
+/// `collectors/ptr_shape_returns.rs`), the typed-shape pointer masks below, and
+/// `expr/object_literal.rs`.
+///
+/// It is an **exhaustive `match`, deliberately**, not a `matches!` list. A
+/// `matches!` list silently defaults a newly added `Type` variant to one answer,
+/// and here the two answers are not symmetric: defaulting to "not a pointer"
+/// means a local with **no shadow-stack slot**, i.e. a heap object the precise
+/// moving-GC root scan cannot see. That is a use-after-move / premature sweep,
+/// not a missed optimisation. The exhaustive match makes the compiler ask.
+///
+/// Per-variant notes, kept here because this is the only copy:
+///
+/// * `Symbol` — **a pointer.** `js_symbol_new` returns `POINTER_TAG`-boxed
+///   storage from `alloc_symbol`, which is
+///   `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`, and
+///   `GC_TYPE_STRING`'s type-info entry is `movable: true`. It was listed as a
+///   non-pointer by `is_definitely_non_pointer_type` (#7236) while this
+///   function already answered `true` — the exact one-variant drift the doc
+///   comment over there warned about, which is why there is now one copy.
+/// * `StringLiteral` — a string-LITERAL type (`"foo"`, or a `"a" | "b"`
+///   discriminant union member) is an ordinary heap `String` at runtime.
+/// * `TypeVar` — an unresolved generic type parameter (`T`) can bind to any
+///   heap type; treat it as a pointer (fail-safe).
+/// * `Generic` — a generic instantiation (`Map<K,V>`, `Set<T>`, `WeakMap`,
+///   `Box<T>`, `Array<T>`, a user generic class, …) is always a heap-reference
+///   type. Without this a `Map`/`Set`-typed local got no shadow-stack slot and
+///   was reaped while live (#7019, crash: "grown Map must retain its
+///   side-allocation owner record"); the non-moving default GC hid it behind
+///   its conservative C-stack scan.
+/// * `Number` / `Int32` / `Boolean` / `Null` / `Void` — NaN-boxed immediates
+///   (a raw `f64`, `INT32_TAG`, `TAG_TRUE`/`TAG_FALSE`, `TAG_NULL`,
+///   `TAG_UNDEFINED`): no allocator produces one, so there is nothing to root.
+///   `Never` has no value at all. These six are the complete non-pointer set.
+/// * `Union` — pointer-bearing if ANY member is, so the negation is "every
+///   member is a non-pointer", which is what the root-slot decision needs.
+///
+/// Over-answering `true` is harmless: the GC decode rejects any slot value that
+/// is not a live heap pointer, so a spurious root costs one slot, never
+/// correctness. Under-answering is #7019 / #7236.
 pub(crate) fn type_is_pointer_bearing(ty: &Type) -> bool {
     match ty {
         Type::String

--- a/docs/src/internals/gc-rooting-invariant.md
+++ b/docs/src/internals/gc-rooting-invariant.md
@@ -192,9 +192,13 @@ bind-anchored check is structurally blind to: the value lives in a plain
 `alloca_entry` for its whole lifetime, so there is no `js_shadow_slot_bind` to
 anchor on and a scan that starts from binds calls the function clean. It found
 `lower_call/new.rs`'s inline-ctor `this_slot` independently of any runtime
-probe. **The gate does not run this mode yet** — its remaining hits are the
-caches, staging arrays and inlined-callee params tracked as #7210, and they are
-deliberately not in the allowlist, which covers the bind-anchored shape only.
+probe.
+
+**The gate runs this mode as of #7236, and the corpus reads 0.** It could not
+before: #7210 measured 66 hits and triaged every one as a false positive, #7235
+split the heap-source predicate by movability (98 → 2 on a grown corpus), and
+the 2 residuals were one bug — `collectors/pointer_locals.rs` classified
+`Type::Symbol` as an immediate, so a `Symbol` local got no shadow slot at all.
 Run it by hand when you touch an `alloca_entry` site:
 
 ```bash
@@ -269,9 +273,27 @@ the exact thing this file exists to prevent.
 which means it cannot turn a merge red — hazard 2, and the reason the #7211 hits
 sat unread on `main` from #7198 onward while the job was visibly failing.
 
-With the allowlist the job is green on `main`, so the remaining step is for a
-repo admin to add `gc-root-dominance` to the required contexts. A workflow
-cannot do this to itself. Until it is done, this is documentation.
+Both of the conditions #7198 named are now met:
+
+- the bind-anchored dominance check is green on `main` with an **empty**
+  allowlist (the #7211 entries were deleted when that predicate was fixed);
+- `--unrooted-allocas --moving-only` reads **0** and is a step in the job
+  (#7236). That was the outstanding one: it was 98 before #7235, 2 after, and 0
+  once `Type::Symbol` stopped being classified as an immediate.
+
+So the remaining step is for a **repo admin** to add `gc-root-dominance` to
+branch protection's required contexts:
+
+```
+Settings → Branches → main → Require status checks to pass
+  → add:  gc-root-dominance
+```
+
+A workflow cannot do this to itself, and neither can a PR. Until it is done,
+this is documentation. Per CLAUDE.md's corollary, promote it **after** the job's
+first green run on `main` with the `--unrooted-allocas` step included — a gate
+that has never been green in its current shape blocks every open PR the day it
+becomes required.
 
 ## Rules of thumb
 

--- a/test-files/test_gap_gc_symbol_local_rooting.ts
+++ b/test-files/test_gap_gc_symbol_local_rooting.ts
@@ -2,52 +2,65 @@
 // shadow-stack slot like any other heap reference.
 //
 // `collectors/pointer_locals.rs` listed `Type::Symbol` in
-// `is_definitely_non_pointer_type`, so `const s = Symbol("w")` got NO
+// `is_definitely_non_pointer_type`, so `const s = Symbol("k")` got NO
 // shadow-stack slot and lived in a plain `alloca` for its whole scope —
 // invisible to the precise root walk. `typed_shape::type_is_pointer_bearing`,
 // which lays out the GC's own field masks, said `Symbol` IS a pointer, so the
 // two copies of one question had drifted by exactly one variant.
 //
-// ★ WHAT ACTUALLY GOES WRONG IS A PREMATURE FREE, NOT A STALE ADDRESS.
-// `alloc_symbol` is `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`, and
-// `gc_malloc` (gc/malloc.rs) is the SYSTEM allocator with a `GcHeader` in front
-// — not an arena allocation. So a fresh symbol is not in the nursery and the
-// copying minor cannot relocate it; what it can do is `dealloc` it. Under the
-// #7235 taxonomy the local is RECLAIMABLE-but-not-MOVABLE, the #7230 class.
-// `alloc_symbol`'s own comment concedes the liveness half — a fresh symbol is
-// kept alive "through the SYMBOL_REGISTRY (for registered symbols) or NOT AT
-// ALL" — and `SYMBOL_POINTERS` does not save it either:
-// `scan_symbol_pointer_metadata_roots_mut` visits it with
-// `visit_metadata_usize_slot`, which rewrites a recorded address WITHOUT
-// marking. With no shadow slot the unrooted `alloca` is the only reference in
-// the world, the collector cannot see it, and `sweep_malloc_objects` frees a
-// live symbol.
+// ★ THE FAILURE IS A PREMATURE FREE, NOT A STALE ADDRESS. `alloc_symbol` is
+// `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`, and `gc_malloc`
+// (gc/malloc.rs) is the SYSTEM allocator with a `GcHeader` in front — not an
+// arena allocation. So a fresh symbol is not in the nursery and the copying
+// minor cannot relocate it; what it can do is `dealloc` it, via
+// `sweep_malloc_objects`. Under #7235's taxonomy the local is
+// RECLAIMABLE-but-not-MOVABLE, the #7230 class. Nothing else holds a fresh
+// symbol — `alloc_symbol`'s own comment says it is kept alive "through the
+// SYMBOL_REGISTRY … or NOT AT ALL", and `scan_symbol_pointer_metadata_roots_mut`
+// visits `SYMBOL_POINTERS` with `visit_metadata_usize_slot`, which rewrites a
+// recorded address WITHOUT marking. With no shadow slot the `alloca` is the
+// only reference in the world and a live symbol is freed.
 //
 // ★ WHY THE PRESSURE IS SYMBOLS AND NOT OBJECTS. The malloc sweep inside the
 // copying minor is gated: `copied_minor_malloc_sweep_due` is true only for a
 // `GcTriggerKind::MallocCount` collection or once `malloc_object_count()`
-// passes its trigger. Driving pressure with object/array churn reaches the
-// ARENA trigger instead, so the malloc sweep is only occasionally due and the
-// defect reproduces intermittently — measured at 1 failure in 80 probes, and at
-// 0 on four of five repeats of another shape. Allocating symbols is what makes
-// the malloc-count trigger the one that fires, and with it the reproduction
-// deterministic. It also makes the reuse deterministic: the freed block is
-// exactly the size class the next `Symbol()` asks for, so the recycled bytes
-// are what the stale local reads back.
+// passes its trigger. Object/array churn reaches the ARENA trigger instead, so
+// the defect reproduces intermittently — measured at 1 failure in 80 probes on
+// one object-churn shape, and at 0 on four of five repeats of another after a
+// first run showed 72. Symbol churn makes the malloc-count trigger the one that
+// fires, and makes the reuse deterministic too: the freed block is exactly the
+// size class the next `Symbol()` asks for, so the recycled bytes are one of
+// `symChurn`'s throwaway `Symbol("t")`s and the stale local reads ITS
+// description back.
 //
-// Measured on `f8f1e7188` (before the fix), `--release`: `A 34` on the
-// `loop_polls` arm, identical on three consecutive runs, and `A 34` on the
-// SHIPPED DEFAULT with no GC env at all. Oracle and fixed build both print
-// `A 0`. This one does not need a moving arm to bite — the conservative stack
-// scan is what has been hiding it, and it stops hiding it as soon as the
-// collection is malloc-count driven.
-//
-// ★ WHY THE PROBES ARE NOT IDENTITY COMPARISONS. `js_symbol_equals`
+// ★ WHY THE PROBE IS NOT AN IDENTITY COMPARISON. `js_symbol_equals`
 // (symbol/constructors.rs) falls back from a bits comparison to dereferencing
 // both headers and comparing `id`, and `js_is_symbol` falls back to reading
-// `magic` — both answer correctly off a freed-but-not-yet-recycled header, so
-// an identity probe reports nothing. What a reaped symbol cannot survive is
-// having its own description read back after its storage is reused.
+// `magic` — and the block that recycles a freed symbol is ANOTHER SYMBOL, so
+// both answer "yes, a symbol" and `typeof` never moves (measured: `typeof`
+// 0/20 at base). What a reaped symbol cannot survive is being used as a
+// computed KEY and then having that key read back and identified, which is
+// #7236's own named shape.
+//
+// ★ WHY THE PROBE SYMBOL HAS NO DESCRIPTION. `Symbol()` rather than
+// `Symbol("k")`, on purpose, to keep this file gating ONE defect.
+// `GC_TYPE_STRING`'s type-info entry is `pointer_free: true` /
+// `GcRewriteDescriptorKind::Leaf` — `alloc_symbol` says so in as many words
+// ("the GC won't try to scan internal pointers") — so a symbol's
+// `description` `StringHeader*` is never traced or rewritten, and a symbol
+// that is itself perfectly rooted can still have its description reaped out
+// from under it. That is a SEPARATE, runtime-side defect (#7246)
+// that this codegen change does not touch, and with `Symbol("k")` it left this
+// file red 2/20 on
+// the `PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off` arms even
+// after the fix. A descriptionless symbol has no such pointer, so what remains
+// is exactly the lifetime of the symbol object — which is what a shadow slot
+// decides. The recycled block is one of `symChurn`'s `Symbol("t")`s, so the
+// stale local reports `Symbol(t)` where the oracle says `Symbol()`.
+//
+// Measured at base (`f8f1e7188`), release, oracle node 26.5.1 (`B 0`):
+// `B 34` of a possible 80, 3/3 identical, on `loop_polls` and on the shipped
+// default; `B 0` after the fix, 3/3.
 //
 // The observable is byte-for-byte identical to `node --experimental-strip-types`.
 
@@ -62,36 +75,10 @@ function symChurn(n: number): number {
   return k;
 }
 
-// A: the symbol is referenced by NOTHING but the local across the collection,
-// and is then asked what it is.
-function heldAcrossCollection(): number {
-  let bad = 0;
-  for (let r = 0; r < 20; r++) {
-    const s = Symbol("w");
-    if (symChurn(50000) !== 50000) {
-      bad++;
-    }
-    if (typeof s !== "symbol") {
-      bad++;
-    }
-    if (String(s) !== "Symbol(w)") {
-      bad++;
-    }
-    if (s.description !== "w") {
-      bad++;
-    }
-  }
-  return bad;
-}
-
-// B: the same local, then used as a COMPUTED KEY — the issue's other named
-// shape. The store must land on a symbol key whose description round-trips, so
-// a local whose storage was recycled into one of `symChurn`'s throwaway
-// `Symbol("t")`s is caught by the description rather than by the count.
 function usedAsComputedKey(): number {
   let bad = 0;
   for (let r = 0; r < 20; r++) {
-    const s = Symbol("k");
+    const s = Symbol();
     if (symChurn(50000) !== 50000) {
       bad++;
     }
@@ -104,12 +91,14 @@ function usedAsComputedKey(): number {
     if (keys.length !== 1) {
       bad++;
     }
-    if (String(keys[0]) !== "Symbol(k)") {
+    if (String(keys[0]) !== "Symbol()") {
+      bad++;
+    }
+    if (keys[0].description !== undefined) {
       bad++;
     }
   }
   return bad;
 }
 
-console.log("A", heldAcrossCollection());
 console.log("B", usedAsComputedKey());

--- a/test-files/test_gap_gc_symbol_local_rooting.ts
+++ b/test-files/test_gap_gc_symbol_local_rooting.ts
@@ -1,0 +1,115 @@
+// #7236: a `Symbol`-typed local names a GC-heap object, and needs a
+// shadow-stack slot like any other heap reference.
+//
+// `collectors/pointer_locals.rs` listed `Type::Symbol` in
+// `is_definitely_non_pointer_type`, so `const s = Symbol("w")` got NO
+// shadow-stack slot and lived in a plain `alloca` for its whole scope —
+// invisible to the precise root walk. `typed_shape::type_is_pointer_bearing`,
+// which lays out the GC's own field masks, said `Symbol` IS a pointer, so the
+// two copies of one question had drifted by exactly one variant.
+//
+// ★ WHAT ACTUALLY GOES WRONG IS A PREMATURE FREE, NOT A STALE ADDRESS.
+// `alloc_symbol` is `gc_malloc(size_of::<SymbolHeader>(), GC_TYPE_STRING)`, and
+// `gc_malloc` (gc/malloc.rs) is the SYSTEM allocator with a `GcHeader` in front
+// — not an arena allocation. So a fresh symbol is not in the nursery and the
+// copying minor cannot relocate it; what it can do is `dealloc` it. Under the
+// #7235 taxonomy the local is RECLAIMABLE-but-not-MOVABLE, the #7230 class.
+// `alloc_symbol`'s own comment concedes the liveness half — a fresh symbol is
+// kept alive "through the SYMBOL_REGISTRY (for registered symbols) or NOT AT
+// ALL" — and `SYMBOL_POINTERS` does not save it either:
+// `scan_symbol_pointer_metadata_roots_mut` visits it with
+// `visit_metadata_usize_slot`, which rewrites a recorded address WITHOUT
+// marking. With no shadow slot the unrooted `alloca` is the only reference in
+// the world, the collector cannot see it, and `sweep_malloc_objects` frees a
+// live symbol.
+//
+// ★ WHY THE PRESSURE IS SYMBOLS AND NOT OBJECTS. The malloc sweep inside the
+// copying minor is gated: `copied_minor_malloc_sweep_due` is true only for a
+// `GcTriggerKind::MallocCount` collection or once `malloc_object_count()`
+// passes its trigger. Driving pressure with object/array churn reaches the
+// ARENA trigger instead, so the malloc sweep is only occasionally due and the
+// defect reproduces intermittently — measured at 1 failure in 80 probes, and at
+// 0 on four of five repeats of another shape. Allocating symbols is what makes
+// the malloc-count trigger the one that fires, and with it the reproduction
+// deterministic. It also makes the reuse deterministic: the freed block is
+// exactly the size class the next `Symbol()` asks for, so the recycled bytes
+// are what the stale local reads back.
+//
+// Measured on `f8f1e7188` (before the fix), `--release`: `A 34` on the
+// `loop_polls` arm, identical on three consecutive runs, and `A 34` on the
+// SHIPPED DEFAULT with no GC env at all. Oracle and fixed build both print
+// `A 0`. This one does not need a moving arm to bite — the conservative stack
+// scan is what has been hiding it, and it stops hiding it as soon as the
+// collection is malloc-count driven.
+//
+// ★ WHY THE PROBES ARE NOT IDENTITY COMPARISONS. `js_symbol_equals`
+// (symbol/constructors.rs) falls back from a bits comparison to dereferencing
+// both headers and comparing `id`, and `js_is_symbol` falls back to reading
+// `magic` — both answer correctly off a freed-but-not-yet-recycled header, so
+// an identity probe reports nothing. What a reaped symbol cannot survive is
+// having its own description read back after its storage is reused.
+//
+// The observable is byte-for-byte identical to `node --experimental-strip-types`.
+
+function symChurn(n: number): number {
+  let k = 0;
+  for (let i = 0; i < n; i++) {
+    const t = Symbol("t");
+    if (typeof t === "symbol") {
+      k++;
+    }
+  }
+  return k;
+}
+
+// A: the symbol is referenced by NOTHING but the local across the collection,
+// and is then asked what it is.
+function heldAcrossCollection(): number {
+  let bad = 0;
+  for (let r = 0; r < 20; r++) {
+    const s = Symbol("w");
+    if (symChurn(50000) !== 50000) {
+      bad++;
+    }
+    if (typeof s !== "symbol") {
+      bad++;
+    }
+    if (String(s) !== "Symbol(w)") {
+      bad++;
+    }
+    if (s.description !== "w") {
+      bad++;
+    }
+  }
+  return bad;
+}
+
+// B: the same local, then used as a COMPUTED KEY — the issue's other named
+// shape. The store must land on a symbol key whose description round-trips, so
+// a local whose storage was recycled into one of `symChurn`'s throwaway
+// `Symbol("t")`s is caught by the description rather than by the count.
+function usedAsComputedKey(): number {
+  let bad = 0;
+  for (let r = 0; r < 20; r++) {
+    const s = Symbol("k");
+    if (symChurn(50000) !== 50000) {
+      bad++;
+    }
+    const o: any = {};
+    o[s] = r;
+    if (o[s] !== r) {
+      bad++;
+    }
+    const keys = Object.getOwnPropertySymbols(o);
+    if (keys.length !== 1) {
+      bad++;
+    }
+    if (String(keys[0]) !== "Symbol(k)") {
+      bad++;
+    }
+  }
+  return bad;
+}
+
+console.log("A", heldAcrossCollection());
+console.log("B", usedAsComputedKey());

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -394,8 +394,8 @@ test_gap_gc_process_env_cache_rooting
 # --- #7236: a Symbol-typed local had no shadow slot at all ------------------
 # Not a representation file, so registered explicitly per the header rule.
 # `collectors/pointer_locals.rs` classified `Type::Symbol` as a NON-pointer, so
-# `const s = Symbol("w")` got no shadow-stack slot and lived in a plain
-# `alloca` — the last violation `gc_root_dominance_check.py --unrooted-allocas
+# `const s = Symbol()` got no shadow-stack slot and lived in a plain `alloca` —
+# the last violation `gc_root_dominance_check.py --unrooted-allocas
 # --moving-only` reported on the #7235 corpus, and the one thing standing
 # between `gc-root-dominance` and promotion to a required context (#7198).
 #
@@ -417,11 +417,20 @@ test_gap_gc_process_env_cache_rooting
 # makes the malloc-count trigger the one that fires AND makes the freed block
 # the exact size class the next `Symbol()` reuses.
 #
-# Measured at base (`f8f1e7188`), `--release`, oracle node 26.5.1 (`A 0 B 0`):
-# `A 30 B 20` on `loop_polls`, 3/3 identical, and `A 30 B 20` on the SHIPPED
-# DEFAULT with no GC env at all, 2/2. `A 0 B 0` after the fix on both, 3/3.
+# ★ THE PROBE SYMBOL DELIBERATELY HAS NO DESCRIPTION, so this file gates ONE
+# defect. `GC_TYPE_STRING` is `pointer_free: true` / `Leaf`, so a symbol's
+# `description` StringHeader is never traced or rewritten and can be reaped out
+# from under a perfectly rooted symbol — a SEPARATE runtime-side defect (#7246)
+# that #7236 does not touch. With `Symbol("k")` this file stayed red 2/20 on the
+# `PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off` arms AFTER the
+# fix; with `Symbol()` there is no such pointer and what remains is exactly the
+# lifetime of the symbol object. If those two arms ever go red here again,
+# suspect the description defect before suspecting the classification.
 #
-# It therefore does NOT need a `requires=move` arm — the conservative stack
-# scan is what was hiding it, and a malloc-count-driven collection stops it
-# hiding. Expect PASS rather than UNVER wherever the arm collects at all.
+# Measured with `--arms all --pressure 8`, oracle node 26.5.1 (`B 0`):
+#   f8f1e7188 (base)  21/21 cells FAIL, 0/21 byte-exact (5 of them exit=1)
+#   with the fix      0 FAIL, 21/21 byte-exact, PASS=17 UNVER=4
+# It does NOT need a `requires=move` arm: the conservative stack scan is what
+# was hiding it, and a malloc-count-driven collection stops it hiding, so it is
+# red on the SHIPPED DEFAULT at base too.
 test_gap_gc_symbol_local_rooting

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -390,3 +390,38 @@ test_gap_gc_interval_args_rooting
 # bad at collection #0 and stays bad, where an unrooted REGISTER needs a
 # collection to land in a narrow window.
 test_gap_gc_process_env_cache_rooting
+
+# --- #7236: a Symbol-typed local had no shadow slot at all ------------------
+# Not a representation file, so registered explicitly per the header rule.
+# `collectors/pointer_locals.rs` classified `Type::Symbol` as a NON-pointer, so
+# `const s = Symbol("w")` got no shadow-stack slot and lived in a plain
+# `alloca` — the last violation `gc_root_dominance_check.py --unrooted-allocas
+# --moving-only` reported on the #7235 corpus, and the one thing standing
+# between `gc-root-dominance` and promotion to a required context (#7198).
+#
+# ★ THE FAILURE IS A PREMATURE FREE, NOT A STALE ADDRESS, and that dictates the
+# shape of the file. `alloc_symbol` is `gc_malloc(_, GC_TYPE_STRING)` and
+# `gc_malloc` is the SYSTEM allocator with a GcHeader in front, not an arena
+# allocation — so the copying minor cannot relocate a symbol, it can only
+# `dealloc` it. Under #7235's taxonomy the local is RECLAIMABLE and not
+# MOVABLE. `SYMBOL_POINTERS` does not save it:
+# `scan_symbol_pointer_metadata_roots_mut` uses `visit_metadata_usize_slot`,
+# which rewrites without marking, exactly as `alloc_symbol`'s own comment says
+# ("kept alive ... or NOT AT ALL").
+#
+# So the pressure is SYMBOLS, not objects. `copied_minor_malloc_sweep_due`
+# gates the malloc sweep on a `MallocCount` trigger or the malloc-object
+# threshold; object churn reaches the ARENA trigger instead, and with it the
+# defect reproduces intermittently — measured at 1 failure in 80 probes on one
+# object-churn shape, and 0 on four of five repeats of another. Symbol churn
+# makes the malloc-count trigger the one that fires AND makes the freed block
+# the exact size class the next `Symbol()` reuses.
+#
+# Measured at base (`f8f1e7188`), `--release`, oracle node 26.5.1 (`A 0 B 0`):
+# `A 30 B 20` on `loop_polls`, 3/3 identical, and `A 30 B 20` on the SHIPPED
+# DEFAULT with no GC env at all, 2/2. `A 0 B 0` after the fix on both, 3/3.
+#
+# It therefore does NOT need a `requires=move` arm — the conservative stack
+# scan is what was hiding it, and a malloc-count-driven collection stops it
+# hiding. Expect PASS rather than UNVER wherever the arm collects at all.
+test_gap_gc_symbol_local_rooting


### PR DESCRIPTION
Closes #7236. This is the last `--unrooted-allocas --moving-only` violation on the corpus, so it is also the last thing standing between `gc-root-dominance` and promotion to a required context (#7198). **The corpus now reads 0**, and the mode is a step in the job rather than a number nobody checks.

## The audit, not the entry

#7236 names `Type::Symbol`. The instruction was to enumerate the whole predicate against the allocators rather than fix one entry, so here is the whole enum. `Type` has 21 variants; `is_ptr_typed` claimed 13, `is_definitely_non_pointer_type` claimed 7, `Union` was handled by both — a complete partition, so the two were exact complements and one wrong answer is one wrong entry.

| variant | runtime representation | evidence | verdict |
|---|---|---|---|
| `Number` | raw `f64` | — | non-pointer ✔ |
| `Int32` | `INT32_TAG` immediate | `nanbox.rs` | non-pointer ✔ |
| `Boolean` | `TAG_TRUE` / `TAG_FALSE` | `nanbox.rs` | non-pointer ✔ |
| `Null` | `TAG_NULL` | `nanbox.rs` | non-pointer ✔ |
| `Void` | `TAG_UNDEFINED` | `nanbox.rs` | non-pointer ✔ |
| `Never` | uninhabited, no value | — | non-pointer ✔ |
| **`Symbol`** | **`POINTER_TAG` \| `alloc_symbol` → `gc_malloc(_, GC_TYPE_STRING)`** | `symbol/constructors.rs:19-39`, `symbol.rs:370` | **WRONG — a GC-heap object** |
| `BigInt` | `BIGINT_TAG` pointer | already `is_ptr_typed` | pointer ✔ |
| `String`, `StringLiteral` | `STRING_TAG` pointer | already `is_ptr_typed` | pointer ✔ |
| `Array`, `Tuple`, `Object`, `Function`, `Promise`, `Named`, `Generic`, `TypeVar`, `Any`, `Unknown` | `POINTER_TAG` | already `is_ptr_typed` | pointer ✔ |
| `Union` | any/all of the members | — | ✔ |

**`Symbol` is the only misclassification.** The six remaining non-pointers are all NaN-boxed immediates with no allocator anywhere in the runtime.

## ★ The drift had already happened, in the same crate

`is_definitely_non_pointer_type`'s doc comment said, in these words:

> **This is the single definition.** … A second copy drifting by one `Type` variant would mean a value this collector left unrooted while another pass treated it as a live, movable pointer — a use-after-move under the evacuating minor (#7019), not a cosmetic inconsistency.

There was a second copy, it had drifted by one `Type` variant, and the variant was `Symbol`:

```rust
// typed_shape.rs — an EXHAUSTIVE match, and the function that lays out
// the GC's own inline-field pointer masks
Type::String | Type::StringLiteral(_) | Type::BigInt | Type::Symbol | … => true,

// collectors/pointer_locals.rs — a matches! list
Type::Number | Type::Int32 | … | Type::Symbol   // "definitely non-pointer"
```

So a `Symbol` local was simultaneously *not a pointer* (no shadow slot) and *pointer-bearing* (scanned as a pointer when it lands in an object's inline fields). There was a **third** copy in `expr/shadow_slot.rs` that also listed `Symbol`, and a **fourth** in `lower_call/closure_analysis.rs` (`local_is_inert_primitive`) that correctly did not.

**Fixed structurally, not by editing the entry.** `typed_shape::type_is_pointer_bearing` is now the one definition; `is_definitely_non_pointer_type` is literally `!type_is_pointer_bearing(ty)` and `is_ptr_typed` is literally `type_is_pointer_bearing(ty)`. Both were already exact complements of it for the other twenty variants, so nothing else changed behaviour. The exhaustive `match` is the point: a new `Type` variant is now a compile error instead of a silent "not a pointer", which is the failure direction that costs a slot.

## ★ Correction to the issue: it is a premature FREE, not a stale address

#7236 and #7235 both describe this as a *movable* object going stale under evacuation. Chasing the runtime witness showed otherwise, and the distinction changed what the witness has to look like:

`alloc_symbol` calls `gc_malloc`, and `gc_malloc` (`gc/malloc.rs:218`) is **the system allocator** with a `GcHeader` in front — not an arena allocation. A symbol is therefore not in the nursery, and **the copying minor cannot relocate it**. What it can do is `dealloc` it: `sweep_malloc_objects`, reached from the copying minor whenever `copied_minor_malloc_sweep_due`. Under #7235's own taxonomy a `Symbol` local is **RECLAIMABLE and not MOVABLE** — the #7230 class, not the #7019 class.

Nothing else keeps a fresh symbol alive, exactly as `alloc_symbol`'s comment concedes ("kept alive through the `SYMBOL_REGISTRY` … or **not at all**"). `SYMBOL_POINTERS` does not: `scan_symbol_pointer_metadata_roots_mut` visits it with `visit_metadata_usize_slot`, which rewrites a recorded address **without marking**. So with no shadow slot the `alloca` is the only reference in the world and a live symbol is freed.

Three things follow, and all three are in the code comments:

- **the pressure has to be symbols, not objects.** The malloc sweep is gated on a `MallocCount` trigger or the malloc-object threshold; object/array churn reaches the *arena* trigger instead. With object churn the defect reproduces **intermittently** — measured at 1 failure in 80 probes on one shape, and at 0 on four of five repeats of another after a first run showed 72. With symbol churn it is deterministic, and the freed block is the exact size class the next `Symbol()` reuses.
- **identity probes report nothing.** `js_symbol_equals` falls back from a bits comparison to dereferencing both headers and comparing `id`, and `js_is_symbol` falls back to reading `magic` — both answer correctly off a freed-but-not-yet-recycled header. `box.sym === s` cannot see this. What a reaped symbol cannot survive is being asked what it *is* after its storage is reused.
- **it is not a moving-arm-only witness.** The conservative stack scan is what was hiding it, and a malloc-count-driven collection stops it hiding.

I am flagging this rather than quietly shipping a witness that matches the issue's wording: `--moving-only` reported these two hits because a *collector in the window* is moving, which is the checker's window classification and not a claim about the symbol itself. The classification fix is unchanged and still right — a `Symbol` local names a heap object the precise root walk must see.

## Red then green

`test-files/test_gap_gc_symbol_local_rooting.ts`, registered in `test-parity/gc_repsel_corpus.txt` (which #7228's `gc-moving-witnesses` arm gates and which rejects `UNVER` as hard as `FAIL`). Two functions: a symbol held across the collection and then asked what it is, and the issue's other named shape — the same local used as a **computed key** afterwards. Oracle node 26.5.1 prints `A 0` / `B 0`.

Release builds, idle Mac mini, same corpus and same commands for both arms:

| | `loop_polls` arm | shipped default |
|---|---|---|
| `f8f1e7188` (base) | **`A 30 B 20`**, 3/3 identical | **`A 30 B 20`**, 2/2 |
| this branch | `A 0 B 0`, 3/3 | `A 0 B 0`, 2/2 |

## The corpus reaches 0

Freshly generated at `f8f1e7188` and on this branch, **same 118 sources / 136 `.ll` files both arms**, `--unrooted-allocas --moving-only`:

| | violations | which |
|---|---|---|
| base | **4** | `…forward_capture_6523_ts__2`, `…__7` (#7236's two), plus the new witness's two functions |
| this branch | **0** | — |

`--self-test OK`, `--audit-alloc-re` clean (70 alternatives vs 3775 exported symbols), `--audit-immovable-sources` clean (4 probes, 0 failing), the bind-anchored dominance step green with an **empty** allowlist, `--seeded-violations 40` → 40 planted, 40 caught, 0 missed.

## No coverage traded

The concern was that giving `Symbol` locals shadow slots could change representation-promotion counts. It does not: `compiler_output_regression.py census --gate` over all 18 workloads is **byte-identical between the two arms** (`diff` of the two runs is empty), and green on both. No floor moved, so no ratchet was needed and none was taken.

## The new CI step, and why it is here rather than in a follow-up

`--unrooted-allocas --moving-only` was 98 before #7235, 2 after, and 0 now. That number is the stated condition for promoting this job, and until this PR **nothing checked it** — it lived in issue bodies. A number that is an acceptance criterion and is checked by nothing regresses silently; that is CLAUDE.md hazard 4 applied to the measurement rather than to the job. It is a step now, sharing the corpus, the exemptions, the allowlist file and the liveness floors with the step above it. Verified it can fail: **exit 1 at `f8f1e7188`, exit 0 here**, same invocation.

If you would rather land the classification fix alone, the CI + docs commit is separable (`a9a83e584`).

## ⚠️ ACTION REQUIRED — the promotion is yours, not mine

Branch protection is admin-only; a workflow cannot promote itself and neither can a PR. Both conditions #7198 named are now met (dominance green with an empty allowlist; unrooted-allocas at 0 **and gated**).

**One clean run is enough, not a week — but it must be a run of the job in its NEW shape.** #7198 wrote "after a clean week", and that wording was calibrated to a job whose allowlist still carried the #7211 entries, i.e. to the question "is it green?". That question is now answered by construction rather than by soak: this is a static IR pass with no timing, no host dependence and no flake surface, and its own liveness is asserted three ways (`--self-test`, `--seeded-violations 40`, the `--min-*` floors). A week of identical green runs would add nothing a single green run does not. What it must **not** be promoted on is this PR's green — that is the corollary in CLAUDE.md: the `--unrooted-allocas` step has never run on `main`, and promoting a gate that has never been green in its current shape blocks every open PR the day it becomes required.

So, after this merges and `gc-root-dominance` goes green once on `main`:

```
Settings → Branches → Branch protection rules → main
  → Require status checks to pass before merging
  → add:  gc-root-dominance
```

Or:

```bash
gh api -X PATCH repos/PerryTS/perry/branches/main/protection/required_status_checks \
  -f 'checks[][context]=gc-root-dominance'
```

(read the current `checks` list first and re-send it whole — that endpoint replaces rather than appends).

## Unmeasured, stated plainly

- **The `expr/shadow_slot.rs` half has no witness of its own.** Once a `Symbol` local gets a shadow slot, that predicate's `!ctx.shadow_slot_map.contains_key(id)` guard short-circuits, so the second edit is defensive — it covers locals that reach it with no slot (inlined-callee locals, #7210 §4). It is fixed because the entry was wrong and because `local_is_inert_primitive` never had it, not because I have a reproducer for it.
- **That arm is deliberately NOT widened to `Union`.** `type_is_pointer_bearing` answers `false` for an all-scalar union (`number | undefined`), which would suppress temp-rooting for locals this predicate never covered. Plausible optimisation, unmeasured, not this change; the arm keeps a `!matches!(Union)` guard so it is exactly the old list minus `Symbol`.
- **Frame-size before/after was not measured as a number.** #7236 asked for it. The corpus's gc-capable alloca count moved 5702 → 5705 across the whole 136-file corpus, and the census is byte-identical, so the observable effect is three slots; I did not produce a per-function frame-size table.
- The `B` probe's shape (`o[s] = r` *after* the collection) is the one that fires. The variant with the store *before* the collection is inert — a symbol that is a live property key is marked through `SYMBOL_PROPERTIES` and correctly survives — so it is not in the file rather than sitting there looking like coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection handling for local `Symbol` values, preventing premature collection during memory pressure.
  * Ensured pointer-bearing values consistently receive the required temporary roots.

* **Tests**
  * Added regression coverage for symbols surviving garbage collection and preserving their behavior.
  * Expanded automated checks for missing GC roots and pointer classification.

* **Documentation**
  * Updated GC rooting guidance, validation results, and promotion requirements for the dominance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->