### PR TITLE
bench: refresh json-polyglot and polyglot results (quiet host, 2026-08-06)

### DIFF
--- a/benchmarks/json_polyglot/RESULTS.md
+++ b/benchmarks/json_polyglot/RESULTS.md
@@ -2,7 +2,7 @@
 
 **Runs per cell:** 11 · **Pinning:** macOS scheduler hint (taskpolicy -t 0 -l 0 — P-core preferred via throughput/latency tiers, NOT strict affinity)
 **Hardware:** Darwin 25.5.0 arm64 on MacBookPro.
-**Date:** 2026-08-03.
+**Date:** 2026-08-06.
 
 Two workloads, each language listed twice (idiomatic / optimized flag profile).
 Median wall-clock time is the headline number; p95, σ (population stddev),
@@ -18,21 +18,21 @@ low — the lazy path can avoid materializing the parse tree entirely.
 
 | Implementation | Profile | Median (ms) | p95 (ms) | σ | Min | Max | Peak RSS (MB) |
 |---|---|---:|---:|---:|---:|---:|---:|
-| rust serde_json (LTO+1cgu) | optimized | 184 | 193 | 2.6 | 184 | 193 | 10 |
-| rust serde_json | idiomatic | 191 | 201 | 2.9 | 190 | 201 | 11 |
-| perry (gen-gc + lazy tape) | optimized | 213 | 221 | 2.3 | 212 | 221 | 110 |
-| bun (default) | idiomatic | 223 | 225 | 1.1 | 221 | 225 | 83 |
-| node (default) | idiomatic | 387 | 397 | 4.5 | 382 | 397 | 103 |
-| node --max-old=4096 | optimized | 388 | 395 | 3.9 | 384 | 395 | 103 |
-| kotlin (kotlinx.serialization) | idiomatic | 455 | 474 | 7.9 | 446 | 474 | 609 |
-| kotlin -server -Xmx512m | optimized | 461 | 495 | 14.9 | 439 | 495 | 422 |
-| perry (mark-sweep, no lazy) | idiomatic | 608 | 616 | 5.3 | 599 | 616 | 301 |
-| go (encoding/json) | idiomatic | 771 | 777 | 2.6 | 768 | 777 | 23 |
-| c++ -O3 -flto (nlohmann/json) | optimized | 773 | 777 | 4.1 | 766 | 777 | 25 |
-| go -ldflags="-s -w" -trimpath | optimized | 778 | 784 | 3.7 | 770 | 784 | 22 |
-| c++ -O2 (nlohmann/json) | idiomatic | 834 | 848 | 4.4 | 831 | 848 | 25 |
-| swift -O -wmo (Foundation) | optimized | 3521 | 3617 | 31.8 | 3502 | 3617 | 33 |
-| swift -O (Foundation) | idiomatic | 3570 | 3588 | 9.8 | 3557 | 3588 | 32 |
+| rust serde_json (LTO+1cgu) | optimized | 180 | 189 | 2.5 | 180 | 189 | 11 |
+| rust serde_json | idiomatic | 190 | 199 | 2.5 | 190 | 199 | 10 |
+| perry (gen-gc + lazy tape) | optimized | 194 | 197 | 1.5 | 192 | 197 | 87 |
+| bun (default) | idiomatic | 221 | 235 | 5.1 | 219 | 235 | 84 |
+| node (default) | idiomatic | 384 | 390 | 4.0 | 377 | 390 | 102 |
+| node --max-old=4096 | optimized | 387 | 392 | 3.3 | 382 | 392 | 103 |
+| kotlin -server -Xmx512m | optimized | 436 | 444 | 4.5 | 431 | 444 | 422 |
+| kotlin (kotlinx.serialization) | idiomatic | 455 | 460 | 5.3 | 441 | 460 | 608 |
+| c++ -O3 -flto (nlohmann/json) | optimized | 760 | 784 | 8.0 | 758 | 784 | 25 |
+| go (encoding/json) | idiomatic | 764 | 776 | 4.4 | 758 | 776 | 23 |
+| go -ldflags="-s -w" -trimpath | optimized | 765 | 768 | 2.9 | 758 | 768 | 23 |
+| c++ -O2 (nlohmann/json) | idiomatic | 824 | 832 | 2.5 | 822 | 832 | 25 |
+| perry (mark-sweep, no lazy) | idiomatic | 1287 | 1298 | 3.6 | 1285 | 1298 | 61 |
+| swift -O -wmo (Foundation) | optimized | 3473 | 3484 | 9.1 | 3456 | 3484 | 31 |
+| swift -O (Foundation) | idiomatic | 3528 | 3544 | 8.1 | 3519 | 3544 | 32 |
 
 ## JSON parse-and-iterate
 
@@ -43,18 +43,18 @@ JSON content. 10k records, ~1 MB blob, 50 iterations per run.
 
 | Implementation | Profile | Median (ms) | p95 (ms) | σ | Min | Max | Peak RSS (MB) |
 |---|---|---:|---:|---:|---:|---:|---:|
-| rust serde_json (LTO+1cgu) | optimized | 181 | 190 | 2.6 | 180 | 190 | 11 |
-| rust serde_json | idiomatic | 191 | 198 | 2.2 | 190 | 198 | 11 |
-| bun (default) | idiomatic | 225 | 230 | 1.7 | 224 | 230 | 88 |
-| node --max-old=4096 | optimized | 389 | 393 | 2.2 | 386 | 393 | 98 |
-| node (default) | idiomatic | 390 | 398 | 3.4 | 386 | 398 | 97 |
-| kotlin -server -Xmx512m | optimized | 445 | 453 | 8.1 | 425 | 453 | 423 |
-| kotlin (kotlinx.serialization) | idiomatic | 473 | 488 | 11.3 | 457 | 488 | 607 |
-| perry (mark-sweep, no lazy) | idiomatic | 660 | 669 | 4.8 | 651 | 669 | 301 |
-| go -ldflags="-s -w" -trimpath | optimized | 775 | 779 | 2.5 | 769 | 779 | 23 |
-| go (encoding/json) | idiomatic | 775 | 782 | 3.8 | 771 | 782 | 23 |
-| c++ -O3 -flto (nlohmann/json) | optimized | 788 | 790 | 1.4 | 786 | 790 | 25 |
-| c++ -O2 (nlohmann/json) | idiomatic | 864 | 866 | 1.9 | 860 | 866 | 25 |
-| perry (gen-gc + lazy tape) | optimized | 2653 | 2920 | 78.4 | 2630 | 2920 | 356 |
-| swift -O (Foundation) | idiomatic | 3566 | 3641 | 38.7 | 3518 | 3641 | 33 |
-| swift -O -wmo (Foundation) | optimized | 3623 | 3709 | 35.2 | 3593 | 3709 | 34 |
+| rust serde_json (LTO+1cgu) | optimized | 184 | 192 | 2.2 | 184 | 192 | 11 |
+| rust serde_json | idiomatic | 190 | 197 | 2.1 | 189 | 197 | 10 |
+| bun (default) | idiomatic | 223 | 235 | 3.6 | 222 | 235 | 91 |
+| node (default) | idiomatic | 384 | 395 | 4.7 | 378 | 395 | 96 |
+| node --max-old=4096 | optimized | 397 | 399 | 4.7 | 383 | 399 | 98 |
+| kotlin -server -Xmx512m | optimized | 437 | 446 | 4.1 | 434 | 446 | 423 |
+| kotlin (kotlinx.serialization) | idiomatic | 451 | 466 | 5.5 | 446 | 466 | 607 |
+| go -ldflags="-s -w" -trimpath | optimized | 767 | 919 | 43.9 | 762 | 919 | 23 |
+| go (encoding/json) | idiomatic | 768 | 864 | 28.5 | 761 | 864 | 23 |
+| c++ -O3 -flto (nlohmann/json) | optimized | 771 | 773 | 1.5 | 769 | 773 | 25 |
+| c++ -O2 (nlohmann/json) | idiomatic | 849 | 851 | 1.5 | 846 | 851 | 25 |
+| perry (mark-sweep, no lazy) | idiomatic | 1340 | 1346 | 2.6 | 1338 | 1346 | 58 |
+| perry (gen-gc + lazy tape) | optimized | 2981 | 3391 | 169.1 | 2867 | 3391 | 218 |
+| swift -O (Foundation) | idiomatic | 3481 | 3500 | 11.5 | 3464 | 3500 | 32 |
+| swift -O -wmo (Foundation) | optimized | 3537 | 3555 | 11.0 | 3517 | 3555 | 30 |

--- a/benchmarks/polyglot/RESULTS_AUTO.md
+++ b/benchmarks/polyglot/RESULTS_AUTO.md
@@ -1,22 +1,22 @@
 # Polyglot Compute-Microbench Results (auto-generated)
 
 **Runs per cell:** 11 · **Pinning:** macOS scheduler hint (taskpolicy -t 0 -l 0 — P-core preferred via throughput/latency tiers, NOT strict affinity)
-**Hardware:** Darwin 25.5.0 arm64 on MacBookPro · **Date:** 2026-08-03
-**Perry version:** v0.5.1279
+**Hardware:** Darwin 25.5.0 arm64 on MacBookPro · **Date:** 2026-08-06
+**Perry version:** v0.5.1280
 
 Headline = median wall-clock ms. Lower is better.
 
 | Benchmark           | Perry |  Rust |   C++ |    Go | Swift |  Java |  Node |   Bun | Hermes |  Python |
 |---------------------|-------|-------|-------|-------|-------|-------|-------|-------|--------|---------|
-| fibonacci           |   394 |   306 |   298 |   435 |   387 |   273 |   924 |   512 |      - |   12140 |
-| loop_overhead       |    93 |    93 |    93 |    93 |    93 |    94 |    63 |    39 |      - |    1941 |
-| loop_data_dependent |   218 |   218 |   124 |   124 |   217 |   220 |   220 |   220 |      - |    5947 |
-| array_write         |     2 |     6 |     1 |     8 |     1 |     5 |     7 |     5 |      - |     317 |
-| array_read          |    24 |     9 |     9 |     9 |     9 |    11 |    11 |    14 |      - |     222 |
-| math_intensive      |    49 |    46 |    48 |    47 |    47 |    48 |    49 |    48 |      - |    1562 |
-| object_create       |     3 |     0 |     0 |     0 |     0 |     5 |     5 |     5 |      - |     135 |
-| nested_loops        |    43 |     8 |     8 |     8 |     8 |    10 |    18 |    18 |      - |     344 |
-| accumulate          |    94 |    93 |    93 |    93 |    93 |    95 |    95 |    95 |      - |    4330 |
+| fibonacci           |   417 |   312 |   302 |   458 |   389 |   273 |  1014 |   512 |      - |   12125 |
+| loop_overhead       |    99 |    94 |    93 |    93 |    93 |    94 |    64 |    40 |      - |    1929 |
+| loop_data_dependent |   229 |   220 |   125 |   124 |   217 |   219 |   239 |   224 |      - |    5940 |
+| array_write         |     1 |     6 |     2 |     8 |     2 |     6 |     7 |     5 |      - |     319 |
+| array_read          |    23 |     9 |     9 |    10 |     9 |    10 |    11 |    14 |      - |     227 |
+| math_intensive      |    51 |    47 |    48 |    47 |    47 |    49 |    51 |    50 |      - |    1555 |
+| object_create       |     2 |     0 |     0 |     0 |     0 |     4 |     5 |     6 |      - |     135 |
+| nested_loops        |    41 |     8 |     8 |     9 |     8 |    10 |    19 |    19 |      - |     339 |
+| accumulate          |   100 |    93 |    93 |    93 |    93 |    95 |   100 |    96 |      - |    4302 |
 
 ## Per-cell full stats
 
@@ -24,93 +24,93 @@ Format: median (p95: X, σ: S, min: Y, max: Z) ms
 
 | Benchmark | Runtime | Stats (ms) |
 |---|---|---|
-| fibonacci | perry | 394 (p95: 420, σ: 7.4, min: 394, max: 420) |
-| fibonacci | rust | 306 (p95: 329, σ: 6.6, min: 305, max: 329) |
-| fibonacci | cpp | 298 (p95: 309, σ: 3.2, min: 297, max: 309) |
-| fibonacci | go | 435 (p95: 454, σ: 5.6, min: 434, max: 454) |
-| fibonacci | swift | 387 (p95: 409, σ: 6.3, min: 386, max: 409) |
-| fibonacci | java | 273 (p95: 277, σ: 2.5, min: 269, max: 277) |
-| fibonacci | node | 924 (p95: 1018, σ: 30.1, min: 923, max: 1018) |
-| fibonacci | bun | 512 (p95: 515, σ: 2.4, min: 507, max: 515) |
+| fibonacci | perry | 417 (p95: 464, σ: 24.1, min: 396, max: 464) |
+| fibonacci | rust | 312 (p95: 334, σ: 6.4, min: 312, max: 334) |
+| fibonacci | cpp | 302 (p95: 320, σ: 5.3, min: 300, max: 320) |
+| fibonacci | go | 458 (p95: 545, σ: 32.3, min: 435, max: 545) |
+| fibonacci | swift | 389 (p95: 407, σ: 5.5, min: 387, max: 407) |
+| fibonacci | java | 273 (p95: 276, σ: 1.0, min: 272, max: 276) |
+| fibonacci | node | 1014 (p95: 1136, σ: 73.8, min: 925, max: 1136) |
+| fibonacci | bun | 512 (p95: 517, σ: 3.1, min: 506, max: 517) |
 | fibonacci | hermes | - |
-| fibonacci | python | 12140 (p95: 13544, σ: 455.8, min: 12017, max: 13544) |
-| loop_overhead | perry | 93 (p95: 116, σ: 6.6, min: 93, max: 116) |
-| loop_overhead | rust | 93 (p95: 96, σ: 1.2, min: 93, max: 96) |
-| loop_overhead | cpp | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
-| loop_overhead | go | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
+| fibonacci | python | 12125 (p95: 13054, σ: 279.8, min: 12112, max: 13054) |
+| loop_overhead | perry | 99 (p95: 162, σ: 18.3, min: 96, max: 162) |
+| loop_overhead | rust | 94 (p95: 96, σ: 0.9, min: 93, max: 96) |
+| loop_overhead | cpp | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
+| loop_overhead | go | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
 | loop_overhead | swift | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
-| loop_overhead | java | 94 (p95: 95, σ: 0.5, min: 94, max: 95) |
-| loop_overhead | node | 63 (p95: 64, σ: 0.4, min: 63, max: 64) |
-| loop_overhead | bun | 39 (p95: 39, σ: 0.0, min: 39, max: 39) |
+| loop_overhead | java | 94 (p95: 96, σ: 0.7, min: 94, max: 96) |
+| loop_overhead | node | 64 (p95: 65, σ: 0.5, min: 64, max: 65) |
+| loop_overhead | bun | 40 (p95: 40, σ: 0.0, min: 40, max: 40) |
 | loop_overhead | hermes | - |
-| loop_overhead | python | 1941 (p95: 1949, σ: 2.9, min: 1940, max: 1949) |
-| loop_data_dependent | perry | 218 (p95: 241, σ: 6.8, min: 217, max: 241) |
-| loop_data_dependent | rust | 218 (p95: 224, σ: 2.2, min: 217, max: 224) |
-| loop_data_dependent | cpp | 124 (p95: 126, σ: 0.6, min: 124, max: 126) |
+| loop_overhead | python | 1929 (p95: 2110, σ: 52.2, min: 1927, max: 2110) |
+| loop_data_dependent | perry | 229 (p95: 420, σ: 55.9, min: 225, max: 420) |
+| loop_data_dependent | rust | 220 (p95: 228, σ: 2.5, min: 218, max: 228) |
+| loop_data_dependent | cpp | 125 (p95: 130, σ: 2.0, min: 124, max: 130) |
 | loop_data_dependent | go | 124 (p95: 124, σ: 0.0, min: 124, max: 124) |
 | loop_data_dependent | swift | 217 (p95: 218, σ: 0.3, min: 217, max: 218) |
-| loop_data_dependent | java | 220 (p95: 226, σ: 2.1, min: 219, max: 226) |
-| loop_data_dependent | node | 220 (p95: 222, σ: 0.7, min: 219, max: 222) |
-| loop_data_dependent | bun | 220 (p95: 223, σ: 1.2, min: 219, max: 223) |
+| loop_data_dependent | java | 219 (p95: 220, σ: 0.4, min: 218, max: 220) |
+| loop_data_dependent | node | 239 (p95: 275, σ: 15.9, min: 224, max: 275) |
+| loop_data_dependent | bun | 224 (p95: 225, σ: 0.4, min: 224, max: 225) |
 | loop_data_dependent | hermes | - |
-| loop_data_dependent | python | 5947 (p95: 5961, σ: 4.7, min: 5942, max: 5961) |
-| array_write | perry | 2 (p95: 2, σ: 0.5, min: 1, max: 2) |
-| array_write | rust | 6 (p95: 7, σ: 0.4, min: 5, max: 7) |
-| array_write | cpp | 1 (p95: 1, σ: 0.0, min: 1, max: 1) |
-| array_write | go | 8 (p95: 8, σ: 0.3, min: 7, max: 8) |
-| array_write | swift | 1 (p95: 1, σ: 0.0, min: 1, max: 1) |
-| array_write | java | 5 (p95: 5, σ: 0.4, min: 4, max: 5) |
-| array_write | node | 7 (p95: 7, σ: 0.3, min: 6, max: 7) |
+| loop_data_dependent | python | 5940 (p95: 6166, σ: 64.7, min: 5934, max: 6166) |
+| array_write | perry | 1 (p95: 2, σ: 0.5, min: 1, max: 2) |
+| array_write | rust | 6 (p95: 7, σ: 0.4, min: 6, max: 7) |
+| array_write | cpp | 2 (p95: 2, σ: 0.5, min: 1, max: 2) |
+| array_write | go | 8 (p95: 9, σ: 0.6, min: 7, max: 9) |
+| array_write | swift | 2 (p95: 2, σ: 0.0, min: 2, max: 2) |
+| array_write | java | 6 (p95: 7, σ: 0.6, min: 5, max: 7) |
+| array_write | node | 7 (p95: 8, σ: 0.4, min: 7, max: 8) |
 | array_write | bun | 5 (p95: 5, σ: 0.3, min: 4, max: 5) |
 | array_write | hermes | - |
-| array_write | python | 317 (p95: 320, σ: 1.2, min: 316, max: 320) |
-| array_read | perry | 24 (p95: 34, σ: 2.9, min: 24, max: 34) |
+| array_write | python | 319 (p95: 320, σ: 0.4, min: 319, max: 320) |
+| array_read | perry | 23 (p95: 29, σ: 1.7, min: 23, max: 29) |
 | array_read | rust | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
 | array_read | cpp | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
-| array_read | go | 9 (p95: 14, σ: 1.5, min: 9, max: 14) |
+| array_read | go | 10 (p95: 10, σ: 0.0, min: 10, max: 10) |
 | array_read | swift | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
-| array_read | java | 11 (p95: 11, σ: 0.5, min: 10, max: 11) |
-| array_read | node | 11 (p95: 11, σ: 0.4, min: 10, max: 11) |
+| array_read | java | 10 (p95: 11, σ: 0.5, min: 10, max: 11) |
+| array_read | node | 11 (p95: 15, σ: 1.2, min: 11, max: 15) |
 | array_read | bun | 14 (p95: 14, σ: 0.4, min: 13, max: 14) |
 | array_read | hermes | - |
-| array_read | python | 222 (p95: 225, σ: 1.0, min: 222, max: 225) |
-| math_intensive | perry | 49 (p95: 71, σ: 6.4, min: 48, max: 71) |
-| math_intensive | rust | 46 (p95: 48, σ: 0.6, min: 46, max: 48) |
-| math_intensive | cpp | 48 (p95: 49, σ: 0.3, min: 48, max: 49) |
-| math_intensive | go | 47 (p95: 48, σ: 0.3, min: 47, max: 48) |
-| math_intensive | swift | 47 (p95: 48, σ: 0.3, min: 47, max: 48) |
-| math_intensive | java | 48 (p95: 49, σ: 0.5, min: 48, max: 49) |
-| math_intensive | node | 49 (p95: 50, σ: 0.4, min: 48, max: 50) |
-| math_intensive | bun | 48 (p95: 49, σ: 0.5, min: 48, max: 49) |
+| array_read | python | 227 (p95: 234, σ: 2.0, min: 227, max: 234) |
+| math_intensive | perry | 51 (p95: 54, σ: 1.5, min: 50, max: 54) |
+| math_intensive | rust | 47 (p95: 48, σ: 0.4, min: 46, max: 48) |
+| math_intensive | cpp | 48 (p95: 48, σ: 0.0, min: 48, max: 48) |
+| math_intensive | go | 47 (p95: 47, σ: 0.0, min: 47, max: 47) |
+| math_intensive | swift | 47 (p95: 47, σ: 0.0, min: 47, max: 47) |
+| math_intensive | java | 49 (p95: 49, σ: 0.5, min: 48, max: 49) |
+| math_intensive | node | 51 (p95: 95, σ: 12.7, min: 49, max: 95) |
+| math_intensive | bun | 50 (p95: 50, σ: 0.5, min: 49, max: 50) |
 | math_intensive | hermes | - |
-| math_intensive | python | 1562 (p95: 1577, σ: 5.9, min: 1556, max: 1577) |
-| object_create | perry | 3 (p95: 7, σ: 1.1, min: 3, max: 7) |
+| math_intensive | python | 1555 (p95: 1558, σ: 1.2, min: 1553, max: 1558) |
+| object_create | perry | 2 (p95: 3, σ: 0.5, min: 2, max: 3) |
 | object_create | rust | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
 | object_create | cpp | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
 | object_create | go | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
 | object_create | swift | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
-| object_create | java | 5 (p95: 5, σ: 0.5, min: 4, max: 5) |
-| object_create | node | 5 (p95: 5, σ: 0.0, min: 5, max: 5) |
-| object_create | bun | 5 (p95: 6, σ: 0.5, min: 5, max: 6) |
+| object_create | java | 4 (p95: 5, σ: 0.5, min: 4, max: 5) |
+| object_create | node | 5 (p95: 6, σ: 0.5, min: 5, max: 6) |
+| object_create | bun | 6 (p95: 6, σ: 0.4, min: 5, max: 6) |
 | object_create | hermes | - |
-| object_create | python | 135 (p95: 145, σ: 2.9, min: 135, max: 145) |
-| nested_loops | perry | 43 (p95: 60, σ: 4.9, min: 43, max: 60) |
+| object_create | python | 135 (p95: 135, σ: 0.4, min: 134, max: 135) |
+| nested_loops | perry | 41 (p95: 56, σ: 4.5, min: 40, max: 56) |
 | nested_loops | rust | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
 | nested_loops | cpp | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
-| nested_loops | go | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
+| nested_loops | go | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
 | nested_loops | swift | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
-| nested_loops | java | 10 (p95: 11, σ: 0.4, min: 10, max: 11) |
-| nested_loops | node | 18 (p95: 18, σ: 0.4, min: 17, max: 18) |
-| nested_loops | bun | 18 (p95: 19, σ: 0.5, min: 18, max: 19) |
+| nested_loops | java | 10 (p95: 11, σ: 0.3, min: 10, max: 11) |
+| nested_loops | node | 19 (p95: 55, σ: 10.4, min: 18, max: 55) |
+| nested_loops | bun | 19 (p95: 19, σ: 0.3, min: 18, max: 19) |
 | nested_loops | hermes | - |
-| nested_loops | python | 344 (p95: 353, σ: 4.3, min: 339, max: 353) |
-| accumulate | perry | 94 (p95: 110, σ: 4.7, min: 93, max: 110) |
-| accumulate | rust | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
-| accumulate | cpp | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
+| nested_loops | python | 339 (p95: 339, σ: 0.5, min: 338, max: 339) |
+| accumulate | perry | 100 (p95: 120, σ: 9.1, min: 96, max: 120) |
+| accumulate | rust | 93 (p95: 94, σ: 0.4, min: 93, max: 94) |
+| accumulate | cpp | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
 | accumulate | go | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
-| accumulate | swift | 93 (p95: 95, σ: 0.6, min: 93, max: 95) |
-| accumulate | java | 95 (p95: 97, σ: 0.8, min: 94, max: 97) |
-| accumulate | node | 95 (p95: 96, σ: 0.6, min: 94, max: 96) |
-| accumulate | bun | 95 (p95: 95, σ: 0.4, min: 94, max: 95) |
+| accumulate | swift | 93 (p95: 96, σ: 0.9, min: 93, max: 96) |
+| accumulate | java | 95 (p95: 95, σ: 0.4, min: 94, max: 95) |
+| accumulate | node | 100 (p95: 151, σ: 17.9, min: 96, max: 151) |
+| accumulate | bun | 96 (p95: 97, σ: 0.5, min: 96, max: 97) |
 | accumulate | hermes | - |
-| accumulate | python | 4330 (p95: 4522, σ: 55.2, min: 4327, max: 4522) |
+| accumulate | python | 4302 (p95: 4546, σ: 70.9, min: 4291, max: 4546) |


### PR DESCRIPTION
First measurement since #7473 fixed the `JSON.stringify` crash that made perry produce **no row at all** for `json_polyglot/field_access`.

## Conditions

Verified-quiet host — CPU active confirmed ≤25% for 60 consecutive seconds before each leg (**15.2%, 15.1%, 3.7%, 4.5%**), AC power, pinned **Node v22.23.1** and **Bun 1.3.14**, 11 runs per cell, median + p95 + σ.

## Headline: perry wins the JSON roundtrip

| roundtrip | median | p95 | σ | RSS |
|---|--:|--:|--:|--:|
| **perry** (gen-gc + lazy tape) | **194 ms** | 197 | 1.5 | 87 MB |
| bun | 221 | 235 | 5.1 | 84 MB |
| node | 384 | 390 | 4.0 | 102 MB |

**Faster than both**, with tight variance (σ 1.5).

## field_access is the inverse, and the variant split is the finding

| field_access | median | RSS |
|---|--:|--:|
| perry (mark-sweep, **no lazy**) | **1340 ms** | 58 MB |
| perry (gen-gc + lazy tape) | 2981 ms | 218 MB |
| bun | 223 | 91 MB |
| node | 384 | 96 MB |

The **lazy tape is a 2.2× net loss** on this access pattern, on ~4× the memory. That is a well-isolated optimisation target rather than a diffuse gap — the same tape that wins roundtrip loses field_access, so the decision could be per-workload.

## Scope

Results files only; no code. The public artifact itself still cannot be published — #7475 (`object_deep_clone` / `promise_all_chains` fail under the auto-optimize path) is the remaining gate, and it is pre-existing rather than anything from this run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark metadata to August 6, 2026.
  * Refreshed JSON polyglot and polyglot benchmark results with newer timing, memory, and per-cell measurements.
  * Updated runtime comparisons, including revised Perry results and continued unavailability of Hermes data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->