### PR TITLE
fix(warnings): SubmodBucket dead-code warning from #7433

### DIFF
--- a/changelog.d/7440-submod-bucket-dead-code.md
+++ b/changelog.d/7440-submod-bucket-dead-code.md
@@ -1,0 +1,1 @@
+fix(warnings): silence the `SubmodBucket::Test`/`TestReporters` dead-code warning that #7433 introduced in `--no-default-features` builds.

--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -758,6 +758,9 @@ static SUBMOD_TEST_REPORTERS: SubmoduleSpec = SubmoduleSpec {
 use std::sync::atomic::AtomicPtr;
 #[derive(Copy, Clone)]
 #[repr(usize)]
+// `Test`/`TestReporters` keep their discriminants (they size and index
+// `SUBMOD_REGISTRY`) but are only constructed under `mod-node-test`.
+#[cfg_attr(not(feature = "mod-node-test"), allow(dead_code))]
 enum SubmodBucket {
     Vm,
     Timers,


### PR DESCRIPTION
## What

#7433 put `node:test` behind `mod-node-test` but left the `SubmodBucket::Test` and `::TestReporters` variants ungated. They carry the discriminants that size and index `SUBMOD_REGISTRY`, so deleting them would shift every other bucket — but with the feature off they are never constructed:

```
$ cargo check -p perry-runtime --no-default-features --features full
warning: variants `Test` and `TestReporters` are never constructed
```

That is the configuration the auto-optimize rebuild uses, and the workspace is meant to be at zero warnings (#6837).

The variants have to stay for their discriminants, so this marks the enum `allow(dead_code)` **only** in that configuration. Default builds are unchanged.

My regression from #7433; found while measuring an unrelated gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary dead-code warning in builds that exclude Node test support.
  * Preserved submodule registry indexing behavior across build configurations.

* **Documentation**
  * Added a changelog entry describing the warning suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->