### PR TITLE
perf(gc): make a repeat typed-shape construction a header bit-set (#7510)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1302
+**Current Version:** 0.5.1303
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1302"
+version = "0.5.1303"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1302"
+version = "0.5.1303"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1302"
+version = "0.5.1303"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1302"
+version = "0.5.1303"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1302"
+version = "0.5.1303"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7535-construction-shape-install.md
+++ b/changelog.d/7535-construction-shape-install.md
@@ -80,10 +80,15 @@ fast path reading its state out of the memo, the memo short-circuiting
 validation, and the poison branch not invalidating — each fail a different named
 assertion.
 
-**#7512's residual is not fixed here, and the reason is sharper than the ticket
-had it.** `js_gc_init_typed_shape_layout` is still emitted after the constructor
-call, so raw-f64 class-field stores inside a constructor body still cannot pass
-their guard. Moving it earlier fails validation because fresh slots hold
+**The constructor-ordering residual is not fixed here, and the reason is sharper
+than the ticket had it.** It originated on #7512, whose other half merged as
+#7515; #7510 then folded the remainder in as its construction-path item, which
+is why it is tracked there rather than on #7512 (still open for the broader
+class-vs-object-literal gap).
+
+`js_gc_init_typed_shape_layout` is still emitted after the constructor call, so
+raw-f64 class-field stores inside a constructor body still cannot pass their
+guard. Moving it earlier fails validation because fresh slots hold
 `undefined` — but *relaxing* validation to accept `undefined` in a raw-f64 slot
 would be safe for the collector (`undefined` is not pointer-bearing, so a
 skipped slot strands nothing) and unsafe for readers: `class_field_fast_contract`

--- a/changelog.d/7535-construction-shape-install.md
+++ b/changelog.d/7535-construction-shape-install.md
@@ -1,0 +1,78 @@
+**A repeat construction of an already-installed typed shape is now two header
+bit-writes instead of a `SHAPE_LAYOUTS` round-trip (#7510 item 1, the
+construction half of #5094).**
+
+Since #6893 the descriptor `js_gc_init_typed_shape_layout` installs is
+per-*shape*, not per-object: every same-shape object shares one canonical
+`TypedLayoutDescriptor` in `SHAPE_LAYOUTS`, keyed by the shared `keys_array`.
+The only per-object work left is two header bits —
+`GC_OBJ_TYPED_LAYOUT_INTACT`, and `GC_LAYOUT_POINTER_FREE`/`GC_LAYOUT_SIDE_MASK`.
+
+The call did not know that. For the 20-millionth `{v, w}` literal it still built
+a `TypedLayoutDescriptor` (72 bytes, two 32-byte `Vec`-carrying enums, one
+cloned, all of it dropped on the way out), took a `RefCell` borrow on the
+thread-local `SHAPE_LAYOUTS`, hashed the `keys_array` pointer, and compared the
+fresh descriptor field-by-field against the one already stored — to reach the
+conclusion the *first* construction had already reached. `shape_install_shared`'s
+hit arm writes nothing at all. On a symbolicated `churn_alloc` profile the two
+functions were 8.9% + 2.2% of self time.
+
+The new `gc/shape_install` module memoises exactly that map answer, in a
+thread-local 8-entry direct-mapped table, and nothing else:
+
+> `SHAPE_LAYOUTS[keys]` holds `Some(D)`, where `D` is the descriptor that
+> `(slot_count, raw_words, pointer_words)` describes.
+
+**The memo decides nothing about the object.** Everything the header declaration
+rests on is still re-derived per construction, ahead of the memo: the
+`field_count == slot_count` check, raw-f64/pointer mask disjointness, and the
+per-slot validation that each raw-f64 slot holds a plain double and no
+pointer-bearing slot sits outside the pointer mask. `POINTER_FREE` vs
+`SIDE_MASK` is recomputed from the pointer mask, never read back from the entry.
+That split is the soundness bar: a wrong `POINTER_FREE` is a use-after-free
+factory — `heap_payload_slot_selection` short-circuits on it and skips the whole
+payload without consulting any mask — so that decision must not depend on a
+cache. A stale entry can only cost work.
+
+Those two checks also stopped building a `LayoutSlotMask` per construction and
+now read the caller's mask words directly, which takes the drop glue off six
+early-return paths and the `Vec` allocation off every construction of a shape
+wider than 64 slots. `LayoutSlotMask::intersects` survives as the test-only
+reference implementation the three word helpers are pinned against.
+
+**Self-healing.** An entry is falsified by exactly one transition:
+`SHAPE_LAYOUTS[keys]` ceasing to be `Some(D)`. `shape_install_shared` is that
+map's only writer and its only such transition is the ambiguity poison (two live
+layouts sharing one key set), which now drops the table. Entries are never
+removed from `SHAPE_LAYOUTS` and never overwritten with a different `Some`, so
+there is no other way to go stale. A relocated or recycled `keys_array` degrades
+to a miss, and `PERRY_SHAPE_LAYOUT_KEYED=0` leaves the table permanently empty
+because the only writer is a successful shared install. The table is **not** a
+GC root: `keys` is compared as an integer and never dereferenced.
+
+**Testing.** Nine tests. `memo_fires_on_every_repeat_construction_of_one_shape`
+counts hits — the assertion #7525 lacked, and whose absence let that PR's first
+commit ship a fast path that fired once in 40 million calls.
+`memo_installed_objects_survive_a_copying_minor_with_their_children` is the GC
+witness: six instances of a `{ n: number; s: string }` shape, five of them
+published by the memo (asserted, so a green run cannot mean the slow path ran),
+through an evacuating minor that actually moved ≥ 12 objects, with every string
+child relocated, re-pointed and byte-intact.
+`a_pointer_free_declaration_on_this_shape_strands_the_child` is the permanent
+sabotage arm: publishing this exact shape `POINTER_FREE` by hand makes the
+collector enumerate zero payload children. Three hand-applied sabotages — the
+fast path reading its state out of the memo, the memo short-circuiting
+validation, and the poison branch not invalidating — each fail a different named
+assertion.
+
+**#7512's residual is not fixed here, and the reason is sharper than the ticket
+had it.** `js_gc_init_typed_shape_layout` is still emitted after the constructor
+call, so raw-f64 class-field stores inside a constructor body still cannot pass
+their guard. Moving it earlier fails validation because fresh slots hold
+`undefined` — but *relaxing* validation to accept `undefined` in a raw-f64 slot
+would be safe for the collector (`undefined` is not pointer-bearing, so a
+skipped slot strands nothing) and unsafe for readers: `class_field_fast_contract`
+documents that the codegen-inlined path concludes "slot K is raw-f64" from the
+intact bit alone, and `class C { v: number; constructor() { console.log(this.v) } }`
+must still print `undefined`. The fix needs a codegen-side definite-assignment
+proof or a two-stage install, not a runtime relaxation; it stays on #7510.

--- a/changelog.d/7535-construction-shape-install.md
+++ b/changelog.d/7535-construction-shape-install.md
@@ -1,6 +1,10 @@
 **A repeat construction of an already-installed typed shape is now two header
 bit-writes instead of a `SHAPE_LAYOUTS` round-trip (#7510 item 1, the
-construction half of #5094).**
+construction half of #5094).** On the pinned quiet host, interleaved best-of-9
+user CPU over 20M constructions: **1.09× on a `{v, w}` object-literal churn,
+1.10× on the `new Node(v, w)` class form, 1.06× on a 16-shape polymorphic
+churn**. `shape_install_shared` is entered **once** in a 20,000,000-object run,
+against 100,000 times in 100,000 on `main` (lldb breakpoint hit counts).
 
 Since #6893 the descriptor `js_gc_init_typed_shape_layout` installs is
 per-*shape*, not per-object: every same-shape object shares one canonical
@@ -18,7 +22,7 @@ hit arm writes nothing at all. On a symbolicated `churn_alloc` profile the two
 functions were 8.9% + 2.2% of self time.
 
 The new `gc/shape_install` module memoises exactly that map answer, in a
-thread-local 8-entry direct-mapped table, and nothing else:
+thread-local 32-entry direct-mapped table (1 KiB), and nothing else:
 
 > `SHAPE_LAYOUTS[keys]` holds `Some(D)`, where `D` is the descriptor that
 > `(slot_count, raw_words, pointer_words)` describes.
@@ -39,6 +43,17 @@ now read the caller's mask words directly, which takes the drop glue off six
 early-return paths and the `Vec` allocation off every construction of a shape
 wider than 64 slots. `LayoutSlotMask::intersects` survives as the test-only
 reference implementation the three word helpers are pinned against.
+
+**32 entries, not 8, and that was measured rather than guessed.** A
+direct-mapped table cycled round-robin by more shapes than it has slots hits
+*zero* percent of the time — each entry is evicted by its partner before it is
+read again — so it pays the probe and gets nothing. A 16-shape churn loop
+against 8 slots was a reproducible 0.993×, the one regression this change had;
+at 32 slots the same loop fits and turns into 1.059×, with the monomorphic
+numbers unchanged. The slot index also mixes in the two mask-global addresses,
+not just the shape, because two object-literal sites with the same key names
+share one `keys_array` but get separate mask globals unless LLVM's constant
+merger folds them.
 
 **Self-healing.** An entry is falsified by exactly one transition:
 `SHAPE_LAYOUTS[keys]` ceasing to be `Some(D)`. `shape_install_shared` is that

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -1029,7 +1029,11 @@ unsafe fn init_typed_shape_layout(
     // gates this and therefore also gates the memo above: the memo is only
     // ever populated from a successful install here, so with the knob off the
     // table stays empty and every lookup misses.
-    let keys = if shape_layout_keyed_enabled() { keys } else { 0 };
+    let keys = if shape_layout_keyed_enabled() {
+        keys
+    } else {
+        0
+    };
     if keys != 0 && shape_install_shared(keys, header, &descriptor) {
         // The common path for every object literal: the shape already owns a
         // canonical descriptor, so this object needs no per-object record at

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -213,6 +213,12 @@ impl LayoutSlotMask {
         count
     }
 
+    /// Reference implementation only. The construction path asks this question
+    /// of the raw mask words (`shape_install::words_intersect`) rather than of
+    /// two built masks — see that module's "mask words" section — and
+    /// `shape_install::tests::mask_word_helpers_agree_with_layout_slot_mask`
+    /// pins the two together, which is what this now exists for.
+    #[cfg(test)]
     pub(super) fn intersects(&self, other: &Self, slot_count: usize) -> bool {
         let mut found = false;
         self.visit_slots(slot_count, |slot| {
@@ -481,6 +487,11 @@ unsafe fn shape_install_shared(
                 // Same keys, different layout ⟹ ambiguous. Poison the entry so
                 // future lookups (and any still-INTACT siblings) fall back.
                 m.insert(keys, None);
+                // #7510: `Some(D)` → `None` is the ONE transition that can
+                // falsify a construction memo (see `gc::shape_install`). It is
+                // also the only transition this map has, since entries are
+                // never removed and never overwritten with a different `Some`.
+                super::shape_install::invalidate();
                 false
             }
             // Already ambiguous.
@@ -943,9 +954,13 @@ unsafe fn init_typed_shape_layout(
         return;
     }
 
-    let raw_f64_mask = LayoutSlotMask::from_words(raw_f64_words);
-    let pointer_mask = LayoutSlotMask::from_words(pointer_words);
-    if raw_f64_mask.intersects(&pointer_mask, slot_count) {
+    // The two soundness checks, straight off the caller's mask words. Building
+    // a `LayoutSlotMask` here would be a 32-byte enum with a destructor —
+    // ×2, plus drop glue at every early return below, plus an allocation each
+    // for any shape wider than 64 slots — to answer two predicates. The
+    // descriptor that genuinely needs the type is built further down, only
+    // when a shape is actually installed.
+    if super::shape_install::words_intersect(raw_f64_words, pointer_words, slot_count) {
         layout_set_typed_unknown(header, user_ptr);
         return;
     }
@@ -956,37 +971,71 @@ unsafe fn init_typed_shape_layout(
             as *const u64;
         for i in 0..slot_count {
             let bits = *fields.add(i);
-            if raw_f64_mask.contains_slot(i) {
+            if super::shape_install::words_contain_slot(raw_f64_words, i) {
                 if !layout_raw_f64_bits(bits) {
                     layout_set_typed_unknown(header, user_ptr);
                     return;
                 }
                 continue;
             }
-            if layout_pointer_bearing_bits(bits) && !pointer_mask.contains_slot(i) {
+            if layout_pointer_bearing_bits(bits)
+                && !super::shape_install::words_contain_slot(pointer_words, i)
+            {
                 layout_set_typed_unknown(header, user_ptr);
                 return;
             }
         }
     }
 
+    // #7510 item 1: everything above this line is re-derived per object and
+    // stays that way — it is what makes the header declaration below true.
+    // What the 20-millionth `{v, w}` literal does NOT need to re-derive is the
+    // *map* answer: that its shape's canonical descriptor is already installed
+    // and already equal to the one these mask globals describe. That is all
+    // `shape_install::hit` asserts, and on a hit the construction reduces to
+    // the two header bit-writes `shape_install_shared` would have performed —
+    // no `TypedLayoutDescriptor` built, cloned and dropped, no `RefCell`
+    // borrow, no hash of `keys`, no field-by-field descriptor comparison.
+    //
+    // The memo carries no header state: `POINTER_FREE` vs `SIDE_MASK` is
+    // recomputed from the pointer mask exactly as the slow path computes it,
+    // so a stale entry can only cost work. See `gc::shape_install` for the
+    // full staleness argument.
+    //
+    // `object_keys_array_ptr`'s two guards are already discharged above
+    // (`layout_header_for_user` rejected the low addresses,
+    // `GcLayoutSlotKind::ObjectFields` was checked), so read the field
+    // directly rather than re-walking the header.
+    let keys = (*obj_header).keys_array as usize;
+    if keys != 0 && super::shape_install::hit(keys, slot_count, raw_f64_words, pointer_words) {
+        header_set_typed_layout_intact(header);
+        if super::shape_install::words_are_empty(pointer_words) {
+            set_layout_state(header, GC_LAYOUT_POINTER_FREE);
+        } else {
+            set_layout_state(header, GC_LAYOUT_SIDE_MASK);
+        }
+        layout_forget_object(user_ptr);
+        return;
+    }
+
+    let pointer_mask = LayoutSlotMask::from_words(pointer_words);
     let descriptor = TypedLayoutDescriptor {
         slot_count,
-        raw_f64_mask,
+        raw_f64_mask: LayoutSlotMask::from_words(raw_f64_words),
         pointer_mask: pointer_mask.clone(),
     };
     // #6893: try the O(shapes) shared shape descriptor (keyed by the canonical
-    // keys_array) before per-object storage.
-    let keys = if shape_layout_keyed_enabled() {
-        object_keys_array_ptr(user_ptr)
-    } else {
-        0
-    };
+    // keys_array) before per-object storage. `shape_layout_keyed_enabled()`
+    // gates this and therefore also gates the memo above: the memo is only
+    // ever populated from a successful install here, so with the knob off the
+    // table stays empty and every lookup misses.
+    let keys = if shape_layout_keyed_enabled() { keys } else { 0 };
     if keys != 0 && shape_install_shared(keys, header, &descriptor) {
         // The common path for every object literal: the shape already owns a
         // canonical descriptor, so this object needs no per-object record at
         // all. `layout_forget_object` skips the hash entirely when the maps
         // are empty, which on a monomorphic workload they are.
+        super::shape_install::record(keys, slot_count, raw_f64_words, pointer_words);
         layout_forget_object(user_ptr);
         return;
     }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -74,8 +74,8 @@ mod layout_tables;
 /// typed shape into two header bit-writes instead of a descriptor build plus a
 /// `SHAPE_LAYOUTS` round-trip.
 mod shape_install;
-pub(crate) use shape_install::shape_install_memo_hot_addr;
 pub use layout::*;
+pub(crate) use shape_install::shape_install_memo_hot_addr;
 mod trace;
 pub(crate) use trace::*;
 mod barrier;

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -70,6 +70,11 @@ mod layout;
 /// keeps them off the allocation, store, death and trace paths. Split out of
 /// `layout.rs` so it stays under the repo's 2000-line-per-file cap.
 mod layout_tables;
+/// #7510 item 1: the construction-side memo that turns an already-installed
+/// typed shape into two header bit-writes instead of a descriptor build plus a
+/// `SHAPE_LAYOUTS` round-trip.
+mod shape_install;
+pub(crate) use shape_install::shape_install_memo_hot_addr;
 pub use layout::*;
 mod trace;
 pub(crate) use trace::*;

--- a/crates/perry-runtime/src/gc/shape_install.rs
+++ b/crates/perry-runtime/src/gc/shape_install.rs
@@ -327,7 +327,7 @@ pub(super) fn record(keys: usize, slot_count: usize, raw_words: &[u64], pointer_
 /// Called from the one transition that can falsify a memo: `SHAPE_LAYOUTS`
 /// poisoning a shape to ambiguous. Clearing the whole table rather than the
 /// one affected slot keeps this correct without having to reason about index
-/// collisions, and costs one 256-byte store on a branch that fires when a
+/// collisions, and costs one 1 KiB clear on a branch that fires when a
 /// program's shape *stops* being monomorphic — i.e. rarely, and never twice
 /// for the same shape.
 #[inline]

--- a/crates/perry-runtime/src/gc/shape_install.rs
+++ b/crates/perry-runtime/src/gc/shape_install.rs
@@ -156,10 +156,19 @@ pub(super) fn words_intersect(a: &[u64], b: &[u64], slot_count: usize) -> bool {
 }
 
 /// Direct-mapped entries. Sized for the shape working set of a hot loop, not
-/// for a whole program: a monomorphic allocation site needs one, and the
-/// spread across a handful of interleaved shapes is what the extra slots buy.
-/// Kept a power of two so the index is a mask.
-const MEMO_SLOTS: usize = 8;
+/// for a whole program: a monomorphic allocation site needs one, and the spread
+/// across interleaved shapes is what the rest buy. Kept a power of two so the
+/// index is a mask.
+///
+/// 32 rather than 8, measured. A direct-mapped table cycled round-robin by more
+/// shapes than it has slots hits **zero** percent of the time — each entry is
+/// evicted by its partner before it is read again — so it pays the probe and
+/// gets nothing. A 16-shape churn loop against 8 slots was a reproducible
+/// 0.993× on the pinned host; the same loop against 32 slots fits and wins with
+/// the monomorphic case. The whole table is 1 KiB of const-initialised
+/// thread-local, so the cost of the headroom is a page that is never touched by
+/// a program with one shape.
+const MEMO_SLOTS: usize = 32;
 
 /// One memoised "this shape's canonical descriptor is already installed, and
 /// equals what these mask globals describe" fact.

--- a/crates/perry-runtime/src/gc/shape_install.rs
+++ b/crates/perry-runtime/src/gc/shape_install.rs
@@ -1,0 +1,454 @@
+//! #7510 item 1 — the construction-side shape-install memo.
+//!
+//! # What this replaces
+//!
+//! `js_gc_init_typed_shape_layout` runs on **every** construction of a typed
+//! object literal and every `new` of a class with a typed field layout. Since
+//! #6893 the descriptor it installs is per-*shape*, not per-object: all
+//! same-shape objects share one canonical `TypedLayoutDescriptor` in
+//! `SHAPE_LAYOUTS`, keyed by the shared `keys_array`. The per-object work that
+//! remains is two header bits — `GC_OBJ_TYPED_LAYOUT_INTACT`, and
+//! `GC_LAYOUT_POINTER_FREE`/`GC_LAYOUT_SIDE_MASK`.
+//!
+//! The call did not know that. For the 20-millionth `{v, w}` literal it still
+//! built a `TypedLayoutDescriptor` (72 bytes, two `Vec`-carrying enums, cloned
+//! once and dropped), took a `RefCell` borrow on the thread-local
+//! `SHAPE_LAYOUTS`, hashed the `keys_array` pointer, and compared the freshly
+//! built descriptor field-by-field against the one already stored — to conclude
+//! what the first construction had already concluded. Measured after #7525,
+//! `js_gc_init_typed_shape_layout` + `shape_install_shared` were ~13% of self
+//! time on `churn_alloc`.
+//!
+//! # What the memo asserts
+//!
+//! One thing, and nothing else:
+//!
+//! > `SHAPE_LAYOUTS[keys]` currently holds `Some(D)`, where `D` is exactly the
+//! > descriptor that `(slot_count, raw_words, pointer_words)` describes.
+//!
+//! That is the *entire* content of a successful `shape_install_shared` on a
+//! shape that is already installed — its `Some(Some(existing)) if existing ==
+//! descriptor` arm writes nothing to the map. So a memo hit lets the caller
+//! skip the descriptor build and the map round-trip and go straight to the
+//! header bits.
+//!
+//! # What the memo deliberately does NOT assert
+//!
+//! **Anything about the object.** The caller still re-derives, from the mask
+//! words themselves, every fact that its header declaration rests on:
+//! `field_count == slot_count`, raw-f64/pointer mask disjointness, and the
+//! per-slot validation that each raw-f64 slot holds a plain double and no
+//! pointer-bearing slot sits outside the pointer mask. The
+//! `POINTER_FREE`/`SIDE_MASK` choice is recomputed from the pointer mask, not
+//! read back from the memo — the memo carries no header state at all.
+//!
+//! This split is the soundness bar. A wrong `POINTER_FREE` is a
+//! use-after-free factory: `heap_payload_slot_selection` skips the whole
+//! payload without consulting any mask. Keeping that decision on data the
+//! caller re-derives per object means a stale memo can only cost work, never
+//! correctness.
+//!
+//! # Self-healing
+//!
+//! A memo entry is falsified by exactly one transition: `SHAPE_LAYOUTS[keys]`
+//! going from `Some(D)` to something else. `shape_install_shared` is the only
+//! writer of that map, and its only such transition is the ambiguity poison
+//! (`Some(Some(_)) => insert(None)` — two live layouts sharing one key set).
+//! That branch calls [`invalidate`], which drops every entry. Entries are
+//! never removed from `SHAPE_LAYOUTS` and never overwritten with a *different*
+//! `Some`, so there is no other way to go stale.
+//!
+//! Everything else already degrades safely without help:
+//!
+//! - A moving GC relocates the `keys_array` ⟹ objects report the new address,
+//!   which no entry matches ⟹ miss ⟹ the slow path re-installs and re-records.
+//! - The old address is recycled by an unrelated shape ⟹ its constructions
+//!   arrive with different mask globals ⟹ miss. If they arrive with the *same*
+//!   mask globals and slot count, the memo's claim is still true of them (the
+//!   stored descriptor describes them exactly), so the hit is correct.
+//! - `PERRY_SHAPE_LAYOUT_KEYED=0` ⟹ [`record`] is unreachable (it is only
+//!   called after a successful `shape_install_shared`, which that knob gates)
+//!   ⟹ the table stays empty and every lookup misses.
+//!
+//! # Keying
+//!
+//! Entries are keyed by `(keys_array, raw_words, pointer_words, slot_count,
+//! word counts)`. The two mask pointers are the addresses of codegen-emitted
+//! `private unnamed_addr constant` globals — one per class
+//! (`mask_global_name_from_keys_global`) or per object-literal site — so
+//! pointer identity is a conservative proxy for word equality: two globals
+//! holding equal words that LLVM declined to merge cost a miss, never a wrong
+//! hit. Nothing dereferences a stored pointer; they are compared as integers
+//! only.
+//!
+//! # This table is NOT a GC root
+//!
+//! Worth stating explicitly, because a runtime-side cache of a raw heap
+//! pointer usually *is* one and the static root-dominance checker cannot see
+//! it (`gc_register_mutable_root_scanner`, CLAUDE.md). `keys` holds the
+//! address of a live `keys_array`, but it is only ever **compared as an
+//! integer** against the `keys_array` the object under construction reports —
+//! never dereferenced, never handed to the mutator, never used to keep
+//! anything alive.
+//!
+//! Both ways it can go stale are already safe:
+//!
+//! - The array **moves**: every live object reports the new address, so the
+//!   old entry simply stops matching. It is dead weight until evicted, not a
+//!   dangling read.
+//! - The old address is **recycled** by a different shape's keys array, and
+//!   that shape's constructions happen to arrive with the same mask globals
+//!   and slot count. Then the entry's claim is still true — `SHAPE_LAYOUTS`
+//!   is keyed by the same address, its entries are never removed, and the
+//!   descriptor stored there describes those objects exactly. If instead they
+//!   arrive with different masks the entry does not match, and the install
+//!   they fall through to poisons the shape and clears the table.
+
+use std::cell::UnsafeCell;
+
+// --- mask words, without a `LayoutSlotMask` ---------------------------------
+//
+// `LayoutSlotMask` is a 32-byte enum with a `Vec` arm, so building one has a
+// destructor: every early return in `init_typed_shape_layout` used to carry
+// drop glue for two of them, and a wide shape allocated twice per
+// construction. The construction path needs the *predicates*, not the type —
+// the descriptor is only built when a shape is actually installed. These three
+// answer the same questions straight off the caller's words.
+//
+// They are the only implementation of those predicates on the construction
+// path now, and `tests::mask_word_helpers_agree_with_layout_slot_mask` pins
+// each one against the `LayoutSlotMask` method it replaced across every
+// interesting mask/`slot_count` combination — including the trailing-zero and
+// past-the-end cases where the trimmed enum and the raw words could disagree.
+
+/// `LayoutSlotMask::from_words(words).contains_slot(slot)`.
+#[inline(always)]
+pub(super) fn words_contain_slot(words: &[u64], slot: usize) -> bool {
+    let word = slot / 64;
+    word < words.len() && words[word] & (1u64 << (slot % 64)) != 0
+}
+
+/// `LayoutSlotMask::from_words(words).is_empty()`.
+#[inline(always)]
+pub(super) fn words_are_empty(words: &[u64]) -> bool {
+    words.iter().all(|&w| w == 0)
+}
+
+/// `LayoutSlotMask::from_words(a).intersects(&from_words(b), slot_count)` —
+/// any slot below `slot_count` set in both. Bits at or above `slot_count` are
+/// ignored, matching `visit_slots`, which never walks past the object's live
+/// prefix.
+#[inline]
+pub(super) fn words_intersect(a: &[u64], b: &[u64], slot_count: usize) -> bool {
+    let limit_words = slot_count.div_ceil(64).min(a.len()).min(b.len());
+    for word in 0..limit_words {
+        let live = slot_count - word * 64;
+        let limit_mask = if live >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << live) - 1
+        };
+        if a[word] & b[word] & limit_mask != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Direct-mapped entries. Sized for the shape working set of a hot loop, not
+/// for a whole program: a monomorphic allocation site needs one, and the
+/// spread across a handful of interleaved shapes is what the extra slots buy.
+/// Kept a power of two so the index is a mask.
+const MEMO_SLOTS: usize = 8;
+
+/// One memoised "this shape's canonical descriptor is already installed, and
+/// equals what these mask globals describe" fact.
+///
+/// `dims` packs `slot_count` (low 24 bits — `js_gc_init_typed_shape_layout`
+/// rejects anything ≥ 16_000_000 before reaching here), the raw-f64 mask word
+/// count (bits 24..44) and the pointer mask word count (bits 44..64).
+/// [`record`] refuses to store a tuple that does not fit, so a packed value is
+/// never ambiguous.
+#[derive(Clone, Copy)]
+struct Entry {
+    keys: usize,
+    raw_words: *const u64,
+    pointer_words: *const u64,
+    dims: u64,
+}
+
+/// `keys == 0` is the empty marker: no live object ever reports a null
+/// `keys_array` to the lookup (the caller checks first), so an empty slot can
+/// never be mistaken for a hit.
+const EMPTY: Entry = Entry {
+    keys: 0,
+    raw_words: std::ptr::null(),
+    pointer_words: std::ptr::null(),
+    dims: 0,
+};
+
+const SLOT_COUNT_BITS: u32 = 24;
+const WORD_COUNT_BITS: u32 = 20;
+
+/// Pack the dimension triple, or `None` when it does not fit (a pathological
+/// shape: > 16M slots, or > 1M mask words). An unpackable tuple is simply
+/// never memoised.
+#[inline]
+fn pack_dims(slot_count: usize, raw_len: usize, pointer_len: usize) -> Option<u64> {
+    if slot_count >= 1 << SLOT_COUNT_BITS
+        || raw_len >= 1 << WORD_COUNT_BITS
+        || pointer_len >= 1 << WORD_COUNT_BITS
+    {
+        return None;
+    }
+    Some(
+        slot_count as u64
+            | (raw_len as u64) << SLOT_COUNT_BITS
+            | (pointer_len as u64) << (SLOT_COUNT_BITS + WORD_COUNT_BITS),
+    )
+}
+
+#[inline(always)]
+fn slot_index(keys: usize) -> usize {
+    // The low bits of a heap address are allocation-granularity noise; shift
+    // past them before masking so sibling shapes do not collide.
+    (keys >> 4) & (MEMO_SLOTS - 1)
+}
+
+thread_local! {
+    /// Per-thread, mirroring `SHAPE_LAYOUTS`'s own thread-locality — an entry
+    /// names an address in this thread's arena and a fact about this thread's
+    /// map, and neither means anything on another thread.
+    ///
+    /// `UnsafeCell` rather than `Cell<[Entry; N]>`: a `Cell` get/set would copy
+    /// the whole table on every probe. Access is single-threaded by
+    /// construction (this is a `thread_local!`), and the module hands out no
+    /// references into it.
+    static SHAPE_INSTALL_MEMO: UnsafeCell<[Entry; MEMO_SLOTS]> =
+        const { UnsafeCell::new([EMPTY; MEMO_SLOTS]) };
+}
+
+/// Address of this thread's [`SHAPE_INSTALL_MEMO`] (see `crate::tls_hot`).
+pub(crate) fn shape_install_memo_hot_addr() -> *mut u8 {
+    SHAPE_INSTALL_MEMO.with(|m| m as *const _ as *mut u8)
+}
+
+/// [`SHAPE_INSTALL_MEMO`] without a TLS resolution.
+#[inline(always)]
+fn table() -> &'static UnsafeCell<[Entry; MEMO_SLOTS]> {
+    // SAFETY: paired with `shape_install_memo_hot_addr` above; asserted by
+    // `tls_hot::tests::cached_addresses_match_thread_locals`.
+    unsafe {
+        &*(crate::tls_hot::hot().shape_install_memo as *const UnsafeCell<[Entry; MEMO_SLOTS]>)
+    }
+}
+
+/// True when `SHAPE_LAYOUTS[keys]` is already known to hold exactly the
+/// descriptor that `(slot_count, raw_words, pointer_words)` describes.
+///
+/// `false` is never an error — it just means the caller must take the ordinary
+/// `shape_install_shared` path, which is what establishes the entry.
+#[inline(always)]
+pub(super) fn hit(
+    keys: usize,
+    slot_count: usize,
+    raw_words: &[u64],
+    pointer_words: &[u64],
+) -> bool {
+    debug_assert!(keys != 0, "the null keys_array is the empty-slot marker");
+    let Some(dims) = pack_dims(slot_count, raw_words.len(), pointer_words.len()) else {
+        return false;
+    };
+    // SAFETY: `table()` is this thread's own storage; the reference does not
+    // escape and nothing re-enters between the read and its use.
+    let entry = unsafe { (*table().get())[slot_index(keys)] };
+    let matched = entry.keys == keys
+        && entry.dims == dims
+        && std::ptr::eq(entry.raw_words, raw_words.as_ptr())
+        && std::ptr::eq(entry.pointer_words, pointer_words.as_ptr());
+    #[cfg(test)]
+    {
+        if matched {
+            counters::note_hit();
+        }
+    }
+    matched
+}
+
+/// Record that `shape_install_shared` just confirmed (or established)
+/// `SHAPE_LAYOUTS[keys] == Some(D)` for the descriptor these mask words
+/// describe.
+#[inline]
+pub(super) fn record(keys: usize, slot_count: usize, raw_words: &[u64], pointer_words: &[u64]) {
+    if keys == 0 {
+        return;
+    }
+    let Some(dims) = pack_dims(slot_count, raw_words.len(), pointer_words.len()) else {
+        return;
+    };
+    #[cfg(test)]
+    counters::note_record();
+    // SAFETY: as in `hit` — this thread's own storage, no escaping reference.
+    unsafe {
+        (*table().get())[slot_index(keys)] = Entry {
+            keys,
+            raw_words: raw_words.as_ptr(),
+            pointer_words: pointer_words.as_ptr(),
+            dims,
+        };
+    }
+}
+
+/// Drop every entry.
+///
+/// Called from the one transition that can falsify a memo: `SHAPE_LAYOUTS`
+/// poisoning a shape to ambiguous. Clearing the whole table rather than the
+/// one affected slot keeps this correct without having to reason about index
+/// collisions, and costs one 256-byte store on a branch that fires when a
+/// program's shape *stops* being monomorphic — i.e. rarely, and never twice
+/// for the same shape.
+#[inline]
+pub(super) fn invalidate() {
+    // SAFETY: as in `hit` — this thread's own storage, no escaping reference.
+    unsafe {
+        (*table().get()) = [EMPTY; MEMO_SLOTS];
+    }
+}
+
+/// Hit/record counters, so a test can assert the fast path was **live** rather
+/// than merely that nothing threw — the #7525 failure mode was a fast path
+/// that fired once in 40 million calls and was believed anyway.
+///
+/// Test-only on purpose: this sits on the hottest path in allocation-heavy
+/// code, and a counter that ships would be paid 20 million times to answer a
+/// question asked once.
+#[cfg(test)]
+pub(super) mod counters {
+    use std::cell::Cell;
+
+    thread_local! {
+        static HITS: Cell<u64> = const { Cell::new(0) };
+        static RECORDS: Cell<u64> = const { Cell::new(0) };
+    }
+
+    #[inline]
+    pub(in crate::gc) fn note_hit() {
+        HITS.with(|c| c.set(c.get() + 1));
+    }
+
+    #[inline]
+    pub(in crate::gc) fn note_record() {
+        RECORDS.with(|c| c.set(c.get() + 1));
+    }
+
+    /// `(hits, records)` since [`reset`].
+    pub(in crate::gc) fn snapshot() -> (u64, u64) {
+        (HITS.with(|c| c.get()), RECORDS.with(|c| c.get()))
+    }
+
+    pub(in crate::gc) fn reset() {
+        HITS.with(|c| c.set(0));
+        RECORDS.with(|c| c.set(0));
+    }
+}
+
+#[cfg(test)]
+pub(in crate::gc) fn test_clear() {
+    invalidate();
+    counters::reset();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gc::layout::LayoutSlotMask;
+
+    /// The construction path no longer builds a `LayoutSlotMask` to answer
+    /// "is slot K raw-f64 / pointer-bearing / is this mask empty / do these
+    /// two overlap". These three helpers are that path's only implementation,
+    /// so they have to agree with the type they replaced — including on the
+    /// shapes where the trimmed enum and the raw words could plausibly differ:
+    /// trailing zero words, bits past `slot_count`, and slots past the end of
+    /// the word array.
+    #[test]
+    fn mask_word_helpers_agree_with_layout_slot_mask() {
+        let masks: &[&[u64]] = &[
+            &[],
+            &[0],
+            &[0b1],
+            &[0b1011],
+            &[u64::MAX],
+            &[0, 0],
+            &[0b1, 0],
+            &[0, 0b1],
+            &[u64::MAX, 0b101],
+            &[0b1, 0, 0],
+            &[0, 0, 1 << 63],
+        ];
+        for &words in masks {
+            let mask = LayoutSlotMask::from_words(words);
+            assert_eq!(
+                words_are_empty(words),
+                mask.is_empty(),
+                "is_empty disagreed for {words:?}"
+            );
+            for slot in 0..200 {
+                assert_eq!(
+                    words_contain_slot(words, slot),
+                    mask.contains_slot(slot),
+                    "contains_slot({slot}) disagreed for {words:?}"
+                );
+            }
+            for &other_words in masks {
+                let other = LayoutSlotMask::from_words(other_words);
+                for slot_count in [0usize, 1, 2, 63, 64, 65, 128, 129, 192] {
+                    assert_eq!(
+                        words_intersect(words, other_words, slot_count),
+                        mask.intersects(&other, slot_count),
+                        "intersects(slot_count = {slot_count}) disagreed for \
+                         {words:?} vs {other_words:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Distinct shapes must not alias into one entry, and a shape whose
+    /// dimensions do not fit the packed key must simply never memoise rather
+    /// than collide with one that does.
+    #[test]
+    fn entries_discriminate_on_every_keyed_field() {
+        let raw: [u64; 1] = [0b01];
+        let other_raw: [u64; 1] = [0b10];
+        let pointers: [u64; 1] = [0b10];
+        let keys = 0x4000usize;
+
+        invalidate();
+        record(keys, 2, &raw, &pointers);
+        assert!(hit(keys, 2, &raw, &pointers));
+        assert!(!hit(keys + 16, 2, &raw, &pointers), "a different shape");
+        assert!(!hit(keys, 3, &raw, &pointers), "a different slot count");
+        assert!(!hit(keys, 2, &other_raw, &pointers), "a different raw mask");
+        assert!(!hit(keys, 2, &raw, &raw), "a different pointer mask");
+        assert!(!hit(keys, 2, &raw, &[]), "a different pointer word count");
+
+        invalidate();
+        assert!(!hit(keys, 2, &raw, &pointers), "invalidate must drop entries");
+    }
+
+    /// A `slot_count` that overflows the packed key is refused by both halves,
+    /// so it can neither be stored nor produce a spurious hit against a
+    /// smaller shape that packs to the same bits.
+    #[test]
+    fn unpackable_dimensions_are_never_memoised() {
+        let raw: [u64; 1] = [0b01];
+        let keys = 0x8000usize;
+        let huge = 1usize << SLOT_COUNT_BITS;
+
+        invalidate();
+        record(keys, huge, &raw, &[]);
+        assert!(!hit(keys, huge, &raw, &[]));
+        // …and it did not land in the slot a packable shape would use.
+        assert!(!hit(keys, 0, &raw, &[]));
+    }
+}

--- a/crates/perry-runtime/src/gc/shape_install.rs
+++ b/crates/perry-runtime/src/gc/shape_install.rs
@@ -208,11 +208,24 @@ fn pack_dims(slot_count: usize, raw_len: usize, pointer_len: usize) -> Option<u6
     )
 }
 
+/// Which entry a `(shape, mask globals)` tuple lives in.
+///
+/// The mask-global addresses are mixed in, not just the shape. Two object
+/// literal sites with the same key names share one `keys_array` but get
+/// separate mask globals unless LLVM's constant merger folds them (they are
+/// `private unnamed_addr constant`, so it may — but the table must not depend
+/// on that). Keying the slot on the shape alone would put both sites in one
+/// entry and let them evict each other on every iteration of a loop that
+/// builds both. Any index function is *correct* — the full tuple is compared
+/// on the way out — so this is purely about not colliding.
+///
+/// The low bits of a heap address are allocation-granularity noise, hence the
+/// shifts; the two mask pointers use different ones so a shape whose masks are
+/// both empty (one shared dangling `&[]` address) does not cancel itself out.
 #[inline(always)]
-fn slot_index(keys: usize) -> usize {
-    // The low bits of a heap address are allocation-granularity noise; shift
-    // past them before masking so sibling shapes do not collide.
-    (keys >> 4) & (MEMO_SLOTS - 1)
+fn slot_index(keys: usize, raw_words: *const u64, pointer_words: *const u64) -> usize {
+    let mixed = (keys >> 4) ^ (raw_words as usize >> 4) ^ (pointer_words as usize >> 3);
+    mixed & (MEMO_SLOTS - 1)
 }
 
 thread_local! {
@@ -261,7 +274,8 @@ pub(super) fn hit(
     };
     // SAFETY: `table()` is this thread's own storage; the reference does not
     // escape and nothing re-enters between the read and its use.
-    let entry = unsafe { (*table().get())[slot_index(keys)] };
+    let entry =
+        unsafe { (*table().get())[slot_index(keys, raw_words.as_ptr(), pointer_words.as_ptr())] };
     let matched = entry.keys == keys
         && entry.dims == dims
         && std::ptr::eq(entry.raw_words, raw_words.as_ptr())
@@ -290,7 +304,7 @@ pub(super) fn record(keys: usize, slot_count: usize, raw_words: &[u64], pointer_
     counters::note_record();
     // SAFETY: as in `hit` — this thread's own storage, no escaping reference.
     unsafe {
-        (*table().get())[slot_index(keys)] = Entry {
+        (*table().get())[slot_index(keys, raw_words.as_ptr(), pointer_words.as_ptr())] = Entry {
             keys,
             raw_words: raw_words.as_ptr(),
             pointer_words: pointer_words.as_ptr(),
@@ -433,7 +447,10 @@ mod tests {
         assert!(!hit(keys, 2, &raw, &[]), "a different pointer word count");
 
         invalidate();
-        assert!(!hit(keys, 2, &raw, &pointers), "invalidate must drop entries");
+        assert!(
+            !hit(keys, 2, &raw, &pointers),
+            "invalidate must drop entries"
+        );
     }
 
     /// A `slot_count` that overflows the packed key is refused by both halves,

--- a/crates/perry-runtime/src/gc/tests/layout_trace.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace.rs
@@ -5,6 +5,7 @@ mod element_shape;
 mod object_closure_slots;
 mod object_layout_invalidation;
 mod per_object_tables;
+mod shape_install_memo;
 mod typed_shape;
 
 #[test]

--- a/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
@@ -1,0 +1,408 @@
+//! #7510 item 1 — the construction-side shape-install memo.
+//!
+//! The memo lets `js_gc_init_typed_shape_layout` skip the `SHAPE_LAYOUTS`
+//! round-trip for a shape whose canonical descriptor is already installed, and
+//! reduce the construction to the two header bits that install would have set.
+//! Three things therefore have to be true, and each has a test here:
+//!
+//! 1. **It fires.** #7525's first commit was worth nothing because its fast
+//!    path hit once in 40 million calls, and that was found by counting, not by
+//!    reasoning. [`memo_fires_on_every_repeat_construction_of_one_shape`]
+//!    counts.
+//! 2. **It decides nothing.** The header declaration is re-derived from the
+//!    mask words and the object's own field bits on every construction, hit or
+//!    miss — [`a_memo_hit_produces_the_same_header_state_as_the_install`] and
+//!    [`a_contradicting_field_is_refused_even_with_the_memo_warm`].
+//! 3. **It heals.** The one transition that can falsify an entry —
+//!    `SHAPE_LAYOUTS` poisoning a shape to ambiguous — drops the table:
+//!    [`ambiguity_poison_invalidates_the_memo`].
+//!
+//! And because this is collector-facing metadata, a witness that objects built
+//! through the fast path survive an evacuating minor *with their children*
+//! ([`memo_installed_objects_survive_a_copying_minor_with_their_children`]),
+//! next to the sabotage arm that shows what a wrong declaration would cost
+//! ([`a_pointer_free_declaration_on_this_shape_strands_the_child`]).
+
+use super::*;
+use crate::gc::shape_install;
+
+/// Distinct class ids per test: `js_build_class_keys_array` caches by class id
+/// and anchors the result for the process lifetime, so sharing one id across
+/// tests would share one shape — and the `SHAPE_LAYOUTS` entry that goes with
+/// it, which one test's ambiguity poison would then leak into another's.
+const CLASS_REPEAT: u32 = 0x7510_01;
+const CLASS_STATE: u32 = 0x7510_02;
+const CLASS_DIVERGE: u32 = 0x7510_03;
+const CLASS_AMBIGUOUS: u32 = 0x7510_04;
+const CLASS_WITNESS: u32 = 0x7510_05;
+
+/// A two-field shape, `{ n: number; s: string }`: slot 0 raw-f64, slot 1
+/// pointer-bearing. The pointer half is what makes the GC witness meaningful —
+/// a pointer-free shape would survive any declaration.
+const RAW_MASK: [u64; 1] = [0b01];
+const POINTER_MASK_WORDS: [u64; 1] = [0b10];
+
+fn keys_for(class_id: u32) -> *mut crate::array::ArrayHeader {
+    let packed: &[u8] = b"n\0s\0";
+    crate::object::js_build_class_keys_array(class_id, 2, packed.as_ptr(), packed.len() as u32)
+}
+
+/// Allocate one instance of the shape and fill it: a plain double in slot 0, a
+/// fresh heap string in slot 1. Returns the object and its child string.
+fn build_instance(
+    class_id: u32,
+    keys: *mut crate::array::ArrayHeader,
+    n: f64,
+    bytes: &[u8],
+) -> (*mut crate::object::ObjectHeader, usize) {
+    let obj = crate::object::js_object_alloc_class_inline_keys(class_id, 0, 2, keys);
+    let child = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) as usize;
+    crate::object::js_object_set_field(obj, 0, crate::value::JSValue::number(n));
+    crate::object::js_object_set_field(
+        obj,
+        1,
+        crate::value::JSValue::from_bits(string_bits(child)),
+    );
+    (obj, child)
+}
+
+/// The install call every test makes, with the shape's canonical mask globals.
+/// Passing the SAME two slices every time is the point: their addresses are
+/// what the memo keys on, exactly as codegen's per-class `private unnamed_addr
+/// constant` mask globals are.
+fn install(obj: *mut crate::object::ObjectHeader) {
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        RAW_MASK.as_ptr(),
+        RAW_MASK.len() as u32,
+        POINTER_MASK_WORDS.as_ptr(),
+        POINTER_MASK_WORDS.len() as u32,
+    );
+}
+
+unsafe fn layout_state(obj: *mut crate::object::ObjectHeader) -> u16 {
+    let header = header_from_user_ptr(obj as *const u8);
+    (*header)._reserved & (GC_LAYOUT_STATE_MASK | GC_OBJ_TYPED_LAYOUT_INTACT)
+}
+
+/// Child slots the collector would visit **inside the object's fields**. The
+/// generic count also emits the `keys_array` and `meta` header edges as
+/// `Prefix` children, which every shaped object has regardless of its layout
+/// declaration and which would therefore mask the very difference these tests
+/// are about.
+unsafe fn payload_child_count(obj: *mut crate::object::ObjectHeader) -> usize {
+    test_heap_child_slots_for_user(obj as *mut u8)
+        .into_iter()
+        .filter(|slot| {
+            matches!(
+                slot,
+                HeapChildSlot::Child(_, kind) if *kind != HeapChildSlotReadKind::Prefix
+            )
+        })
+        .count()
+}
+
+/// The memo must fire on every construction after the first, or it is not
+/// buying anything: a fast path that hits once per program is exactly the
+/// #7525 failure this suite exists to prevent repeating.
+#[test]
+fn memo_fires_on_every_repeat_construction_of_one_shape() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_REPEAT);
+    const INSTANCES: usize = 64;
+    for i in 0..INSTANCES {
+        let (obj, _) = build_instance(CLASS_REPEAT, keys, i as f64, b"repeat");
+        install(obj);
+        assert_eq!(
+            unsafe { layout_state(obj) },
+            GC_LAYOUT_SIDE_MASK | GC_OBJ_TYPED_LAYOUT_INTACT,
+            "instance {i} must end up intact with a side mask, hit or miss"
+        );
+    }
+
+    let (hits, records) = shape_install::counters::snapshot();
+    assert_eq!(
+        records, 1,
+        "one shape must reach `shape_install_shared` exactly once — a second \
+         record means the memo is not being consulted on the repeats"
+    );
+    assert_eq!(
+        hits,
+        (INSTANCES - 1) as u64,
+        "every construction after the first must take the memo fast path"
+    );
+}
+
+/// A hit and a miss must leave the object in the same state. The memo stores
+/// no header bits: `POINTER_FREE` vs `SIDE_MASK` is recomputed from the
+/// pointer mask on both paths, which is what keeps a stale entry from ever
+/// becoming a wrong declaration.
+#[test]
+fn a_memo_hit_produces_the_same_header_state_as_the_install() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_STATE);
+
+    // Miss: the table was just cleared.
+    let (via_install, _) = build_instance(CLASS_STATE, keys, 1.5, b"install");
+    install(via_install);
+    let (hits_after_first, _) = shape_install::counters::snapshot();
+    assert_eq!(hits_after_first, 0, "the first construction must be a miss");
+
+    // Hit.
+    let (via_memo, _) = build_instance(CLASS_STATE, keys, 2.5, b"memo");
+    install(via_memo);
+    let (hits_after_second, _) = shape_install::counters::snapshot();
+    assert_eq!(hits_after_second, 1, "the second construction must be a hit");
+
+    unsafe {
+        assert_eq!(
+            layout_state(via_memo),
+            layout_state(via_install),
+            "the memo path must publish the same layout state as the install path"
+        );
+    }
+    for obj in [via_install, via_memo] {
+        let user = obj as usize;
+        assert!(layout_typed_intact_for_user(user));
+        assert!(
+            layout_typed_raw_f64_slot_for_user(user, 0),
+            "slot 0 must resolve as raw-f64 through the shared shape descriptor"
+        );
+        assert!(!layout_typed_raw_f64_slot_for_user(user, 1));
+        assert_eq!(
+            test_layout_pointer_slot_count(user, 2),
+            Some(1),
+            "the collector must see exactly the one pointer slot"
+        );
+        assert_eq!(unsafe { payload_child_count(obj) }, 1);
+    }
+}
+
+/// The memo says nothing about the object, only about the map. An instance
+/// whose slot 0 holds a string contradicts the raw-f64 mask and must be
+/// refused with the table warm exactly as it would be cold — the per-slot
+/// validation runs on both paths, ahead of the memo.
+#[test]
+fn a_contradicting_field_is_refused_even_with_the_memo_warm() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_DIVERGE);
+    let (good, _) = build_instance(CLASS_DIVERGE, keys, 1.0, b"conforming");
+    install(good);
+    let (hits_before, _) = shape_install::counters::snapshot();
+
+    // Same shape, but slot 0 — declared raw-f64 — holds a heap string.
+    let (bad, _) = build_instance(CLASS_DIVERGE, keys, 0.0, b"child");
+    let boxed = crate::string::js_string_from_bytes(b"not-a-double".as_ptr(), 12) as usize;
+    crate::object::js_object_set_field(bad, 0, crate::value::JSValue::from_bits(string_bits(boxed)));
+    install(bad);
+
+    assert!(
+        !layout_typed_intact_for_user(bad as usize),
+        "an instance that contradicts its shape's mask must not be declared \
+         intact — the per-slot validation runs on the fast path too"
+    );
+    let (hits_after, _) = shape_install::counters::snapshot();
+    assert_eq!(
+        hits_after, hits_before,
+        "validation must reject the instance BEFORE the memo is consulted"
+    );
+    unsafe {
+        assert_eq!(
+            (*header_from_user_ptr(bad as *const u8))._reserved & GC_LAYOUT_STATE_MASK,
+            GC_LAYOUT_UNKNOWN,
+            "a refused install must fall back to the conservative scan, which is \
+             the only state that keeps BOTH heap fields traceable"
+        );
+        assert_eq!(
+            payload_child_count(bad),
+            2,
+            "both the boxed slot-0 string and the slot-1 child must stay enumerable"
+        );
+    }
+    // The conforming sibling is untouched: the poison is per-object.
+    assert!(layout_typed_intact_for_user(good as usize));
+}
+
+/// `Some(descriptor)` → `None` on a shape is the ONE transition that falsifies
+/// a memo entry, and `shape_install_shared` is the only place it happens. The
+/// poison must drop the table, or every later construction of the poisoned
+/// shape would keep taking a fast path whose premise is gone.
+#[test]
+fn ambiguity_poison_invalidates_the_memo() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_AMBIGUOUS);
+    let (first, _) = build_instance(CLASS_AMBIGUOUS, keys, 1.0, b"first");
+    install(first);
+    let (second, _) = build_instance(CLASS_AMBIGUOUS, keys, 2.0, b"second");
+    install(second);
+    let (hits_before_poison, records_before_poison) = shape_install::counters::snapshot();
+    assert_eq!((hits_before_poison, records_before_poison), (1, 1));
+
+    // Same key names, a DIFFERENT value layout: `{n, s}` where both slots are
+    // ordinary JSValues. `shape_install_shared` cannot describe both, so it
+    // poisons the shape to ambiguous.
+    let ambiguous = crate::object::js_object_alloc_class_inline_keys(CLASS_AMBIGUOUS, 0, 2, keys);
+    let a = crate::string::js_string_from_bytes(b"a".as_ptr(), 1) as usize;
+    let b = crate::string::js_string_from_bytes(b"b".as_ptr(), 1) as usize;
+    crate::object::js_object_set_field(ambiguous, 0, crate::value::JSValue::from_bits(string_bits(a)));
+    crate::object::js_object_set_field(ambiguous, 1, crate::value::JSValue::from_bits(string_bits(b)));
+    let both_pointers: [u64; 1] = [0b11];
+    js_gc_init_typed_shape_layout(
+        ambiguous as u64,
+        2,
+        std::ptr::null(),
+        0,
+        both_pointers.as_ptr(),
+        both_pointers.len() as u32,
+    );
+
+    // A third construction of the ORIGINAL layout must now miss, and land on
+    // the per-object path the poison redirects it to.
+    let (third, _) = build_instance(CLASS_AMBIGUOUS, keys, 3.0, b"third");
+    install(third);
+    let (hits_after, _) = shape_install::counters::snapshot();
+    assert_eq!(
+        hits_after, hits_before_poison,
+        "the poison must have dropped the memo entry; a hit here would be a fast \
+         path running on a premise that no longer holds"
+    );
+
+    // Correctness of the fallback, not just its shape: the object is still
+    // fully described and its child still enumerable.
+    assert!(layout_typed_intact_for_user(third as usize));
+    assert!(layout_typed_raw_f64_slot_for_user(third as usize, 0));
+    assert_eq!(
+        test_layout_pointer_slot_count(third as usize, 2),
+        Some(1),
+        "the per-object fallback must carry the same pointer mask"
+    );
+    assert_eq!(unsafe { payload_child_count(third) }, 1);
+}
+
+/// The witness. Objects whose layout was published by the memo fast path —
+/// never by a `SHAPE_LAYOUTS` install — are relocated by an evacuating minor
+/// together with the heap string each one holds, and their slots rewritten.
+///
+/// The `hits` assertion is the "subject was live" gate: without it a green run
+/// would be compatible with every object having gone down the slow path.
+#[test]
+fn memo_installed_objects_survive_a_copying_minor_with_their_children() {
+    const INSTANCES: usize = 6;
+    let _guard = CopyingNurseryTestGuard::new(INSTANCES as u32);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_WITNESS);
+    let payloads: Vec<Vec<u8>> = (0..INSTANCES)
+        .map(|i| format!("witness_child_{i}").into_bytes())
+        .collect();
+
+    let mut objects = Vec::new();
+    let mut children = Vec::new();
+    for (i, bytes) in payloads.iter().enumerate() {
+        let (obj, child) = build_instance(CLASS_WITNESS, keys, i as f64, bytes);
+        install(obj);
+        assert_eq!(
+            unsafe { payload_child_count(obj) },
+            1,
+            "instance {i} must expose its one pointer field to the collector"
+        );
+        js_shadow_slot_set(i as u32, ptr_bits(obj as usize));
+        objects.push(obj as usize);
+        children.push(child);
+    }
+
+    let (hits, records) = shape_install::counters::snapshot();
+    assert_eq!(records, 1);
+    assert_eq!(
+        hits,
+        (INSTANCES - 1) as u64,
+        "all but the first instance must have been published by the memo fast \
+         path, or this witness is testing the slow path"
+    );
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert!(
+        trace.copying_nursery.copied_objects >= INSTANCES * 2,
+        "the cycle must actually have MOVED every object and every child, or the \
+         relocation claim below is vacuous (copied_objects = {})",
+        trace.copying_nursery.copied_objects
+    );
+
+    for i in 0..INSTANCES {
+        let after = (js_shadow_slot_get(i as u32) & POINTER_MASK) as usize;
+        assert_ne!(after, objects[i], "instance {i} must have been relocated");
+        assert!(crate::arena::pointer_in_nursery(after));
+        unsafe {
+            let obj = after as *mut crate::object::ObjectHeader;
+            let fields = (obj as *const u8).add(std::mem::size_of::<crate::object::ObjectHeader>())
+                as *const u64;
+            assert_eq!(
+                f64::from_bits(*fields),
+                i as f64,
+                "instance {i}'s raw-f64 slot must survive the copy verbatim"
+            );
+            let moved_child = (*fields.add(1) & POINTER_MASK) as usize;
+            assert_ne!(
+                moved_child, children[i],
+                "instance {i}'s child must have been relocated and its slot rewritten"
+            );
+            assert!(
+                crate::arena::pointer_in_nursery(moved_child),
+                "instance {i}'s child must live in the to-space, not a stale address"
+            );
+            assert_string_bytes(moved_child as *const crate::StringHeader, &payloads[i]);
+        }
+        js_shadow_slot_set(i as u32, crate::value::TAG_UNDEFINED);
+    }
+}
+
+/// SABOTAGE ARM, made permanent. Publishing this shape `POINTER_FREE` — the
+/// other state the fast path could have chosen if it read the answer out of
+/// the memo instead of recomputing it from the pointer mask — makes the
+/// collector skip the whole payload and enumerate NOTHING. That is the
+/// use-after-free the witness above is green against, and the reason the memo
+/// deliberately stores no header state.
+///
+/// Asserted on the child-slot enumerator rather than by collecting, so no
+/// dangling pointer is ever created; the object's state is restored before the
+/// guard drops.
+#[test]
+fn a_pointer_free_declaration_on_this_shape_strands_the_child() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shape_install::test_clear();
+
+    let keys = keys_for(CLASS_WITNESS);
+    let (obj, _) = build_instance(CLASS_WITNESS, keys, 9.0, b"sabotage_child");
+    install(obj);
+    unsafe {
+        assert_eq!(
+            payload_child_count(obj),
+            1,
+            "the honest declaration enumerates the pointer field"
+        );
+
+        let header = header_from_user_ptr(obj as *const u8);
+        let saved = (*header)._reserved;
+        set_layout_state(header, GC_LAYOUT_POINTER_FREE);
+        assert_eq!(
+            payload_child_count(obj),
+            0,
+            "a POINTER_FREE declaration skips the whole payload — the child is \
+             invisible to marking AND to rewriting, which is what makes a wrong \
+             state a use-after-free rather than a slowdown"
+        );
+        (*header)._reserved = saved;
+        assert_eq!(payload_child_count(obj), 1);
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
@@ -39,8 +39,14 @@ const CLASS_WITNESS: u32 = 0x7510_05;
 /// A two-field shape, `{ n: number; s: string }`: slot 0 raw-f64, slot 1
 /// pointer-bearing. The pointer half is what makes the GC witness meaningful —
 /// a pointer-free shape would survive any declaration.
-const RAW_MASK: [u64; 1] = [0b01];
-const POINTER_MASK_WORDS: [u64; 1] = [0b10];
+///
+/// `static`, not `const`, and that matters here: the memo keys on the *address*
+/// of the mask words, and a `const` is inlined at each use site rather than
+/// having one. These stand in for the `private unnamed_addr constant` globals
+/// codegen emits per class, which do have one address, so a `static` is the
+/// faithful model as well as the stable one.
+static RAW_MASK: [u64; 1] = [0b01];
+static POINTER_MASK_WORDS: [u64; 1] = [0b10];
 
 fn keys_for(class_id: u32) -> *mut crate::array::ArrayHeader {
     let packed: &[u8] = b"n\0s\0";

--- a/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/shape_install_memo.rs
@@ -157,7 +157,10 @@ fn a_memo_hit_produces_the_same_header_state_as_the_install() {
     let (via_memo, _) = build_instance(CLASS_STATE, keys, 2.5, b"memo");
     install(via_memo);
     let (hits_after_second, _) = shape_install::counters::snapshot();
-    assert_eq!(hits_after_second, 1, "the second construction must be a hit");
+    assert_eq!(
+        hits_after_second, 1,
+        "the second construction must be a hit"
+    );
 
     unsafe {
         assert_eq!(
@@ -200,7 +203,11 @@ fn a_contradicting_field_is_refused_even_with_the_memo_warm() {
     // Same shape, but slot 0 — declared raw-f64 — holds a heap string.
     let (bad, _) = build_instance(CLASS_DIVERGE, keys, 0.0, b"child");
     let boxed = crate::string::js_string_from_bytes(b"not-a-double".as_ptr(), 12) as usize;
-    crate::object::js_object_set_field(bad, 0, crate::value::JSValue::from_bits(string_bits(boxed)));
+    crate::object::js_object_set_field(
+        bad,
+        0,
+        crate::value::JSValue::from_bits(string_bits(boxed)),
+    );
     install(bad);
 
     assert!(
@@ -253,8 +260,16 @@ fn ambiguity_poison_invalidates_the_memo() {
     let ambiguous = crate::object::js_object_alloc_class_inline_keys(CLASS_AMBIGUOUS, 0, 2, keys);
     let a = crate::string::js_string_from_bytes(b"a".as_ptr(), 1) as usize;
     let b = crate::string::js_string_from_bytes(b"b".as_ptr(), 1) as usize;
-    crate::object::js_object_set_field(ambiguous, 0, crate::value::JSValue::from_bits(string_bits(a)));
-    crate::object::js_object_set_field(ambiguous, 1, crate::value::JSValue::from_bits(string_bits(b)));
+    crate::object::js_object_set_field(
+        ambiguous,
+        0,
+        crate::value::JSValue::from_bits(string_bits(a)),
+    );
+    crate::object::js_object_set_field(
+        ambiguous,
+        1,
+        crate::value::JSValue::from_bits(string_bits(b)),
+    );
     let both_pointers: [u64; 1] = [0b11];
     js_gc_init_typed_shape_layout(
         ambiguous as u64,

--- a/crates/perry-runtime/src/tls_hot.rs
+++ b/crates/perry-runtime/src/tls_hot.rs
@@ -80,6 +80,8 @@ pub(crate) struct HotTls {
     pub(crate) typed_layouts: *mut u8,
     pub(crate) shape_layouts: *mut u8,
     pub(crate) per_object_layouts_nonempty: *mut u8,
+    // gc/shape_install.rs
+    pub(crate) shape_install_memo: *mut u8,
     // gc/roots/temp_roots.rs
     pub(crate) temp_roots: *mut u8,
 }
@@ -99,6 +101,7 @@ impl HotTls {
         typed_layouts: std::ptr::null_mut(),
         shape_layouts: std::ptr::null_mut(),
         per_object_layouts_nonempty: std::ptr::null_mut(),
+        shape_install_memo: std::ptr::null_mut(),
         temp_roots: std::ptr::null_mut(),
     };
 }
@@ -136,6 +139,7 @@ fn fill(slots: *mut HotTls) {
         (*slots).typed_layouts = crate::gc::typed_layouts_hot_addr();
         (*slots).shape_layouts = crate::gc::shape_layouts_hot_addr();
         (*slots).per_object_layouts_nonempty = crate::gc::per_object_layouts_nonempty_hot_addr();
+        (*slots).shape_install_memo = crate::gc::shape_install_memo_hot_addr();
         // Last, and the field `hot()` tests: every other slot is already
         // written by the time this one is non-null, so a re-entrant call from
         // inside one of the providers above cannot observe a half-filled cache
@@ -230,6 +234,11 @@ mod tests {
             "per_object_layouts_nonempty"
         );
         assert_eq!(
+            hot.shape_install_memo,
+            crate::gc::shape_install_memo_hot_addr(),
+            "shape_install_memo"
+        );
+        assert_eq!(
             hot.temp_roots,
             crate::gc::temp_roots_hot_addr(),
             "temp_roots"
@@ -264,6 +273,7 @@ mod tests {
                 "per_object_layouts_nonempty",
                 hot.per_object_layouts_nonempty,
             ),
+            ("shape_install_memo", hot.shape_install_memo),
             ("temp_roots", hot.temp_roots),
         ] {
             assert!(!ptr.is_null(), "{name} slot was left null by fill()");


### PR DESCRIPTION
Item 1 of #7510 — "construction should become a header bit-set, not a side-table insert" — plus a finding on the #7512 residual that was folded into it. #7525 landed the prerequisite (the per-object side tables are now provably empty on a monomorphic workload) and named this as the next lever.

## Result

| bench (20M constructions) | `main` | this branch | speedup |
|---|--:|--:|--:|
| `churn_alloc` — `{v, w}` object literal | 1.93 s | 1.77 s | **1.090×** |
| `churn_alloc` — independent repeat | 1.99 s | 1.83 s | **1.087×** |
| `push_cls` — `new Node(v, w)` | 2.31 s | 2.10 s | **1.100×** |
| `poly_shapes` — 16 shapes cycled, the memo's worst case | 2.89 s | 2.73 s | **1.059×** |

Interleaved best-of-9 user CPU on the pinned quiet host (`perry-macos.local`, M1/8 cores, load 1.6–2.4 across the runs). Arms alternate every round, so drift in machine state hits both equally.

**Hit rate, counted rather than reasoned about.** An lldb breakpoint with an auto-continue command on `shape_install_shared`, over the identical program:

| binary | constructions | `shape_install_shared` entries |
|---|--:|--:|
| `main` | 100,000 | **100,000** |
| this branch | 100,000 | **1** |
| this branch | 20,000,000 | **1** |

#7525's first commit shipped a fast path that fired once in 40 million calls and was believed anyway. This is the same instrument pointed the other way.

The profile agrees: on the same symbolicated 2 s sample, `shape_install_shared` drops from 33 samples to below the reporting threshold (< 7), and `js_gc_init_typed_shape_layout` from 133 to 106.

**No GC regression, in the strongest available form.** `PERRY_GC_DIAG=1` output is **byte-identical** between the arms on all three benchmarks — 315 lines for `churn_alloc`, 317 for `push_cls`, 311 for `poly_shapes`; every cycle's `copied_objects` / `copied_bytes` / `promoted_*` / `freed_bytes` and every step decision the same. Independently, the 12 `gc_ratchet` probes measured back-to-back under both runtimes agree on **108 of 108** semantic metrics (retention + GC accounting), 0 differing. That is what you would expect: nothing here changes what is allocated or what the collector decides, only how the layout metadata gets published.

> Reproducing that locally: `gc_ratchet.py check` against the pinned baseline fails on my machine with 29 regression rows — and fails with the *same* 29 rows for the unmodified `origin/main` runtime. The pinned artifact was captured on the dedicated bench host at `perry 0.5.1280`; comparing anything to it from a loaded laptop at 0.5.1300 measures baseline drift, not this change. The main-vs-branch diff above is the control that isolates it, and CI's `gc-ratchet` job is the gate.

This does **not** meet #7510's headline `≥1.5×` bar, and the ticket already records why: the profile it was filed from is out of date, and after #7469/#7474/#7486/#7487/#7501/#7525 the whole `gc::layout` family is ~11% of `churn_alloc`, not 33.6%. Removing the shape-install half of it entirely could not have delivered 1.5×. #7510 stays open for items 2 and 3 (`layout_forget_object` is now 1.4%, `layout_note_slot` 7.5%) and for the #7512 residual discussed at the bottom.

## What was costing 11%

Symbolicated leaf profile of `churn_alloc` (20M `{v, w}` object literals; pinned quiet host at load 1.8; 1488 samples):

| symbol | samples | share |
|---|--:|--:|
| `js_gc_init_typed_shape_layout` | 133 | 8.9% |
| `shape_install_shared` | 33 | 2.2% |

Since #6893 the descriptor these two install is per-**shape**, not per-object: every same-shape object shares one canonical `TypedLayoutDescriptor` in `SHAPE_LAYOUTS`, keyed by the shared `keys_array`. The only per-object work left is two header bits — `GC_OBJ_TYPED_LAYOUT_INTACT` and `GC_LAYOUT_POINTER_FREE`/`GC_LAYOUT_SIDE_MASK`.

The call did not know that. For the 20-millionth `{v, w}` literal it still

- built a `TypedLayoutDescriptor` — 72 bytes, two 32-byte `Vec`-carrying enums, one of them cloned, all of it dropped on the way out,
- took a `RefCell` borrow on the thread-local `SHAPE_LAYOUTS`,
- hashed the `keys_array` pointer and probed the map,
- compared the freshly built descriptor field-by-field against the one already stored,

to reach the conclusion the *first* construction had already reached. `shape_install_shared`'s hit arm — `Some(Some(existing)) if existing == descriptor` — writes nothing at all.

## The design

`gc/shape_install.rs` memoises exactly that map answer, in a thread-local direct-mapped table:

> `SHAPE_LAYOUTS[keys]` holds `Some(D)`, where `D` is the descriptor that `(slot_count, raw_words, pointer_words)` describes.

On a hit the construction is: validate, set two header bits, done.

**The memo decides nothing about the object.** Everything the header declaration rests on is still re-derived per construction, ahead of the memo:

- `field_count == slot_count`,
- raw-f64 / pointer mask disjointness,
- the per-slot loop asserting each raw-f64 slot holds a plain double and no pointer-bearing slot sits outside the pointer mask.

And `POINTER_FREE` vs `SIDE_MASK` is **recomputed from the pointer mask**, never read back from the memo — the entry carries no header state at all. That split is the soundness bar: a wrong `POINTER_FREE` is a use-after-free factory (`heap_payload_slot_selection` short-circuits on it and skips the whole payload without consulting any mask), so that decision must not depend on a cache. A stale entry can only cost work.

While reworking those checks they stopped building a `LayoutSlotMask` at all — they read the caller's mask words directly. `LayoutSlotMask` is a 32-byte enum with a `Vec` arm, so two of them meant drop glue on six early-return paths and, for any shape wider than 64 slots, two heap allocations per construction. `LayoutSlotMask::intersects` survives as the test-only reference implementation that `mask_word_helpers_agree_with_layout_slot_mask` pins the three word helpers against, across trailing-zero words, bits past `slot_count`, and slots past the end of the array.

### Self-healing

An entry is falsified by exactly one transition: `SHAPE_LAYOUTS[keys]` ceasing to be `Some(D)`. `shape_install_shared` is the only writer of that map and its only such transition is the ambiguity poison (`Some(Some(_)) => insert(None)`, two live layouts sharing one key set). That branch drops the whole table. Entries are never removed from `SHAPE_LAYOUTS` and never overwritten with a *different* `Some`, so there is no other way to go stale.

Everything else already degrades to a miss:

- the `keys_array` **moves** — live objects report the new address, nothing matches, the slow path re-installs;
- the old address is **recycled** by another shape — its constructions arrive with different mask globals, so they miss and poison; if they arrive with the *same* mask globals and slot count the entry's claim is still true of them, because `SHAPE_LAYOUTS` is keyed by that same address and its entries are never pruned;
- `PERRY_SHAPE_LAYOUT_KEYED=0` — `record` is only reachable from a successful `shape_install_shared`, which that knob gates, so the table stays empty and every lookup misses.

**This table is not a GC root**, and the module says so explicitly, because a runtime-side cache of a raw heap pointer usually *is* one and the static root-dominance checker cannot see it. `keys` is only ever compared as an integer; it is never dereferenced, never handed to the mutator, never used to keep anything alive.

### Two sizing decisions, both measured

The slot index mixes the two mask-global addresses in with the shape. Two object-literal sites with the same key names share one `keys_array` but get separate `private unnamed_addr constant` mask globals unless LLVM's constant merger folds them; keying on the shape alone would put both in one entry and let them evict each other every iteration of a loop that builds both. Any index is correct — the full tuple is compared on the way out — so this is purely about not colliding.

The table is 32 entries, not 8. A direct-mapped table cycled round-robin by more shapes than it has slots hits **zero** percent of the time: each entry is evicted by its partner before it is read again, so it pays the probe and gets nothing. A 16-shape churn loop against 8 slots measured a reproducible **0.993×** — the one regression this change had. At 32 slots the same loop fits and turns into **1.059×** (and 1.070× against the 8-slot build directly), with the monomorphic numbers unchanged. The whole table is 1 KiB of const-initialised thread-local, so a program with one shape pays for a page it never touches.

## Testing

`gc/tests/layout_trace/shape_install_memo.rs` plus `gc/shape_install.rs`'s own unit tests, 9 in total.

**It fires** — `memo_fires_on_every_repeat_construction_of_one_shape` counts: 64 instances of one shape must produce exactly 1 install and 63 hits. This is the assertion #7525 did not have, and its absence is why that PR's first commit shipped a fast path that hit once in 40 million calls.

**It decides nothing** — `a_memo_hit_produces_the_same_header_state_as_the_install` compares the `_reserved` layout bits of an object published by the memo against one published by the install; `a_contradicting_field_is_refused_even_with_the_memo_warm` builds an instance whose raw-f64-declared slot holds a heap string and asserts it is refused with the table warm, that the hit counter did not move (validation ran first), and that both of its heap fields stay enumerable under the conservative fallback.

**It heals** — `ambiguity_poison_invalidates_the_memo` installs a shape, warms the memo, poisons that shape by installing a different layout under the same key names, and asserts the next construction of the original layout misses and lands correctly on the per-object path.

**The GC witness** — `memo_installed_objects_survive_a_copying_minor_with_their_children` builds six instances of a `{ n: number; s: string }` shape, asserts 5 of the 6 were published by the memo (subject-was-live, not merely "nothing threw"), forces an evacuating minor, and asserts the cycle actually moved ≥ 12 objects, that every instance relocated, that its raw-f64 slot survived verbatim, and that its string child relocated with its slot rewritten and its bytes intact.

**The sabotage arm** — `a_pointer_free_declaration_on_this_shape_strands_the_child` is permanent: it publishes this exact shape `POINTER_FREE` by hand and asserts the collector then enumerates **zero** payload children. That is the use-after-free the witness is green against, and it is why the memo stores no header state.

Sabotage verified by hand, three ways, each caught:

| sabotage applied | what failed |
|---|---|
| fast path reads the state out of the memo (`set_layout_state(POINTER_FREE)` unconditionally) | the witness, at `instance 1 must expose its one pointer field to the collector` — left 0, right 1 |
| memo hit short-circuits the per-slot validation | `an instance that contradicts its shape's mask must not be declared intact` |
| poison branch does not call `invalidate()` | `the poison must have dropped the memo entry` |

Beyond the unit tests:

- `cargo test -p perry-runtime` — **1771 passed, 0 failed**.
- 20 object/class/shape-heavy programs from `test-files/` compiled and run under both arms: **byte-identical output, 20/20**. Re-run against the Node oracle on the final build: 18 match byte-for-byte, 1 is skipped (node cannot run it), and 1 is `test_gap_2159_defineproperty_class_prototype`, an entry that is already in `test-parity/known_failures.json` as a standing gap pre-dating v0.5.1205.
- The same 20 programs under `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=64` — the arm that faults on a stale from-space deref — produce output identical to the plain runs, **20/20**. Verified not vacuous: `PERRY_GC_DIAG=1` prints `[gc-fromspace-protect] retired_set=…` five times on those runs, so copying minors really did retire and quarantine from-space pages.
- The #5094 access-path benchmarks (`09_method_calls`, `bench_object_property`, `bench_numeric_array_downgrade`) show no change — they run in 10–120 ms, which is below what this harness can resolve, so this is "no regression", not a measurement.
- `raw_handle_debt.py` 999 (baseline 999); `gc_store_site_inventory.py`, `addr_class_inventory.py`, `check_file_size.sh` all clean; `cargo fmt --all -- --check` clean.

## The #7512 residual: why the reorder still does not work

The comment on #7510 folds in #7512's remaining half — `js_gc_init_typed_shape_layout` is emitted **after** the constructor call, so no raw-f64 class-field store inside a constructor body can pass its guard. This PR does not move it, and the reason is sharper than "the slots hold `undefined`":

`undefined` is `0x7FFC_…`, and `layout_raw_f64_bits` rejects any tag in `[SHORT_STRING_TAG = 0x7FF9, STRING_TAG = 0x7FFF]`, so a pre-ctor install fails validation today. Relaxing that — accepting `undefined` in a raw-f64 slot at install time — would be **safe for the collector**: `undefined` is not pointer-bearing, so a skipped raw-f64 slot strands nothing.

It is not safe for **readers**. `class_field_fast_contract` states the contract the codegen-inlined path relies on: "the codegen-inlined fast path concludes *slot K is raw-f64* purely from the per-object intact bit … the inline path could never read a NaN-boxed value as a raw double". Publishing the layout before the constructor runs makes exactly that false for every declared-but-not-yet-assigned field, and `class C { v: number; constructor() { console.log(this.v) } }` must still print `undefined`.

So it is not a runtime relaxation of the install-time check. It needs a codegen-side definite-assignment proof — every raw-f64-masked field written before any read of it — or a two-stage install that declares slots raw-f64 as the prologue fills them. Either is a separate change with its own soundness surface, so it stays on #7510.

Refs #7510, #7512, #7525, #6893, #5094.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved typed-shape construction by reusing recently installed layout information.
  * Added safe fallback behavior when cached information is unavailable or invalidated.
* **Bug Fixes**
  * Strengthened validation of object fields against their declared layouts.
  * Ensured layout changes invalidate cached installation data.
  * Preserved correct behavior during garbage collection and pointer tracing.
* **Tests**
  * Added coverage for reuse, invalidation, layout validation, pointer tracing, and garbage-collection safety.
* **Chores**
  * Updated the application version to 0.5.1303.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->