### PR TITLE
ci(lint): let every gate report instead of stopping at the first failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,14 +124,17 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
+        if: ${{ !cancelled() }}
         run: cargo fmt --all -- --check
 
       - name: Audit workspace architecture
+        if: ${{ !cancelled() }}
         run: |
           python3 scripts/workspace_architecture.py --self-test
           python3 scripts/workspace_architecture.py --check --print-summary
 
       - name: Public benchmark evidence freshness
+        if: ${{ !cancelled() }}
         run: |
           PYTHONPATH=. python3 tests/test_public_baseline.py
           # README embedded table is optional since #6736 (marketing landing
@@ -145,6 +148,7 @@ jobs:
       # cargo-check incrementality, and hide regressions in code review.
       # Allowlist + exclusions live in the script.
       - name: File size limit
+        if: ${{ !cancelled() }}
         run: ./scripts/check_file_size.sh
 
       # Well-known binding provenance pins: every third-party binding in
@@ -154,6 +158,7 @@ jobs:
       # (no network); the weekly update runs `--check --refresh` to surface
       # newly-soaked upstream releases as advisories.
       - name: Binding upstream pins (lock-step)
+        if: ${{ !cancelled() }}
         run: node scripts/binding_pins.mjs --check
 
       # GC write-barrier store-site inventory: every raw heap-slot store in
@@ -162,6 +167,7 @@ jobs:
       # in scripts/gc_store_site_allowlist.txt). Catches new unbarriered
       # old->young store paths before they become nondeterministic segfaults.
       - name: GC store-site inventory
+        if: ${{ !cancelled() }}
         run: |
           python3 scripts/gc_store_site_inventory.py --self-test
           python3 scripts/gc_store_site_inventory.py
@@ -174,6 +180,7 @@ jobs:
       # they become Linux-only segfaults (#1843, #4004, #4665, #4800 class).
       # Allowlist: scripts/addr_class_allowlist.txt.
       - name: Address-classification audit
+        if: ${{ !cancelled() }}
         run: |
           python3 scripts/addr_class_inventory.py --self-test
           python3 scripts/addr_class_inventory.py
@@ -182,9 +189,11 @@ jobs:
       # its own logic is unit-checked on the cheap job rather than only being
       # exercised 8 shards deep.
       - name: Gap snapshot checker self-test
+        if: ${{ !cancelled() }}
         run: python3 scripts/gap_snapshot.py --self-test
 
       - name: Platform-aware parity allowlist self-test
+        if: ${{ !cancelled() }}
         run: python3 scripts/parity_known_failures.py --self-test
 
       # Moving-GC gate wiring. The GC gates are the ones this repo has most
@@ -201,6 +210,7 @@ jobs:
       # server-side state, not a file in the tree — and says so; `--list` prints
       # what is and is not covered.
       - name: Moving-GC gate wiring
+        if: ${{ !cancelled() }}
         run: |
           python3 scripts/gc_gate_wiring_check.py --self-test
           python3 scripts/gc_gate_wiring_check.py
@@ -215,6 +225,7 @@ jobs:
       # cites an issue, and the matrix still calls the checker at all — a gate
       # nobody invokes is the same hazard one level up).
       - name: GC matrix liveness gate
+        if: ${{ !cancelled() }}
         run: |
           python3 scripts/gc_matrix_liveness_check.py --self-test
           python3 scripts/gc_matrix_liveness_check.py --check-registry

--- a/changelog.d/7306-lint-gates-report-independently.md
+++ b/changelog.d/7306-lint-gates-report-independently.md
@@ -1,0 +1,17 @@
+Every gate step in the `lint` job now carries `if: ${{ !cancelled() }}`, so one
+failing gate no longer hides the ones after it. Setup steps (checkout, Node,
+Rust toolchain) still stop the job — there is nothing to gate without them.
+
+This was not hypothetical. The public-baseline freshness check sits at step 8 and
+was stale for 40+ commits, so **file size, GC store-site inventory,
+address-classification audit, moving-GC gate wiring, GC matrix liveness and the
+dark-test registration check never executed in CI at all**. Four of them were
+found red only by running them by hand (#7256, #7273), and #7253's wiring gate —
+added specifically to catch gates that cannot fail — was itself unreachable.
+
+Before this change 1 of 17 steps ran unconditionally. The job still fails if any
+gate fails; it just reports all of them.
+
+Relevant now because the benchmark artifact is expected to go stale during the
+current optimization work — its only fix is a ~2-hour regeneration on a specific
+quiet host, and that must not silently disarm six other gates each time.


### PR DESCRIPTION
One failing `lint` step hides every step after it. **Before this change, 1 of 17 steps ran unconditionally.**

## This is not hypothetical — it is how four gates went unexecuted for 40+ commits

The public-baseline freshness check sits at **step 8**. While it was stale, everything below it **never ran in CI at all**:

| step | consequence |
|---|---|
| File size limit | found red by hand (#7256) |
| GC store-site inventory | found red by hand (#7273) |
| Address-classification audit | found red by hand (#7273) |
| Moving-GC gate wiring | **#7253 added it to catch gates that cannot fail — and it was itself unreachable** |
| GC matrix liveness gate | never ran |
| Test registration (dark tests) | already had `!cancelled()`, so it survived |

Because `lint` is a *required* context, the visible effect was that every merge needed `--admin` and branch protection became theatre. The invisible effect was worse: six gates reporting nothing, indistinguishable from six gates passing.

## The change

`if: ${{ !cancelled() }}` on all 11 gate steps. Setup steps (checkout, Node, Rust toolchain) still stop the job — there is nothing to gate without a toolchain.

**The job still fails if any gate fails.** This changes reporting, not strictness.

## Why now

The benchmark artifact is expected to go stale repeatedly during the current optimization work — its only fix is a **~2-hour regeneration on a specific quiet host** (#7282 tracks narrowing the trigger). Accepting a stale artifact is a reasonable trade; silently disarming six unrelated gates every time it happens is not.

CI-only. No behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation reporting so all applicable quality checks run and report results, even when an earlier check fails.
  - Cancelled runs continue to stop promptly, while failures still cause the overall validation job to fail.

- **Documentation**
  - Added release documentation describing the updated validation behavior and expected benchmark artifact staleness during optimization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->