### PR TITLE
fix(gc): three more re-read-vs-stale-local orderings around the async result promise (#7497 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1298
+**Current Version:** 0.5.1299
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1298"
+version = "0.5.1299"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1298"
+version = "0.5.1299"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1298"
+version = "0.5.1299"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1298"
+version = "0.5.1299"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1298"
+version = "0.5.1299"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7516-promise-all-chains.md
+++ b/changelog.d/7516-promise-all-chains.md
@@ -126,11 +126,15 @@ frame rather than in a table.
 
 **What is still open, stated rather than papered over.** A protected run of the
 *auto-optimize* binary is not silent: it prints the correct checksum and then
-faults inside `js_async_step_done` on another 72-byte `GC_TYPE_PROMISE`. That is
-a ninth site of the same family, after the program's observable output, and the
-kernel matches the oracle byte for byte with and without the instrument. The
-`PERRY_NO_AUTO_OPTIMIZE=1` binary and the new gap test are both silent under the
-instrument. Separately, `test_gap_gc_iterator_drain_rooting` and
+faults inside `js_async_step_done` on another 72-byte `GC_TYPE_PROMISE`. Three
+separate attempts at it are in this PR and all three are correct on their own
+terms — returning the re-read address instead of the pre-call copy, rooting the
+receiver across `js_assimilate_thenable`, and seeding `INLINE_TRAP` from the
+handles rather than from the arm's locals — and **none of them cleared it**, so
+the holder is somewhere I have not found. It is after the program's observable
+output; the kernel matches the oracle byte for byte with and without the
+instrument, and the `PERRY_NO_AUTO_OPTIMIZE=1` binary and the new gap test are
+both silent under it. Separately, `test_gap_gc_iterator_drain_rooting` and
 `test_gap_iterator_helpers_2874` fail on `origin/main` too — verified by building
 `origin/main`'s runtime from a clean `git archive` export and running both
 against it — and belong to #7498's `array_from_spread_value` prototype walk.

--- a/changelog.d/7529-async-result-rooting.md
+++ b/changelog.d/7529-async-result-rooting.md
@@ -1,0 +1,37 @@
+### Fixed
+
+**Three more `re-read vs stale local` orderings around the async result promise
+(#7497 follow-up to #7516).**
+
+Same family as #7516 — *a value read out of a root and held in a register across
+a call that allocates is not rooted* — in the three places that PR left:
+
+* **`js_async_step_done` passed the pre-root copy.** #7516 rooted `trap_next` and
+  then handed `resolve_trap_next_with_adoption` the original binding anyway.
+  Rooting is not a licence to keep using the old name; that is the exact shape
+  the parent PR exists to remove.
+* **`resolve_trap_next_with_adoption` held its receiver across
+  `js_assimilate_thenable`.** That call runs a *user* `then` getter, and `target`
+  is the receiver of both settlements after it — the one of the three with a real
+  user-facing path behind it (`return <thenable>` from an async fn, e.g.
+  Drizzle's `QueryPromise`, #586).
+* **The `AsyncStep` arm seeded `INLINE_TRAP` from its locals.** Between the
+  re-read at the top of the arm and the `INLINE_TRAP.set` sit the runaway-reentry
+  guard (which allocates a TypeError on its bounded path) and two handle pushes.
+  A stale `next` parked in the trap is what `js_async_step_done` later settles and
+  returns as the async function's own result promise.
+
+**What this does not do.** #7516 recorded one open residual: a protected run
+(`PERRY_GC_PROTECT_FROMSPACE=1`) of the *auto-optimize* binary prints the correct
+checksum and then faults inside `js_async_step_done`. All three changes above were
+attempts at it and **none of them cleared it**, so the holder is still unfound.
+#7516's fragment is amended to say that rather than leaving the impression that
+the instrument is clean or that one more re-read would do it. Each change is kept
+because it is correct on its own terms, not because it was measured to fix
+something.
+
+Re-verified after rebasing onto current `main`: `promise_all_chains` byte-exact
+against node 26.5.1 on both link modes, `scripts/auto_opt_app_patterns.sh` 12/12
+with no skips, `test_gap_gc_global_builtin_lookup_rooting.ts` plus eight
+promise/array/async gap tests byte-exact, `cargo test -p perry-runtime` 1744
+passed / 0 failed, `scripts/raw_handle_debt.py` unchanged at 999.

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -649,11 +649,13 @@ pub extern "C" fn js_async_step_done(value: f64, step_closure: ClosurePtr) -> *m
         // `PERRY_GC_PROTECT_FROMSPACE=1` faults on it here under the
         // auto-optimize link.
         let scope = crate::gc::RuntimeHandleScope::new();
-        let target_h =
-            scope.root_nanbox_f64(crate::value::js_nanbox_pointer(trap.trap_next as i64));
+        let target_h = scope.root_nanbox_f64(boxed_promise_or_undef(trap.trap_next));
         let value_h = scope.root_nanbox_f64(value);
-        resolve_trap_next_with_adoption(trap.trap_next, value_h.get_nanbox_f64());
-        crate::value::js_nanbox_get_pointer(target_h.get_nanbox_f64()) as *mut Promise
+        // Pass the RE-READ address, not `trap.trap_next`: leaving the pre-root
+        // copy nameable is exactly the shape this whole PR is about, and the
+        // rooting above is not a licence to keep using the old binding.
+        resolve_trap_next_with_adoption(unboxed_promise(&target_h), value_h.get_nanbox_f64());
+        unboxed_promise(&target_h)
     } else {
         bump(&MT_STEP_DONE_REUSE_MISS);
         // An async fn always returns a FRESH promise — `js_promise_resolved`'s
@@ -708,7 +710,16 @@ fn resolve_trap_next_with_adoption(target: *mut Promise, value: f64) {
     }
     // User thenable (e.g. Drizzle QueryPromise, #586): assimilate, then
     // chain the wrapper promise into `target`.
-    let assim = js_assimilate_thenable(value);
+    //
+    // #7497: `js_assimilate_thenable` runs the user `then` getter and allocates,
+    // and `target` is the RECEIVER of both settlements below. Root it (and the
+    // value) across the call and re-read.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_h = scope.root_nanbox_f64(boxed_promise_or_undef(target));
+    let value_h = scope.root_nanbox_f64(value);
+    let assim = js_assimilate_thenable(value_h.get_nanbox_f64());
+    let target = unboxed_promise(&target_h);
+    let value = value_h.get_nanbox_f64();
     if assim.to_bits() != value.to_bits() && js_value_is_promise(assim) != 0 {
         let inner = crate::value::js_nanbox_get_pointer(assim) as *mut Promise;
         if !inner.is_null() && inner != target {

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -800,6 +800,14 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                     let prev_trap_step_handle = trap_scope.root_raw_const_ptr(
                         prev_trap.current_step as *const crate::closure::ClosureHeader,
                     );
+                    // #7497: seed the trap from the HANDLES, not from the locals.
+                    // Between the re-read at the top of this arm and here sit the
+                    // runaway-reentry guard (which allocates a TypeError on its
+                    // bounded path) and two handle pushes; a stale `next` stored
+                    // into the trap is what `js_async_step_done` later settles
+                    // and RETURNS as the async function's own result promise.
+                    let next = rooted_promise(&next_handle);
+                    let step_closure = rooted_closure(&step_handle);
                     INLINE_TRAP.with(|c| {
                         c.set(InlineTrap {
                             trap_next: next,


### PR DESCRIPTION
Follow-up to #7516 (which landed as 5edfe99cc while this was in flight). Same
family, three more `re-read vs stale local` orderings around the async result
promise, plus one honesty correction to #7516's changelog fragment.

## The three orderings

1. **`js_async_step_done` passed the pre-root copy.** #7516 rooted `trap_next`
   and then handed `resolve_trap_next_with_adoption` the original binding
   anyway. Rooting is not a licence to keep using the old name — that is the
   exact shape #7516 exists to remove.

2. **`resolve_trap_next_with_adoption` held its receiver across
   `js_assimilate_thenable`.** That call runs a *user* `then` getter, and
   `target` is the receiver of both settlements after it. This is the one with a
   real user-facing path behind it (`return <thenable>` from an async fn —
   Drizzle's `QueryPromise`, #586).

3. **The `AsyncStep` arm seeded `INLINE_TRAP` from its locals.** Between the
   re-read at the top of the arm and the `INLINE_TRAP.set` sit the
   runaway-reentry guard (which allocates a TypeError on its bounded path) and
   two handle pushes. A stale `next` parked in the trap is what
   `js_async_step_done` later settles and returns as the async function's own
   result promise.

## What this does NOT do, stated plainly

#7516's fragment recorded one open residual: a protected run
(`PERRY_GC_PROTECT_FROMSPACE=1`) of the *auto-optimize* binary prints the correct
checksum and then faults inside `js_async_step_done`. **All three changes above
were attempts at it and none of them cleared it** — the holder is somewhere I
have not found. The fragment is amended to say so rather than leaving the
impression that the instrument is clean or that one more re-read would do it.

Each change is nonetheless correct on its own terms and is kept for that reason,
not because it was measured to fix something.

## Verification (before the merge of #7516 moved main under it; re-checked after
the rebase)

* `benchmarks/app-patterns/kernels/promise_all_chains.ts` — `checksum: 2500050000`,
  byte-exact vs node 26.5.1, on both link modes.
* `scripts/auto_opt_app_patterns.sh` — 12/12, no skips.
* `test_gap_gc_global_builtin_lookup_rooting.ts` plus 8 promise/array/async gap
  tests — all byte-exact.
* `cargo test -p perry-runtime` — 1744 passed, 0 failed.
* `scripts/raw_handle_debt.py` 999 (unchanged), `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved async promise handling during garbage collection and thenable adoption.
  - Strengthened preservation of async task state across promise resolution and runtime transitions.
  - Updated async execution safeguards to use current values after memory-management operations.
  - The remaining auto-optimization crash is still under investigation and was not resolved by these changes.

- **Documentation**
  - Added changelog details covering the attempted fixes, verification results, and known limitations.

- **Maintenance**
  - Updated the release version to 0.5.1299.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->