### PR TITLE
fix(runtime): trap-route reverse/splice/fill/copyWithin on Proxy receivers; receiver-less mutator thunks throw (#6908)

### DIFF
--- a/changelog.d/7424-proxy-array-mutators-and-receiverless-thunks.md
+++ b/changelog.d/7424-proxy-array-mutators-and-receiverless-thunks.md
@@ -1,0 +1,13 @@
+**Proxy receivers: `reverse`/`splice`/`fill`/`copyWithin` now run through the traps; receiver-less mutator thunks throw** (#6908, follow-up to #6907)
+
+Part 1 — the remaining `Array.prototype` mutators on a Proxy receiver fired no trap and mutated nothing (the generic dispatch's receiver normalizations both reject proxy handle-band ids, so the call silently returned `undefined`; `fill`/`copyWithin` were additionally noop-backed on `Array.prototype`):
+
+- `proxy_array_mutator` (`perry-runtime/src/array/push_pop.rs`) gains spec loops for `reverse` (§23.1.3.26) and `splice` (§23.1.3.31): `HasProperty`-gated element moves (a source hole deletes the destination), `DeletePropertyOrThrow` before the length write, carried values rooted across traps. `splice` returns a fresh real array with holes preserved.
+- New `proxy_array_fill` (§23.1.3.7) backs the new real `fill` thunk and `js_array_fill_generic`'s proxy branch — a proxy receiver previously fell past both typed branches there into `js_object_coerce` self-recursion.
+- `copyWithin` gets a real thunk over the already proxy-aware `js_array_copy_within_value` via a new `js_arraylike_copy_within` value entry (dense receivers keep the dense helper).
+- `.call` forms pre-route proxies: `js_array_reverse_value` and `js_arraylike_splice` hand proxies to the same trap loops.
+- `sort` already worked via `object_sort` over the proxy-aware `al_*` primitives; now pinned by tests.
+
+Part 2 — a mutator prototype thunk invoked as a plain value (`const f = arr.push; f(3)`) has no receiver (`IMPLICIT_THIS` is undefined) and silently no-opped. `array_proto_mutator` now throws the node-identical `TypeError: Cannot convert undefined or null to object` for nullish receivers (spec step 1 `ToObject(this value)`), and a prior method call's receiver cannot leak into a later bare call.
+
+Validation: 28-case probe + new gap test (`test-files/test_gap_6908_proxy_array_mutators.ts`) byte-identical to node 26.5.1; 4 new integration tests; `perry-runtime --lib` 1636/1636; 14 pre-existing proxy/array gap tests unchanged.

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -249,6 +249,16 @@ pub extern "C" fn js_array_reverse_value(receiver: f64) -> f64 {
         reverse_throw_type_error(b"Cannot convert undefined or null to object");
     }
 
+    // #6908: a Proxy receiver routes every element move through its traps —
+    // the polymorphic index reads/writes below don't decode handle-band ids.
+    if crate::proxy::js_proxy_is_proxy(receiver) != 0 {
+        if let Some(r) =
+            super::push_pop::proxy_array_mutator(receiver, "reverse", std::ptr::null(), 0)
+        {
+            return r;
+        }
+    }
+
     let object = crate::object::js_object_coerce(receiver);
     let len = reverse_length_of_array_like(object);
     if reverse_is_boxed_string(object) && len > 1 {
@@ -488,6 +498,13 @@ pub extern "C" fn js_array_fill_generic(
     let receiver_value = JSValue::from_bits(receiver.to_bits());
     if receiver_value.is_null() || receiver_value.is_undefined() {
         throw_fill_nullish_receiver();
+    }
+
+    // #6908: Proxy receivers — every element write goes through the `set`
+    // trap. Without this branch a proxy's handle-band id fell past both typed
+    // branches below into `js_object_coerce` + self-recursion.
+    if crate::proxy::js_proxy_is_proxy(receiver) != 0 {
+        return super::push_pop::proxy_array_fill(receiver, value, has_start, start, has_end, end);
     }
 
     if receiver_value.is_pointer() {

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -1316,6 +1316,15 @@ pub fn dispatch_arraylike_read_method(
 /// engine; any other receiver yields `undefined`. `recv` is the call-site
 /// `this` (IMPLICIT_THIS) the thunk read.
 pub fn array_proto_mutator(recv: f64, method: &str, args_ptr: *const f64, args_len: usize) -> f64 {
+    // #6908: every mutator's step 1 is `ToObject(this value)`, which throws
+    // for a nullish receiver. This is the receiver-less thunk invocation
+    // (`const f = arr.push; f(3)` — IMPLICIT_THIS holds its `undefined`
+    // default), which previously fell through every normalization below and
+    // silently no-opped; node throws.
+    let bits = recv.to_bits();
+    if bits == TAG_UNDEFINED || bits == TAG_NULL {
+        crate::collection_iter::throw_type_error("Cannot convert undefined or null to object");
+    }
     // A Proxy receiver reaches this generic path whenever the eager HIR array
     // fold bails (untyped receiver — #6397) and the dispatcher resolves the
     // method through `Get(proxy, name)` → prototype thunk → here. Neither
@@ -1328,8 +1337,11 @@ pub fn array_proto_mutator(recv: f64, method: &str, args_ptr: *const f64, args_l
         if let Some(r) = super::push_pop::proxy_array_mutator(recv, method, args_ptr, args_len) {
             return r;
         }
-        // Mutators not yet trap-routed (reverse/sort/splice/fill/copyWithin)
-        // keep the pre-existing fall-through.
+        // `sort` (routed to `object_sort` over the proxy-aware `al_*`
+        // primitives by its thunk), `fill` (`proxy_array_fill` via
+        // `js_array_fill_generic`) and `copyWithin`
+        // (`js_array_copy_within_value`) never arrive here; anything else
+        // keeps the pre-existing fall-through.
     }
     let arr = as_real_array(recv);
     if !arr.is_null() {

--- a/crates/perry-runtime/src/array/generic_object.rs
+++ b/crates/perry-runtime/src/array/generic_object.rs
@@ -449,6 +449,16 @@ pub extern "C" fn js_arraylike_concat(recv: f64, args_ptr: *const f64, count: i3
 pub extern "C" fn js_arraylike_splice(recv: f64, args_ptr: *const f64, count: i32) -> f64 {
     let o = to_object(recv);
     let count = count.max(0) as usize;
+    // #6908: Proxy receivers take the trap-routed spec loop. The `object_splice`
+    // fallback's `al_*` primitives do route proxy element traps, but its
+    // `al_set_length` tail reads the masked handle id as a raw ObjectHeader
+    // address, and its proxy deletes don't throw on a refusing trap
+    // (DeletePropertyOrThrow).
+    if crate::proxy::js_proxy_is_proxy(o) != 0 {
+        if let Some(r) = super::push_pop::proxy_array_mutator(o, "splice", args_ptr, count) {
+            return r;
+        }
+    }
     let arr = as_real_array(o);
     if !arr.is_null() {
         return unsafe { real_array_mutator(arr, "splice", args_ptr, count) };

--- a/crates/perry-runtime/src/array/immutable.rs
+++ b/crates/perry-runtime/src/array/immutable.rs
@@ -548,3 +548,30 @@ pub extern "C" fn js_array_copy_within_value(
 
     receiver
 }
+
+/// `Array.prototype.copyWithin` over a *value* receiver, backing the real
+/// prototype thunk (#6908 — previously noop-backed, so a Proxy or borrowed
+/// reference silently returned `undefined`). Dense receivers route to the
+/// dense helper (mirroring the dynamic-dispatch #2802 arm); everything else —
+/// Proxy / array-like object / primitive — runs [`js_array_copy_within_value`],
+/// which ToObject-throws on nullish receivers and trap-routes proxies.
+#[no_mangle]
+pub extern "C" fn js_arraylike_copy_within(
+    recv: f64,
+    target: f64,
+    start: f64,
+    has_end: i32,
+    end: f64,
+) -> f64 {
+    let arr = super::generic::as_real_array(recv);
+    if !arr.is_null() {
+        let r = js_array_copy_within(arr, target, start, has_end, end);
+        return super::generic::nanbox_arr(r);
+    }
+    js_array_copy_within_value(recv, target, start, has_end, end)
+}
+
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_ARRAYLIKE_COPY_WITHIN: extern "C" fn(f64, f64, f64, i32, f64) -> f64 =
+    js_arraylike_copy_within;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -81,7 +81,7 @@ pub(crate) use self::header::{
 pub use self::immutable::{
     js_array_copy_within, js_array_copy_within_value, js_array_to_reversed,
     js_array_to_sorted_default, js_array_to_sorted_with_comparator, js_array_to_spliced,
-    js_array_with,
+    js_array_with, js_arraylike_copy_within,
 };
 pub(crate) use self::indexing::{
     array_has_own_index, array_iteration_is_exotic, array_proto_iterator_modified,

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -224,11 +224,37 @@ unsafe fn proxy_delete_str_key_or_throw(proxy: f64, key_bytes: &[u8]) {
     }
 }
 
+/// `ToIntegerOrInfinity(ToNumber(v))` — NaN → 0, ±Infinity preserved. The
+/// sibling `generic_object` helper skips the ToNumber step (its callers'
+/// args are pre-coerced); trap-routed args arrive as arbitrary NaN-boxed
+/// values, so coerce first.
+fn to_integer_or_infinity_coerced(v: f64) -> f64 {
+    let n = crate::builtins::js_number_coerce(v);
+    if n.is_nan() {
+        0.0
+    } else if n.is_infinite() {
+        n
+    } else {
+        n.trunc()
+    }
+}
+
+/// Resolve a relative-index argument (`splice`/`fill` start, `fill` end) to
+/// an absolute index clamped to `[0, len]`.
+fn proxy_relative_index(v: f64, len: u64) -> u64 {
+    let n = to_integer_or_infinity_coerced(v);
+    if n < 0.0 {
+        (len as f64 + n).max(0.0) as u64
+    } else {
+        n.min(len as f64) as u64
+    }
+}
+
 /// `Array.prototype` mutators on a Proxy receiver, spec-routed through the
 /// proxy's `get`/`set`/`deleteProperty` traps (§23.1.3.21 push, §23.1.3.19
-/// pop, §23.1.3.24 shift, §23.1.3.32 unshift — length reads/writes and every
-/// element move go through `[[Get]]`/`[[Set]]`, which is what fires the
-/// traps).
+/// pop, §23.1.3.24 shift, §23.1.3.32 unshift, §23.1.3.26 reverse, §23.1.3.31
+/// splice — length reads/writes and every element move go through
+/// `[[Get]]`/`[[Set]]`, which is what fires the traps).
 ///
 /// This is the receiver-normalization gap behind the `holder.list.push(3)`
 /// silent no-op: `array_proto_mutator` normalized the receiver with
@@ -240,8 +266,13 @@ unsafe fn proxy_delete_str_key_or_throw(proxy: f64, key_bytes: &[u8]) {
 /// `array_ptr_as_proxy`) directly, until #6397 correctly deferred untyped
 /// receivers to the runtime dispatch.
 ///
-/// Returns `None` for mutators not yet routed (reverse/sort/splice/fill/
-/// copyWithin) — callers keep their previous fall-through behavior for those.
+/// `sort` is NOT here: `js_arraylike_sort` → `object_sort` already runs the
+/// spec algorithm over the proxy-aware `al_*` primitives (and roots its
+/// carried values). `fill` lives in [`proxy_array_fill`] below (its
+/// `has_start`/`has_end` shape matches `js_array_fill_generic`, its caller),
+/// and `copyWithin` in `js_array_copy_within_value`, which routes proxies
+/// itself. Returns `None` for anything else — callers keep their previous
+/// fall-through behavior.
 pub(super) fn proxy_array_mutator(
     proxy: f64,
     method: &str,
@@ -345,8 +376,187 @@ pub(super) fn proxy_array_mutator(
                 proxy_set_str_key(p(), b"length", new_len as f64);
                 Some(new_len as f64)
             }
+            // §23.1.3.26 Array.prototype.reverse — four-case swap with
+            // HasProperty gating each side: a hole DELETES the opposite slot
+            // instead of materializing an own `undefined`. Returns the
+            // receiver.
+            "reverse" => {
+                let len = proxy_array_length(p());
+                for lower in 0..len / 2 {
+                    let upper = len - lower - 1;
+                    let lower_key = lower.to_string();
+                    let upper_key = upper.to_string();
+                    let lower_handle = if proxy_has_str_key(p(), lower_key.as_bytes()) {
+                        Some(scope.root_nanbox_f64(proxy_get_str_key(p(), lower_key.as_bytes())))
+                    } else {
+                        None
+                    };
+                    let upper_handle = if proxy_has_str_key(p(), upper_key.as_bytes()) {
+                        Some(scope.root_nanbox_f64(proxy_get_str_key(p(), upper_key.as_bytes())))
+                    } else {
+                        None
+                    };
+                    match (&lower_handle, &upper_handle) {
+                        (Some(l), Some(u)) => {
+                            proxy_set_str_key(p(), lower_key.as_bytes(), u.get_nanbox_f64());
+                            proxy_set_str_key(p(), upper_key.as_bytes(), l.get_nanbox_f64());
+                        }
+                        (None, Some(u)) => {
+                            proxy_set_str_key(p(), lower_key.as_bytes(), u.get_nanbox_f64());
+                            proxy_delete_str_key_or_throw(p(), upper_key.as_bytes());
+                        }
+                        (Some(l), None) => {
+                            proxy_delete_str_key_or_throw(p(), lower_key.as_bytes());
+                            proxy_set_str_key(p(), upper_key.as_bytes(), l.get_nanbox_f64());
+                        }
+                        (None, None) => {}
+                    }
+                }
+                Some(p())
+            }
+            // §23.1.3.31 Array.prototype.splice — removed elements land in a
+            // FRESH real array (holes preserved: absent sources leave the
+            // pre-holed slot untouched); tail moves are HasProperty-gated and
+            // a refused `deleteProperty` throws BEFORE the length write.
+            "splice" => {
+                let len = proxy_array_length(p());
+                let actual_start = if args_len >= 1 {
+                    proxy_relative_index(arg(0), len)
+                } else {
+                    0
+                };
+                let actual_delete_count = if args_len == 0 {
+                    0
+                } else if args_len == 1 {
+                    len - actual_start
+                } else {
+                    let dc = to_integer_or_infinity_coerced(arg(1));
+                    dc.max(0.0).min((len - actual_start) as f64) as u64
+                };
+                // ArrayCreate throws RangeError for a count ≥ 2^32 (test262
+                // splice/create-non-array-invalid-len).
+                if actual_delete_count > u32::MAX as u64 {
+                    crate::array::array_length_range_error();
+                }
+                let removed = js_array_alloc_with_length(actual_delete_count as u32);
+                let removed_handle = scope.root_raw_mut_ptr(removed);
+                for k in 0..actual_delete_count {
+                    let from = (actual_start + k).to_string();
+                    if proxy_has_str_key(p(), from.as_bytes()) {
+                        let v = proxy_get_str_key(p(), from.as_bytes());
+                        // Re-derive `removed` from its handle: the traps above
+                        // run arbitrary JS, which can move it.
+                        let removed = removed_handle.get_raw_mut_ptr::<ArrayHeader>();
+                        let elems = (removed as *mut u8).add(std::mem::size_of::<ArrayHeader>())
+                            as *mut f64;
+                        // GC_STORE_AUDIT(BARRIERED): note_array_slot re-stores
+                        // the slot with the barrier.
+                        ptr::write(elems.add(k as usize), v);
+                        note_array_slot(removed, k as usize, v.to_bits());
+                    }
+                }
+                let item_count = args_len.saturating_sub(2) as u64;
+                if item_count < actual_delete_count {
+                    // Close the gap: shift the tail down…
+                    let mut k = actual_start;
+                    while k < len - actual_delete_count {
+                        let from = (k + actual_delete_count).to_string();
+                        let to = (k + item_count).to_string();
+                        if proxy_has_str_key(p(), from.as_bytes()) {
+                            let v_handle =
+                                scope.root_nanbox_f64(proxy_get_str_key(p(), from.as_bytes()));
+                            proxy_set_str_key(p(), to.as_bytes(), v_handle.get_nanbox_f64());
+                        } else {
+                            proxy_delete_str_key_or_throw(p(), to.as_bytes());
+                        }
+                        k += 1;
+                    }
+                    // …then delete the vacated trailing slots.
+                    let mut k = len;
+                    while k > len - actual_delete_count + item_count {
+                        proxy_delete_str_key_or_throw(p(), (k - 1).to_string().as_bytes());
+                        k -= 1;
+                    }
+                } else if item_count > actual_delete_count {
+                    // Open a gap: shift the tail up, high index first.
+                    let mut k = len - actual_delete_count;
+                    while k > actual_start {
+                        let from = (k + actual_delete_count - 1).to_string();
+                        let to = (k + item_count - 1).to_string();
+                        if proxy_has_str_key(p(), from.as_bytes()) {
+                            let v_handle =
+                                scope.root_nanbox_f64(proxy_get_str_key(p(), from.as_bytes()));
+                            proxy_set_str_key(p(), to.as_bytes(), v_handle.get_nanbox_f64());
+                        } else {
+                            proxy_delete_str_key_or_throw(p(), to.as_bytes());
+                        }
+                        k -= 1;
+                    }
+                }
+                for j in 0..args_len.saturating_sub(2) {
+                    proxy_set_str_key(
+                        p(),
+                        (actual_start + j as u64).to_string().as_bytes(),
+                        arg(2 + j),
+                    );
+                }
+                proxy_set_str_key(
+                    p(),
+                    b"length",
+                    (len - actual_delete_count + item_count) as f64,
+                );
+                Some(super::generic::nanbox_arr(
+                    removed_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                ))
+            }
             _ => None,
         }
+    }
+}
+
+/// §23.1.3.7 `Array.prototype.fill` on a Proxy receiver — the length read and
+/// every element write go through the proxy's traps. Parameter shape matches
+/// [`js_array_fill_generic`](crate::array::js_array_fill_generic), its only
+/// caller besides the prototype thunk (which routes through it). Returns the
+/// receiver.
+pub(super) fn proxy_array_fill(
+    proxy: f64,
+    value: f64,
+    has_start: i32,
+    start: f64,
+    has_end: i32,
+    end: f64,
+) -> f64 {
+    // #5552: the same source lands in many slots — demote a uniquely-owned
+    // heap string once (no-op for SSO / non-string), mirroring the dense fill.
+    crate::string::js_string_addref_if_heap_string(value);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let proxy_handle = scope.root_nanbox_f64(proxy);
+    let value_handle = scope.root_nanbox_f64(value);
+    unsafe {
+        let len = proxy_array_length(proxy_handle.get_nanbox_f64());
+        let k = if has_start != 0 {
+            proxy_relative_index(start, len)
+        } else {
+            0
+        };
+        // Spec: `end === undefined` resolves to `len`, not ToIntegerOrInfinity
+        // (which would give 0) — mirror the dense branch's undefined check.
+        let end_absent =
+            has_end == 0 || crate::value::JSValue::from_bits(end.to_bits()).is_undefined();
+        let final_index = if end_absent {
+            len
+        } else {
+            proxy_relative_index(end, len)
+        };
+        for i in k..final_index {
+            proxy_set_str_key(
+                proxy_handle.get_nanbox_f64(),
+                i.to_string().as_bytes(),
+                value_handle.get_nanbox_f64(),
+            );
+        }
+        proxy_handle.get_nanbox_f64()
     }
 }
 

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -684,6 +684,48 @@ pub(crate) extern "C" fn array_prototype_sort_thunk(
     let this = crate::object::js_implicit_this_get();
     crate::array::js_arraylike_sort(this, comparator)
 }
+/// `fill` / `copyWithin` were noop-backed until #6908, so a Proxy receiver
+/// (`p.fill(9)` — the method resolves through `Get(proxy, "fill")` to this
+/// prototype thunk) and borrowed references silently returned `undefined`.
+/// Each routes to the value-generic engine, which takes the dense helper for
+/// real arrays, the trap loop for proxies, the live-`Get`/`Set` loop for
+/// array-like objects, and ToObject-throws on nullish receivers. A supplied-
+/// but-`undefined` trailing argument is normalized to "absent" here (for
+/// `fill.start` the ToIntegerOrInfinity coercion makes them equivalent; for
+/// the `end` params the spec resolves `undefined` to `len`).
+pub(crate) extern "C" fn array_prototype_fill_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    let args = global_this_rest_array_values(rest);
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let value = args.first().copied().unwrap_or(undefined);
+    let (has_start, start) = match args.get(1) {
+        Some(v) => (1, *v),
+        None => (0, 0.0),
+    };
+    let (has_end, end) = match args.get(2) {
+        Some(v) if v.to_bits() != crate::value::TAG_UNDEFINED => (1, *v),
+        _ => (0, 0.0),
+    };
+    crate::array::js_array_fill_generic(this, value, has_start, start, has_end, end)
+}
+pub(crate) extern "C" fn array_prototype_copy_within_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    let args = global_this_rest_array_values(rest);
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let target = args.first().copied().unwrap_or(undefined);
+    let start = args.get(1).copied().unwrap_or(undefined);
+    let (has_end, end) = match args.get(2) {
+        Some(v) if v.to_bits() != crate::value::TAG_UNDEFINED => (1, *v),
+        _ => (0, 0.0),
+    };
+    crate::array::js_arraylike_copy_within(this, target, start, has_end, end)
+}
 
 /// Real thunks for the generic `Array.prototype` iteration / search methods,
 /// each routing the call-site receiver (IMPLICIT_THIS) through the

--- a/crates/perry-runtime/src/object/global_this/proto_methods.rs
+++ b/crates/perry-runtime/src/object/global_this/proto_methods.rs
@@ -88,9 +88,7 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
             install_noop_proto_methods(
                 proto_obj,
                 &[
-                    ("copyWithin", 2),
                     ("entries", 0),
-                    ("fill", 1),
                     ("flat", 0),
                     ("flatMap", 1),
                     ("keys", 0),
@@ -138,6 +136,24 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
                 proto_obj,
                 "splice",
                 array_prototype_splice_thunk as *const u8,
+                2,
+                0,
+            );
+            // #6908: `fill` / `copyWithin` get real thunks too — a Proxy
+            // receiver resolves them through `Get(proxy, name)` to the
+            // prototype thunk, so the previous noop backing silently returned
+            // undefined without firing a trap.
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "fill",
+                array_prototype_fill_thunk as *const u8,
+                1,
+                0,
+            );
+            install_proto_method_rest_with_length(
+                proto_obj,
+                "copyWithin",
+                array_prototype_copy_within_thunk as *const u8,
                 2,
                 0,
             );

--- a/crates/perry/tests/issue_5135_proxy_compound_and_function_tostring.rs
+++ b/crates/perry/tests/issue_5135_proxy_compound_and_function_tostring.rs
@@ -214,3 +214,235 @@ fn proxy_array_mutators_preserve_holes_and_throw_on_refused_delete() {
         "proxy mutators must preserve holes and DeletePropertyOrThrow"
     );
 }
+
+/// #6908 §1: the remaining `Array.prototype` mutators — `reverse` / `splice` /
+/// `fill` / `copyWithin` — on a Proxy receiver run their spec loops through
+/// the traps instead of silently falling through to `undefined` (`fill` /
+/// `copyWithin` were additionally noop-backed on the prototype, so even the
+/// method value was inert). `sort` already worked via the array-like engine;
+/// pinned here so it stays that way. All expectations byte-identical to
+/// `node --experimental-strip-types` (v26.5.1).
+#[test]
+fn proxy_array_remaining_mutators_route_through_traps() {
+    let out = compile_and_run(
+        r#"
+{
+  const t: any = [3, 1, 2];
+  const p: any = new Proxy(t, {});
+  const r = p.reverse();
+  console.log("reverse:", t.join(","), r === p);
+}
+{
+  // Even length with a hole: the (lower-exists, upper-missing) case runs
+  // DeletePropertyOrThrow on the lower side.
+  const t: any = [1, , 3, 4];
+  const p: any = new Proxy(t, {});
+  p.reverse();
+  console.log("reverse-hole:", t.join(","), 0 in t, 1 in t, 2 in t, 3 in t);
+}
+{
+  const t: any = [10, 9, 1];
+  const p: any = new Proxy(t, {});
+  const r = p.sort();
+  console.log("sort:", t.join(","), r === p);
+}
+{
+  const t: any = [1, 2, 3, 4, 5];
+  const p: any = new Proxy(t, {});
+  const removed = p.splice(1, 2, "a", "b", "c");
+  console.log("splice:", t.join(","), t.length, Array.isArray(removed), removed.join(","));
+}
+{
+  // One-arg form deletes to the end; holes stay holes in the removed array.
+  const t: any = [1, , 3];
+  const p: any = new Proxy(t, {});
+  const removed = p.splice(1);
+  console.log("splice-1arg:", t.join(","), t.length, removed.length, 0 in removed, 1 in removed);
+}
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  const r = p.fill(7, 1, 3);
+  console.log("fill:", t.join(","), r === p);
+}
+{
+  const t: any = [1, 2, 3, 4, 5];
+  const p: any = new Proxy(t, {});
+  const r = p.copyWithin(0, 3);
+  console.log("copyWithin:", t.join(","), r === p);
+}
+"#,
+    );
+    assert_eq!(
+        out,
+        "reverse: 2,1,3 true\n\
+         reverse-hole: 4,3,,1 true true false true\n\
+         sort: 1,10,9 true\n\
+         splice: 1,a,b,c,4,5 6 true 2,3\n\
+         splice-1arg: 1 1 2 false true\n\
+         fill: 1,7,7,4 true\n\
+         copyWithin: 4,5,3,4,5 true\n",
+        "proxy reverse/sort/splice/fill/copyWithin must mutate through the traps and return per spec"
+    );
+}
+
+/// #6908 §1 trap-order pin: the spec loops drive `set` / `deleteProperty` in
+/// a defined sequence, and a `deleteProperty` trap returning false throws the
+/// spec TypeError BEFORE the length write. Byte-identical to node.
+#[test]
+fn proxy_array_remaining_mutators_fire_traps_in_spec_order() {
+    let out = compile_and_run(
+        r#"
+{
+  const log: string[] = [];
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {
+    get(o: any, k: any, rc: any) {
+      if (typeof k === "string") log.push("g" + k);
+      return Reflect.get(o, k, rc);
+    },
+    set(o: any, k: any, v: any, rc: any) {
+      log.push("s" + k + "=" + v);
+      return Reflect.set(o, k, v, rc);
+    },
+  });
+  p.reverse();
+  console.log("reverse-traps:", t.join(","), log.join("|"));
+}
+{
+  const log: string[] = [];
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {
+    set(o: any, k: any, v: any, rc: any) {
+      log.push("s" + k + "=" + v);
+      return Reflect.set(o, k, v, rc);
+    },
+    deleteProperty(o: any, k: any) {
+      log.push("d" + k);
+      return Reflect.deleteProperty(o, k);
+    },
+  });
+  const removed = p.splice(0, 1);
+  console.log("splice-traps:", t.join(","), removed.join(","), log.join("|"));
+}
+{
+  const log: string[] = [];
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {
+    set(o: any, k: any, v: any, rc: any) {
+      log.push("s" + k + "=" + v);
+      return Reflect.set(o, k, v, rc);
+    },
+  });
+  p.fill(0, 1);
+  console.log("fill-traps:", t.join(","), log.join("|"));
+}
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, { deleteProperty() { return false; } });
+  try { p.splice(0, 1); console.log("splice-refused: NO-THROW"); }
+  catch (e: any) { console.log("splice-refused:", (e instanceof TypeError) ? "TypeError" : "other"); }
+  console.log("splice-refused-after:", t.join(","), t.length);
+}
+"#,
+    );
+    assert_eq!(
+        out,
+        "reverse-traps: 4,3,2,1 greverse|glength|g0|g3|s0=4|s3=1|g1|g2|s1=3|s2=2\n\
+         splice-traps: 2,3 1 s0=2|s1=3|d2|slength=2\n\
+         fill-traps: 1,0,0 s1=0|s2=0\n\
+         splice-refused: TypeError\n\
+         splice-refused-after: 2,3,3 3\n",
+        "proxy mutator trap sequences must match the spec algorithms"
+    );
+}
+
+/// #6908 §1, `.call` forms: `Array.prototype.<m>.call(proxy, …)` lowers to
+/// the value-generic engines (`js_array_reverse_value` / `js_arraylike_splice`
+/// / `js_array_fill_generic` / `js_array_copy_within_value`), which must
+/// route a Proxy receiver to the same trap loops as the member call.
+#[test]
+fn proxy_array_mutator_call_forms_route_through_traps() {
+    let out = compile_and_run(
+        r#"
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {});
+  Array.prototype.reverse.call(p);
+  console.log("call-reverse:", t.join(","));
+}
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  const rm: any = Array.prototype.splice.call(p, 1, 2);
+  console.log("call-splice:", rm.join(","), t.join(","));
+}
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {});
+  Array.prototype.fill.call(p, 8, 1);
+  console.log("call-fill:", t.join(","));
+}
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  Array.prototype.copyWithin.call(p, 0, 2);
+  console.log("call-copyWithin:", t.join(","));
+}
+"#,
+    );
+    assert_eq!(
+        out,
+        "call-reverse: 3,2,1\ncall-splice: 2,3 1,4\ncall-fill: 1,8,8\ncall-copyWithin: 3,4,3,4\n",
+        "Array.prototype.<m>.call(proxy, ...) must fire the proxy traps"
+    );
+}
+
+/// #6908 §2: a prototype mutator thunk invoked as a plain value has no
+/// receiver (`IMPLICIT_THIS` is undefined) — spec step 1 `ToObject(this)`
+/// throws TypeError. Previously this silently no-opped, the worst outcome:
+/// callers observed neither the mutation nor an error. Also pins that a
+/// PRIOR method call's receiver does not leak into the bare call.
+#[test]
+fn receiverless_prototype_mutator_thunk_throws_type_error() {
+    let out = compile_and_run(
+        r#"
+{
+  const t: any = [1, 2];
+  const f: any = t["push"];
+  console.log("typeof:", typeof f);
+  try { f(3); console.log("bare-push: NO-THROW"); }
+  catch (e: any) { console.log("bare-push:", (e instanceof TypeError) ? "TypeError" : "other", e.message); }
+  console.log("bare-push-after:", t.join(","));
+}
+{
+  const t: any = [1, 2];
+  const p: any = new Proxy(t, {});
+  const g: any = p.push;
+  try { g(3); console.log("proxy-bare-push: NO-THROW"); }
+  catch (e: any) { console.log("proxy-bare-push:", (e instanceof TypeError) ? "TypeError" : "other"); }
+  console.log("proxy-bare-push-after:", t.join(","));
+}
+{
+  // A previous method-style call must not leave its receiver armed.
+  const t: any = [1];
+  t.push(9);
+  const f: any = t["pop"];
+  try { f(); console.log("stale-this: NO-THROW"); }
+  catch (e: any) { console.log("stale-this:", (e instanceof TypeError) ? "TypeError" : "other"); }
+  console.log("stale-this-after:", t.join(","));
+}
+"#,
+    );
+    assert_eq!(
+        out,
+        "typeof: function\n\
+         bare-push: TypeError Cannot convert undefined or null to object\n\
+         bare-push-after: 1,2\n\
+         proxy-bare-push: TypeError\n\
+         proxy-bare-push-after: 1,2\n\
+         stale-this: TypeError\n\
+         stale-this-after: 1,9\n",
+        "a receiver-less builtin mutator thunk must throw the spec TypeError, not silently no-op"
+    );
+}

--- a/test-files/test_gap_6908_proxy_array_mutators.ts
+++ b/test-files/test_gap_6908_proxy_array_mutators.ts
@@ -1,0 +1,194 @@
+// Gap test for #6908 — the remaining Array.prototype mutators on Proxy
+// receivers (reverse / sort / splice / fill / copyWithin), plus the
+// receiver-less prototype-thunk TypeError.
+//
+// A Proxy receiver reaching the generic mutator dispatch used to fall through
+// every normalization (`as_real_array` rightly rejects handle-band ids;
+// `run_object_mutator` only accepts plain objects) and silently return
+// `undefined` — no trap fired, nothing mutated. `fill`/`copyWithin` were
+// additionally noop-backed on Array.prototype. And a mutator thunk invoked as
+// a plain value (`const f = arr.push; f(3)`) had no receiver and silently
+// no-opped where spec step 1 `ToObject(this)` throws.
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// ---- reverse: mutation, identity, trap order ----
+{
+  const t: any = [3, 1, 2];
+  const p: any = new Proxy(t, {});
+  const r = p.reverse();
+  console.log("reverse:", t.join(","), r === p);
+}
+{
+  const log: string[] = [];
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {
+    get(o: any, k: any, rc: any) {
+      if (typeof k === "string") log.push("g" + k);
+      return Reflect.get(o, k, rc);
+    },
+    set(o: any, k: any, v: any, rc: any) {
+      log.push("s" + k + "=" + v);
+      return Reflect.set(o, k, v, rc);
+    },
+  });
+  p.reverse();
+  console.log("reverse-traps:", t.join(","), log.join("|"));
+}
+{
+  const t: any = [1, , 3, 4];
+  const p: any = new Proxy(t, {});
+  p.reverse();
+  console.log("reverse-hole:", t.join(","), 0 in t, 1 in t, 2 in t, 3 in t);
+}
+
+// ---- sort: default (string) order and comparator, identity ----
+{
+  const t: any = [10, 9, 1];
+  const p: any = new Proxy(t, {});
+  const r = p.sort();
+  console.log("sort:", t.join(","), r === p);
+}
+{
+  const t: any = [10, 2, 33, 4];
+  const p: any = new Proxy(t, {});
+  p.sort((a: number, b: number) => a - b);
+  console.log("sort-cmp:", t.join(","));
+}
+
+// ---- splice: remove/insert, fresh real Array result, holes, traps ----
+{
+  const t: any = [1, 2, 3, 4, 5];
+  const p: any = new Proxy(t, {});
+  const removed = p.splice(1, 2, "a", "b", "c");
+  console.log("splice:", t.join(","), t.length, Array.isArray(removed), removed.join(","));
+}
+{
+  const t: any = [1, , 3];
+  const p: any = new Proxy(t, {});
+  const removed = p.splice(1);
+  console.log("splice-1arg:", t.join(","), t.length, removed.length, 0 in removed, 1 in removed);
+}
+{
+  const log: string[] = [];
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {
+    set(o: any, k: any, v: any, rc: any) {
+      log.push("s" + k + "=" + v);
+      return Reflect.set(o, k, v, rc);
+    },
+    deleteProperty(o: any, k: any) {
+      log.push("d" + k);
+      return Reflect.deleteProperty(o, k);
+    },
+  });
+  const removed = p.splice(0, 1);
+  console.log("splice-traps:", t.join(","), removed.join(","), log.join("|"));
+}
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, { deleteProperty() { return false; } });
+  try {
+    p.splice(0, 1);
+    console.log("splice-refused: NO-THROW");
+  } catch (e: any) {
+    console.log("splice-refused:", e instanceof TypeError, e.message);
+  }
+  console.log("splice-refused-after:", t.join(","), t.length);
+}
+
+// ---- fill / copyWithin: mutation through traps, identity ----
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  const r = p.fill(7, 1, 3);
+  console.log("fill:", t.join(","), r === p);
+}
+{
+  const t: any = [1, 2, 3, 4, 5];
+  const p: any = new Proxy(t, {});
+  const r = p.copyWithin(0, 3);
+  console.log("copyWithin:", t.join(","), r === p);
+}
+
+// ---- .call forms hit the same trap loops ----
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {});
+  Array.prototype.reverse.call(p);
+  console.log("call-reverse:", t.join(","));
+}
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  const rm: any = Array.prototype.splice.call(p, 1, 2);
+  console.log("call-splice:", rm.join(","), t.join(","));
+}
+{
+  const t: any = [1, 2, 3];
+  const p: any = new Proxy(t, {});
+  Array.prototype.fill.call(p, 8, 1);
+  console.log("call-fill:", t.join(","));
+}
+{
+  const t: any = [1, 2, 3, 4];
+  const p: any = new Proxy(t, {});
+  Array.prototype.copyWithin.call(p, 0, 2);
+  console.log("call-copyWithin:", t.join(","));
+}
+
+// ---- receiver-less prototype thunks throw the ToObject TypeError ----
+{
+  const t: any = [1, 2];
+  const f: any = t["push"];
+  console.log("thunk-typeof:", typeof f);
+  try {
+    f(3);
+    console.log("bare-push: NO-THROW");
+  } catch (e: any) {
+    console.log("bare-push:", e instanceof TypeError, e.message);
+  }
+  console.log("bare-push-after:", t.join(","));
+}
+{
+  const t: any = [1, 2];
+  const p: any = new Proxy(t, {});
+  const g: any = p.push;
+  try {
+    g(3);
+    console.log("proxy-bare-push: NO-THROW");
+  } catch (e: any) {
+    console.log("proxy-bare-push:", e instanceof TypeError);
+  }
+  console.log("proxy-bare-push-after:", t.join(","));
+}
+{
+  const t: any = [1];
+  t.push(9);
+  const f: any = t["pop"];
+  try {
+    f();
+    console.log("stale-this: NO-THROW");
+  } catch (e: any) {
+    console.log("stale-this:", e instanceof TypeError);
+  }
+  console.log("stale-this-after:", t.join(","));
+}
+
+// ---- regression guards: dense arrays and array-like objects unaffected ----
+{
+  const t: number[] = [3, 1, 2];
+  t.reverse();
+  t.sort((a, b) => a - b);
+  const rem = t.splice(1, 1);
+  t.fill(0, 0, 1);
+  t.copyWithin(2, 0, 1);
+  console.log("dense:", t.join(","), rem.join(","));
+}
+{
+  const o: any = { 0: "c", 1: "a", 2: "b", length: 3 };
+  Array.prototype.reverse.call(o);
+  console.log("objlike-reverse:", o[0], o[1], o[2]);
+  const o2: any = { 0: 5, 1: 3, 2: 4, length: 3 };
+  const rm: any = Array.prototype.splice.call(o2, 0, 2);
+  console.log("objlike-splice:", rm.join(","), o2[0], o2.length);
+}


### PR DESCRIPTION
Fixes #6908 — both halves.

## Part 1: remaining `Array.prototype` mutators on Proxy receivers

`reverse` / `splice` / `fill` / `copyWithin` on a Proxy receiver reaching the generic dispatch fired no trap and mutated nothing: `as_real_array` rightly rejects handle-band ids (the #6279 segfault class), `run_object_mutator` only accepts plain objects, so the call silently returned `undefined`. `fill`/`copyWithin` were additionally **noop-backed on `Array.prototype`**, so even the resolved method value was inert.

- **`proxy_array_mutator`** (`array/push_pop.rs`) gains spec loops for **`reverse`** (§23.1.3.26) and **`splice`** (§23.1.3.31), joining #6907's push/pop/shift/unshift: `HasProperty`-gated element moves (a source hole *deletes* the destination), `DeletePropertyOrThrow` before the length write, and every value carried across a trap rooted in the `RuntimeHandleScope` (traps run arbitrary JS → GC can move things). `splice` returns a fresh real array with holes preserved.
- **`proxy_array_fill`** (§23.1.3.7) backs both the new real `fill` thunk and `js_array_fill_generic`'s new proxy branch — previously a proxy fell past both typed branches there into `js_object_coerce` **self-recursion**.
- **`copyWithin`** gets a real thunk over the already proxy-aware `js_array_copy_within_value` via a new `js_arraylike_copy_within` value entry (dense receivers keep the dense helper, mirroring the dynamic-dispatch #2802 arm).
- **`.call` forms** pre-route proxies: `js_array_reverse_value` and `js_arraylike_splice` now hand proxies to the same trap loops. (`object_splice`'s `al_set_length` tail reads the masked handle id as a raw `ObjectHeader` address, and the `al_*` proxy deletes don't throw on a refusing trap.)
- **`sort` already worked** (its thunk routes to `object_sort` over the proxy-aware `al_*` primitives) — pinned by tests so it stays that way.

## Part 2: prototype thunks losing their receiver as plain values

A mutator thunk invoked as a plain value (`const f = arr.push; f(3)`, or the decomposed proxy form `const g = p.push; g(3)`) has no receiver — `IMPLICIT_THIS` holds its `undefined` default — and silently no-opped. Spec step 1 of every one of these algorithms is `ToObject(this value)`, which throws. `array_proto_mutator` now throws the node-identical `TypeError: Cannot convert undefined or null to object` for nullish receivers, covering all six thunks plus the `js_arraylike_pop`/`js_arraylike_shift` `.call` entries. A test also pins that a *prior* method call's receiver does not leak into a later bare call.

## Validation

- 28-case probe (member calls, trap ordering, holes, refused-`deleteProperty` throws, `.call` forms, receiver-less thunks, dense/array-like regression guards) **byte-identical to node 26.5.1**.
- New gap test `test-files/test_gap_6908_proxy_array_mutators.ts` — byte-identical.
- 4 new integration tests in `crates/perry/tests/issue_5135_proxy_compound_and_function_tostring.rs` (10/10 green, incl. the #6907 ones).
- `perry-runtime --lib` suite: **1636/1636** at `--test-threads=1`.
- 14 pre-existing proxy/array gap tests re-run against the patched build: all still byte-identical to node.
- `check_file_size.sh`, addr-class ratchet, clippy on touched files: clean.

No version bump per contributor flow (maintainer bumps at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Array.prototype` methods—including `reverse`, `sort`, `splice`, `fill`, and `copyWithin`—when used with Proxies.
  * Preserved sparse-array holes, mutation results, trap behavior, and standard errors when deletions are rejected.
  * Receiver-less array mutator calls now consistently throw `TypeError` instead of operating incorrectly.
  * Enabled fully functional `fill` and `copyWithin` methods for reflective and Proxy-mediated calls.

* **Tests**
  * Added comprehensive coverage for Proxy-backed arrays, sparse arrays, `.call()` usage, and array-like values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->