### PR TITLE
fix(gc): a RegExp's flags string was stored into the header already stale

### DIFF
--- a/changelog.d/7374-regexp-flags-stale-store.md
+++ b/changelog.d/7374-regexp-flags-stale-store.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **A `RegExp`'s `flags` string could be stored already-stale, permanently.**
+  `js_regexp_new` allocates the canonical flags string, then calls `gc_malloc`
+  for the header — a collection point — and then writes the *pre-collection*
+  flags pointer into `flags_ptr`. An evacuating minor inside that `gc_malloc`
+  moves the string, so a live `RegExpHeader` ends up holding a retired
+  from-space address for the rest of its life.
+
+  The pattern string was already rooted and re-read across exactly this
+  allocation, with a comment explaining why; the flags string was not. Now both
+  are.
+
+  This is the root cause of the `lookup_fancy_regex` cluster in #7341 — 5
+  catches reaching one read (`string_as_str((*re).flags_ptr)`) from four
+  different callers. Worth recording what it was *not*: a no-move window inside
+  `lookup_fancy_regex` closes 0/5, and rooting the search-value operand in
+  codegen closes 0/5. The helper and the call site were both innocent.
+
+  4 of the 5 cluster tests are now clean and a 6-line reproducer goes 6/6 → 0/6.

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -774,6 +774,19 @@ pub extern "C" fn js_regexp_new(
     // GC-survivable source table all agree on the canonical form, and the
     // header never holds the caller's possibly-temporary input flags.
     let canonical_flags_ptr = js_string_from_str(flags_str);
+    // ★ #7341: root the canonical flags string too. The `gc_malloc` below is an
+    // allocation and therefore a collection point, exactly as the comment above
+    // `pattern_root` says — but only the PATTERN was rooted and re-read. The
+    // flags string is created here and stored into the header AFTER that
+    // allocation, so an evacuating minor in `gc_malloc` moved it and the header
+    // kept the pre-collection address. `flags_ptr` is then permanently stale in
+    // a live header: `lookup_fancy_regex` reads it through `string_as_str` and
+    // faults on retired from-space, which is 5 of the 31 catches in #7341
+    // (four different callers, all reaching that one read).
+    //
+    // The write barrier below already treated this as a real GC edge; what was
+    // missing is that the value written had to survive the allocation first.
+    let flags_root = scope.root_string_ptr(canonical_flags_ptr);
     unsafe {
         let raw = crate::gc::gc_malloc(header_size, crate::gc::GC_TYPE_OBJECT);
         if raw.is_null() {
@@ -789,6 +802,8 @@ pub extern "C" fn js_regexp_new(
         // so the incoming argument may name from-space; the handle is a mutable
         // root the collector rewrote.
         let pattern = pattern_root.get_raw_const_ptr::<StringHeader>();
+        // #7341: same re-read for the flags, for the same reason.
+        let canonical_flags_ptr = flags_root.get_raw_const_ptr::<StringHeader>();
 
         (*ptr).regex_ptr = regex_ptr;
         (*ptr).pattern_ptr = pattern;


### PR DESCRIPTION
Closes the `lookup_fancy_regex` cluster in #7341 — **5 of 31** catches, four different callers reaching one read.

## The bug

`js_regexp_new` allocates the canonical flags string, then calls `gc_malloc` for the header — **a collection point** — and then writes the *pre-collection* pointer:

```rust
let canonical_flags_ptr = js_string_from_str(flags_str);   // allocates a string
let raw = gc::gc_malloc(header_size, GC_TYPE_OBJECT);      // CAN COLLECT
let pattern = pattern_root.get_raw_const_ptr::<StringHeader>();  // pattern re-read ✅
(*ptr).flags_ptr = canonical_flags_ptr;                    // flags stored STALE ✗
```

A live `RegExpHeader` then holds a retired from-space address permanently, and every later `string_as_str((*re).flags_ptr)` reads it.

The **pattern** string was already rooted and re-read across that exact allocation, with a ★-marked comment explaining the hazard. The flags string, created three lines later and stored beside it, was not.

## Two wrong fixes, recorded so nobody repeats them

Both looked obvious and both measured **exactly zero**:

- A no-move window inside `lookup_fancy_regex` — the faulting helper. **0/5.**
- Rooting the search-value operand in codegen's `replace` lowering. **0/5**, even after confirming in the IR that the root landed and moving the re-read to the point of use.

The helper was innocent. The call site was innocent. The header had been carrying a dead pointer since construction.

## Verification

4/5 cluster tests clean, 5/5 byte-identical to Node, 43/43 regex unit tests. A 6-line reproducer goes 6/6 → **0/6**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a memory-related issue affecting regular expression flags that could cause failures in certain scenarios. Regular expressions now function reliably across all use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->