### PR TITLE
fix(gc): fold the post-fp-setup stack allocation into the walker's frame base (#7328)

### DIFF
--- a/changelog.d/7329-fp-offset-trailing-sub.md
+++ b/changelog.d/7329-fp-offset-trailing-sub.md
@@ -1,0 +1,23 @@
+The fast x29-chain stack-map walker computed slot addresses from
+`add x29, sp, #imm` alone, on the premise that establishing the frame pointer is
+a function's last stack adjustment. It is not: LLVM emits a further
+`sub sp, sp, #N` after the `add` when a function has a large or separately
+laid-out local area.
+
+    stp x29, x30, [sp, #0x90]
+    add x29, sp, #0x90        <- fp established
+    sub sp, sp, #0x170        <- body SP drops a further 368 bytes
+
+Every slot in such a frame was therefore read 368 bytes high. `verify` reports
+the fast walk and the unwinder visiting six slots each with five differing by
+exactly that, and forcing `PERRY_STACKMAP_WALKER=unwind` raised objects copied
+from 23 to 110 on the same probe — the wrong addresses were causing live objects
+to be missed.
+
+This is a silent wrong answer rather than a crash, and `verify` is not the
+default, so an ordinary run has nothing to disagree with the fast walker.
+
+The decoder now accumulates the contiguous run of `sub sp, sp, #imm` that follows
+the `add`. A `sub sp` separated from that run is a body operation (a dynamic
+alloca, a call-argument area) whose effect the stack map's own slot offsets
+already carry, and is deliberately not folded in.

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -236,17 +236,54 @@ fn fp_to_sp_offset(function_address: usize) -> Option<usize> {
     if function_address == 0 || function_address & 0x3 != 0 {
         return None;
     }
+    // SUB (immediate, 64-bit, shift 0) with Rn = Rd = 31 (sp):
+    // `word & 0xFFC0_03FF == 0xD100_03FF`, immediate in bits [21:10].
+    const SUB_SP_SP_MASK: u32 = 0xFFC0_03FF;
+    const SUB_SP_SP_PATTERN: u32 = 0xD100_03FF;
+
+    let mut fp_offset = None;
     for i in 0..PROLOGUE_WINDOW_INSNS {
         let word = unsafe { std::ptr::read((function_address + i * 4) as *const u32) };
-        if word & ADD_FP_SP_MASK == ADD_FP_SP_PATTERN {
-            return Some(((word >> 10) & 0xFFF) as usize);
+        match fp_offset {
+            None => {
+                if word & ADD_FP_SP_MASK == ADD_FP_SP_PATTERN {
+                    fp_offset = Some(((word >> 10) & 0xFFF) as usize);
+                }
+            }
+            // #7328: `add x29, sp, #imm` is NOT always the last stack
+            // adjustment. LLVM emits a second allocation *after* establishing
+            // the frame pointer when a function has a large or separately-laid-
+            // out local area:
+            //
+            //     stp x29, x30, [sp, #0x90]
+            //     add x29, sp, #0x90        <- fp established here
+            //     sub sp, sp, #0x170        <- body SP drops a further 368
+            //
+            // Reading only the `add` left the fast walker 368 bytes high on
+            // every slot in such a frame, so it enumerated the wrong addresses
+            // and the collector missed live roots. That is a silent wrong
+            // answer, visible only under `PERRY_STACKMAP_WALKER=verify`, which
+            // is not the default. Accumulate every trailing `sub sp, sp, #imm`.
+            Some(offset) => {
+                if word & SUB_SP_SP_MASK == SUB_SP_SP_PATTERN {
+                    let imm = ((word >> 10) & 0xFFF) as usize;
+                    fp_offset = Some(offset + imm);
+                    continue;
+                }
+                // The prologue's stack adjustments are contiguous; the first
+                // instruction after them that is not a `sub sp` ends the run.
+                // Anything later that touches sp is a body operation (a dynamic
+                // alloca, a call-argument area) which the stack map's own
+                // offsets already account for.
+                break;
+            }
         }
         // `ret` ends the prologue window for a leaf that never sets up fp.
         if word == 0xD65F_03C0 {
             break;
         }
     }
-    None
+    fp_offset
 }
 
 #[cfg(not(target_arch = "aarch64"))]
@@ -1352,5 +1389,64 @@ mod tests {
         assert_eq!(closest_record_pc(&maps, 0x1004), Some(0x1000));
         assert_eq!(closest_record_pc(&maps, 0x101c), Some(0x1020));
         assert_eq!(closest_record_pc(&maps, 0x1020), Some(0x1020));
+    }
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+mod fp_offset_trailing_sub_tests {
+    use super::fp_to_sp_offset;
+
+    /// Assemble a prologue into executable-ish memory and decode it. The
+    /// decoder only reads words, so a plain aligned buffer is enough.
+    fn decode(words: &[u32]) -> Option<usize> {
+        let buf = words.to_vec().into_boxed_slice();
+        let addr = buf.as_ptr() as usize;
+        let out = fp_to_sp_offset(addr);
+        drop(buf);
+        out
+    }
+
+    const ADD_X29_SP_0X90: u32 = 0x9102_43FD; // add x29, sp, #0x90
+    const SUB_SP_SP_0X170: u32 = 0xD105_C3FF; // sub sp, sp, #0x170
+    const RET: u32 = 0xD65F_03C0;
+    const NOP: u32 = 0xD503_201F;
+
+    /// #7328: `add x29, sp, #imm` is not always the last stack adjustment.
+    /// LLVM emits a further `sub sp, sp, #N` after establishing the frame
+    /// pointer, and reading only the `add` left the fast walker N bytes high
+    /// on every slot in that frame — a silent wrong answer, since the walker
+    /// then enumerated addresses the collector treated as roots.
+    #[test]
+    fn a_sub_after_the_fp_setup_is_included() {
+        assert_eq!(
+            decode(&[ADD_X29_SP_0X90, SUB_SP_SP_0X170, NOP, RET]),
+            Some(0x90 + 0x170),
+            "the trailing `sub sp, sp, #0x170` must be added to the fp offset"
+        );
+    }
+
+    /// The common shape — fp established last — must be unchanged.
+    #[test]
+    fn a_prologue_with_no_trailing_sub_is_unchanged() {
+        assert_eq!(decode(&[ADD_X29_SP_0X90, NOP, RET]), Some(0x90));
+    }
+
+    /// Only a contiguous run of `sub sp` immediately after the `add` counts.
+    /// A later `sub sp` is a body operation (dynamic alloca, call-argument
+    /// area) already accounted for by the stack map's own slot offsets.
+    #[test]
+    fn a_sub_after_the_prologue_run_is_not_counted() {
+        assert_eq!(
+            decode(&[ADD_X29_SP_0X90, NOP, SUB_SP_SP_0X170, RET]),
+            Some(0x90),
+            "a `sub sp` separated from the prologue run must not be folded in"
+        );
+    }
+
+    /// A leaf that never sets up fp still fails closed, so the caller falls
+    /// back to the platform unwinder rather than inventing an offset.
+    #[test]
+    fn a_leaf_without_fp_setup_still_fails_closed() {
+        assert_eq!(decode(&[NOP, RET]), None);
     }
 }


### PR DESCRIPTION
Fixes #7328.

## Root cause

The fast x29-chain stack-map walker derived a frame's base from `add x29, sp, #imm` alone, on the premise — stated in the function's own doc comment — that establishing the frame pointer is a function's last stack adjustment.

**It is not.** LLVM emits a further allocation *after* the `add` when a function has a large or separately laid-out local area:

```asm
stp  x29, x30, [sp, #0x90]
add  x29, sp, #0x90      ; fp established — decoder stopped here
sub  sp, sp, #0x170      ; body SP drops a further 368 bytes
```

So every slot in such a frame was read **368 bytes high**.

## Reproduced, then fixed

`PERRY_STACKMAP_WALKER=verify` on `notry_control` with collections forced:

```
left  (fast):     [...776, ...7376, ...7384, ...7392, ...7400, ...7408]
right (unwinder): [...776, ...7008, ...7016, ...7024, ...7032, ...7040]
```

The first slot agrees — that frame has no trailing `sub` — and the other five are each exactly **+368**, matching `sub sp, sp, #0x170` found in the disassembly.

After the fix, the same command is clean, **with movement asserted**: `eligible=true`, `copied_objects=28` per cycle. That distinction matters here — my first attempt reported 5/5 clean while `PERRY_GC_DIAG` showed `eligible=false fallback=conservative_stack`, i.e. **no copying minor ran at all**. `PERRY_CONSERVATIVE_STACK_SCAN=off` was needed to make copying eligible (#7255).

## Why this is worse than a crash

It is a **silent wrong answer**. `verify` is not the default, so an ordinary run has nothing to disagree with the fast walker — it enumerates wrong addresses, the collector treats them as the root set, and live objects are missed. Forcing `PERRY_STACKMAP_WALKER=unwind` on the same probe raised objects copied from **23 to 110**.

It affects **both** statepoint backends, since they share the walker.

## The fix

Accumulate the contiguous run of `sub sp, sp, #imm` immediately following the `add`. A `sub sp` separated from that run is a body operation — a dynamic alloca, a call-argument area — whose effect the stack map's own slot offsets already carry, and is deliberately **not** folded in.

## Verification

Four unit tests: the trailing-`sub` case, the unchanged common shape, a `sub` *after* the prologue run (must not be counted), and a leaf with no fp setup (must still fail closed so the caller falls back to the unwinder).

**Sabotage-checked** — neutralising the accumulation fails `a_sub_after_the_fp_setup_is_included` with *"the trailing `sub sp, sp, #0x170` must be added to the fp offset"*.

`cargo fmt` clean; file-size, GC store-site and addr-class gates green. (`ci_public_baseline_check` is expected-red — the artifact is deliberately stale during the current optimization work.)

## Not verified

aarch64 only — the decoder is `#[cfg(target_arch = "aarch64")]` and x86-64 returns `None` (falls back to the unwinder), so there is no x86-64 path to regress. Whether this clears any of the 13 gap regressions the statepoint soak found is **not** measured here; #7327 (the bridge emitting no statepoint on `invoke`) is the more likely cause of the exception-shaped ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AArch64 stack scanning for functions with contiguous stack-pointer adjustments after frame-pointer setup.
  * Improved detection of live objects during garbage collection by calculating stack locations correctly.
  * Preserved correct behavior for separated stack adjustments and functions without frame-pointer setup.

* **Tests**
  * Added coverage for trailing adjustments, unchanged prologues, separated adjustments, and leaf functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->