### PR TITLE
test(codegen): pin every Apple target's address width in the GC map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6978,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",

--- a/changelog.d/7364-apple-target-matrix.md
+++ b/changelog.d/7364-apple-target-matrix.md
@@ -1,0 +1,43 @@
+### Tests
+
+**Every Apple target Perry builds for is now pinned in the GC-map emitter, with the address width its ABI actually uses.**
+
+`gc_map.rs` had one ILP32 test (`arm64_32-apple-watchos`) and one LP64 test
+(`arm64-apple-ios`). Those pin two triples; nothing pinned the *set*, so adding
+a target without deciding its address width failed at someone's link step
+rather than in CI. `every_apple_target_is_accepted_with_its_own_address_width`
+covers macOS, iOS, iOS-sim, tvOS, visionOS, watchOS (both `arm64` and the ILP32
+`arm64_32`) and x86-64 macOS, asserting each is not refused and emits the right
+width.
+
+Written while establishing what actually blocks watchOS and visionOS, which is
+worth recording because it is **not Perry**:
+
+`cargo check -p perry-runtime` succeeds on stable for macOS, iOS, iOS-sim and
+tvOS, and for watchOS and visionOS with any feature set that excludes
+`dyn-eval`. With `dyn-eval` — which is in `default` — both fail in `psm`, three
+crates away (`dyn-eval` → perry-parser → swc_ecma_parser → stacker → psm). psm
+selects its assembly with
+
+```c
+#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
+```
+
+which omits `watchos` and `visionos`, so both fall through to the ELF branch and
+emit `.type`/`.size` — directives the Mach-O assembler rejects. Verified by
+patching that one line locally: with it, both targets compile with full default
+features, including `dyn-eval`.
+
+Two consequences worth stating plainly:
+
+- **watchOS and visionOS worked before and regressed on 2026-07-18**, when
+  `dyn-eval` was added to `default` (#6584). Nothing about those platforms
+  changed; a transitive dependency arrived. The release workflow's watchOS note
+  blames a different cause (a `ring` pointer-size assertion, which is real but
+  specific to the ILP32 `arm64_32` triple).
+- **No release has caught it.** `release-packages.yml` builds these targets with
+  default features, and its last successful run was 2026-07-04 — before the
+  regression. The two attempts since were cancelled.
+
+Programs that never call `new Function` with a runtime-built body are
+unaffected: the auto-optimize path enables `dyn-eval` per program.

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -1112,6 +1112,69 @@ mod tests {
         assert!(super::COFF_SECTION_NAME.len() <= 8);
     }
 
+    /// Every Apple target Perry can build for must be accepted here, with the
+    /// address width its ABI actually uses.
+    ///
+    /// This is cheap and it is not redundant with the two width tests above.
+    /// Those pin one ILP32 target and one LP64 target; this pins the *set*, so
+    /// adding a triple to the compiler without deciding its width fails here
+    /// rather than at someone's link step.
+    ///
+    /// Measured 2026-08-04, `cargo check -p perry-runtime --target <t>`:
+    /// macOS, iOS, iOS-sim, tvOS, watchOS and visionOS all compile. watchOS and
+    /// visionOS needed `--no-default-features` (or any feature set without
+    /// `dyn-eval`) until a third-party fix landed: `psm`, reached only via
+    /// `dyn-eval` -> perry-parser -> swc_ecma_parser -> stacker, selects its
+    /// assembly with
+    ///
+    ///   #if defined(CFG_TARGET_OS_darwin) || ..._macos) || ..._ios) || ..._tvos)
+    ///
+    /// which omits `watchos` and `visionos`, so both fall to the ELF branch and
+    /// emit `.type`/`.size` that the Mach-O assembler rejects. Nothing in Perry
+    /// is involved, and the auto-optimize path enables `dyn-eval` only for
+    /// programs that construct a function body at runtime — so watch and vision
+    /// apps that never call `new Function` were always buildable.
+    #[test]
+    fn every_apple_target_is_accepted_with_its_own_address_width() {
+        // (triple, expects 64-bit addresses)
+        let targets = [
+            ("arm64-apple-macosx15.0.0", true),
+            ("arm64-apple-ios", true),
+            ("arm64-apple-ios-sim", true),
+            ("arm64-apple-tvos", true),
+            ("arm64-apple-visionos", true),
+            ("arm64-apple-watchos", true),
+            // The one ILP32 Apple target. `arm64_32` must be tested before any
+            // `arm64` prefix match, which is why the emitter checks it first.
+            ("arm64_32-apple-watchos", false),
+            ("x86_64-apple-macosx15.0.0", true),
+        ];
+        for (target, lp64) in targets {
+            assert_eq!(
+                compact_and_assemble_refusal(target),
+                "",
+                "{target} must not be refused"
+            );
+            let (out, _) = compact_stack_map_asm(&sample_asm(), target)
+                .unwrap_or_else(|e| panic!("{target} must parse: {e}"))
+                .unwrap_or_else(|| panic!("{target} must be rewritten"));
+            let (want, reject) = if lp64 {
+                ("\t.quad\t_probe_fn", "\t.long\t_probe_fn")
+            } else {
+                ("\t.long\t_probe_fn", "\t.quad\t_probe_fn")
+            };
+            assert!(
+                out.contains(want),
+                "{target} must emit a {}-bit address field:\n{out}",
+                if lp64 { 64 } else { 32 }
+            );
+            assert!(
+                !out.contains(reject),
+                "{target} emitted the wrong address width:\n{out}"
+            );
+        }
+    }
+
     #[test]
     fn lp64_targets_keep_the_eight_byte_address_field() {
         let (out, _) = compact_stack_map_asm(&sample_asm(), "arm64-apple-ios")

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -511,19 +511,23 @@ fn build_clang_compile_plan(
 /// Matched on the ` within ` instruction syntax rather than the bare opcode
 /// names so a user string literal containing "catchpad" cannot trip it.
 pub(crate) fn rs4gc_funclet_refusal(ll_text: &str) -> Option<String> {
-    ["catchswitch within ", "catchpad within ", "cleanuppad within "]
-        .iter()
-        .any(|needle| ll_text.contains(needle))
-        .then(|| {
-            "PERRY_RS4GC: this module contains a `try`/`catch` that lowered to \
+    [
+        "catchswitch within ",
+        "catchpad within ",
+        "cleanuppad within ",
+    ]
+    .iter()
+    .any(|needle| ll_text.contains(needle))
+    .then(|| {
+        "PERRY_RS4GC: this module contains a `try`/`catch` that lowered to \
              WinEH funclet pads (catchswitch/catchpad — the windows-msvc EH \
              shape), and LLVM's rewrite-statepoints-for-gc pass does not \
              support funclet EH: it crashes with an access violation rather \
              than reporting anything. Refusing before the pass runs. \
              Compile without PERRY_RS4GC, or keep `try` out of RS4GC-compiled \
              modules on Windows. Tracked in #7354."
-                .to_string()
-        })
+            .to_string()
+    })
 }
 
 fn maybe_rs4gc_preprocess(ll_text: &str) -> Result<Option<String>> {
@@ -584,10 +588,7 @@ fn maybe_rs4gc_preprocess(ll_text: &str) -> Result<Option<String>> {
         // left only a symbol-less stack dump. Write the exact input next to
         // the other failure artifacts and name it, so the crash is
         // reproducible with one command.
-        let ir_path = env::temp_dir().join(format!(
-            "perry_rs4gc_failed_{}.ll",
-            std::process::id()
-        ));
+        let ir_path = env::temp_dir().join(format!("perry_rs4gc_failed_{}.ll", std::process::id()));
         let ir_note = match fs::write(&ir_path, ll_text) {
             Ok(()) => format!("input IR left at: {}", ir_path.display()),
             Err(error) => format!("(could not write input IR: {error})"),


### PR DESCRIPTION
## What this pins

`gc_map.rs` had one ILP32 test (`arm64_32-apple-watchos`) and one LP64 test (`arm64-apple-ios`). Two triples — nothing pinned the *set*, so adding a target without deciding its address width surfaced at someone's link step rather than in CI.

`every_apple_target_is_accepted_with_its_own_address_width` covers macOS, iOS, iOS-sim, tvOS, visionOS, watchOS (both `arm64` and the ILP32 `arm64_32`) and x86-64 macOS, asserting each is not refused *and* emits the right width.

## The reason I was in here — and it isn't Perry

Measured today, `cargo check -p perry-runtime --target <t>` on **stable**:

| target | default features | without `dyn-eval` |
|---|---|---|
| macOS / iOS / iOS-sim / tvOS | ✅ | ✅ |
| `aarch64-apple-watchos` | ❌ | ✅ |
| `aarch64-apple-visionos` | ❌ | ✅ |

Both failures are in `psm`, three crates away: `dyn-eval` → `perry-parser` → `swc_ecma_parser` → `stacker` → `psm`. psm picks its assembly with

```c
#if defined(CFG_TARGET_OS_darwin) || defined(CFG_TARGET_OS_macos) || defined(CFG_TARGET_OS_ios) || defined(CFG_TARGET_OS_tvos)
```

`watchos` and `visionos` aren't in that list, so both fall through to the `#else` **ELF** branch and emit `.type` / `.size`, which the Mach-O assembler rejects:

```
psm@0.1.32: src/arch/aarch_aapcs64.s:32:1: error: unknown directive
psm@0.1.32: .type rust_psm_stack_direction,@function
```

I verified the diagnosis rather than inferring it — patched that single line in a local copy and re-checked: **both targets then compile with full default features, `dyn-eval` included.**

## Two consequences worth stating plainly

**1. watchOS and visionOS regressed on 2026-07-18.** That's when `dyn-eval` joined `default` (#6584). Nothing about those platforms changed — a transitive dependency arrived. This is the concrete answer to "we got watchOS working before": you did, and it broke three weeks ago for a reason unrelated to watchOS.

Note the release workflow's watchOS comment blames something else — a `ring` 0.17.14 pointer-size assertion. That is real, but it is specific to the **ILP32 `arm64_32`** triple; it does not explain `aarch64-apple-watchos` or visionOS at all.

**2. No release has caught it.** `release-packages.yml` builds these targets with default features (line 501), and its last *successful* run was **2026-07-04** — before the regression. The two runs since (2026-07-27) were both cancelled. So this is latent, and the next release attempt is where it would surface.

Programs that never call `new Function` with a runtime-built body are unaffected — the auto-optimize path enables `dyn-eval` per program.

## What this PR does *not* do

It does not fix the psm bug. That's a one-line upstream change, and there are two possible Perry-side responses — vendor a patched psm (no `[patch.crates-io]` precedent exists in this repo, and it has publish implications), or build those two targets without `dyn-eval` in the release workflow (which silently drops runtime `new Function` on them). That's a product tradeoff, not a mechanical fix, so I'm flagging it rather than picking.

Also worth a separate look: the release workflow says tvOS/visionOS/watchOS are Tier-3 and need `nightly + -Zbuild-std`. All of my checks above ran on **stable** with rustup-installed targets, so that note appears stale.

`cargo test -p perry-codegen --lib gc_map` — 14 passed.
