### PR TITLE
fix(gc): stop reading a string's bytes after the string moved

### DIFF
--- a/changelog.d/7358-string-borrow-across-alloc.md
+++ b/changelog.d/7358-string-borrow-across-alloc.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **A string's bytes could be read after the string moved.** Two runtime
+  helpers derived a raw pointer into a `StringHeader`'s payload, then allocated,
+  then copied *from that pointer*. An evacuating minor inside the allocation
+  relocates the string, so the copy read retired from-space —
+  `js_buffer_from_string` (`Buffer.from(str)`) and `js_text_encoder_encode_llvm`
+  (`TextEncoder.encode`).
+
+  Not observable from output: evacuation copies rather than zeroes, so the stale
+  address still held the correct bytes and both produced right answers.
+  `PERRY_GC_PROTECT_FROMSPACE=1` unmaps retired from-space and turns the latent
+  read into a fault — which is how they were found (#7341).
+
+  Fixed with a no-move window rather than a root: the borrow is a raw slice
+  handed to a callee that reads it at an arbitrary point, so rooting the header
+  would leave the slice stale anyway. Each window covers one bounded
+  allocate-and-copy.
+
+  Closes **13 of the 54** quarantine catches across the gap suite.

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -20,6 +20,19 @@ pub extern "C" fn js_buffer_from_string(
         return buffer_alloc(0);
     }
 
+    // #7341: `str_bytes` borrows the StringHeader's payload, and every arm of
+    // `buffer_from_str_bytes` allocates before reading it — the UTF-8 arm most
+    // plainly: `buffer_alloc(len)` then `copy_nonoverlapping(str_bytes...)`.
+    // An evacuating minor inside that allocation relocates the string, leaving
+    // the slice pointing at retired from-space, and the copy reads it. That is
+    // the stale-`memmove` fault the from-space quarantine reports.
+    //
+    // A no-move window rather than a root: the borrow is not a value we can
+    // reload, it is a raw slice handed to a callee that reads it at an
+    // arbitrary point, so rooting the header would still leave the slice
+    // stale. The window covers one bounded allocate-and-copy — the same
+    // argument #7249 made for the globalThis bootstrap.
+    let _no_move = crate::gc::GcSuppressScope::new();
     unsafe {
         let len = (*str_ptr).byte_len as usize;
         let data_ptr = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());

--- a/crates/perry-runtime/src/text.rs
+++ b/crates/perry-runtime/src/text.rs
@@ -249,6 +249,11 @@ pub extern "C" fn js_text_decoder_ignore_bom(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_text_encoder_encode_llvm(value: f64) -> i64 {
     let str_ptr = text_encoder_string_ptr(value);
+    // #7341: `data_ptr` points into the StringHeader's payload and is read by
+    // the copy BELOW `buffer_alloc`. An evacuating minor inside that
+    // allocation relocates the string and the copy reads retired from-space —
+    // the same stale-`memmove` fault as `js_buffer_from_string`.
+    let _no_move = crate::gc::GcSuppressScope::new();
     let (data_ptr, len) = unsafe {
         let l = (*str_ptr).byte_len as usize;
         let d = (str_ptr as *const u8).add(std::mem::size_of::<StringHeader>());


### PR DESCRIPTION
Closes 13 of the 54 quarantine catches from #7341.

## The bug

Two runtime helpers derive a raw pointer into a `StringHeader`'s payload, then allocate, then copy **from that pointer**:

```rust
let data_ptr = (str_ptr as *const u8).add(size_of::<StringHeader>());
let buf = buffer_alloc(len);                    // ← can drive an evacuating minor
copy_nonoverlapping(data_ptr, buffer_data_mut(buf), len);   // ← reads the moved-from address
```

- `js_buffer_from_string` — `Buffer.from(str)`
- `js_text_encoder_encode_llvm` — `TextEncoder.encode(str)`

**Invisible from program output.** Evacuation copies rather than zeroes, so the stale address still holds the correct bytes and both produce right answers. `PERRY_GC_PROTECT_FROMSPACE=1` unmaps retired from-space and turns the latent read into a fault — which is how they were found. Both now fault **0/8** and stay byte-identical to Node.

## Why a no-move window, not a root

The borrow is a raw slice handed to a callee that reads it at an arbitrary point, so rooting the header would leave the *slice* stale regardless. Each window covers exactly one bounded allocate-and-copy — the same argument #7249 made for the globalThis bootstrap, where rooting every holder was unbounded and the window cost nothing a collection would have recovered.

## Negative result, recorded so nobody repeats it

The obvious next move is to generalise, and I tried it. A regex for the same shape — derive a payload pointer, then allocate within 25 lines — found **34 sites**. I split them into 28 bounded and 6 loop-carrying (a window inside `js_array_join`'s loop would be unbounded memory, which is worse than the bug), and applied the window to all 28.

**It closed zero additional catches.** The sweep stayed at exactly 41, with an identical signature mix (26 `GC_TYPE_STRING`, 8 `GC_TYPE_PROMISE`, 7 `GC_TYPE_OBJECT`, 2 `GC_TYPE_CLOSURE`).

So: **pattern-matched sites are not the faulting sites.** Only backtraces found real ones — the same lesson as the static parameter census, where 3 of 3 hand-checked hits were false positives. Those 26 speculative suppressions are deliberately **not** in this PR; shipping GC suppressions that demonstrably fix nothing is added risk for no benefit.

The remaining 41 need the same treatment that worked here: `--debug-symbols`, a backtrace, and the triage rule that if the faulting helper already has a `RuntimeHandleScope`, the bug is in its caller.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `Buffer.from(str)` could read stale data during string conversion.
  - Fixed potential data corruption in `TextEncoder.encode` during buffer allocation.
  - Improved reliability when garbage collection occurs while encoding or copying string data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->