### PR TITLE
fix(gc): root the parameter, the spread accumulator and the namespace object (#7280)

### DIFF
--- a/changelog.d/7299-gc-allocate-then-fill-rooting.md
+++ b/changelog.d/7299-gc-allocate-then-fill-rooting.md
@@ -1,0 +1,81 @@
+### Fixed
+
+**GC rooting: a parameter's caller write, and two allocate-then-fill lowerings
+that never got a rooting contract (#7280, #7154).**
+
+Three violations of the invariant at the top of
+`docs/src/internals/gc-rooting-invariant.md` — a GC-managed value live across a
+collection point must be reachable from a root before that point — all found by
+running `scripts/gc_root_dominance_check.py --stale-registers --moving-only`
+over a **dependency-scale** corpus rather than the 25-file curated one. #7284's
+correction to `POLL_CAPABLE_RUNTIME` is what made the property-GET half of that
+report readable at all: on the gate corpus `--moving-only` went 65 → 115, and
+101 of the 115 are a single unaddressed rule (a shadow-slot load cached in a
+register across a collection point).
+
+**A parameter's incoming argument is a write the analysis never saw.**
+`collect_pointer_typed_locals`' refinement fixpoint proves a local non-pointer
+from its `writes`, which is collected by walking the body — so for a *parameter*
+it reasons from a strict subset of the local's definitions. The
+optional-parameter desugaring then supplies, for free and on every optional
+parameter in the program, the one write that completes the false proof:
+`if (p === undefined) { p = undefined; }` is `Type::Void`, definitely
+non-pointer, so `all_non_pointer` held and the parameter lost its shadow slot
+while its declared type said `Object`. Measured on zod's
+`clone(inst, def?, params?)`: `js_shadow_frame_enter(2)` with slot 0 ← `inst`
+and no bind at all for `def` or `params`, so LLVM promoted `params` into
+callee-saved `d8`. Fixed by seeding the caller's write
+(`LocalWrite::Incoming(declared_ty)`) rather than special-casing parameters at
+each conclusion, so every consumer of the fixpoint accounts for it without
+having to know it must; a `number` parameter is still provably non-pointer,
+because its declared type is the one thing that does constrain the caller. Same
+defect as #7291's site (1), found independently and behaviourally equivalent to
+it (identical frame size and bind set on the same probe).
+
+**The spread-array accumulator** (`Expr::ArraySpread`) allocates up front and
+lowers the elements *into* the array — the opposite order from
+`lower_array_literal`, which lowers every element first into a temp root and
+only then allocates. Threading the accumulator through each
+`js_array_push_f64` return value handles *reallocation* and does nothing for
+*relocation*: for `[a, ...gen(), b]` the half-built array was live across an
+iterator protocol while reachable from no root at all, so a minor reclaimed it
+rather than moving it, and the remaining appends wrote into recycled memory.
+Rooted with `temp_root_set_i64`, because the accumulator's address legitimately
+changes on every append (the string-concat contract from #6971).
+
+**The namespace-import object** (`import * as ns` used as a value) materializes
+one property per export of the source module. Every other allocate-then-fill
+lowering has carried a rooting contract since #6951 (`Expr::Object`) or #7211
+(class objects); this one, added for #629's Drizzle/Stripe namespace
+enumeration, never got one — and it builds the largest object in a
+dependency-scale program. Both halves of its loop are collection points:
+resolving `ns.member` for a `const` export is a call into the exporting module's
+accessor, and `js_object_set_field_by_name` performs the allocating keys-array
+transition. Stock zod's `import * as core` materializes 269 members here, and
+the emitted IR carried zero `js_gc_temp_root_*` calls beside its 269 allocating
+stores.
+
+`gc/policy.rs`'s "sound by construction" claim about the loop-polls route is
+also corrected (#7280 ask 2): deferring to a precise safepoint makes the
+*collector* precise and says nothing about whether the mutator's live values are
+reachable from the root set that safepoint scans.
+
+**These do not fix #7280, and #7280 stays open.** Its reproducer is unchanged at
+**0/30** on the revert configuration (`PERRY_GC_MOVING_LOOP_POLLS=1` compiled
+*and* run) and **0/10** on the allocation-point arm with movement asserted
+(10/10 runs `copied_objects>0`); the stock-zod control reads 31/40 against a
+34/40 baseline, which is inside the noise band that configuration has shown
+(31, 32, 34, 35, 35 across five independent builds). The shipped default is
+unaffected: 30/30 and 40/40. #7291 measures 0/30 and 32/40 on the same harness,
+so it does not close the acceptance test either. After the parameter fix the
+`PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` quarantine fault moves off zod's `clone`
+and lands in `js_native_call_method` called from a compiled module-init body — a
+receiver going stale in a *runtime* frame, which is #7249's blind spot.
+
+No witness ships with this change. One was written for the two accumulator
+fixes and confirmed by IR inspection to exercise both lowerings, then discarded:
+it is 20/20 clean on the parent under `loop_polls` and 10/10 clean on the
+allocation-point arm with movement asserted, so it does not discriminate. A test
+that passes on the parent is a dark test with a witness's name on it, which is
+what #7278 exists to stop. The only artifact that discriminates for this class
+remains the dependency-scale reproducer #7280 preserved.

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -908,6 +908,41 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         "js_object_alloc",
                         &[(I32, &zero_str), (I32, &n_str)],
                     );
+                    // #7280: root the half-built namespace object.
+                    //
+                    // Every other lowering that allocates an object and then
+                    // fills it in carries this contract — `Expr::Object` since
+                    // #6951, `Expr::ObjectSpread`, the class-object lowering
+                    // since #7211. This one was added for a different reason
+                    // (#629, Drizzle/Stripe namespace enumeration) and never
+                    // got it, and it builds by far the LARGEST object in a
+                    // dependency-scale program: one property per export of the
+                    // imported module, materialized at every use site.
+                    //
+                    // Both halves of the loop are collection points, on every
+                    // iteration:
+                    //
+                    //   * `lower_expr(member_get)` is a full `ns.member`
+                    //     PropertyGet. For a const export that is a CALL into
+                    //     the exporting module's accessor — arbitrary user
+                    //     code; for a function it allocates a closure
+                    //     singleton; for a class it resolves a class ref.
+                    //   * `js_object_set_field_by_name` performs the keys-array
+                    //     transition, which allocates.
+                    //
+                    // With `handle` in a bare SSA register the object is
+                    // reachable from NO root for the whole build, so a minor
+                    // does not merely relocate it — it reclaims it, and the
+                    // remaining stores land in recycled memory. The caller then
+                    // receives a namespace whose members read back as garbage,
+                    // which surfaces as `TypeError: <x> is not a function` at
+                    // the first member call, arbitrarily far away.
+                    //
+                    // Measured on #7280's stock-zod reproducer: `import * as
+                    // core` materializes 269 members here, and the emitted IR
+                    // carried ZERO `js_gc_temp_root_*` calls beside its 269
+                    // allocating stores.
+                    let rooted = super::temp_root::rooted_handle_begin(ctx, &handle, true);
                     for member in &members {
                         let member_get = Expr::PropertyGet {
                             byte_offset: 0,
@@ -922,6 +957,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let key_idx = ctx.strings.intern(member);
                         let key_handle_global =
                             format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                        // Re-read AFTER the member resolution: that is the
+                        // collection point, so a register captured before it is
+                        // the stale one.
+                        let handle = super::temp_root::rooted_handle_get(ctx, &rooted);
                         let blk = ctx.block();
                         let key_box = blk.load(DOUBLE, &key_handle_global);
                         let key_bits = blk.bitcast_double_to_i64(&key_box);
@@ -931,8 +970,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             &[(I64, &handle), (I64, &key_raw), (DOUBLE, &v_box)],
                         );
                     }
-                    let blk = ctx.block();
-                    return Ok(nanbox_pointer_inline(blk, &handle));
+                    let handle = super::temp_root::rooted_handle_get(ctx, &rooted);
+                    let boxed = nanbox_pointer_inline(ctx.block(), &handle);
+                    super::temp_root::rooted_handle_release(ctx, rooted);
+                    return Ok(boxed);
                 }
                 return Ok(ctx
                     .block()

--- a/crates/perry-codegen/src/expr/objects_arrays_lit.rs
+++ b/crates/perry-codegen/src/expr/objects_arrays_lit.rs
@@ -35,34 +35,67 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         .call(I64, "js_array_clone_for_spread", &[(DOUBLE, &src_box)]);
                 return Ok(nanbox_pointer_inline(ctx.block(), &cloned));
             }
+            // #7280: unlike `lower_array_literal` — which lowers every element
+            // FIRST (each into a temp root) and only then allocates — this path
+            // allocates the accumulator UP FRONT and lowers the elements into
+            // it. The half-built array is therefore live across every element
+            // expression, and for a spread literal those are arbitrary user
+            // code: `[a, ...gen(), b]` runs an iterator protocol between two
+            // pushes. It is live across the lowering's OWN calls too —
+            // `js_array_push_f64`, `js_array_push_hole` and
+            // `js_array_spread_append` all allocate.
+            //
+            // Threading `current_arr` through each call's RETURN value already
+            // handles REALLOCATION (`js_array_push_f64` hands back a new
+            // pointer when it grows). It does nothing for RELOCATION: nothing
+            // rooted the accumulator, so a minor between two elements finds an
+            // array reachable from no root at all — it is reclaimed, not merely
+            // moved, and the remaining appends write into recycled memory.
+            // 29 of the 77 fatal moving stale uses on the #7280 reproducer are
+            // this shape.
+            //
+            // `temp_root_set_i64` rather than a fixed `RootedHandle`: the
+            // accumulator's address legitimately CHANGES on every append, so
+            // the slot must be rewritten, not just re-read. Same contract as
+            // the string-concat accumulator (#6971).
             let cap_str = (elements.len() as u32).to_string();
             let mut current_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap_str)]);
+            let root = super::temp_root::temp_root_push_i64(ctx, &current_arr);
             for elem in elements {
                 match elem {
                     ArrayElement::Expr(e) => {
                         let v = lower_expr(ctx, e)?;
+                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
                         current_arr = ctx.block().call(
                             I64,
                             "js_array_push_f64",
-                            &[(I64, &current_arr), (DOUBLE, &v)],
+                            &[(I64, &arr), (DOUBLE, &v)],
                         );
                     }
                     ArrayElement::Hole => {
-                        current_arr =
-                            ctx.block()
-                                .call(I64, "js_array_push_hole", &[(I64, &current_arr)]);
+                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
+                        current_arr = ctx.block().call(I64, "js_array_push_hole", &[(I64, &arr)]);
                     }
                     ArrayElement::Spread(e) => {
                         let src_box = lower_expr(ctx, e)?;
+                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
                         current_arr = ctx.block().call(
                             I64,
                             "js_array_spread_append",
-                            &[(I64, &current_arr), (DOUBLE, &src_box)],
+                            &[(I64, &arr), (DOUBLE, &src_box)],
                         );
                     }
                 }
+                // The append may have grown the array (a new address) and may
+                // have run a collection that moved it again. The returned
+                // pointer is the live one; republish it before the next
+                // element's lowering can collect.
+                super::temp_root::temp_root_set_i64(ctx, &root, &current_arr);
             }
-            Ok(nanbox_pointer_inline(ctx.block(), &current_arr))
+            let current_arr = super::temp_root::temp_root_get_i64(ctx, &root);
+            let boxed = nanbox_pointer_inline(ctx.block(), &current_arr);
+            super::temp_root::temp_root_truncate(ctx, &root);
+            Ok(boxed)
         }
 
         // `arr[i]` index access. INLINE FAST PATH for typed-Number arrays:


### PR DESCRIPTION
Three emitted-IR rooting fixes that #7284's symbol-set correction made visible,
plus #7280 ask 2.

**Read "What this does NOT fix" before merging.** None of these moves any number
in #7280's acceptance table. They are violations of the invariant at the top of
`docs/src/internals/gc-rooting-invariant.md`, proven present in emitted IR and
proven absent after — not a fix for #7280, which stays open and still blocks a
#7161 revert.

## What #7284 exposed

Corpus rebuilt at `fc9db0553` via `scripts/gc_root_dominance_corpus.sh`
(121/121 sources compiled, 141 `.ll`). Same corpus, both checkers:

| `--stale-registers` | parent `97c69211d` | `fc9db0553` (post-#7284) |
|---|---|---|
| raw | 4862 | 4862 |
| `--moving-only` | 65 | **115** |

The 50 newly-visible uses are the GET side, exactly as #7284 predicted. Grouped
by what makes the window moving:

| mover family | count | dominant source |
|---|---|---|
| property-GET helper (`js_object_get_field_by_name_f64`, `_ic_miss`, `js_typed_feedback_object_get_field_by_name_f64`) | 55 | `slotload` |
| `js_number_coerce` / ToPrimitive family | 36 | `slotload` |
| `js_closure_callN` | 18 | `slotload` / `strhandle` / `global` |
| intra-corpus compiled callee | 6 | `slotload` / `rootread` |

101 of the 115 are `slotload`: a value read out of a shadow slot into a
register, then used below a collection point without being re-read. That is one
rule — "re-read the root after every collection point" — violated at a scale no
point fix reaches. It is **not** what this PR touches; it wants its own change
with its own measured count.

## The dependency-scale corpus, which is where these were actually found

The curated corpus is not where these came from. Running the same checker over
the **reproducer's own IR** (#7280's 86-module registry substitute, 65 MB of
`.ll`) reports **77** `--stale-registers --moving-only --fatal-sinks` hits with
a completely different shape distribution:

| source → sink | count |
|---|---|
| `js_array_alloc` → `js_array_spread_append` / `js_array_concat` | 29 |
| `js_box_get_bits` → `js_closure_callN` | 14 |
| `js_object_alloc` → `js_object_set_field_by_name` | 8 |
| `js_closure_get_capture_bits` → various | 7 |
| `global` / `slotload` load → `js_closure_callN` | 11 |
| other | 8 |

Rows 1 and 3 are one defect in two lowerings. They are what this PR fixes.

## The fixes

**1. `collectors/pointer_locals.rs` — a parameter's caller write.**

The refinement fixpoint proves a local non-pointer from its `writes`, collected
by walking the body. For a parameter that is a strict subset of its definitions:
the incoming argument is not a write. The optional-parameter desugaring then
donates the one write that completes the false proof, for free, on every
optional parameter in the program — `if (p === undefined) p = undefined` is
`Type::Void`, definitely non-pointer, so `all_non_pointer` held and the
parameter lost its shadow slot while its declared type said `Object`.

Measured on zod's `clone(inst, def?, params?)`: `js_shadow_frame_enter(2)`,
slot 0 ← `inst`, and **no bind at all** for `def` or `params` — so LLVM promoted
`params` into callee-saved `d8`, which is exactly the register #7280's
disassembly reports going stale. After: frame 4, all three bound.

> **This is the same defect as #7291's site (1), found independently.** The two
> are behaviourally equivalent — verified by compiling the same probe with both
> binaries and diffing the emitted prologue: identical frame size, identical
> bind set. They differ only in modelling. #7291 exempts parameters from the
> fixpoint's two conclusions with `!is_param` guards; this seeds the missing
> write (`LocalWrite::Incoming(declared_ty)`) so the fixpoint's *input* is
> complete and every consumer of it — present and future — accounts for the
> caller without having to know it must. It also keeps the one honest
> refinement: a `number` parameter is still provably non-pointer, because its
> declared type is the one thing that does constrain the caller.
>
> **If #7291 lands first, drop commit `2706d71b5` from this PR.** The other two
> commits are independent of it and of each other.

**2. `expr/objects_arrays_lit.rs` — the spread-array accumulator.**
`Expr::ArraySpread` allocates the accumulator up front and lowers the elements
into it — the opposite order from `lower_array_literal`, which lowers every
element first (each into a temp root) and only then allocates. Threading the
accumulator through each `js_array_push_f64` return value handles
*reallocation* and does nothing for *relocation*, and nothing rooted it: for
`[a, ...gen(), b]` the half-built array is live across an iterator protocol,
reachable from no root, so a minor reclaims it rather than moving it. Rooted
with `temp_root_set_i64`, because the accumulator's address legitimately changes
on every append (same contract as the string-concat accumulator, #6971).

**3. `expr/dyn_extern_i18n.rs` — the namespace-import object.**
`import * as ns` used as a value materializes one property per export of the
source module. Every other allocate-then-fill lowering has carried a rooting
contract since #6951 (`Expr::Object`) or #7211 (class objects); this one, added
for #629 (Drizzle/Stripe namespace enumeration), never got one — and it builds
the largest object in a dependency-scale program. Both halves of its loop
collect: `lower_expr(ns.member)` is a call into the exporting module's accessor
(arbitrary user code), and `js_object_set_field_by_name` performs the keys-array
transition. Stock zod's `import * as core` materializes **269** members here,
and the emitted IR carried **zero** `js_gc_temp_root_*` calls beside its 269
allocating stores.

**4. `gc/policy.rs` — #7280 ask 2.** "Sound by construction" is corrected, with
the reason: deferring to a precise safepoint makes the *collector* precise and
says nothing about whether the mutator's live values are reachable from the root
set that safepoint scans.

## What this does NOT fix — the important part

#7280's reproducer, release builds, binaries hashed and confirmed distinct at
every hop, compile-time **and** run-time env both set on the revert arm:

| arm | before | this branch |
|---|---|---|
| registry, `PERRY_GC_MOVING_LOOP_POLLS=1` compiled **and** run | 0/30 | **0/30** |
| stock-zod control, same config | 34/40 | 31/40 |
| registry, default | 30/30 | 30/30 |
| stock-zod control, default | 40/40 | 40/40 |
| registry, allocation-point arm (`HEAP_LIMIT=8 INCREMENTAL=0 CONSERVATIVE_STACK_SCAN=off`), **movement asserted — 10/10 runs `copied_objects>0`** | 0/10 | **0/10** |

The control's 34 → 31 is noise: across five independently built configurations
it read 31, 32, 34, 35 and 35 out of 40. Nothing tried moves it.

**#7291 measured on the same harness: registry 0/30, control 32/40.** It does
not close the acceptance test either.

So these defects are real and the reproducer's remaining failure is something
else. After fix (1) the quarantine fault moves off zod's `clone`
(`PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`)
and lands in `js_native_call_method + 580`, called from
`src_lib_api_alerts_ts__init_body` — a receiver going stale in a *runtime*
frame, which is #7249's blind spot and neither PR's subject.

## No witness, and why not

A `test_gap_gc_*` witness was written for fixes (2) and (3) and confirmed by IR
inspection to exercise both lowerings (`js_object_alloc(i32 0, i32 33)` for the
namespace object, 17 `js_array_spread_append`). It was **discarded**: 20/20
clean on the parent under `loop_polls`, and 10/10 clean on the allocation-point
arm with movement asserted. It does not discriminate, so it is not a witness —
it is a dark test with a witness's name on it, which is the exact failure #7278
exists to stop. It is not in this PR.

The only artifact that discriminates for this class remains the
dependency-scale reproducer preserved at `wt-7161rev/gc-eval/`, which is #7280's
still-open ask 3.

## Verification

- `cargo test --release -p perry-codegen collectors::pointer_locals` — 9/9,
  including three new: an optional pointer parameter keeps its slot, an `any`
  parameter assigned only numbers keeps its slot, and a `number` parameter still
  gets none (so the fix is not "root every parameter").
- `cargo fmt --all -- --check` clean, exit status checked directly rather than
  through a pipeline.
- All four `lint` gates green locally: `check_file_size.sh`,
  `addr_class_inventory.py`, `gc_store_site_inventory.py --gate`,
  `check_test_registration.py`.
- Every build `-p perry -p perry-runtime-static -p perry-stdlib-static`, same
  package set at every hop, `PERRY_RUNTIME_DIR` pinned, `.a` mtime confirmed to
  move after each edit.

## Not verified

The gap suite, the parity suite and `gc_repsel_matrix.sh` were not run against
this branch. Fixes (2) and (3) add `js_gc_temp_root_*` traffic to two lowerings
(one push/get/truncate per spread literal and per namespace object, one get per
element/member) and that cost is unmeasured.

Refs #7280, #7154, #7284.

https://claude.ai/code/session_018ZFER8EEg8K7ez2n6oDrT9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime stability when optional pointer, dynamic, and numeric parameters are used.
  - Fixed potential issues when building arrays with spread values during memory cleanup or relocation.
  - Improved reliability when loading internationalized namespaces and their exported values.
  - Strengthened memory-management safeguards for live values, reducing the risk of corrupted or invalid results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->