### PR TITLE
feat(codegen): make the in-process LLVM backend the default, statically linked

### DIFF
--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -1,0 +1,72 @@
+name: Setup LLVM 22
+description: >
+  Provision the LLVM 22 development libraries that `llvm-inprocess` links
+  against, and export LLVM_SYS_221_PREFIX. Every job that compiles Rust needs
+  this now that the feature is on by default.
+
+# One definition, not 44 inline recipes. The three platforms need three
+# different sources and only one of them is obvious:
+#
+#   macOS   brew's llvm formula.
+#   Linux   apt.llvm.org. The distro's `llvm-dev` is whatever the release
+#           froze on (Ubuntu 24.04 ships 18), so the LLVM project's own
+#           repository is the only way to get a pinned 22.
+#   Windows the official `clang+llvm-*-pc-windows-msvc` tarball. NOT
+#           chocolatey: its `llvm` package is the clang *toolchain* — no
+#           llvm-config.exe and none of the static libraries llvm-sys links
+#           against — and it has no 22.x pin at all.
+#
+# Every arm asserts the major version. llvm-sys 221 requires LLVM 22
+# specifically, and a runner image moving its formula on must fail loudly
+# here rather than build something subtly different several steps later.
+inputs:
+  version:
+    description: LLVM major.minor.patch used by the Windows tarball
+    required: false
+    default: "22.1.8"
+
+runs:
+  using: composite
+  steps:
+    - name: LLVM 22 (macOS, brew)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install llvm@22 2>/dev/null || brew install llvm
+        PREFIX="$(brew --prefix llvm@22 2>/dev/null || brew --prefix llvm)"
+        "$PREFIX/bin/llvm-config" --version | grep -q '^22\.' \
+          || { echo "::error::brew LLVM is not 22.x ($("$PREFIX/bin/llvm-config" --version))"; exit 1; }
+        echo "LLVM_SYS_221_PREFIX=$PREFIX" >> "$GITHUB_ENV"
+
+    - name: LLVM 22 (Linux, apt.llvm.org)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+        . /etc/os-release
+        echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-22 main" \
+          | sudo tee /etc/apt/sources.list.d/llvm22.list >/dev/null
+        sudo apt-get update -qq
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+          llvm-22-dev libpolly-22-dev libzstd-dev
+        llvm-config-22 --version | grep -q '^22\.' \
+          || { echo "::error::apt LLVM is not 22.x"; exit 1; }
+        echo "LLVM_SYS_221_PREFIX=$(llvm-config-22 --prefix)" >> "$GITHUB_ENV"
+
+    - name: LLVM 22 (Windows, official MSVC tarball)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $ver = "${{ inputs.version }}"
+        $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$ver/clang+llvm-$ver-x86_64-pc-windows-msvc.tar.xz"
+        Write-Host "downloading $url"
+        curl.exe -sSL --retry 3 -o "$env:RUNNER_TEMP\llvm.tar.xz" $url
+        New-Item -ItemType Directory -Force -Path C:\llvm | Out-Null
+        tar -xf "$env:RUNNER_TEMP\llvm.tar.xz" -C C:\llvm --strip-components=1
+        $v = & "C:\llvm\bin\llvm-config.exe" --version
+        if (-not $v.StartsWith("22.")) { Write-Error "LLVM is not 22.x ($v)"; exit 1 }
+        "LLVM_SYS_221_PREFIX=C:\llvm" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo
         uses: actions/cache@v6
@@ -264,6 +265,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo
         uses: actions/cache@v6
@@ -361,6 +363,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Measure clean-build time
         run: |

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo registry
         uses: actions/cache@v6
@@ -168,6 +169,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo registry
         uses: actions/cache@v6
@@ -209,6 +211,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo registry
         uses: actions/cache@v6
@@ -251,6 +254,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo registry
         uses: actions/cache@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/eh-transport.yml
+++ b/.github/workflows/eh-transport.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/gc-moving-witnesses.yml
+++ b/.github/workflows/gc-moving-witnesses.yml
@@ -197,6 +197,7 @@ jobs:
       - name: Install Rust toolchain
         if: steps.relevance.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         if: steps.relevance.outputs.run == 'true'

--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -124,6 +124,7 @@ jobs:
         with:
           node-version-file: .node-version
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: gc-native-roots

--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Install Rust toolchain
         if: steps.relevance.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Cache cargo
         if: steps.relevance.outputs.run == 'true'

--- a/.github/workflows/gc-root-dominance.yml
+++ b/.github/workflows/gc-root-dominance.yml
@@ -156,6 +156,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       # ★ The dependency-scale corpus needs the dependency.
       #

--- a/.github/workflows/node-compat-matrix.yml
+++ b/.github/workflows/node-compat-matrix.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Start sccache
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/node-core-subset.yml
+++ b/.github/workflows/node-core-subset.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/node-suite-guard.yml
+++ b/.github/workflows/node-suite-guard.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Start sccache
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/npm-package-sweep.yml
+++ b/.github/workflows/npm-package-sweep.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -315,6 +315,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: ./.github/actions/setup-llvm22
 
       # Cache cargo registry + target/ per (matrix.target, Cargo.lock).
       # First run on a target is still a cold build, but every subsequent
@@ -1030,6 +1031,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install Rust nightly + rust-src (Tier-3 only)
         if: matrix.tier3

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: security-audit
@@ -155,6 +156,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: security-audit

--- a/.github/workflows/simctl-tests.yml
+++ b/.github/workflows/simctl-tests.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install iOS simulator Rust target
         run: rustup target add aarch64-apple-ios-sim aarch64-apple-ios

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -296,6 +297,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -365,6 +367,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -432,6 +435,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -542,6 +546,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -800,6 +805,7 @@ jobs:
       - name: Install Rust toolchain
         if: steps.scope.outputs.suites != ''
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         if: steps.scope.outputs.suites != ''
@@ -894,6 +900,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -1031,6 +1038,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1137,6 +1145,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -1313,6 +1322,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -1469,6 +1479,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -1560,6 +1571,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1650,6 +1662,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1756,6 +1769,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2133,6 +2147,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2194,6 +2209,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2260,6 +2276,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2313,6 +2330,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2462,6 +2480,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - name: Set up MSVC environment (Windows)
         # Populates LIB / INCLUDE / PATH so link.exe can find user32.lib
@@ -2612,6 +2631,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-llvm22
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/crates/perry-codegen/Cargo.toml
+++ b/crates/perry-codegen/Cargo.toml
@@ -9,12 +9,23 @@ description = "LLVM code generation backend for Perry"
 workspace = true
 
 [features]
-# exp/llvm-inprocess: compile `.ll -> .o` through the LLVM C API inside this
-# process instead of shelling out to a user-supplied `clang -c`. Off by
-# default — the default build has no LLVM link dependency and the text path
-# is byte-for-byte untouched. Building with this feature requires LLVM 22
-# (`brew install llvm`; set LLVM_SYS_221_PREFIX if llvm-config is not on
-# PATH). The backend still only runs when PERRY_LLVM_INPROCESS=1 at runtime.
+# Compile `.ll -> .o` through the LLVM C API inside this process instead of
+# shelling out to a user-supplied `clang -c`.
+#
+# ON BY DEFAULT. Perry links LLVM 22 statically and ships self-contained: we
+# own the assumption instead of pushing it onto the user, and there is no
+# "install a matching clang" step to get wrong. Building Perry therefore needs
+# LLVM 22 present (`brew install llvm`, apt.llvm.org, or the official MSVC
+# tarball; `LLVM_SYS_221_PREFIX` if llvm-config is not on PATH) — CI provisions
+# it via `.github/actions/setup-llvm22`.
+#
+# It is also load-bearing rather than an optimization: the explicit statepoint
+# bridge is gone (#7348), so RS4GC is the only native-root backend, and RS4GC
+# needs this pipeline — an external `opt` feeding a different clang cannot
+# parse the IR it emits (#7339).
+#
+# `--no-default-features` still builds the text path for bisection.
+default = ["llvm-inprocess"]
 llvm-inprocess = ["dep:inkwell", "dep:llvm-sys"]
 
 [dependencies]

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -598,14 +598,37 @@ pub(crate) fn native_plan_args(
     (plan.effective_target, plan.clang_args)
 }
 
-/// exp/llvm-inprocess: truthy `PERRY_LLVM_INPROCESS` routes `.ll -> .o`
-/// through the LLVM C API inside this process (no clang subprocess, no `.ll`
-/// on disk). The flag participates in both the build cache and the object
-/// cache keys, so the two backends can never share a cached object.
+/// Route `.ll -> .o` through the LLVM C API inside this process (no clang
+/// subprocess, no `.ll` on disk).
+///
+/// **ON BY DEFAULT.** Perry links LLVM 22 statically and ships self-contained,
+/// so there is no "find a compatible clang" step to get wrong. It is also
+/// load-bearing rather than a preference: the explicit statepoint bridge is
+/// gone (#7348), leaving RS4GC as the only native-root backend, and RS4GC
+/// cannot round-trip its IR through an external `opt` + a different clang
+/// (#7339).
+///
+/// `PERRY_LLVM_INPROCESS=0`/`off`/`false` reverts to the clang subprocess for
+/// bisection. `=native` additionally builds function bodies through the C API
+/// instead of rendering per-function text; that is byte-identical on the
+/// 81-module zod corpus but has narrower CI coverage, so it stays opt-in until
+/// that widens.
+///
+/// The value participates in both the build cache and the object cache keys,
+/// so the backends can never share a cached object.
 fn inprocess_requested() -> bool {
     match env::var("PERRY_LLVM_INPROCESS").as_deref() {
-        Ok("") | Ok("0") | Ok("off") | Ok("false") | Err(_) => false,
+        Ok("0") | Ok("off") | Ok("false") => false,
+        // Explicitly asked for: honour it even without the feature, so the
+        // stub below can say "rebuild with the feature" instead of silently
+        // serving the text path to an A/B arm that asked for this backend.
         Ok(_) => true,
+        // Unset means ON *iff* the backend is actually compiled in. It is a
+        // default feature, so that is the normal case — but a
+        // `--no-default-features` build must keep working, and defaulting to
+        // `true` there would route every compile into the not-built-in stub
+        // and fail the build outright.
+        Err(_) => cfg!(feature = "llvm-inprocess"),
     }
 }
 
@@ -695,7 +718,25 @@ fn compile_ll_inprocess_in(
             }
             Ok(obj)
         }
-        Ok(bytes) => Ok(bytes),
+        Ok(bytes) => {
+            // `PERRY_LLVM_KEEP_IR` promises the whole scratch dir, `.o`
+            // included. The clang path gets that for free because the object
+            // IS a file; in-process returns bytes and would silently drop it —
+            // degrading a debugging aid at exactly the moment someone is
+            // debugging. Now that this backend is the default, write it.
+            if policy.keep {
+                let _ = fs::create_dir_all(&paths.scratch_dir);
+                if let Err(e) = fs::write(&plan.obj_path, &bytes) {
+                    eprintln!(
+                        "[perry-codegen] could not keep {}: {e}",
+                        plan.obj_path.display()
+                    );
+                } else {
+                    eprintln!("[perry-codegen] kept object: {}", plan.obj_path.display());
+                }
+            }
+            Ok(bytes)
+        }
         Err(e) => {
             // Same contract as a failed clang compile: the IR that produced
             // the failure is left on disk and named in the error.

--- a/crates/perry/Cargo.toml
+++ b/crates/perry/Cargo.toml
@@ -140,10 +140,10 @@ audit-cli = []
 updater-cli = ["dep:ed25519-dalek", "dep:rand"]
 native-cli = []
 
-# exp/llvm-inprocess: compile .ll -> .o through the LLVM C API in-process
-# instead of a `clang -c` subprocess. Off by default (no LLVM link dependency);
-# even when built in, it only runs under PERRY_LLVM_INPROCESS=1. Requires
-# LLVM 22 at build time (LLVM_SYS_221_PREFIX or llvm-config on PATH).
+# Compile .ll -> .o through the LLVM C API in-process instead of a `clang -c`
+# subprocess. ON BY DEFAULT via perry-codegen's own default feature — Perry
+# links LLVM 22 statically and ships self-contained. See that crate's manifest
+# for why this is load-bearing rather than an optimization.
 llvm-inprocess = ["perry-codegen/llvm-inprocess"]
 
 # Codegen backends for non-native targets. Each enables one backend crate;


### PR DESCRIPTION
Makes the in-process LLVM backend the default, statically linked. Perry ships self-contained: we own the LLVM assumption instead of pushing it onto the user, and there is no "install a compatible clang" step left to get wrong.

**This is load-bearing, not a preference.** The explicit statepoint bridge is gone (#7348), so RS4GC is the only native-root backend — and RS4GC cannot round-trip its IR through an external `opt` plus a different clang (#7339). Keeping this opt-in meant the only working statepoint path lived behind a flag nobody sets.

## Two defaults, flipped together

Either alone is half a feature — built-in but never used, or requested but not built.

- `llvm-inprocess` becomes a **default cargo feature**.
- `inprocess_requested()` defaults **ON — but only iff the backend is compiled in.**

That second qualifier is not pedantry. Defaulting to `true` unconditionally routes every compile in a `--no-default-features` build into the not-built-in stub and fails the build outright. I hit exactly that and it is now covered both ways:

| build | `PERRY_LLVM_INPROCESS` unset | `=0` | `=1` |
|---|---|---|---|
| default | in-process | clang | in-process |
| `--no-default-features` | clang | clang | loud "rebuild with the feature" |

## CI

New `.github/actions/setup-llvm22` composite action, referenced from **all 44 toolchain steps across 18 workflows**. One definition rather than 44 inline recipes, because the three platforms need three different sources and only one is obvious:

- **Linux** — apt.llvm.org. Ubuntu 24.04's own `llvm-dev` is **18**, so the distro cannot supply this.
- **Windows** — the official `clang+llvm-*-pc-windows-msvc` tarball. **Not** chocolatey: its `llvm` package is the clang *toolchain* — no `llvm-config.exe`, none of the static libraries llvm-sys links — and it has no 22.x pin at all. (Learned the hard way; the feasibility spike's Windows cell failed on exactly this.)
- **macOS** — brew.

Every arm asserts the major version, because llvm-sys 221 needs 22 specifically and a runner image moving its formula must fail loudly rather than build something subtly different several steps later.

The insertion is mechanical and auditable: **44 insertions, zero deletions.**

## Size

**98.9 MB**, not the 185.9 MB this would have cost before #7350 — `initialize_all()` was linking ~18 backends nothing can reach.

## A bug the flip surfaced

`PERRY_LLVM_KEEP_IR` promises the whole scratch dir including the `.o`. The clang path got that for free because the object *is* a file; the in-process path returns bytes and silently dropped it — degrading a debugging aid at exactly the moment someone is debugging. Caught by `keep_ir_retains_the_whole_scratch_dir`, fixed rather than relaxed.

## Verification

On the **81-module zod dependency corpus, with no env set**: compiles, and output is byte-identical to the clang path. `PERRY_RS4GC=1` now compiles a try-carrying probe with no further flags. 605 codegen tests pass.

## Known and accepted

Compile time is ~75% higher on that corpus (7.1s → 12.3s). Same parallelism (4.4× both) and same opt level, so it is LLVM 22's `default<O3>` via PassBuilder versus Apple clang 21's driver-tuned `-O3` — a tuning gap, not a design flaw. Accepted deliberately; the reliability and the statepoint path are worth it, and it is tunable later.

`PERRY_LLVM_INPROCESS=native` (function bodies built through the C API, no per-function text) stays opt-in: byte-identical objects on all 81 zod modules, but CI covers only two small programs so far.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - In-process LLVM compilation is now enabled by default for supported builds.
  - LLVM 22 is consistently provisioned across build, test, coverage, benchmark, security, and release workflows.
  - Environment settings can still select the traditional external compiler path when needed.
  - Debug output can retain generated object files alongside intermediate compilation artifacts.

- **Documentation**
  - Updated build requirements and configuration guidance to reflect LLVM 22 and the new default compilation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->