### PR TITLE
fix(gates): gc-root-dominance defrag probe follows the file move (#7443)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1303
+**Current Version:** 0.5.1304
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1303"
+version = "0.5.1304"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1303"
+version = "0.5.1304"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1303"
+version = "0.5.1304"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1303"
+version = "0.5.1304"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1303"
+version = "0.5.1304"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7540-gc-root-dominance-rotted-probe.md
+++ b/changelog.d/7540-gc-root-dominance-rotted-probe.md
@@ -1,0 +1,20 @@
+### Gates: repair the gc-root-dominance probe whose premise rotted on a file move
+
+`gc_root_dominance_check.py`'s `_probe_old_defrag_off_by_default` read
+`crates/perry-runtime/src/gc/oldgen.rs` to confirm old-page defrag is still
+opt-in. #7443 moved that code to `gc/oldgen_defrag.rs`, so the probe stopped
+finding `PERRY_GC_OLD_DEFRAG` and began reporting
+*"old-page defrag may now be unconditional"* — on a tree where it is, in fact,
+still gated exactly as before.
+
+That is worse than a red job. This probe's failure does not merely fail the
+run: by the checker's own contract it declares **the reports it was
+suppressing to be real again**, so a file rename silently converts a passing
+audit into a wall of false positives in the gate family that the whole #7341
+rooting campaign depends on.
+
+The probe now searches a list of candidate sources and reports which one it
+validated, so the next split costs a one-line addition instead of a rotted
+premise. Its failure message names the list. Sabotage-verified both ways:
+deleting the `old_page_defrag_enabled()` short-circuit still makes it refuse,
+so the repair did not turn it into a rubber stamp.

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -2017,27 +2017,47 @@ def _probe_class_keys_longlived():
     return (True, "%d longlived allocation(s)" % len(allocs))
 
 
+# The defrag gate moved from `gc/oldgen.rs` to `gc/oldgen_defrag.rs` in #7443.
+# Search both rather than hardcoding one: this probe FAILING does not merely
+# turn the job red, it declares the reports it suppresses to be real again, so
+# a file rename silently converts a passing audit into a wall of false
+# positives. Listing candidates keeps the next split cheap, and the
+# "not found in ANY of" message names them so the fix is obvious. (#7540)
+_OLD_DEFRAG_SOURCES = (
+    "crates/perry-runtime/src/gc/oldgen_defrag.rs",
+    "crates/perry-runtime/src/gc/oldgen.rs",
+)
+
+
 def _probe_old_defrag_off_by_default():
     """Old-page defrag still returns an empty selection unless opted in."""
-    try:
-        with open("crates/perry-runtime/src/gc/oldgen.rs",
-                  encoding="utf-8", errors="replace") as fh:
-            src = fh.read()
-    except OSError:
-        return (False, "crates/perry-runtime/src/gc/oldgen.rs not readable")
-    if "PERRY_GC_OLD_DEFRAG" not in src:
-        return (False, "gc/oldgen.rs no longer mentions PERRY_GC_OLD_DEFRAG; "
-                       "old-page defrag may now be unconditional")
-    body = rust_fn_body("crates/perry-runtime/src/gc/oldgen.rs",
-                        "select_old_page_defrag_pages")
+    src = None
+    src_path = None
+    for cand in _OLD_DEFRAG_SOURCES:
+        try:
+            with open(cand, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        if "PERRY_GC_OLD_DEFRAG" in text:
+            src, src_path = text, cand
+            break
+    if src is None:
+        return (False, "PERRY_GC_OLD_DEFRAG not mentioned in any of %s; "
+                       "old-page defrag may now be unconditional (or the file "
+                       "moved again -- add it to _OLD_DEFRAG_SOURCES)"
+                       % ", ".join(_OLD_DEFRAG_SOURCES))
+    body = rust_fn_body(src_path, "select_old_page_defrag_pages")
     if body is None:
-        return (False, "select_old_page_defrag_pages not found in gc/oldgen.rs")
+        return (False,
+                "select_old_page_defrag_pages not found in %s" % src_path)
     if not re.search(r"if\s+!old_page_defrag_enabled\(\)\s*\{\s*\n\s*return\s+"
                      r"OldPageDefragSelection::default\(\);", body):
         return (False, "select_old_page_defrag_pages no longer short-circuits "
                        "to an empty selection when defrag is disabled — "
                        "old-arena objects may relocate on a default build")
-    return (True, "gated on PERRY_GC_OLD_DEFRAG, empty selection when off")
+    return (True, "gated on PERRY_GC_OLD_DEFRAG in %s, empty selection when off"
+            % src_path)
 
 
 def _probe_class_keys_global_is_a_root():


### PR DESCRIPTION
`_probe_old_defrag_off_by_default` read `crates/perry-runtime/src/gc/oldgen.rs` to confirm old-page defrag is still opt-in. **#7443 moved that code to `gc/oldgen_defrag.rs`**, so the probe stopped finding `PERRY_GC_OLD_DEFRAG` and began reporting *"old-page defrag may now be unconditional"* — on a tree where it is still gated exactly as before.

This is worse than a red job. By the checker's own contract, this probe failing declares **the reports it was suppressing to be real again** — so a file rename silently converts a passing audit into a wall of false positives, in the gate family the entire #7341 rooting campaign depends on. Found by an agent working #7497, which flagged it alongside `gc-ratchet` as red on `main` for reasons unrelated to its own PR.

The probe now searches a candidate list and reports which source it validated, so the next split costs one line rather than a rotted premise; the failure message names the list.

**Sabotage-verified both directions**, because a repaired probe that can no longer fail is the worse outcome:
- as-is → `(True, 'gated on PERRY_GC_OLD_DEFRAG in .../oldgen_defrag.rs, empty selection when off')`
- with the `old_page_defrag_enabled()` short-circuit deleted → `(False, 'select_old_page_defrag_pages no longer short-circuits …')`

`--self-test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the application version to **0.5.1304**.
  * Improved validation of garbage-collection configuration across updated source layouts.
  * Diagnostics now provide clearer information when expected configuration files or settings are not found.
  * Continued safeguards ensure defragmentation remains disabled by default where required.
* **Documentation**
  * Updated the documented current version and added release notes for the validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->