### PR TITLE
perf(hir): map_1m — the whole gap is `for (… of m.values())` building a {value,done} object per element

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1317
+**Current Version:** 0.5.1318
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1317"
+version = "0.5.1318"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1317"
+version = "0.5.1318"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1317"
+version = "0.5.1318"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1317"
+version = "0.5.1318"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1317"
+version = "0.5.1318"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7561-map-view-for-of.md
+++ b/changelog.d/7561-map-view-for-of.md
@@ -174,6 +174,25 @@ direct `for (… of m)` fast path has the same property. A `Map` subclass types 
 `Type::Named`, never `Type::Generic`, so an overriding subclass method is never
 bypassed.
 
+**One shape had to be excluded after it was measured, not before.** The
+single-ident pair head initially fired for `for await (const e of m)` too, and
+the array-pattern arms have always dropped the per-iteration `Await`, so that
+looked consistent. It is not: the pair head *replaces* a binding that was
+`Await(<materialised>[i])`, and dropping that stopped the loop draining
+microtasks at all —
+
+```
+node    micro-0|pair:a=1|micro-a|pair:b=2|micro-b|pair:c=3|micro-c|after-direct
+before  micro-0|pair:a=1|micro-a|pair:b=2|micro-b|pair:c=3|after-direct|…|micro-c
+after   pair:a=1|pair:b=2|pair:c=3|after-direct|…|micro-0|micro-a|micro-b|micro-c
+```
+
+`map_index_fast_path_head` now takes an `allow_pair_head` flag that the two
+desugars pass as `!is_await`, so a `for await` Map loop keeps exactly the
+lowering it had. `for_await_is_never_rewritten` covers both the view call and
+the direct head, and a sibling case proves the gate is per-loop — a synchronous
+single-ident head in the same function still gets the fast path.
+
 **Measurement trap worth recording.** The first A/B ran all nine loop shapes in
 one process and reported two apparent 2× regressions in shapes this change does
 not touch (`for (const e of m.entries())` 570 → 1180 ms, `[...m.values()]`

--- a/changelog.d/7561-map-view-for-of.md
+++ b/changelog.d/7561-map-view-for-of.md
@@ -93,6 +93,35 @@ the iteration's garbage is gone — and both arms still run copying minors with
 
 ### Fixed
 
+**`for (const k of m.keys())` could hand the loop body a moved string
+(#7561).** The route it took, `make_iter_result`, allocates the strings
+`"value"` and `"done"` on every `.next()` while the caller's `value: JSValue`
+sits in a bare register the collector cannot see or rewrite. A probe over
+40 000 heap-string Map keys that allocates inside the loop body already gets a
+**wrong answer with no instruments at all** (one mismatched key, and a `chars`
+total of 3,944,095,011 where 1,548,890 is correct); under
+`PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1
+PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` on a `PERRY_GC_MOVING_LOOP_POLLS=1`
+build, with the instrument proven live by its
+`[gc-fromspace-protect] mode=ProtectPages retired_set=#0 blocks=17` line, it
+takes a bus error whose reporter names the site exactly:
+
+```
+[gc-fromspace-protect] FAULT: signal 10 at 0x5b6f1f8ffe4
+  This address is RETIRED FROM-SPACE. …
+  last-known object: user_ptr=0x5b6f1f8ffd8 obj_type=3 size=40
+2  perry_runtime::iterator_helpers::make_iter_result + 172
+4  object::native_call_method::handle_methods::dispatch_handle + 4376
+```
+
+The index walk does not build a result object, so the defect is unreachable for
+`for (… of map/set …)` after this change: the same probe under the same flags
+is `mismatch: 0` with **zero faults** and the instrument still live
+(`retired_set=#5`), and a 150 000-key variant is clean across 4 copying minors
+— one moving 150,014 objects — plus a `PERRY_GC_VERIFY_EVACUATION=1` pass. It
+is **not** fixed for generators, custom iterators, `yield*` or spread, which
+still drive `make_iter_result`; that half is #7564.
+
 **A single-ident Map for-of head bound a snapshot, not the Map (#7561).**
 `for (const e of m)` went through `MapEntries`, which materialises the whole Map
 up front, so the loop could not see its own body's writes:
@@ -159,4 +188,5 @@ silently truncating at 100,000 elements (#7562), a SIGSEGV iterating a
 `values()` override on a `class X extends Map` (#7563), and `make_iter_result`
 allocating five objects per `.next()` where four are the same constant every
 call (#7564) — the general form of what this change routes around for Map and
-Set, still paid by every generator and custom iterator.
+Set, still paid by every generator and custom iterator, and carrying the
+rooting defect above on that path too.

--- a/changelog.d/7561-map-view-for-of.md
+++ b/changelog.d/7561-map-view-for-of.md
@@ -1,0 +1,162 @@
+### Performance
+
+**`for (… of m.values() / m.keys() / m.entries())` is now the same
+allocation-free index walk as `for (const [k, v] of m)` (#7561).** `map_1m` was
+the largest absolute time in the public benchmark artifact — 1233.7 ms against
+bun's 256.5 and node's 320.1, nearly double the next-slowest kernel — and
+nobody had looked at it. Profiling first says the Map was never the problem.
+
+Phase decomposition on the pinned quiet mini (5 interleaved runs, load 1.52,
+node 26.5.1 / bun 1.3.14):
+
+| phase | before | after | node | bun |
+|---|--:|--:|--:|--:|
+| insert 500k `m.set("key_" + i, …)` | 220 ms | 219 ms | 140 | 97 |
+| look up 500k `m.get("key_" + i)` | **76 ms** | **76 ms** | 115 | 103 |
+| **`for (const v of m.values())`** | **512 ms** | **5 ms** | 4 | 6 |
+| 10k `m.has("missing_" + i)` misses | ~1 ms | ~1 ms | 5 | 3 |
+
+Perry already **won lookup** — 76 ms against node's 115 and bun's 103 — and won
+the miss loop. Insert is 1.6× node, and its symbolicated profile puts 55.5% in
+`js_string_concat_value` building the keys, with 45.5% of the whole probe inside
+the `gc_collect_minor_with_trigger` those string allocations trigger;
+`find_string_key_index` is 17.25%. That is the #7469 allocation path, not a Map
+story. **Iteration was 128× node**, and it was the entire gap.
+
+Inside it (9679 leaf samples, `PERRY_DEBUG_SYMBOLS=1`): `.values()` produced a
+real Map **iterator object** and drove it through the generic protocol, one
+`.next()` per element.
+
+| stage | inclusive |
+|---|--:|
+| `js_typed_feedback_native_call_method_by_id` — the per-element `.next()` | **76.37%** |
+| └ `dispatch_handle` → `dispatch_map_iterator_method` | 62.91% |
+| **└ `make_iter_result` — building `{ value, done }`** | **55.08%** |
+| ├ `js_array_push_f64` (the two keys) → `note_array_slot` → `invalidate_representation_change` → `pthread_mutex_lock` | 22.09% (10.96% in the mutex) |
+| ├ `string_storage_alloc` — allocating `"value"` and `"done"`, **per element** | 16.05% |
+| ├ `js_array_alloc` (the keys array) | 9.00% |
+| ├ `js_object_set_field` ×2 | 7.09% |
+| ├ `js_object_alloc_with_parent` — the result object | 5.09% |
+| └ `shape_id_for_keys_ensure` | 4.99% |
+| `gc_check_trigger` → `gc_collect_minor_with_trigger` (driven by the above) | 16.59% |
+| `js_object_get_field_ic_miss` — reading `.value` / `.done` back off it | 12.18% |
+| `_tlv_get_addr` | 12.98% |
+
+**Five heap allocations per element** — result object, two key strings,
+two-element keys array, shape install — 2.5 M of them for one sweep of a 500k
+Map. The identical iteration written directly, `for (const [, v] of m)`,
+**already cost 5 ms**: it lowers to a delete-safe index walk over the flat
+entries buffer and allocates nothing. The lowering keyed on the *syntax* of the
+for-of subject rather than on what it produces, so 161× separated two spellings
+of one loop.
+
+`for_head::rewrite_collection_view_for_of` now rewrites the view call to the
+direct-collection form when the receiver's static type proves `Map` / `Set`
+**and** the resulting head is one the index fast path accepts:
+
+| subject | head | becomes |
+|---|---|---|
+| `m.entries()` | any index-fast-path head | `for (<head> of m)` |
+| `m.keys()` | plain ident `k` | `for (const [k] of m)` |
+| `m.values()` | plain ident `v` | `for (const [, v] of m)` |
+| `s.values()` / `s.keys()` | plain ident | `for (<head> of s)` |
+
+The gate is deliberately narrow, and the last clause is the load-bearing one.
+`for (const [a, b] of m.values())` destructures the *value*, not the entry;
+`s.entries()` yields `[v, v]`, which `for (… of s)` does not; `for await` needs
+its per-iteration await. And **any head the index walk would decline is left
+alone too** — because the Map/Set fallback is a `MapEntries` / `SetValues`
+materialisation, i.e. a snapshot, so rewriting onto it would change what a body
+that mutates the collection observes.
+
+Results on the pinned quiet mini, `hyperfine --warmup 3 --runs 15`:
+
+| | before | **after** | node 26.5.1 | bun 1.3.14 |
+|---|--:|--:|--:|--:|
+| **`map_1m` (the kernel)** | 820.0 ± 5.1 ms | **309.1 ± 2.7 ms** | 323.1 ± 1.6 | 221.0 ± 0.9 |
+| insert + `for (const v of m.values())` | 952.4 ± 3.3 | **231.3 ± 0.7** | 205.1 ± 1.9 | 121.0 ± 0.9 |
+| insert + `for (const e of m.entries())` | 1296.7 ± 3.4 | **234.2 ± 0.5** | 206.4 ± 1.4 | 123.4 ± 0.7 |
+
+**2.65× on the kernel, and Perry now beats node on it** (309 vs 323) where it
+was 2.5× node before; perry/bun moves from **3.71× to 1.40×**, and what is left
+is the insert phase's string construction. Per-loop, each measured in its own
+process over a 500k Map: `m.values()` 770 → 5 ms, `m.keys()` 978 → 6 ms,
+`m.entries()` 1128 → 7 ms, `for (const e of m)` 1265 → 6 ms, `s.values()`
+370 → 5 ms, and the untouched `for (const [k, v] of m)` control flat at 5 ms.
+
+`PERRY_GC_TRACE=1` whole-process totals: `map_1m` goes from **8 collections
+(7 minor + 1 full) to 2 minors and no full**, the values sweep from 6 (3+3) to
+2, the entries sweep from 9 (4+5) to 2. Copied objects (445,639) and copied
+bytes (17.8 MB) are **unchanged** — the surviving live set is identical and only
+the iteration's garbage is gone — and both arms still run copying minors with
+`copied_objects > 0`, so the comparison is not the vacuous kind.
+
+### Fixed
+
+**A single-ident Map for-of head bound a snapshot, not the Map (#7561).**
+`for (const e of m)` went through `MapEntries`, which materialises the whole Map
+up front, so the loop could not see its own body's writes:
+
+```ts
+for (const e of m) { …; if (first) m.set("late", 9); }     // node a,b,late — perry a,b
+for (const e of m) { …; if (e[0] === "a") m.delete("b"); } // node a,c      — perry a,b,c
+```
+
+The index fast path now accepts that head and binds one fresh `[key, value]`
+pair per step, read out of the entries buffer at the delete-corrected index —
+the same allocation node's Map iterator makes, and live. Both cases now match
+node, and the shape is also ~180× faster at 500k entries.
+
+### Notes
+
+Both commits dedup what the two for-of desugars (`lower/stmt_loops.rs` for
+module scope, `lower_decl/body_stmt.rs` for function bodies) carried
+byte-identical copies of — the #302/#311 iterable-type resolution and the
+fast-path head predicate. `stmt_loops.rs` 2000 → 1954, `body_stmt.rs`
+2140 → 2092.
+
+A 115-line Map semantics matrix — insertion order, overwrite-in-place,
+delete-then-reinsert, SameValueZero (`NaN`, `-0`/`+0`), string-representation
+boundaries (SSO / heap / multibyte / surrogate pair / NUL / `__proto__`), object
+vs string key identity, iterator invalidation under append and under
+delete-ahead / delete-current / delete-behind, `Symbol.iterator` vs `entries()`
+vs `forEach` agreement, `clear()` and reuse, mixed key kinds, union-typed
+receivers, class fields, object properties, `break` / `continue` /
+labeled-break / `return`, `let` and `var` heads, nested loops — is
+byte-identical before and after except the four lines the fix deliberately
+changes, and matches node everywhere except two divergences that predate this
+work and are unchanged by it (`Map.prototype[Symbol.iterator] ===
+Map.prototype.entries` is `false`; `for (var k of …)` does not leak `k`).
+`test-files/test_gap_map_view_for_of.ts` is byte-identical to node after and had
+two divergences before.
+
+`lower/collection_view_tests.rs` pins the **verdict** — which of the three
+lowerings (index walk / materialisation / iterator protocol) each loop shape
+receives — not the output. The iterator path is a correct fallback, so a test
+comparing program output alone would stay green if the fast path silently
+stopped applying (CLAUDE.md's fourth way a gate can be unable to fail); a
+`the_route_probe_actually_discriminates` case proves the probe can still tell
+them apart.
+
+A patched `Map.prototype.values`, a patched `Map.prototype[Symbol.iterator]`,
+and an own-instance `values` shadow are **already** ignored by Perry before this
+change — verified against node, which honours all three — and the pre-existing
+direct `for (… of m)` fast path has the same property. A `Map` subclass types as
+`Type::Named`, never `Type::Generic`, so an overriding subclass method is never
+bypassed.
+
+**Measurement trap worth recording.** The first A/B ran all nine loop shapes in
+one process and reported two apparent 2× regressions in shapes this change does
+not touch (`for (const e of m.entries())` 570 → 1180 ms, `[...m.values()]`
+115 → 240 ms). Re-measured one shape per process, both are flat (1128 → 1124,
+92 → 92). Removing ~2.5 M allocations from the *earlier* benches moves the whole
+GC regime the *later* ones run in — a multi-bench file stops being a valid A/B
+instrument the moment one of its benches changes its allocation rate.
+
+Three defects found while profiling, filed rather than folded in, all
+reproducing identically at `969b447cc`: spread / `Array.from` over any iterator
+silently truncating at 100,000 elements (#7562), a SIGSEGV iterating a
+`values()` override on a `class X extends Map` (#7563), and `make_iter_result`
+allocating five objects per `.next()` where four are the same constant every
+call (#7564) — the general form of what this change routes around for Map and
+Set, still paid by every generator and custom iterator.

--- a/crates/perry-hir/src/lower/collection_view_tests.rs
+++ b/crates/perry-hir/src/lower/collection_view_tests.rs
@@ -1,0 +1,210 @@
+//! Verdict tests for [`super::for_head::rewrite_collection_view_for_of`].
+//!
+//! These assert **which lowering a loop got**, not what it computes. The
+//! iterator-object path is a correct fallback, so a test that only compared
+//! program output would stay green if the fast path silently stopped
+//! applying — CLAUDE.md's fourth way a gate can be unable to fail. Behaviour
+//! is covered separately by the `.ts` semantics matrix
+//! (`test-files/test_gap_map_view_for_of.ts`, byte-compared against node).
+//!
+//! The verdict is read off the lowered HIR: the Map/Set index fast path emits
+//! `MapEntryKeyAt` / `MapEntryValueAt` / `SetValueAt` reads, the generic
+//! protocol path emits a `GetIterator`, and the materialising fallbacks emit
+//! `MapEntries` / `SetValues`.
+
+#![cfg(test)]
+
+use crate::Module;
+use perry_diagnostics::SourceCache;
+
+fn lower(src: &str) -> Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed =
+                perry_parser::parse_typescript_with_cache(&src, "collection_view.ts", &mut cache)
+                    .expect("parse should succeed");
+            crate::lower_module(&parsed.module, "test", "collection_view.ts")
+                .expect("lower should succeed")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+/// Which lowering a `for-of` over a collection view received.
+#[derive(Debug, PartialEq, Eq)]
+enum Route {
+    /// Delete-safe index walk over the flat entries buffer — allocation-free.
+    IndexFastPath,
+    /// `MapEntries` / `SetValues` materialisation — a snapshot, one Array.
+    Materialised,
+    /// Generic iterator protocol — a `{ value, done }` object per element.
+    IteratorProtocol,
+}
+
+fn route_of(src: &str) -> Route {
+    let hir = format!("{:?}", lower(src));
+    let indexed = hir.contains("MapEntryKeyAt")
+        || hir.contains("MapEntryValueAt")
+        || hir.contains("SetValueAt");
+    let materialised = hir.contains("MapEntries") || hir.contains("SetValues");
+    // `GetIterator` is what the lazy protocol path installs; the fast paths
+    // never emit one.
+    if hir.contains("GetIterator") {
+        return Route::IteratorProtocol;
+    }
+    if indexed {
+        Route::IndexFastPath
+    } else if materialised {
+        Route::Materialised
+    } else {
+        panic!("no recognizable for-of route in lowered HIR for:\n{src}");
+    }
+}
+
+const MAP_DECL: &str = "const m = new Map<string, number>();\nm.set(\"a\", 1);\n";
+const SET_DECL: &str = "const s = new Set<number>();\ns.add(1);\n";
+
+fn map_src(loop_src: &str) -> String {
+    format!("{MAP_DECL}{loop_src}")
+}
+
+fn set_src(loop_src: &str) -> String {
+    format!("{SET_DECL}{loop_src}")
+}
+
+/// The shapes the rewrite exists for. Each must reach the index fast path —
+/// the same route `for (const [k, v] of m)` already had.
+#[test]
+fn map_and_set_views_reach_the_index_fast_path() {
+    for loop_src in [
+        "for (const v of m.values()) { console.log(v); }",
+        "for (const k of m.keys()) { console.log(k); }",
+        "for (const [k, v] of m.entries()) { console.log(k, v); }",
+        "for (const [k] of m.entries()) { console.log(k); }",
+        "for (const [, v] of m.entries()) { console.log(v); }",
+        "for (let v of m.values()) { console.log(v); }",
+        // Single-ident heads bind one fresh `[k, v]` pair per step. Both
+        // spellings are the same iteration; before this they were a
+        // `MapEntries` SNAPSHOT and did not observe the body's own mutations.
+        "for (const e of m) { console.log(e); }",
+        "for (const e of m.entries()) { console.log(e); }",
+        // the pre-existing destructured direct form, as the control
+        "for (const [k, v] of m) { console.log(k, v); }",
+    ] {
+        assert_eq!(
+            route_of(&map_src(loop_src)),
+            Route::IndexFastPath,
+            "map loop should take the index fast path: {loop_src}"
+        );
+    }
+    for loop_src in [
+        "for (const x of s.values()) { console.log(x); }",
+        "for (const x of s.keys()) { console.log(x); }",
+        "for (const x of s) { console.log(x); }",
+    ] {
+        assert_eq!(
+            route_of(&set_src(loop_src)),
+            Route::IndexFastPath,
+            "set loop should take the index fast path: {loop_src}"
+        );
+    }
+}
+
+/// Shapes the rewrite must decline. Each is either not equivalent to the
+/// direct form, or would land on a *materialising* fallback — trading the
+/// iterator's live view for a snapshot, so a body that mutates the collection
+/// would stop seeing its own writes.
+#[test]
+fn shapes_the_rewrite_must_decline_keep_the_lazy_iterator() {
+    // `s.entries()` yields `[v, v]` pairs, which `for (… of s)` does not.
+    assert_eq!(
+        route_of(&set_src("for (const e of s.entries()) { console.log(e); }")),
+        Route::IteratorProtocol,
+        "Set entries() is not the direct Set iteration"
+    );
+    // A destructuring head over `values()` destructures the VALUE.
+    assert_eq!(
+        route_of(&map_src(
+            "const mm = new Map<string, number[]>();\n\
+             for (const [a, b] of mm.values()) { console.log(a, b); }"
+        )),
+        Route::IteratorProtocol,
+        "values() with a destructuring head destructures the value"
+    );
+    // Nested patterns are not a shape the index fast path accepts.
+    assert_eq!(
+        route_of(&map_src(
+            "for (const [[a], b] of m.entries()) { console.log(a, b); }"
+        )),
+        Route::IteratorProtocol,
+        "nested destructuring is not an index-fast-path head"
+    );
+}
+
+/// The receiver's static type is the gate. Without a `Map` / `Set` proof the
+/// rewritten head means something else entirely, so an unproven receiver must
+/// be left on whatever route it had.
+#[test]
+fn an_unproven_receiver_is_never_rewritten() {
+    // A plain object with a `values()` method — rewriting would iterate the
+    // object, not the method's result.
+    let src = "const o = { values() { return [1, 2][Symbol.iterator](); } };\n\
+               for (const v of o.values()) { console.log(v); }";
+    assert_ne!(
+        route_of(src),
+        Route::IndexFastPath,
+        "an object with a values() method is not a Map"
+    );
+    // A `Map` subclass types as `Type::Named`, never `Type::Generic`, so an
+    // overriding `values()` is never bypassed.
+    let src = "class MyMap extends Map<string, number> {}\n\
+               const mm = new MyMap();\n\
+               for (const v of mm.values()) { console.log(v); }";
+    assert_ne!(
+        route_of(src),
+        Route::IndexFastPath,
+        "a Map subclass may override values()"
+    );
+}
+
+/// `for await` is left alone: the fast path emits no `Await` around the
+/// element read, so rewriting onto it would drop the per-iteration await.
+///
+/// Asserted on the rewrite's own footprint rather than through `route_of` —
+/// the async desugar replaces the loop wholesale, so none of the three route
+/// markers survives it either way.
+#[test]
+fn for_await_is_never_rewritten() {
+    let hir = format!(
+        "{:?}",
+        lower(
+            "async function f(m: Map<string, number>) {\n\
+             for await (const v of m.values()) { console.log(v); }\n\
+             }\nf(new Map<string, number>());"
+        )
+    );
+    assert!(
+        !hir.contains("MapEntryValueAt"),
+        "for await must not be routed onto the index fast path"
+    );
+}
+
+/// Sabotage check: the route probe can distinguish the paths at all. If both
+/// arms reported the same route the tests above would be vacuous.
+#[test]
+fn the_route_probe_actually_discriminates() {
+    let fast = route_of(&map_src("for (const v of m.values()) { console.log(v); }"));
+    let slow = route_of(&map_src(
+        "for (const [[a], b] of m.entries()) { console.log(a, b); }",
+    ));
+    assert_eq!(fast, Route::IndexFastPath);
+    assert_eq!(slow, Route::IteratorProtocol);
+    assert_ne!(
+        fast, slow,
+        "route probe cannot tell the two lowerings apart"
+    );
+}

--- a/crates/perry-hir/src/lower/collection_view_tests.rs
+++ b/crates/perry-hir/src/lower/collection_view_tests.rs
@@ -171,25 +171,51 @@ fn an_unproven_receiver_is_never_rewritten() {
     );
 }
 
-/// `for await` is left alone: the fast path emits no `Await` around the
-/// element read, so rewriting onto it would drop the per-iteration await.
+/// `for await` is left alone: the fast path emits no `Await` around the element
+/// read, so rewriting onto it would drop the per-iteration await — measurably,
+/// as a loop that stops draining microtasks until it is over.
 ///
 /// Asserted on the rewrite's own footprint rather than through `route_of` —
 /// the async desugar replaces the loop wholesale, so none of the three route
 /// markers survives it either way.
 #[test]
 fn for_await_is_never_rewritten() {
+    for loop_src in [
+        // the view call — declined by `rewrite_collection_view_for_of`
+        "for await (const v of m.values()) { console.log(v); }",
+        // the direct single-ident head — declined by `allow_pair_head`
+        "for await (const e of m) { console.log(e); }",
+    ] {
+        let hir = format!(
+            "{:?}",
+            lower(&format!(
+                "async function f(m: Map<string, number>) {{\n{loop_src}\n}}\n\
+                 f(new Map<string, number>());"
+            ))
+        );
+        assert!(
+            !hir.contains("MapEntryValueAt") && !hir.contains("MapEntryKeyAt"),
+            "for await must not be routed onto the index fast path: {loop_src}"
+        );
+    }
+}
+
+/// The `allow_pair_head` gate is per-loop, not per-module: a synchronous
+/// single-ident head in the same file still gets the pair fast path.
+#[test]
+fn a_sync_pair_head_beside_a_for_await_still_takes_the_fast_path() {
     let hir = format!(
         "{:?}",
         lower(
             "async function f(m: Map<string, number>) {\n\
-             for await (const v of m.values()) { console.log(v); }\n\
+             for await (const e of m) { console.log(e); }\n\
+             for (const e2 of m) { console.log(e2); }\n\
              }\nf(new Map<string, number>());"
         )
     );
     assert!(
-        !hir.contains("MapEntryValueAt"),
-        "for await must not be routed onto the index fast path"
+        hir.contains("MapEntryKeyAt"),
+        "the synchronous loop should still reach the index fast path"
     );
 }
 

--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -326,7 +326,14 @@ fn type_proves_collection(ty: Option<&Type>, base_name: &str) -> bool {
 /// `m.delete(…)` never removed an entry the loop had not reached, both of
 /// which node observes. Nested patterns, object patterns and defaults still
 /// fall through so their destructuring semantics stay correct.
-pub(crate) fn map_index_fast_path_head(left: &ast::ForHead) -> bool {
+///
+/// `allow_pair_head` must be `false` for a `for await` loop. The array-pattern
+/// arms already drop the per-iteration `Await` (a `MapEntryKeyAt` read is not
+/// wrapped in one), but the single-ident arm *replaces* a binding that was
+/// `Await(<materialised>[i])`, and dropping that changes the loop's microtask
+/// interleaving: `for await (const e of m)` with a `queueMicrotask` in the body
+/// stops draining anything until the loop is over.
+pub(crate) fn map_index_fast_path_head(left: &ast::ForHead, allow_pair_head: bool) -> bool {
     let ast::ForHead::VarDecl(var_decl) = left else {
         return false;
     };
@@ -334,7 +341,7 @@ pub(crate) fn map_index_fast_path_head(left: &ast::ForHead) -> bool {
         return false;
     };
     match &decl.name {
-        ast::Pat::Ident(_) => true,
+        ast::Pat::Ident(_) => allow_pair_head,
         ast::Pat::Array(pat) => {
             (pat.elems.len() == 1 || pat.elems.len() == 2)
                 && pat
@@ -469,7 +476,8 @@ pub(crate) fn rewrite_collection_view_for_of(
             // iteration in the language, for every head the index fast path
             // accepts.
             "entries" => {
-                if !map_index_fast_path_head(&stmt.left) {
+                // `is_await` was rejected above, so the pair head is allowed.
+                if !map_index_fast_path_head(&stmt.left, true) {
                     return None;
                 }
                 stmt.left.clone()

--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -252,6 +252,215 @@ pub(crate) fn guard_for_in_body(
     }]
 }
 
+/// Resolve the static type of a `for-of` subject expression.
+///
+/// Shared by the two for-of desugars (`lower/stmt_loops.rs` for module-level
+/// statements, `lower_decl/body_stmt.rs` for function bodies), which carried
+/// byte-identical copies of this match.
+///
+/// Issue #302: resolve the iterable type from either a local variable or a
+/// class instance field (`this.someMap`) — it was limited to `Ident`, so
+/// `for (const [k, v] of this.someMap)` produced a raw Map handle whose
+/// `.length` read 0 and the loop body never ran. Issue #311 extends the same
+/// treatment to plain object property access (`obj.m` where `obj` is a local
+/// with an inferred `Type::Object` shape), which had the identical
+/// silently-zero-iterations symptom from a different missing arm.
+pub(crate) fn resolve_for_of_iterable_type(
+    ctx: &LoweringContext,
+    subject: &ast::Expr,
+) -> Option<Type> {
+    match subject {
+        ast::Expr::Ident(ident) => ctx.lookup_local_type(ident.sym.as_ref()).cloned(),
+        ast::Expr::Member(m) => {
+            if matches!(m.obj.as_ref(), ast::Expr::This(_)) {
+                if let (Some(cls), ast::MemberProp::Ident(p)) = (ctx.current_class.clone(), &m.prop)
+                {
+                    ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned()
+                } else {
+                    None
+                }
+            } else if let ast::MemberProp::Ident(p) = &m.prop {
+                match crate::lower_types::infer_type_from_expr(&m.obj, ctx) {
+                    Type::Object(ot) => ot.properties.get(p.sym.as_ref()).map(|pi| pi.ty.clone()),
+                    // Class instance: receiver is `new Example()` or a local
+                    // typed `Example`. Consult the same class_field_types
+                    // registry the `this.<field>` arm uses (populated for #302).
+                    Type::Named(cls) => ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned(),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Does `ty` prove the value is a `Map` / a `Set`?
+///
+/// Issue #542/#543: a `Map<K, V> | undefined` parameter narrows to a Map after
+/// `if (!m) return;`, but the narrowing is not propagated into the type, so the
+/// union arm has to be accepted here too.
+fn type_proves_collection(ty: Option<&Type>, base_name: &str) -> bool {
+    let is_base = |t: &Type| matches!(t, Type::Generic { base, .. } if base == base_name);
+    match ty {
+        Some(t) if is_base(t) => true,
+        Some(Type::Union(variants)) => variants.iter().any(is_base),
+        _ => false,
+    }
+}
+
+/// Rewrite `for (… of m.values() / m.keys() / m.entries())` into the
+/// equivalent direct-collection `for-of` so it reaches the delete-safe index
+/// fast path below instead of the generic iterator protocol.
+///
+/// # Why
+///
+/// `for (const [k, v] of m)` is lowered to an index walk over the Map's flat
+/// entries buffer and allocates nothing per step. Reaching the same entries
+/// through `m.values()` produced a **Map iterator object** instead, and every
+/// `.next()` on one builds a fresh `{ value, done }` result — an object, two
+/// key strings, a keys array and a shape install, five heap allocations per
+/// element, plus the allocation-driven collections that follow. On a 500 000
+/// entry Map that is 805 ms against the direct form's 5 ms.
+///
+/// # What is rewritten, and what is not
+///
+/// The rewrite is gated on the receiver's static type proving `Map` / `Set`,
+/// because the rewritten head is only equivalent for a real collection: on
+/// anything else `for (const [, v] of x)` destructures each element rather
+/// than reading entry values.
+///
+/// | subject | head | becomes |
+/// |---|---|---|
+/// | `m.entries()` | 1–2 slot all-ident array pattern | `for (<head> of m)` |
+/// | `m.keys()` | plain ident `k` | `for (const [k] of m)` |
+/// | `m.values()` | plain ident `v` | `for (const [, v] of m)` |
+/// | `s.values()` / `s.keys()` | plain ident | `for (<head> of s)` |
+///
+/// `m.keys()` / `m.values()` with a destructuring head are left alone — `for
+/// (const [a, b] of m.values())` destructures the *value*, which the rewritten
+/// form would not do. `s.entries()` is left alone because it yields `[v, v]`
+/// pairs, which `for (… of s)` does not. `for await` is left alone. Every
+/// remaining head shape is left alone too, because the Map/Set *fallback* is a
+/// `MapEntries` / `SetValues` materialisation — a snapshot, where the iterator
+/// object is live — so rewriting onto it would change what a body that mutates
+/// the collection observes.
+///
+/// # Divergences this does NOT introduce
+///
+/// A patched `Map.prototype.values`, a patched
+/// `Map.prototype[Symbol.iterator]`, and an own-instance `values` shadow are
+/// **already** ignored by Perry before this rewrite (verified against the node
+/// oracle at the parent commit); the direct `for (… of m)` fast path has the
+/// same property. A `class MyMap extends Map` receiver types as `Type::Named`,
+/// not `Type::Generic`, so an overriding subclass method is never rewritten.
+pub(crate) fn rewrite_collection_view_for_of(
+    ctx: &LoweringContext,
+    stmt: &ast::ForOfStmt,
+) -> Option<ast::ForOfStmt> {
+    if stmt.is_await {
+        return None;
+    }
+    let ast::Expr::Call(call) = &*stmt.right else {
+        return None;
+    };
+    if !call.args.is_empty() {
+        return None;
+    }
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let ast::Expr::Member(member) = &**callee else {
+        return None;
+    };
+    let ast::MemberProp::Ident(view) = &member.prop else {
+        return None;
+    };
+    let view = view.sym.as_ref();
+    if !matches!(view, "values" | "keys" | "entries") {
+        return None;
+    }
+    let receiver_ty = resolve_for_of_iterable_type(ctx, &member.obj);
+    let is_map = type_proves_collection(receiver_ty.as_ref(), "Map");
+    let is_set = type_proves_collection(receiver_ty.as_ref(), "Set");
+
+    let ast::ForHead::VarDecl(var_decl) = &stmt.left else {
+        return None;
+    };
+    if var_decl.decls.len() != 1 {
+        return None;
+    }
+    let decl = var_decl.decls.first()?;
+
+    // Every arm below must land on a head shape the index fast path actually
+    // accepts. That is not tidiness: the *fallbacks* for a Map/Set for-of are
+    // `MapEntries` / `SetValues`, which materialise the whole collection up
+    // front. Rewriting onto one of those would trade a live iteration for a
+    // snapshot, so `for (const e of m.entries()) { m.set(…) }` would stop
+    // seeing appended entries. Shapes the fast path would decline keep the
+    // (slower, lazy, correct) iterator-object path instead.
+    let left = if is_set {
+        // Set: `keys()` and `values()` both yield the element, exactly what
+        // `for (… of s)` binds — and the Set fast path takes a plain ident.
+        // `entries()` yields `[v, v]`, which `for (… of s)` does not.
+        match (view, &decl.name) {
+            ("values" | "keys", ast::Pat::Ident(_)) => stmt.left.clone(),
+            _ => return None,
+        }
+    } else if is_map {
+        match view {
+            // `for (… of m.entries())` and `for (… of m)` are the same
+            // iteration in the language. Restricted to the 1–2 slot all-ident
+            // array patterns the Map fast path handles.
+            "entries" => {
+                let ast::Pat::Array(pat) = &decl.name else {
+                    return None;
+                };
+                let slots_ok = (pat.elems.len() == 1 || pat.elems.len() == 2)
+                    && pat
+                        .elems
+                        .iter()
+                        .all(|e| e.is_none() || matches!(e, Some(ast::Pat::Ident(_))));
+                if !slots_ok {
+                    return None;
+                }
+                stmt.left.clone()
+            }
+            "keys" | "values" => {
+                let ast::Pat::Ident(binding) = &decl.name else {
+                    return None;
+                };
+                let slot = Some(ast::Pat::Ident(binding.clone()));
+                let elems = if view == "keys" {
+                    vec![slot]
+                } else {
+                    vec![None, slot]
+                };
+                let mut rewritten = (**var_decl).clone();
+                rewritten.decls[0].name = ast::Pat::Array(ast::ArrayPat {
+                    span: binding.id.span,
+                    elems,
+                    optional: false,
+                    type_ann: None,
+                });
+                ast::ForHead::VarDecl(Box::new(rewritten))
+            }
+            _ => return None,
+        }
+    } else {
+        return None;
+    };
+
+    Some(ast::ForOfStmt {
+        span: stmt.span,
+        is_await: false,
+        left,
+        right: member.obj.clone(),
+        body: stmt.body.clone(),
+    })
+}
+
 /// Build the delete-safe control for the Map/Set `for-of` fast path (#6075).
 ///
 /// The fast path iterates the backing entries array by index (`arr_id` holds the

--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -310,6 +310,61 @@ fn type_proves_collection(ty: Option<&Type>, base_name: &str) -> bool {
     }
 }
 
+/// Head shapes the Map index fast path can bind directly out of the flat
+/// entries buffer, skipping the `MapEntries` materialisation.
+///
+/// Shared by the two for-of desugars, which carried identical copies.
+///
+/// * `for (const [k, v] of m)`, `for (const [k] of m)`, `for (const [, v] of m)`
+///   — each non-empty slot read with `MapEntryKeyAt` / `MapEntryValueAt`.
+/// * `for (const e of m)` — one fresh `[k, v]` pair per step, exactly what the
+///   language says the default Map iterator yields.
+///
+/// The single-ident arm is a **correctness** fix as much as a performance one:
+/// `MapEntries` snapshots the whole Map up front, so before it was accepted
+/// here `for (const e of m) { m.set(…) }` never saw its own append and
+/// `m.delete(…)` never removed an entry the loop had not reached, both of
+/// which node observes. Nested patterns, object patterns and defaults still
+/// fall through so their destructuring semantics stay correct.
+pub(crate) fn map_index_fast_path_head(left: &ast::ForHead) -> bool {
+    let ast::ForHead::VarDecl(var_decl) = left else {
+        return false;
+    };
+    let Some(decl) = var_decl.decls.first() else {
+        return false;
+    };
+    match &decl.name {
+        ast::Pat::Ident(_) => true,
+        ast::Pat::Array(pat) => {
+            (pat.elems.len() == 1 || pat.elems.len() == 2)
+                && pat
+                    .elems
+                    .iter()
+                    .all(|e| e.is_none() || matches!(e, Some(ast::Pat::Ident(_))))
+        }
+        _ => false,
+    }
+}
+
+/// The `[key, value]` pair a single-ident Map for-of head binds each step.
+///
+/// One fresh 2-element Array per iteration, read out of the entries buffer at
+/// the (delete-corrected) loop index — the same allocation node's Map iterator
+/// makes, and live where the `MapEntries` materialisation it replaces was a
+/// snapshot.
+pub(crate) fn map_entry_pair(arr_id: LocalId, idx_id: LocalId) -> Expr {
+    Expr::Array(vec![
+        Expr::MapEntryKeyAt {
+            map: Box::new(Expr::LocalGet(arr_id)),
+            idx: Box::new(Expr::LocalGet(idx_id)),
+        },
+        Expr::MapEntryValueAt {
+            map: Box::new(Expr::LocalGet(arr_id)),
+            idx: Box::new(Expr::LocalGet(idx_id)),
+        },
+    ])
+}
+
 /// Rewrite `for (… of m.values() / m.keys() / m.entries())` into the
 /// equivalent direct-collection `for-of` so it reaches the delete-safe index
 /// fast path below instead of the generic iterator protocol.
@@ -333,7 +388,7 @@ fn type_proves_collection(ty: Option<&Type>, base_name: &str) -> bool {
 ///
 /// | subject | head | becomes |
 /// |---|---|---|
-/// | `m.entries()` | 1–2 slot all-ident array pattern | `for (<head> of m)` |
+/// | `m.entries()` | any [`map_index_fast_path_head`] shape | `for (<head> of m)` |
 /// | `m.keys()` | plain ident `k` | `for (const [k] of m)` |
 /// | `m.values()` | plain ident `v` | `for (const [, v] of m)` |
 /// | `s.values()` / `s.keys()` | plain ident | `for (<head> of s)` |
@@ -411,18 +466,10 @@ pub(crate) fn rewrite_collection_view_for_of(
     } else if is_map {
         match view {
             // `for (… of m.entries())` and `for (… of m)` are the same
-            // iteration in the language. Restricted to the 1–2 slot all-ident
-            // array patterns the Map fast path handles.
+            // iteration in the language, for every head the index fast path
+            // accepts.
             "entries" => {
-                let ast::Pat::Array(pat) = &decl.name else {
-                    return None;
-                };
-                let slots_ok = (pat.elems.len() == 1 || pat.elems.len() == 2)
-                    && pat
-                        .elems
-                        .iter()
-                        .all(|e| e.is_none() || matches!(e, Some(ast::Pat::Ident(_))));
-                if !slots_ok {
+                if !map_index_fast_path_head(&stmt.left) {
                     return None;
                 }
                 stmt.left.clone()

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -52,8 +52,9 @@ mod unimpl_hints;
 pub(crate) use stmt::*;
 mod for_head;
 pub(crate) use for_head::{
-    for_head_binding_stmts, guard_for_in_body, map_set_delete_safe_for_of, predefine_for_head,
-    resolve_for_of_iterable_type, rewrite_collection_view_for_of,
+    for_head_binding_stmts, guard_for_in_body, map_entry_pair, map_index_fast_path_head,
+    map_set_delete_safe_for_of, predefine_for_head, resolve_for_of_iterable_type,
+    rewrite_collection_view_for_of,
 };
 mod stmt_loops;
 pub(crate) use stmt_loops::{
@@ -125,5 +126,7 @@ pub(crate) use crate::lower_decl::*;
 pub(crate) use crate::lower_patterns::*;
 pub(crate) use crate::lower_types::*;
 
+#[cfg(test)]
+mod collection_view_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -53,6 +53,7 @@ pub(crate) use stmt::*;
 mod for_head;
 pub(crate) use for_head::{
     for_head_binding_stmts, guard_for_in_body, map_set_delete_safe_for_of, predefine_for_head,
+    resolve_for_of_iterable_type, rewrite_collection_view_for_of,
 };
 mod stmt_loops;
 pub(crate) use stmt_loops::{

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1314,7 +1314,8 @@ pub(crate) fn lower_stmt_for_of(
     // shapes it accepts and why the single-ident one is a correctness fix.
     // Detected here so the iterable expression stays unwrapped and a different
     // binding/bound shape is emitted below.
-    let map_kv_fastpath = is_iterable_map && map_index_fast_path_head(&for_of_stmt.left);
+    let map_kv_fastpath =
+        is_iterable_map && map_index_fast_path_head(&for_of_stmt.left, !for_of_stmt.is_await);
     // Fast path: `for (const x of setExpr)` with a single-Ident
     // binding. Reads elements directly via `SetValueAt` (→
     // `js_set_value_at`) instead of materializing the buffer with

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1309,37 +1309,12 @@ pub(crate) fn lower_stmt_for_of(
         Some(Type::Union(variants)) => variants.iter().any(type_contains_map),
         _ => false,
     };
-    // Fast path: `for (const [k, v] of mapExpr)` with an exact two-element
-    // identifier destructure can iterate the Map's flat entries buffer
-    // directly via `MapEntryKeyAt` / `MapEntryValueAt`, skipping the N+1
-    // small Array allocations that `MapEntries` would do per iteration.
-    // Detected here so we can keep the iterable expression unwrapped
-    // and emit a different binding/bound shape below.
-    // Map fast path also fires for the single-binding shapes
-    //   for (const [k] of map)        — only key
-    //   for (const [, v] of map)      — only value
-    // Each non-empty slot must be a plain Ident (no nested patterns).
-    // Anything else falls through to the MapEntries materialization
-    // path so destructuring semantics for objects / nested arrays
-    // / defaults stay correct.
-    let map_kv_fastpath = is_iterable_map
-        && match &for_of_stmt.left {
-            ast::ForHead::VarDecl(var_decl) => match var_decl.decls.first() {
-                Some(decl) => match &decl.name {
-                    ast::Pat::Array(arr_pat) => {
-                        let len = arr_pat.elems.len();
-                        (len == 1 || len == 2)
-                            && arr_pat
-                                .elems
-                                .iter()
-                                .all(|e| e.is_none() || matches!(e, Some(ast::Pat::Ident(_))))
-                    }
-                    _ => false,
-                },
-                None => false,
-            },
-            _ => false,
-        };
+    // Fast path: iterate the Map's flat entries buffer directly instead of
+    // materializing it — see `for_head::map_index_fast_path_head` for the head
+    // shapes it accepts and why the single-ident one is a correctness fix.
+    // Detected here so the iterable expression stays unwrapped and a different
+    // binding/bound shape is emitted below.
+    let map_kv_fastpath = is_iterable_map && map_index_fast_path_head(&for_of_stmt.left);
     // Fast path: `for (const x of setExpr)` with a single-Ident
     // binding. Reads elements directly via `SetValueAt` (→
     // `js_set_value_at`) instead of materializing the buffer with
@@ -1683,6 +1658,8 @@ pub(crate) fn lower_stmt_for_of(
                                 set: Box::new(Expr::LocalGet(arr_id)),
                                 idx: Box::new(Expr::LocalGet(idx_id)),
                             }
+                        } else if map_kv_fastpath {
+                            map_entry_pair(arr_id, idx_id)
                         } else {
                             item_expr
                         };

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -781,6 +781,13 @@ pub(crate) fn lower_stmt_for_of(
     module: &mut Module,
     for_of_stmt: &ast::ForOfStmt,
 ) -> Result<()> {
+    // `for (… of m.values()/keys()/entries())` on a statically-proven Map/Set
+    // is the direct-collection loop written another way; rewrite it to that
+    // form so it reaches the delete-safe index fast path instead of building a
+    // `{ value, done }` object per element.
+    let view_rewrite = rewrite_collection_view_for_of(ctx, for_of_stmt);
+    let for_of_stmt = view_rewrite.as_ref().unwrap_or(for_of_stmt);
+
     // --- Iterator protocol path for generators ---
     // Detect: for (const x of genFunc(...)) where genFunc is function*
     let is_generator_call = if let ast::Expr::Call(call) = &*for_of_stmt.right {
@@ -1283,40 +1290,10 @@ pub(crate) fn lower_stmt_for_of(
     };
 
     // Issue #302: resolve iterable type from either local var or
-    // class instance field (`this.someMap`). Was limited to
-    // `Ident` only. Issue #311 extends to plain object property
-    // access (`obj.m` where `obj` is a local with an inferred
-    // `Type::Object` shape) — without this arm `for (const x of
-    // obj.m)` fell through to `None`, the loop read `.length` on
-    // a raw Map handle (returns 0), and silently iterated zero
-    // times.
-    let iterable_type: Option<Type> = match &*for_of_stmt.right {
-        ast::Expr::Ident(ident) => ctx.lookup_local_type(ident.sym.as_ref()).cloned(),
-        ast::Expr::Member(m) => {
-            if matches!(m.obj.as_ref(), ast::Expr::This(_)) {
-                if let (Some(cls), ast::MemberProp::Ident(p)) = (ctx.current_class.clone(), &m.prop)
-                {
-                    ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned()
-                } else {
-                    None
-                }
-            } else if let ast::MemberProp::Ident(p) = &m.prop {
-                let obj_ty = crate::lower_types::infer_type_from_expr(&m.obj, ctx);
-                match obj_ty {
-                    Type::Object(ot) => ot.properties.get(p.sym.as_ref()).map(|pi| pi.ty.clone()),
-                    // Class instance: receiver is `new Example()` or
-                    // a local typed `Example`. Consult the same
-                    // class_field_types registry the `this.<field>`
-                    // arm uses (populated for #302).
-                    Type::Named(cls) => ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned(),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        }
-        _ => None,
-    };
+    // class instance field (`this.someMap`), plus #311's plain object
+    // property access — see `for_head::resolve_for_of_iterable_type`,
+    // which both for-of desugars share.
+    let iterable_type: Option<Type> = resolve_for_of_iterable_type(ctx, &for_of_stmt.right);
 
     // If the iterable is a Map, wrap in MapEntries to convert to array
     // This handles: for (const [k, v] of myMap) { ... } AND

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1357,8 +1357,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             // The head shapes the index fast path accepts — and why the
             // single-ident one is a correctness fix, not just a faster route —
             // live in `for_head::map_index_fast_path_head`.
-            let map_kv_fastpath =
-                is_iterable_map && crate::lower::map_index_fast_path_head(&for_of_stmt.left);
+            let map_kv_fastpath = is_iterable_map
+                && crate::lower::map_index_fast_path_head(&for_of_stmt.left, !for_of_stmt.is_await);
             // Fast path: `for (const x of setExpr)` reads elements directly
             // via `SetValueAt` (→ `js_set_value_at`) instead of materializing
             // the buffer with `js_set_to_array`.

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1354,29 +1354,11 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 Some(Type::Union(variants)) => variants.iter().any(type_contains_map),
                 _ => false,
             };
-            // Map fast path also fires for the single-binding shapes
-            //   for (const [k] of map)        — only key
-            //   for (const [, v] of map)      — only value
-            // Each non-empty slot must be a plain Ident; nested patterns
-            // / object patterns / defaults fall through to the materialized
-            // MapEntries path so destructuring stays correct.
-            let map_kv_fastpath = is_iterable_map
-                && match &for_of_stmt.left {
-                    ast::ForHead::VarDecl(var_decl) => match var_decl.decls.first() {
-                        Some(decl) => match &decl.name {
-                            ast::Pat::Array(arr_pat) => {
-                                let len = arr_pat.elems.len();
-                                (len == 1 || len == 2)
-                                    && arr_pat.elems.iter().all(|e| {
-                                        e.is_none() || matches!(e, Some(ast::Pat::Ident(_)))
-                                    })
-                            }
-                            _ => false,
-                        },
-                        None => false,
-                    },
-                    _ => false,
-                };
+            // The head shapes the index fast path accepts — and why the
+            // single-ident one is a correctness fix, not just a faster route —
+            // live in `for_head::map_index_fast_path_head`.
+            let map_kv_fastpath =
+                is_iterable_map && crate::lower::map_index_fast_path_head(&for_of_stmt.left);
             // Fast path: `for (const x of setExpr)` reads elements directly
             // via `SetValueAt` (→ `js_set_value_at`) instead of materializing
             // the buffer with `js_set_to_array`.
@@ -1686,6 +1668,8 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                         set: Box::new(Expr::LocalGet(arr_id)),
                                         idx: Box::new(Expr::LocalGet(idx_id)),
                                     }
+                                } else if map_kv_fastpath {
+                                    crate::lower::map_entry_pair(arr_id, idx_id)
                                 } else {
                                     item_expr
                                 };

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -901,6 +901,12 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             });
         }
         ast::Stmt::ForOf(for_of_stmt) => {
+            // `for (… of m.values()/keys()/entries())` on a statically-proven
+            // Map/Set is the direct-collection loop written another way; see
+            // `for_head::rewrite_collection_view_for_of`.
+            let view_rewrite = crate::lower::rewrite_collection_view_for_of(ctx, for_of_stmt);
+            let for_of_stmt = view_rewrite.as_ref().unwrap_or(for_of_stmt);
+
             // --- Issue #237: `for await (const c of <ReadableStream>)` ---
             // Lower to a getReader/read loop so the body sees Uint8Array
             // chunks. Detect by checking the iterable's registered native
@@ -1326,49 +1332,11 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
 
             let arr_expr = lower_expr(ctx, &for_of_stmt.right)?;
 
-            // Issue #302: resolve the iterable's declared type. Was
-            // limited to `Ident` (local variable lookup) so
-            // `for (const [k, v] of this.someMap)` produced a raw Map
-            // handle that the for-loop's `.length` read returned 0 on,
-            // silently skipping the loop body. Now also resolves
-            // `Member { obj: This, prop: ident }` via the class field
-            // type registry so class instance fields work too.
-            // Issue #311 extends to plain object property access
-            // (`obj.m` where `obj` is a local with an inferred
-            // `Type::Object` shape) — same silent-zero-iterations
-            // symptom as #302, just a different missing arm.
-            let iterable_type: Option<Type> = match &*for_of_stmt.right {
-                ast::Expr::Ident(ident) => ctx.lookup_local_type(ident.sym.as_ref()).cloned(),
-                ast::Expr::Member(m) => {
-                    if matches!(m.obj.as_ref(), ast::Expr::This(_)) {
-                        if let (Some(cls), ast::MemberProp::Ident(p)) =
-                            (ctx.current_class.clone(), &m.prop)
-                        {
-                            ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned()
-                        } else {
-                            None
-                        }
-                    } else if let ast::MemberProp::Ident(p) = &m.prop {
-                        let obj_ty = crate::lower_types::infer_type_from_expr(&m.obj, ctx);
-                        match obj_ty {
-                            Type::Object(ot) => {
-                                ot.properties.get(p.sym.as_ref()).map(|pi| pi.ty.clone())
-                            }
-                            // Class instance: receiver is `new Example()` or
-                            // a local typed `Example`. Consult the same
-                            // class_field_types registry the `this.<field>`
-                            // arm uses (populated for #302).
-                            Type::Named(cls) => {
-                                ctx.lookup_class_field_type(&cls, p.sym.as_ref()).cloned()
-                            }
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
+            // Issue #302 (class instance fields) + #311 (plain object property
+            // access) — see `for_head::resolve_for_of_iterable_type`, which
+            // both for-of desugars share.
+            let iterable_type: Option<Type> =
+                crate::lower::resolve_for_of_iterable_type(ctx, &for_of_stmt.right);
 
             // Fast path: `for (const [k, v] of mapExpr)` reads flat entries
             // directly via `MapEntryKeyAt` / `MapEntryValueAt` — no pair-Array

--- a/test-files/test_gap_map_view_for_of.ts
+++ b/test-files/test_gap_map_view_for_of.ts
@@ -1,0 +1,303 @@
+// Gap test: `for (… of m.values() / m.keys() / m.entries())` and single-ident
+// Map/Set for-of heads.
+//
+// These loops are lowered to a direct index walk over the collection's flat
+// entries buffer instead of the generic iterator protocol. The walk must be
+// indistinguishable from the protocol it replaces: same insertion order, same
+// live view of a body that mutates the collection mid-iteration, same fresh
+// `[key, value]` pair per step, and the shapes the walk cannot express must
+// keep the protocol.
+//
+// Run: node --experimental-strip-types test_gap_map_view_for_of.ts
+
+function line(label: string, value: unknown): void {
+  console.log(label + ": " + String(value));
+}
+
+function mkMap(n: number): Map<string, number> {
+  const m = new Map<string, number>();
+  for (let i = 0; i < n; i++) m.set("k" + i, i);
+  return m;
+}
+
+// --- values() / keys() / entries(): plain sweeps ---
+{
+  const m = mkMap(5);
+  const v: number[] = [];
+  for (const x of m.values()) v.push(x);
+  line("values", v.join(","));
+
+  const k: string[] = [];
+  for (const x of m.keys()) k.push(x);
+  line("keys", k.join(","));
+
+  const kv: string[] = [];
+  for (const [a, b] of m.entries()) kv.push(a + "=" + b);
+  line("entries.kv", kv.join(","));
+
+  const only_k: string[] = [];
+  for (const [a] of m.entries()) only_k.push(a);
+  line("entries.k", only_k.join(","));
+
+  const only_v: number[] = [];
+  for (const [, b] of m.entries()) only_v.push(b);
+  line("entries.v", only_v.join(","));
+
+  const pairs: string[] = [];
+  for (const e of m.entries()) pairs.push(e[0] + ":" + e[1]);
+  line("entries.pair", pairs.join(","));
+}
+
+// --- the loop body mutates the Map: the view is LIVE, not a snapshot ---
+{
+  const m = mkMap(2);
+  const seen: number[] = [];
+  for (const v of m.values()) {
+    seen.push(v);
+    if (seen.length === 1) m.set("appended", 99);
+    if (seen.length > 8) break;
+  }
+  line("values.liveAppend", seen.join(","));
+  line("values.liveAppend.size", m.size);
+}
+{
+  const m = mkMap(6);
+  const seen: string[] = [];
+  for (const k of m.keys()) {
+    seen.push(k);
+    if (k === "k1") {
+      m.delete("k3");
+      m.delete("k4");
+    }
+  }
+  line("keys.deleteAhead", seen.join(","));
+}
+{
+  const m = mkMap(6);
+  const seen: string[] = [];
+  for (const k of m.keys()) {
+    seen.push(k);
+    m.delete(k);
+  }
+  line("keys.deleteCurrent", seen.join(","));
+  line("keys.deleteCurrent.size", m.size);
+}
+{
+  const m = mkMap(6);
+  const seen: string[] = [];
+  for (const k of m.keys()) {
+    seen.push(k);
+    if (k === "k3") m.delete("k0"); // below the cursor
+  }
+  line("keys.deleteBehind", seen.join(","));
+}
+{
+  const m = mkMap(6);
+  const seen: string[] = [];
+  for (const [k, v] of m.entries()) {
+    seen.push(k + "=" + v);
+    if (k === "k1") m.delete("k2");
+  }
+  line("entries.deleteAhead", seen.join(","));
+}
+
+// --- single-ident heads bind a fresh, live [key, value] pair ---
+{
+  const m = mkMap(4);
+  const out: string[] = [];
+  for (const e of m) out.push(e[0] + "=" + e[1]);
+  line("direct.pair", out.join(","));
+  line("direct.isArray", Array.isArray([...m][0]));
+  line("direct.len", [...m][0].length);
+
+  const kept: unknown[] = [];
+  for (const e of m) kept.push(e);
+  line("direct.freshEachStep", kept[0] !== kept[1] && kept[1] !== kept[2]);
+
+  const m2 = mkMap(2);
+  const seen: string[] = [];
+  for (const e of m2) {
+    seen.push(String(e[0]));
+    if (seen.length === 1) m2.set("late", 9);
+    if (seen.length > 8) break;
+  }
+  line("direct.liveAppend", seen.join(","));
+
+  const m3 = mkMap(4);
+  const seen3: string[] = [];
+  for (const e of m3) {
+    seen3.push(String(e[0]));
+    if (e[0] === "k0") m3.delete("k1");
+  }
+  line("direct.liveDelete", seen3.join(","));
+}
+
+// --- shapes the fast path must DECLINE: the value is destructured, not the
+// --- entry, so the loop must still run the real `values()` iterator.
+{
+  const m = new Map<string, number[]>();
+  m.set("a", [1, 2]);
+  m.set("b", [3, 4]);
+  const out: string[] = [];
+  for (const [x, y] of m.values()) out.push(x + "/" + y);
+  line("decline.destructuredValue", out.join(","));
+
+  const s = new Map<string, string>([["a", "xy"]]);
+  const out2: string[] = [];
+  for (const [c0] of s.values()) out2.push(c0);
+  line("decline.destructuredString", out2.join(","));
+}
+
+// --- Set views ---
+{
+  const s = new Set<number>([1, 2, 3, 4]);
+  const a: number[] = [];
+  for (const x of s.values()) a.push(x);
+  line("set.values", a.join(","));
+  const b: number[] = [];
+  for (const x of s.keys()) b.push(x);
+  line("set.keys", b.join(","));
+  const c: string[] = [];
+  for (const e of s.entries()) c.push(e[0] + "/" + e[1]);
+  line("set.entries", c.join(","));
+
+  const s2 = new Set<number>([1, 2, 3, 4, 5]);
+  const d: number[] = [];
+  for (const x of s2.values()) {
+    d.push(x);
+    if (x === 2) s2.delete(4);
+  }
+  line("set.values.liveDelete", d.join(","));
+}
+
+// --- the receiver reached through a class field, an object property, and a
+// --- `Map | undefined` union parameter ---
+{
+  class Holder {
+    m: Map<string, number> = new Map<string, number>();
+  }
+  const h = new Holder();
+  h.m.set("a", 1);
+  h.m.set("b", 2);
+  const a: number[] = [];
+  for (const v of h.m.values()) a.push(v);
+  line("classField", a.join(","));
+
+  const obj = { m: new Map<string, number>([["c", 3], ["d", 4]]) };
+  const b: string[] = [];
+  for (const k of obj.m.keys()) b.push(k);
+  line("objectProp", b.join(","));
+
+  function walk(m: Map<string, number> | undefined): string {
+    if (!m) return "none";
+    const out: string[] = [];
+    for (const e of m) out.push(e[0] + "=" + e[1]);
+    return out.join(",");
+  }
+  line("union", walk(new Map<string, number>([["u", 1], ["w", 2]])));
+  line("union.undefined", walk(undefined));
+}
+
+// --- control flow out of a view loop ---
+{
+  const m = mkMap(6);
+  const a: number[] = [];
+  for (const v of m.values()) {
+    if (v === 1) continue;
+    if (v === 4) break;
+    a.push(v);
+  }
+  line("breakContinue", a.join(","));
+
+  const b: string[] = [];
+  outer: for (const k of m.keys()) {
+    for (const v of m.values()) {
+      if (v === 2) continue outer;
+      b.push(k + ">" + v);
+      if (b.length > 20) break outer;
+    }
+  }
+  line("nested", b.join(","));
+
+  const seen: number[] = [];
+  const first = (): number => {
+    for (const v of m.values()) {
+      seen.push(v);
+      if (v === 2) return v;
+    }
+    return -1;
+  };
+  line("returnInLoop", first());
+  line("returnInLoop.seen", seen.join(","));
+}
+
+// --- empty / one-entry / cleared collections ---
+{
+  const e = new Map<string, number>();
+  const a: number[] = [];
+  for (const v of e.values()) a.push(v);
+  line("empty", "[" + a.join(",") + "]");
+
+  const one = new Map<string, number>([["x", 1]]);
+  const b: string[] = [];
+  for (const k of one.keys()) b.push(k);
+  line("one", b.join(","));
+
+  const m = mkMap(4);
+  m.clear();
+  const c: number[] = [];
+  for (const v of m.values()) c.push(v);
+  line("cleared", "[" + c.join(",") + "]");
+}
+
+// --- non-string keys and mixed values through the views ---
+{
+  const m = new Map<unknown, unknown>();
+  const o = { tag: "o" };
+  m.set(1, "one");
+  m.set(NaN, "nan");
+  m.set(-0, "zero");
+  m.set(o, "obj");
+  m.set("s", null);
+  const ks: string[] = [];
+  for (const k of m.keys()) {
+    ks.push(typeof k === "object" && k !== null ? "obj" : String(k));
+  }
+  line("mixed.keys", ks.join(","));
+  const vs: string[] = [];
+  for (const v of m.values()) vs.push(String(v));
+  line("mixed.values", vs.join(","));
+}
+
+// --- iterating the same view expression twice, and a `let` head ---
+{
+  const m = mkMap(3);
+  const a: number[] = [];
+  for (const v of m.values()) a.push(v);
+  for (const v of m.values()) a.push(v * 10);
+  line("twice", a.join(","));
+
+  const b: number[] = [];
+  for (let v of m.values()) {
+    v = v + 100;
+    b.push(v);
+  }
+  line("letHead", b.join(","));
+}
+
+// --- scale: the shape `benchmarks/app-patterns/kernels/map_1m.ts` runs ---
+{
+  const N = 20000;
+  const m = new Map<string, number>();
+  for (let i = 0; i < N; i++) m.set("key_" + i, i * 2);
+  let sum = 0;
+  for (const v of m.values()) sum += v;
+  let keyChars = 0;
+  for (const k of m.keys()) keyChars += k.length;
+  let pairSum = 0;
+  for (const e of m) pairSum += e[1] as number;
+  line("scale.values", sum);
+  line("scale.keys", keyChars);
+  line("scale.pairs", pairSum);
+  line("scale.size", m.size);
+}

--- a/test-files/test_gap_map_view_for_of.ts
+++ b/test-files/test_gap_map_view_for_of.ts
@@ -285,6 +285,31 @@ function mkMap(n: number): Map<string, number> {
   line("letHead", b.join(","));
 }
 
+// --- `for await` over a Map: values and order.
+//
+// The microtask INTERLEAVING of a `for await` Map loop is a separate,
+// pre-existing divergence and is deliberately not asserted here; the lowering
+// it depends on is pinned instead by
+// `perry-hir::lower::collection_view_tests::for_await_is_never_rewritten`,
+// because a `.ts` assertion on it would be red for reasons this file is not
+// about.
+async function forAwaitOrder(): Promise<void> {
+  const m = new Map<string, number>([["a", 1], ["b", 2], ["c", 3]]);
+  const log: string[] = [];
+  for await (const e of m) log.push("pair:" + e[0] + "=" + e[1]);
+  for await (const [k, v] of m) log.push("kv:" + k + "=" + v);
+  for await (const v of m.values()) log.push("v:" + v);
+
+  // values that ARE promises: for-await must unwrap them
+  const pm = new Map<string, Promise<number>>([
+    ["p", Promise.resolve(10)],
+    ["q", Promise.resolve(20)],
+  ]);
+  for await (const v of pm.values()) log.push("pv:" + v);
+
+  line("forAwait", log.join("|"));
+}
+
 // --- scale: the shape `benchmarks/app-patterns/kernels/map_1m.ts` runs ---
 {
   const N = 20000;
@@ -301,3 +326,6 @@ function mkMap(n: number): Map<string, number> {
   line("scale.pairs", pairSum);
   line("scale.size", m.size);
 }
+
+// Runs last so its `line()` output lands after every synchronous case.
+forAwaitOrder();


### PR DESCRIPTION
## `map_1m` is the largest absolute time in the public artifact, and the Map was never the problem

`benchmarks/app-patterns/kernels/map_1m.ts` sits at **1233.7 ms** in the
v0.5.1299 sweep — nearly double the next-slowest kernel, 4.8× bun and 3.9×
node. Profiling first, before touching anything, says the Map itself is fine
and **one line of the kernel is the whole gap**.

### Phase decomposition — pinned quiet mini, 5 interleaved runs, load 1.52

| phase | perry before | perry after | node 26.5.1 | bun 1.3.14 |
|---|--:|--:|--:|--:|
| insert 500k `m.set("key_" + i, …)` | 220 ms | 219 ms | 140 | 97 |
| look up 500k `m.get("key_" + i)` | **76 ms** | **76 ms** | 115 | 103 |
| **`for (const v of m.values())`** | **512 ms** | **5 ms** | 4 | 6 |
| 10k `m.has("missing_" + i)` misses | ~1 ms | ~1 ms | 5 | 3 |

Perry already **won lookup** (76 ms against node's 115 and bun's 103) and won
the miss loop. Insert is 1.6× node, and the symbolicated profile puts 55.5% of
it in `js_string_concat_value` — building the 500k keys — with 45.5% of the
whole probe inside `gc_collect_minor_with_trigger` that those string
allocations trigger. `find_string_key_index` is 17.25%. That is the #7469
allocation-path story, not a Map story.

Iteration was **128× node**.

### Where the 512 ms went — 9679 leaf samples, `PERRY_DEBUG_SYMBOLS=1`

`for (const v of m.values())` produced a real Map **iterator object** and drove
it through the generic protocol, one `.next()` per element:

| stage | inclusive |
|---|--:|
| `js_typed_feedback_native_call_method_by_id` — the per-element `.next()` | **76.37%** |
| └ `dispatch_handle` → `dispatch_map_iterator_method` | 62.91% |
| **└ `make_iter_result` — building `{ value, done }`** | **55.08%** |
| ├ `js_array_push_f64` (the two keys) → `note_array_slot` → `invalidate_representation_change` → `pthread_mutex_lock` | 22.09% (10.96% in the mutex) |
| ├ `string_storage_alloc` — allocating the strings `"value"` and `"done"`, **per element** | 16.05% |
| ├ `js_array_alloc` (the keys array) | 9.00% |
| ├ `js_object_set_field` ×2 | 7.09% |
| ├ `js_object_alloc_with_parent` — the result object itself | 5.09% |
| └ `shape_id_for_keys_ensure` | 4.99% |
| `gc_check_trigger` → `gc_collect_minor_with_trigger` (driven by the above) | 16.59% |
| `js_object_get_field_ic_miss` — reading `.value` / `.done` back off it | 12.18% |
| `_tlv_get_addr` | 12.98% |

**Five heap allocations per element** — the result object, two key strings, a
two-element keys array, and a shape install — for a value the loop reads once
and drops. 2.5 M allocations for one sweep of a 500k Map.

And the same iteration written directly, `for (const [, v] of m)`, **already
cost 5 ms**: it lowers to a delete-safe index walk over the Map's flat entries
buffer and allocates nothing. Reaching the identical entries through
`.values()` was 161× more expensive because the lowering keyed on the *syntax*
of the subject, not on what it produces.

## What changed

Two commits in `perry-hir`, no runtime change.

**1. `for (… of m.values() / m.keys() / m.entries())` is rewritten to the
direct-collection form** (`for_head::rewrite_collection_view_for_of`) when the
receiver's static type proves `Map` / `Set` *and* the resulting head is one the
index fast path accepts:

| subject | head | becomes |
|---|---|---|
| `m.entries()` | any index-fast-path head | `for (<head> of m)` |
| `m.keys()` | plain ident `k` | `for (const [k] of m)` |
| `m.values()` | plain ident `v` | `for (const [, v] of m)` |
| `s.values()` / `s.keys()` | plain ident | `for (<head> of s)` |

Everything else keeps the iterator protocol, and the gate is deliberately
narrow. `for (const [a, b] of m.values())` destructures the *value*, not the
entry. `s.entries()` yields `[v, v]`, which `for (… of s)` does not. `for
await` is left alone. And crucially, any head the index walk would decline is
left alone too — because the Map/Set *fallback* is a `MapEntries` /
`SetValues` materialisation, i.e. a **snapshot**, so rewriting onto it would
change what a body that mutates the collection observes.

**2. A single-ident Map for-of head now binds a live `[k, v]` pair** — and this
one is a **correctness fix** as much as a speed fix. `for (const e of m)` went
through that `MapEntries` snapshot, so:

```
for (const e of m) { … if (first) m.set("late", 9); }   // node: a,b,late — perry: a,b
for (const e of m) { … if (e[0] === "a") m.delete("b"); } // node: a,c   — perry: a,b,c
```

Both now match node. The pair is read out of the entries buffer at the
delete-corrected index, one fresh two-element Array per step — the same
allocation node's Map iterator makes.

Both commits also dedup the `#302`/`#311` iterable-type resolution and the
fast-path head predicate, which the two for-of desugars (`lower/stmt_loops.rs`
for module scope, `lower_decl/body_stmt.rs` for function bodies) carried
byte-identical copies of. Net effect on the 2000-LOC cap: `stmt_loops.rs`
2000 → 1954, `body_stmt.rs` 2140 → 2092.

## Results — pinned quiet mini, `hyperfine --warmup 3 --runs 15`

| | before | **after** | node 26.5.1 | bun 1.3.14 |
|---|--:|--:|--:|--:|
| **`map_1m` (the kernel)** | 820.0 ± 5.1 ms | **309.1 ± 2.7 ms** | 323.1 ± 1.6 | 221.0 ± 0.9 |
| insert + `for (const v of m.values())` | 952.4 ± 3.3 | **231.3 ± 0.7** | 205.1 ± 1.9 | 121.0 ± 0.9 |
| insert + `for (const e of m.entries())` | 1296.7 ± 3.4 | **234.2 ± 0.5** | 206.4 ± 1.4 | 123.4 ± 0.7 |

**2.65× on the kernel, and Perry now beats node on it** (309 vs 323) where it
was 2.5× node before. perry/bun moves from **3.71× to 1.40×**, and the
remaining gap is entirely the insert phase's string construction — the #7469
allocation path, not the Map.

Isolated loop timings over a 500k Map (each in its own process — see the note
below on why that matters):

| loop | before | after | node |
|---|--:|--:|--:|
| `for (const v of m.values())` | 770 ms | **5 ms** | 5 |
| `for (const k of m.keys())` | 978 ms | **6 ms** | 3 |
| `for (const e of m.entries())` | 1128 ms | **7 ms** | 6 |
| `for (const e of m)` | 1265 ms | **6 ms** | 7 |
| `for (const x of s.values())` | 370 ms | **5 ms** | 4 |
| `for (const [k, v] of m)` (control, untouched) | 5 ms | 5 ms | 10 |

### GC counters — `PERRY_GC_TRACE=1`, whole-process totals

| probe | cycles before | cycles after | copied objects |
|---|---|---|---|
| `map_1m` | 8 (7 minor + 1 **full**) | **2 minor, 0 full** | 445,639 → 445,639 |
| insert + values sweep | 6 (3 minor + 3 full) | **2 minor, 0 full** | 445,639 → 445,639 |
| insert + entries sweep | 9 (4 minor + 5 full) | **2 minor, 0 full** | 445,639 → 445,638 |

Copied objects and bytes (17.8 MB) are **unchanged** — the surviving live set
is identical; what disappeared is only the garbage the iteration was making.
Both arms still run copying minors with `copied_objects > 0`, so the
comparison is not the vacuous kind CLAUDE.md warns about.

## Correctness

**A 115-line Map semantics matrix** — insertion order, overwrite-in-place,
delete-then-reinsert, SameValueZero (`NaN`, `-0`/`+0`), string-representation
boundaries (SSO/heap/multibyte/surrogate/NUL/`__proto__`), object vs string key
identity, iterator invalidation under append / delete-ahead / delete-current /
delete-behind, `Symbol.iterator` vs `entries()` vs `forEach` agreement,
`clear()` and reuse, mixed key kinds, union-typed receivers, class fields,
object properties, `break`/`continue`/labeled-break/`return`, `let` and `var`
heads, and nested loops — is **byte-identical before and after** except for the
four lines the second commit deliberately fixes, and matches the node oracle
everywhere except two divergences that **predate this work and are unchanged by
it** (filed separately):

- `Map.prototype[Symbol.iterator] === Map.prototype.entries` is `false`.
- `for (var k of …)` does not leak `k` past the loop.

`test-files/test_gap_map_view_for_of.ts` (new) is **byte-identical to node**
after, and had two divergences before — so it is a test that would have been
red, not decoration.

`lower/collection_view_tests.rs` pins the **verdict**, not the output: which of
the three lowerings (index walk / materialisation / iterator protocol) each
loop shape receives. A test comparing only program output would stay green if
the fast path silently stopped applying, which is CLAUDE.md's fourth way a gate
can be unable to fail; a `the_route_probe_actually_discriminates` case proves
the probe can still tell them apart. `an_unproven_receiver_is_never_rewritten`
covers a plain object with a `values()` method and a `class MyMap extends Map`.

**Divergences this does not introduce.** A patched `Map.prototype.values`, a
patched `Map.prototype[Symbol.iterator]`, and an own-instance `values` shadow
are *already* ignored by Perry at the parent commit — verified against node,
which honours all three — and the pre-existing direct `for (… of m)` fast path
has the same property. A `Map` subclass types as `Type::Named`, never
`Type::Generic`, so an overriding subclass method is never bypassed.

## Measurement note worth recording

The first A/B ran all nine loop shapes in **one process**, and reported
`for (const e of m.entries())` at 570 → 1180 ms and `[...m.values()]` at
115 → 240 ms — two apparent 2× regressions in shapes this change does not
touch. Re-measured one shape per process, both are flat (1128 → 1124 and
92 → 92). Removing ~2.5 M allocations from the *earlier* benches moves the
whole GC regime the *later* ones run in. A multi-bench file is not a valid A/B
instrument once one of its benches changes its allocation rate.

## Found while profiling, filed separately, not fixed here

- Spread / `Array.from` over any iterator **silently truncates at 100,000
  elements** — `[...m.values()]` on a 500k Map returns 100k. Three
  `for _ in 0..100_000` "safety limit" loops in `array/iterator.rs`.
- `for (const v of sub.values())` where `sub` is a `class MyMap extends Map`
  **segfaults**.
- `make_iter_result` allocating five objects per `.next()` is the shape behind
  this whole ticket, and three copies of it remain on the generic path that
  every generator and custom iterator still uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `for...of` iteration over `Map` and `Set` views, including keys, values, and entries.
  * Added optimized, allocation-free iteration for supported collection patterns.
  * Expanded support for collections stored in variables, object properties, and class fields.

* **Bug Fixes**
  * Preserved correct behavior for async iteration, destructuring, mutations, receiver expressions, and empty collections.
  * Direct Map iteration now reflects insertions and deletions correctly.

* **Tests**
  * Added comprehensive coverage for optimized, materialized, and protocol-based iteration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->