### PR TITLE
docs: link the engine plan to its tracker

### DIFF
--- a/changelog.d/7295-link-engine-tracker.md
+++ b/changelog.d/7295-link-engine-tracker.md
@@ -1,0 +1,2 @@
+Links `docs/engine-plan.md` to its routing tracker (#7294), and states which of
+the two is authoritative so they cannot drift into disagreeing.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -2,6 +2,8 @@
 
 **Goal (owner):** best performance, best RSS footprint, minimal binary size.
 
+**Tracker:** #7294 (routing only — this document is authoritative).
+
 This is the single entry point. It replaces five overlapping documents and a
 55 KB uncommitted working file. Detail lives in linked RFCs; **sequencing and
 rationale live here**.


### PR DESCRIPTION
Links the plan to its tracker (#7294) and states plainly which is authoritative — the doc — so the two cannot drift into contradicting each other. The tracker holds no content of its own by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the engine plan is the authoritative source for routing-related guidance.
  * Added a reference to the relevant tracking item to improve navigation and prevent conflicting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->