### PR TITLE
fix(test): isolate typed_feedback failures — a poisoned ENV_LOCK turned one failure into five (#7490)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1284
+**Current Version:** 0.5.1285
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "base64",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5720,14 +5720,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "serde",
  "serde_json",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1284"
+version = "0.5.1285"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "clap",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "block2",
  "objc2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "chrono",
  "cron",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5870,14 +5870,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bytes",
  "h2",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bson",
  "futures-util",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6078,14 +6078,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "brotli",
  "flate2",
@@ -6144,7 +6144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "base64",
@@ -6225,14 +6225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6327,14 +6327,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6343,14 +6343,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "itoa",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "block2",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "block2",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1284"
+version = "0.5.1285"
 
 [[package]]
 name = "perry-ui-test"
@@ -6442,11 +6442,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1284"
+version = "0.5.1285"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "block2",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "block2",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "block2",
  "libc",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "base64",
  "libc",
@@ -6508,14 +6508,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "anyhow",
  "base64",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1284"
+version = "0.5.1285"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1284"
+version = "0.5.1285"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7492-typed-feedback-test-isolation.md
+++ b/changelog.d/7492-typed-feedback-test-isolation.md
@@ -58,8 +58,9 @@ multi-module build cannot pin the first module's decision.
 Validation: 16/16 green, three consecutive runs at default parallelism and
 three at `--test-threads=1`, and every test also passes run alone.
 
-The other suites named in the same sweep — `native_proof_buffer_views`,
-`native_proof_regressions`, `shadow_slot_hygiene`, `scalar_replaced_slot_roots`,
-`temp_root_argument_temporaries` — are a different root cause: every one of
-their failures reproduces run alone, so none is order-dependent, and they are
-tracked separately.
+The other suites named in the same sweep are a different root cause: every one
+of their failures reproduces run alone, so none is order-dependent. They split
+into the #7370 native-roots default (#7493 — `shadow_slot_hygiene` goes 0/12 to
+11/12 under `PERRY_RS4GC=0`, while `native_proof_regressions` *loses* 13 tests
+there, so the pin has to be per-test and `NativeRootsPin::shadow()` is
+`#[cfg(test)]`) and four lowering-independent assertion failures (#7494).

--- a/changelog.d/7492-typed-feedback-test-isolation.md
+++ b/changelog.d/7492-typed-feedback-test-isolation.md
@@ -1,0 +1,65 @@
+### Test: `typed_feedback` order dependence was a poisoned mutex, not leaking codegen state (#7490)
+
+`cargo test -p perry-codegen --test typed_feedback` failed 5 of 15 as a suite,
+deterministically under `--test-threads=1` and with a wobbling victim set under
+default parallelism. That reads like process-global codegen state leaking
+between in-process compiles. It was not, and two of the five also fail when run
+**alone** — the premise that all five pass in isolation does not hold.
+
+Two assertions had drifted from intentional codegen changes.
+`typed_feedback_guards_direct_class_field_specialization` matched the numeric
+coercion in the *textual window* between the `class_field_get_number.fallback`
+and `.merge` labels; #7430 split that arm, leaving `.fallback` holding only the
+nullish-receiver check and moving the by-name load plus coercion into
+`.fallback_lookup` — a block rendered **after** `.merge`, so the window could
+never match again. `typed_feedback_trace_dump_runs_before_entry_return` cut
+`main`'s body at the literal header `define i32 @main() {`, which stopped
+matching when #7370 made native roots the default and every emitted function
+gained `"frame-pointer"="non-leaf"`.
+
+The first of those panics *while holding* the suite's `ENV_LOCK`. The unwind
+poisons the mutex for the rest of the process, and every later
+`ENV_LOCK.lock().unwrap()` then dies with `PoisonError` whatever its own
+subject is doing. That is the entire "order dependence": one genuine failure,
+three `PoisonError` casualties, and a victim set that reshuffles with the
+scheduler because *which* tests reach the lock after the poisoning is a
+scheduling fact. It is the test-harness cousin of the "a gate that cannot fail"
+family — here, a gate that fails for a reason unrelated to what it measures.
+
+Fixed by isolation plus two re-pointed assertions, neither loosened:
+
+- `env_lock()` recovers a poisoned guard. Sound because each test declares its
+  `EnvVarGuard` *after* the lock guard, so reverse drop order restores the env
+  var during unwind before the mutex is released — the protected state is
+  already consistent at poison time. One test's failure must fail that test
+  alone.
+- The class-field assertion now proves, end to end, the data flow the
+  positional window stood in for: `.fallback_lookup` records the fallback call,
+  loads by name and coerces; its terminator branches to the numeric merge; and
+  the merge phi's fallback incoming **is** the coerced register. A `block_body()`
+  helper reads a named block by stable label prefix, so per-function label
+  suffixes and block ordering stop being load-bearing.
+- `entry_fn_body` matches `main`'s exact signature and cuts at that line's
+  opening brace, so unrelated function-attribute changes can no longer fail
+  the test.
+- `env_lock_is_poison_tolerant_so_one_failure_cannot_cascade` is a sabotage
+  test for the isolation itself: it plants the exact #7490 shape, asserts the
+  mutex really was poisoned (the gate asserts its subject was live), and then
+  demands the accessor still hands out a guard. Against the pre-fix
+  `.lock().unwrap()` it fails and reproduces the cascade at 9 of 16 red. It
+  sorts first, so the whole suite afterwards runs under a genuinely poisoned
+  lock.
+
+No production change: `PERRY_TYPED_FEEDBACK` is read live at each call site and
+`PERRY_FULL_OUTLINE_IC`'s decision is already a `thread_local!` set once per
+`compile_module` — deliberately not a process-global `OnceLock`, so a
+multi-module build cannot pin the first module's decision.
+
+Validation: 16/16 green, three consecutive runs at default parallelism and
+three at `--test-threads=1`, and every test also passes run alone.
+
+The other suites named in the same sweep — `native_proof_buffer_views`,
+`native_proof_regressions`, `shadow_slot_hygiene`, `scalar_replaced_slot_roots`,
+`temp_root_argument_temporaries` — are a different root cause: every one of
+their failures reproduces run alone, so none is order-dependent, and they are
+tracked separately.

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -6,6 +6,56 @@ use perry_hir::{BinaryOp, Class, ClassField, Expr, Function, Module, ModuleInitK
 /// half-applied variable. Mirrors the guard in `typed_shape_descriptors.rs`.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Acquires [`ENV_LOCK`] tolerating a poisoned mutex (#7490).
+///
+/// A test that panics while holding the lock poisons it during unwind; every
+/// later `lock().unwrap()` in the binary then dies with `PoisonError` even
+/// though its own subject is healthy. That is exactly what #7490 observed:
+/// one genuine assertion failure cascaded into three PoisonError failures
+/// under `--test-threads=1`, and under default parallelism the *victim set
+/// wobbled* with scheduling — which read as order-dependent codegen state
+/// when it was only lock poisoning.
+///
+/// Recovering the guard is sound here because the protected state is already
+/// consistent at poison time: each test declares its `EnvVarGuard` *after*
+/// the lock guard, so during unwind the env var is restored (guard `Drop`)
+/// before the mutex is released. One test's failure must fail that test
+/// alone.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Sabotage test for [`env_lock`] (#7490): a test that panics while holding
+/// the lock must fail *itself* and nothing else.
+///
+/// A gate has to assert its subject was live, not merely that nothing threw —
+/// so this plants the exact failure shape #7490 cascaded from (an unwind out
+/// of a lock-holding test), proves it really did poison the mutex, and then
+/// demands the accessor still hands out a usable guard. It fails against the
+/// pre-fix `ENV_LOCK.lock().unwrap()`, which is what makes a green run here
+/// evidence rather than decoration.
+///
+/// Running first (`e` sorts ahead of `f`/`t`) also means every other test in
+/// this binary executes under a genuinely poisoned lock, so the tolerance is
+/// exercised for the whole suite rather than in one isolated case.
+#[test]
+fn env_lock_is_poison_tolerant_so_one_failure_cannot_cascade() {
+    let sabotage = std::panic::catch_unwind(|| {
+        let _guard = env_lock();
+        panic!("#7490 sabotage: unwinding while holding ENV_LOCK");
+    });
+    assert!(sabotage.is_err(), "the sabotage panic should have unwound");
+    assert!(
+        ENV_LOCK.is_poisoned(),
+        "unwinding out of a lock-holding test should poison ENV_LOCK — if it \
+         no longer does, this test is no longer exercising its subject"
+    );
+    // The invariant under test: a later test still gets the lock.
+    let _lock = env_lock();
+}
+
 /// Sets an env var for the duration of a test and restores the previous value
 /// (or unsets it) on drop, so the mutation never leaks to other tests.
 struct EnvVarGuard {
@@ -245,13 +295,29 @@ fn typed_feedback_trace_dump_runs_before_entry_return() {
 }
 
 /// Body of the entry `main` function, without its `define`/`}` lines.
+///
+/// The define line may carry function attributes after the parens — since
+/// native roots became the default lowering (#7370) every generated function
+/// is tagged `"frame-pointer"="non-leaf"`, and a stack-map-requesting `main`
+/// would add `gc "statepoint-example"`. Match the exact signature, then cut
+/// the body at that line's opening brace instead of demanding an
+/// attribute-free header (which failed the whole test on unrelated attribute
+/// changes, #7490).
 fn entry_fn_body(ir: &str) -> &str {
-    let header = "define i32 @main() {\n";
-    let start = ir
-        .find(header)
-        .expect("entry module should define `i32 @main()`")
-        + header.len();
-    let rest = &ir[start..];
+    let sig = "define i32 @main()";
+    let sig_start = ir
+        .find(sig)
+        .expect("entry module should define `i32 @main()`");
+    let line_end = sig_start
+        + ir[sig_start..]
+            .find('\n')
+            .expect("`main`'s define line should be newline-terminated");
+    let header = &ir[sig_start..line_end];
+    assert!(
+        header.ends_with('{'),
+        "`main`'s define line should end with its opening brace, got `{header}`"
+    );
+    let rest = &ir[line_end + 1..];
     let end = rest
         .find("\n}\n")
         .expect("`main` should be terminated by a closing brace");
@@ -264,7 +330,7 @@ fn typed_feedback_instruments_property_and_method_boundaries() {
     // PERRY_TYPED_FEEDBACK / _TRACE is set); this test exercises the enabled
     // path. Serialize on ENV_LOCK and restore the var on drop so concurrent or
     // later tests in this binary never observe the changed environment.
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     let _env = EnvVarGuard::set("PERRY_TYPED_FEEDBACK", Some("1"));
     let ir = ir_for(module(
         "typed_feedback_property.ts",
@@ -313,7 +379,7 @@ fn typed_feedback_guards_direct_class_field_specialization() {
     // Serialize against the lever-B test (#5334), which sets the process-global
     // PERRY_FULL_OUTLINE_IC in this same test binary; pin it off so this test
     // always observes the inline diamond.
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
     let point = class(101, "Point", vec![field("x", Type::Number)]);
     let ir = ir_for(module_with_classes(
@@ -359,21 +425,87 @@ fn typed_feedback_guards_direct_class_field_specialization() {
     // js_class_field_set_fallback).
     assert!(ir.contains("call void @js_typed_feedback_record_fallback_call"));
     assert!(ir.contains("call double @js_object_get_field_by_name_f64"));
-    let fallback_pos = ir
-        .find("class_field_get_number.fallback")
-        .expect("raw numeric class-field consumer should keep fallback block");
-    let merge_pos = ir[fallback_pos..]
-        .find("class_field_get_number.merge")
-        .map(|pos| fallback_pos + pos)
-        .expect("raw numeric class-field consumer should keep merge block");
+    // #7430 split the GET fallback arm: `class_field_get_number.fallback` now
+    // holds only the nullish-receiver check and branches to `.throw_nullish` /
+    // `.fallback_lookup`, and the by-name load + numeric coercion moved into
+    // `.fallback_lookup` — a block rendered AFTER `.merge`, so the previous
+    // "coerce appears textually between the fallback and merge labels" window
+    // could never match again (#7490). Assert the data flow that window stood
+    // in for, end to end: the lookup arm coerces the by-name fallback value,
+    // branches to the numeric merge, and the merge phi's fallback incoming IS
+    // the coerced register.
+    let lookup = block_body(&ir, "class_field_get_number.fallback_lookup")
+        .expect("raw numeric class-field consumer should keep the fallback lookup block");
+    assert!(lookup.contains("call void @js_typed_feedback_record_fallback_call"));
+    assert!(lookup.contains("call double @js_object_get_field_by_name_f64"));
+    let coerce_line = lookup
+        .lines()
+        .find(|line| line.contains("call double @js_number_coerce"))
+        .unwrap_or_else(|| {
+            panic!("class-field raw fallback must be coerced before the numeric merge:\n{ir}")
+        });
+    let coerced_reg = coerce_line
+        .trim()
+        .split(" = ")
+        .next()
+        .expect("the fallback coercion should assign a register");
+    let lookup_terminator = lookup
+        .lines()
+        .last()
+        .expect("the fallback lookup block should have a terminator")
+        .trim();
     assert!(
-        ir[fallback_pos..merge_pos].contains("call double @js_number_coerce"),
-        "class-field raw fallback must be coerced before the numeric merge:\n{ir}"
+        lookup_terminator.starts_with("br label %class_field_get_number.merge"),
+        "the fallback lookup must branch to the numeric merge, got `{lookup_terminator}`"
+    );
+    let merge = block_body(&ir, "class_field_get_number.merge")
+        .expect("raw numeric class-field consumer should keep merge block");
+    let phi_line = merge
+        .lines()
+        .find(|line| line.contains(" = phi double "))
+        .expect("the numeric merge should phi the fast/fallback values");
+    assert!(
+        phi_line.contains(&format!(
+            "[ {coerced_reg}, %class_field_get_number.fallback_lookup"
+        )),
+        "the numeric merge phi's fallback incoming must be the coerced value \
+         `{coerced_reg}`, got `{phi_line}`"
     );
     assert!(
         ir.contains("call double @js_number_coerce"),
         "class-field raw fallback must be coerced at numeric consumers:\n{ir}"
     );
+}
+
+/// Body of the first rendered block whose label starts with `label_prefix`,
+/// or `None` if no such block exists.
+///
+/// Block labels carry per-function numeric suffixes (`.fast.6`, `.merge.8`),
+/// so callers pass the stable prefix. A block header is a line-initial
+/// `label:`; instruction lines that merely mention the label (branches, phis)
+/// are indented, and are skipped. The body runs from the end of the label
+/// line to the blank line separating it from the next block (or to the
+/// function's closing brace).
+fn block_body<'a>(ir: &'a str, label_prefix: &str) -> Option<&'a str> {
+    let needle = format!("\n{label_prefix}");
+    let mut from = 0;
+    while let Some(rel) = ir[from..].find(&needle) {
+        let label_start = from + rel + 1;
+        let line_end = label_start + ir[label_start..].find('\n')?;
+        if ir[label_start..line_end].ends_with(':') {
+            let rest = &ir[line_end + 1..];
+            // A function-final block is terminated by the closing brace, an
+            // interior one by the blank separator line — whichever comes
+            // first bounds this block.
+            let end = match (rest.find("\n\n"), rest.find("\n}")) {
+                (Some(a), Some(b)) => a.min(b),
+                (a, b) => a.or(b).unwrap_or(rest.len()),
+            };
+            return Some(&rest[..end]);
+        }
+        from = line_end;
+    }
+    None
 }
 
 #[test]
@@ -399,7 +531,7 @@ fn full_outline_ic_collapses_class_field_set_to_single_call() {
         )
     };
 
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
 
     // Forced ON: one outlined call, no inline diamond.
     {
@@ -441,7 +573,7 @@ fn full_outline_ic_collapses_class_field_get_to_single_call() {
         )
     };
 
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
 
     // Forced ON: one outlined call, no inline get diamond.
     {
@@ -483,7 +615,7 @@ fn full_outline_array_literal_uses_builder_call() {
         )
     };
 
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
 
     {
         let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("1"));
@@ -542,7 +674,7 @@ fn full_outline_ic_auto_gate_counts_class_methods() {
         ],
     );
 
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     // Auto path (override unset): callable count = 1 probe fn + 6 methods = 7,
     // which clears MIN_FUNCS=5 even though `hir.functions.len()` is just 1. The
     // pre-fix function-only count (1) would have stayed under the threshold.
@@ -564,7 +696,7 @@ fn class_field_set_elides_write_barrier_for_nonpointer_value() {
     // Serialize against the lever-B full-outline test (#5334) and pin
     // PERRY_FULL_OUTLINE_IC off, so this test always observes the inline diamond
     // (`class_field_set.fast`) rather than the outlined call.
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
     let build = |val: Expr| {
         let c = class(140, "Bx", vec![field("s", Type::String)]);
@@ -602,7 +734,7 @@ fn class_field_set_elides_write_barrier_for_nonpointer_value() {
 fn typed_feedback_guards_direct_class_method_specialization() {
     // Serialize against the lever-B test (#5334) and pin full-outline off so the
     // class's synthesized field-set keeps its inline fallback (asserted below).
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
     let mut point = class(103, "Point", vec![field("x", Type::Number)]);
     point.methods.push(Function {
@@ -770,7 +902,7 @@ fn typed_feedback_marks_numeric_array_literals() {
     // Serialize against the array-literal full-outline test and pin it off, so
     // this test always observes the inline numeric-array construction
     // (js_array_mark_numeric_f64_layout) rather than the outlined builder.
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = env_lock();
     let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
     let numeric_ir = ir_for(module(
         "typed_feedback_numeric_array_literal.ts",


### PR DESCRIPTION
Fixes #7490.

## What the order dependence actually was

The issue's premise — process-global codegen state leaking between in-process compiles — does not hold. There is no leaking codegen state, and two of the five reported failures **also fail when run alone**, contrary to the issue text:

| test | verdict |
|---|---|
| `typed_feedback_guards_direct_class_field_specialization` | genuine, fails alone (stale assertion) |
| `typed_feedback_trace_dump_runs_before_entry_return` | genuine, fails alone (stale assertion) |
| `typed_feedback_guards_direct_class_method_specialization` | `PoisonError` cascade only |
| `typed_feedback_instruments_property_and_method_boundaries` | `PoisonError` cascade only |
| `typed_feedback_marks_numeric_array_literals` | `PoisonError` cascade only |

The three cascade victims pass as a group when the poisoner is not in the run.

### The two genuine assertion drifts

**`typed_feedback_guards_direct_class_field_specialization`** asserted that the numeric coercion appeared in the *textual window* between the `class_field_get_number.fallback` and `.merge` labels. #7430 split that arm — `.fallback` now carries only the nullish-receiver check and branches to `.throw_nullish` / `.fallback_lookup`, and the by-name load plus coercion moved into `.fallback_lookup`, which is rendered **after** `.merge`:

```
class_field_get_number.fallback.7:            ; nullish check only
  br i1 %r115, label %...throw_nullish.11, label %...fallback_lookup.12

class_field_get_number.merge.8:
  %r119 = phi double [ %r112, %...fast.6 ], [ %r118, %...fallback_lookup.12 ]
  ...
class_field_get_number.fallback_lookup.12:    ; the coercion lives here, AFTER merge
  %r117 = call double @js_object_get_field_by_name_f64(i64 %r62, i64 %r66)
  %r118 = call double @js_number_coerce(double %r117)
```

The window could never match again. The codegen is correct; the assertion was stale.

**`typed_feedback_trace_dump_runs_before_entry_return`** cut `main`'s body at the literal header `define i32 @main() {`. Since #7370 made native roots the default, every emitted function carries `"frame-pointer"="non-leaf"` (and a stack-map-requesting function adds `gc "statepoint-example"`), so the header never matches and the `.expect` fires.

### How two failures became five, wobbling

`typed_feedback_guards_direct_class_field_specialization` panics **while holding `ENV_LOCK`**. The unwind poisons the mutex for the rest of the process, so every later `ENV_LOCK.lock().unwrap()` dies with `PoisonError` regardless of whether its own subject is healthy. Under `--test-threads=1` the alphabetically-early poisoner deterministically takes three healthy tests down; under default parallelism the victim set shifts with the scheduler — which is exactly the reported "the failing set wobbles, and `full_outline_ic_*` join and leave it".

## The fix

Three parts, none of which loosens an assertion.

1. **Isolation.** `env_lock()` recovers a poisoned guard (`unwrap_or_else(PoisonError::into_inner)`). This is sound rather than a shrug: each test declares its `EnvVarGuard` *after* the lock guard, so Rust's reverse drop order restores the env var during unwind **before** the mutex is released — the protected state is already consistent at poison time. One test's failure must fail that test alone.

2. **Re-point the two drifted assertions — stronger, not looser.** The class-field test now proves the data flow that the positional window only stood in for, end to end: `.fallback_lookup` records the fallback call, loads by name and coerces; its terminator branches to the numeric merge; and the merge phi's fallback incoming **is** the coerced register. A new `block_body()` helper reads a named block by stable label prefix, so per-function numeric label suffixes and block *ordering* stop being load-bearing. `entry_fn_body` matches the exact signature and cuts at that line's opening brace, so unrelated attribute changes can no longer fail the test.

3. **A sabotage test for the isolation itself.** `env_lock_is_poison_tolerant_so_one_failure_cannot_cascade` plants the exact #7490 shape — an unwind out of a lock-holding test — asserts it really *did* poison the mutex (the gate asserts its subject was live), then demands the accessor still hands out a usable guard. Against the pre-fix `.lock().unwrap()` it fails and reproduces the cascade: **9 of 16 red**. Because it sorts first, every other test in the binary then runs under a genuinely poisoned lock, so the tolerance is exercised suite-wide rather than in one isolated case.

## Is this a production bug too?

No. Both process-global gates these tests touch are already right for the real compiler:

- `PERRY_TYPED_FEEDBACK` is read live at each call site (`crates/perry-codegen/src/expr/typed_feedback.rs:252`), never cached.
- `PERRY_FULL_OUTLINE_IC`'s decision is a `thread_local!` set once per `compile_module` (`crates/perry-codegen/src/codegen/helpers.rs:371`), deliberately *not* a process-global `OnceLock`, precisely so a multi-module build cannot pin the first module's decision.

The defect was confined to the test binary's failure isolation.

## Validation

- `cargo test -p perry-codegen --test typed_feedback` — **16 passed, 0 failed**, three consecutive runs at default parallelism and three at `--test-threads=1`.
- Every one of the 16 tests also passes **run alone** (scripted over the full `--list`), so no test depends on another having run.
- `cargo fmt --all -- --check` clean.
- Sabotage check: reverting only `env_lock()` to `.lock().unwrap()` turns the suite red at 9/16 and restores the cascade — so the isolation is doing the work.

## Other suites checked (different root cause — not fixed here)

The sweep in the issue also named several suites. **Every one of their failures reproduces when the test is run alone**, so none is order-dependent, and this fix heals none of them. Full `--no-fail-fast -- --test-threads=1` sweeps of `-p perry-codegen --tests`, default vs. the lowering override:

```
suite                                   default        PERRY_RS4GC=0
shadow_slot_hygiene                    0 / 12 pass     11 / 12 pass
scalar_replaced_slot_roots             2 / 11 pass      5 / 11 pass
temp_root_operand_temporaries         12 / 19 pass     13 / 19 pass
temp_root_argument_temporaries         3 /  7 pass      3 /  7 pass
native_proof_regressions             249 /253 pass    236 /253 pass   ← INVERSE
native_proof_buffer_views             28 / 30 pass     27 / 30 pass   ← inverse
typed_shape_descriptors               17 / 18 pass     17 / 18 pass
typed_feedback (this PR)              16 / 16 pass     16 / 16 pass
```

They split into two causes, filed granularly rather than folded in:

- **#7493 — the #7370 native-roots default.** `shadow_slot_hygiene` going 0/12 → 11/12 under `PERRY_RS4GC=0` is the diagnosis; three of `native_proof_regressions`' four failures heal the same way. But that suite *loses* 13 tests under `RS4GC=0` — its whole `invalidation::*` family asserts the native-roots lowering and is correct today — so no single global setting satisfies the set. The pin has to be per-test, and the one that repaired the in-crate unit tests, `NativeRootsPin::shadow()`, is `#[cfg(test)]` and therefore unreachable from `tests/*.rs`.
- **#7494 — four lowering-independent failures** (identical with and without `PERRY_RS4GC=0`): `proven_buffer_and_typed_array_reads_are_numeric_operands`, `reassigned_typed_array_store_records_runtime_fallback`, `integer_modulo::i32_counter_mod_unsafe_or_nonliteral_divisors_keep_frem`, and `integer_arithmetic_array_push_omits_inbounds_layout_note_and_barrier`. Each needs a decision on whether the lowering changed on purpose or a proof regressed, so they are deliberately not swept into a test-only PR.

## CI

`cargo-test` and `api-docs-drift` pass. The red jobs are pre-existing and reproduce identically on unrelated PR #7468: `gc-ratchet`, `gc-root-dominance`, `security-audit`, `Warnings`. `lint` fails only on its "Public benchmark evidence freshness" step (stale public baseline — `run_public_baseline.sh` needs a regen); its fingerprints cover `Cargo.toml` and `benchmarks/**` only, and this PR touches neither.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation for environment-sensitive tests so one failing test no longer causes cascading failures.
  * Updated validation for generated entry-function attributes, class-field specialization, and fallback lookup behavior.
  * Replaced fragile output-based checks with more reliable generated-behavior validation.

* **Documentation**
  * Added a changelog entry describing the test-isolation fixes, updated assertions, and validation results.

* **Chores**
  * Updated the workspace version to 0.5.1285.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->