### PR TITLE
fix(gc): root optional parameters, and the instance in runtime-dispatched `new` (#7280)

### DIFF
--- a/changelog.d/7280-optional-param-and-dynamic-construct-rooting.md
+++ b/changelog.d/7280-optional-param-and-dynamic-construct-rooting.md
@@ -1,0 +1,81 @@
+### GC: an optional parameter lost its shadow slot — #7154's surviving residual (#7280)
+
+`sfw-registry --help` under `PERRY_GC_MOVING_LOOP_POLLS=1` faulted in zod
+`src/v4/core/util.ts`'s
+
+```ts
+export function clone<T>(inst: T, def?: T["_zod"]["def"], params?: { parent: boolean }): T {
+  const cl = new inst._zod.constr(def ?? inst._zod.def);
+  if (!def || params?.parent) cl._zod.parent = inst;
+  return cl as any;
+}
+```
+
+`params` is `Object(...)` in HIR and `type_is_pointer_bearing` says true, yet
+`collect_pointer_typed_locals` gave it no slot. It lived in callee-saved `d8`
+across `new inst._zod.constr(...)` — a user constructor crossing ~180 copying
+minors — and `params?.parent` then dereferenced retired from-space.
+
+**The cause is the optional marker, not the object type.** The pointer-locals
+refinement fixpoint proves a local non-pointer from its **writes**, and for a
+**parameter** the write list is a strict *subset* of its definitions: the
+incoming argument is not a write. The optional-parameter desugaring then donates
+the one write that completes the false proof, for free, on every optional
+parameter in the program:
+
+```
+if (p === undefined) { p = undefined; }
+```
+
+`Void` is definitely-non-pointer, so "every write is non-pointer" held. Both of
+that loop's conclusions are unsound for a parameter for the same reason, and
+both are now excluded:
+
+* `all_non_pointer` — fixes the declared-`Object` shape (zod's).
+* `precise_inference` — fixes the `p?: any` shape, where the loop instead
+  concluded `local_value_types[p] = Void` and any local **aliased from** `p`
+  inherited it, was proven non-pointer, and lost *its* slot too. Measured red
+  200/200 with only the first exclusion applied.
+
+One-sided in the safe direction: a parameter that would have been proven
+non-pointer keeps a root the collector rewrites harmlessly. Body `let`s are
+untouched — their `Stmt::Let` init *is* in `writes`, so for them the write list
+really is every definition.
+
+**Found while bisecting toward that: four runtime-side siblings.** Every `new`
+route codegen cannot resolve statically hands construction to perry-runtime,
+and all four held the instance in a bare Rust local across the user constructor
+body — `construct_registered_class_ref`, the class-object arm, the closure tail,
+and `js_new_function_construct_with_new_target`. A runtime frame is not visited
+by the precise root walk, so the helper returned the **pre-move address**.
+Routed through `RuntimeHandleScope`, which is what this file's own
+`CURRENT_NEW_TARGET` doc-comment already said needed doing; the same scope also
+roots the displaced `prev_this` / `prev_new_target` / `prev_current_new_target`
+values named in that comment.
+
+Also corrects `gc/policy.rs`'s "sound by construction" claim for the loop-polls
+route (#7280 ask 2). Deferring to `js_gc_loop_safepoint` makes the collection
+point precise for **codegen** frames; it says nothing about a value parked in a
+runtime Rust frame.
+
+**Measurements** (release, `PERRY_GC_MOVING_LOOP_POLLS=1` at compile):
+
+| arm | before | after |
+|---|---|---|
+| `sfw-registry --help`, `PROTECT_FROMSPACE=1 DEPTH=800` (no zeal) | FAULT 10/10 | **40/40 clean** |
+| `sfw-registry --help`, plain polls | ~2/60 fail | **59/60** |
+| 6 unit reproducers, `POLLS=1 ZEAL=1` | 200/200 iterations wrong | clean, `PERRY_GEN_GC=0` clean both sides |
+
+Codegen cost, `sfw-registry` binary: **+33,088 bytes (+0.1231%)**, all of it from
+the `all_non_pointer` exclusion; the `precise_inference` exclusion and the
+runtime fix are +0.
+
+Two new witnesses, both registered in `test-parity/gc_repsel_corpus.txt`:
+`test_gap_gc_optional_param_receiver_rooting` and
+`test_gap_gc_dynamic_construct_receiver_rooting`.
+
+**#7280 stays open.** The plain arm is 59/60, not 60/60 — the surviving failure
+is a `TypeError: Cannot read properties of undefined (reading 'has')`, a
+different symptom from the pre-fix `object is not a function` / SIGSEGV, so at
+least one more unrooted holder remains on that workload. **#7161's stopgap must
+stay** until that one is found.

--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -751,8 +751,14 @@ pub fn collect_pointer_typed_locals(
     let mut local_types: HashMap<u32, Type> = HashMap::new();
     let mut writes: HashMap<u32, Vec<LocalWrite>> = HashMap::new();
     let mut flat_row_alias_ids: HashSet<u32> = HashSet::new();
+    // #7280: the refinement fixpoint below reasons from `writes`, which is
+    // collected by walking the BODY. For a parameter that is a strict subset of
+    // its definitions — the incoming argument is not a write — so parameters
+    // are excluded from both of that loop's conclusions. See the note there.
+    let mut param_ids: HashSet<u32> = HashSet::new();
     for p in params {
         local_types.insert(p.id, pointer_analysis_type(&p.ty));
+        param_ids.insert(p.id);
     }
     collect_facts(stmts, &mut local_types, &mut writes);
     super::integer_locals::collect_flat_row_aliases(stmts, flat_const_ids, &mut flat_row_alias_ids);
@@ -818,8 +824,39 @@ pub fn collect_pointer_typed_locals(
         changed = false;
         for (id, local_writes) in &writes {
             let mut inferred_ty: Option<Type> = None;
-            let mut precise_inference = true;
-            let mut all_non_pointer = !local_writes.is_empty();
+            // #7280: a PARAMETER has one definition this loop cannot see — the
+            // INCOMING ARGUMENT. `writes` is collected by walking the body, so
+            // for a parameter it lists only the reassignments, and both
+            // conclusions below ("every write is non-pointer" and "every write
+            // has this one precise type") are then drawn from a strict SUBSET
+            // of the local's definitions. That is unsound in the direction that
+            // DROPS a shadow slot.
+            //
+            // It is not a corner case: the optional-parameter desugaring emits
+            //
+            //     if (p === undefined) { p = undefined; }
+            //
+            // for EVERY optional parameter, which is a semantic no-op that
+            // nonetheless registers one `LocalSet(p, Undefined)` write. `Void`
+            // is definitely-non-pointer, so `all_non_pointer` stayed true and
+            // the parameter was proven non-pointer — while its declared type
+            // said `Object` and the caller passed a heap object.
+            //
+            // That is the whole of zod `util.ts`'s
+            // `clone(inst, def?, params?: { parent: boolean })`: `params` is
+            // `Object(...)` in HIR, `is_ptr_typed` says true, and it lost its
+            // slot here anyway. It then lived in callee-saved `d8` across
+            // `new inst._zod.constr(...)` — a user constructor with back-edge
+            // polls — and `params?.parent` dereferenced from-space.
+            //
+            // Excluding parameters is one-sided in the SAFE direction: a
+            // parameter that would have been proven non-pointer instead keeps a
+            // root the collector rewrites harmlessly. Body `let`s are
+            // untouched — their `Stmt::Let` init IS in `writes`, so for them
+            // the write list really is every definition.
+            let is_param = param_ids.contains(id);
+            let mut precise_inference = !is_param;
+            let mut all_non_pointer = !local_writes.is_empty() && !is_param;
             for write in local_writes {
                 let write_ty = match write {
                     LocalWrite::NonPointer => Some(Type::Number),

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1415,7 +1415,26 @@ pub fn gc_check_trigger() {
     // register-imprecise alloc point. Unlike `gc_scavenge_enabled()` (which skips
     // the conservative scan HERE — sound only if the alloc point is precise), the
     // loop-polls path never reaches the skip: it always defers to a real
-    // safepoint, so it is sound by construction.
+    // safepoint.
+    //
+    // #7280: that used to read "so it is sound by construction". IT IS NOT, and
+    // the overclaim is the kind that stops the next person looking. What
+    // deferring to `js_gc_loop_safepoint` buys is precise *codegen* roots — the
+    // loop body has completed, so every live value the COMPILED frame holds is a
+    // named local on the shadow stack. It buys nothing for a value parked in a
+    // RUNTIME (Rust) frame, which the precise walk does not visit at all: no
+    // shadow slot, no temp root, no registered scanner. A back-edge poll that
+    // fires while `js_new_function_construct` is midway through a user
+    // constructor body relocates the instance that helper is holding in a plain
+    // `let`, and no safepoint's root set covers it. That was measured, not
+    // argued — four reproducers in
+    // `test-files/test_gap_gc_dynamic_construct_receiver_rooting.ts`, 200/200
+    // iterations wrong per route before the `RuntimeHandleScope` routing in
+    // `object/class_registry/construct.rs`. The correct statement is: the
+    // loop-polls route makes the COLLECTION POINT precise; keeping runtime
+    // frames rooted across it is a separate obligation, discharged by
+    // `RuntimeHandleScope`, and every runtime helper that calls back into user
+    // JS owes it.
     if !gc_budgeted_cycle_active()
         && (super::gc_scavenge_enabled()
             || gc_moving_loop_polls_enabled()

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -923,6 +923,14 @@ pub unsafe extern "C" fn js_new_function_construct(
                 class_cid,
                 crate::object::learned_inline_field_count(class_cid),
             );
+            // #7280: root the instance across the replay — see the long note
+            // in `construct_registered_class_ref`. The replay runs a user
+            // constructor body, so a bare `*mut ObjectHeader` held across it
+            // is an unrooted receiver and this arm returns the pre-move
+            // address. Reproduced by `new C()` where `C = mk()` is a class
+            // EXPRESSION value.
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let inst_handle = scope.root_raw_mut_ptr(inst);
             // Replay the class's registered constructor (instance-field
             // initializers + body) on the fresh instance, filling the
             // capture params from the snapshotted `__perry_ctor_caps`. The
@@ -931,6 +939,7 @@ pub unsafe extern "C" fn js_new_function_construct(
             super::super::class_constructors::replay_class_object_constructor(
                 func_value, class_cid, inst, args_ptr, args_len,
             );
+            let inst: *mut ObjectHeader = inst_handle.get_raw_mut_ptr();
             // `class X extends Request/Response {}` constructed via the dynamic
             // (class-expression value) path: the replayed ctor's `super()`
             // can't statically route an aliased parent, so attach the native
@@ -943,7 +952,10 @@ pub unsafe extern "C" fn js_new_function_construct(
                     );
                 }
             }
-            return crate::value::js_nanbox_pointer(inst as i64);
+            // Re-read: `attach_fetch_handle_for_construction` allocates.
+            return crate::value::js_nanbox_pointer(
+                inst_handle.get_raw_mut_ptr::<ObjectHeader>() as i64
+            );
         }
     }
 
@@ -1055,19 +1067,33 @@ pub unsafe extern "C" fn js_new_function_construct(
         // result is discarded — JS `new` semantics use the receiver,
         // not the returned value (object returns would override, but
         // dayjs and siblings rely on the receiver mutation pattern).
+        // #7280: `nan_boxed` (the implicit `this` this call is building) and
+        // the three DISPLACED cell values are held across a call that runs a
+        // user constructor body — see the long note in
+        // `construct_registered_class_ref`. Unrooted, the evacuating minor
+        // moves the instance and this arm returns the pre-move address;
+        // reproduced by `new inst.ctor(x)` where `inst.ctor` is a plain
+        // function, 200/200 iterations wrong under
+        // `PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_ZEAL=1`.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let inst_handle = scope.root_nanbox_f64(nan_boxed);
         let prev_this = crate::object::js_implicit_this_get();
+        let prev_this_handle = scope.root_nanbox_f64(prev_this);
         let prev_new_target = crate::object::js_new_target_get();
+        let prev_new_target_handle = scope.root_nanbox_f64(prev_new_target);
         crate::object::js_implicit_this_set(nan_boxed);
         crate::object::js_new_target_set(func_value);
         let prev_current_new_target =
             CURRENT_NEW_TARGET.with(|value| value.replace(func_value.to_bits()));
+        let prev_current_new_target_handle = scope.root_nanbox_u64(prev_current_new_target);
         let result = crate::closure::js_native_call_value(func_value, args_ptr, args_len);
-        CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target));
-        crate::object::js_new_target_set(prev_new_target);
-        crate::object::js_implicit_this_set(prev_this);
+        CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target_handle.get_nanbox_u64()));
+        crate::object::js_new_target_set(prev_new_target_handle.get_nanbox_f64());
+        crate::object::js_implicit_this_set(prev_this_handle.get_nanbox_f64());
         if constructor_return_overrides_this(result) {
             return result;
         }
+        return inst_handle.get_nanbox_f64();
     }
     nan_boxed
 }
@@ -1387,15 +1413,40 @@ unsafe fn construct_registered_class_ref(
     // `new_target_stack` slot avoids this for fully-inlined `new`, but the
     // replayed ctor is a separate compiled function that can only read the cell.
     // Fix holistically with the slot mechanism if it ever bites.
+    // #7280: `inst` — and the two DISPLACED cell values the save/restore idiom
+    // parks beside it — must survive the constructor replay as ROOTS, not as
+    // Rust locals. `replay_registered_class_constructor` runs a user
+    // constructor body: arbitrary allocation, loop back-edge polls, and (under
+    // the evacuating minor) a relocation of the very instance being built. A
+    // runtime frame is not covered by the precise scan and the conservative
+    // stack scan resolves to `SkipDisabled` in shipped builds, so a bare
+    // `*mut ObjectHeader` held across that call is the classic unrooted
+    // receiver: the collector never sees it, never rewrites it, and this
+    // function returns the PRE-MOVE address. Every field the constructor wrote
+    // then reads back as garbage through the stale handle — measured on
+    // `new inst.ctor(x)` under
+    // `PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_ZEAL=1`, 200/200 iterations wrong,
+    // and as a `signal 10` on retired from-space under
+    // `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`.
+    //
+    // This is the `RuntimeHandleScope` routing the `CURRENT_NEW_TARGET`
+    // doc-comment at the top of this file called for. Reading back through the
+    // handles is not bookkeeping: an evacuating cycle rewrites the slot in
+    // place, so the pre-call value is stale by construction.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let inst_handle = scope.root_raw_mut_ptr(inst);
     let prev_new_target = crate::object::js_new_target_get();
+    let prev_new_target_handle = scope.root_nanbox_f64(prev_new_target);
     crate::object::js_new_target_set(new_target);
     let prev_current_new_target =
         CURRENT_NEW_TARGET.with(|value| value.replace(new_target.to_bits()));
+    let prev_current_new_target_handle = scope.root_nanbox_u64(prev_current_new_target);
     super::super::class_constructors::replay_registered_class_constructor(
         target_cid, inst, args_ptr, args_len,
     );
-    CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target));
-    crate::object::js_new_target_set(prev_new_target);
+    let inst: *mut ObjectHeader = inst_handle.get_raw_mut_ptr();
+    CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target_handle.get_nanbox_u64()));
+    crate::object::js_new_target_set(prev_new_target_handle.get_nanbox_f64());
     // ClassRef `new` of a Request/Response subclass — attach the native fetch
     // handle on the dynamic path (mirrors the class-expression arm above).
     if let Some(kind) = fetch_parent_kind_in_chain(target_cid) {
@@ -1407,7 +1458,9 @@ unsafe fn construct_registered_class_ref(
     // a hidden backing cell (only when the compiled ctor's `super()` didn't
     // already attach one). `NewPromiseCapability(Subclass)` reaches here.
     if promise_parent_in_chain(target_cid) {
-        let inst_val = crate::value::js_nanbox_pointer(inst as i64);
+        // Re-read: `attach_fetch_handle_for_construction` above allocates.
+        let inst_val =
+            crate::value::js_nanbox_pointer(inst_handle.get_raw_mut_ptr::<ObjectHeader>() as i64);
         if crate::promise::subclass_backing_promise(inst_val).is_none() {
             let executor = if args_len >= 1 && !args_ptr.is_null() {
                 *args_ptr
@@ -1417,7 +1470,9 @@ unsafe fn construct_registered_class_ref(
             crate::promise::js_promise_subclass_init(inst_val, executor);
         }
     }
-    crate::value::js_nanbox_pointer(inst as i64)
+    // Re-read once more: the executor `js_promise_subclass_init` runs is user
+    // code, so the last two blocks are both collection points.
+    crate::value::js_nanbox_pointer(inst_handle.get_raw_mut_ptr::<ObjectHeader>() as i64)
 }
 
 /// `GetPrototypeFromConstructor(newTarget)` restricted to the "use it only when
@@ -1617,19 +1672,29 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
         super::super::prototype_chain::object_set_static_prototype(obj_ptr as usize, proto_bits);
     }
 
+    // #7280: same unrooted-receiver shape as the plain-`new` tail above —
+    // `nan_boxed` and the three displaced cell values cross a user
+    // constructor body. Reproduced by
+    // `Reflect.construct(plainFn, [x], otherFn)`, 200/200 iterations wrong
+    // under `PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_ZEAL=1`.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let inst_handle = scope.root_nanbox_f64(nan_boxed);
     let prev_this = crate::object::js_implicit_this_get();
+    let prev_this_handle = scope.root_nanbox_f64(prev_this);
     let prev_new_target = crate::object::js_new_target_get();
+    let prev_new_target_handle = scope.root_nanbox_f64(prev_new_target);
     crate::object::js_implicit_this_set(nan_boxed);
     crate::object::js_new_target_set(nt);
     let prev_current_new_target = CURRENT_NEW_TARGET.with(|value| value.replace(nt.to_bits()));
+    let prev_current_new_target_handle = scope.root_nanbox_u64(prev_current_new_target);
     let result = crate::closure::js_native_call_value(func_value, args_ptr, args_len);
-    CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target));
-    crate::object::js_new_target_set(prev_new_target);
-    crate::object::js_implicit_this_set(prev_this);
+    CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target_handle.get_nanbox_u64()));
+    crate::object::js_new_target_set(prev_new_target_handle.get_nanbox_f64());
+    crate::object::js_implicit_this_set(prev_this_handle.get_nanbox_f64());
     if constructor_return_overrides_this(result) {
         return result;
     }
-    nan_boxed
+    inst_handle.get_nanbox_f64()
 }
 
 fn constructor_return_overrides_this(value: f64) -> bool {

--- a/test-files/test_gap_gc_dynamic_construct_receiver_rooting.ts
+++ b/test-files/test_gap_gc_dynamic_construct_receiver_rooting.ts
@@ -1,0 +1,137 @@
+// #7280: the instance a RUNTIME-DISPATCHED `new` builds must be rooted across
+// the constructor body, in the RUNTIME helper's frame.
+//
+// This is `test_gap_gc_new_instance_rooting`'s sibling one layer down. That
+// one covers the codegen route: `new C(n)` with a statically-known `C`, where
+// the caller holds the instance in its own SSA register/shadow slot. This one
+// covers the four routes where codegen CANNOT resolve the callee and hands the
+// whole construction to `js_new_function_construct` in perry-runtime:
+//
+//   1. `new obj.ctor(n)` where `obj.ctor` is a declared class     (ClassRef)
+//   2. `new obj.ctor(n)` where `obj.ctor` is a plain function     (closure)
+//   3. `new obj.ctor(n)` where `obj.ctor` is a class EXPRESSION   (class object)
+//   4. `Reflect.construct(fn, [n], otherFn)`                      (newTarget)
+//
+// Each of those four arms allocates the instance, runs the user constructor
+// body, and returns the instance — holding it in a BARE RUST LOCAL across the
+// call. A runtime frame is not covered by the precise scan and the
+// conservative stack scan resolves to `SkipDisabled` in shipped builds, so
+// that local is an unrooted receiver: the constructor body's loop back-edge
+// polls run an evacuating minor, the instance moves, the collector rewrites
+// the callee's `this` but has no idea about the helper's local, and the helper
+// returns the PRE-MOVE address. Every field the constructor just wrote reads
+// back as garbage through it.
+//
+// CLAUDE.md's "known-weak areas" calls this the sibling class the static IR
+// checker is structurally blind to: `scripts/gc_root_dominance_check.py` reads
+// emitted LLVM IR, and none of this is in the emitted IR — it is Rust.
+//
+// LIVE BY CONSTRUCTION. Each constructor allocates hard enough to reach the
+// collector, and each caller READS BACK a field written by the constructor
+// immediately after it returns, so a stale return address is observable. A
+// non-moving collection cannot expose any of this; the evacuating arms are the
+// ones that bite.
+
+class DeclaredPayload {
+  n: number;
+  len: number;
+  constructor(n: number) {
+    const bits: any[] = [];
+    for (let i = 0; i < 300; i++) {
+      bits.push({ i: i, s: "x" });
+    }
+    this.n = n;
+    this.len = bits.length;
+  }
+}
+
+function FunctionPayload(this: any, n: number): void {
+  const bits: any[] = [];
+  for (let i = 0; i < 300; i++) {
+    bits.push({ i: i, s: "x" });
+  }
+  this.n = n;
+  this.len = bits.length;
+}
+
+function NewTargetMarker(this: any): void {}
+
+function makeClassExpression(): any {
+  return class {
+    n: number;
+    len: number;
+    constructor(n: number) {
+      const bits: any[] = [];
+      for (let i = 0; i < 300; i++) {
+        bits.push({ i: i, s: "x" });
+      }
+      this.n = n;
+      this.len = bits.length;
+    }
+  };
+}
+
+// The receiver is read out of a property, so the callee is a runtime value and
+// codegen has to route the construction through the runtime helper.
+function constructDynamic(holder: any, n: number): number {
+  let bad = 0;
+  const inst = new holder.ctor(n);
+  if (inst === null || inst === undefined) {
+    return 1;
+  }
+  if ((inst.n as number) !== n) {
+    bad++;
+  }
+  if ((inst.len as number) !== 300) {
+    bad++;
+  }
+  return bad;
+}
+
+function runDeclaredClass(): number {
+  let bad = 0;
+  for (let r = 0; r < 200; r++) {
+    bad += constructDynamic({ ctor: DeclaredPayload }, r);
+  }
+  return bad;
+}
+
+function runPlainFunction(): number {
+  let bad = 0;
+  for (let r = 0; r < 200; r++) {
+    bad += constructDynamic({ ctor: FunctionPayload }, r);
+  }
+  return bad;
+}
+
+function runClassExpression(): number {
+  const Made = makeClassExpression();
+  let bad = 0;
+  for (let r = 0; r < 200; r++) {
+    bad += constructDynamic({ ctor: Made }, r);
+  }
+  return bad;
+}
+
+function runReflectConstruct(): number {
+  let bad = 0;
+  for (let r = 0; r < 200; r++) {
+    const inst: any = Reflect.construct(FunctionPayload, [r], NewTargetMarker);
+    if (inst === null || inst === undefined) {
+      bad++;
+    } else {
+      if ((inst.n as number) !== r) {
+        bad++;
+      }
+      if ((inst.len as number) !== 300) {
+        bad++;
+      }
+    }
+  }
+  return bad;
+}
+
+console.log("declared", runDeclaredClass());
+console.log("function", runPlainFunction());
+console.log("classexpr", runClassExpression());
+console.log("reflect", runReflectConstruct());

--- a/test-files/test_gap_gc_optional_param_receiver_rooting.ts
+++ b/test-files/test_gap_gc_optional_param_receiver_rooting.ts
@@ -1,0 +1,105 @@
+// #7280: an OPTIONAL PARAMETER must keep its shadow slot.
+//
+// This is the file that closes #7154's residual — the one that kept
+// `sfw-registry --help` red under the loop-polls configuration and so kept
+// #7161's evacuating-minor stopgap in place. Distilled from zod
+// `src/v4/core/util.ts:485`:
+//
+//   export function clone<T>(inst: T, def?: T["_zod"]["def"], params?: { parent: boolean }): T {
+//     const cl = new inst._zod.constr(def ?? inst._zod.def);
+//     if (!def || params?.parent) cl._zod.parent = inst;
+//     return cl as any;
+//   }
+//
+// `params` is `Object(...)` in HIR and `type_is_pointer_bearing` says true, yet
+// `collect_pointer_typed_locals` gave it no slot: it lived in callee-saved `d8`
+// across `new inst._zod.constr(...)` — a user constructor crossing ~180 copying
+// minors — and `params?.parent` then dereferenced retired from-space.
+//
+// THE CAUSE IS THE OPTIONAL MARKER, not the object type. The pointer-locals
+// refinement fixpoint proves a local non-pointer from its WRITES, and for a
+// PARAMETER the write list is a strict subset of its definitions — the incoming
+// argument is not a write. The optional-parameter desugaring then supplies, for
+// free, the one write needed to complete the false proof:
+//
+//     if (p === undefined) { p = undefined; }
+//
+// `Void` is definitely-non-pointer, so "every write is non-pointer" held, and
+// the parameter lost its slot while its declared type said `Object`.
+//
+// TWO FUNCTIONS, TWO HALVES OF THE SAME PROOF:
+//
+//   `annotated`  — `params?: { parent: boolean }`, zod's exact shape. Fails on
+//                  the `all_non_pointer` half alone.
+//   `inferred`   — `p?: any`, plus a local aliased FROM it. Here the fixpoint's
+//                  SECOND conclusion also fires: `inferred_ty` becomes `Void`,
+//                  `local_value_types[p] = Void`, and the alias inherits that,
+//                  is proven non-pointer, and loses ITS slot too — so the defect
+//                  propagates one hop past the parameter. Measured red 200/200
+//                  with only the first half applied, which is why both are here.
+//
+// LIVE BY CONSTRUCTION: the constructor allocates hard enough to reach the
+// collector, and the optional parameter is READ only after it returns.
+
+class Payload {
+  b: number;
+  constructor(n: number) {
+    const bits: any[] = [];
+    for (let i = 0; i < 300; i++) {
+      bits.push({ i: i, s: "x" });
+    }
+    this.b = bits.length;
+  }
+}
+
+function annotated(inst: any, def?: number, params?: { parent: boolean }): number {
+  let bad = 0;
+  const cl = new inst.ctor(def);
+  if ((cl.b as number) !== 300) {
+    bad++;
+  }
+  if (params !== null && params !== undefined) {
+    if ((params.parent as boolean) !== true) {
+      bad++;
+    }
+  } else {
+    bad++;
+  }
+  return bad;
+}
+
+function inferred(inst: any, def?: number, p?: any): number {
+  const alias = p;
+  let bad = 0;
+  const cl = new inst.ctor(def);
+  if ((cl.b as number) !== 300) {
+    bad++;
+  }
+  if (alias !== null && alias !== undefined) {
+    if ((alias.parent as number) !== 7) {
+      bad++;
+    }
+  } else {
+    bad++;
+  }
+  return bad;
+}
+
+function runAnnotated(): number {
+  let bad = 0;
+  for (let r = 0; r < 150; r++) {
+    bad += annotated({ ctor: Payload }, r, { parent: true });
+  }
+  return bad;
+}
+
+function runInferred(): number {
+  let bad = 0;
+  for (let r = 0; r < 150; r++) {
+    bad += inferred({ ctor: Payload }, r, { parent: 7 });
+  }
+  return bad;
+}
+
+console.log("annotated", runAnnotated());
+console.log("inferred", runInferred());

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -480,3 +480,70 @@ test_gap_gc_process_env_cache_rooting
 # was hiding it, and a malloc-count-driven collection stops it hiding, so it is
 # red on the SHIPPED DEFAULT at base too.
 test_gap_gc_symbol_local_rooting
+
+# --- #7280: RUNTIME-DISPATCHED `new` — the instance in a Rust frame ----------
+# The sibling of `test_gap_gc_new_instance_rooting` one layer down. That file
+# covers the CODEGEN route: `new C(n)` with a statically-known `C`, where the
+# caller holds the instance itself. This one covers the four routes where
+# codegen cannot resolve the callee and hands the whole construction to
+# perry-runtime's `js_new_function_construct` family:
+#
+#   1. `new obj.ctor(n)`, `ctor` a declared class     -> construct_registered_class_ref
+#   2. `new obj.ctor(n)`, `ctor` a plain function     -> the closure tail
+#   3. `new obj.ctor(n)`, `ctor` a class EXPRESSION   -> the class-object arm
+#   4. `Reflect.construct(fn, [n], otherFn)`          -> ..._with_new_target
+#
+# Each allocated the instance, called back into user JS to run the constructor
+# body, and returned the pointer it had captured BEFORE that call. A runtime
+# frame is not visited by the precise root walk and the conservative stack scan
+# resolves to SkipDisabled in shipped builds, so the instance moved and the
+# helper returned the pre-move address — a stale receiver produced OUTSIDE the
+# emitted IR, which is why `scripts/gc_root_dominance_check.py` is structurally
+# blind to it (it reads LLVM IR; none of this is in LLVM IR).
+#
+# Measured on this branch, release, `PERRY_GC_MOVING_LOOP_POLLS=1` at compile:
+#   before the fix, POLLS=1 + ZEAL=1     200/200 iterations wrong on EVERY route
+#   after  the fix, POLLS=1 + ZEAL=1     10/10 runs byte-exact with the oracle
+#   control, + PERRY_GEN_GC=0            clean on both sides
+# and under the loop_polls arm env
+# (`HEAP_LIMIT=8 INCREMENTAL=0 CONSERVATIVE_STACK_SCAN=off POLLS=1 FORCE_EVACUATE=1`)
+# red before / clean after, which is the arm `gc-moving-witnesses` runs.
+#
+# ONE FILE, FOUR ROUTES, FOUR SEPARATE console.log LINES. The matrix byte-diffs
+# stdout, so a regression on any single route names itself instead of collapsing
+# into one `bad N`.
+test_gap_gc_dynamic_construct_receiver_rooting
+
+# --- #7280: OPTIONAL PARAMETERS — the residual that held #7161's stopgap -----
+# THE file for #7154's surviving residual. zod `util.ts`'s
+# `clone(inst, def?, params?: { parent: boolean })` gave `params` no shadow slot
+# even though HIR types it `Object(...)` and `type_is_pointer_bearing` says
+# true, so it crossed `new inst._zod.constr(...)` in callee-saved `d8` and
+# `params?.parent` dereferenced retired from-space.
+#
+# The cause is the OPTIONAL MARKER, not the object type. The pointer-locals
+# refinement fixpoint proves a local non-pointer from its WRITES, and a
+# PARAMETER's write list is a strict SUBSET of its definitions — the incoming
+# argument is not a write. The optional-parameter desugaring then donates the
+# one write that completes the false proof, for free, on every optional
+# parameter in the program:
+#
+#     if (p === undefined) { p = undefined; }
+#
+# Two functions because the fixpoint draws TWO conclusions from that subset and
+# both are unsound for a parameter:
+#   `annotated` — the declared-Object shape (zod's). Needs the `all_non_pointer`
+#                 exclusion.
+#   `inferred`  — `p?: any` plus a local aliased from it. Needs the
+#                 `precise_inference` exclusion as well: measured RED 200/200
+#                 with only the first exclusion applied.
+#
+# Measured on this branch, release, `PERRY_GC_MOVING_LOOP_POLLS=1` at compile:
+#   before, POLLS=1 + ZEAL=1            200/200 iterations wrong, both shapes
+#   after,  POLLS=1 + ZEAL=1            byte-exact with the oracle
+#   after,  loop_polls arm env          byte-exact
+#   control, + PERRY_GEN_GC=0           clean on both sides
+# and on the real workload, `sfw-registry --help` under
+# `PROTECT_FROMSPACE=1 DEPTH=800 POLLS=1` (no zeal): 10/10 FAULT before,
+# 40/40 clean after.
+test_gap_gc_optional_param_receiver_rooting


### PR DESCRIPTION
Closes part of #7280. **#7280 itself stays open** — see "What this does not fix".

## The bug

`sfw-registry --help` under `PERRY_GC_MOVING_LOOP_POLLS=1` faults in zod
`src/v4/core/util.ts:485`:

```ts
export function clone<T>(inst: T, def?: T["_zod"]["def"], params?: { parent: boolean }): T {
  const cl = new inst._zod.constr(def ?? inst._zod.def);
  if (!def || params?.parent) cl._zod.parent = inst;
  return cl as any;
}
```

`params` lives in callee-saved `d8` across `new inst._zod.constr(...)` — a user
constructor crossing ~180 copying minors — with **no shadow slot**, so the
collector never rewrites it and `params?.parent` dereferences retired
from-space. The nullish guard doesn't help: a stale pointer is neither `null`
nor `undefined`.

## Why parameter #2 was classified non-pointer — the HIR answer

Not the type. `--trace hir --focus` says it plainly:

```
param inst   (id=6): Any
param def    (id=7): Number
param params (id=8): Object(ObjectType { properties: {"parent": ... Boolean ...} })
[1] If { condition: Compare { op: Eq, left: LocalGet(8), right: Undefined },
         then_branch: [Expr(LocalSet(8, Undefined))], else_branch: None }
```

`Object(...)` — `type_is_pointer_bearing` returns **true**, so
`is_ptr_typed(&p.ty)` at `pointer_locals.rs:908` was never the problem. The slot
was dropped by `non_pointer_locals`, and statement `[1]` is why.

**The refinement fixpoint proves a local non-pointer from its WRITES. For a
PARAMETER the write list is a strict subset of its definitions — the incoming
argument is not a write.** The optional-parameter desugaring then donates the
one write that completes the false proof, *for free, on every optional
parameter in the program*:

```
if (p === undefined) { p = undefined; }
```

`Void` is definitely-non-pointer, so `all_non_pointer` stayed true and the
parameter was proven non-pointer while its declared type said `Object`.

That is also why a hand-written witness with `params: any` (no `?`) stays green
and misled earlier attempts: without the optional marker there is no write, and
`!local_writes.is_empty()` already guarded that case.

## The fix

**Site (1), `collectors/pointer_locals.rs`** — exclude parameters from *both*
conclusions the fixpoint draws from that subset. Each half has its own
reproducer:

| exclusion | shape it fixes | measured without it |
|---|---|---|
| `all_non_pointer` | `params?: { parent: boolean }` — zod's | 200/200 iterations wrong |
| `precise_inference` | `p?: any` **plus a local aliased from it** — the loop instead concludes `local_value_types[p] = Void`, the alias inherits it and loses *its* slot | 200/200 iterations wrong **with the first exclusion already applied** |

One-sided in the safe direction: a parameter that would have been proven
non-pointer keeps a root the collector rewrites harmlessly. Body `let`s are
untouched — their `Stmt::Let` init *is* in `writes`, so for them the write list
really is every definition.

**Not site (2).** `lower_generic_property_get` is where the fault *lands*, not
where the bug is. The receiver arrives already stale; re-reading it inside the
property-get diamond would re-read the same dead register. I disassembled the
faulting frame to confirm this rather than inferring it: `clone`'s prologue is
`js_shadow_frame_enter(2)`, slot 0 ← `inst`, slot 1 ← `cl`, and `fmov d8, d2` is
never followed by a store. Site (2) needs no change, and `temp_root::lower_exprs_rooted`
is indeed the wrong tool — it is for argument lists.

**Four runtime-side siblings, found while bisecting toward site (1)** and each
independently reproducible. Every `new` route codegen cannot resolve statically
hands construction to perry-runtime, and all four held the instance in a bare
Rust local across the user constructor body, returning the **pre-move address**:

| entry point | reproducer |
|---|---|
| `construct_registered_class_ref` | `new obj.ctor(n)`, `ctor` a declared class |
| `js_new_function_construct`, class-object arm | `ctor` a class *expression* value |
| `js_new_function_construct`, closure tail | `ctor` a plain function |
| `js_new_function_construct_with_new_target` | `Reflect.construct(fn, args, newTarget)` |

A runtime frame is not visited by the precise root walk and the conservative
stack scan resolves to `SkipDisabled` in shipped builds. Routed through
`RuntimeHandleScope` — which this file's own `CURRENT_NEW_TARGET` doc-comment
already said needed doing and deferred. The same scope roots the displaced
`prev_this` / `prev_new_target` / `prev_current_new_target` values named in that
comment.

**`gc/policy.rs`, #7280 ask 2.** "Sound by construction" is corrected. Deferring
to `js_gc_loop_safepoint` makes the collection point precise for **codegen**
frames; it says nothing about a value parked in a runtime Rust frame. The four
sites above are exactly that gap.

## Evidence

Release build, `PERRY_GC_MOVING_LOOP_POLLS=1` at compile time.

| arm | before | after |
|---|---|---|
| `sfw-registry --help`, `PROTECT_FROMSPACE=1 DEPTH=800`, **no zeal** | FAULT 10/10 | **40/40 clean** |
| `sfw-registry --help`, plain polls | ~2/60 fail | **59/60** |
| `wparam` (zod shape), `POLLS=1 ZEAL=1` | `bad 200` (200/200) | `bad 0` |
| `wanyparam` (`p?: any` + alias) | `bad 200` | `bad 0` |
| 4 dynamic-construct reproducers | 200/200 wrong each | clean |
| every one of the above, `+ PERRY_GEN_GC=0` | clean | clean |

Two witnesses added, both registered in `test-parity/gc_repsel_corpus.txt` so
`gc-moving-witnesses` runs them (not left dark — #7278's failure mode):

* `test_gap_gc_optional_param_receiver_rooting` — both parameter shapes.
* `test_gap_gc_dynamic_construct_receiver_rooting` — all four runtime routes.

Both verified green in the exact `loop_polls` arm env
(`HEAP_LIMIT=8 INCREMENTAL=0 CONSERVATIVE_STACK_SCAN=off POLLS=1 FORCE_EVACUATE=1`)
and byte-identical to the Node oracle.

**Codegen cost**, `sfw-registry` binary, measured against `origin/main`:

| change | size | delta |
|---|---|---|
| `origin/main` | 26,881,088 | — |
| runtime `RuntimeHandleScope` fix | 26,881,088 | +0 |
| + `all_non_pointer` exclusion | 26,914,176 | **+33,088 (+0.1231%)** |
| + `precise_inference` exclusion | 26,914,176 | +0 |

All of the cost is the `all_non_pointer` exclusion. **This is above the +0.042%
reference from #7214** and I am flagging it rather than burying it: it is the
price of not proving a parameter non-pointer from a subset of its definitions,
and the cheaper variants are the ones that leave the bug in.

**Tests.** `loop_safepoint_purity` is 1 passed / 6 failed both on this branch
and on the parent `97c69211d` — measured, not assumed, by stashing the three
source changes and re-running. It asserts back-edge polls survive, and polls are
default-off since #7161, so it needs `PERRY_GC_MOVING_LOOP_POLLS=1`; with that
set it is 7/7 on this branch. Not mine, but worth its own issue — it is a test
that cannot pass in the default configuration.

## What this does **not** fix, and why there is no #7161 revert here

The plain-polls arm is **59/60, not 60/60**. The surviving failure is

```
TypeError: Cannot read properties of undefined (reading 'has')
```

which is a *different* symptom from the pre-fix `object is not a function` /
SIGSEGV, so at least one more unrooted holder remains on that workload. **The
revert is not earnable and I have not opened it.** #7161's stopgap must stay.

Separately, and orthogonally: the zeal-only `node-machine-id`
`TypeError: Cannot convert undefined or null to object` reported during triage
is real and reproduces only under `PERRY_GC_ZEAL=1`, which is supposed to be
semantically transparent. It deserves its own issue.

## ★ The gate blind spot

`--stale-registers` classifies the faulting site `MOVING: no`, so
`gc-root-dominance`'s `--moving-only` arm cannot see this bug while the
from-space reporter faults on it every time. **Both are right, and that is the
problem.**

The checker reads emitted LLVM IR. At the property-get it sees a receiver loaded
from a *correctly shadow-bound* alloca, and the collector really does rewrite
that slot — so `MOVING: no` is a true statement about the IR. The staleness was
injected from **outside** the IR: for site (1) by a slot the collector was never
told about, and for the four runtime sites by a Rust frame the IR does not
contain at all. A rooted slot holding a dangling pointer.

So this is not a misclassification to tune. It is a **scope boundary**:
`gc_root_dominance_check.py` can only ever see defects expressible in emitted
IR, and CLAUDE.md's "runtime-side cache" note is one instance of a larger class —
*any* value a runtime helper holds across a call back into user JS. The four
sites here are that class, and no static IR pass will ever find them. The
detector that does is
`PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` on a real
workload. Worth writing into `docs/src/internals/gc-rooting-invariant.md` as a
stated limit, so the next person does not read a green `--moving-only` as
coverage.

One protocol note for whoever picks up the remaining 1/60: `perry compile`
strips symbols, so use `PERRY_DEBUG_SYMBOLS=1` or the protector backtrace is
unreadable. And `PERRY_GC_DIAG=1` is inert in a locally auto-optimized build
(the linked runtime lacks the `diagnostics` feature), so liveness has to come
from CI or from a red-then-green pair.

No version bump in this PR, per instruction; the maintainer bumps at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection issues affecting optional parameters and dynamically constructed objects.
  * Preserved constructor receivers, `this`, and `new.target` values during moving garbage collection.
  * Ensured constructed instances retain their fields and expected return behavior.

* **Tests**
  * Added stress tests covering dynamic construction, optional parameters, and repeated allocations.
  * Added moving-GC regression coverage for affected execution paths.

* **Documentation**
  * Clarified garbage-collection safety requirements for runtime values and loop polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->