### PR TITLE
GC rooting: measure the dependency-scale corpus, then close the rule that dominates it (#7280)

### DIFF
--- a/.github/workflows/gc-root-dominance.yml
+++ b/.github/workflows/gc-root-dominance.yml
@@ -157,6 +157,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # ★ The dependency-scale corpus needs the dependency.
+      #
+      # `zod` is this repo's own package.json devDependency, pinned by
+      # package-lock.json and governed by the same soak window as everything
+      # else in that file -- not a fixture invented for this job.
+      # `--ignore-scripts` because nothing here needs a lifecycle script to
+      # run, and a corpus generator is a bad place to execute one.
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+      - name: Install the npm dependencies the dep corpus compiles
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Cache cargo
         uses: actions/cache@v6
         with:
@@ -242,10 +255,95 @@ jobs:
             --allowlist scripts/gc_root_dominance_allowlist.json \
             -v
 
+      # ★★ The DEPENDENCY-SCALE corpus (#7280).
+      #
+      # Everything above this line runs over ~124 hand-written `test-files/`
+      # sources. That corpus read ZERO in both gated modes while twenty lines of
+      # stock `zod` faulted deterministically under the from-space protector,
+      # and #7280 records the gap in one sentence: 25 curated files pass while
+      # 20 lines of stock zod fail.
+      #
+      # It is not a size problem, it is a distribution problem. Measured with
+      # `--stale-registers --moving-only` on the same compiler:
+      #
+      #   curated (124 sources, 144 modules):   116 stale uses, and what
+      #     dominates is property-GET helper windows and js_number_coerce
+      #   dependency-scale (81 modules, 62 MB): 370 stale uses, and what
+      #     dominates is js_object_assign_one (object spread, 137) and
+      #     js_new_function_construct (102) -- populations the curated corpus
+      #     produces 12 and 1 of
+      #
+      # Nothing is sampled away: all 81 modules and all 62 MB are checked. The
+      # cost is ~8s to emit and ~4s for the two gated arms below, because those
+      # arms are linear in instruction count. The `--stale-registers` ratchet is
+      # the expensive one (~5 min) and says so where it runs.
+      - name: Emit the dependency-scale IR corpus
+        run: ./scripts/gc_root_dominance_dep_corpus.sh ir-corpus-dep
+
+      - name: Check root-store dominance (dependency-scale)
+        run: |
+          set -euo pipefail
+          # Floors from the corpus as of this commit (81 modules, ~12900
+          # functions, ~7700 root stores), set below that with room for the
+          # dependency's own churn. `zod` growing is fine; `zod` no longer
+          # compiling natively is the finding, and these are what make it one.
+          python3 scripts/gc_root_dominance_check.py ir-corpus-dep \
+            --moving-only \
+            --min-files 60 --min-binds 4000 --min-funcs 6000 \
+            --allowlist scripts/gc_root_dominance_allowlist.json \
+            --seeded-violations 40 \
+            -v
+
+      - name: Check that every GC value in an alloca has a root store (dependency-scale)
+        run: |
+          set -euo pipefail
+          python3 scripts/gc_root_dominance_check.py ir-corpus-dep \
+            --unrooted-allocas \
+            --moving-only \
+            --min-files 60 --min-binds 4000 --min-funcs 6000 \
+            --allowlist scripts/gc_root_dominance_allowlist.json \
+            -v
+
+      # ★ The stale-register RATCHET, on both corpora.
+      #
+      # `--stale-registers` asks the third question: not "is the root store
+      # late" and not "is there a root store at all", but "is a register holding
+      # a rooted value used below a collection point". It is the mode that found
+      # #7206's two bugs and the mode #7280's zod fault lives in, and until now
+      # it ran only by hand -- so its number could move in either direction
+      # between one investigation and the next with nothing to say so.
+      #
+      # It is a BUDGET rather than an allowlist because the residual is a
+      # population, not a list of triaged sites: the remaining uses are the ones
+      # whose slot the program itself reassigns inside the window, which need a
+      # temp root rather than a re-read (see crate::root_reload). A budget can
+      # only be lowered, and lowering it is the ratchet.
+      #
+      # This step is minutes, not seconds -- the scan is superlinear in
+      # instruction count and the dependency corpus is 62 MB. That is the price
+      # of checking the population that actually breaks.
+      - name: Stale-register budget (curated)
+        run: |
+          set -euo pipefail
+          python3 scripts/gc_root_dominance_check.py ir-corpus \
+            --stale-registers --moving-only \
+            --min-files 90 --min-binds 1500 --min-funcs 1200 \
+            --max-stale 39
+
+      - name: Stale-register budget (dependency-scale)
+        run: |
+          set -euo pipefail
+          python3 scripts/gc_root_dominance_check.py ir-corpus-dep \
+            --stale-registers --moving-only \
+            --min-files 60 --min-binds 4000 --min-funcs 6000 \
+            --max-stale 118
+
       - name: Upload the IR corpus on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: gc-root-dominance-ir
-          path: ir-corpus
+          path: |
+            ir-corpus
+            ir-corpus-dep
           retention-days: 7

--- a/changelog.d/7311-dep-scale-corpus-and-root-reload.md
+++ b/changelog.d/7311-dep-scale-corpus-and-root-reload.md
@@ -1,0 +1,166 @@
+### GC rooting: measure the right corpus, then fix the one rule that dominates it
+
+Two linked changes: the gate's corpus was measuring the wrong population, and
+once it measured the right one, 73% of what it reported was a single rule.
+
+#### The corpus (#7280)
+
+`scripts/gc_root_dominance_corpus.sh` compiles ~124 hand-written `test-files/`
+sources. It reads **zero** in both modes the CI gate runs, and it read zero
+while twenty lines of stock `zod` faulted deterministically under the from-space
+protector. #7280 puts the gap in one sentence: *25 curated files pass while 20
+lines of stock zod fail.*
+
+That is a distribution problem, not a size problem. Both corpora, same compiler,
+`--stale-registers --moving-only`:
+
+| corpus | stale uses | dominant population |
+|---|---|---|
+| curated — 124 sources, 144 modules, 2378 functions | 116 | property-GET helper windows, `js_number_coerce`, `js_closure_callN` |
+| dependency-scale — 81 modules, 62 MB, 12899 functions | 371 | `js_object_assign_one` 137, `js_new_function_construct` 102, `js_closure_call*` 30 |
+
+The curated corpus produces 12 of the first population and 1 of the second. A
+hand-written test allocates a couple of objects and calls a couple of helpers; a
+library spreads objects into objects, boxes every mutable capture because its
+closures outlive their frames, and builds values field by field out of data.
+The rooting hazards live in the *shapes*.
+
+So `scripts/gc_root_dominance_dep_corpus.sh` generates the second corpus from a
+real npm dependency — `zod`, this repo's own `package.json` devDependency,
+pinned by `package-lock.json` and governed by the same soak window as everything
+else in that file — imported **by source path** so its modules compile natively
+rather than falling back to V8 and emitting no IR to check.
+
+**Nothing is sampled away.** All 81 modules and all 62 MB are checked. Emitting
+costs ~8s; the two gated arms cost ~3s each, because they are linear in
+instruction count. The `--stale-registers` budget is the expensive one (~5 min)
+and the workflow says so where it runs.
+
+`test-files/gc-dep-corpus/main.ts` is the only entry point and the rest of that
+directory reaches the compiler by being imported from it, so the generator
+**asserts that every `.ts` in the directory produced a module** — the check a
+size floor could not be (#7278), since ~90 modules of `zod` swamp any count a
+missing 40-line source would cross.
+
+#### The rule (`crate::root_reload`)
+
+> A load out of a shadow slot is a **copy** of a root. An evacuating minor
+> rewrites the slot; it cannot rewrite the register. So every use a collection
+> point can reach must re-read the slot — unless a store to that slot can also
+> run on the way, in which case re-reading would observe an assignment the
+> program made and the register is left alone.
+
+Verbatim from `zod`'s object-spread lowering, before:
+
+```llvm
+  call void @js_shadow_slot_bind(i32 0, ptr %r7)   ; %r7 IS a root
+  %r8  = load double, ptr %r7                      ; a COPY of the root
+  %r9  = call double @baseFields()                 ; evacuates; rewrites %r7
+  %r10 = call double @js_object_assign_one(double %r8, double %r9)  ; from-space
+  %r11 = load double, ptr %r7                      ; the NEXT statement re-reads
+```
+
+Codegen was never unable to re-read the slot — the following statement does it,
+because a fresh lowering emits a fresh load. The bug is that *within* one
+lowering the load happens once, at the top, and the register is carried across
+everything after it. That is why this is a pass and not another point fix:
+`index_set.rs` alone lowers `object` before `value` at fifteen separate arms,
+and the shape also appears in the object-literal spread, the inline class-field
+store, `new`, property define, `instanceof` and the closure-call family.
+
+The soundness half is the half `expr/temp_root.rs` already documents: re-reading
+a *local* is not unconditionally safe, because `new C(g, bump())` where `bump()`
+assigns `g` must pass the pre-`bump()` value. At IR level that objection is
+decidable — an assignment to a shadow-slotted local is a `store` to its alloca
+in the same function, and a local captured *and* mutated by a closure is boxed
+instead, so it has no plain shadow slot to reload. Both halves are path
+questions over the real CFG, answered the way the checker answers them: a
+back-edge round trip is not an intra-iteration path, because re-entering the
+load's block re-executes the load.
+
+Where the reload was not needed — no call between the two points — LLVM's
+EarlyCSE/GVN forwards it away, since nothing can clobber the alloca. Where it
+was needed the intervening call is opaque and the load stays. The pass is close
+to free exactly where it is redundant.
+
+Recording is at the choke point, not at the thirteen `js_shadow_slot_bind` emit
+sites: `LlBlock::call_void` and `LlFunction::entry_setup_call_void` see every
+bind form, including the slow arm of #7088's inline diamond (which emits the
+same call), so a fourteenth site cannot be added without the set noticing. And
+the pass runs in `compile_module` before **any** rendering path, so the text
+renderer and the in-process constructor (#7301) see the same IR — a pass living
+inside `to_ir` would silently not apply to the other.
+
+#### What it closes, on both corpora
+
+| arm | curated | dependency-scale |
+|---|---|---|
+| `--stale-registers --moving-only`, total | 116 → **39** | 371 → **118** |
+| …of which `source=slotload` | 102 → **25** | 272 → **19** |
+| bind-anchored `--moving-only` | 0 → 0 | 0 → 0 |
+| `--unrooted-allocas --moving-only` | 0 → 0 | 0 → 0 |
+
+`js_object_assign_one` disappears from the dependency-scale report entirely
+(137 → 0); `js_new_function_construct` goes 102 → 29.
+
+Both budgets are now ratchets in `gc-root-dominance.yml` (`--max-stale 39` and
+`--max-stale 118`), because until now this mode ran only by hand — its number
+could move in either direction between one investigation and the next with
+nothing to say so. It is a budget rather than an allowlist because the residual
+is a *population*, not a list of triaged sites: what is left is the uses whose
+slot the program itself reassigns inside the window, which need a temp root
+rather than a re-read.
+
+#### And one runtime-Rust rooting bug the corpus led to
+
+`js_regexp_new` takes `pattern` as a raw `StringHeader*` and then allocates
+twice — `js_string_from_str` for the canonical flags, `gc_malloc` for the header
+— before storing that pointer into `RegExpHeader::pattern_ptr`. Either
+allocation can run an evacuating minor, after which the argument names retired
+from-space and the header keeps a **permanently** dangling `pattern_ptr`; the
+borrowed `pattern_str` had the same exposure and fed the owned `.source` copy.
+
+That is the runtime-Rust half of the invariant (#7249), which
+`gc_root_dominance_check.py` is structurally blind to — it reads emitted IR and
+cannot see a Rust local. Reproduction:
+
+```
+PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off \
+PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800 \
+  ./<gc-dep-corpus-main>
+```
+
+Before: faults deterministically, `RETIRED FROM-SPACE`, `js_regexp_new + 3920`
+← `js_regexp_construct` ← `perry_closure_…zod…regexes_ts__9`. The same fault
+appears with the codegen pass alone, so it is not caused by it. After: clean.
+
+No unit-test witness ships with it, and that is a deliberate statement rather
+than an omission: forcing a *copying* minor inside a runtime function needs a
+collection at an allocation point, and `gc/zeal.rs` documents why that level
+does not exist (an allocation-point collection takes `force_full_scan`, which
+makes the copying minor ineligible, so it would move nothing). A test was
+written, its liveness assert refused to pass, and it was deleted rather than
+shipped as a test that cannot fail for the right reason.
+
+#### Measured after #7301 and #7305, not before
+
+The backend rewrite (typed `LlInst`, two consumers of one finalized-item
+visitor) and the move from setjmp/longjmp to `invoke`/`landingpad` both landed
+while this was in flight, so every number above is re-measured on `b50e857c2`,
+both sides, over identical paths. The dependency-scale parent count moved by
+exactly one (370 → 371); nothing else changed.
+
+Two consequences for the pass, both load-bearing:
+
+* It inserts a **typed** `LlInst::Load` and rewrites operands on typed variants
+  in place, never text, so `native_emit`'s `(typed, raw)` migration ratchet moves
+  in the intended direction. And it runs in `compile_module` before *any*
+  rendering path, so `to_ir` and the native C-API builder consume the same
+  stream — a pass inside `to_ir` would have applied to one consumer only.
+* An `invoke` is modelled as **both** a call and a two-successor terminator.
+  Missing the call half would classify a throwing helper's window as
+  non-collecting and drop every reload inside a `try`; missing the successor half
+  would hide the unwind edge. The unwind edge is also why the rule is "reload at
+  the USE" and not "reload after the call": a load from the slot is valid
+  wherever it sits and reads whatever the collector last wrote, so it is correct
+  on both edges without a placement decision.

--- a/crates/perry-codegen/src/block.rs
+++ b/crates/perry-codegen/src/block.rs
@@ -9,8 +9,8 @@
 //! sorts out the registers. Explicit `phi` nodes are still emitted for
 //! control-flow merges (if/else value context, short-circuit logical ops).
 
-use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::cell::{Cell, Ref, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::codegen::FpContractMode;
@@ -71,6 +71,19 @@ pub struct RegCounter {
     /// catch/finally bodies see the *enclosing* scope, which is exactly
     /// where a throw escaping them lands at runtime.
     eh_unwind_labels: RefCell<Vec<String>>,
+    /// Every alloca this function has published to the precise-root collector
+    /// with `js_shadow_slot_bind(idx, ptr)`.
+    ///
+    /// Recorded at the choke points rather than at the thirteen emit sites,
+    /// because a fourteenth site is exactly the thing that gets added without
+    /// anyone remembering a register list somewhere else.
+    ///
+    /// A shadow slot is the one class of alloca whose contents the collector
+    /// writes behind generated code's back: an evacuating minor rewrites the
+    /// slot to the object's new address. [`crate::root_reload`] reads this set
+    /// to find the loads that rewrite makes stale. See
+    /// `docs/src/internals/gc-rooting-invariant.md`.
+    shadow_slot_allocas: RefCell<HashSet<String>>,
 }
 
 impl RegCounter {
@@ -78,7 +91,37 @@ impl RegCounter {
         Self {
             value: Cell::new(0),
             eh_unwind_labels: RefCell::new(Vec::new()),
+            shadow_slot_allocas: RefCell::new(HashSet::new()),
         }
+    }
+
+    /// Record `ptr` when `callee` is the precise-root bind.
+    ///
+    /// Called from the two choke points every bind form passes through:
+    /// [`LlBlock::call_void`] — which carries the direct call AND the slow arm
+    /// of #7088's inline diamond, since that arm emits the same call — and
+    /// `LlFunction::entry_setup_call_void`, which carries the persistent-slot
+    /// bind hoisted into the entry prelude.
+    pub(crate) fn note_shadow_slot_bind(&self, callee: &str, second_arg: Option<&str>) {
+        if callee != "js_shadow_slot_bind" {
+            return;
+        }
+        // `js_shadow_slot_bind(i32 idx, ptr %slot)`: the slot is argument two.
+        // A non-register operand means the bind was built some other way, and
+        // the conservative answer is to record nothing — a slot this set does
+        // not name is simply never reloaded.
+        if let Some(ptr) = second_arg {
+            if ptr.starts_with('%') {
+                self.shadow_slot_allocas
+                    .borrow_mut()
+                    .insert(ptr.to_string());
+            }
+        }
+    }
+
+    /// The shadow slots bound in this function. See [`crate::root_reload`].
+    pub(crate) fn shadow_slot_allocas(&self) -> Ref<'_, HashSet<String>> {
+        self.shadow_slot_allocas.borrow()
     }
 
     /// Enter an invoke-EH handler scope: calls emitted from here until the
@@ -242,6 +285,14 @@ impl LlBlock {
     /// intermediate `String` per line.
     pub fn insts(&self) -> &[crate::inst::LlInst] {
         &self.instructions
+    }
+
+    /// Mutable instruction list, for the whole-function passes that run after
+    /// lowering. See [`crate::root_reload`]. Not for emitters — they go through
+    /// [`LlBlock::push_inst`] / [`LlBlock::emit`], which keep the terminator
+    /// discipline and the try-region bookkeeping.
+    pub(crate) fn insts_mut(&mut self) -> &mut Vec<crate::inst::LlInst> {
+        &mut self.instructions
     }
 
     // -------- Arithmetic (double) --------
@@ -1136,6 +1187,8 @@ impl LlBlock {
     pub fn call_void(&mut self, func_name: &str, args: &[(LlvmType, &str)]) {
         // #835 + #846: same registry hook as `call` — see comment there.
         crate::ext_registry::record_ffi_call(func_name);
+        self.counter
+            .note_shadow_slot_bind(func_name, args.get(1).map(|(_, v)| *v));
         if let Some((cont, lpad)) = self.eh_invoke_suffix(func_name) {
             let arg_str = format_args(args);
             self.emit(format!(

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -2566,6 +2566,15 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         .native_rep_records
         .extend(typed_clone_rejection_records);
 
+    // #7280: re-read every shadow slot below the collection points that can run
+    // under it. Whole-function, so it runs here rather than inside a lowering —
+    // the shape it fixes is spread over dozens of lowerings, fifteen arms of
+    // `index_set.rs` alone. It runs BEFORE any rendering path so the text
+    // renderer and the in-process constructor see the same IR; a pass living in
+    // one of them would silently not apply to the other.
+    // See `crate::root_reload`.
+    crate::root_reload::apply_to_module(&mut llmod);
+
     let verify_native_regions = opts.verify_native_regions
         || std::env::var("PERRY_VERIFY_NATIVE_REGIONS").ok().as_deref() == Some("1");
     if verify_native_regions {

--- a/crates/perry-codegen/src/function.rs
+++ b/crates/perry-codegen/src/function.rs
@@ -453,6 +453,8 @@ impl LlFunction {
     /// emitted at the top of the entry block with the other entry setup.
     pub fn entry_setup_call_void(&mut self, func_name: &str, args: &[(LlvmType, &str)]) {
         crate::ext_registry::record_ffi_call(func_name);
+        self.reg_counter
+            .note_shadow_slot_bind(func_name, args.get(1).map(|(_, v)| *v));
         let arg_str = args
             .iter()
             .map(|(ty, value)| format!("{} {}", ty, value))
@@ -540,6 +542,58 @@ impl LlFunction {
 
     pub fn blocks(&self) -> &[LlBlock] {
         &self.blocks
+    }
+
+    /// Mutable block list, for the whole-function passes that run after
+    /// lowering. See [`crate::root_reload`].
+    pub(crate) fn blocks_mut(&mut self) -> &mut Vec<LlBlock> {
+        &mut self.blocks
+    }
+
+    pub(crate) fn reg_counter(&self) -> &RegCounter {
+        &self.reg_counter
+    }
+
+    pub(crate) fn reg_counter_rc(&self) -> Rc<RegCounter> {
+        self.reg_counter.clone()
+    }
+
+    /// Index in block 0 where `entry_post_init_setup` is spliced, if this
+    /// function has an init prelude. See [`note_entry_block_insertions`].
+    ///
+    /// [`note_entry_block_insertions`]: LlFunction::note_entry_block_insertions
+    pub(crate) fn entry_init_boundary(&self) -> Option<usize> {
+        self.entry_init_boundary
+    }
+
+    /// Tell the function that `n` instructions were inserted into block 0 **at
+    /// or above** the splice point, so the splice still lands in the same place
+    /// relative to the prelude.
+    ///
+    /// ★ The count must be exactly the insertions at index ≤ the boundary.
+    /// Neither error is cosmetic:
+    ///
+    /// - **under-counting** leaves the splice too early, and the tail of the
+    ///   init prelude ends up below it — a `keys_array` global read hoisted
+    ///   above the `__perry_init_strings_*` call that populates it, i.e. a
+    ///   zero, silently;
+    /// - **over-counting** — bumping by every insertion, including the ones
+    ///   below the boundary — leaves the splice too LATE, and `to_ir` clamps an
+    ///   out-of-range boundary with `.min(instruction_count())`, which moves the
+    ///   whole post-init region to the END of the entry block. For a function
+    ///   built by `enable_post_init_shadow_frame` that region contains the
+    ///   `js_shadow_frame_enter` call itself, so every `js_shadow_slot_bind`
+    ///   in the body then runs with no frame pushed and roots NOTHING. Measured:
+    ///   the allocation-point acceptance arm went 30/30 → 0/30 with
+    ///   `TypeError: value is not a function`, which reads exactly like the
+    ///   rooting bug the pass was written to fix.
+    pub(crate) fn note_entry_block_insertions(&mut self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        if let Some(b) = self.entry_init_boundary.as_mut() {
+            *b += n;
+        }
     }
 
     pub fn num_blocks(&self) -> usize {

--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -30,6 +30,7 @@ pub mod native_emit;
 pub(crate) mod native_value;
 pub(crate) mod nm_install;
 pub mod opt_report;
+pub(crate) mod root_reload;
 pub mod runtime_decls;
 pub(crate) mod stmt;
 pub mod strings;

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -379,6 +379,17 @@ impl LlModule {
         self.functions.get_mut(idx)
     }
 
+    /// Every defined function, mutably — for the whole-module passes that run
+    /// after lowering and before any rendering path. See
+    /// [`crate::root_reload`], and note that "before ANY rendering path" is the
+    /// load-bearing part: the text renderer (`to_ir`, `render_codegen_units`)
+    /// and the in-process constructor (`for_each_final_line`) are separate
+    /// consumers, so a pass living inside one of them would silently not apply
+    /// to the other.
+    pub(crate) fn functions_mut(&mut self) -> impl Iterator<Item = &mut LlFunction> {
+        self.functions.iter_mut()
+    }
+
     /// Number of functions defined so far. Used to recover the index of a
     /// just-`define_function`ed function (whose `&mut` borrow must be released
     /// before the index can be read) when emitting a sequence of functions —

--- a/crates/perry-codegen/src/root_reload.rs
+++ b/crates/perry-codegen/src/root_reload.rs
@@ -1,0 +1,1171 @@
+//! Re-read a shadow slot below every collection point that can run under it
+//! (#7280).
+//!
+//! # The rule
+//!
+//! `docs/src/internals/gc-rooting-invariant.md` states it, and the second half
+//! is the half that keeps getting dropped:
+//!
+//! > Any GC-managed value that is live across a collection point must be
+//! > reachable from a root before that point. **A value read out of a root and
+//! > held in an SSA register across a call is not rooted.** It is a copy, and
+//! > the collector cannot see copies.
+//!
+//! A shadow slot has property (2) — the collector *rewrites* it on evacuation —
+//! but a register loaded from it beforehand has only property (1), liveness.
+//! The object survives, at a new address, and the register names the old one:
+//!
+//! ```llvm
+//!   %r7 = alloca double
+//!   store double %arg1, ptr %r7
+//!   call void @js_shadow_slot_bind(i32 0, ptr %r7)   ; %r7 IS a root
+//!   %r8 = load double, ptr %r7                       ; a COPY of the root
+//!   %r9 = call double @build_schema()                 ; evacuates; rewrites %r7
+//!   %r10 = call double @js_object_assign_one(double %r8, ...)  ; from-space
+//! ```
+//!
+//! That is verbatim from `zod`'s object-spread lowering, and the very next
+//! statement in the same function re-loads `%r7` — because a *fresh* lowering
+//! of the same local emits a fresh load. The bug is never that codegen cannot
+//! re-read the slot; it is that within one lowering the load happens once, at
+//! the top, and the register is carried across everything that follows.
+//!
+//! # Why this is a pass and not another fix
+//!
+//! Because the shape is not in one lowering. Measured over the two IR corpora
+//! (`scripts/gc_root_dominance_corpus.sh`, `scripts/gc_root_dominance_dep_corpus.sh`),
+//! `--stale-registers --moving-only` reports 116 and 370 stale uses; 102 and 271
+//! of them are this one shape, spread across the object-literal spread, the
+//! inline class-field store, the numeric element store, `new`, property
+//! define, `instanceof`, the closure-call family and more. `index_set.rs` alone
+//! lowers `object` before `value` at fifteen separate arms. Fixing them one at
+//! a time is what #7291 and #7299 did, correctly, without moving the acceptance
+//! arm at all.
+//!
+//! So the fix is stated once, over the emitted CFG, where the property is
+//! decidable:
+//!
+//! > For a load out of a shadow slot, every use that a collection point can
+//! > reach re-reads the slot instead.
+//!
+//! # Why re-loading is sound, and when it is not
+//!
+//! Re-reading a slot is NOT unconditionally safe, and `expr/temp_root.rs`'s
+//! [`operand_is_reloadable`] documents exactly why: re-lowering a local reads
+//! its value *now*, and "now" is after the later arguments have run — any of
+//! which may have reassigned it. `new C(g, bump())` where `bump()` assigns `g`
+//! must pass the pre-`bump()` `g`; re-lowering hands it the post-`bump()` one,
+//! which is a miscompile rather than a rooting fix.
+//!
+//! That objection is about the SOURCE program's assignments, and at this level
+//! they are visible: an assignment to a shadow-slotted local is a `store` to
+//! its alloca in this function. (A local captured *and mutated* by a closure is
+//! boxed instead — `boxed_vars.rs` — so it has no plain shadow slot to reload.)
+//! So the rule carries its own side condition:
+//!
+//! > …unless a store to that slot can also run on the way, in which case the
+//! > register is left alone.
+//!
+//! Both halves are path questions over the real CFG, not line order, and both
+//! are answered here the same way `scripts/gc_root_dominance_check.py` answers
+//! them — a back-edge round trip is not an intra-iteration path, because
+//! re-entering the load's block re-executes the load and produces a different
+//! dynamic value.
+//!
+//! Left alone means left as it is today: the 17 curated and 39 dependency-scale
+//! residuals where the slot is reassigned in the window are genuinely the
+//! temp-root case, and they keep their existing behaviour rather than getting a
+//! wrong one.
+//!
+//! # Cost
+//!
+//! A reload is one load from a stack slot. Where it was not needed — no call
+//! between the two points — LLVM's EarlyCSE/GVN forwards it away, because with
+//! no intervening call nothing can clobber the alloca. Where it *was* needed
+//! the intervening call is opaque, LLVM must keep the load, and that is the
+//! whole point. So the pass is close to free exactly where it is redundant.
+//!
+//! [`operand_is_reloadable`]: crate::expr::temp_root
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::function::LlFunction;
+use crate::inst::{LlInst, LoadFlavor};
+use crate::types::LlvmType;
+
+/// Runtime helpers that provably cannot allocate, run user code, or poll, and
+/// which generated code emits often enough that treating them as collection
+/// points would put a reload between every pair of instructions.
+///
+/// **This list is deliberately a SUBSET of `NONCOLLECTING` in
+/// `scripts/gc_root_dominance_check.py`**, which is the authority and names the
+/// runtime line proving each entry. A subset is the safe direction: a helper
+/// missing from here is treated as collecting, which inserts a reload the
+/// checker would not have demanded — a load, not a bug. A helper that is here
+/// and is NOT in the checker's set would be the unsafe direction, so the
+/// invariant to preserve on edit is one-way containment.
+const NON_COLLECTING: &[&str] = &[
+    // shadow stack / roots
+    "js_shadow_slot_bind",
+    "js_shadow_slot_set",
+    "js_shadow_frame_enter",
+    "js_shadow_frame_push",
+    "js_shadow_frame_pop",
+    "js_shadow_state_addr",
+    "js_gc_temp_root_push",
+    "js_gc_temp_root_get",
+    "js_gc_temp_root_set",
+    "js_gc_temp_root_truncate",
+    // layout / barrier bookkeeping
+    "js_gc_init_typed_shape_layout",
+    "js_gc_layout_note_slot",
+    "js_write_barrier",
+    "js_write_barrier_root_nanbox",
+    "js_write_barrier_slot",
+    "js_runtime_write_barrier_slot",
+    "js_gc_register_global_root",
+    // pure value predicates / bit twiddling
+    "js_is_truthy",
+    "js_nanbox_get_pointer",
+    "js_value_is_object",
+    "js_value_is_string",
+    "js_typeof_tag",
+    // inline-cache guards: pure reads
+    "js_typed_feedback_closure_direct_call_guard",
+    "js_typed_feedback_shape_guard",
+    "js_typed_feedback_note",
+    // verified non-allocating bookkeeping stores/reads
+    "js_closure_set_capture_bits",
+    "js_closure_get_capture_bits",
+    "js_closure_set_capture_ptr",
+    "js_closure_get_capture_ptr",
+    "js_box_set_bits",
+    "js_box_get_bits",
+    "js_i32_box_set",
+    "js_bool_box_set",
+    "js_tdz_suppress_begin",
+    "js_tdz_suppress_end",
+    "js_array_note_numeric_write",
+    "js_array_length",
+    "js_object_mark_class",
+    "js_class_object_pin_parent",
+    "js_new_target_get",
+    "js_new_target_set",
+    "js_ctor_return_override",
+];
+
+/// Guard against a pathological function turning this pass into the compile's
+/// bottleneck: the reachability walk is O(blocks) per slot load, so the product
+/// is what matters. Above the cap the function keeps today's IR — the pass is
+/// an improvement, not a correctness precondition, so declining is safe.
+///
+/// Sized from the corpora: the largest function in the dependency-scale corpus
+/// (`zod`'s parse core) is ~1400 blocks with ~90 slot loads, an order of
+/// magnitude under this.
+const MAX_BLOCK_LOAD_PRODUCT: usize = 8_000_000;
+
+fn is_collecting(callee: &str) -> bool {
+    if callee.starts_with("llvm.") {
+        return false;
+    }
+    !NON_COLLECTING.contains(&callee)
+}
+
+/// One instruction, in the vocabulary this pass needs.
+struct Facts {
+    /// Register this instruction defines, without the `%`. Kept even though
+    /// only `load_of` reads it today: `Facts` is the pass's whole vocabulary,
+    /// and a def map is the first thing a follow-up (a dead-load sweep, say)
+    /// needs.
+    #[allow(dead_code)]
+    result: Option<String>,
+    /// Registers it reads, without the `%`. Only operands — never `result`.
+    uses: Vec<String>,
+    /// `Some((dst, ty, slot))` for `dst = load ty, ptr %slot`.
+    load_of: Option<(String, LlvmType, String)>,
+    /// Alloca this instruction stores into, without the `%`.
+    stores_to: Option<String>,
+    collecting: bool,
+    /// A `phi` cannot have an instruction inserted before it. Neither can an
+    /// inline block label (#7305's `invoke` continuation, emitted as a `Raw`
+    /// `<name>:` line inside the same builder block): inserting there would put
+    /// an instruction between a terminator and its label.
+    is_phi: bool,
+    /// Successor block labels, for the CFG.
+    succs: Vec<String>,
+}
+
+/// Apply the reload rule to every function in `module`. Returns the number of
+/// operands rewritten, which the unit tests assert on so a pass that silently
+/// stops firing is a failure rather than a no-op.
+pub(crate) fn apply_to_module(module: &mut crate::module::LlModule) -> usize {
+    let mut total = 0;
+    for f in module.functions_mut() {
+        total += apply_to_function(f);
+    }
+    total
+}
+
+pub(crate) fn apply_to_function(func: &mut LlFunction) -> usize {
+    let slots: HashSet<String> = {
+        let bound = func.reg_counter().shadow_slot_allocas();
+        if bound.is_empty() {
+            return 0;
+        }
+        bound
+            .iter()
+            .map(|s| s.trim_start_matches('%').to_string())
+            .collect()
+    };
+
+    let blocks = func.blocks_mut();
+    if blocks.is_empty() {
+        return 0;
+    }
+
+    let facts: Vec<Vec<Facts>> = blocks
+        .iter()
+        .map(|b| b.insts().iter().map(|i| facts_of(i, &slots)).collect())
+        .collect();
+
+    let label_index: HashMap<&str, usize> = blocks
+        .iter()
+        .enumerate()
+        .map(|(i, b)| (b.label.as_str(), i))
+        .collect();
+
+    // Slot loads, and where they are.
+    let mut loads: Vec<(usize, usize)> = Vec::new();
+    for (bi, fb) in facts.iter().enumerate() {
+        for (ii, f) in fb.iter().enumerate() {
+            if f.load_of.is_some() {
+                loads.push((bi, ii));
+            }
+        }
+    }
+    if loads.is_empty() {
+        return 0;
+    }
+    if blocks.len().saturating_mul(loads.len()) > MAX_BLOCK_LOAD_PRODUCT {
+        return 0;
+    }
+
+    let succs: Vec<Vec<usize>> = facts
+        .iter()
+        .map(|fb| {
+            let mut out: Vec<usize> = Vec::new();
+            for f in fb {
+                for s in &f.succs {
+                    if let Some(&i) = label_index.get(s.as_str()) {
+                        if !out.contains(&i) {
+                            out.push(i);
+                        }
+                    }
+                }
+            }
+            out
+        })
+        .collect();
+
+    // Where a use must be rewritten: (block, insn, old register, new register,
+    // slot, type). Collected first so the instruction vectors are not mutated
+    // while `facts` still indexes them.
+    struct Rewrite {
+        blk: usize,
+        insn: usize,
+        from: String,
+        slot: String,
+        ty: LlvmType,
+    }
+    let mut rewrites: Vec<Rewrite> = Vec::new();
+
+    for (lb, li) in loads {
+        let (dst, ty, slot) = facts[lb][li].load_of.clone().expect("load site");
+        // Forward reachability from the load, never re-entering the load's own
+        // block: a back edge re-executes the load, so the value on the far side
+        // is a different dynamic instance and not this one.
+        //
+        // `collect_in[b]` / `store_in[b]`: can a collecting call / a store to
+        // `slot` have run on some path from the load to the TOP of block `b`?
+        let mut collect_in = vec![false; facts.len()];
+        let mut store_in = vec![false; facts.len()];
+        let mut seen = vec![false; facts.len()];
+        let mut queue: VecDeque<usize> = VecDeque::new();
+
+        // Tail of the load's own block, from just after the load.
+        let mut c = false;
+        let mut s = false;
+        for f in facts[lb].iter().skip(li + 1) {
+            c |= f.collecting;
+            s |= f.stores_to.as_deref() == Some(slot.as_str());
+        }
+        for &succ in &succs[lb] {
+            if succ == lb {
+                continue;
+            }
+            if !seen[succ] || (c && !collect_in[succ]) || (s && !store_in[succ]) {
+                collect_in[succ] |= c;
+                store_in[succ] |= s;
+                seen[succ] = true;
+                queue.push_back(succ);
+            }
+        }
+        while let Some(b) = queue.pop_front() {
+            let mut oc = collect_in[b];
+            let mut os = store_in[b];
+            for f in &facts[b] {
+                oc |= f.collecting;
+                os |= f.stores_to.as_deref() == Some(slot.as_str());
+            }
+            for &succ in &succs[b] {
+                if succ == lb {
+                    continue;
+                }
+                let grew = !seen[succ] || (oc && !collect_in[succ]) || (os && !store_in[succ]);
+                if grew {
+                    collect_in[succ] |= oc;
+                    store_in[succ] |= os;
+                    seen[succ] = true;
+                    queue.push_back(succ);
+                }
+            }
+        }
+
+        for (ub, fb) in facts.iter().enumerate() {
+            // Only blocks the load can reach without re-entering its own block,
+            // plus the load's own block below the load.
+            if ub != lb && !seen[ub] {
+                continue;
+            }
+            let (mut c, mut s) = if ub == lb {
+                (false, false)
+            } else {
+                (collect_in[ub], store_in[ub])
+            };
+            let start = if ub == lb { li + 1 } else { 0 };
+            for (ui, f) in fb.iter().enumerate().skip(start) {
+                if f.uses.iter().any(|u| *u == dst) && c && !s && !f.is_phi {
+                    rewrites.push(Rewrite {
+                        blk: ub,
+                        insn: ui,
+                        from: dst.clone(),
+                        slot: slot.clone(),
+                        ty,
+                    });
+                }
+                c |= f.collecting;
+                s |= f.stores_to.as_deref() == Some(slot.as_str());
+            }
+        }
+    }
+
+    if rewrites.is_empty() {
+        return 0;
+    }
+
+    // Apply back-to-front within each block so earlier indices stay valid.
+    rewrites.sort_by(|a, b| (a.blk, a.insn).cmp(&(b.blk, b.insn)).reverse());
+    let n = rewrites.len();
+    let counter = func.reg_counter_rc();
+    // ★ Only the insertions AT OR ABOVE the post-init splice point move it.
+    // Counting the ones below it too pushes the splice past the end of the
+    // entry block, `to_ir` clamps it, and the whole post-init region — which
+    // for a post-init-frame function contains `js_shadow_frame_enter` itself —
+    // lands after every `js_shadow_slot_bind` in the body. See
+    // `LlFunction::note_entry_block_insertions`; the symptom is indistinguishable
+    // from the bug this pass exists to fix, which is how it was found.
+    let boundary = func.entry_init_boundary();
+    let entry_inserts = match boundary {
+        None => 0,
+        Some(b) => rewrites
+            .iter()
+            .filter(|r| r.blk == 0 && r.insn <= b)
+            .count(),
+    };
+    {
+        let blocks = func.blocks_mut();
+        for r in rewrites {
+            let fresh = format!("%r{}", counter.next());
+            let reload = LlInst::Load {
+                dst: fresh.clone(),
+                ty: r.ty,
+                ptr: format!("%{}", r.slot),
+                flavor: LoadFlavor::Plain,
+            };
+            let insts = blocks[r.blk].insts_mut();
+            rename_operand(&mut insts[r.insn], &r.from, fresh.trim_start_matches('%'));
+            insts.insert(r.insn, reload);
+        }
+    }
+    func.note_entry_block_insertions(entry_inserts);
+    n
+}
+
+fn facts_of(inst: &LlInst, slots: &HashSet<String>) -> Facts {
+    let mut uses = Vec::new();
+    let mut result = None;
+    let mut load_of = None;
+    let mut stores_to = None;
+    let mut collecting = false;
+    let mut is_phi = false;
+    let mut succs = Vec::new();
+
+    let reg = |s: &str| -> Option<String> {
+        s.strip_prefix('%')
+            .map(|r| r.to_string())
+            .filter(|r| !r.is_empty())
+    };
+    let use_op = |uses: &mut Vec<String>, s: &str| {
+        if let Some(r) = reg(s) {
+            uses.push(r);
+        }
+    };
+
+    match inst {
+        LlInst::Raw(text) => return raw_facts(text, slots),
+        LlInst::Bin { dst, a, b, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, a);
+            use_op(&mut uses, b);
+        }
+        LlInst::FNeg { dst, a, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, a);
+        }
+        LlInst::FCmp { dst, a, b, .. } | LlInst::ICmp { dst, a, b, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, a);
+            use_op(&mut uses, b);
+        }
+        LlInst::Alloca { dst, .. } => result = reg(dst),
+        LlInst::Load { dst, ty, ptr, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, ptr);
+            if let (Some(d), Some(p)) = (reg(dst), reg(ptr)) {
+                if slots.contains(&p) {
+                    load_of = Some((d, *ty, p));
+                }
+            }
+        }
+        LlInst::Store { val, ptr, .. } => {
+            use_op(&mut uses, val);
+            use_op(&mut uses, ptr);
+            stores_to = reg(ptr);
+        }
+        LlInst::Cast { dst, v, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, v);
+        }
+        LlInst::Select {
+            dst, cond, a, b, ..
+        } => {
+            result = reg(dst);
+            use_op(&mut uses, cond);
+            use_op(&mut uses, a);
+            use_op(&mut uses, b);
+        }
+        LlInst::Call {
+            dst, callee, args, ..
+        } => {
+            result = dst.as_deref().and_then(reg);
+            for (_, v) in args {
+                use_op(&mut uses, v);
+            }
+            collecting = is_collecting(callee);
+        }
+        LlInst::CallIndirect {
+            dst, fptr, args, ..
+        } => {
+            result = reg(dst);
+            use_op(&mut uses, fptr);
+            for (_, v) in args {
+                use_op(&mut uses, v);
+            }
+            collecting = true;
+        }
+        LlInst::AsmBarrier => {}
+        LlInst::Br { label } => succs.push(label.clone()),
+        LlInst::CondBr { cond, t, f } => {
+            use_op(&mut uses, cond);
+            succs.push(t.clone());
+            succs.push(f.clone());
+        }
+        LlInst::Ret { val, .. } => use_op(&mut uses, val),
+        LlInst::RetVoid | LlInst::Unreachable => {}
+        LlInst::Gep { dst, ptr, idxs, .. } => {
+            result = reg(dst);
+            use_op(&mut uses, ptr);
+            for (_, v) in idxs {
+                use_op(&mut uses, v);
+            }
+        }
+        LlInst::Phi { dst, pairs, .. } => {
+            result = reg(dst);
+            is_phi = true;
+            for (v, _) in pairs {
+                use_op(&mut uses, v);
+            }
+        }
+    }
+
+    Facts {
+        result,
+        uses,
+        load_of,
+        stores_to,
+        collecting,
+        is_phi,
+        succs,
+    }
+}
+
+/// `Raw` is the escape hatch `emit_raw` writes through, so its facts come from
+/// the rendered line. Everything here is one-sided towards doing nothing: an
+/// operand form this does not recognise contributes no rewrite, and a call it
+/// cannot name is treated as collecting.
+fn raw_facts(text: &str, slots: &HashSet<String>) -> Facts {
+    let mut uses = Vec::new();
+    let mut result = None;
+    let mut load_of = None;
+    let mut stores_to = None;
+    let mut succs = Vec::new();
+
+    let body = text.trim_start();
+    let (lhs, rhs) = match body.split_once(" = ") {
+        Some((l, r)) if l.starts_with('%') && !l.contains(' ') => {
+            result = Some(l.trim_start_matches('%').to_string());
+            (Some(l), r)
+        }
+        _ => (None, body),
+    };
+    let _ = lhs;
+
+    for tok in registers_in(rhs) {
+        uses.push(tok);
+    }
+    // A bare `<label>:` line is an inline block header, not an instruction.
+    // Treat it like a phi for insertion purposes — nothing may go above it.
+    let is_label = rhs.ends_with(':') && !rhs.contains(' ');
+    let is_phi = rhs.starts_with("phi ") || is_label;
+
+    if rhs.starts_with("load ") && !rhs.contains("volatile") && !rhs.contains("atomic") {
+        // `load <ty>, ptr %slot[, …]`
+        if let Some((ty, rest)) = rhs["load ".len()..].split_once(", ptr ") {
+            let ty = ty.trim();
+            let ptr = rest
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .next()
+                .unwrap_or("");
+            if let (Some(d), Some(p)) =
+                (result.clone(), ptr.strip_prefix('%').map(|s| s.to_string()))
+            {
+                if slots.contains(&p) {
+                    if let Some(t) = static_llvm_type(ty) {
+                        load_of = Some((d, t, p));
+                    }
+                }
+            }
+        }
+    }
+    if rhs.starts_with("store ") {
+        if let Some((_, ptr_rest)) = rhs.rsplit_once(", ptr ") {
+            let ptr = ptr_rest
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .next()
+                .unwrap_or("");
+            stores_to = ptr.strip_prefix('%').map(|s| s.to_string());
+        }
+    }
+    // ★ `invoke` (#7305) is BOTH a call and a two-successor terminator, and it
+    // has to be modelled as both. Missing the call half would classify a
+    // throwing runtime helper's window as non-collecting and silently drop the
+    // reloads inside a `try`; missing the successor half would hide the unwind
+    // edge from the reachability walk.
+    //
+    // Perry emits `invoke … to label %cont unwind label %lpad` followed by an
+    // INLINE continuation label in the same `LlBlock`, so one builder block can
+    // hold several LLVM blocks. That is why the reload is placed at the USE and
+    // not after the call: a load from the slot is valid wherever it is inserted
+    // and reads whatever the collector last wrote, so it is correct on the
+    // unwind edge and the normal edge alike — there is no "after the call"
+    // position that has to be picked correctly.
+    let is_invoke = rhs.starts_with("invoke ");
+    if rhs.starts_with("br label %") {
+        succs.push(rhs["br label %".len()..].trim().to_string());
+    } else if rhs.starts_with("br i1 ") || rhs.starts_with("switch ") || is_invoke {
+        for part in rhs.split("label %").skip(1) {
+            succs.push(
+                part.split(|c: char| c == ',' || c == ']' || c.is_whitespace())
+                    .next()
+                    .unwrap_or("")
+                    .to_string(),
+            );
+        }
+    }
+
+    // Any call that is not a named non-collecting helper collects. `invoke` is
+    // a call; it reaches this by name exactly like `call` does.
+    let collecting = match rhs.find("call ").or(if is_invoke { Some(0) } else { None }) {
+        None => false,
+        Some(_) => match rhs.split_once('@') {
+            Some((_, after)) => {
+                let name: String = after
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '.' || *c == '$')
+                    .collect();
+                is_collecting(&name)
+            }
+            // An indirect call, or inline asm. `asm sideeffect ""` emits
+            // nothing; anything else through a function pointer is user code.
+            None => !rhs.contains(" asm "),
+        },
+    };
+
+    Facts {
+        result,
+        uses,
+        load_of,
+        stores_to,
+        collecting,
+        is_phi,
+        succs,
+    }
+}
+
+/// The `LlvmType` alphabet is `&'static str`, so a `Raw` load can only be
+/// reloaded when its type text is one of the known ones. Anything else (a
+/// literal `[N x double]`, say) simply is not treated as a slot load.
+fn static_llvm_type(ty: &str) -> Option<LlvmType> {
+    Some(match ty {
+        "double" => crate::types::DOUBLE,
+        "i64" => crate::types::I64,
+        "i32" => crate::types::I32,
+        "i8" => crate::types::I8,
+        "i1" => crate::types::I1,
+        "ptr" => crate::types::PTR,
+        _ => return None,
+    })
+}
+
+/// Register names appearing as operands in a rendered instruction's RHS.
+fn registers_in(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && is_reg_char(bytes[j]) {
+                j += 1;
+            }
+            if j > start {
+                out.push(text[start..j].to_string());
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+fn is_reg_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'.' || b == b'$'
+}
+
+/// Rewrite every operand occurrence of `%from` to `%to`, leaving the
+/// instruction's own result alone.
+fn rename_operand(inst: &mut LlInst, from: &str, to: &str) {
+    let swap = |s: &mut String| {
+        if s.len() == from.len() + 1 && s.starts_with('%') && &s[1..] == from {
+            s.clear();
+            s.push('%');
+            s.push_str(to);
+        }
+    };
+    match inst {
+        LlInst::Raw(text) => *text = rename_in_text(text, from, to),
+        LlInst::Bin { a, b, .. } => {
+            swap(a);
+            swap(b);
+        }
+        LlInst::FNeg { a, .. } => swap(a),
+        LlInst::FCmp { a, b, .. } | LlInst::ICmp { a, b, .. } => {
+            swap(a);
+            swap(b);
+        }
+        LlInst::Alloca { .. } => {}
+        LlInst::Load { ptr, .. } => swap(ptr),
+        LlInst::Store { val, ptr, .. } => {
+            swap(val);
+            swap(ptr);
+        }
+        LlInst::Cast { v, .. } => swap(v),
+        LlInst::Select { cond, a, b, .. } => {
+            swap(cond);
+            swap(a);
+            swap(b);
+        }
+        LlInst::Call { args, .. } => {
+            for (_, v) in args {
+                swap(v);
+            }
+        }
+        LlInst::CallIndirect { fptr, args, .. } => {
+            swap(fptr);
+            for (_, v) in args {
+                swap(v);
+            }
+        }
+        LlInst::AsmBarrier | LlInst::RetVoid | LlInst::Unreachable | LlInst::Br { .. } => {}
+        LlInst::CondBr { cond, .. } => swap(cond),
+        LlInst::Ret { val, .. } => swap(val),
+        LlInst::Gep { ptr, idxs, .. } => {
+            swap(ptr);
+            for (_, v) in idxs {
+                swap(v);
+            }
+        }
+        LlInst::Phi { pairs, .. } => {
+            for (v, _) in pairs {
+                swap(v);
+            }
+        }
+    }
+}
+
+/// Token-exact `%from` -> `%to` in a rendered line, skipping the LHS.
+///
+/// Boundary-checked: `%r1` must not rewrite inside `%r10`, which is the whole
+/// reason this is not a `str::replace`.
+fn rename_in_text(text: &str, from: &str, to: &str) -> String {
+    let (prefix, rhs) = match text.split_once(" = ") {
+        Some((l, r)) if l.trim_start().starts_with('%') && !l.trim().contains(' ') => {
+            (format!("{} = ", l), r)
+        }
+        _ => (String::new(), text),
+    };
+    let mut out = String::with_capacity(text.len() + 8);
+    out.push_str(&prefix);
+    let bytes = rhs.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() && is_reg_char(bytes[j]) {
+                j += 1;
+            }
+            if &rhs[start..j] == from {
+                out.push('%');
+                out.push_str(to);
+            } else {
+                out.push_str(&rhs[i..j]);
+            }
+            i = j;
+        } else {
+            out.push(rhs.as_bytes()[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::function::LlFunction;
+    use crate::types::{DOUBLE, I64, PTR};
+
+    /// Render a function the way `to_ir` does, minus the header, so a test can
+    /// assert on instruction text.
+    fn body(func: &LlFunction) -> String {
+        let mut out = String::new();
+        func.for_each_final_line::<std::convert::Infallible>(&mut |line| {
+            out.push_str(line);
+            out.push('\n');
+            Ok(())
+        })
+        .unwrap_or_else(|e| match e {});
+        out
+    }
+
+    /// `%slot` is a bound shadow slot holding a parameter; `mid` runs between
+    /// the load and the use.
+    ///
+    /// This is #7280's zod object-spread frame, reduced: load the root, call
+    /// something, hand the LOADED REGISTER to a consumer that dereferences it.
+    fn one_block(mid: &str) -> LlFunction {
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        let b = f.create_block("entry");
+        let slot = b.alloca(DOUBLE);
+        b.store(DOUBLE, "%arg", &slot);
+        b.call_void(
+            "js_shadow_slot_bind",
+            &[(crate::types::I32, "0"), (PTR, &slot)],
+        );
+        let v = b.load(DOUBLE, &slot);
+        b.call(DOUBLE, mid, &[]);
+        let r = b.call(
+            DOUBLE,
+            "js_object_assign_one",
+            &[(DOUBLE, &v), (DOUBLE, "0.0")],
+        );
+        b.ret(DOUBLE, &r);
+        f
+    }
+
+    #[test]
+    fn the_planted_hazard_is_rewritten_to_a_reload() {
+        let mut f = one_block("js_object_alloc");
+        assert_eq!(apply_to_function(&mut f), 1, "one stale operand to rewrite");
+        let ir = body(&f);
+        // The consumer must no longer read the pre-call register, and the
+        // register it does read must be defined by a load of the same slot
+        // immediately above it.
+        let lines: Vec<&str> = ir.lines().map(str::trim).collect();
+        let use_idx = lines
+            .iter()
+            .position(|l| l.contains("@js_object_assign_one"))
+            .expect("the consumer survived the pass");
+        let reload = lines[use_idx - 1];
+        assert!(
+            reload.starts_with("%r") && reload.contains("= load double, ptr %r1"),
+            "the instruction above the consumer must re-read the slot, got {reload:?}\n{ir}"
+        );
+        let fresh = reload.split_whitespace().next().unwrap();
+        assert!(
+            lines[use_idx].contains(&format!("double {fresh},")),
+            "the consumer must read the reloaded register, got {:?}",
+            lines[use_idx]
+        );
+        assert!(
+            !lines[use_idx].contains("double %r2,"),
+            "the consumer must NOT still read the pre-call load"
+        );
+    }
+
+    #[test]
+    fn a_non_collecting_window_is_left_byte_for_byte_alone() {
+        // The ONLY difference from the planted case is which helper sits in the
+        // window. `js_write_barrier` cannot allocate, so nothing can move and
+        // the register is still valid — a pass that fires here is firing on the
+        // code shape rather than on the hazard, and would put a reload between
+        // every pair of instructions in the compiler's output.
+        let before = body(&one_block("js_write_barrier"));
+        let mut f = one_block("js_write_barrier");
+        assert_eq!(apply_to_function(&mut f), 0);
+        assert_eq!(body(&f), before);
+    }
+
+    #[test]
+    fn a_slot_the_program_reassigns_in_the_window_is_not_reloaded() {
+        // ★ The soundness half. `f(x, (x = other, 1))` must pass the ORIGINAL
+        // `x`; re-reading the slot below the assignment would hand the consumer
+        // the new value, which is a miscompile and not a rooting fix. See
+        // `expr::temp_root::operand_is_reloadable`.
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        let b = f.create_block("entry");
+        let slot = b.alloca(DOUBLE);
+        b.store(DOUBLE, "%arg", &slot);
+        b.call_void(
+            "js_shadow_slot_bind",
+            &[(crate::types::I32, "0"), (PTR, &slot)],
+        );
+        let v = b.load(DOUBLE, &slot);
+        let other = b.call(DOUBLE, "js_object_alloc", &[]);
+        b.store(DOUBLE, &other, &slot); // the reassignment
+        let r = b.call(
+            DOUBLE,
+            "js_object_assign_one",
+            &[(DOUBLE, &v), (DOUBLE, "0.0")],
+        );
+        b.ret(DOUBLE, &r);
+        assert_eq!(
+            apply_to_function(&mut f),
+            0,
+            "a slot the program itself stores to in the window must be left alone"
+        );
+    }
+
+    #[test]
+    fn the_window_is_a_cfg_path_not_a_line_range() {
+        // Load in the entry block, collection point in one arm, use in the
+        // merge. A line-order scan sees the same thing a path-based one does
+        // here; the point of the test is that the merge block IS considered at
+        // all, since the dominant population in both corpora is cross-block.
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        let entry = f.create_block("entry").label.clone();
+        let then = f.create_block("then").label.clone();
+        let merge = f.create_block("merge").label.clone();
+        let _ = entry;
+        let slot;
+        let v;
+        {
+            let b = f.block_mut(0).unwrap();
+            slot = b.alloca(DOUBLE);
+            b.store(DOUBLE, "%arg", &slot);
+            b.call_void(
+                "js_shadow_slot_bind",
+                &[(crate::types::I32, "0"), (PTR, &slot)],
+            );
+            v = b.load(DOUBLE, &slot);
+            b.cond_br("%c", &then, &merge);
+        }
+        {
+            let b = f.block_mut(1).unwrap();
+            b.call(DOUBLE, "js_object_alloc", &[]);
+            b.br(&merge);
+        }
+        {
+            let b = f.block_mut(2).unwrap();
+            let r = b.call(
+                DOUBLE,
+                "js_object_assign_one",
+                &[(DOUBLE, &v), (DOUBLE, "0.0")],
+            );
+            b.ret(DOUBLE, &r);
+        }
+        assert_eq!(apply_to_function(&mut f), 1);
+        let ir = body(&f);
+        assert!(
+            ir.matches("= load double, ptr %r1").count() == 2,
+            "the merge block must re-read the slot:\n{ir}"
+        );
+    }
+
+    #[test]
+    fn a_back_edge_round_trip_is_not_an_intra_iteration_path() {
+        // The load is INSIDE the loop, so every iteration re-executes it and the
+        // register is fresh when the use runs. Counting the back edge would make
+        // the pass reload on every loop body in the program.
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        f.create_block("entry");
+        let looplbl = f.create_block("loop").label.clone();
+        let done = f.create_block("done").label.clone();
+        let slot;
+        {
+            let b = f.block_mut(0).unwrap();
+            slot = b.alloca(DOUBLE);
+            b.store(DOUBLE, "%arg", &slot);
+            b.call_void(
+                "js_shadow_slot_bind",
+                &[(crate::types::I32, "0"), (PTR, &slot)],
+            );
+            b.br(&looplbl);
+        }
+        {
+            let b = f.block_mut(1).unwrap();
+            let v = b.load(DOUBLE, &slot);
+            b.call(
+                DOUBLE,
+                "js_object_assign_one",
+                &[(DOUBLE, &v), (DOUBLE, "0.0")],
+            );
+            b.call(DOUBLE, "js_object_alloc", &[]); // collects, but AFTER the use
+            b.cond_br("%c", &looplbl, &done);
+        }
+        {
+            let b = f.block_mut(2).unwrap();
+            b.ret(DOUBLE, "0.0");
+        }
+        assert_eq!(apply_to_function(&mut f), 0);
+    }
+
+    /// ★ #7305 turned every throwing call into an `invoke` with TWO successors,
+    /// and perry emits the continuation label INLINE in the same builder block.
+    /// Both halves have to be modelled:
+    ///
+    /// * the call half — an `invoke` of a collecting helper opens a window, so
+    ///   a use below it must reload. Missing this drops every reload inside a
+    ///   `try`, silently.
+    /// * the terminator half — the unwind edge is a real path, so a use in the
+    ///   landing pad is reached from the load and must reload too.
+    ///
+    /// The unwind edge is also why the rule is "reload at the USE" rather than
+    /// "reload after the call": a load from the slot reads whatever the
+    /// collector last wrote and is valid wherever it sits, so it is correct on
+    /// the unwind edge and the normal edge alike. There is no "after the call"
+    /// position that would have to be chosen correctly for two successors.
+    #[test]
+    fn an_invoke_opens_a_window_on_both_of_its_edges() {
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        f.create_block("entry");
+        let cont = f.create_block("cont").label.clone();
+        let lpad = f.create_block("lpad").label.clone();
+        let slot;
+        let v;
+        {
+            let b = f.block_mut(0).unwrap();
+            slot = b.alloca(DOUBLE);
+            b.store(DOUBLE, "%arg", &slot);
+            b.call_void(
+                "js_shadow_slot_bind",
+                &[(crate::types::I32, "0"), (PTR, &slot)],
+            );
+            v = b.load(DOUBLE, &slot);
+            b.emit_raw(format!(
+                "invoke double @js_object_alloc(i32 4) to label %{cont} unwind label %{lpad}"
+            ));
+        }
+        {
+            let b = f.block_mut(1).unwrap();
+            b.call(
+                DOUBLE,
+                "js_object_assign_one",
+                &[(DOUBLE, &v), (DOUBLE, "0.0")],
+            );
+            b.ret(DOUBLE, "0.0");
+        }
+        {
+            let b = f.block_mut(2).unwrap();
+            b.call(
+                DOUBLE,
+                "js_object_assign_one",
+                &[(DOUBLE, &v), (DOUBLE, "1.0")],
+            );
+            b.ret(DOUBLE, "0.0");
+        }
+        assert_eq!(
+            apply_to_function(&mut f),
+            2,
+            "both the normal and the unwind successor use the stale register"
+        );
+        let ir = body(&f);
+        assert_eq!(
+            ir.matches("= load double, ptr %r1").count(),
+            3,
+            "the original load plus one reload on each edge:\n{ir}"
+        );
+    }
+
+    #[test]
+    fn a_function_with_no_bound_slot_is_untouched() {
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        let b = f.create_block("entry");
+        let slot = b.alloca(DOUBLE);
+        b.store(DOUBLE, "%arg", &slot);
+        let v = b.load(DOUBLE, &slot);
+        b.call(DOUBLE, "js_object_alloc", &[]);
+        let r = b.call(
+            DOUBLE,
+            "js_object_assign_one",
+            &[(DOUBLE, &v), (DOUBLE, "0.0")],
+        );
+        b.ret(DOUBLE, &r);
+        assert_eq!(apply_to_function(&mut f), 0);
+    }
+
+    #[test]
+    fn the_bind_is_recorded_through_the_inline_form_too() {
+        // #7088's inline slot store emits the SAME `js_shadow_slot_bind` call on
+        // its slow arm, which is why the recording hook lives in `call_void`
+        // rather than at the thirteen sites that build a bind. If a future bind
+        // form stops going through `call_void`, this is the assertion that has
+        // to be updated with it.
+        let mut f = LlFunction::new("t", DOUBLE, vec![]);
+        let b = f.create_block("entry");
+        let slot = b.alloca(DOUBLE);
+        b.call_void(
+            "js_shadow_slot_bind",
+            &[(crate::types::I32, "3"), (PTR, &slot)],
+        );
+        b.ret(DOUBLE, "0.0");
+        assert!(f
+            .reg_counter()
+            .shadow_slot_allocas()
+            .contains(slot.as_str()));
+    }
+
+    #[test]
+    fn a_raw_operand_is_renamed_by_token_not_by_substring() {
+        // `%r1` must not rewrite inside `%r10`. This is the reason the Raw arm
+        // does not use `str::replace`.
+        let line = "  %r99 = fadd double %r1, %r10";
+        assert_eq!(
+            rename_in_text(line, "r1", "r42"),
+            "  %r99 = fadd double %r42, %r10"
+        );
+        // And the LHS is never a use.
+        assert_eq!(
+            rename_in_text("  %r1 = fadd double %r2, %r3", "r1", "r42"),
+            "  %r1 = fadd double %r2, %r3"
+        );
+    }
+
+    /// ★ The regression that cost the acceptance arm 30/30 -> 0/30.
+    ///
+    /// `entry_post_init_setup` is spliced into block 0 at `entry_init_boundary`,
+    /// and for a function built by `enable_post_init_shadow_frame` that region
+    /// contains the `js_shadow_frame_enter` call itself. Bumping the boundary by
+    /// EVERY insertion into block 0 — rather than only the ones at or above it —
+    /// pushes the index past the block, `to_ir` clamps it with
+    /// `.min(instruction_count())`, and the frame push lands after every
+    /// `js_shadow_slot_bind` in the body. Nothing is rooted, and the symptom is
+    /// `TypeError: value is not a function` — the bug this pass fixes, wearing
+    /// its own fix as a disguise.
+    #[test]
+    fn an_insertion_below_the_post_init_splice_does_not_move_it() {
+        let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);
+        {
+            let b = f.create_block("entry");
+            // The "init prelude": everything before mark_entry_init_boundary.
+            b.call_void("js_gc_init", &[]);
+        }
+        f.mark_entry_init_boundary();
+        let boundary_before = f.entry_init_boundary();
+        assert_eq!(boundary_before, Some(1));
+        {
+            let b = f.block_mut(0).unwrap();
+            let slot = b.alloca(DOUBLE);
+            b.store(DOUBLE, "%arg", &slot);
+            b.call_void(
+                "js_shadow_slot_bind",
+                &[(crate::types::I32, "0"), (PTR, &slot)],
+            );
+            let v = b.load(DOUBLE, &slot);
+            b.call(DOUBLE, "js_object_alloc", &[]);
+            let r = b.call(
+                DOUBLE,
+                "js_object_assign_one",
+                &[(DOUBLE, &v), (DOUBLE, "0.0")],
+            );
+            b.ret(DOUBLE, &r);
+        }
+        let n_insts = f.blocks()[0].instruction_count();
+        assert_eq!(apply_to_function(&mut f), 1);
+        assert_eq!(
+            f.entry_init_boundary(),
+            boundary_before,
+            "the reload went in BELOW the splice, so the splice must not move"
+        );
+        assert!(
+            f.entry_init_boundary().unwrap() <= f.blocks()[0].instruction_count(),
+            "a boundary past the block gets clamped to the END by to_ir, which \
+             relocates the whole post-init region including the frame push"
+        );
+        assert_eq!(f.blocks()[0].instruction_count(), n_insts + 1);
+    }
+
+    #[test]
+    fn an_i64_slot_reloads_at_its_own_width() {
+        let mut f = LlFunction::new("t", DOUBLE, vec![]);
+        let b = f.create_block("entry");
+        let slot = b.alloca(I64);
+        b.call_void(
+            "js_shadow_slot_bind",
+            &[(crate::types::I32, "0"), (PTR, &slot)],
+        );
+        let v = b.load(I64, &slot);
+        b.call(DOUBLE, "js_object_alloc", &[]);
+        b.call(
+            DOUBLE,
+            "js_object_assign_one",
+            &[(I64, &v), (DOUBLE, "0.0")],
+        );
+        b.ret(DOUBLE, "0.0");
+        assert_eq!(apply_to_function(&mut f), 1);
+        assert!(body(&f).contains("= load i64, ptr %r1"), "{}", body(&f));
+    }
+}

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -617,6 +617,21 @@ pub extern "C" fn js_regexp_new(
     pattern: *const StringHeader,
     flags: *const StringHeader,
 ) -> *mut RegExpHeader {
+    // ★ `pattern` is a raw `StringHeader*` in a Rust local, and this function
+    // allocates twice below (`js_string_from_str` for the canonical flags, then
+    // `gc_malloc` for the header). Either can drive an evacuating minor that
+    // relocates the pattern string, after which this argument names retired
+    // from-space — and it is then *stored into the header* as `pattern_ptr`,
+    // so the damage is permanent rather than transient.
+    //
+    // This is the runtime-Rust half of the rooting invariant (#7249), the half
+    // `scripts/gc_root_dominance_check.py` is structurally blind to: it reads
+    // emitted IR and cannot see a Rust local. It was found the way that class
+    // has to be found — `PERRY_GC_PROTECT_FROMSPACE=1
+    // PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` faulted here on a `zod` workload,
+    // in `js_regexp_new` itself, on BOTH sides of an unrelated codegen change.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let pattern_root = scope.root_string_ptr(pattern);
     let pattern_str = if is_valid_ptr(pattern) {
         string_as_str(pattern)
     } else {
@@ -739,6 +754,16 @@ pub extern "C" fn js_regexp_new(
     let arc = get_or_compile_regex(pattern_str, flags_str);
     let regex_ptr = Arc::into_raw(arc) as *mut Regex;
 
+    // ★ Last use of the borrowed pattern text before this function allocates.
+    // `pattern_str` borrows the GC string; the two allocations below can move
+    // it, and everything after this point reads the pattern from `owned_pattern`
+    // (a Rust `String`, which relocation cannot invalidate) or from
+    // `pattern_root` (a runtime handle the collector rewrites). Nothing below
+    // may use `pattern_str` or the incoming `pattern` argument again.
+    let owned_pattern = pattern_str.to_string();
+    #[allow(unused_variables)]
+    let pattern_str: () = ();
+
     // Allocate the header via gc_malloc so it's tracked by the GC and gets
     // freed when no longer referenced. Previously this used raw alloc() and
     // leaked every header, which was a 64-byte-per-call leak on top of the
@@ -759,6 +784,11 @@ pub extern "C" fn js_regexp_new(
         // A previous (collected) RegExp at this address may have left expando
         // properties in the side table; a fresh RegExp must start clean.
         crate::object::exotic_expando::expando_clear_on_alloc(ptr as usize);
+
+        // ★ Re-read the pattern from its root. Both allocations above have run,
+        // so the incoming argument may name from-space; the handle is a mutable
+        // root the collector rewrote.
+        let pattern = pattern_root.get_raw_const_ptr::<StringHeader>();
 
         (*ptr).regex_ptr = regex_ptr;
         (*ptr).pattern_ptr = pattern;
@@ -813,7 +843,7 @@ pub extern "C" fn js_regexp_new(
         (*ptr).fancy_ptr = FANCY_CACHE.with(|fc| {
             match fc
                 .borrow()
-                .get(&(pattern_str.to_string(), flags_str.to_string()))
+                .get(&(owned_pattern.clone(), flags_str.to_string()))
             {
                 Some(arc) => Arc::into_raw(arc.clone()) as *const (),
                 None => std::ptr::null(),
@@ -829,10 +859,8 @@ pub extern "C" fn js_regexp_new(
         // Issue #637: side-table owned copies of pattern + flags so
         // `.source` / `.flags` survive GC of the input StringHeaders.
         REGEX_SOURCE_TABLE.with(|t| {
-            t.borrow_mut().insert(
-                ptr as usize,
-                (pattern_str.to_string(), flags_str.to_string()),
-            );
+            t.borrow_mut()
+                .insert(ptr as usize, (owned_pattern.clone(), flags_str.to_string()));
         });
 
         ptr

--- a/docs/src/internals/gc-rooting-invariant.md
+++ b/docs/src/internals/gc-rooting-invariant.md
@@ -296,13 +296,57 @@ only copy is in a register, there is nothing at that moment for any runtime
 probe to notice. These instruments catch the *consequence*, later. The static
 checker catches the *cause*, now.
 
+## The corpus problem, and the two corpora (#7280)
+
+**A hand-written corpus cannot express this class of bug at dependency scale,
+and for a while nobody could tell, because it was green.**
+
+`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources
+chosen for the lowerings they exercise. It reads **zero** in both modes the CI
+gate runs — and it read zero while twenty lines of stock `zod` faulted
+deterministically under `PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. #7280 puts it in
+one sentence: *25 curated files pass while 20 lines of stock zod fail.*
+
+That is not a size problem. Both corpora were measured on the same compiler with
+`--stale-registers --moving-only`:
+
+| corpus | stale uses | what dominates |
+|---|---|---|
+| curated, 124 sources / 144 modules | 116 | property-GET helper windows, `js_number_coerce`, `js_closure_callN` |
+| dependency-scale, 81 modules / 62 MB | 370 | `js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, `js_closure_call*` 30 |
+
+The curated corpus produces 12 of the first population and 1 of the second. A
+hand-written test allocates a couple of objects and calls a couple of helpers; a
+library spreads objects into objects, boxes every mutable capture because its
+closures outlive their frames, and builds values field by field out of data.
+**The rooting hazards live in the shapes**, so a corpus without the shapes
+cannot express them however many files it has.
+
+So there is a second corpus, generated from a real npm dependency rather than
+from anything written for the occasion:
+
+```bash
+npm ci --ignore-scripts                       # zod is a package.json devDependency
+./scripts/gc_root_dominance_dep_corpus.sh ir-corpus-dep
+python3 scripts/gc_root_dominance_check.py ir-corpus-dep --moving-only -v
+```
+
+`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that
+directory reaches the compiler by being imported from it, and the generator
+**asserts that every `.ts` in the directory produced a module** — which is a
+check a size floor could not be, since ~90 modules of `zod` swamp any count a
+missing 40-line source would cross.
+
+Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting
+costs ~8s and the two gated arms ~4s, because those are linear in instruction
+count. The `--stale-registers` budget is the expensive one (~5 min): its scan is
+superlinear, and 62 MB is 62 MB.
+
 ## The CI gate
 
-`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over a
-versioned corpus of ~99 `test-files/` sources chosen for the lowerings they
-exercise (class expressions, constructors, object/array literals, computed
-reads, property stores, closures, dynamic dispatch). The whole job is a few
-minutes; the check itself is about three seconds over ~2000 functions.
+`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over both
+corpora. The whole job is a few minutes plus the compiler build; the two gated
+checks are about three seconds each over ~2000 and ~12900 functions.
 
 It is built to be able to fail, against all four hazards in CLAUDE.md:
 

--- a/scripts/check_test_registration.py
+++ b/scripts/check_test_registration.py
@@ -372,6 +372,12 @@ GLOB_DRIVEN = (
     ("scripts/gc_root_dominance_corpus.sh", "PATTERNS globs over test-files/; "
      "a pattern that matches nothing is already loud, and MIN_COMPILED floors "
      "the corpus size"),
+    ("scripts/gc_root_dominance_dep_corpus.sh", "ONE fixed entry point; the "
+     "rest of test-files/gc-dep-corpus/ reaches the compiler only by being "
+     "imported from it, so the registry is the import graph. The script "
+     "itself asserts that every .ts in that directory produced a module — "
+     "which is the check a size floor could NOT be, since ~90 modules of "
+     "`zod` swamp any count a missing 40-line source would cross"),
     ("benchmarks/public_baseline.py", "glob list over benchmarks/**"),
     ("cargo test", "crates/<c>/tests/*.rs suite roots are auto-discovered "
      "targets; the deeper files are mechanism `rust-test-modules` above"),

--- a/scripts/gc_root_dominance_dep_corpus.sh
+++ b/scripts/gc_root_dominance_dep_corpus.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Emit the DEPENDENCY-SCALE LLVM IR corpus for
+# scripts/gc_root_dominance_check.py.
+#
+#   ./scripts/gc_root_dominance_dep_corpus.sh [OUTDIR]
+#
+# The sibling script, gc_root_dominance_corpus.sh, compiles ~99 hand-written
+# `test-files/` sources. That corpus reads ZERO in both modes the CI gate runs
+# — and it read zero while twenty lines of stock `zod` faulted deterministically
+# under the from-space protector (#7280). Twenty-five curated files passing
+# while a real dependency fails is not noise, it is the corpus measuring the
+# wrong population:
+#
+#   curated, --stale-registers --moving-only:
+#     property-GET helper windows, ToPrimitive/js_number_coerce, js_closure_callN
+#   dependency-scale, the same command:
+#     js_array_alloc -> js_array_spread_append/concat,
+#     js_box_get_bits -> js_closure_callN,
+#     js_object_alloc -> js_object_set_field_by_name
+#
+# A hand-written test allocates a couple of objects and calls a couple of
+# helpers. A library spreads arrays into arrays, boxes every mutable capture
+# because its closures outlive their frames, and builds objects field by field
+# out of data. The rooting hazards live in the SHAPES, so a corpus without the
+# shapes cannot express them however many files it has.
+#
+# The dependency is `zod`, this repo's own `package.json` devDependency, pinned
+# by `package-lock.json` and governed by the same soak window as everything
+# else in that file. It is imported BY SOURCE PATH
+# (`node_modules/zod/src/index.js`) rather than by bare specifier, because that
+# is what makes its modules NATIVE — a bare import resolves to the published
+# bundle and can fall back to V8, which emits no IR to check.
+#
+# Exit status is non-zero if the corpus is thinner than MIN_MODULES. "0
+# violations over 3 modules" and "0 violations over 90 modules" print the same
+# verdict and mean opposite things, and this corpus has one more way to go thin
+# than the curated one does: a checkout with no `node_modules/`.
+
+set -euo pipefail
+
+OUTDIR="${1:-ir-corpus-dep}"
+PERRY_BIN="${PERRY_BIN:-target/release/perry}"
+ENTRY="${ENTRY:-test-files/gc-dep-corpus/main.ts}"
+
+# The floor, not a target. `zod@4` compiles to ~90 native modules here; the
+# floor sits below that with room for the dependency's own churn and well above
+# "something compiled". Raise it when the dependency grows; never lower it to
+# make a run pass.
+MIN_MODULES="${MIN_MODULES:-60}"
+
+if [ ! -x "$PERRY_BIN" ]; then
+  echo "error: $PERRY_BIN not found or not executable." >&2
+  echo "  cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static" >&2
+  exit 2
+fi
+
+if [ ! -f node_modules/zod/src/index.ts ]; then
+  echo "::error::node_modules/zod/src/index.ts is missing." >&2
+  echo "This corpus is generated FROM a real npm dependency, so it needs the" >&2
+  echo "dependency. Run:" >&2
+  echo "  npm ci --ignore-scripts" >&2
+  echo "Refusing to emit a corpus without it: a compile that silently drops the" >&2
+  echo "library still produces .ll files, and a thin corpus reporting zero is" >&2
+  echo "exactly the false green this whole gate exists to prevent." >&2
+  exit 2
+fi
+
+if [ ! -f "$ENTRY" ]; then
+  echo "::error::corpus entry point $ENTRY is missing" >&2
+  exit 2
+fi
+
+rm -rf "$OUTDIR" .perry-trace/llvm
+mkdir -p "$OUTDIR"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# Same two env knobs as the curated corpus, for the same two reasons.
+# PERRY_GC_MOVING_LOOP_POLLS=1 is what puts `js_gc_loop_safepoint` in the IR
+# (it is off by default since #7161, so without it the corpus cannot express a
+# back-edge collection at all). PERRY_INLINE_SHADOW_SLOT=0 makes every root
+# store the @js_shadow_slot_bind call form the checker anchors on.
+if ! env PERRY_GC_MOVING_LOOP_POLLS=1 \
+         PERRY_INLINE_SHADOW_SLOT=0 \
+         PERRY_NO_AUTO_OPTIMIZE=1 \
+     "$PERRY_BIN" compile "$ENTRY" -o "$scratch/dep-corpus" --trace llvm \
+     >"$scratch/compile.log" 2>&1; then
+  echo "::error::$ENTRY failed to compile; the corpus cannot be emitted" >&2
+  tail -40 "$scratch/compile.log" >&2
+  exit 1
+fi
+
+modules=0
+for ll in .perry-trace/llvm/*.ll; do
+  [ -e "$ll" ] || break
+  cp "$ll" "$OUTDIR/dep__$(basename "$ll")"
+  modules=$((modules + 1))
+done
+
+bytes="$(find "$OUTDIR" -name '*.ll' -exec cat {} + | wc -c | tr -d ' ')"
+echo "dep corpus: $modules module(s), $((bytes / 1024)) KiB of IR in $OUTDIR"
+
+if [ "$modules" -lt "$MIN_MODULES" ]; then
+  echo "::error::only $modules module(s) emitted IR, need at least $MIN_MODULES." >&2
+  echo "Either the dependency stopped compiling natively (which is the finding)," >&2
+  echo "or --trace llvm did not run because the build was fully cached." >&2
+  exit 1
+fi
+
+# ★ Every source in the corpus directory must have contributed a module.
+#
+# There is ONE entry point and the rest of the directory reaches the compiler
+# only by being imported from it. A file nobody imports is compiled by nothing
+# and checked by nothing — a dark test with a corpus file's name on it (#7278),
+# and one this corpus cannot detect by counting, because 90 modules of `zod`
+# swamp any floor a missing 40-line source would cross.
+#
+# So the registry is the import graph and this is the check on it: the module
+# name perry derives from a path is the path with every non-alphanumeric
+# character replaced by `_`, so each source names exactly one expected `.ll`.
+dark=()
+for src in test-files/gc-dep-corpus/*.ts; do
+  sanitized="$(printf '%s' "$src" | tr -c 'A-Za-z0-9' '_')"
+  if [ ! -f "$OUTDIR/dep__${sanitized}.ll" ]; then
+    dark+=("$src")
+  fi
+done
+if [ "${#dark[@]}" -gt 0 ]; then
+  echo "::error::these corpus sources produced no IR — nothing imports them:" >&2
+  printf '  %s\n' "${dark[@]}" >&2
+  echo "Import them from test-files/gc-dep-corpus/main.ts, or delete them." >&2
+  echo "An unimported corpus source is not a weak test, it is no test at all." >&2
+  exit 1
+fi

--- a/test-files/gc-dep-corpus/README.md
+++ b/test-files/gc-dep-corpus/README.md
@@ -1,0 +1,50 @@
+# The dependency-scale GC-rooting corpus
+
+`scripts/gc_root_dominance_corpus.sh` compiles ~99 hand-written `test-files/`
+sources. Each is a few dozen lines, written to exercise one lowering. That
+corpus reads **zero** violations in the two modes `gc-root-dominance.yml` gates
+on, and it has read zero while a twenty-line program that imports a stock npm
+package faulted deterministically (#7280).
+
+That is not a paradox, it is a distribution problem. The two corpora do not
+contain the same code:
+
+| corpus | what dominates its `--stale-registers --moving-only` report |
+|---|---|
+| curated (`gc_root_dominance_corpus.sh`) | property-GET helper windows, `js_number_coerce`, `js_closure_callN` |
+| dependency-scale (this directory) | `js_array_alloc → js_array_spread_append`, `js_box_get_bits → js_closure_callN`, `js_object_alloc → js_object_set_field_by_name` |
+
+A hand-written test allocates a couple of objects and calls a couple of
+helpers. A real library allocates in loops, spreads arrays into arrays, boxes
+every mutable capture because its closures outlive their frames, and builds
+objects field by field from data. Those are different *shapes*, and the rooting
+hazards live in the shapes.
+
+So this corpus is generated from a real npm dependency —
+`zod`, the repo's own `package.json` devDependency, pinned by
+`package-lock.json` — rather than from anything written for the occasion. It is
+emitted by `scripts/gc_root_dominance_dep_corpus.sh`.
+
+## Layout
+
+`main.ts` is the only entry point. It pulls in three shapes at once so that one
+compile produces the whole corpus:
+
+* **the library itself** — `zod`'s own modules, imported by source path
+  (`node_modules/zod/src/index.js`), which is what makes them *native* modules
+  rather than a V8-fallback bundle. This is where the module count comes from
+  and it is what the distribution above is about.
+* **an app over the library** — `shared.ts` plus the three endpoint modules,
+  which build a registry at MODULE INIT time out of cross-module calls whose
+  arguments are string literals, object literals, closures and schemas. That is
+  the frame shape #7154's disassembly named.
+* **a parse loop** — the twenty-line library-only control from #7280, which is
+  the program that failed 5/40 while the curated corpus passed 25/25.
+
+## These files are not gap tests
+
+They are corpus inputs: they are compiled for their **IR**, and the compile is
+the assertion. `run_parity_tests.sh` globs `test-files` at `-maxdepth 1`, so a
+subdirectory is out of its scope by construction — which is deliberate, because
+these need `node_modules/` and would otherwise be a parity failure on any
+checkout that has not run `npm ci`.

--- a/test-files/gc-dep-corpus/alerts.ts
+++ b/test-files/gc-dep-corpus/alerts.ts
@@ -1,0 +1,37 @@
+import * as z from "../../node_modules/zod/src/index.js";
+import { defineApiCall, baseFields } from "./shared.js";
+
+const Alert = z.object({
+  ...baseFields(),
+  severity: z.string(),
+  meta: z.object({ note: z.string(), rank: z.number() }),
+});
+
+defineApiCall(
+  "https://registry.example.com/v1/alerts",
+  "GET",
+  { paginated: true, cache: "no-store", retries: 3 },
+  ["alerts", "read"],
+  Alert.array(),
+  (body) => "alerts:" + String((body as { id?: string }).id ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/alerts/{alertId}",
+  "GET",
+  { paginated: false, cache: "no-store", retries: 1 },
+  ["alerts", "read", "one"],
+  Alert,
+  (body) => "alert:" + String((body as { id?: string }).id ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/alerts/{alertId}/ack",
+  "POST",
+  { paginated: false, cache: "no-store", retries: 0 },
+  ["alerts", "write"],
+  Alert,
+  (body) => "ack:" + String((body as { id?: string }).id ?? "-"),
+);
+
+export { Alert };

--- a/test-files/gc-dep-corpus/main.ts
+++ b/test-files/gc-dep-corpus/main.ts
@@ -1,0 +1,101 @@
+// Entry point for the dependency-scale GC-rooting IR corpus.
+//
+// Compiled by scripts/gc_root_dominance_dep_corpus.sh for its IR, not for its
+// stdout — see README.md in this directory. It is also runnable, and is run as
+// the acceptance workload for the moving collector, so the printed line is
+// deterministic on purpose.
+import * as z from "../../node_modules/zod/src/index.js";
+import "./alerts.js";
+import "./orgs.js";
+import "./scans.js";
+import { allApiCalls, SCHEMAS, CALLBACKS } from "./shared.js";
+
+// The #7280 library-only control: twenty lines of stock zod, no scaffolding.
+// This is the program that failed 5/40 under the moving arm while the curated
+// 25-file corpus passed 25/25.
+function parseLoop(iterations: number): number {
+  let ok = 0;
+  for (let i = 0; i < iterations; i++) {
+    const S = z
+      .object({
+        id: z.string().min(1).max(64),
+        kind: z.string(),
+        count: z.number().int(),
+        ratio: z.number(),
+        active: z.boolean(),
+        labels: z.array(z.string()),
+        meta: z.object({ note: z.string(), rank: z.number() }),
+      })
+      .array();
+    const r = (S as unknown as { safeParse: (v: unknown) => { success: boolean } })
+      .safeParse([
+        {
+          id: "id-" + i,
+          kind: "k",
+          count: i,
+          ratio: i + 0.5,
+          active: i % 2 === 0,
+          labels: ["a", "b", "c"],
+          meta: { note: "n" + i, rank: i },
+        },
+      ]);
+    if (r.success) ok++;
+  }
+  return ok;
+}
+
+// The registry walk: cross-module closures created at module init, called back
+// long after the frames that built them are gone.
+function describeAll(): string[] {
+  const calls = allApiCalls();
+  const out: string[] = [];
+  for (let i = 0; i < calls.length; i++) {
+    out.push(calls[i].describe());
+  }
+  return out;
+}
+
+// Schemas built at module init, parsed later — the shape that keeps a library
+// object live across many collections before it is finally dereferenced.
+function parseRegistered(): number {
+  let ok = 0;
+  const keys: string[] = [];
+  SCHEMAS.forEach((_v, k) => keys.push(k));
+  keys.sort();
+  for (let i = 0; i < keys.length; i++) {
+    const schema = SCHEMAS.get(keys[i]) as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    const cb = CALLBACKS.get(keys[i]);
+    const sample = {
+      id: "row-" + i,
+      kind: "k",
+      count: i,
+      ratio: 1.5,
+      active: true,
+      labels: ["x", "y"],
+      severity: "high",
+      meta: { note: "n", rank: i },
+      slug: "org-" + i,
+      seats: 4,
+      owners: [{ login: "a", role: "admin" }],
+      digest: "deadbeef",
+      findings: [{ rule: "r", level: "warn", line: i }],
+      summary: "s",
+    };
+    const r = schema.safeParse(Array.isArray(sample) ? sample : [sample]);
+    const r2 = schema.safeParse(sample);
+    if (r.success || r2.success) ok++;
+    if (cb) cb(sample);
+  }
+  return ok;
+}
+
+const described = describeAll();
+const parsed = parseLoop(96);
+const registered = parseRegistered();
+
+console.log("endpoints=" + described.length);
+console.log("parsed=" + parsed);
+console.log("registered=" + registered);
+console.log(described[0]);

--- a/test-files/gc-dep-corpus/orgs.ts
+++ b/test-files/gc-dep-corpus/orgs.ts
@@ -1,0 +1,38 @@
+import * as z from "../../node_modules/zod/src/index.js";
+import { defineApiCall, baseFields } from "./shared.js";
+
+const Org = z.object({
+  ...baseFields(),
+  slug: z.string().min(2),
+  seats: z.number().int(),
+  owners: z.array(z.object({ login: z.string(), role: z.string() })),
+});
+
+defineApiCall(
+  "https://registry.example.com/v1/orgs",
+  "GET",
+  { paginated: true, cache: "default", retries: 2 },
+  ["orgs", "read"],
+  Org.array(),
+  (body) => "orgs:" + String((body as { slug?: string }).slug ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/orgs/{orgId}/members",
+  "GET",
+  { paginated: true, cache: "default", retries: 2 },
+  ["orgs", "read", "members"],
+  Org,
+  (body) => "members:" + String((body as { slug?: string }).slug ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/orgs/{orgId}/seats",
+  "PUT",
+  { paginated: false, cache: "no-store", retries: 0 },
+  ["orgs", "write"],
+  Org,
+  (body) => "seats:" + String((body as { slug?: string }).slug ?? "-"),
+);
+
+export { Org };

--- a/test-files/gc-dep-corpus/scans.ts
+++ b/test-files/gc-dep-corpus/scans.ts
@@ -1,0 +1,40 @@
+import * as z from "../../node_modules/zod/src/index.js";
+import { defineApiCall, baseFields } from "./shared.js";
+
+const Scan = z.object({
+  ...baseFields(),
+  digest: z.string().regex(/^[a-f0-9]{8,}$/),
+  findings: z.array(
+    z.object({ rule: z.string(), level: z.string(), line: z.number().int() }),
+  ),
+  summary: z.union([z.string(), z.number()]),
+});
+
+defineApiCall(
+  "https://registry.example.com/v1/scans",
+  "POST",
+  { paginated: false, cache: "no-store", retries: 0, timeoutMs: 30000 },
+  ["scans", "write"],
+  Scan,
+  (body) => "scan:" + String((body as { digest?: string }).digest ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/scans/{scanId}",
+  "GET",
+  { paginated: false, cache: "default", retries: 2 },
+  ["scans", "read"],
+  Scan,
+  (body) => "scanone:" + String((body as { digest?: string }).digest ?? "-"),
+);
+
+defineApiCall(
+  "https://registry.example.com/v1/scans/{scanId}/findings",
+  "GET",
+  { paginated: true, cache: "default", retries: 2 },
+  ["scans", "read", "findings"],
+  Scan.array(),
+  (body) => "findings:" + String((body as { digest?: string }).digest ?? "-"),
+);
+
+export { Scan };

--- a/test-files/gc-dep-corpus/shared.ts
+++ b/test-files/gc-dep-corpus/shared.ts
@@ -1,0 +1,83 @@
+// Cross-module API registry built at MODULE INIT time.
+//
+// The shape is taken from #7154's disassembly: a cross-module call whose first
+// arguments are string literals parked in registers across an object
+// allocation, a schema build (library code with its own allocations) and a
+// closure allocation. Every argument here is live across the evaluation of the
+// ones that follow it, which is the "evaluate-then-allocate" hazard in
+// docs/src/internals/gc-rooting-invariant.md.
+import * as z from "../../node_modules/zod/src/index.js";
+
+export interface ApiCall {
+  readonly url: string;
+  readonly method: string;
+  readonly opts: Record<string, unknown>;
+  readonly tags: string[];
+  readonly describe: () => string;
+}
+
+const REGISTRY: ApiCall[] = [];
+
+const ABSOLUTE_RE = /^https?:\/\/[a-z0-9.-]+\//;
+const PATH_SEGMENT_RE = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+
+export function defineApiCall(
+  url: string,
+  method: string,
+  opts: Record<string, unknown>,
+  tags: string[],
+  schema: unknown,
+  cb: (body: unknown) => string,
+): ApiCall {
+  // js_regexp_new allocates, then the subject string is coerced (another
+  // allocation) before js_regexp_test consumes both.
+  const absolute = ABSOLUTE_RE.test(String(url));
+  const params: string[] = [];
+  let m: RegExpExecArray | null;
+  PATH_SEGMENT_RE.lastIndex = 0;
+  while ((m = PATH_SEGMENT_RE.exec(url)) !== null) {
+    params.push(m[1]);
+  }
+  // A spread into a fresh array: js_array_alloc followed by
+  // js_array_spread_append, which is the single largest population in the
+  // dependency-scale report.
+  const allTags = [...tags, method.toLowerCase(), absolute ? "abs" : "rel"];
+  const call: ApiCall = {
+    url,
+    method,
+    opts,
+    tags: allTags,
+    describe(): string {
+      // A boxed mutable capture read back across a closure call.
+      let n = 0;
+      const bump = (): number => ++n;
+      bump();
+      bump();
+      const shown = params.length > 0 ? params.join(",") : "-";
+      return `${method} ${url} [${allTags.join("|")}] {${shown}} #${n}`;
+    },
+  };
+  REGISTRY.push(call);
+  // Keep the schema reachable so the parse loop below has something to run.
+  SCHEMAS.set(url + " " + method, schema);
+  CALLBACKS.set(url + " " + method, cb);
+  return call;
+}
+
+export const SCHEMAS = new Map<string, unknown>();
+export const CALLBACKS = new Map<string, (body: unknown) => string>();
+
+export function allApiCalls(): ApiCall[] {
+  return REGISTRY.slice();
+}
+
+export function baseFields() {
+  return {
+    id: z.string().min(1).max(64),
+    kind: z.string(),
+    count: z.number().int(),
+    ratio: z.number(),
+    active: z.boolean(),
+    labels: z.array(z.string()),
+  };
+}


### PR DESCRIPTION
Two linked changes for #7280, in the order the issue asks for them: fix what the gate measures, then fix the rule that dominates the measurement.

Rebased onto `b50e857c2`, **after** #7301 (in-process LLVM backend, typed
`LlInst`) and #7305 (setjmp/longjmp → `invoke`/`landingpad`). Every number below
is re-measured on that base, both sides, path-identical.

## 1. The corpus was measuring the wrong population

`scripts/gc_root_dominance_corpus.sh` compiles ~124 hand-written `test-files/`
sources. It reads **zero** in both modes the CI gate runs, and it read zero
while twenty lines of stock `zod` faulted deterministically under
`PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. #7280 puts
the gap in one sentence: *25 curated files pass while 20 lines of stock zod
fail.*

That is a distribution problem, not a size problem. Both corpora, same compiler,
`--stale-registers --moving-only`:

| corpus | stale uses | dominant population |
|---|---|---|
| curated — 124 sources, 144 modules, 2378 functions | 116 | property-GET helper windows, `js_number_coerce`, `js_closure_callN` |
| dependency-scale — 81 modules, 62 MB, 12899 functions | 371 | `js_object_assign_one` 137, `js_new_function_construct` 102, `js_closure_call*` 30 |

The curated corpus produces 12 of the first population and 1 of the second. A
hand-written test allocates a couple of objects and calls a couple of helpers; a
library spreads objects into objects, boxes every mutable capture because its
closures outlive their frames, and builds values field by field out of data.
The rooting hazards live in the *shapes*.

So `scripts/gc_root_dominance_dep_corpus.sh` generates the second corpus from a
real npm dependency — `zod`, this repo's own `package.json` devDependency,
pinned by `package-lock.json` and under the same soak window as everything else
in that file. It is imported **by source path** so its modules compile natively;
a bare specifier resolves to the published bundle, which can fall back to V8 and
emits no IR to check.

**Nothing is sampled away.** All 81 modules and all 62 MB are checked. Measured
cost: ~8s to emit, ~3s for each of the two gated arms (both linear in
instruction count). The `--stale-registers` budget is the expensive one — 5m10s
— and the workflow says so where it runs.

`test-files/gc-dep-corpus/main.ts` is the only entry point and the rest of that
directory reaches the compiler by being imported from it, so the generator
**asserts every `.ts` in the directory produced a module**. That is the check a
size floor could not be (#7278): ~90 modules of `zod` swamp any count a missing
40-line source would cross.

## 2. One rule, 73% of both reports

> A load out of a shadow slot is a **copy** of a root. An evacuating minor
> rewrites the slot; it cannot rewrite the register. So every use a collection
> point can reach must re-read the slot — unless a store to that slot can also
> run on the way, in which case re-reading would observe an assignment the
> program made, and the register is left alone.

Verbatim from `zod`'s object-spread lowering, before:

```llvm
  call void @js_shadow_slot_bind(i32 0, ptr %r7)   ; %r7 IS a root
  %r8  = load double, ptr %r7                      ; a COPY of the root
  %r9  = call double @baseFields()                 ; evacuates; rewrites %r7
  %r10 = call double @js_object_assign_one(double %r8, double %r9)  ; from-space
  %r11 = load double, ptr %r7                      ; the NEXT statement re-reads
```

Codegen was never unable to re-read the slot — the following statement does,
because a fresh lowering emits a fresh load. The bug is that *within* one
lowering the load happens once, at the top, and the register is carried across
everything after it. That is why this is a pass and not another point fix:
`index_set.rs` alone lowers `object` before `value` at fifteen separate arms,
and the same shape appears in the object-literal spread, the inline class-field
store, `new`, property define, `instanceof` and the closure-call family. #7291
and #7299 fixed three instances correctly and moved no arm at all.

The soundness half is the one `expr/temp_root.rs` already documents: re-reading
a *local* is not unconditionally safe, because `new C(g, bump())` where `bump()`
assigns `g` must pass the pre-`bump()` value. At IR level that objection is
decidable — an assignment to a shadow-slotted local is a `store` to its alloca
in the same function, and a local captured *and* mutated by a closure is boxed
instead, so it has no plain shadow slot to reload. Both halves are path
questions over the real CFG, answered the way the checker answers them: a
back-edge round trip is not an intra-iteration path, because re-entering the
load's block re-executes the load.

Where the reload was not needed — no call between the two points — LLVM's
EarlyCSE/GVN forwards it away, since nothing can clobber the alloca. Where it
was needed the intervening call is opaque and the load stays.

Recording is at the choke point, not at the thirteen `js_shadow_slot_bind` emit
sites: `LlBlock::call_void` and `LlFunction::entry_setup_call_void` see every
bind form, including the slow arm of #7088's inline diamond (which emits the
same call). The pass runs in `compile_module` **before any rendering path**, so
the text renderer and the in-process constructor (#7301) see the same IR — a
pass living inside `to_ir` would silently not apply to the other.

### Results, both corpora

| arm | curated | dependency-scale |
|---|---|---|
| `--stale-registers --moving-only`, total | 116 → **39** | 371 → **118** |
| …of which `source=slotload` | 102 → **25** | 272 → **19** |
| bind-anchored `--moving-only` | 0 → 0 | 0 → 0 |
| `--unrooted-allocas --moving-only` | 0 → 0 | 0 → 0 |

`js_object_assign_one` disappears from the dependency-scale report entirely
(137 → 0); `js_new_function_construct` goes 102 → 29. Both budgets are ratchets
in `gc-root-dominance.yml` now (`--max-stale 39`, `--max-stale 118`) — until now
this mode ran only by hand, so its number could move in either direction between
one investigation and the next with nothing to say so. A budget rather than an
allowlist, because the residual is a *population*: the uses whose slot the
program itself reassigns in the window, which need a temp root and not a
re-read.

### Post-rebase: the distribution did not move

#7301 rewrote instruction emission and #7305 replaced setjmp/longjmp with
`invoke`/`landingpad`, so the corpus was re-measured on both sides at
`b50e857c2` rather than carried over. The dependency-scale parent count moved by
**one** (370 → 371, one extra `slotload`); the curated parent count and both
post-fix counts are identical to the pre-rebase measurement. The two ratchets in
the workflow (`--max-stale 39`, `--max-stale 118`) are the re-measured numbers.

### `invoke` — how this behaves on the unwind edge

An `invoke` is both a call and a two-successor terminator, and the pass models
it as both. Missing the call half would classify a throwing helper's window as
non-collecting and silently drop every reload inside a `try`; missing the
successor half would hide the unwind edge from the reachability walk. Perry also
emits the continuation label *inline* in the same builder block, so one
`LlBlock` can hold several LLVM blocks — a bare `<label>:` line is treated like
a `phi` for insertion purposes, so nothing is ever placed between a terminator
and its label.

The unwind edge is the reason the rule is stated as **"reload at the use"**
rather than "reload after the call". A load from the slot reads whatever the
collector last wrote and is valid wherever it is inserted, so it is correct on
the unwind edge and the normal edge alike — there is no "after the call"
position that has to be chosen correctly for two successors.
`an_invoke_opens_a_window_on_both_of_its_edges` plants exactly that shape and
asserts a reload on **each** edge.

### Typed `LlInst`, so both consumers see it

The pass inserts `LlInst::Load` (typed) and rewrites operands in place on the
existing typed variants; it never emits text. So the `(typed, raw)` migration
ratchet in `native_emit::stream_functions` moves in the intended direction —
`raw` is unchanged, `typed` grows by the reload count. And it runs in
`compile_module` **before any rendering path**, so `to_ir` and the native C-API
builder consume the same `for_each_final_item` stream. A pass living inside
`to_ir` would have applied to one consumer and not the other, which is the
failure mode #7301 built the shared visitor to prevent.

### One bug this introduced, and the shape of it

The first build of this pass sent the allocation-point acceptance arm to 0/30
with `TypeError: value is not a function` — i.e. it read exactly like the bug it
was written to fix. Cause: `note_entry_block_insertions` bumped
`entry_init_boundary` by *every* insertion into block 0 rather than only those
at or above the splice point. `to_ir` clamps an out-of-range boundary with
`.min(instruction_count())`, which relocates the whole post-init region — and
for a function built by `enable_post_init_shadow_frame` that region contains
`js_shadow_frame_enter` itself, so every bind in the body ran with no frame
pushed and rooted nothing. `an_insertion_below_the_post_init_splice_does_not_move_it`
pins it.

## 3. `js_regexp_new` held its pattern across its own allocations

Found while chasing the above, with the instrument the invariant doc prescribes.
`js_regexp_new` takes `pattern` as a raw `StringHeader*` and then allocates
twice — `js_string_from_str` for the canonical flags, `gc_malloc` for the header
— before storing that pointer into `RegExpHeader::pattern_ptr`. Either
allocation can run an evacuating minor, after which the argument names retired
from-space and the header keeps a **permanently** dangling `pattern_ptr`. The
borrowed `pattern_str` had the same exposure and fed the owned `.source` copy.

This is the runtime-Rust half of the invariant (#7249) — the static checker
reads emitted IR and is structurally blind to a Rust local:

```
PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off \
PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800 \
  ./gc-dep-corpus-main
```

`3c8dddc2e`, symbolicated: **faults deterministically**, `RETIRED FROM-SPACE`,
`js_regexp_new + 3920` ← `js_regexp_construct` ← `perry_closure_…zod…regexes_ts__9`.
Identical fault with the codegen pass alone, so it is not caused by it. With the
rooting fix: **clean, 3/3, correct output**.

## Acceptance arms — and why they cannot adjudicate this workload

30 runs per arm, both compilers driven over the **same paths** (module names are
path-derived; compiling one arm through a symlinked `node_modules` changes every
module name and every feedback site id, which is not an A/B — the first
measurement did that and was discarded).

| arm | parent `b50e857c2` | this PR |
|---|---|---|
| `loop_polls` (POLLS=1 compiled **and** run) | 16/30 | **21/30** |
| `evac_minor` (default compile; `HEAP_LIMIT=8 INCREMENTAL=0 CONSERVATIVE_STACK_SCAN=off`) | 8/30 | **0/30** |
| `polls_evac` (both) | 26/30 | **27/30** |

Copying minors were live in every cell (`copied_objects` 4.3M–19.1M).

The same three arms were also run at the pre-rebase base `3c8dddc2e`
(23/30 → 26/30, 9/30 and 6/30 on two runs of the same parent binary → 0/30,
28/30 → 21/30). Two arms move up, `evac_minor` moves down, and the parent's own
`evac_minor` reads 6, 8 and 9 out of 30 across three runs — so the arm's
resolution at this failure rate is poor.

**These arms are red on the parent and this PR does not make them green.** The
workload has at least one further live rooting defect that is *not* from-space
shaped — with the protector on it runs correctly 3/3, with the protector off it
fails 3/3, which is the signature of a value being **swept** rather than moved.
The parent's own numbers move 9/30 → 6/30 between two runs of the same binary,
so the arm's resolution is poor at this failure rate; I am not claiming the
23→13 and 9→0 deltas are noise, only that I cannot separate them from it on a
workload every arm already fails.

What *is* unambiguous is the instrument that is designed to be one-sided: the
from-space protector faults deterministically on the parent and is clean here.

## What I did NOT verify

- **No unit-test witness for the `js_regexp_new` fix.** It is not reachable:
  forcing a *copying* minor inside a runtime function needs a collection at an
  allocation point, and `gc/zeal.rs` documents why that level deliberately does
  not exist (an allocation-point collection takes `force_full_scan`, which makes
  the copying minor ineligible, so it would move nothing). I wrote the test,
  watched its liveness assert refuse to pass, and deleted it rather than ship a
  test that cannot fail for the right reason. Evidence is the protector arm above.
- **No full gap/parity sweep.** Local disk was ~7 GB; a full sweep at that level
  produces a skip storm rather than a result. Ran instead: the whole
  `perry-codegen` / `perry-hir` / `perry-transform` / `perry-runtime` unit suites
  (green; the two `perry-runtime` failures are the known macOS parallel-test
  flakes and pass with `--test-threads=1`) and a `test_gap_gc_` parity run. **The
  full suite needs to run in CI before this merges.**
- **The residual on both corpora is not triaged one by one.** It is budgeted, not
  allowlisted, deliberately — see above.
- **Compile-time cost of the pass is not benchmarked.** It is O(blocks) per slot
  load with a hard cap, and the dependency-scale corpus emits in ~8s, but there
  is no before/after compile-time number.
- **Linux/x86-64 untested.** All measurements are macOS arm64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory safety during garbage collection, reducing stale references and preventing related runtime failures.
  * Fixed regular expression creation when memory allocation triggers garbage collection.
* **Tests**
  * Added dependency-scale validation covering complex modules, control-flow paths, loops, and collection scenarios.
  * Expanded automated checks and failure diagnostics for garbage-collection safety.
* **Documentation**
  * Added guidance on garbage-collection rooting behavior, validation coverage, performance, and known test limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->