### PR TITLE
size: compile node:test only into programs that import it

### DIFF
--- a/changelog.d/7433-gate-node-test.md
+++ b/changelog.d/7433-gate-node-test.md
@@ -1,0 +1,1 @@
+size: `node:test` is now compiled only into programs that import it — the runner was the sole retainer of the JSON serializer, so hello world drops 82,672 bytes (4,791,416 → 4,708,744).

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["rlib"]
 # actually needs (see optimized_libs.rs), so the heavy subsystems below
 # (regex engine, Temporal, URL/IDNA, normalize, segmenter) are *opt-in per
 # app* and absent from binaries that never use them.
-default = ["full", "regex-engine", "temporal", "url-engine", "string-normalize", "intl-segmenter", "intl-namespace", "global-math", "global-json", "global-reflect", "global-atomics", "global-url", "global-text", "global-websocket", "global-webcrypto", "global-webfetch", "proc-ipc", "intl-locale", "intl-datetime", "diagnostics", "mod-dgram", "mod-http2-constants", "dyn-eval", "keepalive-anchors", "alloc-mimalloc"]
+default = ["full", "regex-engine", "temporal", "url-engine", "string-normalize", "intl-segmenter", "intl-namespace", "global-math", "global-json", "global-reflect", "global-atomics", "global-url", "global-text", "global-websocket", "global-webcrypto", "global-webfetch", "proc-ipc", "intl-locale", "intl-datetime", "diagnostics", "mod-dgram", "mod-http2-constants", "mod-node-test", "dyn-eval", "keepalive-anchors", "alloc-mimalloc"]
 # Compile the ~490 `#[used]` keep-alive anchor statics (`KEEP_*`, `keep!`,
 # `K*`/`G*` fn-pointer statics) that pin codegen-facing `#[no_mangle]` entry
 # points as dead-strip roots. They exist for the whole-program bitcode-LTO
@@ -65,6 +65,17 @@ mod-dgram = []
 # only the constant tables — the HTTP/2 server surface (`js_node_http2_*`) is
 # unaffected (it lives in perry-ext-http, routed via `http-client`).
 mod-http2-constants = []
+# Per-module Node-API gate (binary-size): compiles the `node:test` runner
+# (`node_submodules::test` + its snapshot/property/reporter helpers, ~2.7k LOC)
+# and its two dispatch buckets only when the program imports `node:test` or
+# `node:test/reporters`. Measured with `-why_live`: the runner is the ONLY
+# retainer of the JSON serializer in an otherwise plain program —
+# `test::snapshot::assert_snapshot` calls `js_json_stringify_full`, so every
+# binary carried `crate::json` whether or not it could reach it. The compiler
+# enables this on `test`/`test/reporters` in `native_module_imports`, and on
+# `process.getBuiltinModule` (whose target is only known at runtime), the same
+# way `mod-http2-constants` does. Pure cfg gate, no extra deps.
+mod-node-test = []
 # Cold-path diagnostic JSON serializers (~67 KB of code + the `serde_json`
 # pulled only by them, which dead-strips when unreferenced): GC cycle telemetry
 # (`PERRY_GC_DIAG`), typed-feedback trace dump (`PERRY_TYPED_FEEDBACK`), the v8

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -114,6 +114,7 @@ mod consumers;
 mod fs_promises;
 mod hono_jsx;
 mod stream_promises;
+#[cfg(feature = "mod-node-test")]
 mod test;
 mod timers;
 mod trace_events;
@@ -152,6 +153,7 @@ use fs_promises::{
     thunk_readline_Interface, thunk_readline_Readline, thunk_readline_createInterface,
 };
 use stream_promises::{thunk_streamP_finished, thunk_streamP_pipeline, value_from_ptr};
+#[cfg(feature = "mod-node-test")]
 use test::{
     thunk_reporter_dot, thunk_reporter_junit, thunk_reporter_lcov, thunk_reporter_spec,
     thunk_reporter_tap, thunk_test, thunk_test_hook, thunk_test_only, thunk_test_run,
@@ -657,6 +659,7 @@ static SUBMOD_TRACE_EVENTS: SubmoduleSpec = SubmoduleSpec {
     ],
 };
 
+#[cfg(feature = "mod-node-test")]
 static SUBMOD_TEST: SubmoduleSpec = SubmoduleSpec {
     key: "test",
     exports: &[
@@ -724,6 +727,7 @@ static SUBMOD_TEST: SubmoduleSpec = SubmoduleSpec {
     ],
 };
 
+#[cfg(feature = "mod-node-test")]
 static SUBMOD_TEST_REPORTERS: SubmoduleSpec = SubmoduleSpec {
     key: "test_reporters",
     exports: &[
@@ -789,7 +793,9 @@ fn submod_index(key: &str) -> Option<SubmodBucket> {
         "sys" => Some(SubmodBucket::Sys),
         "diagnostics_channel" => Some(SubmodBucket::DiagnosticsChannel),
         "trace_events" => Some(SubmodBucket::TraceEvents),
+        #[cfg(feature = "mod-node-test")]
         "test" => Some(SubmodBucket::Test),
+        #[cfg(feature = "mod-node-test")]
         "test_reporters" => Some(SubmodBucket::TestReporters),
         _ => None,
     }
@@ -938,6 +944,7 @@ pub extern "C" fn js_node_submod_install_trace_events() {
         Ordering::Relaxed,
     );
 }
+#[cfg(feature = "mod-node-test")]
 #[no_mangle]
 pub extern "C" fn js_node_submod_install_test() {
     SUBMOD_REGISTRY[SubmodBucket::Test as usize].store(
@@ -945,6 +952,7 @@ pub extern "C" fn js_node_submod_install_test() {
         Ordering::Relaxed,
     );
 }
+#[cfg(feature = "mod-node-test")]
 #[no_mangle]
 pub extern "C" fn js_node_submod_install_test_reporters() {
     SUBMOD_REGISTRY[SubmodBucket::TestReporters as usize].store(
@@ -967,8 +975,11 @@ pub extern "C" fn js_node_submod_install_all() {
     js_node_submod_install_sys();
     js_node_submod_install_diagnostics_channel();
     js_node_submod_install_trace_events();
-    js_node_submod_install_test();
-    js_node_submod_install_test_reporters();
+    #[cfg(feature = "mod-node-test")]
+    {
+        js_node_submod_install_test();
+        js_node_submod_install_test_reporters();
+    }
 }
 static SUBMOD_INSTALL_ALL_HOOK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 #[no_mangle]
@@ -1132,6 +1143,7 @@ fn special_export_value(submod_key: &str, name: &str) -> Option<f64> {
                 name.len(),
             ))
         }
+        #[cfg(feature = "mod-node-test")]
         "test" => test::test_special_export_value(name),
         _ => None,
     };
@@ -1139,6 +1151,39 @@ fn special_export_value(submod_key: &str, name: &str) -> Option<f64> {
         ANY_SINGLETON_ALLOCATED.store(1, Ordering::Release);
     }
     value
+}
+
+/// `node:test` wraps a handful of its exports so `test.skip`/`test.only`-style
+/// chaining works. Behind `mod-node-test` so a program that never imports
+/// `node:test` links none of the runner (see the feature's comment in
+/// `Cargo.toml` for why that also unpins the JSON serializer).
+#[cfg(feature = "mod-node-test")]
+fn maybe_decorate_test_export(
+    submod: &'static SubmoduleSpec,
+    export: &'static ExportSpec,
+    key_name: &'static str,
+    allocated: *mut ClosureHeader,
+) -> Option<*mut ClosureHeader> {
+    if submod.key == "test"
+        && matches!(
+            export.name,
+            "default" | "test" | "suite" | "describe" | "it"
+        )
+    {
+        Some(test::decorate_test_export(allocated, key_name == "test"))
+    } else {
+        None
+    }
+}
+
+#[cfg(not(feature = "mod-node-test"))]
+fn maybe_decorate_test_export(
+    _submod: &'static SubmoduleSpec,
+    _export: &'static ExportSpec,
+    _key_name: &'static str,
+    _allocated: *mut ClosureHeader,
+) -> Option<*mut ClosureHeader> {
+    None
 }
 
 fn ensure_export_singleton(
@@ -1203,13 +1248,9 @@ fn ensure_export_singleton(
             allocated_handle.get_raw_mut_ptr::<ClosureHeader>() as usize,
         );
         allocated_handle.get_raw_mut_ptr()
-    } else if submod.key == "test"
-        && matches!(
-            export.name,
-            "default" | "test" | "suite" | "describe" | "it"
-        )
+    } else if let Some(decorated) = maybe_decorate_test_export(submod, export, key_name, allocated)
     {
-        test::decorate_test_export(allocated, key_name == "test")
+        decorated
     } else {
         allocated
     };
@@ -1480,6 +1521,7 @@ pub fn scan_node_submodule_singleton_roots_mut(visitor: &mut crate::gc::RuntimeR
     });
     diagnostics_tail::scan_diagnostics_tail_roots_mut(visitor);
     trace_events::scan_trace_events_roots_mut(visitor);
+    #[cfg(feature = "mod-node-test")]
     test::scan_test_module_roots_mut(visitor);
 }
 

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -464,6 +464,25 @@ pub(super) fn detect_optional_feature_usage(
         if hir_debug.contains("module: \"dgram\"") {
             ctx.uses_dgram = true;
         }
+        // `node:test` → gates `perry-runtime/mod-node-test` (the runner, and
+        // with it the JSON serializer its snapshot assertions call). Like
+        // dgram it is runtime-only, so `requires_stdlib` is false for it and
+        // `native_module_imports` never learns about it. Match the import
+        // list rather than the lowered body: `node:test` reaches the body as
+        // `module: "test"`, but `node:test/reporters` lowers its specifiers
+        // to bare `ExternFuncRef`s and leaves no module marker there at all,
+        // so a body-only scan links a program that calls
+        // `js_node_submod_install_test_reporters` against a runtime that no
+        // longer defines it.
+        if !ctx.uses_node_test {
+            ctx.uses_node_test = hir_module.imports.iter().any(|import| {
+                let bare = import
+                    .source
+                    .strip_prefix("node:")
+                    .unwrap_or(&import.source);
+                bare == "test" || bare == "test/reporters"
+            });
+        }
         if debug_hir_uses_get_builtin_module(&hir_debug) {
             ctx.uses_get_builtin_module = true;
         }

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -11,6 +11,14 @@ fn needs_http2_constants(ctx: &CompilationContext) -> bool {
     ctx.native_module_imports.contains("http2") || ctx.uses_get_builtin_module
 }
 
+/// `node:test` drags in the whole runner, and with it the JSON serializer its
+/// snapshot assertions call. Keep it for a program that imports either entry
+/// point, or that can reach any builtin by runtime string via
+/// `process.getBuiltinModule`.
+fn needs_node_test(ctx: &CompilationContext) -> bool {
+    ctx.uses_node_test || ctx.uses_get_builtin_module
+}
+
 pub(crate) fn auto_optimized_archives_are_fresh(
     workspace_root: &Path,
     runtime_path: &Path,
@@ -104,7 +112,7 @@ pub(crate) fn auto_optimized_cache_key(
 ) -> String {
     let target_str = target.unwrap_or("host");
     format!(
-        "{}|{}|{}|wasm={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|dyneval={}|sizeopt={}|anchors={}|v={}",
+        "{}|{}|{}|wasm={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|nodetest={}|dyneval={}|sizeopt={}|anchors={}|v={}",
         feature_arg,
         panic_abort_safe,
         target_str,
@@ -133,6 +141,9 @@ pub(crate) fn auto_optimized_cache_key(
         // `perry-runtime/mod-http2-constants`, so key the cache on the shared
         // gate like the other optional runtime features.
         needs_http2_constants(ctx),
+        // `node:test` gates `perry-runtime/mod-node-test`, which changes the
+        // built archive, so it keys the cache like every other feature toggle.
+        needs_node_test(ctx),
         // #6559: dyn-eval presence changes the built archive, so it must
         // key the freshness stamp like every other runtime feature toggle.
         perry_hir::has_deferred_dynamic_code_sites(),
@@ -249,6 +260,9 @@ pub(crate) fn auto_optimized_cross_features(
     // known at runtime. Programs using neither path still link none of them.
     if needs_http2_constants(ctx) {
         cross_features.push("perry-runtime/mod-http2-constants".to_string());
+    }
+    if needs_node_test(ctx) {
+        cross_features.push("perry-runtime/mod-node-test".to_string());
     }
     // #6559: a deferred dynamic-code site (`eval(...)` / `new Function(...)`
     // with a runtime body) means the binary may construct functions from

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -516,6 +516,62 @@ fn explicit_undici_import_routes_to_well_known_undici() {
 }
 
 #[test]
+fn node_test_usage_enables_mod_node_test_cross_feature() {
+    // The `node:test` runner is the only retainer of the JSON serializer in an
+    // otherwise plain program (`test::snapshot::assert_snapshot` calls
+    // `js_json_stringify_full`), so it sits behind `mod-node-test`. Codegen
+    // emits a direct `js_node_submod_install_test` call for any program that
+    // imports it, so the gate MUST be on whenever that call is emitted or the
+    // link dies with an undefined symbol.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let empty_features: std::collections::BTreeSet<&'static str> =
+        std::collections::BTreeSet::new();
+
+    let mut with_test = CompilationContext::new(dir.path().to_path_buf());
+    with_test.uses_node_test = true;
+    let cross_on = auto_optimized_cross_features(&with_test, &empty_features, &[]);
+    assert!(
+        cross_on.iter().any(|f| f == "perry-runtime/mod-node-test"),
+        "node:test usage should enable mod-node-test, got {cross_on:?}"
+    );
+
+    let without = CompilationContext::new(dir.path().to_path_buf());
+    let cross_off = auto_optimized_cross_features(&without, &empty_features, &[]);
+    assert!(
+        !cross_off.iter().any(|f| f == "perry-runtime/mod-node-test"),
+        "no node:test usage should leave mod-node-test off, got {cross_off:?}"
+    );
+
+    // `process.getBuiltinModule("node:test")` resolves at runtime, so the
+    // runner has to be present even though no import statement names it.
+    let mut dynamic = CompilationContext::new(dir.path().to_path_buf());
+    dynamic.uses_get_builtin_module = true;
+    let cross_dynamic = auto_optimized_cross_features(&dynamic, &empty_features, &[]);
+    assert!(
+        cross_dynamic
+            .iter()
+            .any(|f| f == "perry-runtime/mod-node-test"),
+        "getBuiltinModule should enable mod-node-test, got {cross_dynamic:?}"
+    );
+}
+
+#[test]
+fn node_test_gate_keys_the_auto_optimize_cache() {
+    // Two programs that differ ONLY in `node:test` usage build different
+    // archives, so they must not share a `target/perry-auto-<hash>` dir.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut with_test = CompilationContext::new(dir.path().to_path_buf());
+    with_test.uses_node_test = true;
+    let without = CompilationContext::new(dir.path().to_path_buf());
+
+    assert_ne!(
+        auto_optimized_cache_key("", true, false, None, &with_test),
+        auto_optimized_cache_key("", true, false, None, &without),
+        "mod-node-test must participate in the auto-optimize cache key"
+    );
+}
+
+#[test]
 fn http2_import_enables_http2_constants_cross_feature() {
     // #6468: importing `node:http2` records "http2" in `native_module_imports`,
     // which must flip on `perry-runtime/mod-http2-constants` so the constant

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -788,6 +788,9 @@ pub struct CompilationContext {
     /// none of it. NB: not via `native_module_imports`, which only tracks
     /// `requires_stdlib` modules — dgram is runtime-only.
     pub uses_dgram: bool,
+    /// Program imports `node:test` / `node:test/reporters` — gates
+    /// `perry-runtime/mod-node-test`.
+    pub uses_node_test: bool,
     /// Whether any module calls `process.getBuiltinModule`. The requested
     /// module is only known at runtime, so auto-optimized runtimes must retain
     /// optional builtin namespace data such as the HTTP/2 key tables.
@@ -1141,6 +1144,7 @@ impl CompilationContext {
             uses_intl_datetime: false,
             uses_diagnostics: false,
             uses_dgram: false,
+            uses_node_test: false,
             uses_get_builtin_module: false,
             needs_thread: false,
             cross_module_class_field_types: HashMap::new(),


### PR DESCRIPTION
## What

`-why_live` on a hello-world binary shows the `node:test` runner is the **sole retainer of the JSON serializer**:

```
json::stringify::stringify_object_inner
  <- js_json_stringify_full
    <- node_submodules::test::snapshot::assert_snapshot
      <- test::run_test_registration
        <- node_submodules::ensure_export_singleton
```

The runner (~2.7k LOC across `test.rs`, `test_snapshot.rs`, `test_property.rs`, `test_reporters.rs`) and its two dispatch buckets were compiled unconditionally, so every binary carried both it and `crate::json`.

This gates both behind a new `mod-node-test` feature, following the `mod-dgram` pattern. The compiler enables it on an import of `node:test` / `node:test/reporters`, and on `process.getBuiltinModule`, whose target is only known at runtime.

## Size

hello world: **4,791,416 → 4,708,744 bytes (−82,672)**. Within that, `rt::node_submodules` −47,800 and `rt::json` −24,148.

## Two things that make this gate subtle

**1. Detection must scan the import list, not the lowered body.** `node:test` reaches the body as `module: "test"` (same shape as `dgram`), but `node:test/reporters` lowers its specifiers to bare `ExternFuncRef`s and leaves **no module marker in the body at all**. A body-only scan therefore compiles a program that calls `js_node_submod_install_test_reporters` against a runtime that no longer defines it. Both forms broke a draft of this gate before the detection moved to `hir_module.imports`.

**2. `native_module_imports` is not usable here.** `perry_hir::requires_stdlib` is false for `node:test` (it is runtime-only), so that set never learns about the import — the same reason `uses_dgram` exists as its own flag.

## Verification

- `cargo check -p perry-runtime` on both cfg paths, and `-p perry`. `cargo fmt --all -- --check` clean.
- `import test from "node:test"` — links, runs all 4 tests, pass/skip correct.
- `import { spec, tap } from "node:test/reporters"` — links, both resolve as functions.
- `process.getBuiltinModule("node:test")` — links, resolves.
- hello world still prints, and no `node_submodules::test::` or `perry_runtime::json::` symbol survives in it.
- Two new unit tests: the cross-feature decision (import / absent / `getBuiltinModule`), and that the gate keys the auto-optimize cache so two programs differing only in `node:test` usage cannot share an archive.

**Pre-existing, not touched:** Perry's `node:test` summary formatting differs from Node's (per-test summary blocks instead of one aggregate, no `▶` suite nesting). Confirmed identical on released perry 0.5.1220, so it predates this change.
