### PR TITLE
fix(gc): parse GNU-as symbol assignments in the stack-map block

### DIFF
--- a/changelog.d/7390-gcmap-elf-symbol-assignment.md
+++ b/changelog.d/7390-gcmap-elf-symbol-assignment.md
@@ -30,3 +30,23 @@ Reproduced locally without a Linux host by retargeting a traced module to
 `aarch64-unknown-linux-gnu`, running `rewrite-statepoints-for-gc`, and emitting
 with `llc -O3 -mattr=+jsconv,+v8.3a`; the real assembly parses at `-O2` and
 refused at `-O3` exactly as CI reported, and parses at both with the fix.
+
+**Also fixed** the assembler was invoked without the CPU the code generator was
+given, so aarch64-linux failed a second time once the parse was fixed:
+
+```
+error: instruction requires: sve or sme
+        mov     z1.d, #0x7fffffffffffffff
+```
+
+Perry compiles with `-mcpu=native`. On a host whose CPU has SVE — Graviton, and
+any aarch64 server part — LLVM emits SVE instructions. `compact_and_assemble`
+then handed that text to clang with no `-mcpu` at all, so the assembler applied
+the portable baseline and rejected what the generator had just produced.
+
+The two invocations describe the same machine and now say so: the codegen argv's
+`-mcpu=`/`-march=`/`-mtune=` flags are forwarded to the assembler. Optimisation
+and output flags are deliberately not, since they mean nothing to an assembler
+and forwarding them wholesale would be a second way for the two to disagree.
+
+This is invisible on the macOS arms, whose runner CPUs have no SVE.

--- a/changelog.d/7390-gcmap-elf-symbol-assignment.md
+++ b/changelog.d/7390-gcmap-elf-symbol-assignment.md
@@ -1,0 +1,32 @@
+**Fixed** the compact stack-map rewrite refused every module on aarch64-ELF at
+`-O3`, so `native-roots-rs4gc (ubuntu-24.04-arm)` could never pass and statepoints
+— on by default for aarch64 — could not compile on Linux arm64.
+
+`gc_map`'s parser walks the stack-map block directive by directive, because the
+block is a byte stream decoded by structural offset: one unmodelled directive
+that *does* emit bytes shifts everything after it, so anything unrecognised is a
+hard error rather than a skip. That is the right default and it is why this
+surfaced as a refusal instead of a corrupt decode.
+
+What it did not model is the GNU-as **symbol assignment**, `sym = expr` — the
+bare spelling of `.set`, which emits zero bytes and has no leading directive. The
+dispatch therefore reported the *symbol* as an unrecognised directive:
+
+```
+line 5114: unrecognised directive `perry_class_keys__…__AnonShape_…`
+           inside the stack-map block
+```
+
+Only `-O3` emits it (the optimiser materialises absolute-symbol aliases such as
+`perry_null_guard_zero = 0` and `.Lperry_ic_8 = .Ltmp3-4`), and only on ELF —
+Mach-O's asm printer does not use this spelling, so every macOS arm stayed green.
+
+The guard tests for "not a directive this module already models" rather than "no
+leading dot", because ELF local labels legitimately start with `.L` and appear on
+the left of these assignments. Expression operators (`==`, `!=`, `>=`, `<=`) are
+excluded so an `.if` is never mistaken for one.
+
+Reproduced locally without a Linux host by retargeting a traced module to
+`aarch64-unknown-linux-gnu`, running `rewrite-statepoints-for-gc`, and emitting
+with `llc -O3 -mattr=+jsconv,+v8.3a`; the real assembly parses at `-O2` and
+refused at `-O3` exactly as CI reported, and parses at both with the fix.

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -913,6 +913,7 @@ pub fn compact_and_assemble(
     target: &str,
     asm_path: &Path,
     obj_path: &Path,
+    codegen_args: &[String],
 ) -> Result<()> {
     let asm = fs::read_to_string(asm_path)
         .with_context(|| format!("Failed to read assembly at {}", asm_path.display()))?;
@@ -1013,15 +1014,47 @@ pub fn compact_and_assemble(
         crate::statepoint_report::note_gc_map(stats.functions, stats.records, stats.roots);
     }
 
-    assemble(clang, target, asm_path, obj_path)
+    assemble(clang, target, asm_path, obj_path, codegen_args)
 }
 
-fn assemble(clang: &Path, target: &str, asm_path: &Path, obj_path: &Path) -> Result<()> {
+/// The subset of the codegen's clang argv that selects the target MACHINE.
+///
+/// The assembler must be told the same machine the code generator was told, or
+/// it rejects instructions the generator legitimately emitted. Optimisation and
+/// output flags are excluded: they mean nothing to an assembler, and forwarding
+/// them wholesale would be a second way for the two invocations to disagree.
+fn cpu_selection_flags(codegen_args: &[String]) -> Vec<&String> {
+    codegen_args
+        .iter()
+        .filter(|a| a.starts_with("-mcpu=") || a.starts_with("-march=") || a.starts_with("-mtune="))
+        .collect()
+}
+
+fn assemble(
+    clang: &Path,
+    target: &str,
+    asm_path: &Path,
+    obj_path: &Path,
+    codegen_args: &[String],
+) -> Result<()> {
+    // Mirror the codegen's CPU selection onto the assembler.
+    //
+    // Perry compiles with `-mcpu=native`, so on a host with SVE (Graviton, and
+    // any aarch64 server part) LLVM emits SVE instructions -- `mov z1.d, #…`.
+    // Assembling that text with a clang that was given no `-mcpu` fails with
+    // `instruction requires: sve or sme`, because the assembler defaults to the
+    // portable baseline while the code generator did not.
+    //
+    // The two invocations describe the SAME machine and must agree. Forwarding
+    // only the CPU-selection flags keeps that contract without dragging along
+    // optimisation or output flags, which mean nothing to an assembler.
+    let cpu_flags = cpu_selection_flags(codegen_args);
     let output = Command::new(clang)
         .arg("-c")
         .arg(asm_path)
         .arg("-o")
         .arg(obj_path)
+        .args(&cpu_flags)
         .arg("-target")
         .arg(target)
         .output()
@@ -1354,6 +1387,34 @@ mod tests {
         // the dispatch reported the SYMBOL as an unrecognised directive and
         // refused the module. Mach-O never emits this spelling, which is why
         // every macOS arm stayed green.
+    }
+
+    #[test]
+    fn the_assembler_is_told_the_same_machine_as_the_code_generator() {
+        // `-mcpu=native` on a host with SVE makes LLVM emit `mov z1.d, #…`.
+        // Assembling that with a clang given no `-mcpu` fails with
+        // `instruction requires: sve or sme` — the aarch64-linux arm's second
+        // failure, after the parse fix. Forward machine selection, nothing else.
+        let args: Vec<String> = [
+            "-O3",
+            "-mcpu=native",
+            "-fno-math-errno",
+            "-march=armv8.3-a",
+            "-mtune=neoverse-n1",
+            "-o",
+            "out.o",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let got: Vec<&str> = super::cpu_selection_flags(&args)
+            .into_iter()
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(
+            got,
+            ["-mcpu=native", "-march=armv8.3-a", "-mtune=neoverse-n1"]
+        );
     }
 
     #[test]

--- a/crates/perry-codegen/src/gc_map.rs
+++ b/crates/perry-codegen/src/gc_map.rs
@@ -163,6 +163,38 @@ fn directive_width(directive: &str, word_width: usize) -> Option<usize> {
 /// everything after it; the decode then either fails somewhere unrelated or,
 /// worse, succeeds against garbage. Anything not on this list and not in
 /// `directive_width` is a refusal that names the directive.
+/// Is this a GNU-as symbol assignment (`sym = expr`) rather than a directive?
+///
+/// Assemblers accept `.set sym, expr` and the bare `sym = expr` for the same
+/// thing. Only the former starts with a `.`, so the directive dispatch sees the
+/// SYMBOL as the mnemonic and refuses it. Both emit zero bytes.
+///
+/// Deliberately narrow: the name must be a single token that is not itself a
+/// directive, and the `=` must not be part of a comparison inside a longer
+/// expression. `.size sym, .-sym` and `.byte 1` are unaffected.
+fn is_symbol_assignment(line: &str) -> bool {
+    let Some((lhs, _rhs)) = line.split_once('=') else {
+        return false;
+    };
+    // `==`, `>=`, `<=`, `!=` are expression operators, not an assignment.
+    if lhs.ends_with(['=', '>', '<', '!']) {
+        return false;
+    }
+    let name = lhs.trim();
+    // ELF local labels start with `.L`, so "does not start with a dot" is the
+    // wrong test -- it would reject `.Lperry_ic_8 = …`, which -O3 emits. Test
+    // what actually matters instead: the LHS must not be a directive this
+    // module already models. Anything else that is a single bare token before
+    // an `=` is a symbol assignment.
+    !name.is_empty()
+        && !name.contains(char::is_whitespace)
+        && directive_width(name, 8).is_none()
+        && !is_zero_width_directive(name)
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '$' || c == '.')
+}
+
 fn is_zero_width_directive(directive: &str) -> bool {
     matches!(
         directive,
@@ -235,6 +267,20 @@ fn parse_block(lines: &[&str], word_width: usize) -> Result<RawBlock, String> {
         {
             continue;
         }
+        // GNU-as symbol assignment: `sym = expr`, the bare form of `.set`.
+        // It defines a symbol and emits ZERO bytes. `.set`/`.equ` are already on
+        // the zero-width list; this spelling is not a directive at all, so the
+        // dispatch below would report the SYMBOL as an unrecognised directive.
+        //
+        // It only shows up at -O3, which is why the arm CI caught it and the -O2
+        // paths never did: the optimiser materialises absolute-symbol aliases
+        // (`perry_null_guard_zero = …`, `perry_class_keys__… = …`) and the ELF
+        // asm printer emits them in this form. Mach-O output does not, so this
+        // is invisible on the macOS arms.
+        if is_symbol_assignment(line) {
+            continue;
+        }
+
         let mut parts = line.splitn(2, char::is_whitespace);
         let directive = parts.next().unwrap_or_default();
         let operand = parts.next().unwrap_or_default();
@@ -1302,6 +1348,51 @@ mod tests {
         assert!(!out.contains("__LLVM_StackMaps"));
         // The dead-strip guard must survive, retargeted.
         assert!(out.contains(".no_dead_strip\t_perry_gc_map"));
+
+        // Guard the -O3 ELF shapes that broke the aarch64-linux arm. Both are
+        // GNU-as symbol assignments -- zero bytes, no leading directive -- so
+        // the dispatch reported the SYMBOL as an unrecognised directive and
+        // refused the module. Mach-O never emits this spelling, which is why
+        // every macOS arm stayed green.
+    }
+
+    #[test]
+    fn elf_symbol_assignments_parse_as_zero_width() {
+        let asm = concat!(
+            "\t.section\t.llvm_stackmaps,\"a\",@progbits\n",
+            "__LLVM_StackMaps:\n",
+            "\t.byte\t3\n",
+            "perry_null_guard_zero = 0\n",
+            "\t.byte\t0\n",
+            ".Lperry_ic_8 = .Ltmp3-4\n",
+            "\t.hword\t0\n",
+            "\t.word\t2\n",
+        );
+        let lines: Vec<&str> = asm.lines().collect();
+        let block = super::parse_block(&lines, 4).expect("ELF symbol assignments must parse");
+        // 1 + 1 + 2 + 4 -- the assignments contribute nothing.
+        assert_eq!(block.bytes.len(), 8);
+    }
+
+    #[test]
+    fn expression_operators_are_not_mistaken_for_assignments() {
+        for line in [
+            ".byte\t1",
+            "\t.size\tsym, .-sym",
+            "\t.if a == b",
+            "\t.if a != b",
+        ] {
+            assert!(
+                !super::is_symbol_assignment(line),
+                "`{line}` must not be treated as a symbol assignment"
+            );
+        }
+        for line in ["sym = 1", ".Lfoo = .Ltmp1-4", "a$b = 7"] {
+            assert!(
+                super::is_symbol_assignment(line),
+                "`{line}` is a symbol assignment"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -782,6 +782,7 @@ fn compile_ll_inprocess_in(
                 &plan.effective_target,
                 asm_path,
                 &plan.obj_path,
+                &plan.clang_args,
             )?;
             let obj = fs::read(&plan.obj_path)
                 .with_context(|| format!("Failed to read assembled {}", plan.obj_path.display()))?;
@@ -978,6 +979,7 @@ fn compile_ll_to_object_in(
             &plan.effective_target,
             asm_path,
             &obj_path,
+            &plan.clang_args,
         )?;
     }
 


### PR DESCRIPTION
Fixes the red `native-roots-rs4gc (ubuntu-24.04-arm, aarch64, ELF)` arm. Statepoints are on by default for aarch64, and aarch64-Linux is inside the allowed set — so this was a **hard compile failure on a default-on path**, not just a CI annoyance.

## The bug

`gc_map`'s parser walks the stack-map block directive by directive, because the block is a byte stream decoded by structural offset: one unmodelled directive that *does* emit bytes shifts everything after it. So anything unrecognised is a hard error rather than a skip — the right default, and why this surfaced as a refusal instead of a corrupt decode.

What it did not model is the GNU-as **symbol assignment** — `sym = expr`, the bare spelling of `.set`. Zero bytes, no leading directive, so the dispatch reported the *symbol* as the mnemonic:

```
line 5114: unrecognised directive `perry_class_keys__…__AnonShape_…`
           inside the stack-map block
```

Only `-O3` emits it — the optimiser materialises absolute-symbol aliases like `perry_null_guard_zero = 0` and `.Lperry_ic_8 = .Ltmp3-4` — and only on ELF. Mach-O's asm printer doesn't use this spelling, which is why every macOS arm stayed green.

The guard tests for **"not a directive this module already models"** rather than "no leading dot": ELF local labels start with `.L` and appear on the left of exactly these assignments. Expression operators (`==`, `!=`, `>=`, `<=`) are excluded so an `.if` is never mistaken for one.

## Reproduced locally, without a Linux host

My first instinct was to defer this as unverifiable from macOS. That was wrong — the parser is a pure function over assembly text, so what I needed was ELF *text*, not an ELF *machine*:

1. `--trace llvm` on the failing probe
2. retarget the module to `aarch64-unknown-linux-gnu`, drop the Mach-O-only `.no_dead_strip` module asm
3. `opt -passes=rewrite-statepoints-for-gc` → 109 statepoints
4. `llc -mattr=+jsconv,+v8.3a` (generic ARMv8.0 can't select `fjcvtzs`)

The real assembly then parses at `-O2` and **refuses at `-O3` exactly as CI reported** — and parses at both with the fix.

## Verification

| | before | after |
|---|---|---|
| real ELF asm `-O2` | OK (6400 B) | OK (6400 B) |
| real ELF asm `-O3` | **refused** | OK (6656 B) |
| `gc_map` suite | 15 pass | 17 pass |

Both new tests fail with the guard disabled — checked, not assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stack-map processing for optimized AArch64 ELF builds containing GNU assembler symbol assignments.
  * Prevented valid zero-byte symbol assignments from causing parsing failures while preserving correct handling of comparisons and supported directives.
  * Improved AArch64 assembly compatibility by applying the compiler’s CPU, architecture, and tuning settings during assembly, including configurations using SVE features.

* **Tests**
  * Added coverage for symbol assignments, expression operators, and matching compilation and assembly settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->