### PR TITLE
docs(engine-plan): #7510 measured out; _tlv_get_addr is the top lever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1316
+**Current Version:** 0.5.1317
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1316"
+version = "0.5.1317"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1316"
+version = "0.5.1317"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1316"
+version = "0.5.1317"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1316"
+version = "0.5.1317"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1316"
+version = "0.5.1317"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7560-plan-tls-lever.md
+++ b/changelog.d/7560-plan-tls-lever.md
@@ -1,0 +1,17 @@
+### Docs: #7510 measured out; `_tlv_get_addr` is the top remaining lever
+
+All three of #7510's items are now answered by measurement rather than
+argument. Item 1 shipped (#7535), item 2 shipped (#7525), and **item 3
+collapsed on its own**: `layout_note_slot` costs **0.03%** on `churn_alloc`
+(2 of 5,869 leaf samples), codegen emits **zero** `js_gc_note_slot_layout`
+sites for that workload, and stubbing the function out entirely is worth
+1.016x. The type-propagation work (#7550/#7552) and declaration-at-allocation
+(#7501/#7532) removed the calls before anyone optimised them.
+
+The plan's next lever is now `_tlv_get_addr` at **30.5%** of `churn_alloc` —
+#7469's structural half. It has grown as a *share* because everything around
+it shrank, not because it regressed.
+
+Also records the campaign's most repeated failure mode: three times a ticket's
+headline number was stale by the time it was worked (33.6% -> 11%,
+14.5% -> 3.0% -> 1.7%, 7.5% -> 0.03%). Re-measure before scoping.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -158,11 +158,24 @@ already be 2.2x better. Tracked in **#7478**.
    them — they close real use-after-frees.
 2. **#7478 — the JSON tape's scan path**, where our optimized build is 2.2x
    slower than our unoptimized one. The 1350 ms idiomatic row is the floor.
-3. **#7510 — `gc::layout` side tables**, whose real remaining lever is
-   `js_gc_init_typed_shape_layout` + `shape_install_shared` (~13%), rebuilding
-   both masks on every construction of an already-installed shape. #7525 landed
-   the emptiness prerequisite and corrected the ticket's stale premise
-   (`layout_forget_object` is 3.0%, not the 14.5% it was filed on).
+3. **`_tlv_get_addr` — thread-local addressing, now 30.5% of `churn_alloc`**
+   and the largest single line in the profile. This is #7469's structural half
+   (a context pointer, or inlined bump-allocation in generated code); #7474's
+   hot-TLS cache took it from 34% to ~14–17%, and it has climbed back as a
+   *share* because everything around it shrank, not because it regressed.
+
+   **#7510 is effectively closed.** All three items were measured out rather
+   than argued away: item 1 shipped (#7535, install now 1x per 20M
+   constructions), item 2 shipped (#7525), and **item 3 collapsed to 0.03%** —
+   2 samples of 5,869, with codegen emitting *zero* `js_gc_note_slot_layout`
+   sites for `churn_alloc` and a stub-it-entirely ceiling of 1.016x. The
+   type-propagation work (#7550/#7552) plus declaration-at-allocation
+   (#7501/#7532) removed the calls before anyone optimised them.
+
+   **Three times this campaign a ticket's headline number was stale by the time
+   it was worked** (#7510's 33.6% -> 11%, `layout_forget_object`'s 14.5% ->
+   3.0% -> 1.7%, item 3's 7.5% -> 0.03%). Re-measure before scoping; a profile
+   more than a few merges old sends people at the wrong thing.
 4. **#7511 — write barriers (16.1%)**. Correctness-first: acceptance requires
    `PERRY_GC_VERIFY_EVACUATION=1` / `PERRY_GC_VERIFY_MARK=1` and the ratchet
    probes, because a wrong answer here corrupts memory rather than slowing it.


### PR DESCRIPTION
All three #7510 items are now answered by measurement. Items 1 and 2 shipped (#7535, #7525); **item 3 collapsed on its own** — `layout_note_slot` is **0.03%** of `churn_alloc` (2 of 5,869 leaf samples), codegen emits **zero** `js_gc_note_slot_layout` sites for that workload, and a stub-it-entirely ceiling A/B is worth 1.016×. The type-propagation work (#7550/#7552) and declaration-at-allocation (#7501/#7532) removed the calls before anyone optimised them.

Next lever: **`_tlv_get_addr` at 30.5%** of `churn_alloc` — #7469's structural half. It grew as a *share* because everything around it shrank, not because it regressed.

Also records the campaign's most repeated failure mode, now three for three: a ticket's headline number was stale by the time it was worked (#7510 33.6% → 11%; `layout_forget_object` 14.5% → 3.0% → 1.7%; item 3 7.5% → 0.03%). Re-measure before scoping.

Docs only.