### PR TITLE
test(gc): register the dark call-argument witness from #7252

### DIFF
--- a/changelog.d/7263-register-dark-call-arg-witness.md
+++ b/changelog.d/7263-register-dark-call-arg-witness.md
@@ -1,0 +1,9 @@
+`test_gap_gc_call_argument_rooting` shipped with #7252 but was never added to
+`test-parity/gc_repsel_corpus.txt`, so it never ran anywhere. Registering it is
+the whole fix.
+
+This is the third occurrence of the same mistake (#7192 and #7216 are documented
+in that file directly above), and the first one caught automatically: the
+`test_gap_gc_*` enforcement added in response to the earlier two failed the
+`GC Moving Witnesses` job on its first main-line run — which only happened at
+all because #7253 gave that matrix a main-line trigger.

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -286,6 +286,16 @@ test_gap_gc_closure_call_callee_rooting
 test_gap_gc_closure_call_this_rooting
 test_gap_gc_closure_call_argument_rooting
 
+# --- A THIRD witness that was registered nowhere (#7252) --------------------
+# `test_gap_gc_call_argument_rooting` shipped with #7252 (cross-module direct
+# call argument rooting, authored by @jdalton, restacked at merge). Same defect
+# as #7192 and #7216 above: the PR added the witness and did not add the line.
+# It was dark from merge until the `test_gap_gc_*` enforcement added for those
+# two caught it on the first `GC Moving Witnesses` run on main -- which is the
+# enforcement working exactly as designed, on the third occurrence of the same
+# mistake. Registering the file is the whole fix.
+test_gap_gc_call_argument_rooting
+
 # --- Two witnesses that were registered nowhere (#7192, #7216) ---------------
 # Both files exist in test-files/, both say in their own headers that they are
 # LIVE BY CONSTRUCTION and bite only on the moving arms, and neither was in this


### PR DESCRIPTION
`test-files/test_gap_gc_call_argument_rooting.ts` shipped with #7252 and was never added to `test-parity/gc_repsel_corpus.txt`. It has not run anywhere since that merge. Adding the line is the entire fix.

## How it surfaced

The `GC Moving Witnesses` job failed on `main` with:

> `test_gap_gc_call_argument_rooting exists but was not run: register it in test-parity/gc_repsel_corpus.txt. The matrix only auto-detects the test_gap_repsel_*/test_gap_specabi_* prefixes, so a test_gap_gc_* witness that is not registered is silently dark (#6925 is the precedent).`

**This is the third occurrence of the same mistake.** #7192 and #7216 did it before, and are documented in that file immediately above the line this PR adds. The difference is that this one was caught by a machine instead of by someone noticing months later — the `test_gap_gc_*` enforcement written in response to those two did its job.

It only got the chance because **#7253 gave the moving-GC matrix a main-line trigger two hours earlier**. Before that, `gc-stress` reported `skipped` on 12/12 nightly runs, and this witness would have stayed dark indefinitely.

I merged #7252 (restacking @jdalton's branch past two squash-merged parents), so this omission is mine to fix.

## What is NOT verified

**CI is the first real execution of this test.** I did not build locally to run it — the box is disk-constrained. If it goes red, that is the test doing its job on first contact, and it would be the first independent exercise of the rooting fix #7252 shipped. A dark test is strictly worse than a red one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the missing garbage-collection test to the test corpus so it runs as intended.
  * Improved test coverage for call argument rooting scenarios.

* **Documentation**
  * Added a changelog entry documenting the previously omitted test and its correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->