### PR TITLE
perf(repsel): per-array homogeneous element-shape invariant (#7480)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1285
+**Current Version:** 0.5.1286
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "base64",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5720,14 +5720,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "serde",
  "serde_json",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1285"
+version = "0.5.1286"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "clap",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "block2",
  "objc2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "chrono",
  "cron",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5870,14 +5870,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bytes",
  "h2",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bson",
  "futures-util",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6078,14 +6078,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "brotli",
  "flate2",
@@ -6144,7 +6144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "base64",
@@ -6225,14 +6225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6327,14 +6327,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6343,14 +6343,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "itoa",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "block2",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "block2",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1285"
+version = "0.5.1286"
 
 [[package]]
 name = "perry-ui-test"
@@ -6442,11 +6442,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1285"
+version = "0.5.1286"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "block2",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "block2",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "block2",
  "libc",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "base64",
  "libc",
@@ -6508,14 +6508,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "anyhow",
  "base64",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1285"
+version = "0.5.1286"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1285"
+version = "0.5.1286"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7496-element-shape-invariant.md
+++ b/changelog.d/7496-element-shape-invariant.md
@@ -1,0 +1,65 @@
+### Repsel: per-array homogeneous element-shape invariant (#7480)
+
+`keep[j].v` measures **6.2× vs node** on the pure shape because a shape proof
+does not survive an array element read: the element-read tier and the
+field-read precheck stack two inline guard diamonds per access. #7480's
+scoping found that its two candidate routes — extending the #5093
+versioned-loop clone, and full element `Ptr<Shape>` representation — are not
+alternatives: both need the same missing fact first. This lands that fact,
+and only that fact. **No consumer, no emitted-code change** (the diff touches
+`crates/perry-runtime` only), because #6377's lesson is that every added
+proof un-gates latent fast paths its own microbench never exercises.
+
+The invariant is "every element of this array is an object of class `C`".
+Its storage deliberately mirrors Phase 4a's dense bit, which works because
+the collector copies the whole `_reserved` word on a move: a
+`GcHeader._reserved` bit (11, disjoint-by-`obj_type` with the object-only
+`OBJ_FLAG_HAS_DESCRIPTORS`, the same reuse `GC_ARRAY_RAW_F64_HOLES` already
+makes) rides relocation for free, and the shape id — which does not fit in a
+bit — lives in an address-keyed record moved by `transfer_element_shape` from
+inside `layout_transfer`, the same call site and the same split as
+`TYPED_LAYOUTS`. The bit stays the authority: a fresh allocation's
+`_reserved` is zero, so a stale record at a recycled address is unreachable,
+and a bit with no record fails closed. The record is four integers and holds
+no heap pointer, so it is deliberately not a `gc_register_mutable_root_scanner`
+entry; dead keys are dropped on the hook that already prunes
+`ARRAY_NAMED_PROPS`.
+
+Maintenance hangs off one funnel, `gc::layout_note_slot` — the only place
+both the runtime's element-store helpers and codegen's *inline* element
+stores already meet, since `array_store_needs_layout_note` elides the note
+only for arrays statically proven numeric and pointer-free, which an
+element-shape array can never be. It sits ahead of that function's
+`GC_LAYOUT_UNKNOWN` early return and costs a `GC_TYPE_ARRAY` compare plus a
+bit test on a header word the next line reads anyway; an array without the
+bit leaves on one predictable-not-taken branch.
+
+The record also pins the `length` it was verified against, which is what
+keeps the invalidation matrix small enough to enumerate: `pop`, `shift`,
+`splice`, `length = n`, sparse extend and codegen's inline append all fail
+the proof automatically, with no call site of their own. Explicitly wired:
+mismatched or non-pointer stores and `delete arr[i]` clear through the store
+hook; `shift`/`unshift`/`splice`/`fill`/`copyWithin`/`reverse`/`sort` clear
+through `rebuild_array_layout`, the post-hoc funnel they all already use;
+`set_array_numeric_layout` clears (the numeric and element-shape invariants
+are mutually exclusive); and prototype surgery bumps a global generation
+counter from `invalidate_class_prototype_fast_guards` and from
+`object_set_static_prototype_impl`'s `instance_override` arm, retiring every
+outstanding record at O(1) without enumerating arrays. Arrays built outside
+the funnels (inline literals, `JSON.parse`, `map`) re-earn the proof through
+`ensure_element_shape`, a rescan that mirrors `ensure_array_numeric_raw_f64`.
+
+Two counters, both `AtomicU64` starting at 1 like `PROP_PLAN_EPOCH`:
+`js_array_element_shape_epoch()` advances on every clear anywhere and is the
+one-load word a hoisted guard re-reads without rescanning, while the
+per-array `epoch` in the record distinguishes "still the same proof" from
+"re-established after a break". `js_array_element_shape_check` pins both.
+
+26 new tests. 24 cover the matrix row by row in
+`array/element_shape_tests.rs`; 2 in `gc/tests/layout_trace/element_shape.rs`
+put a proven array through a real copying minor and assert the subject was
+live first — the collector actually copied, and the array actually moved —
+so a run with zero copying minors cannot pass. One of them pushes *after* the
+move and asserts the proof both extends on a match and retires on a
+mismatch, which is what proves the record is reachable at the new key rather
+than merely readable once.

--- a/changelog.d/7496-element-shape-invariant.md
+++ b/changelog.d/7496-element-shape-invariant.md
@@ -49,17 +49,27 @@ outstanding record at O(1) without enumerating arrays. Arrays built outside
 the funnels (inline literals, `JSON.parse`, `map`) re-earn the proof through
 `ensure_element_shape`, a rescan that mirrors `ensure_array_numeric_raw_f64`.
 
-Two counters, both `AtomicU64` starting at 1 like `PROP_PLAN_EPOCH`:
+Three `AtomicU64` counters, all starting at 1 like `PROP_PLAN_EPOCH`.
 `js_array_element_shape_epoch()` advances on every clear anywhere and is the
-one-load word a hoisted guard re-reads without rescanning, while the
-per-array `epoch` in the record distinguishes "still the same proof" from
-"re-established after a break". `js_array_element_shape_check` pins both.
+one-load word a hoisted guard re-reads without rescanning; a class-shape
+generation retires every record at once on prototype surgery; and a proof
+sequence hands each *established* proof an identity that is never reused.
+That last one is what makes address recycling safe — establishing takes a new
+number rather than reading back whatever record sits at the address, so a
+record that outlives its array (left by a fail-closed relocation, or by a
+death whose prune has not run yet) can never donate its identity to the next
+array proven there. `js_array_element_shape_check` pins class and identity
+together.
 
-26 new tests. 24 cover the matrix row by row in
-`array/element_shape_tests.rs`; 2 in `gc/tests/layout_trace/element_shape.rs`
-put a proven array through a real copying minor and assert the subject was
-live first — the collector actually copied, and the array actually moved —
-so a run with zero copying minors cannot pass. One of them pushes *after* the
-move and asserts the proof both extends on a match and retires on a
-mismatch, which is what proves the record is reachable at the new key rather
-than merely readable once.
+29 new tests. 27 cover the matrix row by row in
+`array/element_shape_tests.rs`, including the two lifecycle hooks that stop a
+recycled address inheriting a stale record; 2 in
+`gc/tests/layout_trace/element_shape.rs` put a proven array through a real
+copying minor and assert the subject was live first — the collector actually
+copied, and the array actually moved — so a run with zero copying minors
+cannot pass. One of them pushes *after* the move and asserts the proof both
+extends on a match and retires on a mismatch, which is what proves the record
+is reachable at the new key rather than merely readable once. Both files
+serialize on a shared poison-tolerant lock, taken before any state-restoring
+guard, because the three counters are process-wide while the record table is
+thread-local (#7490's failure shape).

--- a/crates/perry-runtime/src/array/element_shape.rs
+++ b/crates/perry-runtime/src/array/element_shape.rs
@@ -1,0 +1,582 @@
+//! Repsel #7480: the per-array **homogeneous element-shape invariant** —
+//! "every element of this array is an object of class `C`".
+//!
+//! ## Why this layer exists
+//!
+//! `keep[j].v` measures 6.2× vs node on the pure shape (#7480). The cost is
+//! two *stacked* inline guard diamonds per access: the element-read tier
+//! proves `keep[j]` is an in-bounds slot of a real array, then the field-read
+//! precheck re-proves that the value it produced is an object of the right
+//! shape. Both candidate fixes — extending the #5093 versioned-loop clone
+//! (hoist ONE whole-array guard into the preheader) and full element
+//! `Ptr<Shape>` representation — need the *same* missing fact: an O(1),
+//! array-level answer to "are all the elements the same shape?". The only
+//! array-level invariants that existed before this module were the numeric
+//! ones (`GC_ARRAY_RAW_F64_LAYOUT` / `_HOLES`).
+//!
+//! **This module is the invariant only.** Nothing consumes it yet, by
+//! design: #6377's lesson is that every added proof un-gates latent fast
+//! paths its own microbench never exercises, so the proof lands and is
+//! tested on its own before a consumer reads it. No emitted code changes.
+//!
+//! ## Storage — deliberately the same shape as Phase 4a's dense bit
+//!
+//! 4a's `GC_ARRAY_RAW_F64_LAYOUT` is a bit in `GcHeader._reserved` plus a
+//! rebuild-on-demand scan, and it works because the collector copies the
+//! whole `_reserved` word when it moves an object — the invariant survives a
+//! copying minor with no side-table walk and no per-move bookkeeping. This
+//! module mirrors that, point for point:
+//!
+//! | | 4a (`RAW_F64_LAYOUT`) | here (`ELEMENT_SHAPE`) |
+//! |---|---|---|
+//! | fast proof | `_reserved` bit 7 | `_reserved` bit 11 |
+//! | rides a move | yes (`_reserved` is copied) | yes (same word) |
+//! | self-heals by rescan | `ensure_array_numeric_raw_f64` | [`ensure_element_shape`] |
+//! | move fixup | `transfer_array_numeric_layout` | [`transfer_element_shape`] |
+//! | clear funnel | `clear_array_numeric_layout` | [`clear_element_shape`] |
+//!
+//! The one thing 4a does not need is a *payload*: "raw f64" is the whole
+//! fact, so the bit is the whole record. A shape id does not fit in a bit,
+//! so it lives in `ELEMENT_SHAPES`, keyed by the array's user address and
+//! moved by [`transfer_element_shape`] from inside `layout_transfer` —
+//! exactly how `TYPED_LAYOUTS` is moved. **The bit stays the authority.** A
+//! fresh allocation's `_reserved` is zero, so a stale record left at a
+//! recycled address is unreachable, and a missing record fails closed.
+//!
+//! The two are mutually exclusive by construction: an element-shape array's
+//! slots are NaN-boxed pointers, which no raw-f64 layout admits, so
+//! `set_array_numeric_layout` clears this bit and vice versa.
+//!
+//! ## The record holds no heap pointer
+//!
+//! [`ElementShapeRecord`] is four plain integers. It is **not** a cache of a
+//! raw heap pointer, so it is deliberately NOT registered with
+//! `gc_register_mutable_root_scanner` — there is nothing in it for the
+//! collector to mark or rewrite. The `class_id` is a registry index; the key
+//! is only ever compared, never dereferenced. Dead keys are dropped by
+//! [`prune_dead_element_shape_owners`] on the same collection hook that
+//! prunes `ARRAY_NAMED_PROPS` — a footprint concern only, since the bit on a
+//! recycled allocation's fresh `_reserved` is zero.
+//!
+//! ## Two counters, two different questions
+//!
+//! * [`element_shape_epoch`] — monotone, bumped on **every** clear or
+//!   invalidation, of any array. This is the word a consumer's hoisted guard
+//!   re-reads: "has anything that could retire any element-shape proof
+//!   happened since the preheader?" One relaxed load, one compare, no
+//!   side-table probe, no rescan. Deliberately coarse — an unrelated array's
+//!   clear deopts a running loop, which errs in the safe direction.
+//! * `CLASS_SHAPE_GENERATION` — bumped only when a *class* stops being a
+//!   reliable shape (prototype surgery). A record installed under an older
+//!   generation is retired lazily on its next query, so one prototype write
+//!   retires every outstanding record at O(1) without enumerating arrays.
+//!
+//! Both follow the crate's convention for invalidation counters (`AtomicU64`
+//! starting at 1, `PROP_PLAN_EPOCH` / `PERRY_IC_EPOCH`), not a per-thread
+//! `Cell`: the class registry a generation bump answers to is process-wide.
+//!
+//! ## Verified length: the structural half of the invalidation matrix
+//!
+//! The record pins the `length` it was verified against, and a query
+//! requires the array's current `length` to still match. Every operation
+//! that changes `length` outside the store funnels — `pop`, `shift`,
+//! `splice`, `length = n`, sparse extend, codegen's inline append — is
+//! therefore invalidated *automatically* on the next query, with no call
+//! site of its own. That is what keeps the invalidation matrix small enough
+//! to enumerate.
+
+use super::header::{
+    array_elements_ptr, array_gc_header, array_object_flags, clean_arr_ptr, clean_arr_ptr_mut,
+};
+use super::ArrayHeader;
+use crate::gc::GC_ARRAY_ELEMENT_SHAPE;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Same ceiling the raw-f64 rebuild walk uses — an array claiming a length
+/// past this is corrupt or pathological and gets no proof.
+const MAX_VERIFIED_LEN: usize = 16_000_000;
+
+/// The side-table half of the invariant. Four integers; **no heap pointer**
+/// (see the module docs on why this is not a GC root).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ElementShapeRecord {
+    /// `ObjectHeader::class_id` shared by every element in `[0, length)`.
+    class_id: u32,
+    /// The `length` this record was verified against. A query requires the
+    /// array's current `length` to still equal it, so every length-changing
+    /// mutation invalidates the proof without needing its own call site.
+    verified_len: u32,
+    /// Bumped each time THIS array's invariant is cleared, so a consumer
+    /// holding a proof can tell "still the same proof" from "re-established
+    /// with the same class after a break".
+    epoch: u32,
+    /// `CLASS_SHAPE_GENERATION` at install time. A prototype write bumps the
+    /// global and retires every record at once.
+    generation: u64,
+}
+
+/// What a query hands back. Deliberately not the raw record: `generation` is
+/// a validity input, not a consumer-visible fact.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ElementShapeProof {
+    pub(crate) class_id: u32,
+    pub(crate) verified_len: u32,
+    pub(crate) epoch: u32,
+}
+
+thread_local! {
+    /// Address-keyed element-shape records. `PtrHashMap` for the same reason
+    /// `ARRAY_NAMED_PROPS` uses it (#6386): the key is already a
+    /// well-distributed address and SipHash dominates the probe.
+    ///
+    /// Thread-local because arenas are: an array address is only meaningful
+    /// on the thread that allocated it.
+    static ELEMENT_SHAPES: RefCell<crate::fast_hash::PtrHashMap<usize, ElementShapeRecord>> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_map());
+}
+
+/// Bumped on every clear/invalidation. See the module docs.
+static ELEMENT_SHAPE_EPOCH: AtomicU64 = AtomicU64::new(1);
+
+/// Bumped only when a class stops being a reliable shape.
+static CLASS_SHAPE_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+/// The consumer-facing "nothing has been retired" word. See the module docs.
+#[inline]
+pub(crate) fn element_shape_epoch() -> u64 {
+    ELEMENT_SHAPE_EPOCH.load(Ordering::Relaxed)
+}
+
+#[inline]
+fn bump_epoch() {
+    ELEMENT_SHAPE_EPOCH.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+fn class_shape_generation() -> u64 {
+    CLASS_SHAPE_GENERATION.load(Ordering::Relaxed)
+}
+
+/// Retire **every** outstanding element-shape record at O(1).
+///
+/// Called when a class stops being a reliable shape — a method written onto
+/// a prototype object, a `[[Prototype]]` swap. Records are not enumerated:
+/// each carries the generation it was installed under and fails its next
+/// query, which clears the bit. An array that is still homogeneous
+/// self-heals on the next [`ensure_element_shape`].
+pub(crate) fn invalidate_all_element_shapes() {
+    CLASS_SHAPE_GENERATION.fetch_add(1, Ordering::Relaxed);
+    bump_epoch();
+}
+
+/// The class id an element must have to keep the invariant, or `None` if the
+/// value cannot participate at all.
+///
+/// Strict on purpose. `POINTER_TAG` alone is not enough: `RegExpHeader` is
+/// also tagged `GC_TYPE_OBJECT` (see the aliasing caution on `ObjectMeta`),
+/// and reading `class_id` off a non-`ObjectHeader` payload yields garbage
+/// that would then be *compared equal* across two unrelated arrays.
+/// Requiring `object_type == OBJECT_TYPE_REGULAR` and a nonzero class id
+/// keeps every accepted value a genuine shaped instance.
+#[inline]
+pub(crate) fn element_class_of_bits(value_bits: u64) -> Option<u32> {
+    if value_bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
+        return None;
+    }
+    let addr = (value_bits & crate::value::POINTER_MASK) as usize;
+    if !crate::value::addr_class::is_plausible_heap_addr(addr) {
+        return None;
+    }
+    unsafe {
+        let header =
+            (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        if (*header).obj_type != crate::gc::GC_TYPE_OBJECT {
+            return None;
+        }
+        let obj = addr as *const crate::object::ObjectHeader;
+        if (*obj).object_type != crate::error::OBJECT_TYPE_REGULAR {
+            return None;
+        }
+        let class_id = (*obj).class_id;
+        if class_id == 0 {
+            return None;
+        }
+        Some(class_id)
+    }
+}
+
+#[inline]
+unsafe fn header_has_bit(header: *const crate::gc::GcHeader) -> bool {
+    (*header)._reserved & GC_ARRAY_ELEMENT_SHAPE != 0
+}
+
+#[inline]
+unsafe fn set_bit(header: *mut crate::gc::GcHeader) {
+    (*header)._reserved |= GC_ARRAY_ELEMENT_SHAPE;
+}
+
+#[inline]
+unsafe fn clear_bit(header: *mut crate::gc::GcHeader) {
+    (*header)._reserved &= !GC_ARRAY_ELEMENT_SHAPE;
+}
+
+/// An array carrying per-index descriptors (accessors, custom attrs) can
+/// hand back a value its element slot does not hold, so no element proof is
+/// admissible — the same stand-down the raw-f64 element accessors make on
+/// `OBJ_FLAG_ARRAY_DESCRIPTORS`.
+#[inline]
+unsafe fn array_admits_element_proof(arr: *const ArrayHeader) -> bool {
+    array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS == 0
+}
+
+#[inline]
+fn record_for(key: usize) -> Option<ElementShapeRecord> {
+    ELEMENT_SHAPES.with(|m| m.borrow().get(&key).copied())
+}
+
+/// Drop the invariant for `arr` and bump the global epoch.
+///
+/// Idempotent and cheap when nothing was set: the bit test short-circuits
+/// before the side-table borrow, so the overwhelming majority of arrays
+/// (which never carry the invariant) pay one predictable-not-taken branch.
+#[inline]
+pub(crate) unsafe fn clear_element_shape(arr: *const ArrayHeader) {
+    let Some(header) = array_gc_header(arr) else {
+        return;
+    };
+    if !header_has_bit(header) {
+        return;
+    }
+    clear_bit(header);
+    let key = arr as usize;
+    ELEMENT_SHAPES.with(|m| {
+        // Keep the record, with a bumped per-array epoch, so a later
+        // re-establishment is distinguishable from the proof just retired.
+        // The bit — not the record — is the authority, so a retained record
+        // under a cleared bit proves nothing.
+        if let Some(record) = m.borrow_mut().get_mut(&key) {
+            record.epoch = record.epoch.wrapping_add(1);
+        }
+    });
+    bump_epoch();
+}
+
+/// Address-keyed sibling of [`clear_element_shape`], for the `layout_*`
+/// family and other callers that hold a `usize`.
+#[inline]
+pub(crate) fn clear_element_shape_ptr(user_ptr: usize) {
+    if user_ptr == 0 {
+        return;
+    }
+    unsafe { clear_element_shape(user_ptr as *const ArrayHeader) }
+}
+
+/// Forget everything about an address, bit included. Used when an allocation
+/// dies and its address may be recycled (`layout_clear_for_ptr`).
+pub(crate) fn forget_element_shape(user_ptr: usize) {
+    if user_ptr == 0 {
+        return;
+    }
+    unsafe { clear_element_shape(user_ptr as *const ArrayHeader) };
+    ELEMENT_SHAPES.with(|m| {
+        m.borrow_mut().remove(&user_ptr);
+    });
+}
+
+/// Install the invariant for `arr` at `class_id`, verified over
+/// `[0, verified_len)`.
+unsafe fn install(arr: *mut ArrayHeader, class_id: u32, verified_len: u32) {
+    let Some(header) = array_gc_header(arr) else {
+        return;
+    };
+    let key = arr as usize;
+    let generation = class_shape_generation();
+    ELEMENT_SHAPES.with(|m| {
+        let mut map = m.borrow_mut();
+        let epoch = map.get(&key).map_or(1, |r| r.epoch);
+        map.insert(
+            key,
+            ElementShapeRecord {
+                class_id,
+                verified_len,
+                epoch,
+                generation,
+            },
+        );
+    });
+    set_bit(header);
+}
+
+/// The O(1) query: does `arr` still carry a homogeneous element-shape proof?
+///
+/// Self-healing in the invalidating direction — a record that lost its
+/// generation, or whose `verified_len` no longer matches the array's
+/// `length`, clears the bit here rather than lingering as a lie. Never
+/// *establishes* anything; that is [`ensure_element_shape`].
+#[inline]
+pub(crate) unsafe fn element_shape_proof(arr: *const ArrayHeader) -> Option<ElementShapeProof> {
+    let arr = clean_arr_ptr(arr);
+    let header = array_gc_header(arr)?;
+    if !header_has_bit(header) {
+        return None;
+    }
+    let Some(record) = record_for(arr as usize) else {
+        // Fail closed: the bit rode a move `layout_transfer` did not fix up,
+        // or the record was pruned. Clearing keeps the halves in agreement.
+        clear_bit(header);
+        bump_epoch();
+        return None;
+    };
+    if record.generation != class_shape_generation()
+        || record.verified_len != (*arr).length
+        || !array_admits_element_proof(arr)
+    {
+        clear_element_shape(arr);
+        return None;
+    }
+    Some(ElementShapeProof {
+        class_id: record.class_id,
+        verified_len: record.verified_len,
+        epoch: record.epoch,
+    })
+}
+
+/// Establish the invariant by scanning, if it holds — the self-healing entry
+/// point, and the direct analogue of `ensure_array_numeric_raw_f64`.
+///
+/// Returns the existing proof without scanning when the bit is already
+/// valid, so a consumer may call this unconditionally in a preheader and pay
+/// O(n) only on the first visit (or after a break).
+pub(crate) unsafe fn ensure_element_shape(arr: *mut ArrayHeader) -> Option<ElementShapeProof> {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return None;
+    }
+    if let Some(proof) = element_shape_proof(arr) {
+        return Some(proof);
+    }
+    array_gc_header(arr)?;
+    if !array_admits_element_proof(arr) {
+        return None;
+    }
+    let length = (*arr).length as usize;
+    let capacity = (*arr).capacity as usize;
+    // An empty array has no element shape to prove: the fact would be
+    // vacuous and a consumer guarding on it would licence reads that cannot
+    // happen. Decline rather than install a class-less proof.
+    if length == 0 || length > capacity || length > MAX_VERIFIED_LEN {
+        return None;
+    }
+    let elements = array_elements_ptr(arr);
+    let class_id = element_class_of_bits(*elements)?;
+    for i in 1..length {
+        if element_class_of_bits(*elements.add(i)) != Some(class_id) {
+            return None;
+        }
+    }
+    install(arr, class_id, length as u32);
+    element_shape_proof(arr)
+}
+
+/// The single element-store hook, called from `gc::layout_note_slot` — the
+/// one funnel **both** the runtime's element-store helpers and codegen's
+/// inline element stores already pass through.
+///
+/// Routing it there rather than through `array::note_array_slot` is what
+/// makes the invariant hold against emitted code: `array_store_needs_layout_note`
+/// elides the note only when the array is *statically proven numeric and
+/// pointer-free*, which an element-shape array can never be, so every
+/// codegen-inlined store into a shape-proven array reaches this hook. The
+/// call sits before `layout_note_slot`'s `GC_LAYOUT_UNKNOWN` early return
+/// (an all-pointer array is marked unknown on its first generic write) and
+/// costs a `GC_TYPE_ARRAY` compare plus a bit test on a header word that
+/// line is about to read anyway.
+///
+/// Three cases, each with its own named test:
+///
+/// * **establish** — no proof yet, this store writes element 0 of an empty
+///   array, and the value is a shaped object. That is the
+///   `const rows = []; rows.push(new C(…))` construction shape, which is
+///   exactly the form the compile-time collector already admits (#7034
+///   E1/E2). Growth beyond element 0 then rides the *keep* case.
+/// * **keep** — a proof exists and the value's class matches. A contiguous
+///   append additionally extends `verified_len`.
+/// * **clear** — anything else: a different class, a non-pointer, a
+///   `TAG_HOLE` (so `delete arr[i]` and `arr.length = n`, which both funnel
+///   `TAG_HOLE` stores through here, are covered with no call site of their
+///   own), or a store that would leave a gap.
+///
+/// `arr` must already be forwarding-resolved; `layout_note_slot` chases the
+/// chain before calling.
+#[inline]
+pub(crate) unsafe fn note_element_store(arr: *mut ArrayHeader, index: usize, value_bits: u64) {
+    let Some(header) = array_gc_header(arr) else {
+        return;
+    };
+    if !header_has_bit(header) {
+        // Establish only from empty. Adopting a longer array here would
+        // claim a prefix was verified when it never was.
+        if index == 0 && (*arr).length == 0 && array_admits_element_proof(arr) {
+            if let Some(class_id) = element_class_of_bits(value_bits) {
+                install(arr, class_id, 1);
+            }
+        }
+        return;
+    }
+    let Some(record) = record_for(arr as usize) else {
+        clear_element_shape(arr);
+        return;
+    };
+    // A store past the end of the verified prefix leaves a gap of holes.
+    if index > record.verified_len as usize {
+        clear_element_shape(arr);
+        return;
+    }
+    if element_class_of_bits(value_bits) != Some(record.class_id) {
+        clear_element_shape(arr);
+        return;
+    }
+    if index == record.verified_len as usize {
+        // Contiguous append. Callers bump `length` immediately after the
+        // store, so the record leads it for exactly the store's duration.
+        install(arr, record.class_id, record.verified_len.saturating_add(1));
+    }
+}
+
+/// Move the record when the array's storage moves — growth forwarding, a
+/// copying minor, an old-gen defrag. Called from `layout_transfer`, the one
+/// funnel every relocation already goes through.
+///
+/// `_reserved` (and with it the bit) is copied verbatim by both the
+/// collector and `js_array_grow`, so the bit is normally already correct on
+/// `new_user`; this sets it explicitly anyway so the two halves cannot
+/// disagree if a future move path forgets the word copy.
+pub(crate) fn transfer_element_shape(old_user: usize, new_user: usize) {
+    if old_user == 0 || new_user == 0 || old_user == new_user {
+        return;
+    }
+    let moved = ELEMENT_SHAPES.with(|m| {
+        let mut map = m.borrow_mut();
+        map.remove(&new_user);
+        match map.remove(&old_user) {
+            Some(record) => {
+                map.insert(new_user, record);
+                true
+            }
+            None => false,
+        }
+    });
+    unsafe {
+        let Some(new_header) = array_gc_header(new_user as *const ArrayHeader) else {
+            return;
+        };
+        let had_bit = array_gc_header(old_user as *const ArrayHeader)
+            .is_some_and(|old_header| header_has_bit(old_header));
+        if moved && had_bit {
+            set_bit(new_header);
+        } else {
+            // Fail closed. The epoch is deliberately NOT bumped for a plain
+            // move: no proof was retired, there was never one to retire.
+            clear_bit(new_header);
+        }
+    }
+}
+
+/// Drop records whose array owners are provably dead, on the same collection
+/// hook that prunes `ARRAY_NAMED_PROPS`. Footprint only — a stale record can
+/// never be *read*, because a recycled allocation's fresh `_reserved` is
+/// zero.
+pub(crate) fn prune_dead_element_shape_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    ELEMENT_SHAPES.with(|m| {
+        m.borrow_mut().retain(|owner, _| !is_dead_owner(*owner));
+    });
+}
+
+// ---------------------------------------------------------------------------
+// FFI surface — the codegen-observable query. No emitted code calls these
+// yet (#7480 ships the invariant without a consumer); they are the contract
+// the #5093 versioned-loop clone will guard on.
+// ---------------------------------------------------------------------------
+
+/// Establish-or-confirm, returning the proven `class_id` or `0`. The
+/// preheader entry point: O(n) on first visit, O(1) afterwards.
+#[no_mangle]
+pub extern "C" fn js_array_ensure_element_shape(arr: *mut ArrayHeader) -> i32 {
+    unsafe { ensure_element_shape(arr).map_or(0, |p| p.class_id as i32) }
+}
+
+/// The O(1) query with no scan: the proven `class_id`, or `0`.
+#[no_mangle]
+pub extern "C" fn js_array_element_shape_class(arr: *const ArrayHeader) -> i32 {
+    unsafe { element_shape_proof(arr).map_or(0, |p| p.class_id as i32) }
+}
+
+/// The per-array proof identity a consumer pins alongside the class id.
+#[no_mangle]
+pub extern "C" fn js_array_element_shape_version(arr: *const ArrayHeader) -> i64 {
+    unsafe { element_shape_proof(arr).map_or(-1, |p| i64::from(p.epoch)) }
+}
+
+/// The global "nothing was retired" word. One relaxed load; see module docs.
+#[no_mangle]
+pub extern "C" fn js_array_element_shape_epoch() -> i64 {
+    element_shape_epoch() as i64
+}
+
+/// Re-validate a hoisted guard without rescanning: the array still proves
+/// `class_id`, and it is still the same proof (`epoch`).
+#[no_mangle]
+pub extern "C" fn js_array_element_shape_check(
+    arr: *const ArrayHeader,
+    class_id: i32,
+    epoch: i64,
+) -> i32 {
+    unsafe {
+        match element_shape_proof(arr) {
+            Some(p) if p.class_id as i32 == class_id && i64::from(p.epoch) == epoch => 1,
+            _ => 0,
+        }
+    }
+}
+
+// `#[no_mangle]` exports for generated code, so release/LTO builds cannot
+// internalize and strip them in the window before a consumer exists.
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_JS_ARRAY_ENSURE_ELEMENT_SHAPE: extern "C" fn(*mut ArrayHeader) -> i32 =
+    js_array_ensure_element_shape;
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_JS_ARRAY_ELEMENT_SHAPE_CLASS: extern "C" fn(*const ArrayHeader) -> i32 =
+    js_array_element_shape_class;
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_JS_ARRAY_ELEMENT_SHAPE_VERSION: extern "C" fn(*const ArrayHeader) -> i64 =
+    js_array_element_shape_version;
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_JS_ARRAY_ELEMENT_SHAPE_EPOCH: extern "C" fn() -> i64 = js_array_element_shape_epoch;
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_JS_ARRAY_ELEMENT_SHAPE_CHECK: extern "C" fn(*const ArrayHeader, i32, i64) -> i32 =
+    js_array_element_shape_check;
+
+#[cfg(test)]
+pub(crate) fn test_element_shape_record_exists(owner: usize) -> bool {
+    ELEMENT_SHAPES.with(|m| m.borrow().contains_key(&owner))
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_element_shape_table() {
+    ELEMENT_SHAPES.with(|m| m.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn test_element_shape_bit_set(arr: *const ArrayHeader) -> bool {
+    array_gc_header(arr).is_some_and(|header| header_has_bit(header))
+}
+
+#[cfg(test)]
+#[path = "element_shape_tests.rs"]
+mod tests;

--- a/crates/perry-runtime/src/array/element_shape.rs
+++ b/crates/perry-runtime/src/array/element_shape.rs
@@ -185,13 +185,15 @@ pub(crate) fn element_class_of_bits(value_bits: u64) -> Option<u32> {
         return None;
     }
     let addr = (value_bits & crate::value::POINTER_MASK) as usize;
-    if !crate::value::addr_class::is_plausible_heap_addr(addr) {
-        return None;
-    }
     unsafe {
-        let header =
-            (addr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        if (*header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        // The canonical validated header read: it rejects the handle bands and
+        // implausible magnitudes BEFORE touching `addr - GC_HEADER_SIZE`, and
+        // it also rejects small-buffer slab addresses, which are heap-plausible
+        // but carry no `GcHeader` at all.
+        let Some(header) = crate::value::addr_class::try_read_gc_header(addr) else {
+            return None;
+        };
+        if header.obj_type != crate::gc::GC_TYPE_OBJECT {
             return None;
         }
         let obj = addr as *const crate::object::ObjectHeader;

--- a/crates/perry-runtime/src/array/element_shape.rs
+++ b/crates/perry-runtime/src/array/element_shape.rs
@@ -71,6 +71,14 @@
 //!   generation is retired lazily on its next query, so one prototype write
 //!   retires every outstanding record at O(1) without enumerating arrays.
 //!
+//! A third counter, `ELEMENT_SHAPE_PROOF_SEQ`, is not an invalidation signal
+//! but an identity source: every *established* proof takes the next value and
+//! carries it unchanged while it is kept or extended. Because identities are
+//! never reused and are never read back from the table, a record that
+//! outlives its array — left by a fail-closed transfer, or by a death whose
+//! prune has not run yet — cannot donate its identity to whatever is
+//! established at that recycled address next.
+//!
 //! Both follow the crate's convention for invalidation counters (`AtomicU64`
 //! starting at 1, `PROP_PLAN_EPOCH` / `PERRY_IC_EPOCH`), not a per-thread
 //! `Cell`: the class registry a generation bump answers to is process-wide.
@@ -107,10 +115,13 @@ struct ElementShapeRecord {
     /// array's current `length` to still equal it, so every length-changing
     /// mutation invalidates the proof without needing its own call site.
     verified_len: u32,
-    /// Bumped each time THIS array's invariant is cleared, so a consumer
-    /// holding a proof can tell "still the same proof" from "re-established
-    /// with the same class after a break".
-    epoch: u32,
+    /// This proof's identity, drawn from `ELEMENT_SHAPE_PROOF_SEQ` when the
+    /// proof is *established*, and carried unchanged while it is merely kept
+    /// or extended. Values are never reused, so a consumer that pinned
+    /// `(class_id, epoch)` can never be fooled by the same array being
+    /// re-proven with the same class after a break — nor by a *different*
+    /// array being established at a recycled address.
+    epoch: u64,
     /// `CLASS_SHAPE_GENERATION` at install time. A prototype write bumps the
     /// global and retires every record at once.
     generation: u64,
@@ -122,7 +133,7 @@ struct ElementShapeRecord {
 pub(crate) struct ElementShapeProof {
     pub(crate) class_id: u32,
     pub(crate) verified_len: u32,
-    pub(crate) epoch: u32,
+    pub(crate) epoch: u64,
 }
 
 thread_local! {
@@ -141,6 +152,34 @@ static ELEMENT_SHAPE_EPOCH: AtomicU64 = AtomicU64::new(1);
 
 /// Bumped only when a class stops being a reliable shape.
 static CLASS_SHAPE_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+/// Hands out a fresh identity to every proof that is *established*. Values
+/// are never reused, which is what makes address recycling safe: a record
+/// that survives at an address its array no longer owns cannot donate its
+/// identity to whatever is established there next, because establishing
+/// always takes a new number rather than reading the old one.
+static ELEMENT_SHAPE_PROOF_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// A shared serialization guard for the tests, which observe the two
+/// process-wide counters above. `ELEMENT_SHAPES` is thread-local, so each
+/// test thread gets its own table, but a concurrent test's clear or
+/// generation bump is visible in `ELEMENT_SHAPE_EPOCH` — order-dependent
+/// tests are exactly the failure #7490 spent a day untangling. Both test
+/// files take this lock, and it is deliberately poison-tolerant (#7492): a
+/// panicking test must not cascade into every other one.
+#[cfg(test)]
+pub(crate) static ELEMENT_SHAPE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Take [`ELEMENT_SHAPE_TEST_LOCK`], recovering from poisoning.
+///
+/// Declare this guard **first** in a test, before any `…TestGuard`, so unwind
+/// order drops the state-restoring guards while this one is still held.
+#[cfg(test)]
+pub(crate) fn test_serialize() -> std::sync::MutexGuard<'static, ()> {
+    ELEMENT_SHAPE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// The consumer-facing "nothing has been retired" word. See the module docs.
 #[inline]
@@ -252,14 +291,12 @@ pub(crate) unsafe fn clear_element_shape(arr: *const ArrayHeader) {
     }
     clear_bit(header);
     let key = arr as usize;
+    // Drop the record outright. Keeping a retired one buys nothing —
+    // identities come from `ELEMENT_SHAPE_PROOF_SEQ`, never from whatever
+    // happens to sit at the address — and a record with no bit is a
+    // liability: it is the thing a later establishment could read.
     ELEMENT_SHAPES.with(|m| {
-        // Keep the record, with a bumped per-array epoch, so a later
-        // re-establishment is distinguishable from the proof just retired.
-        // The bit — not the record — is the authority, so a retained record
-        // under a cleared bit proves nothing.
-        if let Some(record) = m.borrow_mut().get_mut(&key) {
-            record.epoch = record.epoch.wrapping_add(1);
-        }
+        m.borrow_mut().remove(&key);
     });
     bump_epoch();
 }
@@ -286,28 +323,46 @@ pub(crate) fn forget_element_shape(user_ptr: usize) {
     });
 }
 
-/// Install the invariant for `arr` at `class_id`, verified over
-/// `[0, verified_len)`.
-unsafe fn install(arr: *mut ArrayHeader, class_id: u32, verified_len: u32) {
+/// **Establish** the invariant for `arr` at `class_id`, verified over
+/// `[0, verified_len)`, under a brand-new proof identity.
+///
+/// The identity is drawn from `ELEMENT_SHAPE_PROOF_SEQ` rather than read back
+/// from whatever record happens to sit at this address. That is the whole
+/// defence against address recycling: a survivor record — left by a
+/// fail-closed transfer, a dead array whose prune has not run yet — can never
+/// donate its identity to the array established here next.
+unsafe fn establish(arr: *mut ArrayHeader, class_id: u32, verified_len: u32) {
     let Some(header) = array_gc_header(arr) else {
         return;
     };
-    let key = arr as usize;
-    let generation = class_shape_generation();
+    let record = ElementShapeRecord {
+        class_id,
+        verified_len,
+        epoch: ELEMENT_SHAPE_PROOF_SEQ.fetch_add(1, Ordering::Relaxed),
+        generation: class_shape_generation(),
+    };
     ELEMENT_SHAPES.with(|m| {
-        let mut map = m.borrow_mut();
-        let epoch = map.get(&key).map_or(1, |r| r.epoch);
-        map.insert(
-            key,
+        m.borrow_mut().insert(arr as usize, record);
+    });
+    set_bit(header);
+}
+
+/// **Keep** an existing proof while extending its verified prefix. The
+/// identity is carried unchanged — a consumer that pinned it stays valid,
+/// which is the point: appending a matching element does not retire anything.
+unsafe fn extend_verified_len(arr: *mut ArrayHeader, record: ElementShapeRecord, new_len: u32) {
+    if array_gc_header(arr).is_none() {
+        return;
+    }
+    ELEMENT_SHAPES.with(|m| {
+        m.borrow_mut().insert(
+            arr as usize,
             ElementShapeRecord {
-                class_id,
-                verified_len,
-                epoch,
-                generation,
+                verified_len: new_len,
+                ..record
             },
         );
     });
-    set_bit(header);
 }
 
 /// The O(1) query: does `arr` still carry a homogeneous element-shape proof?
@@ -377,7 +432,7 @@ pub(crate) unsafe fn ensure_element_shape(arr: *mut ArrayHeader) -> Option<Eleme
             return None;
         }
     }
-    install(arr, class_id, length as u32);
+    establish(arr, class_id, length as u32);
     element_shape_proof(arr)
 }
 
@@ -421,7 +476,7 @@ pub(crate) unsafe fn note_element_store(arr: *mut ArrayHeader, index: usize, val
         // claim a prefix was verified when it never was.
         if index == 0 && (*arr).length == 0 && array_admits_element_proof(arr) {
             if let Some(class_id) = element_class_of_bits(value_bits) {
-                install(arr, class_id, 1);
+                establish(arr, class_id, 1);
             }
         }
         return;
@@ -442,7 +497,7 @@ pub(crate) unsafe fn note_element_store(arr: *mut ArrayHeader, index: usize, val
     if index == record.verified_len as usize {
         // Contiguous append. Callers bump `length` immediately after the
         // store, so the record leads it for exactly the store's duration.
-        install(arr, record.class_id, record.verified_len.saturating_add(1));
+        extend_verified_len(arr, record, record.verified_len.saturating_add(1));
     }
 }
 
@@ -458,28 +513,41 @@ pub(crate) fn transfer_element_shape(old_user: usize, new_user: usize) {
     if old_user == 0 || new_user == 0 || old_user == new_user {
         return;
     }
-    let moved = ELEMENT_SHAPES.with(|m| {
-        let mut map = m.borrow_mut();
-        map.remove(&new_user);
-        match map.remove(&old_user) {
-            Some(record) => {
-                map.insert(new_user, record);
-                true
-            }
-            None => false,
-        }
-    });
     unsafe {
         let Some(new_header) = array_gc_header(new_user as *const ArrayHeader) else {
             return;
         };
+        // Decide BEFORE touching the table. Moving the record first and then
+        // discovering the source had no bit would leave an ORPHAN record at
+        // `new_user`: the bit is the authority so no proof is readable, but a
+        // later `install` at that address inherits the orphan's `epoch` and
+        // silently continues a *different* array's proof identity — which is
+        // exactly the versioning a consumer guards on.
         let had_bit = array_gc_header(old_user as *const ArrayHeader)
             .is_some_and(|old_header| header_has_bit(old_header));
-        if moved && had_bit {
+        let moved = ELEMENT_SHAPES.with(|m| {
+            let mut map = m.borrow_mut();
+            map.remove(&new_user);
+            if !had_bit {
+                // The source proved nothing; drop its record too rather than
+                // leave it addressable under a new key.
+                map.remove(&old_user);
+                return false;
+            }
+            match map.remove(&old_user) {
+                Some(record) => {
+                    map.insert(new_user, record);
+                    true
+                }
+                None => false,
+            }
+        });
+        if moved {
             set_bit(new_header);
         } else {
-            // Fail closed. The epoch is deliberately NOT bumped for a plain
-            // move: no proof was retired, there was never one to retire.
+            // Fail closed, with no record left behind at `new_user`. The
+            // epoch is deliberately NOT bumped for a plain move: no proof was
+            // retired, there was never one to retire.
             clear_bit(new_header);
         }
     }
@@ -517,7 +585,7 @@ pub extern "C" fn js_array_element_shape_class(arr: *const ArrayHeader) -> i32 {
 /// The per-array proof identity a consumer pins alongside the class id.
 #[no_mangle]
 pub extern "C" fn js_array_element_shape_version(arr: *const ArrayHeader) -> i64 {
-    unsafe { element_shape_proof(arr).map_or(-1, |p| i64::from(p.epoch)) }
+    unsafe { element_shape_proof(arr).map_or(-1, |p| p.epoch as i64) }
 }
 
 /// The global "nothing was retired" word. One relaxed load; see module docs.
@@ -536,7 +604,7 @@ pub extern "C" fn js_array_element_shape_check(
 ) -> i32 {
     unsafe {
         match element_shape_proof(arr) {
-            Some(p) if p.class_id as i32 == class_id && i64::from(p.epoch) == epoch => 1,
+            Some(p) if p.class_id as i32 == class_id && p.epoch as i64 == epoch => 1,
             _ => 0,
         }
     }

--- a/crates/perry-runtime/src/array/element_shape.rs
+++ b/crates/perry-runtime/src/array/element_shape.rs
@@ -542,27 +542,11 @@ pub extern "C" fn js_array_element_shape_check(
     }
 }
 
-// `#[no_mangle]` exports for generated code, so release/LTO builds cannot
-// internalize and strip them in the window before a consumer exists.
-#[cfg(feature = "keepalive-anchors")]
-#[used]
-static KEEP_JS_ARRAY_ENSURE_ELEMENT_SHAPE: extern "C" fn(*mut ArrayHeader) -> i32 =
-    js_array_ensure_element_shape;
-#[cfg(feature = "keepalive-anchors")]
-#[used]
-static KEEP_JS_ARRAY_ELEMENT_SHAPE_CLASS: extern "C" fn(*const ArrayHeader) -> i32 =
-    js_array_element_shape_class;
-#[cfg(feature = "keepalive-anchors")]
-#[used]
-static KEEP_JS_ARRAY_ELEMENT_SHAPE_VERSION: extern "C" fn(*const ArrayHeader) -> i64 =
-    js_array_element_shape_version;
-#[cfg(feature = "keepalive-anchors")]
-#[used]
-static KEEP_JS_ARRAY_ELEMENT_SHAPE_EPOCH: extern "C" fn() -> i64 = js_array_element_shape_epoch;
-#[cfg(feature = "keepalive-anchors")]
-#[used]
-static KEEP_JS_ARRAY_ELEMENT_SHAPE_CHECK: extern "C" fn(*const ArrayHeader, i32, i64) -> i32 =
-    js_array_element_shape_check;
+// NOTE — no `keepalive-anchors` `#[used]` statics here, deliberately.
+// `keepalive-anchors` is a DEFAULT feature, so an anchor would pin these
+// five functions into every shipped binary while nothing calls them: the
+// exact dead-strip defeat the hello-size campaign traced its regression to.
+// The consumer PR adds an anchor for whichever symbol it actually emits.
 
 #[cfg(test)]
 pub(crate) fn test_element_shape_record_exists(owner: usize) -> bool {

--- a/crates/perry-runtime/src/array/element_shape_tests.rs
+++ b/crates/perry-runtime/src/array/element_shape_tests.rs
@@ -6,6 +6,15 @@
 //! half (the bit and the record riding a real copying minor) lives with the
 //! other layout-trace tests, in `gc/tests/layout_trace/element_shape.rs` —
 //! that is where the copying-nursery guards are.
+//!
+//! **Both files serialize on `element_shape::ELEMENT_SHAPE_TEST_LOCK`**, taken
+//! as the FIRST statement of every test so unwind order drops the
+//! state-restoring `…TestGuard`s while it is still held. `ELEMENT_SHAPES` is
+//! thread-local and therefore already isolated per test thread, but
+//! `ELEMENT_SHAPE_EPOCH` / `CLASS_SHAPE_GENERATION` / `ELEMENT_SHAPE_PROOF_SEQ`
+//! are process-wide, so without the lock one test's clear is another test's
+//! observation. The lock is poison-tolerant: a panicking test must not
+//! cascade into every other one (#7490's ENV_LOCK, #7492's fix).
 
 use super::*;
 use crate::array::{
@@ -47,6 +56,7 @@ fn proof(arr: *mut ArrayHeader) -> Option<ElementShapeProof> {
 
 #[test]
 fn first_push_of_a_shaped_object_into_an_empty_array_sets_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 1);
     let proof = proof(arr).expect("first shaped push must establish the invariant");
     assert_eq!(proof.class_id, CLASS_A);
@@ -57,6 +67,7 @@ fn first_push_of_a_shaped_object_into_an_empty_array_sets_the_invariant() {
 
 #[test]
 fn matching_pushes_extend_the_verified_prefix() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 8);
     let proof = proof(arr).expect("homogeneous pushes must keep the invariant");
     assert_eq!(proof.class_id, CLASS_A);
@@ -66,6 +77,7 @@ fn matching_pushes_extend_the_verified_prefix() {
 
 #[test]
 fn a_scan_establishes_the_invariant_for_an_array_built_outside_the_funnels() {
+    let _serialized = test_serialize();
     // Direct slot writes, the way an inline array literal's codegen fills a
     // fresh allocation: nothing establishes the invariant on the way in.
     let arr = js_array_alloc(4);
@@ -85,6 +97,7 @@ fn a_scan_establishes_the_invariant_for_an_array_built_outside_the_funnels() {
 
 #[test]
 fn ensure_declines_an_empty_array() {
+    let _serialized = test_serialize();
     let arr = js_array_alloc(0);
     assert!(
         unsafe { ensure_element_shape(arr) }.is_none(),
@@ -95,6 +108,7 @@ fn ensure_declines_an_empty_array() {
 
 #[test]
 fn ensure_declines_a_mixed_array() {
+    let _serialized = test_serialize();
     let mut arr = js_array_alloc(2);
     arr = push(arr, instance(CLASS_A));
     arr = push(arr, instance(CLASS_B));
@@ -103,6 +117,7 @@ fn ensure_declines_a_mixed_array() {
 
 #[test]
 fn ensure_is_idempotent_and_does_not_rescan_a_live_proof() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 3);
     let first = unsafe { ensure_element_shape(arr) }.expect("already proven");
     let second = unsafe { ensure_element_shape(arr) }.expect("still proven");
@@ -115,6 +130,7 @@ fn ensure_is_idempotent_and_does_not_rescan_a_live_proof() {
 
 #[test]
 fn a_push_of_a_different_class_clears_the_invariant() {
+    let _serialized = test_serialize();
     let mut arr = built_from_pushes(CLASS_A, 3);
     assert!(proof(arr).is_some());
     arr = push(arr, instance(CLASS_B));
@@ -127,6 +143,7 @@ fn a_push_of_a_different_class_clears_the_invariant() {
 
 #[test]
 fn a_push_of_a_non_pointer_clears_the_invariant() {
+    let _serialized = test_serialize();
     let mut arr = built_from_pushes(CLASS_A, 3);
     arr = push(arr, 42.0);
     assert!(proof(arr).is_none());
@@ -134,6 +151,7 @@ fn a_push_of_a_non_pointer_clears_the_invariant() {
 
 #[test]
 fn an_in_bounds_overwrite_with_a_matching_shape_keeps_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 4);
     let before = proof(arr).expect("proven");
     js_array_set_f64(arr, 2, instance(CLASS_A));
@@ -145,6 +163,7 @@ fn an_in_bounds_overwrite_with_a_matching_shape_keeps_the_invariant() {
 
 #[test]
 fn an_in_bounds_overwrite_with_a_different_shape_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 4);
     js_array_set_f64(arr, 1, instance(CLASS_B));
     assert!(proof(arr).is_none());
@@ -152,13 +171,15 @@ fn an_in_bounds_overwrite_with_a_different_shape_clears_the_invariant() {
 
 #[test]
 fn an_in_bounds_overwrite_with_a_number_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 4);
     js_array_set_f64(arr, 1, 7.0);
     assert!(proof(arr).is_none());
 }
 
 #[test]
-fn re_establishing_after_a_clear_bumps_the_per_array_epoch() {
+fn re_establishing_after_a_clear_draws_a_fresh_proof_identity() {
+    let _serialized = test_serialize();
     let mut arr = built_from_pushes(CLASS_A, 2);
     let before = proof(arr).expect("proven").epoch;
     js_array_set_f64(arr, 0, 1.0);
@@ -180,6 +201,7 @@ fn re_establishing_after_a_clear_bumps_the_per_array_epoch() {
 
 #[test]
 fn deleting_an_element_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 4);
     assert_eq!(js_array_delete(arr, 1), 1);
     assert!(
@@ -190,6 +212,7 @@ fn deleting_an_element_clears_the_invariant() {
 
 #[test]
 fn truncating_the_length_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 4);
     js_array_set_length(arr, 2.0);
     assert!(proof(arr).is_none());
@@ -197,6 +220,7 @@ fn truncating_the_length_clears_the_invariant() {
 
 #[test]
 fn extending_the_length_with_holes_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 2);
     js_array_set_length(arr, 6.0);
     assert!(proof(arr).is_none());
@@ -204,6 +228,7 @@ fn extending_the_length_with_holes_clears_the_invariant() {
 
 #[test]
 fn a_length_change_behind_the_runtimes_back_fails_the_proof_closed() {
+    let _serialized = test_serialize();
     // The structural half of the matrix: nothing calls a funnel here, the
     // record's pinned `verified_len` is what catches it. This is what makes
     // `pop` and codegen's inline append safe without call sites of their own.
@@ -218,6 +243,7 @@ fn a_length_change_behind_the_runtimes_back_fails_the_proof_closed() {
 
 #[test]
 fn a_bulk_mutator_rebuild_clears_the_invariant() {
+    let _serialized = test_serialize();
     // `shift`/`unshift`/`splice`/`fill`/`copyWithin`/`reverse`/`sort` all
     // mutate slots with bare writes and then land in `rebuild_array_layout`.
     let arr = built_from_pushes(CLASS_A, 4);
@@ -228,6 +254,7 @@ fn a_bulk_mutator_rebuild_clears_the_invariant() {
 
 #[test]
 fn declaring_a_numeric_layout_clears_the_invariant() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 2);
     assert!(proof(arr).is_some());
     unsafe {
@@ -248,6 +275,7 @@ fn declaring_a_numeric_layout_clears_the_invariant() {
 
 #[test]
 fn prototype_surgery_retires_every_outstanding_proof() {
+    let _serialized = test_serialize();
     let a = built_from_pushes(CLASS_A, 2);
     let b = built_from_pushes(CLASS_B, 2);
     assert!(proof(a).is_some());
@@ -283,35 +311,46 @@ fn prototype_surgery_retires_every_outstanding_proof() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn the_global_epoch_advances_on_a_clear_and_holds_still_otherwise() {
+fn a_clear_advances_the_global_epoch_and_a_keep_preserves_the_proof_identity() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 3);
     let quiet = element_shape_epoch();
-    // A matching overwrite retires nothing.
+    let pinned = proof(arr).expect("proven").epoch;
+
+    // A matching overwrite retires nothing. The *per-array* identity is the
+    // deterministic half of this assertion — it lives in the thread-local
+    // record, so no concurrent test can move it. The shared lock keeps other
+    // element-shape tests out, but the global counter is also bumped by
+    // prototype surgery anywhere in the suite, so asserting it "held still"
+    // would be asserting something this test does not control.
     js_array_set_f64(arr, 0, instance(CLASS_A));
     assert_eq!(
-        element_shape_epoch(),
-        quiet,
-        "a keep must not deopt an unrelated hoisted guard"
+        proof(arr).expect("still proven").epoch,
+        pinned,
+        "a keep must not retire the proof a consumer pinned"
     );
-    // A mismatch does.
+
+    // A mismatch does retire it, and that has to be visible in the global
+    // word a hoisted guard re-reads.
     js_array_set_f64(arr, 0, instance(CLASS_B));
-    assert!(element_shape_epoch() > quiet);
+    assert!(proof(arr).is_none());
+    assert!(
+        element_shape_epoch() > quiet,
+        "a clear must advance the word a hoisted guard re-reads"
+    );
 }
 
 #[test]
 fn the_check_helper_pins_class_and_proof_identity() {
+    let _serialized = test_serialize();
     let arr = built_from_pushes(CLASS_A, 3);
     let proof = proof(arr).expect("proven");
     assert_eq!(
-        crate::array::js_array_element_shape_check(
-            arr,
-            proof.class_id as i32,
-            i64::from(proof.epoch)
-        ),
+        crate::array::js_array_element_shape_check(arr, proof.class_id as i32, proof.epoch as i64),
         1
     );
     assert_eq!(
-        crate::array::js_array_element_shape_check(arr, CLASS_B as i32, i64::from(proof.epoch)),
+        crate::array::js_array_element_shape_check(arr, CLASS_B as i32, proof.epoch as i64),
         0,
         "a different class must not validate"
     );
@@ -319,7 +358,7 @@ fn the_check_helper_pins_class_and_proof_identity() {
         crate::array::js_array_element_shape_check(
             arr,
             proof.class_id as i32,
-            i64::from(proof.epoch) + 1
+            proof.epoch as i64 + 1
         ),
         0,
         "a stale proof identity must not validate"
@@ -328,6 +367,7 @@ fn the_check_helper_pins_class_and_proof_identity() {
 
 #[test]
 fn the_ffi_query_reports_zero_for_an_unproven_array() {
+    let _serialized = test_serialize();
     let arr = js_array_alloc(0);
     assert_eq!(crate::array::js_array_element_shape_class(arr), 0);
     assert_eq!(crate::array::js_array_element_shape_version(arr), -1);
@@ -340,6 +380,7 @@ fn the_ffi_query_reports_zero_for_an_unproven_array() {
 
 #[test]
 fn growth_forwarding_carries_the_invariant_to_the_new_backing() {
+    let _serialized = test_serialize();
     // `js_array_grow` copies `_reserved` verbatim and calls `layout_transfer`,
     // which is where `transfer_element_shape` hangs.
     let arr = built_from_pushes(CLASS_A, 2);
@@ -354,6 +395,7 @@ fn growth_forwarding_carries_the_invariant_to_the_new_backing() {
 
 #[test]
 fn a_transfer_without_a_record_fails_the_destination_closed() {
+    let _serialized = test_serialize();
     let src = built_from_pushes(CLASS_A, 2);
     let dst = built_from_pushes(CLASS_A, 2);
     // Simulate the hazard the bit-is-authority rule exists for: the bit rides
@@ -365,4 +407,91 @@ fn a_transfer_without_a_record_fails_the_destination_closed() {
         "a bit with no record must never read as a proof"
     );
     unsafe { assert!(!test_element_shape_bit_set(dst)) };
+}
+
+#[test]
+fn a_fail_closed_transfer_leaves_no_record_for_the_next_array_to_inherit() {
+    // The destination of a fail-closed transfer must be left with NO record,
+    // not merely a cleared bit. A survivor there is exactly what a later
+    // establishment could read an identity out of, which would silently
+    // continue a *different* array's proof identity — defeating the very
+    // versioning a consumer guards on. Two independent defences are asserted:
+    // the record is gone, AND establishing draws a fresh identity anyway.
+    let _serialized = test_serialize();
+    let src = built_from_pushes(CLASS_A, 2);
+    let dst = built_from_pushes(CLASS_A, 2);
+    let doomed = proof(dst).expect("proven").epoch;
+
+    // `src` proves nothing, so the transfer must fail closed at `dst`.
+    unsafe { clear_element_shape(src) };
+    transfer_element_shape(src as usize, dst as usize);
+
+    assert!(
+        !test_element_shape_record_exists(dst as usize),
+        "a fail-closed transfer must not leave an orphan record at the destination"
+    );
+    unsafe { assert!(!test_element_shape_bit_set(dst)) };
+
+    // Now establish at that very address, as a recycled allocation would.
+    let reproven = unsafe { ensure_element_shape(dst) }.expect("still homogeneous");
+    assert_ne!(
+        reproven.epoch, doomed,
+        "a re-established proof must not continue the retired proof's identity"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle hooks — what stops a recycled address inheriting a stale identity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn forget_element_shape_removes_the_record_on_address_recycling() {
+    // Reached from `gc::layout_clear_for_ptr` on object death — the only path
+    // that REMOVES the record rather than clearing the bit.
+    let _serialized = test_serialize();
+    let arr = built_from_pushes(CLASS_A, 3);
+    let retired = proof(arr).expect("proven").epoch;
+    assert!(test_element_shape_record_exists(arr as usize));
+
+    forget_element_shape(arr as usize);
+
+    assert!(
+        !test_element_shape_record_exists(arr as usize),
+        "a dead allocation's record must not outlive it"
+    );
+    unsafe { assert!(!test_element_shape_bit_set(arr)) };
+    assert!(proof(arr).is_none());
+
+    let reused = unsafe { ensure_element_shape(arr) }.expect("still homogeneous");
+    assert_ne!(
+        reused.epoch, retired,
+        "an address reused after a death must not inherit the dead proof's identity"
+    );
+}
+
+#[test]
+fn pruning_dead_owners_removes_their_records() {
+    // `gc::dead_owner::fan_out` calls this with the collection's liveness
+    // predicate, on the same hook that prunes `ARRAY_NAMED_PROPS`.
+    let _serialized = test_serialize();
+    let dead = built_from_pushes(CLASS_A, 2);
+    let live = built_from_pushes(CLASS_A, 2);
+    assert!(test_element_shape_record_exists(dead as usize));
+    assert!(test_element_shape_record_exists(live as usize));
+
+    let dead_key = dead as usize;
+    prune_dead_element_shape_owners(&|owner| owner == dead_key);
+
+    assert!(
+        !test_element_shape_record_exists(dead as usize),
+        "a provably dead owner's record must be pruned"
+    );
+    assert!(
+        test_element_shape_record_exists(live as usize),
+        "a live owner's record must survive the prune"
+    );
+    assert!(
+        proof(live).is_some(),
+        "pruning must not disturb a live array's proof"
+    );
 }

--- a/crates/perry-runtime/src/array/element_shape_tests.rs
+++ b/crates/perry-runtime/src/array/element_shape_tests.rs
@@ -303,7 +303,11 @@ fn the_check_helper_pins_class_and_proof_identity() {
     let arr = built_from_pushes(CLASS_A, 3);
     let proof = proof(arr).expect("proven");
     assert_eq!(
-        crate::array::js_array_element_shape_check(arr, proof.class_id as i32, i64::from(proof.epoch)),
+        crate::array::js_array_element_shape_check(
+            arr,
+            proof.class_id as i32,
+            i64::from(proof.epoch)
+        ),
         1
     );
     assert_eq!(

--- a/crates/perry-runtime/src/array/element_shape_tests.rs
+++ b/crates/perry-runtime/src/array/element_shape_tests.rs
@@ -1,0 +1,364 @@
+//! #7480 element-shape invariant: set / keep / clear across the whole
+//! invalidation matrix.
+//!
+//! Every conjunct of the invariant gets its own named test, so a regression
+//! names the rule it broke rather than "an assert failed". The GC-survival
+//! half (the bit and the record riding a real copying minor) lives with the
+//! other layout-trace tests, in `gc/tests/layout_trace/element_shape.rs` —
+//! that is where the copying-nursery guards are.
+
+use super::*;
+use crate::array::{
+    js_array_alloc, js_array_delete, js_array_push_f64, js_array_set_f64, js_array_set_length,
+};
+
+/// Two distinct shaped classes, chosen well clear of the ids the runtime
+/// registers for itself.
+const CLASS_A: u32 = 0x0007_4801;
+const CLASS_B: u32 = 0x0007_4802;
+
+fn instance(class_id: u32) -> f64 {
+    let obj = crate::object::js_object_alloc(class_id, 2);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+fn push(arr: *mut ArrayHeader, value: f64) -> *mut ArrayHeader {
+    js_array_push_f64(arr, value)
+}
+
+/// `const rows = []; rows.push(new C())` — the construction shape the
+/// compile-time collector already admits (#7034 E1/E2), and the one the
+/// measured kernel uses.
+fn built_from_pushes(class_id: u32, count: usize) -> *mut ArrayHeader {
+    let mut arr = js_array_alloc(count as u32);
+    for _ in 0..count {
+        arr = push(arr, instance(class_id));
+    }
+    arr
+}
+
+fn proof(arr: *mut ArrayHeader) -> Option<ElementShapeProof> {
+    unsafe { element_shape_proof(arr) }
+}
+
+// ---------------------------------------------------------------------------
+// SET
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_push_of_a_shaped_object_into_an_empty_array_sets_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 1);
+    let proof = proof(arr).expect("first shaped push must establish the invariant");
+    assert_eq!(proof.class_id, CLASS_A);
+    assert_eq!(proof.verified_len, 1);
+    unsafe { assert!(test_element_shape_bit_set(arr)) };
+    assert!(test_element_shape_record_exists(arr as usize));
+}
+
+#[test]
+fn matching_pushes_extend_the_verified_prefix() {
+    let arr = built_from_pushes(CLASS_A, 8);
+    let proof = proof(arr).expect("homogeneous pushes must keep the invariant");
+    assert_eq!(proof.class_id, CLASS_A);
+    assert_eq!(proof.verified_len, 8);
+    assert_eq!(unsafe { (*arr).length }, 8);
+}
+
+#[test]
+fn a_scan_establishes_the_invariant_for_an_array_built_outside_the_funnels() {
+    // Direct slot writes, the way an inline array literal's codegen fills a
+    // fresh allocation: nothing establishes the invariant on the way in.
+    let arr = js_array_alloc(4);
+    unsafe {
+        let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;
+        for i in 0..4 {
+            std::ptr::write(elements.add(i), instance(CLASS_A).to_bits());
+        }
+        (*arr).length = 4;
+        clear_element_shape(arr);
+        assert!(proof(arr).is_none(), "no funnel ran, so no proof yet");
+        let healed = ensure_element_shape(arr).expect("a homogeneous array must self-heal");
+        assert_eq!(healed.class_id, CLASS_A);
+        assert_eq!(healed.verified_len, 4);
+    }
+}
+
+#[test]
+fn ensure_declines_an_empty_array() {
+    let arr = js_array_alloc(0);
+    assert!(
+        unsafe { ensure_element_shape(arr) }.is_none(),
+        "an empty array's element shape is vacuous and must not be claimed"
+    );
+    unsafe { assert!(!test_element_shape_bit_set(arr)) };
+}
+
+#[test]
+fn ensure_declines_a_mixed_array() {
+    let mut arr = js_array_alloc(2);
+    arr = push(arr, instance(CLASS_A));
+    arr = push(arr, instance(CLASS_B));
+    assert!(unsafe { ensure_element_shape(arr) }.is_none());
+}
+
+#[test]
+fn ensure_is_idempotent_and_does_not_rescan_a_live_proof() {
+    let arr = built_from_pushes(CLASS_A, 3);
+    let first = unsafe { ensure_element_shape(arr) }.expect("already proven");
+    let second = unsafe { ensure_element_shape(arr) }.expect("still proven");
+    assert_eq!(first, second);
+}
+
+// ---------------------------------------------------------------------------
+// CLEAR — value-shaped
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_push_of_a_different_class_clears_the_invariant() {
+    let mut arr = built_from_pushes(CLASS_A, 3);
+    assert!(proof(arr).is_some());
+    arr = push(arr, instance(CLASS_B));
+    assert!(
+        proof(arr).is_none(),
+        "a mismatched element must retire the proof"
+    );
+    unsafe { assert!(!test_element_shape_bit_set(arr)) };
+}
+
+#[test]
+fn a_push_of_a_non_pointer_clears_the_invariant() {
+    let mut arr = built_from_pushes(CLASS_A, 3);
+    arr = push(arr, 42.0);
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn an_in_bounds_overwrite_with_a_matching_shape_keeps_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 4);
+    let before = proof(arr).expect("proven");
+    js_array_set_f64(arr, 2, instance(CLASS_A));
+    let after = proof(arr).expect("a same-class overwrite must keep the proof");
+    assert_eq!(after.class_id, CLASS_A);
+    assert_eq!(after.verified_len, 4);
+    assert_eq!(after.epoch, before.epoch, "the proof itself is unchanged");
+}
+
+#[test]
+fn an_in_bounds_overwrite_with_a_different_shape_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 4);
+    js_array_set_f64(arr, 1, instance(CLASS_B));
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn an_in_bounds_overwrite_with_a_number_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 4);
+    js_array_set_f64(arr, 1, 7.0);
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn re_establishing_after_a_clear_bumps_the_per_array_epoch() {
+    let mut arr = built_from_pushes(CLASS_A, 2);
+    let before = proof(arr).expect("proven").epoch;
+    js_array_set_f64(arr, 0, 1.0);
+    assert!(proof(arr).is_none());
+    // Rebuild a homogeneous array at the same address and re-prove it.
+    js_array_set_f64(arr, 0, instance(CLASS_A));
+    js_array_set_f64(arr, 1, instance(CLASS_A));
+    arr = crate::array::header::clean_arr_ptr_mut(arr);
+    let after = unsafe { ensure_element_shape(arr) }.expect("homogeneous again");
+    assert_ne!(
+        after.epoch, before,
+        "a consumer must be able to tell a re-established proof from the retired one"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CLEAR — structural (holes, length)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deleting_an_element_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 4);
+    assert_eq!(js_array_delete(arr, 1), 1);
+    assert!(
+        proof(arr).is_none(),
+        "a hole breaks 'every element is an object of class C'"
+    );
+}
+
+#[test]
+fn truncating_the_length_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 4);
+    js_array_set_length(arr, 2.0);
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn extending_the_length_with_holes_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 2);
+    js_array_set_length(arr, 6.0);
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn a_length_change_behind_the_runtimes_back_fails_the_proof_closed() {
+    // The structural half of the matrix: nothing calls a funnel here, the
+    // record's pinned `verified_len` is what catches it. This is what makes
+    // `pop` and codegen's inline append safe without call sites of their own.
+    let arr = built_from_pushes(CLASS_A, 4);
+    assert!(proof(arr).is_some());
+    unsafe { (*arr).length = 3 };
+    assert!(
+        proof(arr).is_none(),
+        "a length that no longer matches the verified prefix must fail closed"
+    );
+}
+
+#[test]
+fn a_bulk_mutator_rebuild_clears_the_invariant() {
+    // `shift`/`unshift`/`splice`/`fill`/`copyWithin`/`reverse`/`sort` all
+    // mutate slots with bare writes and then land in `rebuild_array_layout`.
+    let arr = built_from_pushes(CLASS_A, 4);
+    assert!(proof(arr).is_some());
+    unsafe { crate::array::header::rebuild_array_layout(arr) };
+    assert!(proof(arr).is_none());
+}
+
+#[test]
+fn declaring_a_numeric_layout_clears_the_invariant() {
+    let arr = built_from_pushes(CLASS_A, 2);
+    assert!(proof(arr).is_some());
+    unsafe {
+        crate::array::header::set_array_numeric_layout(
+            arr,
+            crate::array::header::NumericArrayLayout::RawF64,
+        )
+    };
+    assert!(
+        proof(arr).is_none(),
+        "the numeric and element-shape invariants are mutually exclusive"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CLEAR — class-level (prototype surgery)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prototype_surgery_retires_every_outstanding_proof() {
+    let a = built_from_pushes(CLASS_A, 2);
+    let b = built_from_pushes(CLASS_B, 2);
+    assert!(proof(a).is_some());
+    assert!(proof(b).is_some());
+
+    let name = b"patched";
+    unsafe {
+        crate::object::js_register_prototype_method(
+            CLASS_A,
+            name.as_ptr(),
+            name.len(),
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+        );
+    }
+
+    assert!(
+        proof(a).is_none(),
+        "a prototype write must retire the patched class's proofs"
+    );
+    assert!(
+        proof(b).is_none(),
+        "the generation bump is global — conservative in the safe direction"
+    );
+    // …and the array self-heals if it is still homogeneous.
+    assert_eq!(
+        unsafe { ensure_element_shape(b) }.map(|p| p.class_id),
+        Some(CLASS_B)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// EPOCH
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_global_epoch_advances_on_a_clear_and_holds_still_otherwise() {
+    let arr = built_from_pushes(CLASS_A, 3);
+    let quiet = element_shape_epoch();
+    // A matching overwrite retires nothing.
+    js_array_set_f64(arr, 0, instance(CLASS_A));
+    assert_eq!(
+        element_shape_epoch(),
+        quiet,
+        "a keep must not deopt an unrelated hoisted guard"
+    );
+    // A mismatch does.
+    js_array_set_f64(arr, 0, instance(CLASS_B));
+    assert!(element_shape_epoch() > quiet);
+}
+
+#[test]
+fn the_check_helper_pins_class_and_proof_identity() {
+    let arr = built_from_pushes(CLASS_A, 3);
+    let proof = proof(arr).expect("proven");
+    assert_eq!(
+        crate::array::js_array_element_shape_check(arr, proof.class_id as i32, i64::from(proof.epoch)),
+        1
+    );
+    assert_eq!(
+        crate::array::js_array_element_shape_check(arr, CLASS_B as i32, i64::from(proof.epoch)),
+        0,
+        "a different class must not validate"
+    );
+    assert_eq!(
+        crate::array::js_array_element_shape_check(
+            arr,
+            proof.class_id as i32,
+            i64::from(proof.epoch) + 1
+        ),
+        0,
+        "a stale proof identity must not validate"
+    );
+}
+
+#[test]
+fn the_ffi_query_reports_zero_for_an_unproven_array() {
+    let arr = js_array_alloc(0);
+    assert_eq!(crate::array::js_array_element_shape_class(arr), 0);
+    assert_eq!(crate::array::js_array_element_shape_version(arr), -1);
+    assert_eq!(crate::array::js_array_ensure_element_shape(arr), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Relocation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn growth_forwarding_carries_the_invariant_to_the_new_backing() {
+    // `js_array_grow` copies `_reserved` verbatim and calls `layout_transfer`,
+    // which is where `transfer_element_shape` hangs.
+    let arr = built_from_pushes(CLASS_A, 2);
+    let before = proof(arr).expect("proven");
+    let grown = crate::array::js_array_grow(arr, 512);
+    assert_ne!(grown as usize, arr as usize, "the array must actually move");
+    let after = proof(grown).expect("the proof must follow the storage");
+    assert_eq!(after, before);
+    assert!(test_element_shape_record_exists(grown as usize));
+    assert!(!test_element_shape_record_exists(arr as usize));
+}
+
+#[test]
+fn a_transfer_without_a_record_fails_the_destination_closed() {
+    let src = built_from_pushes(CLASS_A, 2);
+    let dst = built_from_pushes(CLASS_A, 2);
+    // Simulate the hazard the bit-is-authority rule exists for: the bit rides
+    // a move whose record did not.
+    test_clear_element_shape_table();
+    transfer_element_shape(src as usize, dst as usize);
+    assert!(
+        proof(dst).is_none(),
+        "a bit with no record must never read as a proof"
+    );
+    unsafe { assert!(!test_element_shape_bit_set(dst)) };
+}

--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -899,7 +899,7 @@ unsafe fn array_slots_are_numeric(arr: *const ArrayHeader) -> bool {
 }
 
 #[inline]
-unsafe fn array_gc_header(arr: *const ArrayHeader) -> Option<*mut crate::gc::GcHeader> {
+pub(super) unsafe fn array_gc_header(arr: *const ArrayHeader) -> Option<*mut crate::gc::GcHeader> {
     if arr.is_null() || (arr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
         return None;
     }
@@ -1233,6 +1233,12 @@ pub(crate) unsafe fn set_array_numeric_layout(arr: *mut ArrayHeader, layout: Num
     match layout {
         NumericArrayLayout::RawF64 => set_array_raw_f64_layout_flag(arr),
     }
+    // #7480: the numeric and element-shape invariants are mutually exclusive
+    // — an element-shape array's slots are NaN-boxed pointers, which no
+    // raw-f64 layout admits. This is also what covers the bulk numeric
+    // producers (`js_array_fill_f64_*_extend`) that write slots directly and
+    // then declare the layout.
+    super::element_shape::clear_element_shape(arr);
     crate::gc::layout_init_pointer_free(arr as *mut u8);
 }
 
@@ -1520,7 +1526,7 @@ pub(crate) fn array_byte_size(capacity: usize) -> usize {
 }
 
 #[inline]
-unsafe fn array_elements_ptr(arr: *mut ArrayHeader) -> *mut u64 {
+pub(super) unsafe fn array_elements_ptr(arr: *mut ArrayHeader) -> *mut u64 {
     (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64
 }
 
@@ -1604,6 +1610,13 @@ pub(crate) unsafe fn rebuild_array_layout(arr: *mut ArrayHeader) {
     if arr.is_null() {
         return;
     }
+    // #7480: this is the post-hoc funnel every bulk element mutator uses —
+    // `shift`, `unshift`, `splice`, `fill`, `copyWithin`, `reverse`, and the
+    // dense `sort` write-back all mutate slots with bare `ptr::write` /
+    // `ptr::copy` and then land here. They are permutations or arbitrary
+    // rewrites, so the element-shape proof is dropped conservatively; a
+    // still-homogeneous array re-earns it on the next `ensure`.
+    super::element_shape::clear_element_shape(arr);
     let length = (*arr).length as usize;
     let capacity = (*arr).capacity as usize;
     if length > capacity || length > 16_000_000 {
@@ -1627,6 +1640,8 @@ pub(crate) unsafe fn rebuild_array_layout_exact(arr: *mut ArrayHeader) {
     if arr.is_null() {
         return;
     }
+    // #7480: same conservative drop as `rebuild_array_layout` — see there.
+    super::element_shape::clear_element_shape(arr);
     let length = (*arr).length as usize;
     let capacity = (*arr).capacity as usize;
     if length > capacity || length > 16_000_000 {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -1,6 +1,7 @@
 //! Array representation for Perry — split into topical sub-modules.
 mod alloc;
 mod concat_reverse;
+mod element_shape;
 mod fill_extend;
 mod flat_clone;
 mod from_concat;
@@ -63,6 +64,14 @@ pub use self::generic_object::{js_arraylike_concat, js_arraylike_sort, js_arrayl
 pub(crate) use self::generic_object::{
     object_pop as generic_object_pop, object_shift as generic_object_shift, object_sort,
     object_splice,
+};
+pub(crate) use self::element_shape::{
+    clear_element_shape_ptr, forget_element_shape, invalidate_all_element_shapes,
+    note_element_store, prune_dead_element_shape_owners, transfer_element_shape,
+};
+pub use self::element_shape::{
+    js_array_element_shape_check, js_array_element_shape_class, js_array_element_shape_epoch,
+    js_array_element_shape_version, js_array_ensure_element_shape,
 };
 pub(crate) use self::header::{
     array_has_arguments_object_flag, mark_array_as_arguments_object,

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -37,6 +37,14 @@ pub use self::concat_reverse::{
     js_array_concat, js_array_concat_new, js_array_fill, js_array_fill_generic,
     js_array_fill_range, js_array_reverse, js_array_reverse_value,
 };
+pub(crate) use self::element_shape::{
+    clear_element_shape_ptr, forget_element_shape, invalidate_all_element_shapes,
+    note_element_store, prune_dead_element_shape_owners, transfer_element_shape,
+};
+pub use self::element_shape::{
+    js_array_element_shape_check, js_array_element_shape_class, js_array_element_shape_epoch,
+    js_array_element_shape_version, js_array_ensure_element_shape,
+};
 pub use self::flat_clone::{
     js_array_clone, js_array_entries, js_array_flat, js_array_flat_depth, js_array_keys,
     js_array_values,
@@ -64,14 +72,6 @@ pub use self::generic_object::{js_arraylike_concat, js_arraylike_sort, js_arrayl
 pub(crate) use self::generic_object::{
     object_pop as generic_object_pop, object_shift as generic_object_shift, object_sort,
     object_splice,
-};
-pub(crate) use self::element_shape::{
-    clear_element_shape_ptr, forget_element_shape, invalidate_all_element_shapes,
-    note_element_store, prune_dead_element_shape_owners, transfer_element_shape,
-};
-pub use self::element_shape::{
-    js_array_element_shape_check, js_array_element_shape_class, js_array_element_shape_epoch,
-    js_array_element_shape_version, js_array_ensure_element_shape,
 };
 pub(crate) use self::header::{
     array_has_arguments_object_flag, mark_array_as_arguments_object,

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -45,6 +45,8 @@ pub use self::element_shape::{
     js_array_element_shape_check, js_array_element_shape_class, js_array_element_shape_epoch,
     js_array_element_shape_version, js_array_ensure_element_shape,
 };
+#[cfg(test)]
+pub(crate) use self::element_shape::{test_element_shape_record_exists, test_serialize};
 pub use self::flat_clone::{
     js_array_clone, js_array_entries, js_array_flat, js_array_flat_depth, js_array_keys,
     js_array_values,

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -217,6 +217,7 @@ fn fan_out(
     // collection — flush every cached verdict.
     crate::object::prop_plan::prop_plan_epoch_bump();
     crate::array::prune_dead_array_named_property_owners(is_dead_owner);
+    crate::array::prune_dead_element_shape_owners(is_dead_owner);
     crate::map::prune_dead_map_iterator_array_owners(is_dead_owner);
     crate::set::prune_dead_set_iterator_array_owners(is_dead_owner);
     crate::object::prune_dead_descriptor_owner_entries(is_dead_owner);

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -644,6 +644,9 @@ pub(crate) fn layout_clear_for_ptr(user_ptr: usize) {
         return;
     }
     crate::array::clear_array_numeric_layout_ptr(user_ptr);
+    // #7480: this runs on object death / address recycle, so drop the record
+    // outright rather than only clearing the bit.
+    crate::array::forget_element_shape(user_ptr);
     LAYOUT_SLOT_MASKS.with(|m| {
         m.borrow_mut().remove(&user_ptr);
     });
@@ -696,6 +699,23 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
                 layout_note_slot(new_user, slot_index, value_bits);
             }
             return;
+        }
+        // #7480: maintain the per-array homogeneous element-shape invariant.
+        // This is the one funnel BOTH the runtime's element-store helpers
+        // (`note_array_slot` and siblings) and codegen's inline element
+        // stores already pass through — `array_store_needs_layout_note`
+        // elides the note only for an array statically proven numeric and
+        // pointer-free, which an element-shape array can never be. It sits
+        // ahead of the `GC_LAYOUT_UNKNOWN` early return below because an
+        // all-pointer array is marked unknown on its first generic write,
+        // and costs one `obj_type` compare on the header word the next line
+        // reads anyway.
+        if (*header).obj_type == GC_TYPE_ARRAY {
+            crate::array::note_element_store(
+                parent_user as *mut crate::array::ArrayHeader,
+                slot_index,
+                value_bits,
+            );
         }
         if (*header)._reserved & GC_LAYOUT_STATE_MASK == GC_LAYOUT_UNKNOWN {
             return;
@@ -1069,8 +1089,13 @@ pub(crate) unsafe fn layout_transfer(old_user: *mut u8, new_user: *mut u8) {
     }
     if (*old_header).obj_type == GC_TYPE_ARRAY && (*new_header).obj_type == GC_TYPE_ARRAY {
         crate::array::transfer_array_numeric_layout(old_user as usize, new_user as usize);
+        // #7480: the element-shape bit rides `_reserved` for free, but its
+        // record is address-keyed and has to follow the move — same split,
+        // and same call site, as `TYPED_LAYOUTS` below.
+        crate::array::transfer_element_shape(old_user as usize, new_user as usize);
     } else {
         crate::array::clear_array_numeric_layout_ptr(new_user as usize);
+        crate::array::clear_element_shape_ptr(new_user as usize);
     }
     // Read the source object's intact bit BEFORE the transfer clears it — it is
     // the per-object half of the shape-keyed resolution below. `_reserved` is

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 use super::support::*;
 mod array_layout;
+mod element_shape;
 mod object_closure_slots;
 mod object_layout_invalidation;
 mod typed_shape;

--- a/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
@@ -10,6 +10,7 @@
 //! did").
 
 use super::*;
+use crate::array::{test_element_shape_record_exists, test_serialize};
 
 const CLASS_ELEM: u32 = 0x0007_4810;
 
@@ -35,6 +36,7 @@ fn proven_array(count: usize) -> *mut crate::array::ArrayHeader {
 
 #[test]
 fn test_element_shape_invariant_survives_a_copying_minor() {
+    let _serialized = test_serialize();
     let _guard = CopyingNurseryTestGuard::new(1);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
 
@@ -64,6 +66,15 @@ fn test_element_shape_invariant_survives_a_copying_minor() {
         CLASS_ELEM as i32,
         "the address-keyed record must have followed the move via layout_transfer"
     );
+    assert!(
+        test_element_shape_record_exists(after),
+        "the record must be keyed by the post-move address"
+    );
+    assert!(
+        !test_element_shape_record_exists(arr as usize),
+        "and must not be left addressable under the pre-move key, where a \
+         recycled allocation could inherit its identity"
+    );
     // A caller still holding the pre-move head must reach the SAME proof, not
     // a second one: the query resolves the forwarding chain before it looks
     // the record up, exactly as the 4a element tiers do
@@ -78,6 +89,7 @@ fn test_element_shape_invariant_survives_a_copying_minor() {
 
 #[test]
 fn test_element_shape_invariant_keeps_growing_after_a_copying_minor() {
+    let _serialized = test_serialize();
     // A moved array must still be *maintainable*, not merely readable: the
     // record has to be reachable at the new key for the store funnel to find
     // it, or the next matching push would clear the proof instead of

--- a/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
@@ -1,0 +1,113 @@
+//! #7480: the element-shape invariant has to survive a real copying minor.
+//!
+//! The header bit rides `_reserved`, which the collector copies verbatim —
+//! that is the whole reason the storage mirrors Phase 4a's dense bit. The
+//! *record*, though, is keyed by the array's user address, so it only
+//! survives because `transfer_element_shape` hangs off `layout_transfer`.
+//! These tests assert the pair, and they assert the collector actually MOVED
+//! something first: a copying minor that never ran would make both green
+//! while proving nothing (CLAUDE.md's "the gate runs but its subject never
+//! did").
+
+use super::*;
+
+const CLASS_ELEM: u32 = 0x0007_4810;
+
+fn shaped_instance() -> f64 {
+    let obj = crate::object::js_object_alloc(CLASS_ELEM, 2);
+    crate::value::js_nanbox_pointer(obj as i64)
+}
+
+/// `const rows = []; rows.push(new C()); …` built through the real push
+/// funnel, so the invariant is established the way production establishes it.
+fn proven_array(count: usize) -> *mut crate::array::ArrayHeader {
+    let mut arr = crate::array::js_array_alloc(count as u32);
+    for _ in 0..count {
+        arr = crate::array::js_array_push_f64(arr, shaped_instance());
+    }
+    assert_eq!(
+        crate::array::js_array_element_shape_class(arr),
+        CLASS_ELEM as i32,
+        "the push funnel must establish the invariant before the GC test starts"
+    );
+    arr
+}
+
+#[test]
+fn test_element_shape_invariant_survives_a_copying_minor() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let arr = proven_array(4);
+    js_shadow_slot_set(0, ptr_bits(arr as usize));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    let after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+
+    // The subject has to have been live: a run with zero copying minors, or
+    // one where the array did not move, proves nothing about the transfer.
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_ne!(after, arr as usize, "the array must actually have moved");
+    assert!(crate::arena::pointer_in_nursery(after));
+
+    let moved = after as *mut crate::array::ArrayHeader;
+    unsafe {
+        let header = header_from_user_ptr(after as *const u8);
+        assert_ne!(
+            (*header)._reserved & crate::gc::GC_ARRAY_ELEMENT_SHAPE,
+            0,
+            "the header bit rides `_reserved` across the copy"
+        );
+    }
+    assert_eq!(
+        crate::array::js_array_element_shape_class(moved),
+        CLASS_ELEM as i32,
+        "the address-keyed record must have followed the move via layout_transfer"
+    );
+    // A caller still holding the pre-move head must reach the SAME proof, not
+    // a second one: the query resolves the forwarding chain before it looks
+    // the record up, exactly as the 4a element tiers do
+    // (`js_array_refresh_local_head`). If it did not, a stale head would read
+    // as unproven and the consumer would deopt for the rest of the loop.
+    assert_eq!(
+        crate::array::js_array_element_shape_class(arr as *const _),
+        CLASS_ELEM as i32,
+        "a stale head must resolve through forwarding to the moved proof"
+    );
+}
+
+#[test]
+fn test_element_shape_invariant_keeps_growing_after_a_copying_minor() {
+    // A moved array must still be *maintainable*, not merely readable: the
+    // record has to be reachable at the new key for the store funnel to find
+    // it, or the next matching push would clear the proof instead of
+    // extending it.
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let arr = proven_array(3);
+    js_shadow_slot_set(0, ptr_bits(arr as usize));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let moved = (js_shadow_slot_get(0) & POINTER_MASK) as usize as *mut crate::array::ArrayHeader;
+    assert_ne!(moved as usize, arr as usize);
+
+    let grown = crate::array::js_array_push_f64(moved, shaped_instance());
+    assert_eq!(
+        crate::array::js_array_element_shape_class(grown),
+        CLASS_ELEM as i32,
+        "a matching push after the move must keep the proof, not retire it"
+    );
+    let mismatched = crate::object::js_object_alloc(CLASS_ELEM + 1, 1);
+    let grown = crate::array::js_array_push_f64(
+        grown,
+        crate::value::js_nanbox_pointer(mismatched as i64),
+    );
+    assert_eq!(
+        crate::array::js_array_element_shape_class(grown),
+        0,
+        "and a mismatched push after the move must still retire it"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/element_shape.rs
@@ -101,10 +101,8 @@ fn test_element_shape_invariant_keeps_growing_after_a_copying_minor() {
         "a matching push after the move must keep the proof, not retire it"
     );
     let mismatched = crate::object::js_object_alloc(CLASS_ELEM + 1, 1);
-    let grown = crate::array::js_array_push_f64(
-        grown,
-        crate::value::js_nanbox_pointer(mismatched as i64),
-    );
+    let grown =
+        crate::array::js_array_push_f64(grown, crate::value::js_nanbox_pointer(mismatched as i64));
     assert_eq!(
         crate::array::js_array_element_shape_class(grown),
         0,

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -957,7 +957,8 @@ pub const OBJ_FLAG_ARRAY_DESCRIPTORS: u16 = 0x400;
 // on this specific object — the dynamic-write fast path must take the full
 // descriptor-aware OrdinarySet walk. Bit 11; only meaningful for
 // `GC_TYPE_OBJECT`. Set-only (clearing a descriptor leaves it set; the slow
-// path is always correct).
+// path is always correct). #7480 reuses bit 11 for `GC_TYPE_ARRAY` as
+// `GC_ARRAY_ELEMENT_SHAPE`; the two are disjoint by `obj_type`.
 pub const OBJ_FLAG_HAS_DESCRIPTORS: u16 = 0x800;
 // #2145: this object is a per-kind `<TypedArrayCtor>.prototype` whose
 // `[[Prototype]]` is the shared `%TypedArray%.prototype` intrinsic.
@@ -983,6 +984,26 @@ pub(crate) const GC_ARRAY_ARGUMENTS_OBJECT: u16 = 0x200;
 /// bits 12..13 were the last free `_reserved` bits (see the bit map above).
 /// Only meaningful for `GC_TYPE_ARRAY`.
 pub(crate) const GC_ARRAY_RAW_F64_HOLES: u16 = 0x1000;
+/// #7480: every element slot in `[0, length)` holds a `POINTER_TAG`-boxed
+/// `GC_TYPE_OBJECT` whose `class_id` is the one recorded in the array's
+/// element-shape record — the *pointer* sibling of the two raw-f64 bits
+/// above, and the shared prerequisite of both element-shape routes.
+///
+/// This is the O(1) half of the proof and it exists for the same reason the
+/// raw-f64 bit does: it rides in `_reserved`, which the copying collector
+/// copies verbatim, so the invariant survives a move without a side-table
+/// walk. The *shape id* itself cannot fit here, so it lives in the
+/// address-keyed record `array::element_shape` maintains, moved on
+/// relocation by `layout_transfer` exactly like `TYPED_LAYOUTS`. The bit is
+/// the authority: a fresh allocation's `_reserved` is zero, so a stale
+/// record left behind at a recycled address is never consulted.
+///
+/// Bit 11 — shared with `OBJ_FLAG_HAS_DESCRIPTORS`, which is only
+/// meaningful for `GC_TYPE_OBJECT`, exactly as `GC_ARRAY_RAW_F64_HOLES`
+/// (bit 12) shares with `GC_OBJ_TYPED_LAYOUT_INTACT`. Only meaningful for
+/// `GC_TYPE_ARRAY`; every accessor goes through `array::element_shape`,
+/// which checks `obj_type` first.
+pub(crate) const GC_ARRAY_ELEMENT_SHAPE: u16 = 0x800;
 
 pub(super) const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 pub(super) const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;

--- a/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
@@ -59,6 +59,14 @@ pub(crate) fn class_prototype_fast_guards_invalidated() -> bool {
 
 pub(crate) fn invalidate_class_prototype_fast_guards() {
     CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED.store(true, std::sync::atomic::Ordering::Release);
+    // #7480: prototype surgery is the one event that retires an element-shape
+    // proof without touching any array — the class's shape stopped being a
+    // reliable description of its instances. This is the existing single
+    // latch all three prototype-write entry points funnel through
+    // (`js_register_prototype_method`, `class_prototype_method_root_store`,
+    // and the class-registry state path), so one generation bump here retires
+    // every outstanding record at O(1).
+    crate::array::invalidate_all_element_shapes();
 }
 
 pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, value_bits: u64) {

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -189,6 +189,12 @@ fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_ov
     // object itself must never satisfy a class-keyed plan again.
     if instance_override {
         crate::object::prop_plan::prop_plan_epoch_bump();
+        // #7480: a `[[Prototype]]` swap on a live instance is prototype
+        // surgery — the same class of event as writing onto `C.prototype`, so
+        // it retires every outstanding element-shape proof. Deliberately
+        // inside the `instance_override` gate: the quiet sibling
+        // (`object_link_class_default_prototype`) fires on every `new F()`.
+        crate::array::invalidate_all_element_shapes();
     }
     // #6759 Phase B: shaped objects store the recorded prototype in their
     // own meta record; only non-object owners fall through to the residual


### PR DESCRIPTION
Builds the shared prerequisite decided in #7480. **Invariant layer only — no consumer, and no emitted-code change.**

#7480's scoping finding was that its two candidate routes are not "A vs B": both need the same missing fact first — a per-array *homogeneous element-shape invariant*, "every element of this array is an object of class `C`". The only array-level invariants that existed were the numeric ones (`GC_ARRAY_RAW_F64_LAYOUT` / `_HOLES`). This PR adds the pointer sibling and stops there, because #6377's lesson is that every added proof un-gates latent fast paths its own microbench never exercises: the proof lands and is tested on its own before anything reads it.

## Storage — deliberately the same shape as Phase 4a's dense bit

4a's dense bit works because the collector copies the whole `_reserved` word when it moves an object, so the invariant survives a copying minor with no side-table walk and no per-move bookkeeping. This mirrors it point for point:

| | 4a (`RAW_F64_LAYOUT`) | here (`ELEMENT_SHAPE`) |
|---|---|---|
| fast proof | `_reserved` bit 7 | `_reserved` bit 11 |
| rides a move | yes (`_reserved` is copied) | yes (same word) |
| self-heals by rescan | `ensure_array_numeric_raw_f64` | `ensure_element_shape` |
| move fixup | `transfer_array_numeric_layout` | `transfer_element_shape` |
| clear funnel | `clear_array_numeric_layout` | `clear_element_shape` |

Bit 11 is shared with the object-only `OBJ_FLAG_HAS_DESCRIPTORS` — the same disjoint-by-`obj_type` reuse `GC_ARRAY_RAW_F64_HOLES` (bit 12) already makes against `GC_OBJ_TYPED_LAYOUT_INTACT`. `_reserved` had no free bit left.

The one thing 4a does not need is a payload: "raw f64" is the whole fact, so its bit is the whole record. A shape id does not fit in a bit, so it lives in an address-keyed thread-local record moved by `transfer_element_shape` from inside `layout_transfer` — the same call site, and the same split, as `TYPED_LAYOUTS`. **The bit stays the authority**: a fresh allocation's `_reserved` is zero, so a stale record left at a recycled address is unreachable, and a bit with no record fails closed (and clears itself).

The record is `{ class_id: u32, verified_len: u32, epoch: u64, generation: u64 }` — four integers, **no heap pointer**. It is therefore deliberately *not* a `gc_register_mutable_root_scanner` entry: there is nothing in it for the collector to mark or rewrite, the `class_id` is a registry index, and the key is only ever compared, never dereferenced. Dead keys are dropped by `prune_dead_element_shape_owners` on the same collection hook that prunes `ARRAY_NAMED_PROPS` (footprint only).

## Where it is maintained, and why that one place is enough

The single element-store hook hangs off `gc::layout_note_slot`. That is the one funnel **both** the runtime's element-store helpers (`note_array_slot`, `note_array_slot_layout_only`, `store_array_slot`, `note_array_hole_fill_slot`) **and codegen's inline element stores** already pass through — `array_store_needs_layout_note` elides the note only when the array is *statically proven numeric and pointer-free*, which an element-shape array can never be. The call sits ahead of `layout_note_slot`'s `GC_LAYOUT_UNKNOWN` early return (an all-pointer array is marked unknown on its first generic write) and costs a `GC_TYPE_ARRAY` compare plus a bit test on the header word the next line reads anyway. An array without the bit exits on one predictable-not-taken branch.

`verified_len` is the structural half, and it is what keeps the matrix small enough to enumerate: the record pins the `length` it was verified against, and a query requires the current `length` to still match. Every operation that changes `length` outside the store funnels — `pop`, `shift`, `splice`, `length = n`, sparse extend, **codegen's inline append** — is therefore invalidated automatically on the next query, with no call site of its own.

## Invalidation matrix as implemented

| event | outcome | mechanism |
|---|---|---|
| first shaped push into an empty array | **set** | `layout_note_slot` hook, `index == 0 && length == 0` |
| matching push / matching in-bounds overwrite | **keep** (append extends `verified_len`) | same hook |
| array built outside the funnels (inline literal, `JSON.parse`, `map`) | **set on demand** | `ensure_element_shape` rescan — self-healing, like 4a |
| push / store of a different class, or of a non-pointer | **clear** | same hook |
| `delete arr[i]` | **clear** | funnels a `TAG_HOLE` store through the same hook |
| `arr.length = n` (truncate *and* extend) | **clear** | `TAG_HOLE` stores + `verified_len` mismatch |
| `pop`, and any length change behind the runtime's back | **clear** | `verified_len != length`, fail-closed |
| `shift`/`unshift`/`splice`/`fill`/`copyWithin`/`reverse`/`sort` | **clear** | `rebuild_array_layout` — the post-hoc funnel they all already use |
| a numeric layout being declared (`js_array_fill_f64_*`, `js_array_alloc`) | **clear** | `set_array_numeric_layout`; the two invariants are mutually exclusive |
| `C.prototype.m = …`, `Object.defineProperty(C.prototype, …)` | **clear, globally** | generation bump in `invalidate_class_prototype_fast_guards`, the existing single latch all three prototype-write entries funnel through |
| `Object.setPrototypeOf(o, …)` / `__proto__ =` | **clear, globally** | generation bump in `object_set_static_prototype_impl`, inside the `instance_override` gate (its quiet sibling fires on every `new F()`) |
| copying minor / old-gen defrag / growth forwarding | **keep** | bit rides `_reserved`; record moved by `transfer_element_shape` |
| empty array | **declined** | a vacuous proof would licence reads that cannot happen |
| array with per-index descriptors | **declined** | same stand-down the raw-f64 element accessors make |

An element object *gaining an expando* is deliberately **not** an invalidation: `class_id` is unchanged, so "every element is an object of class `C`" still holds. Layout stability *within* a class is the existing `GC_OBJ_TYPED_LAYOUT_INTACT` bit's job, and a consumer composes the two.

## Versioning

Three `AtomicU64` counters, all starting at 1 (the crate's convention for invalidation counters — `PROP_PLAN_EPOCH`, `PERRY_IC_EPOCH` — not a per-thread `Cell`, since the class registry a generation bump answers to is process-wide):

* `js_array_element_shape_epoch()` — bumped on **every** clear or invalidation, of any array. This is the word a hoisted guard re-reads. One relaxed load, one compare, no side-table probe, no rescan. Deliberately coarse: an unrelated array's clear deopts a running loop, which errs in the safe direction.
* `CLASS_SHAPE_GENERATION` — bumped only by prototype surgery. Records carry the generation they were installed under and fail their next query, so one prototype write retires every outstanding record at O(1) without enumerating arrays.
* `ELEMENT_SHAPE_PROOF_SEQ` — not an invalidation signal but an *identity source*. Every **established** proof takes the next value and carries it unchanged while it is kept or extended, so a consumer that pinned `(class_id, epoch)` can never be fooled by the same array being re-proven after a break, nor by a different array being established at a recycled address. Identities are never read back out of the table, which is what makes a record that outlives its array harmless rather than a donor (review finding 2).

## Design note: how #5093's versioned-loop clone consumes this

`lower_class_field_versioned_for` (`crates/perry-codegen/src/stmt/loops.rs`) already has exactly the skeleton the element-shape consumer needs, and the extension is mechanical:

1. **Match.** The array analogue of `match_class_field_versioned_loop`: `for (let i = 0; i < A.length; i++) { … A[i].f … }` over a region-local `A`. `collectors/ptr_shape_elements.rs`'s E1–E5 already computes this candidate set (empty-literal provenance, push-only mutation, in-bounds induction-variable reads, no `IndexSet` / `splice` / `length` write), so the matcher reuses those facts rather than re-deriving them.

2. **Preheader guard.** Where the class-field version emits `emit_class_field_loop_preheader_check` (class id + `keys_array` + intact bit), the array version emits:
   ```
   %cid = call i32 @js_array_ensure_element_shape(i64 %arr_handle)   ; O(n) once, O(1) after
   %ok  = icmp eq i32 %cid, <expected_class_id>
   br i1 %ok, label %fast.preheader, label %slow.preheader
   ```
   `<expected_class_id>` is the compile-time class the E2 producers push, already available as a `class_keys_global`. The `ensure` call must be placed **before** the array head is reloaded into the fast clone's cached register, for the same reason the class-field version keeps "receiver load → check → loop entry" call-free: the pointer the check validated has to be the pointer the clone uses.

3. **Clone + entry condition.** Reuse `lower_for_after_init_with_i32_bound` for the fast clone and `lower_for_after_init` for the slow one, and keep the existing `fast_clone_call_free` verification verbatim. That check is what makes an epoch re-read unnecessary in this first consumer: a call-free clone cannot allocate, cannot collect, and — because E3 admits no mutator on `A` — cannot retire the invariant, so the preheader guard holds for the whole trip count. `js_array_element_shape_epoch()` is the back-edge re-check for the *later*, weaker form whose clone is allowed to contain calls: reload it and side-exit to `slow.preheader` on change. `js_array_element_shape_check(arr, class_id, epoch)` is the same test pinned to one array's proof identity, for a consumer that would rather not deopt on an unrelated array's clear.

4. **Body.** Inside the fast clone, `A[i]` yields a value whose class is `<expected_class_id>` by the guard, so it is rule-1 `new C(...)`-strength provenance for `ptr_shape.rs` — `element_read_class` already issues exactly that fact — and every `r.field` lowers guard-free through 3b's existing proven-local machinery. Nothing new is needed on the read side.

5. **Deopt.** Guard false → `slow.preheader`, the unmodified clone, exactly as today. There is no state to unwind: the fast clone is entered only from the preheader.

Group integrity, the `numeric_fields` stand-down and the rooting contract are all unchanged from `ptr_shape_elements.rs` — this adds a runtime witness for a fact that pass could previously only assert statically.

## Verification

**29 new tests** — 27 in `array/element_shape_tests.rs` covering every row of the matrix above plus the two lifecycle hooks (`forget_element_shape`, `prune_dead_element_shape_owners`), and 2 in `gc/tests/layout_trace/element_shape.rs` for GC survival. The GC pair asserts its subject was live before it asserts a verdict — `assert_copied_minor_trace(…)` plus "the array must actually have moved" — so a run with zero copying minors cannot pass. One of them additionally pushes *after* the move and asserts the proof both extends on a match and retires on a mismatch, which is what proves the record is reachable at the new key rather than merely readable once. Both files serialize on a shared poison-tolerant lock taken ahead of any state-restoring guard (review finding 1).

| `cargo test -p perry-runtime element_shape` | run 1 | run 2 | run 3 |
|---|---|---|---|
| default parallelism | 29 passed | 29 passed | 29 passed |
| `--test-threads=1` | 29 passed | 29 passed | 29 passed |

Full runtime suite, 6 runs at default parallelism: 4 green, 2 red — both reds `promise::keyed_table::tests::settling_many_keys_is_not_quadratic`, never an element-shape test. Pre-existing: pristine `main` (f05ae3b83), same host, same 6-run protocol, is **also** 4 green / 2 red, once on that same wall-clock scaling assertion and once on `tui::tree::tests::register_increments_handle`. Same rate, same tests, neither in a module this PR touches.

- `python3 scripts/raw_handle_debt.py` — 999 (baseline 999); the new module has zero bare reads and takes no raw pointer across an allocation point.
- `python3 scripts/addr_class_inventory.py` — passed; element headers are read through `addr_class::try_read_gc_header`, which also rejects the small-buffer slab addresses that pass a bare plausibility check but carry no `GcHeader`.
- `bash scripts/check_file_size.sh` — OK. `cargo fmt --all -- --check` — clean.
- **No emitted-code change**, checked both ways. `git diff --name-only main...HEAD` touches `crates/perry-runtime` only, so `perry-codegen` / `perry-hir` / `perry-transform` / `perry` are byte-identical to `main` and the emitted IR is unchanged by construction; and a `--trace llvm` probe over an array-of-`new C(…)` workload (build-by-push, indexed field reads, an inline object-literal array) emits **0** occurrences of `element_shape` in its `.ll` and links **0** such symbols into the binary. The same probe emits 6 `js_gc_note_slot_layout` calls, which is the funnel this PR's maintenance hook rides — the design claim is exercised, not assumed. No `keepalive-anchors` `#[used]` statics were added: that feature is on by default, so an anchor would pin five uncalled functions into every shipped binary, the exact dead-strip defeat the hello-size campaign traced its regression to. The consumer PR anchors whichever symbol it emits.

Refs #7480.
