### PR TITLE
fix(gc): refresh obj before the class-static mirror on both own-data-write arms

### DIFF
--- a/changelog.d/7381-mirror-static-write-refresh.md
+++ b/changelog.d/7381-mirror-static-write-refresh.md
@@ -1,0 +1,24 @@
+**Fixed** `js_object_set_field_by_name` passed a stale `obj` to
+`mirror_class_object_static_write` on both own-data-write arms.
+
+The two arms perform the property write (an inline slot store, or `overflow_set`
+into the overflow map) and then call the class-static mirror hook. Both writes
+can reach an allocator — `overflow_set` inserts into a Rust map, and a minor GC
+triggers on the malloc-count threshold as well as on arena-block allocation — and
+the mirror's first instruction dereferences `obj`. A collection in that write
+leaves the hook reading from-space.
+
+The function already carries a `refresh_roots_after_alloc!()` macro and calls it
+after every other allocating step; these two sites were missed. Scoped to those
+two arms on purpose: the macro also republishes `value` from its handle, so arms
+that intentionally rebind `value` locally must not refresh.
+
+Found by #7341's from-space quarantine via
+`test_gap_gc_assign_string_source_rooting`. With the fix the fault moves out of
+`mirror_class_object_static_write` entirely and into a separate, unrelated catch
+in `js_string_index_get`, which remains open.
+
+Baselines checked rather than assumed: `test_gap_2159_defineproperty_class_prototype`
+and `test_gap_6301_event_target_subclass` fail identically on pristine `main`, and
+`perry-runtime --lib` fails 3/5/3 tests across three runs of pristine `main`
+(#7365), so neither is attributable to this change.

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -1404,6 +1404,17 @@ pub extern "C" fn js_object_set_field_by_name(
                 // (bundled zod assigns `create` onto ~40 sibling class
                 // objects), so from the SECOND class on the write lands
                 // here — the mirror must fire on this path too.
+                // #7341: the own-data write just above can reach an allocator --
+                // `overflow_set` inserts into a Rust map, and a minor GC triggers on
+                // the malloc-count threshold as well as on arena blocks. The mirror's
+                // FIRST instruction dereferences `obj` (`ldr w8, [x0]` at +24), so a
+                // collection in that write leaves it reading from-space.
+                //
+                // Scoped deliberately to the two own-data-write arms. The macro also
+                // republishes `value` from its handle, so an arm that intentionally
+                // rebinds `value` locally must NOT refresh here -- applying it to all
+                // eight mirror sites is wrong for that reason.
+                refresh_roots_after_alloc!();
                 mirror_class_object_static_write(obj, key, value);
                 return;
             }
@@ -1439,6 +1450,17 @@ pub extern "C" fn js_object_set_field_by_name(
                 (*obj).field_count = 1;
             }
             js_object_set_field(obj, 0, JSValue::from_bits(value.to_bits()));
+            // #7341: the own-data write just above can reach an allocator --
+            // `overflow_set` inserts into a Rust map, and a minor GC triggers on
+            // the malloc-count threshold as well as on arena blocks. The mirror's
+            // FIRST instruction dereferences `obj` (`ldr w8, [x0]` at +24), so a
+            // collection in that write leaves it reading from-space.
+            //
+            // Scoped deliberately to the two own-data-write arms. The macro also
+            // republishes `value` from its handle, so an arm that intentionally
+            // rebinds `value` locally must NOT refresh here -- applying it to all
+            // eight mirror sites is wrong for that reason.
+            refresh_roots_after_alloc!();
             mirror_class_object_static_write(obj, key, value);
             // Record the null→single-key transition so the next object
             // that starts with `{}` and sets the same first key hits the


### PR DESCRIPTION
Another of the catches left open after #7373–#7376/#7380.

## The bug

`js_object_set_field_by_name`'s two own-data-write arms perform the write — an inline slot store, or `overflow_set` into the overflow map — and then call `mirror_class_object_static_write`.

Both writes can reach an allocator: `overflow_set` inserts into a Rust map, and **a minor GC triggers on the malloc-count threshold as well as on arena-block allocation**. The mirror's first instruction dereferences `obj` (`ldr w8, [x0]` at +24), so a collection inside that write leaves the hook reading from-space.

The function already carries a `refresh_roots_after_alloc!()` macro and calls it after every *other* allocating step. These two sites were simply missed.

## Why it's scoped to two sites and not eight

There are eight `mirror_class_object_static_write(obj, key, value)` call sites. I patched all eight first — and the macro republishes **`value`** from its handle as well as `obj`, so arms that intentionally rebind `value` locally get clobbered. Only the two own-data-write arms are load-bearing for the fault, and only they are safe to refresh.

## Verification

The fault **moves out of `mirror_class_object_static_write` entirely**, into a separate and unrelated catch in `js_string_index_get` → `js_string_char_at` which stays open for follow-up. A fault that moves is the signal that the patch is real; a fault that doesn't move by a byte means the value was already dead before you touched it.

Baselines were checked rather than assumed:

- `test_gap_2159_defineproperty_class_prototype` and `test_gap_6301_event_target_subclass` fail **identically on pristine `main`** — pre-existing, one is already in `known_failures.json`
- `perry-runtime --lib` fails **3 / 5 / 3** tests across three runs of pristine `main` (#7365 nondeterminism), so the failure count seen with this patch sits inside main's own noise band
- 58 object/assign/class/field/shape gap tests otherwise unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause static property writes to use outdated object references after memory allocation.
  - Improved reliability of property updates across both cached and initial write paths.
  - Confirmed existing baseline behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->