### PR TITLE
perf(iterator): build one object per .next(), not five (#7564)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1325
+**Current Version:** 0.5.1326
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1325"
+version = "0.5.1326"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1325"
+version = "0.5.1326"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1325"
+version = "0.5.1326"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1325"
+version = "0.5.1326"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1325"
+version = "0.5.1326"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7579-iter-result-one-allocation.md
+++ b/changelog.d/7579-iter-result-one-allocation.md
@@ -1,0 +1,66 @@
+### `perf(iterator)`: one allocation per `.next()`, not five (#7564)
+
+Every `.next()` the runtime answered itself allocated **five** heap objects to
+deliver one value, and four were the same constant on every call: the `"value"`
+and `"done"` key strings, the two-element keys array holding them, and a shape
+install keyed on that array's address. There were **five** copies of the
+constructor, not the three the issue named — `array/iter_object.rs`,
+`collection_iter_object.rs`, `string/iter_object.rs`, `buffer/iter.rs` and
+`iterator_helpers.rs` — reached by, respectively, array iteration and
+`node:sqlite`, `Map`/`Set` method iterators, string iteration, `Buffer`/typed
+arrays, and `Iterator.from(...)`.
+
+They collapse into one `crate::iter_result` that shares a keys array per key
+order per thread, so the steady-state path performs exactly one allocation: the
+result object the language actually requires. Sharing is not a new idea here —
+it is already how object literals and `JSON.parse` results work. The array
+carries `GC_FLAG_SHAPE_SHARED`, and every path that would mutate an object's
+key list (`field_set_by_name`, `delete_rest`, `proxy::put_value`) clones before
+writing. `node:sqlite`'s `{ done, value }` order is observable through
+`Object.keys`, so it keeps its own array rather than being normalized.
+
+**The shape install was worth more than the allocations.**
+`shape_id_for_keys_ensure` keys the shape table on the keys array's *address*,
+so a fresh array per `.next()` minted a fresh shape id per `.next()`: every
+read of `.value`/`.done` off a result was a guaranteed inline-cache miss
+(12.18% of the profile in the issue), and the shape table grew without bound.
+One shared array means one shape id for every iterator result in the program.
+
+**A stale-from-space deref went with it.** Four of the five copies ran five
+allocations back to back with every intermediate in a bare Rust local, so a
+copying minor inside allocation *k* moved what locals 1..k-1 named and rewrote
+only slots it could see — which a Rust local is not. Under
+`PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1` this took a SIGBUS at
+`iterator_helpers::make_iter_result + 172`. The fix is structural rather than
+more roots: with one allocation, both pointers used after it are re-read from
+storage the collector rewrites — the object from its `RuntimeHandleScope`
+handle, the keys array from the scanned thread-local.
+
+`iterator_step` — the *read* side of the protocol, in the same call chain — had
+the identical defect and is fixed with it. It allocated `"next"`, `"done"` and
+`"value"` on every step and held the iterator object, the result object and the
+earlier keys across those allocations *and* across a call into the user's own
+`next`, which can run arbitrary JS.
+
+`ITER_RESULT_KEYS` is exactly the "runtime-side cache of a raw heap pointer"
+the static `gc_root_dominance_check.py` cannot see, so its scanner is
+registered in `gc_init` in the same commit, with mark, rewrite, registration
+and copy-on-write tests. The tests are sabotage-verified: making the scanner
+visit only slot 0 fails mark and rewrite; dropping `GC_FLAG_SHAPE_SHARED` fails
+the copy-on-write test.
+
+**Measured**, A/B on identical sources with a full
+`-p perry -p perry-runtime-static -p perry-stdlib-static` rebuild per arm, 9
+interleaved rounds each: `map.values()` **2.10×**, `string` **1.73×**,
+`typedarray.entries()` **1.85×**, `array` manual `.next()` **1.88×** (min; the
+medians agree within 5%). Deterministic and host-independent: the same workload
+drives **16 → 5** garbage collections. Wall-clock was taken on the shared dev
+machine because the pinned quiet host was in use, so treat the ratios as
+approximate and the collection count as exact.
+
+Three unrelated pre-existing defects were found and filed while validating
+this, all verified present on the pre-fix runtime: #7576 (`Iterator.from(x)`
+returns an already-exhausted iterator and `.map`/`.filter` return `undefined`,
+so the whole iterator-helpers surface is dead) and #7577
+(`js_generator_attach_prototype` derefs retired from-space memory). The gap
+test documents why it routes around each.

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -518,63 +518,13 @@ pub extern "C" fn js_array_entries_iter_obj(arr: *const ArrayHeader) -> i64 {
     }
 }
 
-/// Root every heap value an iterator-result constructor carries across its own
-/// allocations, and hand back the finished `{ … }` object.
-///
-/// #7475: `value` is a caller-supplied JSValue that is very often a heap
-/// pointer (an array element), `obj` is freshly allocated, and the two key
-/// strings and the keys array are all allocated while the earlier ones are
-/// still live. Every one of those lines can trigger the copying minor, and
-/// before this helper each was held in a bare Rust local the collector cannot
-/// see — so a collection during `make_iter_result` stored a from-space address
-/// into the result object, which the spread/`Array.from` drain then read back.
-///
-/// `first`/`second` name the two field slots in declaration order, since the
-/// array iterator stores `{ value, done }` and the `node:sqlite` iterator
-/// stores `{ done, value }`.
-unsafe fn build_iter_result(first: (&[u8], JSValue), second: (&[u8], JSValue)) -> f64 {
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let first_h = scope.root_nanbox_u64(first.1.bits());
-    let second_h = scope.root_nanbox_u64(second.1.bits());
-
-    let obj_h = scope.root_nanbox_f64(js_nanbox_pointer(js_object_alloc(0, 2) as i64));
-
-    // keys array so destructuring + property reads find named slots.
-    let first_key_h = scope.root_nanbox_u64(
-        JSValue::string_ptr(crate::string::js_string_from_bytes(
-            first.0.as_ptr(),
-            first.0.len() as u32,
-        ))
-        .bits(),
-    );
-    let second_key_h = scope.root_nanbox_u64(
-        JSValue::string_ptr(crate::string::js_string_from_bytes(
-            second.0.as_ptr(),
-            second.0.len() as u32,
-        ))
-        .bits(),
-    );
-    let keys_h = scope.root_nanbox_f64(js_nanbox_pointer(crate::array::js_array_alloc(2) as i64));
-    let keys = || js_nanbox_get_pointer(keys_h.get_nanbox_f64()) as *mut ArrayHeader;
-    crate::array::js_array_push(keys(), JSValue::from_bits(first_key_h.get_nanbox_u64()));
-    crate::array::js_array_push(keys(), JSValue::from_bits(second_key_h.get_nanbox_u64()));
-
-    let obj = || js_nanbox_get_pointer(obj_h.get_nanbox_f64()) as *mut ObjectHeader;
-    crate::object::js_object_set_keys(obj(), keys());
-    js_object_set_field(obj(), 0, JSValue::from_bits(first_h.get_nanbox_u64()));
-    js_object_set_field(obj(), 1, JSValue::from_bits(second_h.get_nanbox_u64()));
-    js_nanbox_pointer(obj() as i64)
-}
-
-/// Build the `{ value, done }` iterator-result object. `value` arrives as
-/// a NaN-boxed JSValue; `done` is a JS boolean.
-unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
-    build_iter_result((b"value", value), (b"done", JSValue::bool(done)))
-}
-
-unsafe fn make_sqlite_iter_result(value: JSValue, done: bool) -> f64 {
-    build_iter_result((b"done", JSValue::bool(done)), (b"value", value))
-}
+// #7564: `build_iter_result` lived here, rooted by #7475 but still allocating
+// the two key strings and the keys array on EVERY call — and minting a fresh
+// shape id per call, because `shape_id_for_keys_ensure` keys the shape table on
+// the keys array's address. Both constructors now come from the single
+// `crate::iter_result` implementation, which shares one keys array (and so one
+// shape) per key order per thread and allocates only the result object.
+use crate::iter_result::{make_iter_result, make_sqlite_iter_result};
 
 unsafe fn make_pair_array(idx: u32, value: f64) -> f64 {
     let pair = crate::array::js_array_alloc(2);

--- a/crates/perry-runtime/src/buffer/iter.rs
+++ b/crates/perry-runtime/src/buffer/iter.rs
@@ -88,21 +88,8 @@ pub extern "C" fn js_buffer_entries(buf_f64: f64) -> f64 {
 
 /// Build the `{ value, done }` iterator-result object.  `value`
 /// arrives as a NaN-boxed JSValue; `done` is a JS boolean.
-unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
-    let obj = js_object_alloc(0, 2);
-
-    // keys array so destructuring + for-of can find named slots.
-    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
-    let keys = crate::array::js_array_alloc(2);
-    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
-    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
-    crate::object::js_object_set_keys(obj, keys);
-
-    js_object_set_field(obj, 0, value);
-    js_object_set_field(obj, 1, JSValue::bool(done));
-    js_nanbox_pointer(obj as i64)
-}
+// #7564: was a local five-allocation copy with unrooted intermediates.
+use crate::iter_result::make_iter_result;
 
 unsafe fn make_pair_array(idx: u32, byte: u8) -> f64 {
     let pair = crate::array::js_array_alloc(2);

--- a/crates/perry-runtime/src/collection_iter_object.rs
+++ b/crates/perry-runtime/src/collection_iter_object.rs
@@ -159,21 +159,11 @@ static KEEP_SET_ENTRIES_ITER: extern "C" fn(*const SetHeader) -> i64 = js_set_en
 
 /// Build the `{ value, done }` iterator-result object. Mirrors
 /// `array/iter_object.rs::make_iter_result`.
-unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
-    let obj = js_object_alloc(0, 2);
-
-    // keys array so destructuring + property reads find named slots.
-    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
-    let keys = crate::array::js_array_alloc(2);
-    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
-    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
-    crate::object::js_object_set_keys(obj, keys);
-
-    js_object_set_field(obj, 0, value);
-    js_object_set_field(obj, 1, JSValue::bool(done));
-    js_nanbox_pointer(obj as i64)
-}
+// #7564: this was a local five-allocation copy with every intermediate in a
+// bare Rust local — see `crate::iter_result` for what that cost and why it was
+// a stale-from-space hazard. `use` rather than a wrapper so the call sites
+// below read unchanged.
+use crate::iter_result::make_iter_result;
 
 /// `[key, value]` pair array for Map entries / Set entries (`[v, v]`).
 unsafe fn make_pair_array(a: f64, b: f64) -> f64 {

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -648,6 +648,14 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::dgram_reactor::scan_roots_mut);
     gc_register_mutable_root_scanner(json_parse_mutable_root_scanner);
     gc_register_mutable_root_scanner(intern_table_mutable_root_scanner);
+    // #7564: the per-thread `{ value, done }` / `{ done, value }` keys arrays
+    // shared by every iterator result the runtime builds. Nothing else in the
+    // heap references them — the result objects that use them are short-lived
+    // while the cache outlives them — so without this scanner they would be
+    // swept and the next `.next()` would install a freed keys array. It also
+    // REWRITES: an evacuating collection moves them like any other array, and
+    // the thread-local slot is the only place the new address can be recorded.
+    gc_register_mutable_root_scanner(crate::iter_result::scan_iter_result_keys_roots_mut);
     gc_register_mutable_root_scanner(small_int_cache_mutable_root_scanner);
     gc_register_mutable_root_scanner(crate::builtins::scan_console_log_singleton_roots_mut);
     gc_register_mutable_root_scanner(crate::builtins::scan_boxed_primitive_payload_roots_mut);

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 mod callback_scanners;
 mod hook_dispatch_handles;
 mod interned_string_caches;
+mod iter_result_keys;
 mod prototype_addr_cache;
 mod side_table_scanners;
 mod string_slice;

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/iter_result_keys.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/iter_result_keys.rs
@@ -1,0 +1,218 @@
+//! #7564 — the per-thread `{ value, done }` / `{ done, value }` keys arrays
+//! that every runtime-built iterator result shares.
+//!
+//! This is the "runtime-side cache of a raw heap pointer" shape CLAUDE.md
+//! warns about: `scripts/gc_root_dominance_check.py` reads emitted LLVM IR, so
+//! a thread-local holding a `*mut ArrayHeader` into the heap is structurally
+//! invisible to it. The runtime scanner is the only thing standing between
+//! that cache and a use-after-free, and — being a cache rather than a register
+//! — it would go bad at collection #0 and stay bad, corrupting every later
+//! `.next()` on the thread rather than failing intermittently.
+//!
+//! Two halves have to hold, and marking alone is not enough: a marked but
+//! un-rewritten slot still hands out a pre-move address after a copying minor,
+//! which is the whole failure. So there is a MARK test and a REWRITE test,
+//! plus a registration check — a scanner a test can call directly is a no-op
+//! in production until `gc_init` names it.
+//!
+//! The shape invariants the sharing DEPENDS on are asserted here too. Sharing
+//! one keys array across every result object is only sound because the array
+//! carries `GC_FLAG_SHAPE_SHARED`, which is what makes `result.extra = 1`
+//! clone before appending instead of mutating the array every other result is
+//! using. Lose that flag and one user-added property corrupts every iterator
+//! result in the program.
+
+use super::*;
+use crate::array::ArrayHeader;
+use crate::iter_result::IterResultOrder;
+
+/// Empties the cache on entry and on exit, so a test starts from slots it
+/// populated itself and a later test on this thread does not inherit a slot
+/// pointing into this test's arena.
+///
+/// It also pins the GC triggers for the body: these tests hand-build the
+/// evacuation the collector would perform, and a real collection landing
+/// between `build_valid_pointer_set` and the forwarding write would move the
+/// arrays out from under it and go red for a reason unrelated to the scanner.
+struct IterResultKeysGuard {
+    _triggers: GcTriggerThresholdTestGuard,
+}
+
+impl IterResultKeysGuard {
+    fn new() -> Self {
+        let triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+        crate::iter_result::reset_shared_keys_for_test();
+        Self {
+            _triggers: triggers,
+        }
+    }
+}
+
+impl Drop for IterResultKeysGuard {
+    fn drop(&mut self) {
+        crate::iter_result::reset_shared_keys_for_test();
+    }
+}
+
+/// Allocate an old-gen destination and forward `from` → `to`, the shape an
+/// evacuating minor leaves behind.
+fn evacuate_array(from: *mut ArrayHeader) -> *mut ArrayHeader {
+    let to = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_ARRAY);
+    unsafe {
+        set_forwarding_address(header_from_user_ptr(from as *const u8), to);
+    }
+    to as *mut ArrayHeader
+}
+
+/// MARK. The cache is the ONLY reference to these arrays — the result objects
+/// that point at them are short-lived while the cache outlives them — so an
+/// unmarked slot is a swept slot, and every later `.next()` on the thread
+/// installs a freed keys array as an object's shape.
+#[test]
+fn iter_result_keys_cache_is_marked_by_the_collector() {
+    let _guard = IterResultKeysGuard::new();
+    clear_marks();
+    clear_mark_seeds();
+
+    let arrays = crate::iter_result::populate_shared_keys_for_test();
+    let valid_ptrs = build_valid_pointer_set();
+
+    crate::iter_result::scan_iter_result_keys_roots_mut(&mut RuntimeRootVisitor::for_mark(
+        &valid_ptrs,
+    ));
+
+    for (i, arr) in arrays.iter().enumerate() {
+        assert!(!arr.is_null(), "keys slot {i} should have been populated");
+        assert_marked_user_ptr(
+            *arr as usize,
+            &format!("iterator-result keys array {i} (nothing else references it)"),
+        );
+    }
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+/// REWRITE, both slots. Marking keeps the array alive; only the rewrite makes
+/// the slot name the surviving copy. Both orders are forwarded, so a dropped
+/// `visit(...)` — or a scanner that iterates only slot 0 — fails here.
+#[test]
+fn every_iter_result_keys_slot_is_rewritten_by_the_collector() {
+    let _guard = IterResultKeysGuard::new();
+
+    let before = crate::iter_result::populate_shared_keys_for_test();
+    // The from-space objects must exist before the valid-pointer set is built:
+    // that set is what tells the rewrite visitor an address is a real heap
+    // object, exactly as in a real cycle.
+    let valid_ptrs = build_valid_pointer_set();
+    let expected: Vec<*mut ArrayHeader> = before.iter().map(|p| evacuate_array(*p)).collect();
+
+    crate::iter_result::scan_iter_result_keys_roots_mut(&mut RuntimeRootVisitor::for_rewrite(
+        &valid_ptrs,
+    ));
+
+    for (i, order) in [IterResultOrder::ValueDone, IterResultOrder::DoneValue]
+        .into_iter()
+        .enumerate()
+    {
+        assert_eq!(
+            crate::iter_result::shared_keys_peek_for_test(order),
+            expected[i],
+            "iterator-result keys slot {i} ({order:?}) must be rewritten to the \
+             relocated array. A marked-but-stale slot is worse than an \
+             intermittent bug: it goes bad at collection #0 and then EVERY \
+             `.next()` on this thread installs a from-space keys array as the \
+             result object's shape (#7564)."
+        );
+    }
+}
+
+/// An empty cache is the state between process start and the first `.next()`,
+/// and every cycle in that window scans it. A null slot must be skipped, not
+/// treated as an address.
+#[test]
+fn scanning_an_empty_iter_result_keys_cache_is_a_no_op() {
+    let _guard = IterResultKeysGuard::new();
+    let valid_ptrs = build_valid_pointer_set();
+
+    crate::iter_result::scan_iter_result_keys_roots_mut(&mut RuntimeRootVisitor::for_rewrite(
+        &valid_ptrs,
+    ));
+
+    for order in [IterResultOrder::ValueDone, IterResultOrder::DoneValue] {
+        assert!(
+            crate::iter_result::shared_keys_peek_for_test(order).is_null(),
+            "scanning must not populate the {order:?} keys slot"
+        );
+    }
+}
+
+/// …and it must actually be REGISTERED. The scanner can be called directly
+/// from a test whether or not `gc_init` ever mentions it, so the wiring is
+/// asserted separately: an unregistered scanner is a no-op in production,
+/// which is precisely the bug this cache would otherwise introduce.
+#[test]
+fn iter_result_keys_scanner_is_registered() {
+    crate::gc::gc_init();
+    let registered = |scanner: MutableRootScanner| {
+        crate::gc::roots::MUTABLE_ROOT_SCANNERS.with(|scanners| {
+            scanners
+                .borrow()
+                .iter()
+                .any(|entry| entry.scanner as usize == scanner as usize)
+        })
+    };
+
+    assert!(
+        registered(crate::iter_result::scan_iter_result_keys_roots_mut as MutableRootScanner),
+        "scan_iter_result_keys_roots_mut must be registered in gc_init — unregistered, \
+         the shared iterator-result keys arrays are swept by the first minor and every \
+         later `.next()` installs a freed array as the result object's shape (#7564)"
+    );
+}
+
+/// The cache must be STABLE: a second `.next()` reuses the array the first one
+/// built. If it did not, nothing would have been saved — and, because
+/// `shape_id_for_keys_ensure` keys the shape table on the array's ADDRESS, a
+/// fresh array per call is also a fresh shape id per call, which is what made
+/// every read of `.value` off a result an inline-cache miss.
+#[test]
+fn iter_result_keys_are_built_once_per_order() {
+    let _guard = IterResultKeysGuard::new();
+
+    let first = crate::iter_result::populate_shared_keys_for_test();
+    let second = crate::iter_result::populate_shared_keys_for_test();
+
+    assert_eq!(
+        first, second,
+        "the shared keys arrays must be built once per thread per order; rebuilding \
+         them per call restores both the four-allocation cost and the one-shape-id- \
+         per-`.next()` inline-cache miss (#7564)"
+    );
+    assert_ne!(
+        first[0], first[1],
+        "`{{ value, done }}` and `{{ done, value }}` are DIFFERENT observable key \
+         orders (the latter is `node:sqlite`'s) and must not share one array"
+    );
+}
+
+/// The copy-on-write marker is the entire soundness argument for sharing.
+/// `field_set_by_name`, `delete_rest` and `proxy::put_value` all consult
+/// `GC_FLAG_SHAPE_SHARED` to decide whether to clone before mutating an
+/// object's key list. Without it, `result.extra = 1` on ONE result object
+/// appends to the array every other result is using.
+#[test]
+fn shared_iter_result_keys_are_marked_copy_on_write() {
+    let _guard = IterResultKeysGuard::new();
+
+    for arr in crate::iter_result::populate_shared_keys_for_test() {
+        let gc_header = unsafe { &*header_from_user_ptr(arr as *const u8) };
+        assert!(
+            gc_header.gc_flags & crate::gc::GC_FLAG_SHAPE_SHARED != 0,
+            "the shared iterator-result keys array must carry GC_FLAG_SHAPE_SHARED. \
+             Without it a single `result.extra = 1` appends to the array EVERY other \
+             iterator result on this thread is using, and they all silently grow a \
+             third key (#7564)"
+        );
+    }
+}

--- a/crates/perry-runtime/src/iter_result.rs
+++ b/crates/perry-runtime/src/iter_result.rs
@@ -1,0 +1,241 @@
+//! Canonical `{ value, done }` iterator-result construction (#7564).
+//!
+//! Every `.next()` that the runtime answers itself — array, string, typed
+//! array/Buffer, Map/Set, and the `Iterator.from(...)` helper chain — hands
+//! back a two-field object. Five copies of the constructor had drifted apart,
+//! and all five allocated **five** heap objects to deliver one value:
+//!
+//! | allocation | information it carries |
+//! |---|---|
+//! | the result object | the value and the done flag |
+//! | `"value"` string | none — same six bytes every call |
+//! | `"done"` string | none — same four bytes every call |
+//! | the 2-element keys array | none — same two pointers every call |
+//! | the shape install keyed on that array's ADDRESS | none, and worse: a *new* shape id per call |
+//!
+//! Four of the five are the same constant on every call, so this module
+//! builds them once per thread and shares them. That is sound because
+//! `keys_array` sharing is already how object literals and `JSON.parse`
+//! results work: the array is stamped [`GC_FLAG_SHAPE_SHARED`], and every
+//! path that would mutate an object's key list — adding a property
+//! (`field_set_by_name`), deleting one (`delete_rest`), or a proxy trap
+//! (`proxy::put_value`) — clones before writing. Nothing can reach through
+//! a result object and disturb the shared array.
+//!
+//! The shape install is the reason this is more than an allocation win.
+//! `shape_id_for_keys_ensure` keys the shape table on the keys array's
+//! ADDRESS, so a fresh array per `.next()` minted a fresh shape id per
+//! `.next()` — every read of `.value`/`.done` off the result was a
+//! guaranteed inline-cache miss, and the shape table grew without bound.
+//! One shared array means one shape id for every iterator result in the
+//! program.
+//!
+//! ## Rooting
+//!
+//! The old constructors were also a live stale-from-space defect. They ran
+//! five allocations back to back with every intermediate in a bare Rust
+//! local: a copying minor inside allocation *k* moved what locals 1..k-1
+//! named and rewrote only slots it could see, which a Rust local is not.
+//! `array/iter_object.rs`'s copy was rooted by #7475; the other four were
+//! not, and `collection_iter_object.rs`'s was observed taking a bus error on
+//! a retired from-space key string under `PERRY_GC_PROTECT_FROMSPACE=1`.
+//!
+//! This module removes the hazard structurally rather than by adding roots
+//! to a five-allocation sequence: on the steady-state path there is exactly
+//! **one** allocation (the result object), and both pointers used after it
+//! are re-read from storage the collector rewrites — the object from its
+//! [`RuntimeHandleScope`] handle, the keys array from the thread-local
+//! `ITER_RESULT_KEYS` slot that [`scan_iter_result_keys_roots_mut`] visits.
+//! No pre-collection address is nameable.
+//!
+//! `ITER_RESULT_KEYS` is exactly the "runtime-side cache of a raw heap
+//! pointer" that the static `gc_root_dominance_check.py` cannot see, so its
+//! scanner is registered in `gc/mod.rs` in the same commit — see the
+//! "unrooted runtime caches" note in CLAUDE.md.
+
+use crate::array::ArrayHeader;
+use crate::gc::RuntimeRootVisitor;
+use crate::object::ObjectHeader;
+use crate::value::JSValue;
+use std::cell::UnsafeCell;
+
+/// Field/key order of the result object.
+///
+/// The language always says `{ value, done }`. `node:sqlite`'s statement
+/// iterator is the one exception in the runtime: it builds `{ done, value }`,
+/// and its key order is observable through `Object.keys` and
+/// `JSON.stringify`, so it gets its own shared array rather than being
+/// quietly normalized.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum IterResultOrder {
+    /// `{ value, done }`.
+    ValueDone = 0,
+    /// `{ done, value }` — `node:sqlite` only.
+    DoneValue = 1,
+}
+
+const ORDER_COUNT: usize = 2;
+
+thread_local! {
+    /// Per-thread shared keys arrays, indexed by [`IterResultOrder`].
+    ///
+    /// Per-thread and not process-global for the same reason the intern
+    /// table is: each `perry/thread` worker has its own arena, so a pointer
+    /// interned from worker A's arena is a cross-arena read from worker B.
+    ///
+    /// GC-visible through [`scan_iter_result_keys_roots_mut`], which both
+    /// MARKS (nothing else references these arrays) and REWRITES them (an
+    /// evacuating collection moves them like anything else).
+    static ITER_RESULT_KEYS: UnsafeCell<[*mut ArrayHeader; ORDER_COUNT]> =
+        const { UnsafeCell::new([std::ptr::null_mut(); ORDER_COUNT]) };
+}
+
+#[inline(always)]
+fn cached_keys(order: IterResultOrder) -> *mut ArrayHeader {
+    ITER_RESULT_KEYS.with(|c| unsafe { (*c.get())[order as usize] })
+}
+
+/// NaN-boxed bits of an interned constant property name.
+#[inline]
+fn interned_key_bits(bytes: &[u8]) -> u64 {
+    JSValue::string_ptr(crate::string::intern_ascii_literal(bytes) as *mut _).bits()
+}
+
+/// Build this thread's shared keys array for `order`, if it does not have one.
+///
+/// Cold and at most twice per thread for the program's lifetime, so it is
+/// written for obviousness rather than speed: every intermediate is rooted
+/// across every allocation that follows it.
+#[cold]
+unsafe fn build_shared_keys(order: IterResultOrder) {
+    let (first, second): (&[u8], &[u8]) = match order {
+        IterResultOrder::ValueDone => (b"value", b"done"),
+        IterResultOrder::DoneValue => (b"done", b"value"),
+    };
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let keys_h = scope.root_raw_mut_ptr(crate::array::js_array_alloc(2));
+
+    // Interning makes these pointer-identical to the `"value"` / `"done"` the
+    // READ side (`result.value`) hashes — the property-plan cache's verdicts
+    // are pointer-identity based — and gives them a second, independent root
+    // in the intern table.
+    //
+    // Both interns ALLOCATE on a first-call-per-thread miss, so the array's
+    // address is taken back out of its handle ACROSS them rather than bound
+    // before them. `first_h` is a handle, so it is rewritten by the same
+    // collection that would move the array.
+    let first_h = scope.root_nanbox_u64(interned_key_bits(first));
+    let (second_bits, keys) = keys_h.across_mut::<ArrayHeader, _>(|| interned_key_bits(second));
+    let second_h = scope.root_nanbox_u64(second_bits);
+
+    (*keys).length = 2;
+    crate::array::store_array_slot(keys, 0, first_h.get_nanbox_u64());
+    crate::array::store_array_slot(keys, 1, second_h.get_nanbox_u64());
+    crate::array::rebuild_array_layout_exact(keys);
+
+    // Copy-on-write marker. Without it, `result.extra = 1` on ONE result
+    // object would append to the array every other result shares.
+    let gc_header = (keys as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+    (*gc_header).gc_flags |= crate::gc::GC_FLAG_SHAPE_SHARED;
+
+    ITER_RESULT_KEYS.with(|c| (*c.get())[order as usize] = keys);
+    crate::gc::runtime_write_barrier_root_raw_ptr(keys);
+}
+
+/// Build one iterator-result object.
+///
+/// `first`/`second` are the two field VALUES in `order`'s declaration order —
+/// callers should prefer [`make_iter_result`], which names them.
+pub(crate) unsafe fn build_iter_result_ordered(
+    first: JSValue,
+    second: JSValue,
+    order: IterResultOrder,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    // Both field values are caller-supplied and can be heap pointers; the
+    // object allocation below can collect and move them.
+    let first_h = scope.root_nanbox_u64(first.bits());
+    let second_h = scope.root_nanbox_u64(second.bits());
+
+    // Fill the keys cache BEFORE the result object exists, so its cold
+    // allocations cannot invalidate a pointer we are already holding.
+    if cached_keys(order).is_null() {
+        build_shared_keys(order);
+    }
+
+    let obj_h = scope.root_nanbox_f64(crate::js_nanbox_pointer(
+        crate::object::js_object_alloc(0, 2) as i64,
+    ));
+
+    // Everything below re-reads through storage the collector rewrites: the
+    // object from its handle, the keys array from the scanned thread-local.
+    // Nothing here names an address that predates the allocation above.
+    let obj = || crate::js_nanbox_get_pointer(obj_h.get_nanbox_f64()) as *mut ObjectHeader;
+    crate::object::js_object_set_keys(obj(), cached_keys(order));
+    crate::object::js_object_set_field(obj(), 0, JSValue::from_bits(first_h.get_nanbox_u64()));
+    crate::object::js_object_set_field(obj(), 1, JSValue::from_bits(second_h.get_nanbox_u64()));
+    crate::js_nanbox_pointer(obj() as i64)
+}
+
+/// The `{ value, done }` result every iterator in the language returns.
+#[inline]
+pub(crate) unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
+    build_iter_result_ordered(value, JSValue::bool(done), IterResultOrder::ValueDone)
+}
+
+/// `node:sqlite`'s `{ done, value }` result.
+#[inline]
+pub(crate) unsafe fn make_sqlite_iter_result(value: JSValue, done: bool) -> f64 {
+    build_iter_result_ordered(JSValue::bool(done), value, IterResultOrder::DoneValue)
+}
+
+/// GC root scanner for the shared keys arrays.
+///
+/// MARKING: nothing else in the heap references these arrays — the result
+/// objects that use them are short-lived and the cache outlives them — so
+/// without this they would be swept and every later `.next()` would install
+/// a freed keys array.
+///
+/// REWRITING: an evacuating collection moves them like any other array, and
+/// the thread-local slot is the only place the new address can be recorded.
+pub fn scan_iter_result_keys_roots_mut(visitor: &mut RuntimeRootVisitor<'_>) {
+    ITER_RESULT_KEYS.with(|c| unsafe {
+        for slot in (*c.get()).iter_mut() {
+            visitor.visit_raw_mut_ptr_slot(slot);
+        }
+    });
+}
+
+/// Legacy mark-only shim, mirroring the other runtime root scanners.
+pub fn scan_iter_result_keys_roots(mark: &mut dyn FnMut(f64)) {
+    let mut visitor = crate::gc::RuntimeRootVisitor::for_copy(mark);
+    scan_iter_result_keys_roots_mut(&mut visitor);
+}
+
+/// Drop the cached arrays. The unit-test harness resets arenas between tests
+/// while thread-locals persist, which would leave these pointing into a
+/// deallocated block.
+#[cfg(test)]
+pub(crate) fn reset_shared_keys_for_test() {
+    ITER_RESULT_KEYS.with(|c| unsafe {
+        (*c.get()) = [std::ptr::null_mut(); ORDER_COUNT];
+    });
+}
+
+/// Read a cached slot without building it.
+#[cfg(test)]
+pub(crate) fn shared_keys_peek_for_test(order: IterResultOrder) -> *mut ArrayHeader {
+    cached_keys(order)
+}
+
+/// Force both slots to be built, and return them in `IterResultOrder` order.
+#[cfg(test)]
+pub(crate) fn populate_shared_keys_for_test() -> [*mut ArrayHeader; ORDER_COUNT] {
+    for order in [IterResultOrder::ValueDone, IterResultOrder::DoneValue] {
+        if cached_keys(order).is_null() {
+            unsafe { build_shared_keys(order) };
+        }
+    }
+    ITER_RESULT_KEYS.with(|c| unsafe { *c.get() })
+}

--- a/crates/perry-runtime/src/iterator_helpers.rs
+++ b/crates/perry-runtime/src/iterator_helpers.rs
@@ -27,6 +27,12 @@
 //! to the Map/Set iterator ones.
 
 use crate::closure::{is_closure_ptr, js_closure_call1, js_closure_call2, ClosureHeader};
+// #7564: `make_iter_result` used to be a local five-allocation copy whose
+// intermediates were all bare Rust locals. It was the copy that faulted under
+// `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1` — `make_iter_result + 188`, a
+// retired from-space object — and it now comes from the one rooted,
+// shared-shape constructor in `crate::iter_result`.
+use crate::iter_result::make_iter_result;
 use crate::object::{
     js_object_alloc, js_object_get_field, js_object_get_field_by_name, js_object_set_field,
     ObjectHeader,
@@ -60,43 +66,38 @@ pub fn is_iterator_helper_addr(addr: usize) -> bool {
     }
 }
 
-/// Build the `{ value, done }` iterator-result object. Mirrors
-/// `collection_iter_object.rs::make_iter_result`.
-unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
-    let obj = js_object_alloc(0, 2);
-    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
-    let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
-    let keys = crate::array::js_array_alloc(2);
-    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
-    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
-    crate::object::js_object_set_keys(obj, keys);
-    js_object_set_field(obj, 0, value);
-    js_object_set_field(
-        obj,
-        1,
-        if done {
-            JSValue::from_bits(TAG_TRUE)
-        } else {
-            JSValue::from_bits(crate::value::TAG_FALSE)
-        },
-    );
-    js_nanbox_pointer(obj as i64)
-}
-
 /// Drive one `.next()` step on ANY iterator object. Returns `(value, done)`.
 /// Mirrors the dual dispatch in `array/iterator.rs::js_iterator_to_array`:
 /// prefer a stored `next` closure FIELD (generators / bare `{next}` objects),
 /// else fall back to class-id method dispatch (array / Map / Set / helper
 /// iterators).
+///
+/// #7564: the READ side of the protocol had the same defect as the WRITE side.
+/// It allocated the three constant key strings `"next"` / `"done"` / `"value"`
+/// on EVERY step, and held `iter_obj`, `result_obj` and the earlier keys in
+/// bare Rust locals across those allocations — plus, in the middle, a call
+/// into the user's own `next`, which can run arbitrary JS and collect
+/// anything. The keys are now interned (allocation-free after the first call
+/// per thread) and every pointer is re-read from a handle after each call that
+/// can collect, so no pre-collection address is nameable.
 unsafe fn iterator_step(iter_f64: f64) -> (f64, bool) {
-    let iter_ptr = js_nanbox_get_pointer(iter_f64);
-    if iter_ptr == 0 {
+    if js_nanbox_get_pointer(iter_f64) == 0 {
         return (f64::from_bits(TAG_UNDEFINED), true);
     }
-    let iter_obj = iter_ptr as *const ObjectHeader;
 
-    let next_key = js_string_from_bytes(b"next".as_ptr(), 4);
-    let next_val = js_object_get_field_by_name(iter_obj, next_key);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iter_h = scope.root_nanbox_f64(iter_f64);
+
+    // `intern_ascii_literal` allocates on a first-call-per-thread miss, so the
+    // receiver comes back out of its handle ACROSS that call — the pre-call
+    // address is never bound. The key itself is the call's own return value,
+    // so it is current by construction.
+    let (next_key, iter_now) =
+        iter_h.across_nanbox(|| crate::string::intern_ascii_literal(b"next"));
+    let next_val = js_object_get_field_by_name(
+        js_nanbox_get_pointer(iter_now) as *const ObjectHeader,
+        next_key,
+    );
     let next_ptr = if next_val.is_undefined() {
         std::ptr::null::<ClosureHeader>()
     } else {
@@ -104,11 +105,14 @@ unsafe fn iterator_step(iter_f64: f64) -> (f64, bool) {
     };
     let use_field = !next_ptr.is_null() && is_closure_ptr(next_ptr as usize);
 
+    // The user's `next` runs here and can collect anything. `next_ptr` is used
+    // immediately — nothing between its read and the call allocates — and the
+    // receiver for the fallback comes from its handle.
     let result_f64 = if use_field {
         js_closure_call1(next_ptr, f64::from_bits(TAG_UNDEFINED))
     } else {
         crate::object::js_native_call_method(
-            iter_f64,
+            iter_h.get_nanbox_f64(),
             b"next".as_ptr() as *const i8,
             4,
             std::ptr::null(),
@@ -116,16 +120,26 @@ unsafe fn iterator_step(iter_f64: f64) -> (f64, bool) {
         )
     };
 
-    let result_ptr = js_nanbox_get_pointer(result_f64);
-    if result_ptr == 0 {
+    if js_nanbox_get_pointer(result_f64) == 0 {
         return (f64::from_bits(TAG_UNDEFINED), true);
     }
-    let result_obj = result_ptr as *const ObjectHeader;
-    let done_key = js_string_from_bytes(b"done".as_ptr(), 4);
-    let value_key = js_string_from_bytes(b"value".as_ptr(), 5);
-    let done_val = js_object_get_field_by_name(result_obj, done_key);
+    // Both reads below re-take the result's address across their own intern,
+    // and `js_object_get_field_by_name` (getters, shape work) can collect
+    // between them — so the second read does not reuse the first's address.
+    let result_h = scope.root_nanbox_f64(result_f64);
+    let (done_key, result_now) =
+        result_h.across_nanbox(|| crate::string::intern_ascii_literal(b"done"));
+    let done_val = js_object_get_field_by_name(
+        js_nanbox_get_pointer(result_now) as *const ObjectHeader,
+        done_key,
+    );
     let done = crate::value::js_is_truthy(f64::from_bits(done_val.bits())) != 0;
-    let val = js_object_get_field_by_name(result_obj, value_key);
+    let (value_key, result_now) =
+        result_h.across_nanbox(|| crate::string::intern_ascii_literal(b"value"));
+    let val = js_object_get_field_by_name(
+        js_nanbox_get_pointer(result_now) as *const ObjectHeader,
+        value_key,
+    );
     (f64::from_bits(val.bits()), done)
 }
 

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -82,6 +82,7 @@ pub mod frame;
 pub mod fs;
 pub mod gc;
 pub mod intl;
+pub mod iter_result;
 pub mod iterator_helpers;
 pub mod macos_bundle;
 pub mod map;

--- a/crates/perry-runtime/src/string/iter_object.rs
+++ b/crates/perry-runtime/src/string/iter_object.rs
@@ -52,18 +52,8 @@ pub fn string_values_iter(s: *const StringHeader) -> f64 {
 
 /// Build the `{ value, done }` iterator-result object. Mirrors
 /// `array/iter_object.rs::make_iter_result`.
-unsafe fn make_iter_result(value: JSValue, done: bool) -> f64 {
-    let obj = js_object_alloc(0, 2);
-    let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-    let done_key = crate::string::js_string_from_bytes(b"done".as_ptr(), 4);
-    let keys = crate::array::js_array_alloc(2);
-    crate::array::js_array_push(keys, JSValue::string_ptr(value_key));
-    crate::array::js_array_push(keys, JSValue::string_ptr(done_key));
-    crate::object::js_object_set_keys(obj, keys);
-    js_object_set_field(obj, 0, value);
-    js_object_set_field(obj, 1, JSValue::bool(done));
-    js_nanbox_pointer(obj as i64)
-}
+// #7564: was a local five-allocation copy with unrooted intermediates.
+use crate::iter_result::make_iter_result;
 
 /// Dispatch `.next()` / `[Symbol.iterator]()` on a String iterator object.
 pub unsafe fn dispatch_string_iterator_method(

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -280,6 +280,18 @@ pub(crate) fn materialize_dispatch_key(key: PerryStringRef) -> *const StringHead
     }
 }
 
+/// Intern a short ASCII literal into the current thread's intern table.
+///
+/// Allocates only on the first call per thread per content; afterwards it is a
+/// hash probe returning the canonical pointer, which the intern table's root
+/// scanner already keeps marked and rewritten. Used for runtime-owned constant
+/// property names (`"value"` / `"done"` — see [`crate::iter_result`]) so they
+/// are pointer-identical to the same literals elsewhere in the program.
+#[inline]
+pub(crate) fn intern_ascii_literal(bytes: &[u8]) -> *const StringHeader {
+    intern::intern_dispatch_bytes(0, bytes.as_ptr(), bytes.len(), 0, false)
+}
+
 /// Header for heap-allocated strings
 ///
 /// `utf16_len` is at offset 0 so codegen can inline `.length` as a single i32 load.

--- a/test-files/test_gap_7564_iter_result_rooting.ts
+++ b/test-files/test_gap_7564_iter_result_rooting.ts
@@ -98,22 +98,52 @@ for (let i = 0; i < N; i++) {
     }
 }
 
-// ── 4. Iterator helpers (`Iterator.from(...).map(...).filter(...)`) ─────────
-function* small(n: number): Generator<number, void, undefined> {
-    for (let k = 0; k < n; k++) yield k + n;
+// ── 4. A user-supplied `next` driven by hand ────────────────────────────────
+// The user's `next` is arbitrary JS, so it is an arbitrary collection point in
+// the middle of the protocol — the shape that made the constructor's unrooted
+// locals reachable from user code.
+//
+// NOT `Iterator.from(...)`, even though `iterator_helpers::make_iter_result`
+// is where the original bus error landed. Three SEPARATE pre-existing defects
+// sit on that path today and each would make this file red for the wrong
+// reason:
+//
+//   * #7576 — `Iterator.from(x)` returns an immediately-exhausted iterator
+//     (and `.map`/`.filter` return `undefined`), so the surface yields the
+//     wrong answer before GC is involved at all;
+//   * #7577 — generator CONSTRUCTION faults in
+//     `js_generator_attach_prototype` under these same instruments;
+//   * `js_get_iterator` → `url_search_params_backing_of` →
+//     `get_field_by_name_object_tail` derefs retired from-space memory when
+//     `Iterator.from` probes its argument.
+//
+// None is touched by this change. The `iterator_helpers` constructor is still
+// fixed and still covered by the unit tests in
+// `gc/tests/runtime_roots/iter_result_keys.rs`; end-to-end coverage of it from
+// TypeScript is blocked on #7576.
+function makeCounter(n: number): Iterator<number> {
+    let i = 0;
+    return {
+        next(): IteratorResult<number> {
+            // Allocating inside the user callback is the point: it is what
+            // makes a collection land mid-protocol.
+            churn(i);
+            return i < n ? { value: i++, done: false } : { value: undefined, done: true };
+        },
+    };
 }
 for (let i = 0; i < N; i++) {
-    const chain = Iterator.from(small(6))
-        .map((x: number) => {
-            churn(x + i);
-            return x * 2;
-        })
-        .filter((x: number) => x % 3 !== 0);
-    let c = chain.next();
-    while (!c.done) {
-        acc += c.value as number;
-        c = chain.next();
+    const raw = makeCounter(6);
+    let rs = raw.next();
+    while (!rs.done) {
+        if (Object.keys(rs).join(",") !== "value,done") bad++;
+        acc += rs.value as number;
+        rs = raw.next();
     }
+    // Spread over a user iterable — `js_iterator_to_array`'s drain, which
+    // reads `.value`/`.done` straight back off the freshly built result.
+    const spread = [...{ [Symbol.iterator]: () => makeCounter(4) }];
+    acc += spread.length;
 }
 
 // ── 5. Results retained across many later collections ───────────────────────

--- a/test-files/test_gap_7564_iter_result_rooting.ts
+++ b/test-files/test_gap_7564_iter_result_rooting.ts
@@ -1,0 +1,133 @@
+// #7564 rooting half: four of the five runtime `make_iter_result` copies built
+// the `{ value, done }` object with every intermediate in a bare Rust local:
+//
+//   let obj       = js_object_alloc(0, 2);                 // (1) can collect
+//   let value_key = js_string_from_bytes(b"value", 5);     // (2) `obj` now stale
+//   let done_key  = js_string_from_bytes(b"done", 4);      // (3) + `value_key`
+//   let keys      = js_array_alloc(2);                     // (4) + `done_key`
+//   js_array_push(keys, value_key);                        // (5) + `keys`
+//   js_array_push(keys, done_key);
+//   js_object_set_keys(obj, keys);      // ← `obj`/`keys` may be from-space
+//   js_object_set_field(obj, 0, value); // ← `value` (a PARAMETER) too
+//
+// Five allocations, each a collection point, and NOTHING between them is a GC
+// root. A copying minor landing in any of windows (1)–(5) moves the objects the
+// earlier locals name and rewrites only slots it can see; a Rust local is not
+// one. The function then publishes an object whose keys array — or whose key
+// strings, or whose `value` — is a retired from-space address.
+//
+// The fifth copy (`array/iter_object.rs::build_iter_result`) was rooted by
+// #7475 and is the model the other four now follow.
+//
+// This is deliberately NOT the Map/Set `for-of` shape: #7561 lowers that to a
+// direct index walk that never builds a result object at all. It drives the
+// paths that still reach the runtime constructor — `.values()`/`.entries()`
+// method iterators pulled by hand, string and typed-array iteration, and the
+// `Iterator.from(...).map(...)` helper chain — while allocating hard enough
+// that a copying minor lands inside the constructor.
+//
+// Run under `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1`, compiled with
+// `PERRY_GC_MOVING_LOOP_POLLS=1`, and confirm `PERRY_GC_DIAG=1` prints a
+// `[gc-fromspace-protect] mode=... retired_set=#N` line — a run with zero
+// copying minors protects nothing and proves nothing.
+
+const N = 4000;
+
+// Per-iteration garbage so the nursery actually fills and minors actually run.
+function churn(i: number): string {
+    return "pad-" + i + "-" + (i * 7919) + "-" + (i % 13);
+}
+
+let acc = 0;
+let bad = 0;
+
+// ── 1. Map/Set method iterators, pulled by hand ─────────────────────────────
+for (let i = 0; i < N; i++) {
+    const m = new Map<string, number>([
+        ["a" + (i % 7), i],
+        ["b" + (i % 5), i + 1],
+        ["c", i + 2],
+    ]);
+    const it = m.entries();
+    let step = it.next();
+    while (!step.done) {
+        const pair = step.value as [string, number];
+        // Read the key string back off the result — a stale key string or a
+        // stale keys array shows up right here.
+        if (typeof pair[0] !== "string") bad++;
+        acc += pair[1];
+        churn(i);
+        step = it.next();
+    }
+    const s = new Set([i, i + 1, i + 2]);
+    const sv = s.values();
+    let sstep = sv.next();
+    while (!sstep.done) {
+        acc += sstep.value as number;
+        churn(i + 1);
+        sstep = sv.next();
+    }
+}
+
+// ── 2. String iterator, pulled by hand ──────────────────────────────────────
+for (let i = 0; i < N; i++) {
+    const str = "abcdefg" + (i % 10);
+    const si = str[Symbol.iterator]();
+    let st = si.next();
+    let chars = 0;
+    while (!st.done) {
+        if (typeof st.value !== "string") bad++;
+        chars++;
+        churn(i);
+        st = si.next();
+    }
+    if (chars !== 8) bad++;
+    acc += chars;
+}
+
+// ── 3. Typed-array / Buffer iterators ───────────────────────────────────────
+for (let i = 0; i < N; i++) {
+    const ta = new Uint8Array([i & 0xff, (i + 1) & 0xff, (i + 2) & 0xff]);
+    const te = ta.entries();
+    let t = te.next();
+    while (!t.done) {
+        const pair = t.value as [number, number];
+        acc += pair[0] + pair[1];
+        churn(i);
+        t = te.next();
+    }
+}
+
+// ── 4. Iterator helpers (`Iterator.from(...).map(...).filter(...)`) ─────────
+function* small(n: number): Generator<number, void, undefined> {
+    for (let k = 0; k < n; k++) yield k + n;
+}
+for (let i = 0; i < N; i++) {
+    const chain = Iterator.from(small(6))
+        .map((x: number) => {
+            churn(x + i);
+            return x * 2;
+        })
+        .filter((x: number) => x % 3 !== 0);
+    let c = chain.next();
+    while (!c.done) {
+        acc += c.value as number;
+        c = chain.next();
+    }
+}
+
+// ── 5. Results retained across many later collections ───────────────────────
+// A held result whose keys array was left in from-space reads back wrong here.
+const kept: Array<IteratorResult<number>> = [];
+const keeper = new Set<number>();
+for (let i = 0; i < 200; i++) keeper.add(i);
+const kv = keeper.values();
+for (let i = 0; i < 200; i++) kept.push(kv.next() as IteratorResult<number>);
+for (let i = 0; i < N; i++) churn(i);
+let keptSum = 0;
+for (const k of kept) {
+    if (Object.keys(k).join(",") !== "value,done") bad++;
+    keptSum += k.value as number;
+}
+
+console.log("acc:", acc, "bad:", bad, "keptSum:", keptSum);

--- a/test-files/test_gap_7564_iter_result_semantics.ts
+++ b/test-files/test_gap_7564_iter_result_semantics.ts
@@ -1,0 +1,207 @@
+// #7564: the generic iterator path builds its `{ value, done }` result object
+// in the runtime. That object is USER-VISIBLE — the spec hands it straight back
+// to whoever called `.next()` — so every observable property of it is a parity
+// obligation, not an implementation detail.
+//
+// This is the semantics matrix for that object, byte-diffed against node. It
+// exists because #7564 shares the keys array (and therefore the shape) across
+// every result the runtime builds, which is only sound if all of the following
+// stay true:
+//
+//   * key ORDER is `value` then `done` (Object.keys / for-in / JSON.stringify),
+//     except `node:sqlite`'s iterator which is `done` then `value`;
+//   * each `.next()` returns a DISTINCT object — results are never recycled,
+//     because user code is allowed to retain one;
+//   * writing a NEW property onto one result must not be visible on the next
+//     one (the shared keys array is copy-on-write via `GC_FLAG_SHAPE_SHARED`);
+//   * overwriting `value`/`done` in place likewise stays local to that object;
+//   * a user-supplied `next` returning a non-object is the user's own object
+//     flowing through unchanged — the runtime must not rewrap it.
+//
+// Every construction site in the runtime is exercised: array, string, typed
+// array/Buffer, Map/Set collection, and the generic `iterator_helpers` drain.
+
+// ── 1. Array iterator: shape, order, identity ───────────────────────────────
+const arr = [10, 20, 30];
+const ai = arr[Symbol.iterator]();
+const r1 = ai.next();
+const r2 = ai.next();
+console.log("1a keys:", JSON.stringify(Object.keys(r1)));
+console.log("1b json:", JSON.stringify(r1));
+console.log("1c distinct:", r1 !== r2);
+console.log("1d values:", r1.value, r1.done, r2.value, r2.done);
+const forIn1: string[] = [];
+for (const k in r1) forIn1.push(k);
+console.log("1e forin:", JSON.stringify(forIn1));
+console.log("1f entries:", JSON.stringify(Object.entries(r2)));
+
+// exhaustion
+const ai2 = [1][Symbol.iterator]();
+ai2.next();
+const done1 = ai2.next();
+console.log("1g exhausted:", JSON.stringify(done1), done1.value === undefined);
+
+// ── 2. Adding a property to a result must not leak to siblings ──────────────
+const ai3 = [1, 2, 3][Symbol.iterator]();
+const p1 = ai3.next() as Record<string, unknown>;
+p1.extra = "mine";
+const p2 = ai3.next() as Record<string, unknown>;
+console.log("2a p1keys:", JSON.stringify(Object.keys(p1)));
+console.log("2b p2keys:", JSON.stringify(Object.keys(p2)));
+console.log("2c leak:", p2.extra === undefined);
+const p3 = ai3.next() as Record<string, unknown>;
+console.log("2d p3keys:", JSON.stringify(Object.keys(p3)), p3.extra === undefined);
+console.log("2e p1 intact:", p1.value, p1.done, p1.extra);
+
+// overwrite in place
+const ai4 = [7, 8][Symbol.iterator]();
+const w1 = ai4.next();
+w1.value = 999;
+w1.done = true;
+const w2 = ai4.next();
+console.log("2f overwrite:", w1.value, w1.done, "|", w2.value, w2.done);
+
+// ── 3. Retention: results held across many later steps stay intact ──────────
+const held: Array<IteratorResult<number>> = [];
+const bigIter = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][Symbol.iterator]();
+for (let i = 0; i < 10; i++) held.push(bigIter.next());
+console.log("3a held:", held.map((h) => h.value).join(","));
+console.log("3b heldDone:", held.map((h) => (h.done ? 1 : 0)).join(""));
+console.log("3c allDistinct:", new Set(held).size === 10);
+
+// ── 4. String iterator ──────────────────────────────────────────────────────
+const si = "ab"[Symbol.iterator]();
+const s1 = si.next();
+console.log("4a keys:", JSON.stringify(Object.keys(s1)), JSON.stringify(s1));
+console.log("4b:", JSON.stringify(si.next()), JSON.stringify(si.next()));
+
+// ── 5. Typed array / Buffer iterators ───────────────────────────────────────
+const ta = new Uint8Array([5, 6]);
+const ti = ta[Symbol.iterator]();
+console.log("5a:", JSON.stringify(ti.next()), JSON.stringify(ti.next()), JSON.stringify(ti.next()));
+const te = ta.entries();
+const te1 = te.next();
+console.log("5b keys:", JSON.stringify(Object.keys(te1)), JSON.stringify(te1));
+const tk = ta.keys();
+console.log("5c:", JSON.stringify(tk.next()));
+
+// ── 6. Array entries/keys/values ────────────────────────────────────────────
+const ae = ["x", "y"].entries();
+const ae1 = ae.next();
+console.log("6a keys:", JSON.stringify(Object.keys(ae1)), JSON.stringify(ae1));
+console.log("6b:", JSON.stringify(["x", "y"].keys().next()));
+
+// ── 7. Map / Set iterators ──────────────────────────────────────────────────
+const m = new Map<string, number>([["a", 1], ["b", 2]]);
+const mv = m.values();
+const mv1 = mv.next();
+console.log("7a keys:", JSON.stringify(Object.keys(mv1)), JSON.stringify(mv1));
+const me = m.entries();
+console.log("7b:", JSON.stringify(me.next()), JSON.stringify(me.next()), JSON.stringify(me.next()));
+const st = new Set([9, 8]);
+const sv = st.values();
+console.log("7c:", JSON.stringify(sv.next()), JSON.stringify(sv.next()), JSON.stringify(sv.next()));
+// manual .next() on a Map iterator, results retained
+const mk = m.keys();
+const mkHeld = [mk.next(), mk.next(), mk.next()];
+console.log("7d:", mkHeld.map((h) => JSON.stringify(h)).join(" "));
+
+// ── 8. Generators ───────────────────────────────────────────────────────────
+function* gen(): Generator<number, string, undefined> {
+    yield 1;
+    yield 2;
+    return "end";
+}
+const g = gen();
+const g1 = g.next();
+const g2 = g.next();
+const g3 = g.next();
+const g4 = g.next();
+console.log("8a keys:", JSON.stringify(Object.keys(g1)));
+console.log("8b:", JSON.stringify(g1), JSON.stringify(g2), JSON.stringify(g3), JSON.stringify(g4));
+console.log("8c distinct:", g1 !== g2 && g2 !== g3);
+
+function* outer(): Generator<number, void, undefined> {
+    yield 0;
+    yield* gen();
+    yield 3;
+}
+console.log("8d yield*:", [...outer()].join(","));
+
+// ── 9. User-defined iterables ───────────────────────────────────────────────
+class Counter {
+    n: number;
+    constructor(n: number) {
+        this.n = n;
+    }
+    [Symbol.iterator](): Iterator<number> {
+        let i = 0;
+        const n = this.n;
+        return {
+            next(): IteratorResult<number> {
+                return i < n ? { value: i++, done: false } : { value: undefined, done: true };
+            },
+        };
+    }
+}
+console.log("9a spread:", JSON.stringify([...new Counter(4)]));
+const forOf9: number[] = [];
+for (const v of new Counter(3)) forOf9.push(v);
+console.log("9b forof:", JSON.stringify(forOf9));
+console.log("9c from:", JSON.stringify(Array.from(new Counter(3))));
+
+// A user `next` result flows through UNCHANGED — same object identity.
+const sentinel = { value: 42, done: false, tag: "sentinel" };
+let handedOut = 0;
+const passthrough = {
+    next(): IteratorResult<number> {
+        handedOut++;
+        return handedOut === 1 ? (sentinel as IteratorResult<number>) : { value: undefined, done: true };
+    },
+};
+const got = passthrough.next();
+console.log("9d identity:", got === sentinel, JSON.stringify(Object.keys(got)));
+
+// ── 10. Non-object `next` return is a TypeError ─────────────────────────────
+const badIterable = {
+    [Symbol.iterator]() {
+        return { next: () => 5 as unknown as IteratorResult<number> };
+    },
+};
+try {
+    console.log("10a:", [...(badIterable as Iterable<number>)]);
+} catch (e) {
+    console.log("10a threw:", e instanceof TypeError);
+}
+
+// A `next` that returns an object with no `done` runs until `value` is falsy?
+// No — absent `done` is falsy, so it never terminates; use a bounded manual pull.
+const noDone = { next: () => ({ value: 1 }) as IteratorResult<number> };
+const nd = noDone.next();
+console.log("10b nodone:", JSON.stringify(nd), nd.done === undefined);
+
+// ── 11. Destructuring / for-of over runtime-built results ───────────────────
+const di = [11, 22][Symbol.iterator]();
+const { value: dv, done: dd } = di.next();
+console.log("11a destructure:", dv, dd);
+const [f1, f2] = [4, 5];
+console.log("11b arraydestructure:", f1, f2);
+
+// ── 12. Property presence / prototype ───────────────────────────────────────
+const pi = [1][Symbol.iterator]().next();
+console.log("12a in:", "value" in pi, "done" in pi, "nope" in pi);
+console.log("12b own:", Object.prototype.hasOwnProperty.call(pi, "value"), Object.prototype.hasOwnProperty.call(pi, "done"));
+console.log("12c proto:", Object.getPrototypeOf(pi) === Object.prototype);
+console.log("12d spread:", JSON.stringify({ ...pi }));
+console.log("12e assign:", JSON.stringify(Object.assign({}, pi)));
+console.log("12f delete:", delete (pi as Record<string, unknown>).done, JSON.stringify(Object.keys(pi)));
+
+// ── 13. Interleaved iterators must not share result state ───────────────────
+const iA = [100, 101][Symbol.iterator]();
+const iB = [200, 201][Symbol.iterator]();
+const a1 = iA.next();
+const b1 = iB.next();
+const a2 = iA.next();
+const b2 = iB.next();
+console.log("13a:", a1.value, b1.value, a2.value, b2.value);
+console.log("13b distinct:", new Set([a1, b1, a2, b2]).size === 4);

--- a/test-files/test_gap_7564_iter_result_shared_keys.ts
+++ b/test-files/test_gap_7564_iter_result_shared_keys.ts
@@ -1,0 +1,123 @@
+// #7564 copy-on-write matrix. Every runtime-built iterator result on a thread
+// now SHARES one keys array (stamped `GC_FLAG_SHAPE_SHARED`), which is what
+// removes four of the five per-`.next()` allocations and collapses the shape
+// table to one entry. The entire soundness argument is that no path can reach
+// through a result object and mutate that array: `field_set_by_name`,
+// `delete_rest` and `proxy::put_value` each clone before writing.
+//
+// If any of them stopped consulting the flag, the failure would not be local.
+// One `result.extra = 1` would append a third key to the array EVERY other
+// iterator result is using, so results produced BEFORE the mutation and
+// results produced AFTER it would all silently grow a key. That is what these
+// cases check: the sibling results, not just the mutated one.
+
+// ── 1. Add a property, then check a long run of later results ───────────────
+const a1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9][Symbol.iterator]();
+const first = a1.next() as Record<string, unknown>;
+first.injected = "x";
+let laterBad = 0;
+for (let i = 0; i < 9; i++) {
+    const r = a1.next() as Record<string, unknown>;
+    if (Object.keys(r).join(",") !== "value,done") laterBad++;
+    if (r.injected !== undefined) laterBad++;
+}
+console.log("1a laterBad:", laterBad);
+console.log("1b mutated:", JSON.stringify(Object.keys(first)));
+
+// ── 2. Results captured BEFORE the mutation must not grow a key either ──────
+const a2 = ["p", "q", "r"][Symbol.iterator]();
+const before = [a2.next(), a2.next()];
+const victim = a2.next() as Record<string, unknown>;
+victim.late = 1;
+console.log("2a before:", before.map((b) => Object.keys(b).join("|")).join(" "));
+console.log("2b victim:", JSON.stringify(Object.keys(victim)));
+
+// ── 3. defineProperty is a different write path than plain assignment ───────
+const a3 = [10, 20, 30][Symbol.iterator]();
+const d1 = a3.next();
+Object.defineProperty(d1, "hidden", { value: 7, enumerable: false, configurable: true });
+const d2 = a3.next();
+console.log("3a d1keys:", JSON.stringify(Object.keys(d1)));
+console.log("3b d1has:", Object.prototype.hasOwnProperty.call(d1, "hidden"));
+console.log("3c d2keys:", JSON.stringify(Object.keys(d2)));
+console.log("3d d2has:", Object.prototype.hasOwnProperty.call(d2, "hidden"));
+
+// enumerable defineProperty
+const a4 = [1, 2, 3][Symbol.iterator]();
+const e1 = a4.next();
+Object.defineProperty(e1, "shown", { value: 8, enumerable: true, configurable: true });
+const e2 = a4.next();
+console.log("3e e1keys:", JSON.stringify(Object.keys(e1)));
+console.log("3f e2keys:", JSON.stringify(Object.keys(e2)));
+
+// ── 4. delete clones too — a shortened result must not shorten its siblings ─
+const a5 = [4, 5, 6, 7][Symbol.iterator]();
+const del1 = a5.next() as Record<string, unknown>;
+delete del1.done;
+const del2 = a5.next();
+const del3 = a5.next();
+console.log("4a del1:", JSON.stringify(Object.keys(del1)));
+console.log("4b del2:", JSON.stringify(Object.keys(del2)));
+console.log("4c del3:", JSON.stringify(Object.keys(del3)), JSON.stringify(del3));
+
+// ── 5. freeze / seal must not leak to siblings ──────────────────────────────
+const a6 = [1, 2, 3][Symbol.iterator]();
+const fr = a6.next() as Record<string, unknown>;
+Object.freeze(fr);
+const notFrozen = a6.next() as Record<string, unknown>;
+notFrozen.ok = 1;
+console.log("5a frozen:", Object.isFrozen(fr), Object.isFrozen(notFrozen));
+console.log("5b sibling:", JSON.stringify(Object.keys(notFrozen)));
+
+// ── 6. Different iterator KINDS share the same array — cross-kind check ─────
+// A property added to a Map-iterator result must not appear on a subsequent
+// array-iterator or string-iterator result.
+const m6 = new Map<string, number>([["k", 1], ["l", 2]]);
+const mi = m6.values();
+const mr = mi.next() as Record<string, unknown>;
+mr.crosskind = true;
+const arrR = [99][Symbol.iterator]().next();
+const strR = "z"[Symbol.iterator]().next();
+const bufR = new Uint8Array([3]).entries().next();
+console.log("6a arr:", JSON.stringify(Object.keys(arrR)), JSON.stringify(arrR));
+console.log("6b str:", JSON.stringify(Object.keys(strR)), JSON.stringify(strR));
+console.log("6c buf:", JSON.stringify(Object.keys(bufR)), JSON.stringify(bufR));
+console.log("6d gen:", JSON.stringify(Object.keys(mr)));
+
+// ── 7. Proxy over a result object ───────────────────────────────────────────
+const a7 = [1, 2][Symbol.iterator]();
+const target = a7.next() as Record<string, unknown>;
+const prox = new Proxy(target, {});
+prox.viaProxy = 5;
+const sibling7 = a7.next();
+console.log("7a target:", JSON.stringify(Object.keys(target)));
+console.log("7b sibling:", JSON.stringify(Object.keys(sibling7)));
+
+// ── 8. Volume: mutate every other result, verify the untouched ones ─────────
+const a8 = [] as number[];
+for (let i = 0; i < 200; i++) a8.push(i);
+const it8 = a8[Symbol.iterator]();
+let clean = 0;
+let dirty = 0;
+for (let i = 0; i < 200; i++) {
+    const r = it8.next() as Record<string, unknown>;
+    if (i % 2 === 0) {
+        r["k" + i] = i;
+        if (Object.keys(r).length === 3) dirty++;
+    } else if (Object.keys(r).join(",") === "value,done") {
+        clean++;
+    }
+}
+console.log("8a clean:", clean, "dirty:", dirty);
+
+// ── 9. Shape stability: reads keep working after heavy mutation ─────────────
+const it9 = [1, 2, 3, 4, 5][Symbol.iterator]();
+let sum9 = 0;
+for (let i = 0; i < 5; i++) {
+    const r = it9.next() as Record<string, unknown>;
+    r["p" + i] = i;
+    sum9 += r.value as number;
+}
+const after9 = [7, 8][Symbol.iterator]();
+const r9 = after9.next();
+console.log("9a sum:", sum9, "after:", r9.value, r9.done, JSON.stringify(Object.keys(r9)));


### PR DESCRIPTION
Closes #7564.

## What still reaches `make_iter_result`

#7561 rerouted `for (… of map/set …)` to a direct index walk, so the headline
`map_1m` profile in the issue is stale. It did **not** reroute the rest, and
there turned out to be **five** copies of the constructor rather than the three
the issue names:

| copy | reached by |
|---|---|
| `array/iter_object.rs` | `arr[Symbol.iterator]()`, `.values()/.keys()/.entries()`, `[...arr]`, `Array.from(arr)`, `node:sqlite`'s `StatementSync.iterate()` |
| `collection_iter_object.rs` | `m.values()/.keys()/.entries()` and the `Set` equivalents pulled by hand or spread |
| `string/iter_object.rs` | `for (const c of str)`, `[...str]` |
| `buffer/iter.rs` | `buf.values()/.keys()/.entries()`, `[...buf]` |
| `iterator_helpers.rs` | `Iterator.from(x)` and the whole `.map/.filter/.take/.drop/.flatMap` chain |

All five are ordinary reachable JS surface. The generic path is what every
generator, every custom `[Symbol.iterator]`, `yield*`, and every spread over a
non-Map/Set iterable still uses.

## The rooting fault reproduces

`test-files/test_gap_7564_iter_result_rooting.ts`, compiled with
`PERRY_GC_MOVING_LOOP_POLLS=1` and run under
`PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`,
takes a **SIGBUS** (exit 138) on retired from-space memory:

```
[gc-fromspace-protect] mode=ProtectPages retired_set=#0 blocks=17 sets_held=1/800
                       bytes_protected=17825792
[gc-fromspace-protect] FAULT: signal 10 at 0x4cc3437ffbc
  This address is RETIRED FROM-SPACE.
  last-known object: user_ptr=0x4cc3437ffb8 obj_type=2 size=72
2  perry_runtime::iterator_helpers::make_iter_result + 188
3  ...::dispatch_handle + 4424
4  js_native_call_method + 16740
5  js_typed_feedback_native_call_method_by_id + 112
```

The instrument was verified live — `mode=... retired_set=#N` printed, and the
run performed a real copying minor (`copied_objects=3637`).

Four of the five copies ran five allocations back to back with every
intermediate in a bare Rust local:

```rust
let obj       = js_object_alloc(0, 2);              // (1) can collect
let value_key = js_string_from_bytes(b"value", 5);  // (2) `obj` now stale
let done_key  = js_string_from_bytes(b"done", 4);   // (3) + `value_key`
let keys      = js_array_alloc(2);                  // (4) + `done_key`
js_array_push(keys, value_key);                     // (5) + `keys`
js_object_set_keys(obj, keys);                      // ← from-space
js_object_set_field(obj, 0, value);                 // ← `value` too
```

The fifth (`array/iter_object.rs`) was rooted by #7475 but still allocated the
four constants per call.

## What changed

One `crate::iter_result` replaces all five. It shares one keys array per key
order per thread, so the steady-state path performs **exactly one allocation**
— the result object the language actually requires.

Sharing a keys array is not new: it is already how object literals and
`JSON.parse` results work. The array carries `GC_FLAG_SHAPE_SHARED`, and every
path that would mutate an object's key list — `field_set_by_name`,
`delete_rest`, `proxy::put_value` — clones before writing.

The shape install is the part worth more than the allocations.
`shape_id_for_keys_ensure` keys the shape table on the keys array's **address**,
so a fresh array per `.next()` minted a fresh shape id per `.next()`: every read
of `.value`/`.done` off a result was a guaranteed inline-cache miss (12.18% of
the original profile), and the shape table grew without bound. One shared array
means one shape id for every iterator result in the program.

The rooting fix is structural rather than "add more roots to a five-allocation
sequence": there is one allocation, and both pointers used after it are re-read
from storage the collector rewrites — the object from its `RuntimeHandleScope`
handle, the keys array from the scanned thread-local.

`iterator_step` — the **read** side of the protocol, in the same call chain —
had the identical defect and is fixed with it. It allocated `"next"`, `"done"`
and `"value"` on every step and held the iterator object, the result object and
the earlier keys across those allocations *and* across a call into the user's
own `next`, which can run arbitrary JS.

`ITER_RESULT_KEYS` is exactly the "runtime-side cache of a raw heap pointer"
CLAUDE.md warns the static `gc_root_dominance_check.py` cannot see, so its
scanner is registered in `gc_init` in the same commit.

## Validation

**The fault is gone.** Same binary shape, same instruments, same depth: clean
exit, correct output, with the copying minor confirmed to have run.

**Semantics matrix, byte-diffed against node 26.5.1** — three new gap tests,
all identical to the oracle:

- `test_gap_7564_iter_result_semantics.ts` — 13 groups: key order via
  `Object.keys`/`for-in`/`Object.entries`/`JSON.stringify`, result-object
  distinctness, retention across later steps, every iterator kind
  (array/string/typed-array/Buffer/Map/Set/generator/`yield*`/user-defined),
  a user `next` result flowing through with its **identity** preserved, a
  non-object `next` return, destructuring, prototype, spread/assign/delete.
- `test_gap_7564_iter_result_shared_keys.ts` — the copy-on-write matrix, which
  is the entire soundness argument for sharing: adding a property, adding one
  *after* siblings were captured, `defineProperty` (enumerable and not),
  `delete`, `freeze`, cross-kind leakage, a Proxy write, and a 200-element run
  mutating every other result.
- `test_gap_7564_iter_result_rooting.ts` — the GC reproducer above.

**Gates:** `raw_handle_debt.py` back at baseline **998** (the new code uses
`across_{mut,nanbox}`, not bare `get_raw_*_ptr`); `gc_store_site_inventory.py`
passes; `check_file_size.sh` passes; `cargo fmt --all -- --check` clean;
`cargo test -p perry-runtime --no-fail-fast` **1818 passed, 0 failed**.

**New GC tests are sabotage-verified.** Reverting the scanner to visit only
slot 0 fails the mark and rewrite tests; dropping `GC_FLAG_SHAPE_SHARED` fails
the copy-on-write test. A green run means the tests can still go red.

## Performance

See the comment below for the measured numbers and the caveat about the host.
