### PR TITLE
ci(security): ignore RUSTSEC-2026-0235 with build-graph evidence (#7555)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -58,6 +58,22 @@ jobs:
         #   PDF objects. Fixed in lopdf >=0.42.0, but lopdf is transitive
         #   via printpdf (perry-ext-pdf); printpdf's latest (0.9.1) still
         #   pins lopdf ^0.39, so there is no actionable upstream bump yet.
+        #   (Re-checked 2026-08-07: printpdf 0.10.1 — the version dependabot
+        #   proposes in #7412 — STILL pins lopdf 0.39.0, so that PR does not
+        #   close this. See #7555.)
+        # - RUSTSEC-2026-0235 (rkyv 0.7.46) — OOB reads validating archives
+        #   containing Rc/Arc. **Not in Perry's build graph at all.** `rkyv`
+        #   is an OPTIONAL feature of rust_decimal (`rkyv = ["dep:rkyv"]`);
+        #   perry-stdlib enables only `features = ["maths"]`, so it is never
+        #   activated. Verified three ways on 2026-08-07:
+        #     * `cargo tree -e normal -i rkyv` -> "did not match any packages"
+        #     * `cargo tree -p rust_decimal --depth 1 -e features` resolves to
+        #       arrayvec / serde / num-traits only
+        #     * zero `rkyv` artifacts in the dev or release deps directories
+        #   cargo-audit reads Cargo.lock, which lists optional dependencies
+        #   whether or not any feature activates them, so this is a
+        #   lockfile-only finding. Re-evaluate if anything ever enables the
+        #   `rkyv` or `rkyv-safe` feature of rust_decimal.
         #   perry-ext-pdf is a PDF *creation* API (createPdf/addText/…),
         #   not a parser of untrusted PDFs, so the deeply-nested-input
         #   surface is not reached. Tracking for a printpdf release that
@@ -74,7 +90,8 @@ jobs:
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0118 \
             --ignore RUSTSEC-2026-0119 \
-            --ignore RUSTSEC-2026-0187
+            --ignore RUSTSEC-2026-0187 \
+            --ignore RUSTSEC-2026-0235
 
   # Soak parity gate + external-tool pin gate. Always-run (deliberately not
   # path-filtered — nub hid this gate in a path-gated job and it silently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1314
+**Current Version:** 0.5.1315
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1314"
+version = "0.5.1315"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1314"
+version = "0.5.1315"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1314"
+version = "0.5.1315"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1314"
+version = "0.5.1315"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1314"
+version = "0.5.1315"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7555-rkyv-audit-ignore.md
+++ b/changelog.d/7555-rkyv-audit-ignore.md
@@ -1,0 +1,24 @@
+### CI: unblock `security-audit`, a REQUIRED context that was red on every merge
+
+`security-audit` is in branch protection's required set and had failed its last
+six completed `main` runs, which means **every merge was bypassing it** — the
+"REQUIRED + red ⇒ universal bypass" pattern CLAUDE.md names.
+
+The sole unignored finding was **RUSTSEC-2026-0235** (`rkyv` 0.7.46, OOB reads
+when validating archives containing `Rc`/`Arc`). It is **not in Perry's build
+graph**: `rkyv` is an optional feature of `rust_decimal`
+(`rkyv = ["dep:rkyv"]`) and `perry-stdlib` enables only `maths`. Verified three
+ways — `cargo tree -e normal -i rkyv` reports "did not match any packages",
+`cargo tree -p rust_decimal --depth 1 -e features` resolves to
+arrayvec/serde/num-traits only, and there are zero `rkyv` artifacts in the dev
+or release deps directories. `cargo audit` reads `Cargo.lock`, which lists
+optional dependencies regardless of feature activation, so this is a
+lockfile-only finding.
+
+Added to the existing `--ignore` list with that evidence recorded inline, plus
+a re-evaluation trigger (anything enabling `rkyv`/`rkyv-safe` on
+`rust_decimal`). `cargo audit` now exits 0.
+
+Also corrects the note on **RUSTSEC-2026-0187** (`lopdf`): dependabot #7412
+proposes printpdf 0.10.1, which **still pins lopdf 0.39.0**, so that PR does
+not close the advisory despite looking like it would.


### PR DESCRIPTION
`security-audit` is a **required** branch-protection context and had failed its last six completed `main` runs — so every merge was bypassing it. That is CLAUDE.md's "REQUIRED + red ⇒ universal bypass" pattern, live.

The sole *unignored* finding was **RUSTSEC-2026-0235** (`rkyv` 0.7.46, OOB reads validating archives containing `Rc`/`Arc`). It is **not in Perry's build graph**:

- `rkyv` is an **optional feature** of `rust_decimal` (`rkyv = ["dep:rkyv"]`); `perry-stdlib` enables only `features = ["maths"]`.
- `cargo tree -e normal -i rkyv` → **"did not match any packages"**
- `cargo tree -p rust_decimal --depth 1 -e features` → arrayvec / serde / num-traits only
- zero `rkyv` artifacts in the dev or release deps directories

`cargo audit` reads `Cargo.lock`, which lists optional dependencies whether or not any feature activates them — so this is a lockfile-only finding, not exposure. Added to the existing `--ignore` list with that evidence inline and an explicit re-evaluation trigger (anything enabling `rkyv`/`rkyv-safe`). `cargo audit` now **exits 0**.

Also corrects the standing note on **RUSTSEC-2026-0187** (`lopdf`, already ignored): dependabot #7412 proposes printpdf 0.10.1, which **still pins lopdf 0.39.0**. I checked out that branch's lockfile — it does not close the advisory despite appearing to. Commented on #7412 so nobody merges it as the security fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 0.5.1315.
  - Improved security audit handling and documentation for a non-active advisory.
  - Added guidance for reviewing the advisory if the affected optional component becomes active.

- **Documentation**
  - Updated release documentation with the latest security-audit status.
  - Clarified the current status of a separate print-related security advisory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->