### PR TITLE
style: rustfmt after #7434

### DIFF
--- a/changelog.d/7442-fmt-after-7434.md
+++ b/changelog.d/7442-fmt-after-7434.md
@@ -1,0 +1,7 @@
+**Fixed** `cargo fmt --all -- --check` failed on `main` after #7434.
+
+`lint` is a required context, so a red `lint` means every subsequent merge
+bypasses a required gate. Two hunks, six lines: an `assert!` in
+`gc/tests/telemetry_verifier.rs` exceeding rustfmt's default `fn_call_width`, and
+a `pub(crate) use` in `object/field_get_set.rs` added below the `pub use` block
+where `reorder_imports` wants it above.

--- a/crates/perry-runtime/src/gc/tests/telemetry_verifier.rs
+++ b/crates/perry-runtime/src/gc/tests/telemetry_verifier.rs
@@ -396,7 +396,10 @@ fn test_pause_ring_records_max_and_window() {
 fn test_record_collection_bumps_read_pic_epoch() {
     use std::sync::atomic::Ordering;
     let before = crate::object::PERRY_IC_EPOCH.load(Ordering::Relaxed);
-    assert!(before >= 1, "epoch starts at 1 so zeroinitializer never hits");
+    assert!(
+        before >= 1,
+        "epoch starts at 1 so zeroinitializer never hits"
+    );
     GC_STATS.with(|stats| {
         stats.borrow_mut().record_collection(0, 1);
     });

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -192,6 +192,7 @@ pub(crate) use has_property::{
     wide_key_index_note_hit, WIDE_KEY_INDEX_MIN_KEYS,
 };
 pub use has_property::{js_in_operator, js_object_has_property};
+pub(crate) use ic_miss::pic_epoch_bump;
 pub(crate) use ic_miss::{
     is_array_method_value_name, is_primitive_proto_method, is_timer_handle_method_key,
     set_method_value_name,
@@ -201,7 +202,6 @@ pub use ic_miss::{
     js_object_get_field_ic_miss, js_object_set_field_by_property_id, js_private_brand_check,
     js_private_guard, PERRY_IC_EPOCH,
 };
-pub(crate) use ic_miss::pic_epoch_bump;
 
 #[cfg(test)]
 mod buffer_ic_miss_tests {


### PR DESCRIPTION
`cargo fmt --all -- --check` fails on `main` (exit 1) after #7434.

`lint` is a **required** context, so while it is red every merge bypasses a required gate — the exact hazard CLAUDE.md's gate list describes, and it is how a 2000-line cap violation went unnoticed for 40 commits earlier today.

Two hunks, six lines:
- `gc/tests/telemetry_verifier.rs:396` — an `assert!` 72 columns from col 4, over rustfmt's default `fn_call_width` of 60
- `object/field_get_set.rs:192` — `pub(crate) use ic_miss::pic_epoch_bump;` added below the `pub use ic_miss::{…}` block; `reorder_imports` wants it above

Not a toolchain artifact: CI uses `dtolnay/rust-toolchain@stable`, and the repo has no `rust-toolchain.toml` or `rustfmt.toml`.

My miss — I merged #7434 without running `cargo fmt --check` first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting issues so automated formatting checks now pass consistently.
  * Reorganized import ordering and reformatted a long assertion without changing runtime behavior.

* **Documentation**
  * Updated the changelog to document the formatting fix and its impact on lint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->