### PR TITLE
fix(gc): refresh obj at the remaining six class-static mirror sites

### DIFF
--- a/changelog.d/7382-mirror-remaining-sites.md
+++ b/changelog.d/7382-mirror-remaining-sites.md
@@ -1,0 +1,16 @@
+**Fixed** the remaining six `mirror_class_object_static_write` call sites in
+`js_object_set_field_by_name` passed a stale `obj`, completing #7381.
+
+#7381 fixed two of the eight sites and scoped itself there on the theory that
+the `refresh_roots_after_alloc!()` macro — which republishes `obj`, `key`,
+`value` and `interned_key` together — could clobber an arm that rebinds `value`
+locally. That theory was wrong: none of the eight arms rebinds any of the four
+after its handle is taken, so republishing is a no-op except for the relocation
+it repairs. Verified by measurement, not inspection — the full-coverage build
+scores 58 pass / 2 fail on the object/assign/class/field/shape gap set, byte-identical
+to pristine `main` (both failures pre-existing, one already in
+`known_failures.json`).
+
+With all eight refreshed, `test_gap_gc_assign_string_source_rooting`'s fault
+leaves `mirror_class_object_static_write` entirely and surfaces the next catch in
+the chain at `js_jsvalue_equals`, which remains open.

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -1574,6 +1574,12 @@ pub extern "C" fn js_object_set_field_by_name(
                     };
                     overflow_set(obj as usize, i, vbits);
                 }
+                // #7341: same as the two own-data-write arms -- the write above can
+                // reach an allocator and the mirror's first instruction dereferences
+                // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+                // handles are taken, so republishing all four is a no-op except for
+                // the relocation it repairs.
+                refresh_roots_after_alloc!();
                 mirror_class_object_static_write(obj, key, value);
                 return;
             }
@@ -1644,6 +1650,12 @@ pub extern "C" fn js_object_set_field_by_name(
                     super::shapes::shape_keys_grown(prev_keys_usize, new_keys);
                 }
                 overflow_set(obj as usize, new_index, vbits);
+                // #7341: same as the two own-data-write arms -- the write above can
+                // reach an allocator and the mirror's first instruction dereferences
+                // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+                // handles are taken, so republishing all four is a no-op except for
+                // the relocation it repairs.
+                refresh_roots_after_alloc!();
                 mirror_class_object_static_write(obj, key, value);
                 transition_cache_insert(
                     prev_keys_usize,
@@ -1685,6 +1697,12 @@ pub extern "C" fn js_object_set_field_by_name(
                 (*obj).field_count = new_index as u32 + 1;
             }
             js_object_set_field(obj, new_index as u32, JSValue::from_bits(value.to_bits()));
+            // #7341: same as the two own-data-write arms -- the write above can
+            // reach an allocator and the mirror's first instruction dereferences
+            // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+            // handles are taken, so republishing all four is a no-op except for
+            // the relocation it repairs.
+            refresh_roots_after_alloc!();
             mirror_class_object_static_write(obj, key, value);
             transition_cache_insert(
                 prev_keys_usize,
@@ -1755,6 +1773,12 @@ pub extern "C" fn js_object_set_field_by_name(
                     };
                     overflow_set(obj as usize, i, vbits);
                 }
+                // #7341: same as the two own-data-write arms -- the write above can
+                // reach an allocator and the mirror's first instruction dereferences
+                // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+                // handles are taken, so republishing all four is a no-op except for
+                // the relocation it repairs.
+                refresh_roots_after_alloc!();
                 mirror_class_object_static_write(obj, key, value);
                 return;
             }
@@ -1843,6 +1867,12 @@ pub extern "C" fn js_object_set_field_by_name(
                 super::shapes::shape_keys_grown(prev_keys_usize, new_keys);
             }
             overflow_set(obj as usize, new_index, vbits);
+            // #7341: same as the two own-data-write arms -- the write above can
+            // reach an allocator and the mirror's first instruction dereferences
+            // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+            // handles are taken, so republishing all four is a no-op except for
+            // the relocation it repairs.
+            refresh_roots_after_alloc!();
             mirror_class_object_static_write(obj, key, value);
             // Record the shape transition so the next object sharing
             // `prev_keys` that adds the same key hits the fast path.
@@ -1886,6 +1916,12 @@ pub extern "C" fn js_object_set_field_by_name(
             (*obj).field_count = new_index as u32 + 1;
         }
         js_object_set_field(obj, new_index as u32, JSValue::from_bits(value.to_bits()));
+        // #7341: same as the two own-data-write arms -- the write above can
+        // reach an allocator and the mirror's first instruction dereferences
+        // `obj`. None of these arms rebinds `obj`/`key`/`value` after the
+        // handles are taken, so republishing all four is a no-op except for
+        // the relocation it repairs.
+        refresh_roots_after_alloc!();
         mirror_class_object_static_write(obj, key, value);
         // Record the shape transition — see above for semantics.
         transition_cache_insert(


### PR DESCRIPTION
Completes #7381.

## Correcting my own scoping call

#7381 fixed **two** of the eight `mirror_class_object_static_write` sites, and scoped itself there on the theory that `refresh_roots_after_alloc!()` — which republishes `obj`, `key`, `value` and `interned_key` together — could clobber an arm that rebinds `value` locally.

**That theory was wrong.** None of the eight arms rebinds any of the four after its handle is taken, so republishing is a no-op except for the relocation it repairs.

What made me narrow it was two gap tests failing alongside the full patch. Those two turned out to fail identically on pristine `main` — pre-existing, one already in `known_failures.json`. I attributed them to my change before checking the baseline, and narrowed a correct patch on that basis.

## Measured, not inspected

| | pass | fail |
|---|---|---|
| pristine `main` | 58 | 2 |
| all eight sites refreshed | 58 | 2 |

Byte-identical, same two pre-existing failures.

## Result

With all eight refreshed, `test_gap_gc_assign_string_source_rooting`'s fault leaves `mirror_class_object_static_write` entirely and surfaces the **next** catch in the chain, at `js_jsvalue_equals` — still open. This test is a chain rather than a single defect, which is expected for one purpose-built to stress that path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating object fields by name during memory allocation.
  * Ensured object, key, and value references remain valid when static properties are mirrored.
  * Covered all affected field-write paths to prevent issues caused by relocated references.

* **Documentation**
  * Added a changelog entry documenting the completed fixes and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->