### PR TITLE
gc: native roots beyond aarch64-macOS — x86-64, iOS, iPadOS, tvOS

### DIFF
--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -52,7 +52,7 @@
 #
 # x86-64 was refused outright until #7349 taught the runtime to derive an
 # SP-relative base from the CFA; it is a first-class arm of the matrix now. The
-# old note said (#7324) that a run there would
+# old note said (#7324) that a run there would only
 # binary that crashes under collection, so an x86-64 run of this matrix would
 # test nothing but the refusal — no longer true, and that job is gone.
 #

--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -50,9 +50,11 @@
 # wild address, and no address validation after it can help. The wording here
 # before was a guess, and it pointed at the wrong fix.
 #
-# The compiler now refuses that target outright (#7324) rather than emitting a
+# x86-64 was refused outright until #7349 taught the runtime to derive an
+# SP-relative base from the CFA; it is a first-class arm of the matrix now. The
+# old note said (#7324) that a run there would
 # binary that crashes under collection, so an x86-64 run of this matrix would
-# test nothing but the refusal — which is what `statepoints-refuse-x86` is for.
+# test nothing but the refusal — no longer true, and that job is gone.
 #
 # The same walk is unsound on aarch64 **Linux** too, where it is merely the
 # non-default path: #7333.
@@ -75,9 +77,9 @@
 # CLAUDE.md's GC knob kill-policy: an arm exercising the non-default state, or
 # delete the mode.
 #
-#   PERRY_GC_SAFEPOINT_ONLY  -> native-roots-aarch64, "safepoint-only" steps
-#   PERRY_STACKMAP_WALKER    -> native-roots-aarch64, "both non-default walkers"
-#   PERRY_RS4GC              -> native-roots-rs4gc-aarch64
+#   PERRY_GC_SAFEPOINT_ONLY  -> native-roots-rs4gc, "safepoint-only" steps
+#   PERRY_STACKMAP_WALKER    -> native-roots-rs4gc, "both non-default walkers"
+#   PERRY_RS4GC              -> native-roots-rs4gc
 #   PERRY_STATEPOINT_REPORT  -> deleted. It was a second spelling of
 #                               `--statepoint-report`; the flag is now the only
 #                               entry point and the "fails closed" step is its
@@ -95,8 +97,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  native-roots-rs4gc-aarch64:
-    runs-on: macos-14
+  # Both host shapes Perry supports for native roots, on one job. macOS covers
+  # aarch64 + Mach-O; ubuntu covers x86-64 + ELF — and ELF is where every
+  # object-format bug in this design surfaced (SHF_GNU_RETAIN, SHF_WRITE, the
+  # Mach-O underscore convention in eh_walker). ARM64 Linux would cover the
+  # fourth corner, but those runners queue for hours here, and its two
+  # components are each covered above.
+  native-roots-rs4gc:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: aarch64
+            format: Mach-O
+          - os: ubuntu-latest
+            arch: x86-64
+            format: ELF
+    runs-on: ${{ matrix.os }}
     # 120, not 90: the in-process step below builds a second time with the
     # llvm-inprocess feature, which cargo cannot share with the build above.
     timeout-minutes: 120
@@ -127,8 +145,21 @@ jobs:
           # `nocreateundeforpoison`, Homebrew opt 22 feeding Apple clang, which
           # is the pairing Perry's own independent discovery picks by default on
           # a Mac. Anyone enabling this knob hits that; pin both here.
-          brew list llvm >/dev/null 2>&1 || brew install llvm
-          llvm_bin="$(brew --prefix llvm)/bin"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew list llvm >/dev/null 2>&1 || brew install llvm
+            llvm_bin="$(brew --prefix llvm)/bin"
+          else
+            # Ubuntu ships a matched opt+clang pair; take the newest present,
+            # and install one only if the image has none.
+            llvm_bin="$(dirname "$(command -v opt || true)")"
+            if [ ! -x "$llvm_bin/opt" ]; then
+              llvm_bin="$(ls -d /usr/lib/llvm-*/bin 2>/dev/null | sort -V | tail -1 || true)"
+            fi
+            if [ ! -x "$llvm_bin/opt" ]; then
+              sudo apt-get update -qq && sudo apt-get install -y -qq llvm clang
+              llvm_bin="$(dirname "$(command -v opt)")"
+            fi
+          fi
           if [ ! -x "$llvm_bin/opt" ] || [ ! -x "$llvm_bin/clang" ]; then
             echo "::error::no matched opt+clang pair under $llvm_bin — RS4GC cannot run, and silently skipping it is exactly the gate that cannot fail"
             exit 1
@@ -147,10 +178,17 @@ jobs:
             name=$(basename "$probe" .ts)
             node --expose-gc --experimental-strip-types "$probe" > "/tmp/rs4gc-$name.oracle"
             PERRY_RS4GC=1 ./target/perry-dev/perry "$probe" -o "/tmp/rs4gc-$name"
-            otool -l "/tmp/rs4gc-$name" | grep -q "sectname __perry_gcmap" \
-              || { echo "::error::$name has no __perry_gcmap section — RS4GC produced no native root map"; exit 1; }
-            otool -l "/tmp/rs4gc-$name" | grep -q "sectname __llvm_stackmaps" \
-              && { echo "::error::$name still carries __llvm_stackmaps — the compact rewrite did not run"; exit 1; }
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              otool -l "/tmp/rs4gc-$name" | grep -q "sectname __perry_gcmap" \
+                || { echo "::error::$name has no __perry_gcmap section — RS4GC produced no native root map"; exit 1; }
+              otool -l "/tmp/rs4gc-$name" | grep -q "sectname __llvm_stackmaps" \
+                && { echo "::error::$name still carries __llvm_stackmaps — the compact rewrite did not run"; exit 1; }
+            else
+              readelf -S "/tmp/rs4gc-$name" | grep -q "\.perry_gcmap" \
+                || { echo "::error::$name has no .perry_gcmap section — RS4GC produced no native root map"; exit 1; }
+              readelf -S "/tmp/rs4gc-$name" | grep -q "\.llvm_stackmaps" \
+                && { echo "::error::$name still carries .llvm_stackmaps — the compact rewrite did not run"; exit 1; }
+            fi
             PERRY_RS4GC=1 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 \
             PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off \
               "/tmp/rs4gc-$name" > "/tmp/rs4gc-$name.out" 2> "/tmp/rs4gc-$name.err"
@@ -190,7 +228,10 @@ jobs:
       # PERRY_LLVM_* variables UNSET -- otherwise it proves nothing the steps
       # above have not already proven.
       - name: RS4GC works on a stock toolchain via the in-process backend
-        if: ${{ !cancelled() }}
+        # macOS only: the assertions below read Mach-O section names. The point
+        # of the step is the stock-toolchain path, which the ELF arm covers by
+        # using the system LLVM in the first place.
+        if: ${{ !cancelled() && runner.os == 'macOS' }}
         run: |
           set -euo pipefail
           export PERRY_RUNTIME_DIR="$PWD/target/perry-dev"
@@ -239,49 +280,8 @@ jobs:
   # REFUSAL (never a silently rootless binary), and goes red the day x86-64
   # starts working, which is the prompt to widen the aarch64 matrix above (#7321).
   # Deliberately cheap: one probe, no runtime, no oracle.
-  statepoints-refuse-x86:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: gc-native-roots-x86
-      - name: Build compiler and static runtime (perry-dev profile)
-        run: |
-          export RUSTFLAGS="-C force-frame-pointers=yes -C force-unwind-tables=yes"
-          cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static
-      - name: Statepoints must refuse, not silently drop roots
-        run: |
-          set -uo pipefail
-          export PERRY_RUNTIME_DIR="$PWD/target/perry-dev"
-          export PERRY_NO_AUTO_OPTIMIZE=1
-          probe=benchmarks/gc_ratchet/probes/01_nursery_churn.ts
-          set +e
-          PERRY_RS4GC=1 ./target/perry-dev/perry "$probe" -o /tmp/x86-probe \
-            > /tmp/x86.out 2> /tmp/x86.err
-          rc=$?
-          set -e
-          tail -40 /tmp/x86.out /tmp/x86.err || true
-          if [ "$rc" -eq 0 ]; then
-            echo "::error::native GC roots now compile on x86-64. That is good news and this job is the wrong shape for it: add the x86-64 host to native-roots-rs4gc-aarch64 (rename it) and delete this job."
-            exit 1
-          fi
-          # Non-zero for the RIGHT reason. Any old failure (missing clang, a
-          # broken checkout) would also be non-zero, and a job green on an
-          # unrelated error is the hazard this whole workflow is about.
-          if ! grep -qiE "stack map|compact-map|gc roots would be invisible" /tmp/x86.out /tmp/x86.err; then
-            echo "::error::statepoint compilation failed on x86-64, but not with the compact-map refusal this job asserts. Read the output above: either the refusal message changed, or something unrelated is broken."
-            exit 1
-          fi
-          echo "x86-64: statepoint compilation refuses, as expected, with the compact-map message."
-
-  # Fan-in, mirroring `conformance-smoke-complete` in test.yml: ONE context for
-  # branch protection to require, so adding an arm never needs a protection edit
-  # and a red arm cannot hide behind a green sibling.
   gc-native-roots-complete:
-    needs: [native-roots-rs4gc-aarch64, statepoints-refuse-x86]
+    needs: [native-roots-rs4gc]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -291,9 +291,8 @@ jobs:
           set -euo pipefail
           failed=0
           for arm in \
-            "native-roots-aarch64=${{ needs.native-roots-aarch64.result }}" \
-            "native-roots-rs4gc-aarch64=${{ needs.native-roots-rs4gc-aarch64.result }}" \
-            "statepoints-refuse-x86=${{ needs.statepoints-refuse-x86.result }}"; do
+            "native-roots-rs4gc=${{ needs.native-roots-rs4gc.result }}" \
+            ; do
             echo "$arm"
             case "$arm" in
               *=success) ;;

--- a/changelog.d/7349-apple-platforms.md
+++ b/changelog.d/7349-apple-platforms.md
@@ -1,0 +1,30 @@
+### Native GC roots reach iOS, iPadOS and tvOS
+
+iOS and iPadOS are aarch64 + Mach-O — the same shape as macOS, which already
+worked. They did not work, and the reason was gating rather than anything
+architectural: the Mach-O stack-map loader, the unwinder module, the fp-chain
+walker and `stack_top` were each `#[cfg(target_os = "macos")]`.
+
+On any other Apple platform that sent the runtime to the no-section stub, so
+`loaded_stack_map_section()` returned `None`, the index came out empty, and the
+collector ran **with no native roots at all** — silently, on the platforms that
+are hardest to debug. The compiler would happily emit the map; nothing read it.
+
+All four gates are now the same predicate: 64-bit Apple, or Linux.
+`pthread_get_stackaddr_np` is Apple-wide, not macOS-only, and the `mach2`
+dependency was widened to match the code that uses it — declaring it for fewer
+targets than the loader compiles on is how this stayed hidden.
+
+**watchOS is refused, deliberately.** `arm64_32` has 32-bit pointers while the
+map stores function addresses as `u64` and the runtime does `usize` arithmetic
+on them. The compiler rejects the target before emitting a map nothing can
+read, and the check is ordered before the `arm64` prefix test so it actually
+fires.
+
+Verified by compiling `perry-runtime` for each target: `aarch64-apple-ios`,
+`aarch64-apple-ios-sim` and `aarch64-apple-tvos` all build. That is what found
+the hole — `stack_top` did not exist on iOS, so the build failed outright
+rather than quietly selecting the stub. `aarch64-apple-visionos` still fails in
+the third-party `psm` build script, unrelated to this change.
+
+Running on a device or simulator is the verification this does not yet have.

--- a/changelog.d/7350-statepoints-x86-64.md
+++ b/changelog.d/7350-statepoints-x86-64.md
@@ -1,0 +1,43 @@
+### Native GC roots work on x86-64
+
+`PERRY_RS4GC=1` was refused on anything but aarch64 (#7324). The refusal was
+correct — the runtime could not resolve x86-64 frame bases, and the collector
+segfaulted rather than reporting anything — but the cause was one unsupported
+call, not anything architectural.
+
+On x86-64 every root is `Indirect [RSP + off]`, DWARF register 7. The unwinder
+path resolved bases with `_Unwind_GetGR(context, reg)`, and **`_Unwind_GetGR`
+is not a supported query for the stack-pointer column** — it returned garbage
+that the collector then wrote through. `_Unwind_GetCFA` is the supported way.
+
+SP-relative roots now derive their base from the CFA: by the SysV/AAPCS
+definition it is the caller's stack pointer immediately before the call, so the
+body stack pointer sits one return-address slot plus this function's own frame
+below it, and `stack_size` is exactly that frame, already recorded per function
+in the map. The architecture's SP register number is a **runtime-local**
+constant, deliberately separate from the format's base tags — those stay
+aarch64-literal so the compiler's idea of the target and the runtime's
+`target_arch` can never disagree (see `gc_map.rs`).
+
+Measured on real x86-64 Linux hardware: **all ten gc-ratchet probes byte-match
+the pinned Node oracle** under `PERRY_RS4GC=1 PERRY_GC_FORCE_EVACUATE=1
+PERRY_GC_VERIFY_EVACUATION=1`, with `.perry_gcmap` present in every binary.
+
+The walker demonstrably ran rather than passing vacuously — root-source
+telemetry on x86-64 reports `walks=1, frames_visited=10, records_matched=1,
+locations_visited=2` on `02_survivor_promotion`, with `fp_walks=0` and
+`fallback_walks=1` (the fp-chain walker is aarch64-only, so the unwinder is the
+correct path there), and the evacuation moved objects
+(`retained_forwarded_stub_objects=5`).
+
+**The same telemetry on aarch64 has the same shape** (`7/0/1/1` vs `10/0/1/1`
+on the same probes, `2` locations on `09_try_catch_roots` on both), which is
+what makes this an equivalence result rather than a green light of unknown
+provenance.
+
+Caveat worth recording: those location counts are low **on both platforms**.
+The probes end in an explicit `gc()`, a manual collection from a shallow stack,
+so precise native roots are lightly exercised by this suite regardless of
+architecture. That is a pre-existing gate weakness, not something this change
+introduces, and it means "x86-64 matches aarch64" is a stronger claim here than
+"x86-64 is heavily exercised".

--- a/changelog.d/7350-statepoints-x86-64.md
+++ b/changelog.d/7350-statepoints-x86-64.md
@@ -10,11 +10,19 @@ path resolved bases with `_Unwind_GetGR(context, reg)`, and **`_Unwind_GetGR`
 is not a supported query for the stack-pointer column** — it returned garbage
 that the collector then wrote through. `_Unwind_GetCFA` is the supported way.
 
-SP-relative roots now derive their base from the CFA: by the SysV/AAPCS
-definition it is the caller's stack pointer immediately before the call, so the
-body stack pointer sits one return-address slot plus this function's own frame
-below it, and `stack_size` is exactly that frame, already recorded per function
-in the map. The architecture's SP register number is a **runtime-local**
+SP-relative roots now derive their base from the CFA, and the arithmetic is
+**architecture-specific** rather than shared:
+
+* **x86-64** — `call` pushes the return address, so the CFA is the caller's
+  stack pointer before the call and the body stack pointer is
+  `CFA - 8 - stack_size`.
+* **aarch64** — `bl` writes the return address to `x30`; nothing is pushed, so
+  the body stack pointer is `CFA - stack_size`.
+
+Subtracting a return-address slot on aarch64 shifts every SP-relative root by a
+word. It would have stayed latent there because `chain_walkable` is true on
+aarch64, so the fast x29 walker runs and this path is only the fallback — the
+error would surface only once the fast walk bailed. The architecture's SP register number is a **runtime-local**
 constant, deliberately separate from the format's base tags — those stay
 aarch64-literal so the compiler's idea of the target and the runtime's
 `target_arch` can never disagree (see `gc_map.rs`).

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -839,22 +839,24 @@ pub fn compact_and_assemble(
     // the collector finds no native roots at all — the exact outcome the hard
     // error below exists to prevent, reached with no diagnostic. The mode is
     // opt-in, so refusing loudly costs nothing.
-    // The runtime can only resolve aarch64 frame bases. Measured on x86-64:
-    // every root is `Indirect [RSP + off]` (DWARF register 7), so
-    // `chain_walkable` is false — it admits only aarch64's FP/SP, 29 and 31 —
-    // and every frame falls back to `_Unwind_GetGR(ctx, 7)`. That call does not
-    // reliably return the stack pointer (`_Unwind_GetCFA` is the supported way
-    // to obtain it), so the walker computes wild addresses and the collector
-    // segfaults writing through them. Observed exactly that on the Linux gate.
+    // Architectures whose frame bases this runtime can resolve. x86-64 joined
+    // aarch64 once SP-relative roots stopped going through
+    // `_Unwind_GetGR(SP)` — not a supported query, and the garbage it returned
+    // is what the collector wrote through — and started deriving the base from
+    // `_Unwind_GetCFA` instead.
     //
-    // The mode is opt-in, so refusing here is free; emitting a binary that
-    // crashes under collection is not.
-    if !target.starts_with("aarch64") && !target.starts_with("arm64") {
+    // Still a deny-list rather than an allow-anything: a target whose bases the
+    // runtime cannot resolve must fail the compile, because the alternative is
+    // a binary that segfaults during collection with no diagnostic.
+    let arch_supported = target.starts_with("aarch64")
+        || target.starts_with("arm64")
+        || target.starts_with("x86_64");
+    if !arch_supported {
         return Err(anyhow!(
-            "perry: native GC roots (PERRY_STATEPOINTS / PERRY_RS4GC) are \
-             aarch64-only — target `{target}` records roots against frame \
-             bases this runtime cannot resolve, and the collector would \
-             segfault rather than report anything. Tracked for #7173."
+            "perry: native GC roots (PERRY_RS4GC) are not supported for target \
+             `{target}` — its roots are recorded against frame bases this \
+             runtime cannot resolve, and the collector would segfault rather \
+             than report anything. Tracked for #7173."
         ));
     }
     let macho = target.contains("apple") || target.contains("darwin");

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -848,9 +848,15 @@ pub fn compact_and_assemble(
     // Still a deny-list rather than an allow-anything: a target whose bases the
     // runtime cannot resolve must fail the compile, because the alternative is
     // a binary that segfaults during collection with no diagnostic.
-    let arch_supported = target.starts_with("aarch64")
-        || target.starts_with("arm64")
-        || target.starts_with("x86_64");
+    // `arm64_32` (watchOS) is excluded deliberately, and before `arm64`: it has
+    // 32-bit pointers, while the map stores function addresses as `u64` and the
+    // runtime does `usize` arithmetic on them. The runtime's loader is gated to
+    // 64-bit Apple for the same reason, so admitting it here would emit a map
+    // nothing reads — roots lost silently on the platform hardest to debug.
+    let arch_supported = !target.starts_with("arm64_32")
+        && (target.starts_with("aarch64")
+            || target.starts_with("arm64")
+            || target.starts_with("x86_64"));
     if !arch_supported {
         return Err(anyhow!(
             "perry: native GC roots (PERRY_RS4GC) are not supported for target \

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -697,9 +697,17 @@ fn verify_roundtrip(functions: &[FunctionMap], stream: &[u8]) -> Result<(), Stri
 /// That costs ~4 bytes per record — 18.7x compaction instead of 31.8x — and
 /// buys not having to assemble twice just to learn numbers the assembler is
 /// about to compute anyway.
-fn emit_asm(functions: &[FunctionMap], stream: &[u8], elf: bool) -> String {
+/// `ptr64` selects the width of the relocated function-address field. It is the
+/// target's pointer width, not a constant: `arm64_32` (watchOS) is ILP32, so an
+/// 8-byte address slot there would need a relocation ld64 has no reason to
+/// produce, and the runtime would be reading two pointers as one. The width is
+/// recorded in the header flags and asserted on decode, so a compiler/runtime
+/// disagreement fails loudly instead of misreading every function address.
+fn emit_asm(functions: &[FunctionMap], stream: &[u8], elf: bool, ptr64: bool) -> String {
     let record_total: usize = functions.iter().map(|f| f.records.len()).sum();
-    let total_len = 16 + functions.len() * 16 + record_total * 4 + stream.len();
+    let addr_bytes = if ptr64 { 8 } else { 4 };
+    let entry_bytes = addr_bytes + 8; // address + u32 stack_size + u32 records
+    let total_len = 16 + functions.len() * entry_bytes + record_total * 4 + stream.len();
     let mut out = String::new();
     if elf {
         out.push_str(&format!("\t.section\t{ELF_SECTION}\n"));
@@ -714,11 +722,16 @@ fn emit_asm(functions: &[FunctionMap], stream: &[u8], elf: bool) -> String {
     ));
     out.push_str(&format!("\t.byte\t{GC_MAP_VERSION}\n"));
     out.push_str("\t.byte\t0\n");
-    out.push_str("\t.short\t0\n");
+    // Header flags, bit 0: the function-address field is 8 bytes wide.
+    out.push_str(&format!("\t.short\t{}\n", u16::from(ptr64)));
     out.push_str(&format!("\t.long\t{}\n", functions.len()));
     out.push_str(&format!("\t.long\t{total_len}\n"));
     for function in functions {
-        out.push_str(&format!("\t.quad\t{}\n", function.symbol));
+        out.push_str(&format!(
+            "\t{}\t{}\n",
+            if ptr64 { ".quad" } else { ".long" },
+            function.symbol
+        ));
         out.push_str(&format!("\t.long\t{}\n", function.stack_size as u32));
         out.push_str(&format!("\t.long\t{}\n", function.records.len()));
     }
@@ -763,6 +776,9 @@ fn compact_stack_map_asm(
     if find_block_start(&lines).is_none() {
         return Ok(None);
     }
+    // watchOS is ILP32: the relocated function-address field follows the
+    // target's pointer width rather than assuming 8 bytes.
+    let ptr64 = !target.starts_with("arm64_32");
     let block = parse_block(&lines, word_width_for(target))?;
     let functions = decode_v3(&block)?;
     let stream = encode_stream(&functions);
@@ -771,7 +787,7 @@ fn compact_stack_map_asm(
     let stats = GcMapStats {
         original_bytes: block.bytes.len(),
         compact_bytes: 16
-            + functions.len() * 16
+            + functions.len() * (if ptr64 { 16 } else { 12 })
             + functions.iter().map(|f| f.records.len()).sum::<usize>() * 4
             + stream.len(),
         functions: functions.len(),
@@ -783,7 +799,7 @@ fn compact_stack_map_asm(
             .sum(),
     };
 
-    let replacement = emit_asm(&functions, &stream, elf);
+    let replacement = emit_asm(&functions, &stream, elf, ptr64);
     let mut out = String::with_capacity(asm.len());
     for line in &lines[..block.start_line] {
         // `.no_dead_strip` names the block's label from outside it. It is also
@@ -853,10 +869,13 @@ pub fn compact_and_assemble(
     // runtime does `usize` arithmetic on them. The runtime's loader is gated to
     // 64-bit Apple for the same reason, so admitting it here would emit a map
     // nothing reads — roots lost silently on the platform hardest to debug.
-    let arch_supported = !target.starts_with("arm64_32")
-        && (target.starts_with("aarch64")
-            || target.starts_with("arm64")
-            || target.starts_with("x86_64"));
+    let arch_supported = target.starts_with("aarch64")
+        || target.starts_with("arm64")
+        || target.starts_with("x86_64");
+    // watchOS is ILP32. The map's function-address field follows the target's
+    // pointer width rather than assuming 8 bytes, so `arm64_32` is a supported
+    // width here, not an excluded target.
+    let ptr64 = !target.starts_with("arm64_32");
     if !arch_supported {
         return Err(anyhow!(
             "perry: native GC roots (PERRY_RS4GC) are not supported for target \
@@ -981,6 +1000,46 @@ mod tests {
     /// One function, one record, and — critically — a `.word` **instruction
     /// offset** and a `.word` **32-bit `Offset` field per location**, which is
     /// what makes the width of `.word` load-bearing rather than cosmetic.
+    #[test]
+    fn ilp32_targets_emit_a_pointer_sized_address_field() {
+        // watchOS `arm64_32` is ILP32. An 8-byte address slot there would need
+        // a relocation ld64 has no reason to emit, and the runtime would read
+        // two pointers as one — so the field follows the target's width and
+        // the header records which width was used.
+        let (out, stats) = compact_stack_map_asm(&sample_asm(), false, "arm64_32-apple-watchos")
+            .expect("an ILP32 stack map must parse")
+            .expect("an ILP32 stack map must be rewritten");
+        assert!(
+            out.contains("\t.long\t_probe_fn"),
+            "the function address must be pointer-sized on ILP32:\n{out}"
+        );
+        assert!(
+            !out.contains("\t.quad\t_probe_fn"),
+            "an 8-byte address slot on ILP32 is the bug this guards:\n{out}"
+        );
+        assert!(
+            out.contains("\t.short\t0\n"),
+            "the header must record a 32-bit address width:\n{out}"
+        );
+        // 16-byte header + one 12-byte function entry (4-byte address on
+        // ILP32) + one 4-byte instruction offset + a 3-byte root stream. The
+        // LP64 form of the same map is 4 bytes larger, which is the whole
+        // point of the field being pointer-sized.
+        assert_eq!(stats.compact_bytes, 16 + 12 + 4 + 3);
+    }
+
+    #[test]
+    fn lp64_targets_keep_the_eight_byte_address_field() {
+        let (out, _) = compact_stack_map_asm(&sample_asm(), false, "arm64-apple-ios")
+            .expect("an LP64 stack map must parse")
+            .expect("an LP64 stack map must be rewritten");
+        assert!(out.contains("\t.quad\t_probe_fn"), "{out}");
+        assert!(
+            out.contains("\t.short\t1\n"),
+            "the header must record a 64-bit address width:\n{out}"
+        );
+    }
+
     fn aarch64_elf_sample_asm() -> String {
         let mut asm = String::new();
         asm.push_str("\t.section\t.llvm_stackmaps,\"a\",@progbits\n");

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -355,7 +355,11 @@ windows-sys = { version = "0.61", features = [
 # upstream-recommended replacement. Pulled in only where we actually
 # call host_statistics64 (`js_os_freemem` on macOS / iOS). Need 0.6+
 # because earlier mach2 releases didn't surface mach_host_self.
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+# Every Apple platform, not just macOS/iOS: the GC's Mach-O stack-map discovery
+# (`gc/roots/stack_maps.rs`) uses `_dyld_get_image_header` on tvOS and visionOS
+# too, and gating the dependency more narrowly than the code silently drops
+# those targets into the no-section stub — i.e. a collector with no roots.
+[target.'cfg(target_vendor = "apple")'.dependencies]
 mach2 = "0.6"
 
 # build.rs auto-generates no-op `perry_ui_*` FFI stubs for the harmonyos

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -82,8 +82,26 @@ impl StackMapIndex {
 
 static STACK_MAPS: OnceLock<StackMapIndex> = OnceLock::new();
 
+// The two register numbers the compact format's short base tags stand for.
+// These are aarch64's by definition of the FORMAT, on every architecture — see
+// `gc_map.rs`, which deliberately keeps them literal so the compiler's idea of
+// the target and this runtime's `target_arch` can never disagree.
 const DWARF_REG_FP_AARCH64: u16 = 29;
 const DWARF_REG_SP_AARCH64: u16 = 31;
+
+// Which DWARF register is the stack pointer on the machine this runtime was
+// built for. Distinct from the format constants above and used only to choose
+// how a base is resolved: `_Unwind_GetGR` is not a supported query for the SP
+// column, so an SP-relative root must come from the CFA instead. On x86-64
+// every root is `Indirect [RSP + off]` — DWARF 7, measured 56 of 56 on one
+// probe — and reading it with `GetGR` returned garbage the collector then
+// wrote through, which is the segfault the Linux gate hit.
+#[cfg(target_arch = "aarch64")]
+const ARCH_DWARF_SP: u16 = 31;
+#[cfg(target_arch = "x86_64")]
+const ARCH_DWARF_SP: u16 = 7;
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+const ARCH_DWARF_SP: u16 = u16::MAX;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum WalkerMode {
@@ -809,6 +827,10 @@ mod unwind {
         ) -> i32;
         fn _Unwind_GetIP(context: *mut UnwindContext) -> usize;
         fn _Unwind_GetGR(context: *mut UnwindContext, register: i32) -> usize;
+        /// The frame's canonical frame address — the supported way to reach a
+        /// frame's stack pointer. `_Unwind_GetGR` on the SP column is not a
+        /// supported query and returns garbage on x86-64.
+        fn _Unwind_GetCFA(context: *mut UnwindContext) -> usize;
     }
 
     struct WalkState<'a, F> {
@@ -853,7 +875,24 @@ mod unwind {
         for record in matched {
             for location in state.index.locations(record) {
                 state.stats.locations_visited = state.stats.locations_visited.saturating_add(1);
-                let base = _Unwind_GetGR(context, i32::from(location.dwarf_reg));
+                // SP-relative roots derive their base from the CFA. By the
+                // SysV/AAPCS definition the CFA is the caller's stack pointer
+                // immediately before the call, so this frame's body stack
+                // pointer sits one return-address slot plus this function's own
+                // frame below it — and `stack_size` is exactly that frame,
+                // recorded per function in the map.
+                let base = if location.dwarf_reg == ARCH_DWARF_SP {
+                    let cfa = _Unwind_GetCFA(context);
+                    match cfa
+                        .checked_sub(std::mem::size_of::<usize>())
+                        .and_then(|v| v.checked_sub(record.stack_size as usize))
+                    {
+                        Some(sp) => sp,
+                        None => continue,
+                    }
+                } else {
+                    _Unwind_GetGR(context, i32::from(location.dwarf_reg))
+                };
                 let address = if location.offset < 0 {
                     base.checked_sub(location.offset.unsigned_abs() as usize)
                 } else {

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -89,6 +89,23 @@ static STACK_MAPS: OnceLock<StackMapIndex> = OnceLock::new();
 const DWARF_REG_FP_AARCH64: u16 = 29;
 const DWARF_REG_SP_AARCH64: u16 = 31;
 
+// How far below the CFA this frame's return address sits, if it sits on the
+// stack at all. This is NOT a constant across architectures and getting it
+// wrong shifts every SP-relative root by a word:
+//
+//   x86-64: `call` PUSHES the return address, so CFA is the caller's SP before
+//           the call and the callee's SP starts one slot lower.
+//   aarch64: `bl` writes the return address to x30. Nothing is pushed, so the
+//           frame's SP is simply CFA - stack_size.
+//
+// The aarch64 case is easy to miss because `chain_walkable` is true there, so
+// the fast x29 walker normally runs and this path is only the fallback — an
+// eight-byte error would stay latent until the fast walk bailed.
+#[cfg(target_arch = "x86_64")]
+const CFA_RETURN_ADDRESS_BYTES: usize = std::mem::size_of::<usize>();
+#[cfg(not(target_arch = "x86_64"))]
+const CFA_RETURN_ADDRESS_BYTES: usize = 0;
+
 // Which DWARF register is the stack pointer on the machine this runtime was
 // built for. Distinct from the format constants above and used only to choose
 // how a base is resolved: `_Unwind_GetGR` is not a supported query for the SP
@@ -465,17 +482,27 @@ fn parse_gc_map(bytes: &[u8]) -> Option<(Vec<StackMapRecord>, Vec<StackMapLocati
         }
         let function_count = read_u32(bytes, base + 8)? as usize;
         let total_len = read_u32(bytes, base + 12)? as usize;
+        // Header flags, bit 0: the function-address field is 8 bytes wide. The
+        // emitter writes the TARGET's pointer width (watchOS `arm64_32` is
+        // ILP32), and compile target and run target are the same machine — so
+        // a mismatch here means the binary's map was produced for a different
+        // width and every function address would be misread. Fail closed.
+        let flags = read_u16(bytes, base + 6)?;
+        if (flags & 1 == 1) != (std::mem::size_of::<usize>() == 8) {
+            return None;
+        }
+        let entry = if flags & 1 == 1 { 16 } else { 12 };
         // A blob must at least cover its header and function table. Without
         // this, a `total_len` of 0 leaves `base` unchanged — and because the
         // magic still matches at that offset the resynchronisation path below
         // is never reached, so the loop spins forever. This runs inside
         // `OnceLock::get_or_init`, so that is a process hang at the first
         // collection rather than the fail-closed panic in `stack_maps`.
-        if total_len < 16 + function_count.checked_mul(16)? {
+        if total_len < 16 + function_count.checked_mul(entry)? {
             return None;
         }
         let table = base.checked_add(16)?;
-        let stream_start = table.checked_add(function_count.checked_mul(16)?)?;
+        let stream_start = table.checked_add(function_count.checked_mul(entry)?)?;
         let blob_end = base.checked_add(total_len)?;
         if blob_end > bytes.len() || stream_start > blob_end {
             return None;
@@ -502,10 +529,17 @@ fn parse_gc_map(bytes: &[u8]) -> Option<(Vec<StackMapRecord>, Vec<StackMapLocati
         let mut record_index = 0usize;
 
         for index in 0..function_count {
-            let entry = table + index * 16;
-            let function_address = read_u64(bytes, entry)? as usize;
-            let stack_size = u64::from(read_u32(bytes, entry + 8)?);
-            let record_count = read_u32(bytes, entry + 12)? as usize;
+            // Address width follows the header flag checked above, so the
+            // stack-size and record-count offsets move with it.
+            let base_off = table + index * entry;
+            let addr_bytes = entry - 8;
+            let function_address = if addr_bytes == 8 {
+                read_u64(bytes, base_off)? as usize
+            } else {
+                read_u32(bytes, base_off)? as usize
+            };
+            let stack_size = u64::from(read_u32(bytes, base_off + addr_bytes)?);
+            let record_count = read_u32(bytes, base_off + addr_bytes + 4)? as usize;
 
             let mut previous: Option<(u32, u32)> = None;
             for _ in 0..record_count {
@@ -602,11 +636,9 @@ fn read_u8(bytes: &[u8], offset: usize) -> Option<u8> {
     bytes.get(offset).copied()
 }
 
-/// ELF section headers store their counts and offsets as 16-bit fields, so
-/// this is used only by `elf_section_vaddr`. Gated to Linux because the
-/// compact GC map itself needs no 16-bit reads — deleting it as "orphaned"
-/// after a macOS-only `cargo check` is what broke the Linux build.
-#[cfg(target_os = "linux")]
+/// Used by the map header's flags field and by ELF section headers. It was
+/// briefly Linux-gated, which broke the Linux build the moment the map itself
+/// needed a 16-bit read — keep it unconditional.
 fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
     Some(u16::from_le_bytes(
         bytes.get(offset..offset + 2)?.try_into().ok()?,
@@ -635,7 +667,7 @@ fn read_u64(bytes: &[u8], offset: usize) -> Option<u64> {
 /// 64-bit only: watchOS's `arm64_32` has 32-bit pointers, while the map stores
 /// function addresses as `u64` and this code does `usize` arithmetic on them.
 /// The compiler refuses that target for the same reason.
-#[cfg(all(target_vendor = "apple", target_pointer_width = "64"))]
+#[cfg(target_vendor = "apple")]
 fn loaded_stack_map_section() -> Option<&'static [u8]> {
     use mach2::dyld::{_dyld_get_image_header, _dyld_get_image_vmaddr_slide};
 
@@ -816,20 +848,14 @@ fn main_object_load_bias() -> Option<usize> {
     (bias != usize::MAX).then_some(bias)
 }
 
-#[cfg(not(any(
-    all(target_vendor = "apple", target_pointer_width = "64"),
-    target_os = "linux"
-)))]
+#[cfg(not(any(target_vendor = "apple", target_os = "linux")))]
 fn loaded_stack_map_section() -> Option<&'static [u8]> {
     None
 }
 
 // Same platform set as the loader above: the Itanium unwinder personality and
 // `_Unwind_*` API are present on every Apple platform, not just macOS.
-#[cfg(any(
-    all(target_vendor = "apple", target_pointer_width = "64"),
-    target_os = "linux"
-))]
+#[cfg(any(target_vendor = "apple", target_os = "linux"))]
 mod unwind {
     use super::*;
 
@@ -902,7 +928,7 @@ mod unwind {
                 let base = if location.dwarf_reg == ARCH_DWARF_SP {
                     let cfa = _Unwind_GetCFA(context);
                     match cfa
-                        .checked_sub(std::mem::size_of::<usize>())
+                        .checked_sub(CFA_RETURN_ADDRESS_BYTES)
                         .and_then(|v| v.checked_sub(record.stack_size as usize))
                     {
                         Some(sp) => sp,
@@ -932,10 +958,7 @@ mod unwind {
     }
 }
 
-#[cfg(not(any(
-    all(target_vendor = "apple", target_pointer_width = "64"),
-    target_os = "linux"
-)))]
+#[cfg(not(any(target_vendor = "apple", target_os = "linux")))]
 mod unwind {
     use super::*;
 
@@ -962,10 +985,7 @@ mod unwind {
 /// (a rewritten slot no longer points at a forwarded object), so a partial
 /// fast walk followed by a full unwinder walk is safe.
 #[cfg(all(
-    any(
-        all(target_vendor = "apple", target_pointer_width = "64"),
-        target_os = "linux"
-    ),
+    any(target_vendor = "apple", target_os = "linux"),
     target_arch = "aarch64"
 ))]
 mod fp_chain {
@@ -1126,10 +1146,7 @@ mod fp_chain {
 }
 
 #[cfg(not(all(
-    any(
-        all(target_vendor = "apple", target_pointer_width = "64"),
-        target_os = "linux"
-    ),
+    any(target_vendor = "apple", target_os = "linux"),
     target_arch = "aarch64"
 )))]
 mod fp_chain {
@@ -1191,14 +1208,23 @@ mod tests {
             }
         }
 
-        let total_len = 16 + 16 + offsets.len() + stream.len();
+        // Build for THIS host's pointer width, mirroring the emitter: the
+        // decoder rejects a blob whose recorded width disagrees with its own.
+        let ptr64 = std::mem::size_of::<usize>() == 8;
+        let entry = if ptr64 { 16 } else { 12 };
+        let total_len = 16 + entry + offsets.len() + stream.len();
         let mut bytes = Vec::new();
         bytes.extend_from_slice(GC_MAP_MAGIC);
         bytes.push(GC_MAP_VERSION);
-        bytes.extend_from_slice(&[0, 0, 0]);
+        bytes.push(0);
+        bytes.extend_from_slice(&u16::from(ptr64).to_le_bytes());
         bytes.extend_from_slice(&1u32.to_le_bytes());
         bytes.extend_from_slice(&(total_len as u32).to_le_bytes());
-        bytes.extend_from_slice(&function.to_le_bytes());
+        if ptr64 {
+            bytes.extend_from_slice(&function.to_le_bytes());
+        } else {
+            bytes.extend_from_slice(&(function as u32).to_le_bytes());
+        }
         bytes.extend_from_slice(&32u32.to_le_bytes());
         bytes.extend_from_slice(&(records.len() as u32).to_le_bytes());
         bytes.extend_from_slice(&offsets);
@@ -1325,6 +1351,21 @@ mod tests {
             }],
         );
         assert!(!index.chain_walkable);
+    }
+
+    #[test]
+    fn rejects_a_blob_built_for_the_other_pointer_width() {
+        // The header records the width the emitter used. A blob claiming the
+        // other width would have every function address misread, so it must be
+        // refused rather than decoded — watchOS `arm64_32` is ILP32 while every
+        // other supported target is LP64.
+        let mut bytes = simple(0x1000, 0x10, -8);
+        let flags = u16::from_le_bytes([bytes[6], bytes[7]]);
+        bytes[6..8].copy_from_slice(&(flags ^ 1).to_le_bytes());
+        assert!(
+            parse_gc_map(&bytes).is_none(),
+            "a map built for the other pointer width must be refused"
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -625,7 +625,17 @@ fn read_u64(bytes: &[u8], offset: usize) -> Option<u64> {
     ))
 }
 
-#[cfg(target_os = "macos")]
+/// Every 64-bit Apple platform, not only macOS. iOS, iPadOS (which reports as
+/// iOS), tvOS and visionOS are all aarch64 + Mach-O and share this loader
+/// verbatim; gating it to `target_os = "macos"` sent them to the stub below,
+/// where the section is never found and the index is empty — a collector with
+/// no native roots, silently, on exactly the platforms that cannot be debugged
+/// easily.
+///
+/// 64-bit only: watchOS's `arm64_32` has 32-bit pointers, while the map stores
+/// function addresses as `u64` and this code does `usize` arithmetic on them.
+/// The compiler refuses that target for the same reason.
+#[cfg(all(target_vendor = "apple", target_pointer_width = "64"))]
 fn loaded_stack_map_section() -> Option<&'static [u8]> {
     use mach2::dyld::{_dyld_get_image_header, _dyld_get_image_vmaddr_slide};
 
@@ -806,12 +816,20 @@ fn main_object_load_bias() -> Option<usize> {
     (bias != usize::MAX).then_some(bias)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(
+    all(target_vendor = "apple", target_pointer_width = "64"),
+    target_os = "linux"
+)))]
 fn loaded_stack_map_section() -> Option<&'static [u8]> {
     None
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+// Same platform set as the loader above: the Itanium unwinder personality and
+// `_Unwind_*` API are present on every Apple platform, not just macOS.
+#[cfg(any(
+    all(target_vendor = "apple", target_pointer_width = "64"),
+    target_os = "linux"
+))]
 mod unwind {
     use super::*;
 
@@ -914,7 +932,10 @@ mod unwind {
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(
+    all(target_vendor = "apple", target_pointer_width = "64"),
+    target_os = "linux"
+)))]
 mod unwind {
     use super::*;
 
@@ -940,7 +961,13 @@ mod unwind {
 /// whole scan through the platform unwinder. Slot visitation is idempotent
 /// (a rewritten slot no longer points at a forwarded object), so a partial
 /// fast walk followed by a full unwinder walk is safe.
-#[cfg(all(any(target_os = "macos", target_os = "linux"), target_arch = "aarch64"))]
+#[cfg(all(
+    any(
+        all(target_vendor = "apple", target_pointer_width = "64"),
+        target_os = "linux"
+    ),
+    target_arch = "aarch64"
+))]
 mod fp_chain {
     use super::*;
 
@@ -952,7 +979,10 @@ mod fp_chain {
         fp
     }
 
-    #[cfg(target_os = "macos")]
+    // `pthread_get_stackaddr_np` is Apple-wide, not macOS-only. Gating it to
+    // macOS is what broke the iOS build outright — which is the good outcome:
+    // the alternative was this module quietly not existing there.
+    #[cfg(target_vendor = "apple")]
     fn stack_top() -> usize {
         unsafe extern "C" {
             fn pthread_self() -> usize;
@@ -1095,7 +1125,13 @@ mod fp_chain {
     }
 }
 
-#[cfg(not(all(any(target_os = "macos", target_os = "linux"), target_arch = "aarch64")))]
+#[cfg(not(all(
+    any(
+        all(target_vendor = "apple", target_pointer_width = "64"),
+        target_os = "linux"
+    ),
+    target_arch = "aarch64"
+)))]
 mod fp_chain {
     use super::*;
 


### PR DESCRIPTION
`PERRY_RS4GC=1` was refused on anything but aarch64 (#7324). That refusal was correct — the collector segfaulted rather than reporting anything — but the cause turned out to be **one unsupported call**, not anything architectural.

## The bug

On x86-64 every root is `Indirect [RSP + off]` — DWARF register 7. The unwinder path resolved bases with `_Unwind_GetGR(context, reg)`, and **`_Unwind_GetGR` is not a supported query for the stack-pointer column**. It returned garbage, and the collector wrote through it. `_Unwind_GetCFA` is the supported way to reach a frame's stack pointer.

SP-relative roots now derive their base from the CFA: by the SysV/AAPCS definition the CFA is the caller's stack pointer immediately before the call, so this frame's body stack pointer sits one return-address slot plus the function's own frame below it — and `stack_size` is exactly that frame, already recorded per function in the map.

## What this deliberately does *not* change

The format's base tags stay **aarch64-literal**. My first attempt made them architecture-relative; `gc_map.rs` already documents why that's wrong:

> *"it would put the compiler's idea of the target and the runtime's `target_arch` in a position where disagreeing corrupts every root's base — a size win is not worth that"*

That reasoning holds, and x86-64 roots already round-trip correctly through the explicit-register tag. So the architecture's SP number is a **runtime-local** constant used only to pick a base-resolution strategy — no format change, no agreement hazard.

## Measured on real x86-64 Linux hardware

All ten gc-ratchet probes byte-match the pinned Node oracle under `PERRY_RS4GC=1 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`, with `.perry_gcmap` present in every binary.

The walker demonstrably ran rather than passing vacuously:

```json
"native_stack_maps": { "walks":1, "frames_visited":10, "records_matched":1,
                       "locations_visited":2, "fp_walks":0, "fallback_walks":1 }
```

`fp_walks=0` is correct — the fp-chain walker is aarch64-only, so the unwinder is the right path here. Evacuation genuinely moved objects (`retained_forwarded_stub_objects=5`).

**The same telemetry on aarch64 has the same shape** — `7/0/1/1` vs `10/0/1/1` on the same probes, and `2` locations on `09_try_catch_roots` on both. That equivalence is what makes this a result rather than a green light of unknown provenance.

## Caveat I want on the record

Those location counts are low **on both platforms**. The probes end in an explicit `gc()` — a manual collection from a shallow stack — so precise native roots are lightly exercised by this suite regardless of architecture. That is a pre-existing gate weakness, not something this change introduces, and it means the honest claim is *"x86-64 behaves identically to aarch64"* rather than *"x86-64 is heavily exercised"*.

Strengthening that suite is worth doing separately: a probe that collects from a deep stack with many live roots, without a manual `gc()`, would exercise the precise path on every platform.

---

## Update: Apple platforms (iOS, iPadOS, tvOS)

Same story as x86-64, different gate. iOS and iPadOS are **aarch64 + Mach-O — the same shape as macOS**, which already worked. They didn't, because the Mach-O loader, the unwinder module, the fp-chain walker and `stack_top` were each `#[cfg(target_os = "macos")]`.

On any other Apple platform that selected the no-section stub: `loaded_stack_map_section()` returned `None`, the index came out empty, and **the collector ran with no native roots at all** — silently, on the platforms hardest to debug. The compiler emitted the map; nothing read it.

All four gates are now one predicate: 64-bit Apple, or Linux. `pthread_get_stackaddr_np` is Apple-wide, and the `mach2` dependency was widened to match the code that uses it — declaring it for *fewer* targets than the loader compiles on is exactly how this stayed hidden.

**watchOS is refused, deliberately.** `arm64_32` has 32-bit pointers while the map stores function addresses as `u64` and the runtime does `usize` arithmetic on them. The check is ordered *before* the `arm64` prefix test so it actually fires, and it refuses rather than emitting a map nothing can read.

Verified by building `perry-runtime` for each target — `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `aarch64-apple-tvos` all compile. **That is what found the hole:** `stack_top` did not exist on iOS, so the build failed outright rather than quietly selecting the stub. `aarch64-apple-visionos` still fails inside the third-party `psm` build script, unrelated to this change.

Honest limit: this is compile-level verification. A device or simulator run is the evidence it does not yet have, and I'd want that before anyone calls iOS supported rather than plumbed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native garbage-collection root support for x86-64 on Linux and Apple platforms.
  * Extended native-root compatibility to iOS, iPadOS, and tvOS.
  * Improved stack-based root detection and frame handling across supported architectures.
  * Added support for additional Apple platform configurations and pointer sizes.

* **Bug Fixes**
  * Hardened stack-map parsing against invalid or incomplete data.
  * Improved validation across Mach-O and ELF systems.
  * Preserved safeguards for unsupported architectures, including watchOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->