### PR TITLE
compile(diag): --verbose brackets the linker spawn (#6899 instrumentation)

### DIFF
--- a/changelog.d/7420-linker-verbose-breadcrumb.md
+++ b/changelog.d/7420-linker-verbose-breadcrumb.md
@@ -1,0 +1,7 @@
+**compile(diag): `--verbose` now brackets the linker spawn (#6899 instrumentation)**
+
+The hang reported in #6899 sits between the `[strip-dedup]` stderr line and the `Wrote executable:` line — a window covering ~1500 lines of link-argument assembly, the link-cache check, the response-file rewrite, and the linker child process itself, none of which logged anything even under `--verbose`. A hang report therefore could not distinguish "linker never spawned" from "linker hung" from "post-link step hung".
+
+`build_and_run_link` now takes the CLI verbosity and, at `--verbose`, prints `[link] invoking: <program> <args…>` immediately before spawning the linker and `[link] linker exited: <status>` (or `[link] linker spawn failed: <err>`) immediately after it returns. On Windows the printed args are usually a single `@<response-file>` — deliberately useful: the response file still exists on disk while the linker is hung (cleanup runs after the wait), so a stuck user can inspect the full argument vector.
+
+Investigation notes recorded on the issue: the link runs via `Command::status()` with inherited stdio (no pipe-fill deadlock is possible), plain compiles pass no `/DEBUG` (no mspdbsrv involvement), and the process-exit paths (telemetry flush, compat-report prompt, update check) are all bounded or TTY-guarded. The hang did not reproduce on a Windows 11 host at current main across repeated runtime-only links, including the cached-object flow from the report.

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -45,6 +45,13 @@ pub(crate) fn build_and_run_link(
     // `--debug-symbols`: keep symbols / emit a PDB so RUST_BACKTRACE
     // panics in the compiled app symbolize. Windows-active today.
     debug_symbols: bool,
+    // `--verbose` (#6899): print the exact linker invocation before spawning
+    // it and its exit status after. The hang reported in #6899 sits between
+    // the `[strip-dedup]` line and the `Wrote executable:` line — a window
+    // that previously logged NOTHING even under `--verbose`, so a report
+    // could not tell "linker never spawned" from "linker hung" from
+    // "post-link step hung". These two lines split that window.
+    verbose: u8,
 ) -> Result<LinkCacheStatus> {
     // #498 - supply-chain gate. Before any prebuilt archive hits the
     // linker, hash it and compare against `perry.lock`. First build
@@ -1901,7 +1908,25 @@ pub(crate) fn build_and_run_link(
         }
     }
 
+    // #6899 breadcrumbs: everything between `[strip-dedup]` and
+    // `Wrote executable:` used to run silently, so a hang in this window was
+    // unattributable. Print the spawn and the return, on stderr like the
+    // strip-dedup lines, flushed via eprintln's line buffering.
+    if verbose > 0 {
+        let program = cmd.get_program().to_string_lossy().into_owned();
+        let rendered: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        eprintln!("[link] invoking: {} {}", program, rendered.join(" "));
+    }
     let status_result = cmd.status();
+    if verbose > 0 {
+        match &status_result {
+            Ok(status) => eprintln!("[link] linker exited: {status}"),
+            Err(e) => eprintln!("[link] linker spawn failed: {e}"),
+        }
+    }
     if let Some(path) = response_file_to_clean {
         let _ = fs::remove_file(path);
     }

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -5917,6 +5917,7 @@ pub fn run_with_parse_cache(
         &exe_path,
         format,
         args.debug_symbols,
+        verbose,
     )?;
 
     // HarmonyOS: emit the ArkTS EntryAbility + Index page next to the .so,


### PR DESCRIPTION
Instrumentation toward #6899 (does not close it - the hang has not been reproduced).

## The problem this solves

The #6899 report shows `perry compile` hanging after the `[strip-dedup]` stderr line, with `--verbose` adding nothing. Reading the driver, that window covers the remaining link-argument assembly (~1500 lines of `build_and_run_link`), the link-cache check, the Windows response-file rewrite, and the linker child process itself - and none of it logs a single line at any verbosity. A hang report therefore cannot distinguish three very different bugs: linker never spawned, linker hung, or a post-link step hung.

## The change

`build_and_run_link` now takes the CLI verbosity. At `--verbose` it prints:

- `[link] invoking: <program> <args...>` immediately before spawning the linker
- `[link] linker exited: <status>` (or `[link] linker spawn failed: <err>`) immediately after `cmd.status()` returns

On Windows the printed args are usually a single `@<response-file>` path. That is deliberately useful: the response file still exists on disk while the linker is hung (cleanup runs after the wait), so a stuck user can inspect the complete argument vector.

Verified on Windows 11: both lines appear under `--verbose` bracketing an lld-link spawn (exit code 0 case), and are absent without the flag.

## Investigation notes (posted to #6899)

Ruled out while reading for the hang: pipe-fill deadlock (the link runs via `Command::status()` with inherited stdio), mspdbsrv involvement (plain compiles pass no `/DEBUG`; only `--debug-symbols` does), and unbounded exit paths (telemetry flush is bounded at 3s with connect/request timeouts, the compat-report prompt is TTY-guarded and visible, the update-check receiver times out at 100ms). The hang did not reproduce on a Windows 11 host at current main across repeated runtime-only links, including the cached-object flow from the report.

No version bump per external-contributor flow - maintainer bumps at merge.
