### PR TITLE
fix(runtime): a globalThis constructor called as a value is not a method name (#7518)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1294
+**Current Version:** 0.5.1295
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1294"
+version = "0.5.1295"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1294"
+version = "0.5.1295"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1294"
+version = "0.5.1295"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1294"
+version = "0.5.1295"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1294"
+version = "0.5.1295"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7520-eventtarget-subclass.md
+++ b/changelog.d/7520-eventtarget-subclass.md
@@ -1,0 +1,79 @@
+### `class X extends EventTarget` threw `TypeError: EventTarget is not a function` (#7518)
+
+Fixes #7518 — a regression of #6301, which #6311 closed on 2026-07-13 and covered
+with `test-files/test_gap_6301_event_target_subclass.ts`. That test had been red
+since **c6ed8175d** ("fix(globals): complete Node parity", #6853, 2026-07-30) with
+nothing to notice it: `parity` (which runs the gap suite) is gated to tag pushes,
+so a gap regression lands on `main` without a red check.
+
+**Bisect.** Predicate: compile and run `class Bus extends EventTarget {}; new
+Bus()`, own `--profile perry-dev` build of `-p perry -p perry-runtime -p
+perry-stdlib -p perry-runtime-static -p perry-stdlib-static` at every hop.
+GOOD at `81ab8e5d6` (#6311, the commit that added the test) and at `17c0ff952`
+(`c6ed8175d^`); BAD at `c6ed8175d` and at `main` (`33acba4c1`).
+
+**Root cause.** One line of #6853 — adding `"EventTarget"` to
+`builtin_constructor_spec_length` in
+`crates/perry-runtime/src/object/global_this_tables.rs`, so `EventTarget.length`
+reads `0` like Node — silently flipped a gate in another module.
+
+`try_dispatch_value_called_proto_method`
+(`crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs`)
+implements the #3716 uncurry-this idiom: a built-in *prototype method* invoked as
+a value arrives backed by the shared `global_this_builtin_noop_thunk`, so the
+helper recovers the closure's recorded `name` and re-dispatches
+`IMPLICIT_THIS.<name>(…)` through the real by-name tower. Global *constructors*
+share that same no-op thunk, and the only thing keeping them out was incidental —
+its own doc comment said it was "gated on a recorded built-in `.length` so bare
+no-op-backed global constructors … which never call `set_builtin_closure_length`,
+are excluded". `populate_global_this_builtins` calls `set_builtin_closure_length`
+for every name `builtin_constructor_spec_length` answers, so the moment
+`EventTarget` joined that table the exclusion stopped holding for it. It was never
+an invariant, just an incomplete table.
+
+The break: `class Bus extends EventTarget {}` has no static parent class id, so
+HIR captures the heritage as a dynamic `extends_expr` and `lower_call/new.rs`
+emits `js_fetch_or_value_super(<globalThis.EventTarget>, this, …)`. That helper
+binds `IMPLICIT_THIS` to the new instance and calls `js_native_call_value`, which
+— gate now open — re-dispatched `bus.EventTarget()`; the by-name tower's catch-all
+threw. Before #6853 the same call reached the no-op thunk, returned `undefined`,
+and `super()` was the intended best-effort no-op.
+
+The same latent hole applied to every other no-op-thunk-backed global constructor
+carrying a spec `.length` (`AbortController`, `AbortSignal`, `FormData`,
+`TextEncoder`, `DisposableStack`, `URLSearchParams`, …); `EventTarget` is simply
+the one with a gap test. The `Function | GeneratorFunction |
+AsyncGeneratorFunction` special case already in the same function (#5588) is an
+earlier instance of exactly this bug, patched name-by-name.
+
+**Fix.** Make the exclusion explicit and table-driven: decline any name in
+`GLOBAL_THIS_BUILTIN_CONSTRUCTORS` (new `is_global_this_builtin_constructor_name`),
+which subsumes the #5588 special case. A global constructor invoked as a value is
+never a prototype-method uncurry, so re-dispatching it by name on the receiver is
+always wrong. Global builtin *functions* (`parseInt`, `fetch`, `structuredClone`,
+…) are untouched: they are installed with their own thunks, never the no-op one,
+so they never reach the helper.
+
+**Regression proofing.** `crates/perry-runtime/src/object/tests.rs` gains
+`global_builtin_constructor_values_are_not_redispatched_by_name`, which walks the
+whole `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` table and asserts the helper declines
+every entry, so a future `builtin_constructor_spec_length` addition cannot
+re-open the hole for a different name. It asserts its own subject was live (it
+fails if no entry still reaches the no-op-thunk-plus-recorded-`.length` shape the
+bug needs) and pins that the fix is the exclusion, not dropping the Node-parity
+`.length`. Reverting the production change fails it on all ~70 entries. It runs in
+the per-PR `cargo-test` tier rather than the tag-gated gap suite.
+
+**Validation.** `test_gap_6301_event_target_subclass` byte-identical to
+`node --experimental-strip-types` (Node 26.5.1), 37 lines, exit 0. Untouched
+neighbours all still byte-identical: `test_gap_3716_uncurry_this` (the idiom this
+helper exists for), `test_issue_2142_builtin_proto_method_values`,
+`test_issue_3579_function_call_apply_eval`, `test_gap_global_builtins_2905_2889`,
+`test_globalthis_builtins`, `test_gap_new_globalthis_builtin_6726`,
+`test_gap_globals_abortsignal_navigator_2582_2923`,
+`test_gap_escape_unescape_global_4511`. A before/after A/B on the same host
+confirms the change is behaviour-neutral outside the bug: `const S = Symbol;
+S("x")` and `AbortController.length` read the same (pre-existing gaps, unrelated
+to this path), while `class X extends AbortController | FormData | TextEncoder |
+DisposableStack | URLSearchParams {}` stops throwing (their instance surface is a
+separate, older gap).

--- a/crates/perry-runtime/src/object/global_this_tables.rs
+++ b/crates/perry-runtime/src/object/global_this_tables.rs
@@ -101,6 +101,24 @@ pub(crate) const GLOBAL_THIS_BUILTIN_CONSTRUCTORS: &[&str] = &[
     "Buffer",
 ];
 
+/// Is `name` one of the built-in CONSTRUCTORS installed on `globalThis`?
+///
+/// #7518: `try_dispatch_value_called_proto_method` needs this to tell a built-in
+/// *prototype method* invoked as a value — the #3716 uncurry-this idiom, which it
+/// must re-dispatch by name on `IMPLICIT_THIS` — from a global *constructor*
+/// invoked as a value, which it must not: `IMPLICIT_THIS.EventTarget(…)` resolves
+/// to nothing and the by-name tower's catch-all throws
+/// `TypeError: EventTarget is not a function`.
+///
+/// Both are backed by the same `global_this_builtin_noop_thunk`, and the only
+/// thing that used to separate them was the accident that constructors carried no
+/// recorded builtin `.length`. That stopped being true as
+/// [`builtin_constructor_spec_length`] below grew to cover them, so the
+/// distinction has to be stated rather than inferred.
+pub(crate) fn is_global_this_builtin_constructor_name(name: &str) -> bool {
+    GLOBAL_THIS_BUILTIN_CONSTRUCTORS.contains(&name)
+}
+
 /// #3655: spec `length` (declared-parameter count) for each built-in
 /// constructor, so `Ctor.length` reads the right arity through the runtime
 /// value path (`const C = DataView; C.length === 1`) and

--- a/crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs
@@ -14,9 +14,11 @@ use super::*;
 /// tower using the current `IMPLICIT_THIS` as the receiver. Returns `None` for
 /// any other closure so normal dispatch proceeds untouched.
 ///
-/// Gated on a recorded built-in `.length` so bare no-op-backed global
-/// constructors (`const O = SomeCtor; O()`), which never call
-/// `set_builtin_closure_length`, are excluded.
+/// Gated on a recorded built-in `.length` (a proto method always has one) AND on
+/// the recovered name not being a global CONSTRUCTOR. The `.length` gate alone
+/// used to imply the second — bare no-op-backed global constructors recorded no
+/// spec length — but that was an accident of an incomplete table, not an
+/// invariant, and it stopped holding (#7518). See the exclusion below.
 pub(crate) unsafe fn try_dispatch_value_called_proto_method(
     closure: *const crate::closure::ClosureHeader,
     args_ptr: *const f64,
@@ -38,18 +40,34 @@ pub(crate) unsafe fn try_dispatch_value_called_proto_method(
     // heap StringHeader so the byte read below is valid for inline-stored names.
     let name_hdr = crate::builtins::js_string_coerce(name_val);
     let name = super::has_own_helpers::str_from_string_header(name_hdr)?;
-    // #5588: Function-family constructors (Function, GeneratorFunction,
-    // AsyncGeneratorFunction) share the noop thunk and have builtin_closure_length
-    // set, so this dispatch fires when any of them is reached via js_native_call_value
-    // inside js_new_function_construct — treating the newly-allocated receiver as
-    // the dispatch target. Exclude them: the noop thunk's undefined return lets
-    // `new` fall back to the allocated object, which is what Object.seal tests
-    // expect (they don't care whether the result is callable, only that sealing
-    // doesn't throw).
-    if matches!(
-        name,
-        "Function" | "GeneratorFunction" | "AsyncGeneratorFunction"
-    ) {
+    // #7518: a global CONSTRUCTOR reached as a VALUE is never a prototype-method
+    // uncurry, so re-dispatching it as `IMPLICIT_THIS.<Name>(…)` is always wrong:
+    // the by-name tower has no such method and its catch-all throws
+    // `TypeError: <Name> is not a function`. Constructors share the no-op thunk
+    // with the proto methods this helper serves, and the `.length` gate above
+    // used to exclude them only by accident (they recorded no spec length).
+    // c6ed8175d (#6853) added `EventTarget` to `builtin_constructor_spec_length`
+    // for Node parity on `EventTarget.length`, which gave the EventTarget global
+    // a recorded length and opened the gate — re-breaking #6301: a
+    // `class Bus extends EventTarget {}` has no static parent class id, so its
+    // `super()` runs the parent VALUE through `js_fetch_or_value_super`, which
+    // binds `IMPLICIT_THIS` to the new instance before the value call. That then
+    // re-dispatched `bus.EventTarget()` and threw. Make the exclusion explicit
+    // and table-driven so growing the spec-length table cannot re-open it.
+    //
+    // `Function` is in that table. `GeneratorFunction` / `AsyncGeneratorFunction`
+    // are not globals but share the shape (#5588): they are reached via
+    // `js_native_call_value` inside `js_new_function_construct`, which would treat
+    // the newly-allocated receiver as the dispatch target — the no-op thunk's
+    // `undefined` return is what lets `new` fall back to that object, which is
+    // what the Object.seal tests expect.
+    //
+    // Global builtin FUNCTIONS (`parseInt`, `fetch`, …) are deliberately NOT
+    // excluded here: they are installed with their own thunks, never the no-op
+    // one, so they never reach this point at all.
+    if is_global_this_builtin_constructor_name(name)
+        || matches!(name, "GeneratorFunction" | "AsyncGeneratorFunction")
+    {
         return None;
     }
     let receiver = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -1220,3 +1220,85 @@ fn map_size_by_name_does_not_oob_read_keys_array() {
         assert_eq!(v2.as_number(), 2.0, "populated Map .size");
     }
 }
+
+/// #7518: a `globalThis` built-in CONSTRUCTOR reached as a VALUE must never be
+/// re-dispatched as a method name on `IMPLICIT_THIS`.
+///
+/// `try_dispatch_value_called_proto_method` exists for the #3716 uncurry-this
+/// idiom: a built-in *prototype method* invoked as a value arrives backed by the
+/// shared `global_this_builtin_noop_thunk`, so the helper recovers its recorded
+/// `name` and re-dispatches `IMPLICIT_THIS.<name>(…)` through the real by-name
+/// tower. Global constructors share that same no-op thunk, and the only thing
+/// keeping them out was incidental — they recorded no builtin `.length`.
+///
+/// c6ed8175d (#6853) added `EventTarget` to `builtin_constructor_spec_length` so
+/// `EventTarget.length` reads `0` like Node. That gave the EventTarget global a
+/// recorded length, opened the gate, and re-broke #6301: `class Bus extends
+/// EventTarget {}` has no static parent class id, so its `super()` runs the
+/// parent VALUE through `js_fetch_or_value_super` — which binds `IMPLICIT_THIS`
+/// to the new instance before the value call — and the helper turned that into
+/// `bus.EventTarget()`, whose miss throws `TypeError: EventTarget is not a
+/// function`. `parity` is tag-gated, so the gap test that covers this sat red on
+/// `main` for a week unnoticed; this assertion lives in the per-PR `cargo-test`
+/// tier instead.
+///
+/// Walks the whole table so a future `builtin_constructor_spec_length` addition
+/// cannot silently re-open the hole for a different name.
+#[test]
+fn global_builtin_constructor_values_are_not_redispatched_by_name() {
+    // The closure `name` / `length` props these assertions read live in the
+    // PROCESS-global CLOSURE_PROPS table (#6965).
+    let _global = crate::gc::global_side_table_test_lock();
+    // Give the pre-fix failure mode a real receiver to miss on, so a regression
+    // surfaces as a clean catchable throw rather than a dispatch on whatever
+    // `IMPLICIT_THIS` happened to hold.
+    let receiver = crate::value::js_nanbox_pointer(js_object_alloc(0, 0) as i64);
+    let prev_this = crate::object::js_implicit_this_set(receiver);
+
+    let mut with_recorded_length = 0usize;
+    let mut offenders: Vec<String> = Vec::new();
+    for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
+        let ctor_raw = test_global_this_builtin_constructor_value(name);
+        let ctor = JSValue::from_bits(ctor_raw.to_bits());
+        assert!(ctor.is_pointer(), "{name} should be a closure-backed global");
+        let closure = ctor.as_pointer::<crate::closure::ClosureHeader>();
+        if super::native_module::builtin_closure_length(closure as usize).is_some() {
+            with_recorded_length += 1;
+        }
+        let verdict = catch_js(|| {
+            match unsafe {
+                crate::object::try_dispatch_value_called_proto_method(closure, std::ptr::null(), 0)
+            } {
+                None => 1.0,
+                Some(_) => 0.0,
+            }
+        });
+        match verdict {
+            Ok(v) if v == 1.0 => {}
+            Ok(_) => offenders.push(format!("{name} (re-dispatched by name)")),
+            Err(_) => offenders.push(format!("{name} (threw)")),
+        }
+    }
+
+    crate::object::js_implicit_this_set(prev_this);
+
+    assert!(
+        offenders.is_empty(),
+        "globalThis built-in constructors must not be value-dispatched as \
+         `IMPLICIT_THIS.<Name>(…)`; offenders: {offenders:?}"
+    );
+    // Non-vacuity: the bug needs the no-op thunk PLUS a recorded spec `.length`.
+    // If nothing in the table carries a length, every entry above declined at the
+    // `.length` gate and this test proved nothing about the exclusion.
+    assert!(
+        with_recorded_length > 0,
+        "no globalThis built-in constructor carries a recorded builtin `.length` — \
+         this test can no longer reach the shape it guards"
+    );
+    // And pin the specific input that regressed: the fix is the explicit
+    // constructor exclusion, NOT dropping the Node-parity `.length` #6853 added.
+    assert!(
+        crate::object::builtin_constructor_spec_length("EventTarget").is_some(),
+        "#7518: EventTarget must keep its spec `.length`"
+    );
+}

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -1244,6 +1244,11 @@ fn map_size_by_name_does_not_oob_read_keys_array() {
 ///
 /// Walks the whole table so a future `builtin_constructor_spec_length` addition
 /// cannot silently re-open the hole for a different name.
+/// `test_global_this_builtin_constructor_value` builds the no-op-thunk shape for
+/// every name, including the ones `populate_global_this_builtins` currently gives
+/// a dedicated thunk — deliberately: the assertion is about the helper's contract
+/// for a constructor NAME, so it stays meaningful if a name is later moved onto
+/// the shared thunk. Reverting the exclusion fails this on all ~70 entries.
 #[test]
 fn global_builtin_constructor_values_are_not_redispatched_by_name() {
     // The closure `name` / `length` props these assertions read live in the
@@ -1260,7 +1265,10 @@ fn global_builtin_constructor_values_are_not_redispatched_by_name() {
     for name in GLOBAL_THIS_BUILTIN_CONSTRUCTORS.iter().copied() {
         let ctor_raw = test_global_this_builtin_constructor_value(name);
         let ctor = JSValue::from_bits(ctor_raw.to_bits());
-        assert!(ctor.is_pointer(), "{name} should be a closure-backed global");
+        assert!(
+            ctor.is_pointer(),
+            "{name} should be a closure-backed global"
+        );
         let closure = ctor.as_pointer::<crate::closure::ClosureHeader>();
         if super::native_module::builtin_closure_length(closure as usize).is_some() {
             with_recorded_length += 1;


### PR DESCRIPTION
Fixes #7518.

## Symptom

`class Bus extends EventTarget {}` threw `TypeError: EventTarget is not a
function` at `new Bus()`. `test-files/test_gap_6301_event_target_subclass.ts`
printed 5 of its 37 lines and exited 1.

## Bisect: c6ed8175d ("fix(globals): complete Node parity", #6853, 2026-07-30)

Predicate: compile and run `class Bus extends EventTarget {}; new Bus()` with a
`--profile perry-dev` build of `-p perry -p perry-runtime -p perry-stdlib -p
perry-runtime-static -p perry-stdlib-static` at each hop (own build every time,
object cache cleared between hops).

| commit | | verdict |
|---|---|---|
| `81ab8e5d6` | #6311 — the commit that fixed #6301 and added the test | **GOOD** |
| `17c0ff952` | `c6ed8175d^` | **GOOD** |
| `c6ed8175d` | #6853 | **BAD** |
| `33acba4c1` | `main` | **BAD** |

## Root cause

One line of #6853 — adding `"EventTarget"` to `builtin_constructor_spec_length`
in `crates/perry-runtime/src/object/global_this_tables.rs`, so
`EventTarget.length` reads `0` like Node — silently flipped a gate in a
different file.

`try_dispatch_value_called_proto_method`
(`crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs:20`)
implements the #3716 uncurry-this idiom. A built-in *prototype method* read off
its prototype and invoked as a value reaches `js_native_call_value` backed by the
shared `global_this_builtin_noop_thunk`, so the helper recovers the closure's
recorded `name` and re-dispatches `IMPLICIT_THIS.<name>(…)` through the real
by-name tower.

Global **constructors** share that same no-op thunk. The only thing keeping them
out was incidental, and the helper's own doc comment said so:

> Gated on a recorded built-in `.length` so bare no-op-backed global constructors
> (`const O = SomeCtor; O()`), which **never call `set_builtin_closure_length`**,
> are excluded.

`populate_global_this_builtins` calls `set_builtin_closure_length` for every name
`builtin_constructor_spec_length` answers, so the moment `EventTarget` joined that
table the exclusion stopped holding for it. That was never an invariant — just an
incomplete table.

The break: `class Bus extends EventTarget {}` has no static parent class id, so
HIR captures the heritage as a dynamic `extends_expr` and `lower_call/new.rs`
emits `js_fetch_or_value_super(<globalThis.EventTarget>, this, …)`. That helper
binds `IMPLICIT_THIS` to the new instance and calls `js_native_call_value`, which
— gate now open — re-dispatched `bus.EventTarget()`. The by-name tower's
catch-all threw `TypeError: EventTarget is not a function`. Before #6853 the same
call reached the no-op thunk, returned `undefined`, and `super()` was the intended
best-effort no-op.

The same latent hole applied to every other no-op-thunk-backed global constructor
carrying a spec `.length` (`AbortController`, `AbortSignal`, `FormData`,
`TextEncoder`, `DisposableStack`, `URLSearchParams`, …) — `EventTarget` is simply
the one with a gap test. And the `Function | GeneratorFunction |
AsyncGeneratorFunction` special case already sitting in the same function (#5588)
is an earlier instance of exactly this bug, patched name-by-name.

## Fix

Make the exclusion explicit and table-driven instead of incidental: decline any
name in `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` (new
`is_global_this_builtin_constructor_name`). A global constructor invoked as a
value is never a prototype-method uncurry, so re-dispatching it by name on the
receiver is always wrong. This subsumes the #5588 special case.

Global builtin **functions** (`parseInt`, `fetch`, `structuredClone`, …) are
deliberately untouched — they are installed with their own thunks, never the
no-op one, so they never reach this helper.

## Regression proofing

`crates/perry-runtime/src/object/tests.rs` gains
`global_builtin_constructor_values_are_not_redispatched_by_name`. It walks the
whole `GLOBAL_THIS_BUILTIN_CONSTRUCTORS` table and asserts the helper declines
every entry, so a future `builtin_constructor_spec_length` addition cannot
re-open the hole for a different name. It asserts its own subject was live —
the test fails if no entry still reaches the no-op-thunk-plus-recorded-`.length`
shape the bug needs — and it pins that the fix is the constructor exclusion, not
dropping the Node-parity `.length` #6853 added.

It runs in the per-PR `cargo-test` tier. That matters: `parity` (which runs the
gap suite) is gated to tag pushes only, which is exactly why this regression
landed on `main` and sat there for a week with no red check.

## Validation

- `test_gap_6301_event_target_subclass` — byte-identical to
  `node --experimental-strip-types` (Node 26.5.1, the `.node-version` pin), 37
  lines, exit 0.
- Untouched neighbours, all byte-identical to node:
  `test_gap_3716_uncurry_this` (the idiom this helper exists for),
  `test_issue_2142_builtin_proto_method_values`,
  `test_issue_3579_function_call_apply_eval`,
  `test_gap_global_builtins_2905_2889`, `test_globalthis_builtins`,
  `test_gap_new_globalthis_builtin_6726`,
  `test_gap_globals_abortsignal_navigator_2582_2923`,
  `test_gap_escape_unescape_global_4511`.
- `cargo test -p perry-runtime --no-fail-fast`, `cargo test -p perry-codegen --lib`.
- `python3 scripts/raw_handle_debt.py` → 999 (baseline 999);
  `bash scripts/check_file_size.sh` → OK; `cargo fmt --all -- --check` → clean.

## The three sibling failures — this root cause explains none of them

#7518 listed three other non-snapshot gap failures. Re-measured on this host with
`--profile perry-dev` builds, own build at each point:

| test | `17c0ff952` | `c6ed8175d` | `main` + this fix |
|---|---|---|---|
| `test_gap_diagchannel_3082_3084_3085_3086` | PASS | PASS | **FAIL** |
| `test_gap_crypto_cipher_3382_3381_2954` | PASS | PASS | PASS |
| `test_gap_zlib_4917_level` | PASS | PASS | PASS |

None touches the value-called-constructor path, and none changed with this fix.
Filed granularly, not fixed here:

- **#7521** — `tracingChannel().traceCallback` loses every `events.push(...)`
  (including the one inside the traced function itself, which *does* run and
  *does* return its value). A confirmed regression in `c6ed8175d..main`.
- **#7522** — the zlib `js_zlib_deflate_raw_sync` link failure does not reproduce
  under `perry-dev`. It is a **dead-strip** symptom and `perry-dev` has no LTO, so
  it is profile-dependent rather than host-local; `KEEP_ZLIB_FFI` in
  `perry-stdlib/src/zlib.rs` exists for exactly that failure mode.
- **#7523** — the crypto-cipher one does not reproduce under `perry-dev` either;
  needs a genuine `--release` arm (at `codegen-units=1`) before anyone bisects.

The common thread with #7518: "fails on clean `main`" was read as evidence of a
host quirk when it was evidence of an older unnoticed regression.

## Could a per-PR gate have caught this, and what would it cost

- **`cargo-test` — yes, and it now does.** The new assertion runs in 0.08 s inside
  a test binary `cargo-test` already builds. Marginal cost ≈ 0. This is the
  cheapest possible coverage for the actual defect, which is a *table/consumer
  coupling inside one crate* — a shape no compile-and-diff test is needed for.
- **The gap suite — yes, immediately, but it is tag-gated by design** (v0.5.1018).
  Ungating all ~479 tests per PR means a compiler build plus 479 compile+link+run
  pairs; that is why it was gated.
- **A `gap-smoke` PR job would have caught it** — a fixed ~30-test core subset
  (one per subsystem, `test_gap_6301_event_target_subclass` among them) on a
  `--profile perry-dev` build. Cost is dominated by the one build; the test
  compiles add a couple of minutes. Worth proposing separately. Deliberately
  **not** wired here: a new gate has never been green, so promoting it to required
  in the same PR would block every open PR (CLAUDE.md, "Four ways a gate can be
  unable to fail", corollary).
- **`node_compat_matrix --check` would NOT have caught it.** It compares export
  *shape* (`name:typeof` over the module namespace). `EventTarget`'s `typeof`,
  `name` and `length` were all correct throughout — the breakage was in
  construction behaviour, which the matrix does not model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where built-in global constructors, including `EventTarget`, could be incorrectly treated as prototype methods.
  * Preserved expected constructor behavior and validation against Node.js behavior.

* **Tests**
  * Added regression coverage for global constructors and the `EventTarget` `.length` property.

* **Documentation**
  * Documented the regression, root cause, fix, and related test coverage.
  * Updated the documented release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->