### PR TITLE
fix(gc): clear the five denied warnings blocking the Warnings jobs (#7277)

### DIFF
--- a/changelog.d/7278-barrier-arming-product-warnings.md
+++ b/changelog.d/7278-barrier-arming-product-warnings.md
@@ -1,0 +1,19 @@
+`Warnings (product)` has failed on every PR opened since #7250 landed. Two denied
+warnings in the lazy-barrier-arming code:
+
+- `gc/mod.rs` re-exported `barrier_arming::*` as `pub(crate)`, but every item in
+  that module is `pub(super)` — narrower — so the glob re-exported nothing and
+  rustc said so. A plain `use` is what the in-module callers actually need.
+- `remembered_reconstruct_census`'s only non-test caller is `telemetry.rs`'s
+  cycle-JSON emitter, which is itself `allow(dead_code)` without the
+  `diagnostics` feature, so a product build saw the function as unused. Now
+  carries the same `cfg_attr` as the three sibling sites in `telemetry.rs`.
+
+Neither was caught before merge because `main`'s last `Tests` run predates #7250,
+so no run on `main` had ever compiled this code with `-D warnings`.
+
+Three further pre-existing denied warnings were blocking the same job family and
+are fixed here too: a redundant `unsafe` wrapper in `pointer_publish_7154.rs`
+(#7179), a dead initializer in `oldgen.rs` re-derived by its own loop (#7147),
+and `reset_typeof_string_cache_for_test` (#7226), which has no callers anywhere
+in the workspace.

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -591,6 +591,10 @@ pub fn scan_typeof_string_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<
 /// arenas between tests while thread-locals persist, so a cache entry from a
 /// previous test names memory the new arena does not own.
 #[cfg(test)]
+// #7277: no callers anywhere in the workspace. Kept rather than deleted because
+// it is the only handle on this cache's reset path, but it is dead today — if
+// nothing adopts it, delete it rather than letting it rot behind this attribute.
+#[allow(dead_code)]
 pub(crate) fn reset_typeof_string_cache_for_test() {
     for cache in [
         &TYPEOF_UNDEFINED,

--- a/crates/perry-runtime/src/gc/barrier_arming.rs
+++ b/crates/perry-runtime/src/gc/barrier_arming.rs
@@ -115,6 +115,11 @@ thread_local! {
     static TEST_ARMED_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
 }
 
+// #7277: the only non-test caller is `telemetry.rs`'s cycle-JSON emitter,
+// which is itself `allow(dead_code)` without the `diagnostics` feature — so a
+// product build (`cargo check -p perry --bins`, `-D warnings`) sees this as
+// unused. Same `cfg_attr` the three sibling sites in `telemetry.rs` use.
+#[cfg_attr(not(feature = "diagnostics"), allow(dead_code))]
 pub(super) fn remembered_reconstruct_census() -> RememberedReconstructCensus {
     RECONSTRUCT_CENSUS.with(Cell::get)
 }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -67,7 +67,11 @@ pub(crate) use trace::*;
 mod barrier;
 pub use barrier::*;
 mod barrier_arming;
-pub(crate) use barrier_arming::*;
+// #7277: every item in `barrier_arming` is `pub(super)` (i.e. `pub(in gc)`),
+// which is narrower than `pub(crate)` — so the glob re-exported nothing and
+// rustc warned. A plain `use` brings them into `gc`'s namespace, which is all
+// the in-module callers (`telemetry.rs`, `cycle.rs`) actually need.
+use barrier_arming::*;
 mod copying;
 use copying::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry

--- a/crates/perry-runtime/src/gc/tests/copying/pointer_publish_7154.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/pointer_publish_7154.rs
@@ -228,23 +228,22 @@ fn test_weakmap_overwrite_value_is_traced_7154() {
 /// map's entries array the same way `js_weakmap_get` does.
 fn weak_entry_addr_for(map: f64, key: f64) -> usize {
     let map_ptr = (map.to_bits() & POINTER_MASK) as *mut crate::ObjectHeader;
-    unsafe {
-        let entries = crate::object::js_object_get_field(map_ptr, 0);
-        let entries_ptr = (entries.bits() & POINTER_MASK) as *mut crate::array::ArrayHeader;
-        let len = crate::array::js_array_length(entries_ptr) as usize;
-        for i in 0..len {
-            let entry_val = crate::array::js_array_get(entries_ptr, i as u32);
-            let entry = (entry_val.bits() & POINTER_MASK) as *mut crate::ObjectHeader;
-            if entry.is_null() {
-                continue;
-            }
-            let stored_key = crate::object::js_object_get_field(entry, 0);
-            if stored_key.bits() == key.to_bits() {
-                return entry as usize;
-            }
+    // #7277: the calls below are safe fns; the wrapper was redundant.
+    let entries = crate::object::js_object_get_field(map_ptr, 0);
+    let entries_ptr = (entries.bits() & POINTER_MASK) as *mut crate::array::ArrayHeader;
+    let len = crate::array::js_array_length(entries_ptr) as usize;
+    for i in 0..len {
+        let entry_val = crate::array::js_array_get(entries_ptr, i as u32);
+        let entry = (entry_val.bits() & POINTER_MASK) as *mut crate::ObjectHeader;
+        if entry.is_null() {
+            continue;
         }
-        0
+        let stored_key = crate::object::js_object_get_field(entry, 0);
+        if stored_key.bits() == key.to_bits() {
+            return entry as usize;
+        }
     }
+    0
 }
 
 /// A freshly allocated closure's capture slots must read as a non-pointer

--- a/crates/perry-runtime/src/gc/tests/oldgen.rs
+++ b/crates/perry-runtime/src/gc/tests/oldgen.rs
@@ -1185,7 +1185,10 @@ fn test_minor_preserves_old_to_young_edge_across_minors() {
     // Re-derived from the parent's slot after every minor (see the loop), so
     // both are `mut`: a relocating minor moves the child.
     let mut child = crate::arena::arena_alloc_gc(40, 8, GC_TYPE_OBJECT) as usize;
-    let mut child_header = unsafe { header_from_user_ptr(child as *const u8) };
+    // #7277: no initializer — the loop below re-derives this from the parent's
+    // slot after every minor (a relocating minor moves the child), so the
+    // initial value was never read.
+    let mut child_header;
     assert!(crate::arena::pointer_in_nursery(child));
     unsafe {
         *fields = ptr_bits(child);


### PR DESCRIPTION
Fixes #7277.

`Warnings (product)` has failed on **every PR opened since #7250 landed**, and `Warnings (host-compatible)` has been failing on three unrelated pre-existing items. Both are fixed here.

## Why nobody caught the #7250 pair before merge

`main`'s last `Tests` run predates #7250, so **no run on `main` had ever compiled that code with `-D warnings`**. Every PR since has inherited the failure and read it as "pre-existing noise" — which it was, but nobody owned it.

## The two from #7250

1. **`gc/mod.rs`** re-exported `barrier_arming::*` as `pub(crate)`, but every item in that module is `pub(super)` — strictly narrower — so the glob re-exported **nothing** and rustc said so. A plain `use` is what the in-module callers (`telemetry.rs`, `cycle.rs`) actually need.
2. **`remembered_reconstruct_census`**'s only non-test caller is `telemetry.rs`'s cycle-JSON emitter, which is itself `allow(dead_code)` without the `diagnostics` feature — so a product build saw the function as unused. It now carries the **same `cfg_attr` as the three sibling sites in `telemetry.rs`**, rather than a new idiom.

## Three pre-existing, same job family

3. `pointer_publish_7154.rs` (#7179) — redundant `unsafe` wrapper around 15 lines of safe calls.
4. `oldgen.rs` (#7147) — dead initializer; the loop below re-derives it from the parent's slot after every minor, so the initial value was never read.
5. `arithmetic.rs` (#7226) — `reset_typeof_string_cache_for_test` has **zero references anywhere in the workspace**. Annotated rather than deleted, with a comment saying plainly: if nothing adopts it, delete it rather than letting it rot behind the attribute.

## Verified

- `cargo check -p perry --bins` with `-D warnings` → **clean** (the exact `Warnings (product)` command).
- `cargo check -p perry-runtime --all-targets` with `-D warnings` → **clean**.
- `cargo check -p perry-runtime --features diagnostics` with `-D warnings` → **clean** (the `cfg_attr` doesn't break the other arm).
- Reproduced all five against `origin/main` first, so each is demonstrably pre-existing rather than introduced.
- `cargo fmt --check` and `scripts/check_file_size.sh` clean.

No behaviour change: three comment/attribute edits, one `pub(crate) use` → `use`, one dropped dead initializer, one dedent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved several product warning issues across runtime and garbage-collection diagnostics.
  * Preserved correct handling of conditional code in builds without diagnostic features.
  * Removed redundant safety handling and unused test initialization without changing behavior.

* **Chores**
  * Cleaned up internal visibility and unused test-only code.
  * Documented the resolved warning issues and why they were not detected earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->