### PR TITLE
ci: stop three main gates being starved to zero executions (#7205)

### DIFF
--- a/.github/workflows/eh-transport.yml
+++ b/.github/workflows/eh-transport.yml
@@ -32,9 +32,13 @@ on:
     branches: [main]
 
 concurrency:
-  group: eh-transport-${{ github.ref }}
-  # Cancel superseded PR runs, never main runs — a busy merge day would
-  # otherwise starve the gate to zero executions.
+  group: eh-transport-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  # One group per main COMMIT, cancelling PR runs only. `cancel-in-progress:
+  # false` alone does not protect a `main` run: GitHub allows at most one
+  # PENDING run per group and cancels the previously pending one when a new run
+  # enters, regardless of that setting. That is #7205 — measured here as EIGHT
+  # consecutive `main` runs cancelled, zero executions. Keying push runs on the
+  # SHA gives every merged commit a group of its own.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/llvm-inprocess.yml
+++ b/.github/workflows/llvm-inprocess.yml
@@ -20,9 +20,13 @@ on:
     branches: [main]
 
 concurrency:
-  group: llvm-inprocess-${{ github.ref }}
-  # Gate-trap 3: cancel superseded PR runs, but NEVER cancel main runs — a
-  # busy merge day would otherwise starve the gate to zero executions.
+  group: llvm-inprocess-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  # One group per main COMMIT, cancelling PR runs only. `cancel-in-progress:
+  # false` alone does not protect a `main` run: GitHub allows at most one
+  # PENDING run per group and cancels the previously pending one when a new run
+  # enters, regardless of that setting. That is #7205 — measured here as EIGHT
+  # consecutive `main` runs cancelled, zero executions. Keying push runs on the
+  # SHA gives every merged commit a group of its own.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,8 +12,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: security-audit-${{ github.ref }}
-  cancel-in-progress: true
+  # One group per main COMMIT, cancelling PR runs only. Two separate problems
+  # were live here, and this is a REQUIRED status check: it had NINE cancelled
+  # `main` runs and zero executions.
+  #
+  # `cancel-in-progress: true` cancels main runs outright, and even `false`
+  # would not have been enough — GitHub allows at most one PENDING run per
+  # group and cancels the previously pending one when a new run enters,
+  # regardless of that setting (#7205). Keying push runs on the SHA gives every
+  # merged commit a group of its own.
+  group: security-audit-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   security-audit:


### PR DESCRIPTION
Measured on `main`, last ~10 runs each:

| workflow | cancelled | success | |
|---|---:|---:|---|
| `security-audit` | **9** | **0** | **required status check** |
| `eh-transport` | 8 | 0 | |
| `llvm-inprocess` | 8 | 0 | gate for the backend #7353 just defaulted |
| `gc-moving-witnesses` | 0 | 2 | already fixed by #7205 |

**Two of the three had a comment claiming they were already safe:**

> "Cancel superseded PR runs, never main runs — a busy merge day would otherwise starve the gate to zero executions."

A busy merge day starved them anyway, by a mechanism that comment didn't anticipate. `cancel-in-progress: false` is **not sufficient**: GitHub allows at most one *pending* run per concurrency group and cancels the previously pending one when a new run enters, regardless of that setting. With the group keyed on `github.ref`, every main push shares one group, so a merge burst cancels the intermediates.

`gc-moving-witnesses.yml` already carries both the diagnosis and the fix (#7205) — keying push runs on `github.sha` so every merged commit gets its own group. This applies it to the three still on the old shape. `security-audit` additionally had `cancel-in-progress: true`, which cancels main runs outright.

## How it was found, because the method matters

Not by reading the config — two of these *looked* correct, and I'd have skipped them. It came from watching what main runs actually **concluded** after the flip: a `cancelled` notification that looked benign turned out to be the eighth in a row.

That's CLAUDE.md's hazard 3 in a form the existing guard was written against and still didn't stop.

`cache-warm` is also 9/9 cancelled but deliberately left alone — it's an idempotent cache warmer, where cancelling a superseded run is the intended behaviour.

Config-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated validation workflows so independent commits can complete without being cancelled by newer changes.
  * Pull-request checks remain cancellable when superseded, reducing unnecessary resource usage while preserving faster feedback.
  * Scheduled security audits now run to completion reliably, improving the consistency of ongoing project checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->