### PR TITLE
fix(gates): gap suite could neither pass nor fail on macOS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1320
+**Current Version:** 0.5.1321
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1320"
+version = "0.5.1321"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1320"
+version = "0.5.1321"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1320"
+version = "0.5.1321"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1320"
+version = "0.5.1321"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1320"
+version = "0.5.1321"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7566-macos-gap-snapshot-fallback.md
+++ b/changelog.d/7566-macos-gap-snapshot-fallback.md
@@ -1,0 +1,20 @@
+### Gates: the gap suite could neither pass nor fail on macOS
+
+`run_gap_tests.sh` selects `test-parity/gap_snapshot.${platform}.json` for
+non-Linux hosts. There is no `gap_snapshot.macos.json` in the repo, so every
+local macOS run did all ~490 tests' worth of work and then died in a
+`FileNotFoundError` — an exit 1 that is indistinguishable from "here is your
+regression list". The per-test results were only recoverable by reading the
+log by hand, which is exactly how this campaign's verification runs were
+actually read.
+
+A missing platform baseline now **says so and falls back to the shared
+baseline** — the one the required CI gate uses, so a local run is measured
+against the same bar. The fallback is announced on stderr rather than applied
+silently, because the platforms genuinely differ (macOS carries known
+host-local failures) and quietly comparing against another platform's
+expectations would be its own kind of lie. An explicitly-passed
+`GAP_SNAPSHOT=` that does not exist is still a hard error (exit 2) — the
+fallback is for the unset default, not for a typo.
+
+Found by an agent whose gap run failed this way while validating #7565.

--- a/scripts/run_gap_tests.sh
+++ b/scripts/run_gap_tests.sh
@@ -76,7 +76,33 @@ if [[ "$host_platform" == "linux" ]]; then
 else
   default_snapshot="test-parity/gap_snapshot.${host_platform}.json"
 fi
+if [[ -n "${GAP_SNAPSHOT:-}" ]]; then GAP_SNAPSHOT_EXPLICIT=1; fi
 GAP_SNAPSHOT="${GAP_SNAPSHOT:-$default_snapshot}"
+
+# #7566: a platform baseline that does not exist must SAY SO, not die in a
+# FileNotFoundError whose exit 1 is indistinguishable from a regression list.
+# On macOS there is no `gap_snapshot.macos.json`, so every local run of this
+# script ended in a traceback after doing all ~490 tests' worth of work — the
+# gate could neither pass nor fail, and the useful per-test results were only
+# recoverable by reading the log by hand.
+#
+# Falling back to the shared Linux baseline is the honest default: it is the
+# one the required CI gate uses, so a local run is measured against the same
+# bar. It is announced loudly rather than silently, because the two platforms
+# genuinely differ (macOS carries known host-local failures), and a run that
+# silently compared against another platform's expectations would be its own
+# kind of lie.
+if [[ ! -f "$GAP_SNAPSHOT" ]]; then
+  if [[ -n "${GAP_SNAPSHOT_EXPLICIT:-}" ]]; then
+    echo "ERROR: GAP_SNAPSHOT='$GAP_SNAPSHOT' does not exist." >&2
+    exit 2
+  fi
+  echo "NOTE: no $host_platform baseline at '$GAP_SNAPSHOT'; comparing against" >&2
+  echo "      test-parity/gap_snapshot.json (the shared baseline required CI uses)." >&2
+  echo "      Establish a $host_platform baseline with UPDATE_SNAPSHOT=1 if its" >&2
+  echo "      expected-failure set genuinely differs." >&2
+  GAP_SNAPSHOT="test-parity/gap_snapshot.json"
+fi
 
 # Run-scoped temp dir — fixed /tmp names would let concurrent runs (a second
 # PR, local + CI on the same box, or the future node-suite-guard alongside)


### PR DESCRIPTION
`run_gap_tests.sh` selects `test-parity/gap_snapshot.${platform}.json` for non-Linux hosts. **There is no `gap_snapshot.macos.json` in the repo**, so every local macOS run did all ~490 tests' worth of work and then died in a `FileNotFoundError` — an exit 1 indistinguishable from "here is your regression list".

This is the fifth gate pathology found this campaign, and a notable one: the useful per-test results were only recoverable by reading the log by hand, which is literally how this session's verification runs were read.

A missing platform baseline now **says so and falls back to the shared baseline** — the one required CI uses, so a local run is measured against the same bar. Announced on stderr rather than applied silently, because the platforms genuinely differ (macOS carries known host-local failures) and quietly comparing against another platform's expectations would be its own kind of lie.

An explicitly-passed `GAP_SNAPSHOT=` that does not exist stays a hard error (exit 2) — the fallback is for the unset default, not for a typo.

Found by an agent whose gap run failed this way while validating #7565.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS gap tests now fall back to the shared baseline when a platform-specific snapshot is unavailable.
  * A warning is shown when this fallback occurs.
  * Explicitly requested but missing snapshots continue to produce an error.

* **Documentation**
  * Added release notes describing snapshot fallback behavior.

* **Chores**
  * Updated the application version to 0.5.1321.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->