### PR TITLE
fix(gc): run the globalThis bootstrap in a no-move window (#7217)

### DIFF
--- a/changelog.d/7249-realm-bootstrap-no-move-window.md
+++ b/changelog.d/7249-realm-bootstrap-no-move-window.md
@@ -1,0 +1,139 @@
+### Fixed
+
+- **GC: the lazy `globalThis` bootstrap now runs in a no-move window (#7217).**
+  `test_gap_gc_spread_accessor_rooting` — #7207's reproducer for #7200 —
+  SIGSEGV'd 10/10 deterministically under
+  `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off`
+  (the allocation-point route) months after three separate rooting fixes had
+  been verified green on the safepoint route. **The failing collection was not
+  in the code any of those fixes touched.**
+
+  `js_get_global_this()` builds the whole realm on first use, and it is reached
+  *lazily* — in this program from `js_object_set_field_by_name` →
+  `object_prototype_addr_matches` → `js_get_global_this_builtin_value`, i.e.
+  from an ordinary property write several hundred loop iterations in, after
+  ~8 MB of churn. The bootstrap then allocates ~1.15 MB of its own, so under an
+  8 MB heap limit **minor #0 lands in the middle of it**. #6982 rooted the
+  `globalThis` singleton — one pointer. The bootstrap builds a *graph*:
+  `intl::install_constructor` threads `ctor`, `proto` and `ns_obj` as bare
+  `*mut ObjectHeader` locals across dozens of allocating installs, and so do the
+  error, typed-array, generator, Reflect, Atomics and WebAssembly installers,
+  across a dozen files. Every one is a slot the collector does not rewrite.
+
+  `PERRY_GC_PROTECT_FROMSPACE=1` (#7196) named it without inference:
+  `set_builtin_property_attrs` ← `intl::install_function` ←
+  `install_constructor` ← `install_intl_namespace` ←
+  `populate_global_this_builtins` ← `js_get_global_this`, on an address with
+  `retired_by_minor=#0`. Confirmed before any code changed: adding
+  `const __warm = typeof (globalThis as any).Intl;` at the top of the
+  *unmodified* reproducer — so the bootstrap runs while the arena is nearly
+  empty — makes it clean 5/5 with 6 copying minors and 4 613–5 797 objects
+  copied each.
+
+  **Why the safepoint route could not see it, which is the general finding.** A
+  loop back-edge poll fires only while user JS is running, and the bootstrap
+  runs no user JS, so none of those locals is ever live across a collection
+  there. On the allocation-point route the bootstrap's *own* allocations are the
+  collection points, so the entire graph is exposed at once. The two routes are
+  not two chances to catch the same bug: `loop_polls` cannot expose an unrooted
+  local in any runtime code that does not re-enter user JS, which is most of the
+  runtime.
+
+  **The invariant: a bootstrap that builds an IMMORTAL object graph through raw
+  pointers held across its own allocations must run in a NO-MOVE WINDOW.**
+  Rooting each holder individually is unbounded (hundreds of sites) and
+  ungateable — `scripts/gc_root_dominance_check.py` reads emitted LLVM IR and is
+  structurally blind to all of them. The window is one line and provably enough,
+  and it costs nothing a collection would have recovered: every object born in
+  it is reachable from `globalThis` for the life of the thread.
+
+  The fix is one line: `crate::gc::GcSuppressScope` (the existing nesting-safe
+  RAII no-move window, already used by `descriptor_state.rs`) at the top of
+  `populate_global_this_builtins`. `GC_FLAG_SUPPRESSED` gates
+  `gc_check_trigger`, the budgeted stepper **and** `gc_safepoint_moving_minor`,
+  so the window is comprehensive rather than allocation-point-only. No
+  installer's rooting was touched — adding a `RuntimeHandleScope` to one of
+  fifty installers would imply the other forty-nine are fine. No env knob is
+  added and no collector behaviour changes anywhere else.
+
+  Measured on the allocation-point arm, same host, idle, one target dir, 10 runs
+  per cell. The base arm was produced by reverting the source change and
+  rebuilding, and came back **bit-identical** to the pre-change build
+  (`perry` md5 `6142b49f…` both times) against `068af604…` for the fix, so the
+  two arms are demonstrably different binaries. Every row was then re-run
+  against the final shipped tree (`f1f002f8…`, after the two #7251 windows were
+  dropped) and is unchanged:
+
+  | witness | base `8b024958f` | fixed |
+  |---|---|---|
+  | `test_gap_gc_spread_accessor_rooting` | **exit=139, no output, 10/10** | **`bad plain 0 hot 0 tail 0` 10/10** |
+  | `test_gap_gc_static_block_this_rooting` | `bad 1` 10/10 | **`bad 0` 10/10** |
+  | `test_gap_gc_inline_ctor_this_rooting` | green 10/10 | green 10/10 |
+
+  `loop_polls` (compiled **and** run with `PERRY_GC_MOVING_LOOP_POLLS=1` plus
+  `PERRY_GC_FORCE_EVACUATE=1`): all five `test_gap_gc_*_rooting` witnesses green
+  5/5, and all five still relocate (1–5 cycles, 224–26 063 objects copied), so
+  none went inert. Shipped default: clean 3/3, byte-exact against
+  `node --experimental-strip-types`. `PERRY_GC_PROTECT_FROMSPACE=1` on the
+  reproducer now reports **no fault at all**. The static
+  `gc_root_dominance_check.py` reports 0 violations before *and* after, in both
+  its default and `--unrooted-allocas` modes — it reads emitted LLVM IR, so it
+  is structurally blind to a bug that lives in the runtime's Rust locals, which
+  is worth recording as a limit of that gate rather than as a clean bill.
+
+  **The window defers a collection, it does not add one.** On
+  `console.log("hi", typeof globalThis.Intl)`, peak RSS drops from
+  10 878 976 / 10 895 360 / 10 878 976 bytes to
+  10 649 600 / 10 649 600 / 10 633 216, and GC cycles at `HEAP_LIMIT=8` go from
+  2 to 1 — the collection that used to run mid-bootstrap copied the bootstrap's
+  own live set and then had all of it survive anyway.
+
+### Testing
+
+- **`crates/perry-runtime/src/gc/tests/global_bootstrap.rs`** — a `--lib` unit
+  test, so it runs in the per-PR `cargo-test` gate rather than in a
+  nightly-only `tests/*.rs` suite. It arms **one** pending collection, runs
+  the bootstrap, and asserts it was not serviced, that the request is
+  **deferred rather than dropped**, that the window spans at least one arena
+  block (so `arena_alloc_gc` genuinely reached `gc_check_trigger` inside it),
+  and that the window closed. Each then runs **the control**: the *same* armed
+  request, on the *same* thread, must be serviced by ordinary allocation once
+  the window is over. Without that second half the test would pass on a tree
+  where nothing was ever due — CLAUDE.md's fourth way a gate cannot fail.
+  Sabotage-checked in the failing direction: removing the `GcSuppressScope`
+  reddens it with `left: 1, right: 0` and the message naming the installer
+  locals.
+
+### Known issues
+
+- Two of the five `test_gap_gc_*_rooting` witnesses remain red on the
+  allocation-point route for **unrelated** reasons, and their twenty
+  `test-parity/gc_repsel_triage.txt` entries are retargeted rather than deleted
+  — one of the two triage texts was asserting a cause now known to be wrong.
+  Both are green on `loop_polls`, which `gc-moving-witnesses.yml` gates.
+  - **#7247** — `test_gap_gc_regexp_receiver_rooting`, unchanged (exit=139 10/10
+    on both arms). `js_regexp_new` holds `string_as_str(pattern)` /
+    `string_as_str(flags)` — `&str` borrows into a movable `StringHeader`
+    payload — across its whole body. The #7215 borrow shape.
+  - **#7248** — `test_gap_gc_assign_string_source_rooting`, improved from
+    `bad char 3 count 3` to `bad char 1 count 1` (10/10 each). The residual
+    failure is a stale `js_eq` left operand in the test's own
+    `got !== ALPHA[i % 26]` assertion — a register loaded above the allocating
+    `js_string_index_get_boxed` sibling and never re-read — not anything in
+    `js_object_assign_one`. The #7206/#7214 operand family.
+- **#7251** — the same defect shape exists in `ensure_generator_intrinsics` and
+  `ensure_typed_array_intrinsic`, which build the same kind of immortal tower
+  through the same kind of raw locals and are *also* reachable lazily ahead of
+  the bootstrap. Windows for them were written and then **deliberately dropped
+  from this PR**: a tower is three orders of magnitude smaller than the
+  bootstrap, fits inside one arena block's tail, and so may reach no
+  `gc_check_trigger` at all — three successive versions of a gate for them
+  passed with the window deleted. Shipping a GC-trigger change with no test that
+  can fail without it is the thing CLAUDE.md's knob-kill policy exists to stop,
+  so the exposure is tracked instead, with the two candidate gate designs and an
+  unexplained observation (something may already be suppressing across part of
+  the tower build) written up in the issue.
+- **#7154's `sfw-registry --help` symptom was not run** (the workload is not
+  present on this machine) and is **not** claimed resolved. What is measured is
+  that the five witnesses are green in the configuration a #7161 revert would
+  ship.

--- a/crates/perry-runtime/src/gc/tests/global_bootstrap.rs
+++ b/crates/perry-runtime/src/gc/tests/global_bootstrap.rs
@@ -1,0 +1,157 @@
+//! #7217: the lazy `globalThis` bootstrap must run in a NO-MOVE WINDOW.
+//!
+//! `populate_global_this_builtins` constructs an IMMORTAL object graph —
+//! everything it allocates is reachable from `globalThis` for the life of the
+//! thread. It constructs it by threading raw `*mut ObjectHeader` /
+//! `*mut ClosureHeader` locals through several hundred installs in a dozen
+//! installer modules, each of which allocates. Those locals are slots the
+//! collector does not rewrite, so a *relocating* collection inside the window
+//! leaves the rest of the bootstrap writing into from-space.
+//!
+//! This was invisible on the safepoint route (`PERRY_GC_MOVING_LOOP_POLLS=1`):
+//! a back-edge poll only fires while user JS runs, and the bootstrap runs no
+//! user JS. It is reachable on the allocation-point route, where the
+//! bootstrap's own block allocations are the collection points — which is why
+//! `test_gap_gc_spread_accessor_rooting` still SIGSEGV'd 10/10 under
+//! `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0
+//! PERRY_CONSERVATIVE_STACK_SCAN=off` after three rooting fixes that were all
+//! green at safepoints.
+//!
+//! ***BOTH HALVES ARE ASSERTED*** (CLAUDE.md's fourth way a gate cannot fail).
+//! A test that only checked "no collection ran during the bootstrap" would pass
+//! on a tree where nothing was ever due. The test below therefore arms ONE
+//! pending collection, shows the bootstrap did not service it, and then shows
+//! that the SAME armed request is serviced by ordinary allocation once the
+//! window has closed. Same thread, same lever, same magnitude — the only
+//! variable is whether the allocations happened inside the window.
+//!
+//! SCOPE. Only `populate_global_this_builtins` is covered, and deliberately so.
+//! `ensure_generator_intrinsics` / `ensure_typed_array_intrinsic` build the same
+//! shape of immortal graph through the same kind of raw locals and are ALSO
+//! reachable lazily, ahead of the bootstrap — but a tower is three orders of
+//! magnitude smaller than the bootstrap, fits inside one arena block's tail, and
+//! so may reach no `gc_check_trigger` at all. A version of this file that armed a
+//! collection around them PASSED with their windows deleted. Rather than ship a
+//! GC-trigger change with no test that can fail without it — the exact thing
+//! CLAUDE.md's knob-kill policy exists to stop — those two windows were dropped
+//! and the exposure is tracked separately.
+
+use super::super::*;
+use super::support::*;
+
+/// Run `body` on a thread that has never touched `globalThis`, so the lazy
+/// bootstrap really runs instead of returning the per-thread cache hit.
+/// `THREAD_GLOBAL_THIS`, the arena, `GC_STATS` and `GC_OLD_RECLAIM_PENDING` are
+/// all thread-local, so the arming and the measurement stay on this thread.
+fn on_a_fresh_thread(body: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        .stack_size(16 << 20)
+        .spawn(body)
+        .expect("spawn bootstrap test thread")
+        .join()
+        .expect("bootstrap test thread panicked");
+}
+
+/// Make one collection due at the very next `gc_check_trigger()` — which
+/// `arena_alloc_gc` calls every time the current block fills. This is the same
+/// lever `scan_fallback.rs` uses, and it completes synchronously on the
+/// allocation-point arm rather than deferring to a safepoint.
+fn arm_one_pending_collection() {
+    GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(true));
+}
+
+fn pending_collection_still_owed() -> bool {
+    GC_OLD_RECLAIM_PENDING.with(std::cell::Cell::get)
+}
+
+fn clear_pending_collection() {
+    GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(false));
+    GC_SAFEPOINT_PENDING.with(|pending| pending.set(false));
+    let old_in_use = crate::arena::old_gen_in_use_bytes();
+    GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.set(old_in_use));
+}
+
+/// THE CONTROL. Allocate ordinary young objects — nothing rooted, nothing
+/// exotic — until either the armed collection is serviced or two arena blocks
+/// have been consumed without it. Returns whether it was serviced.
+///
+/// Two blocks is deliberately more than the bootstrap window spans (measured:
+/// ~1.15 MB, i.e. just over one 1 MB block), so a `false` here means the
+/// arming is inert on this thread and the subject assertion above it proved
+/// nothing.
+fn ordinary_allocation_services_the_armed_collection(collections_before: u64) -> bool {
+    let arena_before = crate::arena::arena_total_bytes();
+    for _ in 0..500_000 {
+        let _ = young_leaf();
+        if gc_collection_count() > collections_before {
+            return true;
+        }
+        if crate::arena::arena_total_bytes() >= arena_before + (2 << 20) {
+            return false;
+        }
+    }
+    false
+}
+
+#[test]
+fn global_this_bootstrap_runs_in_a_no_move_window() {
+    on_a_fresh_thread(|| {
+        // Pin the shipped pacing (#7161 flipped `PERRY_GC_MOVING_LOOP_POLLS`
+        // off) so this asserts against a declared mode rather than whatever the
+        // process-wide OnceLock happened to resolve to.
+        let _pacing = crate::gc::policy::force_legacy_gc_pacing();
+        crate::gc::ensure_gc_initialized();
+        clear_pending_collection();
+
+        arm_one_pending_collection();
+        let arena_before = crate::arena::arena_total_bytes();
+        let collections_before = gc_collection_count();
+
+        // THE SUBJECT: the one-shot realm bootstrap.
+        let global = crate::object::js_get_global_this();
+        assert!(
+            crate::value::JSValue::from_bits(global.to_bits()).is_pointer(),
+            "js_get_global_this must return a real singleton, else the \
+             bootstrap never ran and this test measured nothing"
+        );
+
+        let arena_after = crate::arena::arena_total_bytes();
+        let collections_after = gc_collection_count();
+
+        // LIVE SUBJECT, half 1: the window really did span a block boundary, so
+        // `arena_alloc_gc` really did reach `gc_check_trigger()` inside it.
+        assert!(
+            arena_after >= arena_before + (1 << 20),
+            "the bootstrap must consume at least one arena block for this test \
+             to say anything (before={arena_before} after={arena_after})"
+        );
+        // THE INVARIANT: nothing collected, and therefore nothing moved, while
+        // the installers held raw pointers.
+        assert_eq!(
+            collections_after, collections_before,
+            "a collection ran inside the globalThis bootstrap — every installer \
+             local (`ctor`, `proto`, `ns_obj`, …) is now a from-space address"
+        );
+        assert!(
+            pending_collection_still_owed(),
+            "the window must DEFER the request, not drop it: leaving it \
+             unserviced-and-unset would disable the trigger for the rest of \
+             the thread"
+        );
+        assert!(
+            !crate::gc::gc_is_suppressed(),
+            "the no-move window must close when the bootstrap returns"
+        );
+
+        // LIVE SUBJECT, half 2 — THE CONTROL. Same thread, same armed request,
+        // ordinary allocation. If this does not collect, the arming was inert
+        // and the assertion above is vacuous.
+        assert!(
+            ordinary_allocation_services_the_armed_collection(collections_after),
+            "the armed collection was never serviceable on this thread, so \
+             'the bootstrap did not collect' proved nothing"
+        );
+
+        clear_pending_collection();
+    });
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -13,6 +13,7 @@ mod error_side_tables;
 mod evacuation;
 mod fromspace_protect;
 mod fromspace_scan;
+mod global_bootstrap;
 mod helper_stores;
 mod host_safepoints;
 mod incremental_sweep_reclaim;

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -40,6 +40,43 @@ pub(crate) fn populate_global_this_builtins(singleton_at_entry: *mut ObjectHeade
     // Only reachable when the conservative native-stack scan is off, which is
     // production's `Auto -> SkipDisabled` resolution; the scan was masking this
     // by pinning the argument register.
+    //
+    // #7217: rooting the singleton is necessary but NOT sufficient, and the
+    // difference is the whole point of the allocation-point route.
+    //
+    // The singleton is one pointer. The bootstrap it drives is a *graph*:
+    // `install_intl_namespace` -> `install_constructor` -> `install_function`
+    // holds `ctor`, `proto` and `ns_obj` as raw `*mut ObjectHeader` locals
+    // across dozens of allocating installs, and so do the error, typed-array,
+    // generator, Reflect, Atomics, WebAssembly, … installers, in a dozen files
+    // and several hundred call sites. Every one of those is a slot the
+    // collector does not rewrite.
+    //
+    // On the SAFEPOINT route none of them can be exposed: a collection reached
+    // from a loop back-edge poll only happens while user JS is running, and the
+    // bootstrap runs no user JS. On the ALLOCATION-POINT route every one of the
+    // bootstrap's own ~1.15 MB of allocations is a collection point, so the
+    // whole graph is exposed at once. That is why three separate rooting fixes
+    // verified green on `PERRY_GC_MOVING_LOOP_POLLS=1` were still red under
+    // `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0
+    // PERRY_CONSERVATIVE_STACK_SCAN=off`: the collection they were failing on
+    // was not in the code they had fixed, it was minor #0 landing inside this
+    // bootstrap. `PERRY_GC_PROTECT_FROMSPACE=1` names it exactly —
+    // `set_builtin_property_attrs` <- `intl::install_function` <-
+    // `install_constructor` <- `install_intl_namespace` <- here, on an address
+    // `retired_by_minor=#0`.
+    //
+    // THE INVARIANT: a bootstrap that builds an IMMORTAL object graph through
+    // raw pointers held across its own allocations must run in a NO-MOVE
+    // WINDOW. Rooting each holder individually is unbounded (hundreds of sites
+    // across a dozen installer modules) and ungateable (no checker can prove
+    // the set complete), while the window is one line and provably enough. It
+    // costs nothing a collection would have recovered: every object born here
+    // is reachable from `globalThis` for the life of the process, so a
+    // collection inside the window frees nothing. Measured footprint of the
+    // whole window: ~1.15 MB allocated, ~410 KB of it live afterwards, once per
+    // thread.
+    let _no_move = crate::gc::GcSuppressScope::new();
     let scope = crate::gc::RuntimeHandleScope::new();
     let singleton_handle = scope.root_raw_mut_ptr(singleton_at_entry);
     let singleton = || singleton_handle.get_raw_mut_ptr::<ObjectHeader>();

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -197,6 +197,19 @@ test_gap_repsel_gc_stress
 #   inline_ctor_this_rooting    green — see its own header; it is a STATIC
 #                               gate, pinned by the codegen test and by
 #                               `gc_root_dominance_check.py --unrooted-allocas`
+#
+# #7217 UPDATE: `spread_accessor_rooting` and `static_block_this_rooting` are now
+# ALSO green on the ALLOCATION-POINT route, which they were not when #7207
+# landed. That route's failure was never in the code #7207 fixed: it was minor #0
+# landing inside the lazy `globalThis` bootstrap, which threads raw
+# `*mut ObjectHeader` installer locals across its own ~1.15 MB of allocations.
+# The bootstrap now runs in a no-move window. Measured on `origin/main`
+# (8b024958f) vs this branch, same profile, same host, idle, 10 runs each, at
+# `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off`
+# with NO compile-time GC env:
+#   spread_accessor_rooting     exit=139 10/10  ->  `plain 0 hot 0 tail 0` 10/10
+#   static_block_this_rooting   `bad 1`  10/10  ->  `bad 0`               10/10
+#   inline_ctor_this_rooting    green    10/10  ->  green                 10/10
 test_gap_gc_spread_accessor_rooting
 test_gap_gc_static_block_this_rooting
 test_gap_gc_inline_ctor_this_rooting
@@ -292,6 +305,13 @@ test_gap_gc_closure_call_argument_rooting
 # Measured on this commit (7d1dc9ca2), `--arms loop_polls --filter test_gap_gc_`:
 # both PASS with copy-minor > 0, i.e. they relocate and they are byte-exact.
 # Also measured on the `gc-stress` PR arm set: PASS/UNVER only, no new red.
+#
+# #7217 UPDATE for `assign_string_source_rooting`: partly improved by #7217's
+# no-move bootstrap window (`bad char 3 count 3` -> `bad char 1 count 1`, 10/10
+# each) but NOT green. The residual iteration is a stale `js_eq` left operand in
+# the test's own `got !== ALPHA[i % 26]` assertion, not anything in
+# `js_object_assign_one` — tracked as #7248 with the emitted IR; the triage
+# entries are retargeted there.
 test_gap_gc_new_instance_rooting
 test_gap_gc_assign_string_source_rooting
 
@@ -347,7 +367,13 @@ test_gap_gc_closure_call_prev_this_rooting
 # PASS on `loop_polls` 8/8 (`bad 0`, matching the oracle), and exit=139 on all
 # TEN allocation-point arms, also deterministic. See gc_repsel_triage.txt: the
 # fix in this PR is verified on the safepoint route and is NOT claimed on the
-# allocation-point route, which is #7217's open defect class at a second site.
+# allocation-point route.
+#
+# #7217 UPDATE: that class turned out to be TWO unrelated sites, not one. #7217
+# itself (the lazy `globalThis` bootstrap) is fixed and this file is UNCHANGED by
+# it — exit=139 10/10 both before and after. Its own site is `js_regexp_new`
+# holding `&str` borrows into a movable `StringHeader` across its whole body,
+# tracked as #7247; the triage entries are retargeted there.
 test_gap_gc_regexp_receiver_rooting
 # --- #7210: argument staging buffers filled interleaved with lowering -------
 # `setTimeout(cb, 0, {…}, churn())` kept the CALLBACK closure in a bare SSA

--- a/test-parity/gc_repsel_triage.txt
+++ b/test-parity/gc_repsel_triage.txt
@@ -16,88 +16,83 @@
 
 test_gap_repsel_ptr_shape_locals | rep_ptr_shape_off | #6976 -- REGRESSION IN THE REPRESENTATION'S OWN OFF-SWITCH, not a defect in this PR. Bisected: passes at 8327ced52, fails at 1a533a3a8 (#6925, repsel Phase 5a proven `this`). With PERRY_PTR_SHAPE_LOCALS=0 the program dies partway with `TypeError: Cannot read properties of undefined (reading 'area')`, losing its last five output lines. It was invisible until now because #6925 also left test_gap_repsel_proven_this_frozen.ts unregistered, which makes this script exit 3 before it runs anything -- the gate was dark, not green. REMOVE THIS ENTRY when #6976 is fixed; an OFF arm is supposed to be the safest cell in the matrix.
 
-# --- #7216's Object.assign witness on the ALLOCATION-POINT arms (#7217) ------
-# `test_gap_gc_assign_string_source_rooting` shipped with #7216 but was never
-# registered in the corpus, so it had never run anywhere. Registering it (see
-# gc_repsel_corpus.txt) surfaced a pre-existing red on every arm that forces the
-# collection at the register-imprecise ALLOCATION point (`%E%` without the
-# compile-time `PERRY_GC_MOVING_LOOP_POLLS=1`).
+# --- #7216's Object.assign witness on the ALLOCATION-POINT arms (#7248) ------
+# RETARGETED FROM #7217, AND ITS STATED CAUSE WAS WRONG.
 #
-# This is #7217, not a new defect and not a representation defect. #7217 already
-# says the mechanism in words -- "an allocation-point collection inside the
-# helper ... can fire between any two of the helper's own allocations, including
-# ones inside `object_assign_set_string_key`'s interning and keys-array growth,
-# where #7207 re-reads its handles only at the top of each key iteration" -- and
-# this file is that sentence's reproducer, and a sharper one than the
-# `spread_accessor_rooting` case #7217 names -- that one is load-dependent and
-# passed idle here, while this one reproduces on demand at the same env.
+# #7217 is fixed: the allocation-point failure it names was minor #0 landing
+# inside the lazy `globalThis` bootstrap, whose installers thread raw
+# `*mut ObjectHeader` locals across their own allocations. That bootstrap now
+# runs in a no-move window. It fixed `spread_accessor_rooting` (exit=139 ->
+# clean, 10/10) and `static_block_this_rooting` (`bad 1` -> `bad 0`, 10/10).
 #
-# Measured on 7d1dc9ca2, release, idle host, oracle node 26.5.1
-# (`bad char 0 count 0`):
-#   PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off
-#     -> `bad char 2 count 2`, 5/5
-#   shipped default                    -> `bad char 0 count 0`, 3/3
-#   compiled+run PERRY_GC_MOVING_LOOP_POLLS=1 (`loop_polls`) -> PASS, copy-minor > 0
+# It did NOT fix this file, and it moved the number rather than the verdict:
 #
-# EVERY %E% ARM IS LISTED, INCLUDING ONE THAT WAS GREEN WHEN FIRST SAMPLED.
-# `rep_str_off` PASSED on the first `--arms all` sweep and FAILED on the third --
-# same binary, same idle host. The first read ("PERRY_CANONICAL_STR_LOCALS=0
-# makes it pass, so the borrow is in a canonical Str local") was an artefact of a
-# single sample. The window is timing-sensitive within the allocation point and
-# the repsel knobs are not discriminators, so the entries cover the arm class
-# rather than the arms that happened to be red on one run. Anyone bisecting
-# #7217 with this file should repeat each candidate before believing a green.
+#   merge-base 8b024958f, perry-dev, idle    -> `bad char 3 count 3`, 10/10
+#   with the #7217 no-move window            -> `bad char 1 count 1`, 10/10
+#   loop_polls (safepoint route)             -> PASS, copy-minor > 0
+#   shipped default                          -> `bad char 0 count 0`
 #
-# THE FILE IS NOT DARK WHILE THESE ENTRIES EXIST. It is a hard gate on
+# Two of the three bad iterations were the bootstrap. The residual one is NOT in
+# `js_object_assign_one` / `object_assign_string_source` at all -- the old
+# triage text asserting "allocation-point relocation inside js_object_assign_one
+# ... interning and keys-array growth" is not what the quarantine shows. Under
+# `PERRY_GC_PROTECT_FROMSPACE=1` the fault is in the test's OWN assertion:
+#
+#   js_jsvalue_equals + 332  <- js_eq + 20  <- main       obj_type=3 (string)
+#   retired_by_minor=#2  (not #0 -- which is why the bootstrap fix missed it)
+#
+# and the emitted IR names it exactly: `got` is loaded into a register above the
+# allocating `js_string_index_get_boxed` lowering of `ALPHA[i % 26]` and handed
+# to `js_eq` below it, never re-read. That is the #7206/#7214 codegen operand
+# family, filed as #7248 with the IR.
+#
+# THE FILE IS NOT DARK WHILE THESE ENTRIES EXIST -- it is a hard gate on
 # `loop_polls`, which .github/workflows/gc-moving-witnesses.yml runs on every
-# collector-touching PR and which requires it to relocate before it may pass.
-# That arm was green 8/8 across these sweeps.
+# collector-touching PR.
 #
-# DELETE ALL TEN when #7217 is fixed. An entry that matches nothing fails
-# nothing here, but a stale triage is a gate quietly narrowed.
-test_gap_gc_assign_string_source_rooting | evac_minor           | #7217 -- allocation-point relocation inside js_object_assign_one / object_assign_string_source, pre-existing on main. Clean on the safepoint route (loop_polls) and on the shipped default.
-test_gap_gc_assign_string_source_rooting | force_evac           | #7217 -- same allocation-point window, with force-evacuate on top.
-test_gap_gc_assign_string_source_rooting | force_verify         | #7217 -- same allocation-point window, force + verify.
-test_gap_gc_assign_string_source_rooting | rep_i32_off          | #7217 -- %E% allocation-point window; the repsel knob is not the discriminator.
-test_gap_gc_assign_string_source_rooting | rep_str_off          | #7217 -- %E% allocation-point window. Green on the first sweep and red on the third, same binary and idle host: sampled, not fixed.
-test_gap_gc_assign_string_source_rooting | rep_str_static_off   | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_assign_string_source_rooting | rep_ptr_shape_off    | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_assign_string_source_rooting | rep_ptr_numarray_off | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_assign_string_source_rooting | rep_spec_abi_off     | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_assign_string_source_rooting | rep_int_valued_off   | #7217 -- %E% allocation-point window; see rep_i32_off.
-# --- The regexp receiver on the ALLOCATION-POINT arms (#7217 class) ----------
-# `test_gap_gc_regexp_receiver_rooting` is a HARD GATE on `loop_polls`, where the
-# fix it ships with is claimed and verified: `bad 0`, 8/8, byte-exact against the
-# oracle, with the copying minor live. These ten entries cover the arms where no
-# fix is claimed -- the ones that force the collection at the register-imprecise
-# ALLOCATION point (`%E%` without the compile-time PERRY_GC_MOVING_LOOP_POLLS=1)
-# rather than at a loop safepoint.
+# DELETE ALL TEN when #7248 is fixed.
+test_gap_gc_assign_string_source_rooting | evac_minor           | #7248 -- stale `js_eq` left operand in the test's own assertion (was mis-attributed to #7217/js_object_assign_one). `bad char 1 count 1`, 10/10. Clean on the safepoint route (loop_polls) and on the shipped default.
+test_gap_gc_assign_string_source_rooting | force_evac           | #7248 -- same allocation-point window, with force-evacuate on top.
+test_gap_gc_assign_string_source_rooting | force_verify         | #7248 -- same allocation-point window, force + verify.
+test_gap_gc_assign_string_source_rooting | rep_i32_off          | #7248 -- %E% allocation-point window; the repsel knob is not the discriminator.
+test_gap_gc_assign_string_source_rooting | rep_str_off          | #7248 -- %E% allocation-point window. Green on the first sweep and red on the third, same binary and idle host: sampled, not fixed.
+test_gap_gc_assign_string_source_rooting | rep_str_static_off   | #7248 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_assign_string_source_rooting | rep_ptr_shape_off    | #7248 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_assign_string_source_rooting | rep_ptr_numarray_off | #7248 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_assign_string_source_rooting | rep_spec_abi_off     | #7248 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_assign_string_source_rooting | rep_int_valued_off   | #7248 -- %E% allocation-point window; see rep_i32_off.
+# --- The regexp receiver on the ALLOCATION-POINT arms (#7247) ----------------
+# RETARGETED FROM #7217. #7217 is fixed (the lazy `globalThis` bootstrap now runs
+# in a no-move window) and this file is UNCHANGED by it:
 #
-# Measured on this branch, release, oracle node 26.5.1 (`bad 0`):
-#   PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off
-#     -> exit=139, no output, 8/8 deterministic
-#   compiled+run PERRY_GC_MOVING_LOOP_POLLS=1  -> `bad 0`, 8/8
+#   merge-base 8b024958f, perry-dev, idle -> exit=139, no output, 10/10
+#   with the #7217 no-move window         -> exit=139, no output, 10/10
+#   compiled+run PERRY_GC_MOVING_LOOP_POLLS=1  -> `bad 0`
 #   shipped default                            -> `bad 0`
-# `--arms all` reports the SAME `exit=139 cycles=1 scavenged=14` on all ten, and
-# PASS on `loop_polls`. The split is the route, not the arm's other knobs.
 #
-# THIS IS THE SECOND FILE WITH EXACTLY THIS SIGNATURE. #7216's
-# `test_gap_gc_assign_string_source_rooting` behaves the same way and is triaged
-# to #7217 for the same reason. Two independent sites where a rooting fix that
-# holds at a safepoint does not hold when the collection is forced inside the
-# allocating helper is a statement about the route, not about either fix -- and
-# it is what #7217 says in words about `object_assign_set_string_key`'s interning
-# and keys-array growth. Whoever closes #7217 should check this file too; if it
-# turns out to need its own fix, split these entries onto their own issue.
+# It is a separate site, and #7196's quarantine names it:
 #
-# DELETE ALL TEN when the allocation-point route is fixed.
-test_gap_gc_regexp_receiver_rooting | evac_minor           | #7217 -- allocation-point relocation; the fix is verified on the safepoint route (loop_polls, 8/8) and not claimed here. exit=139, deterministic.
-test_gap_gc_regexp_receiver_rooting | force_evac           | #7217 -- same allocation-point window, with force-evacuate on top.
-test_gap_gc_regexp_receiver_rooting | force_verify         | #7217 -- same allocation-point window, force + verify.
-test_gap_gc_regexp_receiver_rooting | rep_i32_off          | #7217 -- %E% allocation-point window; the repsel knob is not the discriminator (identical evidence on all ten).
-test_gap_gc_regexp_receiver_rooting | rep_str_off          | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_regexp_receiver_rooting | rep_str_static_off   | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_regexp_receiver_rooting | rep_ptr_shape_off    | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_regexp_receiver_rooting | rep_ptr_numarray_off | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_regexp_receiver_rooting | rep_spec_abi_off     | #7217 -- %E% allocation-point window; see rep_i32_off.
-test_gap_gc_regexp_receiver_rooting | rep_int_valued_off   | #7217 -- %E% allocation-point window; see rep_i32_off.
+#   LocalKey<RefCell<HashMap<(String,String), Arc<fancy_regex::Regex>>>>::with
+#     <- js_regexp_new + 1396   obj_type=3 (string)  retired_by_minor=#0
+#
+# `js_regexp_new` (`regex.rs:616`) opens with `string_as_str(pattern)` /
+# `string_as_str(flags)` -- `&str` borrows INTO the movable `StringHeader`
+# payload -- and holds them across the whole body, including the `REGEX_CACHE`
+# probe's `.to_string()` calls and the `RegExpHeader` allocation. That is the
+# #7215 borrow shape, the one #7216 fixed for `object_assign_string_source` with
+# one owned copy. Filed as #7247.
+#
+# THIS FILE IS A HARD GATE ON `loop_polls` and stays one: PASS 8/8 there, which
+# .github/workflows/gc-moving-witnesses.yml runs on every collector-touching PR.
+#
+# DELETE ALL TEN when #7247 is fixed.
+test_gap_gc_regexp_receiver_rooting | evac_minor           | #7247 -- `&str` borrowed into a movable StringHeader across js_regexp_new's body. The #7227 fix is verified on the safepoint route (loop_polls, 8/8) and not claimed here. exit=139, deterministic 10/10.
+test_gap_gc_regexp_receiver_rooting | force_evac           | #7247 -- same allocation-point window, with force-evacuate on top.
+test_gap_gc_regexp_receiver_rooting | force_verify         | #7247 -- same allocation-point window, force + verify.
+test_gap_gc_regexp_receiver_rooting | rep_i32_off          | #7247 -- %E% allocation-point window; the repsel knob is not the discriminator (identical evidence on all ten).
+test_gap_gc_regexp_receiver_rooting | rep_str_off          | #7247 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_regexp_receiver_rooting | rep_str_static_off   | #7247 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_regexp_receiver_rooting | rep_ptr_shape_off    | #7247 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_regexp_receiver_rooting | rep_ptr_numarray_off | #7247 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_regexp_receiver_rooting | rep_spec_abi_off     | #7247 -- %E% allocation-point window; see rep_i32_off.
+test_gap_gc_regexp_receiver_rooting | rep_int_valued_off   | #7247 -- %E% allocation-point window; see rep_i32_off.


### PR DESCRIPTION
Closes #7217.

## The answer to the question #7217 actually asked

> the question to answer first is what differs about a collection initiated *inside* the allocating helper versus at a back-edge poll — the answer probably explains all three at once.

It does, and it is not what the issue guessed. **The collection that was killing `test_gap_gc_spread_accessor_rooting` was not in `js_object_assign_one`, was not in interning, and was not in keys-array growth. It was minor #0 landing inside the lazy `globalThis` bootstrap.**

`js_get_global_this()` builds the entire realm on first use. It is reached lazily — here from `js_object_set_field_by_name` → `object_prototype_addr_matches` → `js_get_global_this_builtin_value`, i.e. from an ordinary property write several hundred iterations into the loop, after ~8 MB of churn. The bootstrap then allocates ~1.15 MB of its own in one go, so under `PERRY_GC_HEAP_LIMIT=8` the very first collection of the program lands in the middle of it.

That matters because the bootstrap builds a **graph** through raw pointers. `intl::install_constructor` holds `ctor`, `proto` and `ns_obj` as bare `*mut ObjectHeader` locals across dozens of allocating installs; so do the error, typed-array, generator, Reflect, Atomics and WebAssembly installers, across a dozen files. #6982 rooted **the singleton** — one pointer — and that is all it rooted.

`PERRY_GC_PROTECT_FROMSPACE=1` (#7196) names the site without inference:

```
[gc-fromspace-protect] FAULT: signal 10 at 0x478b0f8fc60
  block=0x478b0e90000 +1047648 retired_bytes=1048536 retired_by_minor=#0
  last-known object: user_ptr=0x478b0f8fc68 obj_type=2 size=168
2  perry_runtime::object::descriptor_state::set_builtin_property_attrs
3  perry_runtime::intl::install_function + 576
4  perry_runtime::intl::install::install_constructor + 564
5  perry_runtime::intl::install_intl_namespace + 1828
6  ...global_this::populate::populate_global_this_builtins + 13768
7  js_get_global_this + 220
8  js_get_global_this_builtin_value + 72
9  perry_runtime::array::indexing::object_prototype_addr_matches + 156
10 js_object_set_field_by_name + 1004
11 test_gap_gc_spread_accessor_rooting_ts____AnonShape_..._constructor + 208
```

`retired_by_minor=#0`, deterministic 10/10 — the signature CLAUDE.md records for a table rather than a register, and here it is a whole subsystem's worth of them.

Confirmed independently before writing any code: adding one line, `const __warm = typeof (globalThis as any).Intl;`, at the top of the unmodified reproducer — so the bootstrap runs while the arena is nearly empty — makes it **clean 5/5 on the allocation-point arm, with 6 copying minors and 4 613–5 797 objects copied each**. The spread path was never the bug.

### Why the safepoint route could not see it

A back-edge poll fires only while user JS is running, and **the bootstrap runs no user JS**. So on the `loop_polls` route not one of those installer locals is ever live across a collection. On the allocation-point route the bootstrap's *own* allocations are the collection points, so the whole graph is exposed at once.

That is the general statement #7217's second comment asked for: the two routes are not two chances to catch the same bug. `loop_polls` cannot expose an unrooted local in any runtime code that does not re-enter user JS — which is most of the runtime. Three fixes verified green there and red here were not three flawed fixes; two of the three were failing on a collection in code they had never touched.

## The invariant

> **A bootstrap that builds an IMMORTAL object graph through raw pointers held across its own allocations must run in a NO-MOVE WINDOW.**

Rooting each holder individually is unbounded (hundreds of sites across a dozen installer modules) and ungateable — no checker can prove the set complete, and `gc_root_dominance_check.py` reads emitted LLVM IR so it is structurally blind to all of them. The window is one line and is provably enough. It costs nothing a collection would have recovered: **every object born in the window is reachable from `globalThis` for the life of the thread, so a collection inside it frees nothing.**

## The change

One line: `crate::gc::GcSuppressScope` (the existing RAII no-move window, nesting-safe, already used by `descriptor_state.rs`) at the top of `populate_global_this_builtins`.

`GC_FLAG_SUPPRESSED` gates `gc_check_trigger`, the budgeted stepper **and** `gc_safepoint_moving_minor`, so the window is comprehensive rather than alloc-point-only. No collector behaviour changes anywhere else, and no env knob is added.

**No installer's rooting was touched.** Adding a `RuntimeHandleScope` to one of fifty installers would imply the other forty-nine are fine.

**Two sibling windows were written and then deliberately dropped — see #7251.** `ensure_generator_intrinsics` and `ensure_typed_array_intrinsic` build the same shape of immortal tower through the same kind of raw locals and are *also* reachable lazily ahead of the bootstrap. But a tower is three orders of magnitude smaller than the bootstrap, fits inside one arena block's tail, and may reach no `gc_check_trigger` at all — **three successive gate designs for them PASSED with the window deleted** (an armed-collection gate; the same with a block-boundary pre-fill and a re-exec into a virgin process, because the intrinsic slots are process-global and libtest's ordering meant `array::tests` built the towers first; and a `#[cfg(test)]` observer of `gc_is_suppressed()` inside the builder, which reported *suppressed* even with the scope removed, unexplained). Shipping a GC-trigger change with no test that can fail without it is the thing CLAUDE.md's knob-kill policy exists to stop, so the exposure is tracked with both candidate gate designs written up rather than shipped ungated.

## Verification

Same host, idle, `--profile perry-dev`, one target dir, **10 runs per cell**, at
`PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off`
with **no compile-time GC env** — the allocation-point arm #7217 names.

The base arm was produced by reverting the three source files, rebuilding, and it came back **bit-identical to the pre-change build** (`perry` md5 `6142b49fcf7f29f0f7ee9ab09ccc2f2d` both times), while the fixed build is `068af60471ba94006e4fe6ac828e326d`. The two arms are demonstrably different binaries.

| witness | base `8b024958f` | this PR |
|---|---|---|
| **`test_gap_gc_spread_accessor_rooting`** (#7217) | **exit=139, no output, 10/10** | **`bad plain 0 hot 0 tail 0` 10/10** |
| `test_gap_gc_static_block_this_rooting` | `bad 1` 10/10 | **`bad 0` 10/10** |
| `test_gap_gc_inline_ctor_this_rooting` | green 10/10 | green 10/10 |
| `test_gap_gc_assign_string_source_rooting` | `bad char 3 count 3` 10/10 | `bad char 1 count 1` 10/10 — **not green**, see below |
| `test_gap_gc_regexp_receiver_rooting` | exit=139 10/10 | exit=139 10/10 — **unchanged**, see below |

Other arms, this PR:

| arm | result |
|---|---|
| `loop_polls` (compiled **and** run with `PERRY_GC_MOVING_LOOP_POLLS=1`, `+FORCE_EVACUATE=1`) | all five witnesses green, 5/5 each |
| shipped default (no env) | `bad plain 0 hot 0 tail 0`, 3/3 |
| `node --experimental-strip-types` oracle | `bad plain 0 hot 0 tail 0` — byte-exact |
| `PERRY_GC_PROTECT_FROMSPACE=1` on the reproducer | **no fault at all** (was: fault at `intl::install_function`, `retired_by_minor=#0`) |
| `gc_root_dominance_check.py` (default + `--unrooted-allocas`) | 0 violations before **and** after — it reads emitted LLVM IR and is structurally blind to this bug, exactly as expected |

Cost — the window defers one collection, it does not add one:

| `console.log("hi", typeof globalThis.Intl)` | base | this PR |
|---|---|---|
| peak RSS (3 runs) | 10 878 976 / 10 895 360 / 10 878 976 | **10 649 600 / 10 649 600 / 10 633 216** |
| GC cycles at `HEAP_LIMIT=8` | 2 | **1** |

RSS is ~230 KB *lower*: the collection that used to run mid-bootstrap copied the bootstrap's own live set and then immediately had it all survive anyway.

`cargo test -p perry-runtime`: **1637 passed, 0 failed** (`--test-threads=1`, which is how CI runs this crate — `RUST_TEST_THREADS=1` at `.github/workflows/test.yml:565`). The crate's parallel-mode flakes are pre-existing and measured at the same 2–4/run with and without the new tests.

## The gate

`crates/perry-runtime/src/gc/tests/global_bootstrap.rs`, in the per-PR `cargo-test` surface (a `--lib` unit test, not a `tests/*.rs` integration suite, which per CLAUDE.md would only run nightly).

It arms **one** pending collection, runs the bootstrap, and asserts it was not serviced, that the request is **deferred rather than dropped** (leaving it unserviced-and-unset would disable the trigger for the rest of the thread), that the window spans at least one arena block (so `arena_alloc_gc` genuinely reached `gc_check_trigger` inside it), and that the window closed.

Then it runs **the control**: the *same* armed request, on the *same* thread, must be serviced by ordinary allocation once the window is over. Without that second half the test would pass on a tree where nothing was ever due — CLAUDE.md's fourth way a gate cannot fail.

Sabotage-checked in the failing direction:

```
global_this_bootstrap_runs_in_a_no_move_window ... FAILED
  a collection ran inside the globalThis bootstrap — every installer local
  (`ctor`, `proto`, `ns_obj`, …) is now a from-space address
  left: 1   right: 0
```

## The two witnesses this does NOT fix, and why their triage is retargeted rather than deleted

`test-parity/gc_repsel_triage.txt` says "DELETE ALL TEN when #7217 is fixed" for each. Both are still red, so the twenty entries are **retargeted with their real causes** — and one of the two triage texts was asserting a cause that is now known to be wrong.

* **#7247** — `test_gap_gc_regexp_receiver_rooting`, unchanged by this PR (exit=139 10/10 both arms). `js_regexp_new` (`regex.rs:616`) takes `string_as_str(pattern)` / `string_as_str(flags)` — `&str` borrows **into the movable `StringHeader` payload** — and holds them across its whole body including the `REGEX_CACHE` probe's `.to_string()` calls. The #7215 borrow shape, quarantine backtrace in the issue.
* **#7248** — `test_gap_gc_assign_string_source_rooting`, improved 3→1. The old triage blamed "allocation-point relocation inside `js_object_assign_one` / `object_assign_string_source`". It is not there. The residual failure is in the test's **own assertion**, and the IR says so:

  ```llvm
  %r136 = load double, ptr %r97                    ; `got` — loaded ABOVE
  %r149 = call double @js_string_index_get_boxed(...)  ; ALLOCATES
  %r150 = bitcast double %r136 to i64              ; the STALE register
  %r152 = call i64 @js_eq(i64 %r150, i64 %r151)
  ```

  `%r97` may well be a rewritten shadow slot, but `%r136` is a register taken before the collection point and never re-read — the third property #7207 says a root must buy. The #7206/#7214 operand family, at `js_eq`.

Both remain **hard gates on `loop_polls`**, which `gc-moving-witnesses.yml` runs on every collector-touching PR, and both are green there 5/5.

## #7161 / #7154

**Not claimed, and here is exactly what was and was not measured.**

I could not find the `sfw-registry` workload anywhere on this machine, so **#7154's own symptom was not run and I am not asserting it is resolved.** That check still belongs to whoever proposes the #7161 revert.

What *is* measured: in the configuration a #7161 revert would ship — compiled and run with `PERRY_GC_MOVING_LOOP_POLLS=1`, plus `PERRY_GC_FORCE_EVACUATE=1` — all five `test_gap_gc_*_rooting` witnesses are green 5/5 on this branch. And this PR removes one of the two reasons #7217 gave for calling the revert-readiness statement incomplete: the object-spread path is now verified on the allocation-point route, not merely at safepoints. #7247 and #7248 remain open on that route, but neither is a *shipped* configuration — the allocation-point relocating arm requires an explicit `PERRY_CONSERVATIVE_STACK_SCAN=off`, which the matrix header itself calls a measurement configuration and not one anyone ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection safety while initializing global built-ins, preventing potential allocation-related crashes during startup.
  - Ensured deferred collection requests are handled correctly after initialization completes.

- **Tests**
  - Added coverage for global initialization across allocation boundaries and pending collection scenarios.
  - Updated garbage-collection test tracking to reflect resolved and remaining issues.

- **Documentation**
  - Added release notes describing the fix, validation results, and known follow-up items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->