### PR TITLE
docs(engine-plan): add the object-construction row; retire the stale JSON roadmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "base64",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5720,14 +5720,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "serde",
  "serde_json",
@@ -5735,7 +5735,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1289"
+version = "0.5.1290"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "clap",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "block2",
  "objc2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "chrono",
  "cron",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5870,14 +5870,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bytes",
  "h2",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5953,7 +5953,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bson",
  "futures-util",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6043,7 +6043,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6078,14 +6078,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "brotli",
  "flate2",
@@ -6144,7 +6144,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "base64",
@@ -6225,14 +6225,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6327,14 +6327,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6343,14 +6343,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "itoa",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "block2",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "block2",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1289"
+version = "0.5.1290"
 
 [[package]]
 name = "perry-ui-test"
@@ -6442,11 +6442,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1289"
+version = "0.5.1290"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "block2",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "block2",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "block2",
  "libc",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "base64",
  "libc",
@@ -6508,14 +6508,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "anyhow",
  "base64",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1289"
+version = "0.5.1290"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1289"
+version = "0.5.1290"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7514-engine-plan-allocation-row.md
+++ b/changelog.d/7514-engine-plan-allocation-row.md
@@ -1,0 +1,25 @@
+### Docs: engine plan gains the object-construction row; JSON roadmap retired
+
+The #7469 mutator campaign's symbolicated decomposition was invisible to
+`docs/engine-plan.md` — the performance backlog had no object-allocation row
+and referenced none of #7469/#7510/#7511/#7512, so the best-measured part of
+the engine was absent from the plan that sequences work.
+
+The plan now leads its performance section with object construction: the
+`churn` variant decomposition (which isolates `push_num` at 2.7× to show the
+array machinery is fine, putting ~79% of `churn` in construction), and the
+group profile showing **~76% of construction is GC/feedback bookkeeping
+against 7.7% for the allocation itself**. "What is left" is re-ordered to put
+the 33.6% layout side-table lever (#7510) first and the #7512 bisect ahead of
+the write-barrier work (#7511) it might account for; repsel's remaining
+consumer work is explicitly sequenced after the bookkeeping levers, since
+element reads are the best ratio in the table.
+
+Two traps are recorded inline because both have already cost time:
+`PERRY_WRITE_BARRIERS=0` cannot bound barrier cost (it also switches the
+collector out of evacuating mode, making the benchmark *slower*), and a TS
+annotation is never a layout fact — elision must be by-construction, and even
+a static layout declaration can be revoked at runtime (#7501).
+
+`docs/memory-perf-roadmap.md` is marked superseded: its goal was met (the
+roundtrip win, #7476) and its standings are v0.5.211 against a v0.5.1289 HEAD.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -43,6 +43,47 @@ share one prerequisite (a per-array homogeneous-element-shape invariant,
 construction-maintained, self-healing like 4a's dense bit), consumed first by
 the #5093 versioned-loop clone, then by element `Ptr<Shape>`.
 
+### Object construction — the dominant cost (#7469 campaign)
+
+**This is the top row of the backlog and the best-measured part of the engine.**
+Symbolicated decomposition of `churn` on the pinned quiet host
+(`PERRY_DEBUG_SYMBOLS=1`, 1500 leaf samples, best-of-3):
+
+| variant | Perry | node | ratio |
+|---|--:|--:|--:|
+| `churn` (full) | 2.72 s | 0.17 s | 16.0× |
+| `churn_alloc` — object literal + push | 2.44 s | 0.14 s | 17.4× |
+| **`push_cls` — `new Node(v,w)` + push** | **3.99 s** | 0.14 s | **28.5×** |
+| `push_num` — numbers into array | 0.30 s | 0.11 s | 2.7× |
+| `churn_read` — element reads only | 0.35 s | 0.08 s | 4.3× |
+
+`push_num` at 2.7× shows the array machinery is fine; subtracting it puts
+**~79% of `churn` in object construction**. Within construction, **~76% is GC
+and feedback bookkeeping and 7.7% is the allocation itself**:
+
+| group | share | ticket |
+|---|--:|---|
+| `gc::layout` side tables (`layout_forget_*` 14.5%, `layout_note_slot` 7.9%, `js_gc_init_typed_shape_layout` 7.7%, …) | **33.6%** | **#7510** (construction/death half of #5094) |
+| `_tlv_get_addr` | 17.0% | #7469 structural half (partly the same thread-locals as #7510) |
+| write barriers | 16.1% | **#7511** — *correctness-first: a missed barrier is a use-after-free, not a slowdown* |
+| typed-feedback guards | 9.2% | repsel 3b |
+| array helpers | 6.2% | partly closed by #7501 |
+| **the actual allocation** | **7.7%** | — |
+| user code | 3.7% | — |
+
+A declared class costing **63% more than an object literal** is backwards and
+is tracked as a suspected defect (**#7512**), with an explicit off-ramp: if the
+cause lands in the layout or barrier subsystems it closes as a duplicate.
+
+**Two traps recorded here because they cost real time.** `PERRY_WRITE_BARRIERS=0`
+**cannot** bound barrier cost — it makes `churn_alloc` *slower* (2.44 → 5.21 s)
+because it also switches the collector out of evacuating mode; the 16.1% is
+profile-derived only. And a TS annotation is never a layout fact, so no
+bookkeeping may be elided because a field is declared `number` — elision must
+be by-construction (`expr_produces_non_pointer_bits_by_construction`), and
+#7501 found that even a static layout *declaration* gets revoked at runtime, so
+collector-facing metadata needs a live header test at the store.
+
 ### Performance backlog (public-baseline sweep, 2026-08-06, quiet host)
 
 Pinned Node v22.23.1 / Bun 1.3.14, 11 runs per cell. Worst-first vs bun:
@@ -52,8 +93,8 @@ Pinned Node v22.23.1 / Bun 1.3.14, 11 runs per cell. Worst-first vs bun:
 | `json_parse_1mb` | 6.27× | JSON parser speed (shared with tape) |
 | `map_1m` | 5.74× | Map internals |
 | `batch` | 5.29× | app-pattern batch |
-| `field_access` (json_polyglot) | ~13× | JSON tape scan — #7478, **now unblocked** (#7477 fixed by #7483) |
-| element-shape kernel (`keep[j].v`) | 6.2× vs node | repsel #7480 |
+| `field_access` (json_polyglot) | ~13× | JSON tape scan. #7499 landed the reparse path but is a deliberate **no-op here** — the cost is the 10k `lazy_get` calls, so the early batch-flip trigger is the real fix |
+| element-shape kernel (`keep[j].v`) | 6.2× vs node | repsel — invariant landed (#7496), consumer pending |
 | `string_template_interp` | 3.09× | string building |
 | `json_stringify_1mb` | 2.62× | JSON stringify |
 
@@ -83,25 +124,32 @@ numbers); `date_format_parse` 0.82× vs bun.
 
 ## What is left, in order
 
-1. **#7475** — fix the auto-optimize-archive failures, rerun
-   `benchmarks/run_public_baseline.sh`, publish the artifact. This also turns
-   `lint` green and ends admin-bypass merging.
-2. **JSON workstream** — re-land #7478's reparse-on-materialize (now
-   unblocked by #7483; projected ~1500 ms field_access from 2981 while
-   keeping the roundtrip win). The measured dead ends are recorded in #7478 —
-   do not re-walk them.
-3. **Repsel** — build the #7480 element-shape invariant → versioned-loop
-   consumer → element `Ptr<Shape>`. This is the dependency chain for the
-   follow-on optimization work (4b itself is done — #6919).
-4. **Layer 1** — migrate remaining lowerings onto the rooted-combinator API
+1. **#7510 — `gc::layout` side tables (33.6%)**, the single biggest lever in
+   the engine. Its thread-local lookups are also part of the 17% TLS residue,
+   so one fix pays twice. Needs the quiet host to verify.
+2. **#7497** — the last blocker on the public benchmark artifact. Publishing
+   turns `lint` green and **ends admin-bypass merging**; #7475 is closed
+   (it was a rooting bug, not the feature-stripped archive — #7495).
+3. **#7512** — cheap bisect first: a static IR call-census diff says what the
+   class path emits that the literal path does not. May collapse into #7510 or
+   #7511, which is why it runs before either.
+4. **#7511 — write barriers (16.1%)**, sequenced after #7512 in case that
+   accounts for it. Correctness-first: acceptance requires
+   `PERRY_GC_VERIFY_EVACUATION=1` / `PERRY_GC_VERIFY_MARK=1` and the ratchet
+   probes, because a wrong answer here corrupts memory rather than slowing it.
+5. **Repsel** — the element-shape invariant landed (#7496); the versioned-loop
+   consumer and element `Ptr<Shape>` remain. Deliberately sequenced **after**
+   the bookkeeping levers: element reads are 13% of `churn` at 4.3×, the best
+   ratio in the table, so this is an RSS/footprint play more than a time one.
+6. **Layer 1** — migrate remaining lowerings onto the rooted-combinator API
    (`crates/perry-codegen/src/rooting.rs`); the arm-aware scan is the
    worklist tool. **Layer 3** — shrink the 107-module ceiling list toward
    empty; the end state is the raw accessor unreachable, not counted.
-5. **Statepoint-side static checker** — teach `gc_root_dominance_check.py` to
+7. **Statepoint-side static checker** — teach `gc_root_dominance_check.py` to
    read relocation bundles, closing the gap the #7452/#7460 repairs named.
-6. **RSS re-derivation under the statepoint default** (#7056) — the earlier
+8. **RSS re-derivation under the statepoint default** (#7056) — the earlier
    numbers were measured under the shadow stack.
-7. **Ratchet large-Eden probe arm** (#7481's lesson), plus the pending
+9. **Ratchet large-Eden probe arm** (#7481's lesson), plus the pending
    quiet-host re-pins (`wt-scavtenure` baseline).
 
 ---

--- a/docs/memory-perf-roadmap.md
+++ b/docs/memory-perf-roadmap.md
@@ -1,6 +1,16 @@
 # Memory & Performance Roadmap: Beating Bun and Node on `bench_json_roundtrip`
 
-**Status:** active. Written 2026-04-24 alongside v0.5.193.
+> **SUPERSEDED — 2026-08-06.** This document's goal was met: Perry now beats
+> both oracles on the reference roundtrip (**194 ms** vs bun 221 / node 384,
+> pinned in #7476). Its standings below are from **v0.5.211**; HEAD is
+> v0.5.1289, so every number and tier here is stale by ~1000 patch versions
+> and must not be cited. It is kept for the tier reasoning and the historical
+> record only.
+>
+> The live plan is **[`engine-plan.md`](engine-plan.md)**; JSON-specific
+> remaining work is tracked in #7478.
+
+**Status:** superseded (see the note above). Written 2026-04-24 alongside v0.5.193.
 **Goal:** beat **both** Node and Bun on **both** time and peak RSS on the reference
 `bench_json_roundtrip.ts` workload — a 50-iteration `JSON.parse + JSON.stringify`
 loop over a ~1 MB blob with a 10k-record module-level setup array.


### PR DESCRIPTION
Two gaps flagged during the #7469 profiling work.

**1. The plan had no object-allocation row.** The symbolicated `churn` decomposition — the best-measured part of the engine — was invisible to `docs/engine-plan.md`, which referenced none of #7469/#7510/#7511/#7512. The performance section now leads with it: the variant table (with `push_num` at 2.7× isolating the array machinery as fine, putting ~79% of `churn` in construction), and the group profile showing **~76% of construction is GC/feedback bookkeeping against 7.7% for the allocation**.

"What is left" is re-sequenced accordingly: the 33.6% layout side-table lever (#7510) is now first; the #7512 bisect runs *before* the write-barrier work (#7511) it may turn out to explain; #7475 is struck (closed — it was a rooting bug, #7495, not the feature-stripped archive); and repsel's remaining consumer work is explicitly placed after the bookkeeping levers, since element reads are 13% of `churn` at 4.3×, the best ratio in the table.

Two traps are written into the plan because both already cost time:
- `PERRY_WRITE_BARRIERS=0` **cannot** bound barrier cost — it makes `churn_alloc` slower (2.44 → 5.21 s) by also switching the collector out of evacuating mode. The 16.1% figure is profile-derived only.
- A TS annotation is never a layout fact, so nothing may be elided because a field is declared `number`; and #7501 found even a static layout *declaration* gets revoked at runtime, so collector-facing metadata needs a live header test.

**2. `docs/memory-perf-roadmap.md` is retired.** Its goal was achieved — Perry beats both oracles on the reference roundtrip (194 ms vs bun 221 / node 384, pinned in #7476) — and its standings are **v0.5.211 against a v0.5.1289 HEAD**, roughly a thousand patch versions stale. Marked superseded with a pointer to the live plan rather than rewritten, since the tier reasoning is still worth reading as history.

Docs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the engine performance plan with revised priorities, benchmark findings, implementation sequencing, and acceptance requirements.
  - Marked the memory performance roadmap as superseded and identified the current plan for ongoing work.
  - Added a changelog entry summarizing the updated engine-plan priorities and performance guidance.

- **Chores**
  - Bumped the workspace version to 0.5.1290.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->