### PR TITLE
chore(codegen): drop the object-cache field and doc claim that outlived setjmp

### DIFF
--- a/changelog.d/7312-drop-orphaned-setjmp-state.md
+++ b/changelog.d/7312-drop-orphaned-setjmp-state.md
@@ -1,0 +1,15 @@
+#7302/#7305 replaced setjmp/longjmp exception lowering with `invoke`/`landingpad`
+and deleted `volatile_setjmp.rs`. Two references to that machinery outlived it:
+
+- `PERRY_SETJMP_VOLATILE` was still hashed into the object-cache key. The pass it
+  gated no longer exists, so the field could never vary — dead state in a cache
+  key, plus a test asserting its presence. Both removed. (Object-cache keys shift
+  once as a result; the next build repopulates.)
+- `native_emit.rs`'s module doc still claimed `has_try` functions render text
+  "whose setjmp volatile pass needs whole-function analysis". That pass is gone
+  and no such exception remains. Reworded to record the history rather than
+  assert a present-tense behaviour that is no longer true.
+
+The `_setjmp` link in `perry-ext-fastify` is deliberate and untouched — #7305
+keeps the private Rust-side boundary trap, since Rust cannot catch a foreign
+exception.

--- a/crates/perry-codegen/src/native_emit.rs
+++ b/crates/perry-codegen/src/native_emit.rs
@@ -25,8 +25,10 @@
 //! per-line stream including entry-alloca hoists, boundary splices and
 //! return-site rewrites, shared with `to_ir` so those transforms have
 //! exactly one implementation. No per-function text is materialized on this
-//! path; the exception is `has_try` functions, whose setjmp volatile pass
-//! needs whole-function analysis and therefore still renders text. What
+//! path. (Until #7302 `has_try` functions were an exception, because the
+//! setjmp volatile pass needed whole-function analysis and forced a text
+//! render; invoke/landingpad deleted that pass, so no such exception
+//! remains.) What
 //! stops existing everywhere is the module-scale concatenation and the
 //! full-grammar LLVM parse. The follow-up (typed `LlInst` variants) removes
 //! the remaining per-LINE formatting; the `instructions=` counter logged per

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -907,10 +907,6 @@ fn compute_object_cache_key_with_env(
         env_var("PERRY_CODEGEN_UNIT_SIZE").as_deref().unwrap_or(""),
     );
     h.field(
-        "env_setjmp_volatile",
-        env_var("PERRY_SETJMP_VOLATILE").as_deref().unwrap_or(""),
-    );
-    h.field(
         "env_gc_moving_loop_polls",
         env_var("PERRY_GC_MOVING_LOOP_POLLS")
             .as_deref()

--- a/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
+++ b/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
@@ -603,7 +603,6 @@ fn key_changes_with_codegen_env_vars() {
         "PERRY_ENTRY_SYMBOL",
         "PERRY_CODEGEN_UNITS",
         "PERRY_CODEGEN_UNIT_SIZE",
-        "PERRY_SETJMP_VOLATILE",
         "PERRY_GC_MOVING_LOOP_POLLS",
         // Inline-hot-small (#6850 follow-up).
         "PERRY_INLINE_HOT_SMALL",


### PR DESCRIPTION
#7302/#7305 replaced setjmp/longjmp with `invoke`/`landingpad` and deleted `volatile_setjmp.rs`. Two references to that machinery outlived it.

## Dead state in a cache key

`PERRY_SETJMP_VOLATILE` was still hashed into the object-cache key. The pass it gated no longer exists, so the field can never vary — it is a constant contribution to every key, plus a test asserting it belongs there.

Per CLAUDE.md's kill-policy: a knob that survives its mechanism is a configuration nobody has verified. Removed, along with its entry in the key-coverage test.

**Object-cache keys shift once as a result**; the next build repopulates. No correctness impact.

## A doc claim that stopped being true

`native_emit.rs`'s module doc said:

> No per-function text is materialized on this path; **the exception is `has_try` functions, whose setjmp volatile pass needs whole-function analysis and therefore still renders text.**

That pass is gone and no such exception remains. This is exactly the failure mode that has cost this project repeatedly — `gc_repsel_matrix.sh`'s header asserting `copy-minor 12/22` when the truth was `0/49` (#7255), and `policy.rs` claiming the loop-polls route was "sound by construction" (#7280). A present-tense claim about deleted machinery reads as fact and stops the next person looking.

Reworded to record the history rather than assert the behaviour.

## Deliberately untouched

`perry-ext-fastify`'s `_setjmp` link is **not** dead — #7305 keeps the private Rust-side boundary trap, because Rust cannot catch a foreign exception. The remaining `setjmp` mentions in `module.rs`, `dialect/mod.rs` and `try_stmt.rs` are historical notes explaining what the current gating mirrors, which is useful context rather than stale assertion.

## Verified

`cargo check -p perry` clean; `cargo test -p perry --bins object_cache` 46 passed; `cargo fmt --check` clean; file-size, GC store-site and addr-class gates green. (The public-baseline gate is expected-red on `main` while the artifact is deliberately stale during optimization work — #7306 ensures that no longer hides the others.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete setjmp-related object-cache state.
  * Updated exception-handling documentation to reflect the current implementation.
  * Improved build cache consistency by eliminating unnecessary cache-key variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->