### PR TITLE
docs(plan): supersede the v0.5.1299 construction profile with the v0.5.1325 one (#7578)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1326
+**Current Version:** 0.5.1327
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1326"
+version = "0.5.1327"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1326"
+version = "0.5.1327"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1326"
+version = "0.5.1327"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1326"
+version = "0.5.1327"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1326"
+version = "0.5.1327"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7581-plan-profile-resync.md
+++ b/changelog.d/7581-plan-profile-resync.md
@@ -1,0 +1,47 @@
+### Documentation
+
+- **The engine plan's construction profile is now the v0.5.1325 one, not the
+  v0.5.1299 one (#7581).** Docs only.
+
+  Three rows of the `#7469` decomposition are closed, and the plan still
+  presented them as the backlog. Re-measured in #7578 (two independent `sample`
+  runs of `push_cls`, leaf shares): **`_tlv_get_addr` is 1.0%**, from 27.0%
+  (closed by #7565), and **`layout_forget_object` is 1.7–2.9%**, from 14.5%
+  (closed by #7525/#7532). Neither is a lever any more. Nothing regressed — the
+  rows that remain grew as *shares* because everything around them collapsed.
+
+  The new top lever is **`gc::layout::typed_shape_layout_entry` at ~25%**, tied
+  with write barriers (~25%, #7511). It is characterised rather than merely
+  named: it is **not** the `ValidateSlots` loop, because `push_cls` takes the
+  `js_gc_declare_typed_shape_layout` path (confirmed in the emitted IR — one
+  call to `declare`, zero to `init`), so #7515/#7532 are working as intended. It
+  is the install itself, whose hit path `layout.rs:1022` documents as reducing to
+  "the two header bit-writes `shape_install_shared` would have performed",
+  reached through an FFI call whose every argument but the object pointer is a
+  compile-time constant for the class. That is the same shape #7566 just won
+  1.81× on.
+
+  Records that **#7512 is closed by #7515** — not by diffuse side effects, which
+  is how a first pass at this attributed it. The root cause generalises and is
+  the reason it is written down rather than just closed: the dead-field-init
+  elision matched `Expr::PropertySet`, which the compiler *synthesizes* for
+  anon-shape literal constructors, while every source-level `this.v = v` lowers
+  to `Expr::PutValueSet`. **Nothing a user can type produces `PropertySet`**, so
+  the elision was structurally unreachable for the declared class it was
+  documented as covering, and every class construction paid two extra IC diamonds
+  writing an `undefined` that the next statements overwrote. *An unreachable
+  predicate passes every soundness test there is* — #7486 was correct in
+  everything it asserted and did nothing on the case it named. A predicate over a
+  synthesized-vs-source IR distinction needs a test that the **source form**
+  reaches it, not only that the transform is sound when it fires.
+
+  Finally it flags the one row in #7578 that is **unexplained**, so it is not
+  worked from as written: `js_array_length` at 10–15%, against a single call site
+  executing 20,000 times in a 20,000,000-push workload. Both isolation attempts
+  failed and are recorded on the issue — varying array size moved the workload
+  into a different GC regime (leaf samples 379 → 5,816, the top rows becoming
+  btree and remembered-set work), and a `.length`-only microbenchmark measured
+  1.00 ns/iter for **both** a 1,000- and a 10-element array, which looks like a
+  clean O(1) proof and is not one: that is an empty loop, because the read is
+  loop-invariant and was hoisted. A microbenchmark that proves a runtime call is
+  free has usually proved that it was deleted.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -74,9 +74,51 @@ and feedback bookkeeping and 7.7% is the allocation itself**:
 | **the actual allocation** | **7.7%** | — |
 | user code | 3.7% | — |
 
-A declared class costing **63% more than an object literal** is backwards and
-is tracked as a suspected defect (**#7512**), with an explicit off-ramp: if the
-cause lands in the layout or barrier subsystems it closes as a duplicate.
+That table is the **v0.5.1299 decomposition and is now superseded** — three of
+its rows are closed. Re-profiled on v0.5.1325 (#7578, two independent `sample`
+runs of `push_cls`, leaf shares):
+
+| item | then | **now** |
+|---|--:|--:|
+| **`gc::layout::typed_shape_layout_entry`** | — | **~25%** ← new top lever |
+| **write barriers** (4 symbols) | 16.1% | **~25%** (#7511) |
+| user code | 3.7% | ~21% |
+| `_tlv_get_addr` | 27.0% | **1.0%** ✅ #7565 |
+| `gc::layout_tables::layout_forget_object` | 14.5% | **1.7–2.9%** ✅ #7525/#7532 |
+
+**Nothing regressed** — the two survivors grew as *shares* because the rows
+around them collapsed. `_tlv_get_addr` and `layout_forget_object` are no longer
+levers and should not be worked.
+
+**The new top lever, `typed_shape_layout_entry` (~25%)**, is not the
+`ValidateSlots` loop: `push_cls` takes the `js_gc_declare_typed_shape_layout`
+path (confirmed in the emitted IR — one call to `declare`, zero to `init`), so
+#7515/#7532 are working. It is the install itself, whose hit path
+`layout.rs:1022` documents as reducing to "the two header bit-writes
+`shape_install_shared` would have performed". Every argument to that call but the
+object pointer is a **compile-time constant for the class** — which is exactly
+the shape #7566 just won 1.81× on, so the same remedy (emit the hit path inline,
+keep the call as the slow path, gate it so non-hot sites pay no bytes) is the
+obvious first thing to try.
+
+**A declared class is no longer slower than an object literal.** #7512 is
+**closed**: `churn_alloc` and `push_cls` both measure 0.75 s. The cause was not
+diffuse — **#7515** fixed it, and the root cause is worth carrying forward
+because it generalises: the dead-field-init elision matched `Expr::PropertySet`,
+which the compiler *synthesizes* for anon-shape literal constructors, while
+every source-level `this.v = v` lowers to `Expr::PutValueSet`. **Nothing a user
+can type produces `PropertySet`**, so the elision was structurally unreachable
+for the declared class it was documented as covering. *An unreachable predicate
+passes every soundness test there is* — #7486 was correct in everything it
+asserted and did nothing on the case it named.
+
+One row in #7578 is **unexplained and should not be acted on as written**:
+`js_array_length` at 10–15%, against a single call site executing 20,000 times
+in a 20,000,000-push workload. Two isolation attempts failed — varying array
+size moved the workload into a different GC regime, and a `.length`-only
+microbenchmark measured 1.00 ns/iter for both a 1,000- and a 10-element array,
+which is an empty loop (the read is loop-invariant and was hoisted). Both dead
+ends are recorded on the issue.
 
 **Workstream A has landed (#7566, v0.5.1324): the inline bump allocator is back
 at `new` sites inside loop bodies**, outlined everywhere else.


### PR DESCRIPTION
Docs only. Keeps `docs/engine-plan.md` true after #7565, #7566, #7515/#7532 and #7579.

Three rows of the `#7469` construction decomposition are closed, and the table still presented them as the backlog:

| item | plan said | measured on v0.5.1325 (#7578) |
|---|--:|--:|
| `_tlv_get_addr` | 27.0% | **1.0%** (closed by #7565) |
| `layout_forget_object` | 14.5% | **1.7–2.9%** (closed by #7525/#7532) |
| write barriers | 16.1% | **~25%** |
| **`typed_shape_layout_entry`** | not listed | **~25% — the new top lever** |

Nothing regressed: the survivors grew as *shares* because everything around them collapsed. The point of the edit is that someone reading the plan for "what to work next" was being pointed at two rows that are now noise.

The new top lever is characterised rather than just named — it is **not** the `ValidateSlots` loop (`push_cls` takes the `declare` path, confirmed in the emitted IR), so #7515/#7532 are working. It is the install, whose hit path is documented as two header bit-writes, reached through an FFI call whose every argument but the object pointer is a compile-time constant. That is the same shape #7566 just won 1.81× on.

Also records that **#7512 is closed by #7515**, and why the root cause is worth carrying forward: the dead-field-init elision matched `Expr::PropertySet`, which the compiler synthesizes for anon-shape literal constructors, while every source-level `this.v = v` lowers to `Expr::PutValueSet`. Nothing a user can type produces `PropertySet`, so the elision was structurally unreachable for the declared class it was documented as covering. **An unreachable predicate passes every soundness test there is.**

And it flags the one #7578 row that is **unexplained**, so nobody works it as written: `js_array_length` at 10–15% against a single call site executing 20,000 times in a 20M-push workload. Both of my isolation attempts failed and are recorded on the issue — varying array size moved the workload into a different GC regime, and a `.length`-only microbenchmark measured 1.00 ns/iter for both a 1,000- and a 10-element array, which is an empty loop rather than an O(1) proof.

`check_file_size.sh` clean. No code touched.
