### PR TITLE
fix(gc): root the generator instance across its own prototype wiring (#7577)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1330
+**Current Version:** 0.5.1331
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1330"
+version = "0.5.1331"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1330"
+version = "0.5.1331"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1330"
+version = "0.5.1331"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1330"
+version = "0.5.1331"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1330"
+version = "0.5.1331"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7584-generator-attach-prototype-rooting.md
+++ b/changelog.d/7584-generator-attach-prototype-rooting.md
@@ -1,0 +1,53 @@
+### Fixed
+
+- **`js_generator_attach_prototype` derefed retired from-space memory (#7577).**
+  It bound the generator instance's address at function entry and used it at the
+  tail, with four allocating calls in between — and **this frame owns the only
+  reference**: codegen drops the caller's statepoint root immediately before the
+  call (`store ptr addrspace(1) null, ptr %rN` ahead of the `call`), which is the
+  ordinary contract for a runtime helper except that this one never rooted its
+  argument.
+
+  Everything it calls allocates: `wrap_async_generator_instance` (three closures
+  plus three keys-array transitions), `generator_prototype_ptr` (lazily builds
+  the whole generator intrinsic tower on first call), `js_object_alloc`, and
+  `object_set_static_prototype` itself, whose `object_meta_ensure` mints the
+  object's meta record out of the arena. A copying minor in any of those windows
+  gave **two** wrong answers with no diagnostic: the `[[Prototype]]` link was
+  recorded against the **pre-move** address, so `Object.getPrototypeOf(gen())` on
+  the live object found nothing; and the function **returned** that pre-move
+  address, so the caller's generator was a dangling pointer into retired
+  from-space. Under the #7154 instruments that is a SIGBUS; without them it is a
+  wrong answer and exit 0.
+
+  Same shape fixed in `js_generator_attach_closure_prototype`,
+  `generator_function_prototype_of`, and `wrap_async_generator_instance` /
+  `set_method` below them — fixing only the named function would have handed a
+  freshly re-read receiver to a callee that lets it go stale again. Every pointer
+  now comes back out of a `RuntimeHandleScope` handle after the call that could
+  have moved it, and `generator_prototype_ptr` is called a second time rather
+  than cached (it reads a GC-rooted atomic the collector rewrites, so a fresh
+  call *is* the re-read). `make_method_wrapper` is **deleted** rather than fixed:
+  taking `original` as a parameter forced every caller to bind that pointer
+  before the `js_closure_alloc` inside, so the capture store wrote a
+  pre-collection address — per CLAUDE.md's kill-policy the losing shape stops
+  compiling.
+
+  **Reproduced deterministically, not under zeal.** A moving collection needs a
+  safepoint and there is none inside the function (allocation-triggered minors
+  force a conservative scan, which makes the copying minor ineligible), so the
+  issue's end-to-end reproducer does not fault reliably even with the instrument
+  proven live and `copied_objects` in the thousands. The new tests inject the
+  collection into the window instead: `force_next_general_arena_alloc_slow()` +
+  `GcTriggerThresholdTestGuard::make_arena_trigger_due()` arm the next arena
+  block allocation to collect, and the next one is the callee's own.
+
+  Coverage: `crates/perry-runtime/src/gc/tests/runtime_roots/generator_attach_prototype.rs`
+  (two `cargo test -p perry-runtime` tests, one per entry point, each asserting
+  its subject was live before asserting anything else, and each calling
+  `register_runtime_handle_root_scanner_for_tests()` — without which the
+  `RuntimeHandleScope` under test is decorative and the test passes for the
+  wrong reason). Plus `test-files/test_gap_7577_generator_prototype_rooting.ts`,
+  byte-identical to `node --experimental-strip-types` and clean under
+  `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1
+  PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`.

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use super::support::*;
 use std::cell::Cell;
 mod callback_scanners;
+mod generator_attach_prototype;
 mod hook_dispatch_handles;
 mod interned_string_caches;
 mod iter_result_keys;

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/generator_attach_prototype.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/generator_attach_prototype.rs
@@ -1,0 +1,155 @@
+//! #7577: the generator-instance prototype wiring must survive a copying minor
+//! that lands **inside** its own call.
+//!
+//! `js_generator_attach_prototype` and its closure-identity sibling are the
+//! last thing generator construction does, and codegen drops the caller's root
+//! immediately before the call:
+//!
+//! ```llvm
+//! %r67 = bitcast i64 %r66 to double
+//! store ptr addrspace(1) null, ptr %r28              ; the caller's root, dropped
+//! %r68 = call double @js_generator_attach_prototype(double %r67, i32 0)
+//! ```
+//!
+//! So the callee owns the only reference — and it allocates, twice
+//! (`js_object_alloc`, and `object_set_static_prototype` via
+//! `object_meta_ensure`). Pre-fix it bound the receiver's address at entry and
+//! used it at the tail, producing two wrong answers at once: the
+//! `[[Prototype]]` link went onto the **pre-move** address, and the function
+//! **returned** that address to the caller as the generator object.
+//!
+//! Both tests here force the collection into that window deterministically —
+//! `force_next_general_arena_alloc_slow` + `make_arena_trigger_due` make the
+//! next arena block allocation collect, and the next one is the callee's own —
+//! so neither depends on `PERRY_GC_ZEAL` or on the timing luck the #7577
+//! reproducer needs. Each asserts its subject was live (the receiver actually
+//! moved), per CLAUDE.md's "a gate must assert its subject was live": a run in
+//! which nothing moved proves nothing, and says so rather than passing.
+
+use super::*;
+
+/// A function pointer to register in the generator-function registry. Never
+/// called — only its address is used.
+extern "C" fn fake_generator_body(_c: *const crate::closure::ClosureHeader, _a: f64) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Build the generator intrinsic tower up front. It is lazily constructed on
+/// the first `generator_prototype_ptr` call and costs dozens of allocations;
+/// paying it here keeps the call under test down to its own two, so the
+/// injected trigger lands where we intend.
+fn warm_generator_intrinsics() {
+    let _ = crate::object::js_generator_attach_prototype(
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        0,
+    );
+}
+
+/// A shadow-rooted, freshly allocated object standing in for a generator
+/// instance, as `(nanboxed, raw_addr)`.
+fn rooted_instance() -> (f64, usize) {
+    let obj = crate::object::js_object_alloc(0, 0);
+    let addr = obj as usize;
+    js_shadow_slot_set(0, ptr_bits(addr));
+    (f64::from_bits(ptr_bits(addr)), addr)
+}
+
+/// Arm the next arena block allocation to collect.
+fn arm_collection_on_next_block(trigger_guard: &GcTriggerThresholdTestGuard) {
+    force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+}
+
+fn current_addr() -> usize {
+    (js_shadow_slot_get(0) & POINTER_MASK) as usize
+}
+
+/// The two observable consequences of the pre-#7577 shape, asserted together:
+/// the value handed back to the caller, and where the `[[Prototype]]` link
+/// landed.
+///
+/// Deliberately NOT asserted: that `before` carries no recorded prototype. The
+/// nursery recycles addresses between tests on this thread, and the collector's
+/// `object_static_prototype_owner_moved` migrates an entry off the old address
+/// when the owner moves — so that slot's contents are not a stable signal
+/// either way. What is asserted is what the bug got wrong: the receiver moved
+/// (subject live), the return value is the current address, and the LIVE object
+/// owns the link.
+fn assert_wiring_followed_the_move(returned: f64, before: usize, label: &str) {
+    let after = current_addr();
+    assert_ne!(
+        after, before,
+        "{label}: subject not live — no copying minor moved the receiver during \
+         the call, so this test proved nothing. Check the arena trigger arming."
+    );
+    assert_eq!(
+        crate::value::js_nanbox_get_pointer(returned) as usize,
+        after,
+        "{label}: must return the receiver's CURRENT address; returning the \
+         pre-move one hands the caller a dangling generator object"
+    );
+    let recorded =
+        crate::object::prototype_chain::object_static_prototype(after).unwrap_or_else(|| {
+            panic!(
+                "{label}: no `[[Prototype]]` recorded against the LIVE object. \
+                 Recorded against the pre-move address instead, it is unreachable \
+                 and `Object.getPrototypeOf(gen())` silently finds nothing."
+            )
+        });
+    let proto_addr = (recorded & crate::value::POINTER_MASK) as usize;
+    assert!(
+        crate::value::addr_class::is_plausible_heap_addr(proto_addr),
+        "{label}: the recorded `[[Prototype]]` is not a heap address ({proto_addr:#x})"
+    );
+}
+
+/// SABOTAGE CHECK: bind `obj_ptr` at the top of `js_generator_attach_prototype`
+/// again and use it at the tail (the pre-#7577 shape). Both the returned
+/// address and the prototype link go to the dead object and this fails.
+#[test]
+fn attach_prototype_survives_a_copying_minor_inside_the_call() {
+    let _guard = CopyingNurseryTestGuard::new(4);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    // Without this the `RuntimeHandleScope` inside the function under test is
+    // decorative — the guard above took the thread's mutable-root scanners with
+    // it, so the fix would look absent and the test would fail for the wrong
+    // reason. See `register_runtime_handle_root_scanner_for_tests`.
+    register_runtime_handle_root_scanner_for_tests();
+    warm_generator_intrinsics();
+
+    let (obj_value, before) = rooted_instance();
+    arm_collection_on_next_block(&trigger_guard);
+
+    let returned = crate::object::js_generator_attach_prototype(obj_value, 0);
+
+    assert_wiring_followed_the_move(returned, before, "js_generator_attach_prototype");
+}
+
+/// The closure-identity path, whose extra allocation is
+/// `generator_function_prototype_of` minting this function's `g.prototype`.
+///
+/// SABOTAGE CHECK: restore the entry-bound `obj_ptr` in
+/// `js_generator_attach_closure_prototype` and this goes red.
+#[test]
+fn attach_closure_prototype_survives_a_copying_minor_inside_the_call() {
+    let _guard = CopyingNurseryTestGuard::new(4);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+    warm_generator_intrinsics();
+
+    let func_ptr = fake_generator_body as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 1);
+    crate::closure::js_register_closure_generator_function(func_ptr);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    assert!(!closure.is_null(), "closure allocation failed");
+
+    let (obj_value, before) = rooted_instance();
+    arm_collection_on_next_block(&trigger_guard);
+
+    let returned = crate::object::js_generator_attach_closure_prototype(
+        obj_value,
+        closure as *const crate::closure::ClosureHeader,
+    );
+
+    assert_wiring_followed_the_move(returned, before, "js_generator_attach_closure_prototype");
+}

--- a/crates/perry-runtime/src/object/async_generator_queue.rs
+++ b/crates/perry-runtime/src/object/async_generator_queue.rs
@@ -48,6 +48,25 @@ thread_local! {
     static STATES: RefCell<Vec<AsyncGeneratorQueueState>> = const { RefCell::new(Vec::new()) };
 }
 
+/// Install the queue wrappers on an async-generator instance's own
+/// `next`/`return`/`throw`.
+///
+/// # Rooting (#7577)
+///
+/// Called from `js_generator_attach_prototype` /
+/// `js_generator_attach_closure_prototype`, both of which now hand in a
+/// freshly re-read receiver — which this function then let go stale again.
+/// Each `set_method` pair allocates twice (`js_closure_alloc` for the wrapper,
+/// `js_object_set_field_by_name` for the keys-array transition), so by the
+/// third `set_method` the `obj` bound at entry was two collections old, and the
+/// two ORIGINAL closures still waiting to be captured were as well — a wrapper
+/// built over a moved `original` calls into retired from-space on the first
+/// `gen.return()`.
+///
+/// Everything is therefore held in a `RuntimeHandleScope` and re-read at each
+/// use. `own_closure` reads are allocation-free
+/// (`js_object_get_own_field_or_undef` matches by byte slice), so the three
+/// lookups can be done up front; it is the writes that move things.
 pub(crate) fn wrap_async_generator_instance(obj: *mut ObjectHeader) {
     if obj.is_null() {
         return;
@@ -67,6 +86,12 @@ pub(crate) fn wrap_async_generator_instance(obj: *mut ObjectHeader) {
         return;
     };
 
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_nanbox_f64(js_nanbox_pointer(obj as i64));
+    let next_h = scope.root_nanbox_f64(js_nanbox_pointer(next as i64));
+    let ret_h = scope.root_nanbox_f64(js_nanbox_pointer(ret as i64));
+    let throw_h = scope.root_nanbox_f64(js_nanbox_pointer(throw as i64));
+
     let state_id = STATES.with(|states| {
         let mut states = states.borrow_mut();
         let id = states.len() + 1;
@@ -78,21 +103,32 @@ pub(crate) fn wrap_async_generator_instance(obj: *mut ObjectHeader) {
         id
     });
 
-    set_method(
-        obj,
-        b"next",
-        make_method_wrapper(state_id, next, async_generator_next_wrapper),
-    );
-    set_method(
-        obj,
-        b"return",
-        make_method_wrapper(state_id, ret, async_generator_return_wrapper),
-    );
-    set_method(
-        obj,
-        b"throw",
-        make_method_wrapper(state_id, throw, async_generator_throw_wrapper),
-    );
+    let obj_now = || js_nanbox_get_pointer(obj_h.get_nanbox_f64()) as *mut ObjectHeader;
+    let closure_now = |h: &crate::gc::RuntimeHandle<'_>| {
+        js_nanbox_get_pointer(h.get_nanbox_f64()) as *const ClosureHeader
+    };
+
+    for (name, original_h, func) in [
+        (
+            b"next".as_slice(),
+            &next_h,
+            async_generator_next_wrapper as extern "C" fn(*const ClosureHeader, f64) -> f64,
+        ),
+        (b"return".as_slice(), &ret_h, async_generator_return_wrapper),
+        (b"throw".as_slice(), &throw_h, async_generator_throw_wrapper),
+    ] {
+        // Inlined rather than routed through `make_method_wrapper` for one
+        // reason: that helper takes `original` as a parameter, so the caller
+        // would have to bind it BEFORE `js_closure_alloc` runs and the capture
+        // store would write a pre-collection address. Reading it from the
+        // handle after the allocation is the whole fix.
+        let wrapper = js_closure_alloc(func as *const u8, 2);
+        js_closure_set_capture_f64(wrapper, 0, state_id as f64);
+        js_closure_set_capture_ptr(wrapper, 1, closure_now(original_h) as i64);
+        // `set_method` roots both of its pointer arguments before it allocates
+        // its key string; nothing between here and the call allocates.
+        set_method(obj_now(), name, wrapper);
+    }
 }
 
 pub(crate) fn scan_async_generator_queue_roots_mut(
@@ -122,9 +158,22 @@ fn own_closure(obj: *mut ObjectHeader, name: &[u8]) -> Option<*const ClosureHead
     None
 }
 
+/// `obj[name] = closure`.
+///
+/// #7577: `js_string_from_bytes` allocates, so both pointer arguments are
+/// rooted across it and re-read at the store. Pre-fix, building the key could
+/// move the receiver and the closure, and the store then wrote a moved closure
+/// into a moved object using both pre-collection addresses.
 fn set_method(obj: *mut ObjectHeader, name: &[u8], closure: *mut ClosureHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_nanbox_f64(js_nanbox_pointer(obj as i64));
+    let closure_h = scope.root_nanbox_f64(js_nanbox_pointer(closure as i64));
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    js_object_set_field_by_name(obj, key, js_nanbox_pointer(closure as i64));
+    js_object_set_field_by_name(
+        js_nanbox_get_pointer(obj_h.get_nanbox_f64()) as *mut ObjectHeader,
+        key,
+        closure_h.get_nanbox_f64(),
+    );
 }
 
 /// #4547: the queue wrappers each take a single `arg` (the value passed to
@@ -147,16 +196,13 @@ fn register_wrapper_arities() {
     });
 }
 
-fn make_method_wrapper(
-    state_id: usize,
-    original: *const ClosureHeader,
-    func: extern "C" fn(*const ClosureHeader, f64) -> f64,
-) -> *mut ClosureHeader {
-    let wrapper = js_closure_alloc(func as *const u8, 2);
-    js_closure_set_capture_f64(wrapper, 0, state_id as f64);
-    js_closure_set_capture_ptr(wrapper, 1, original as i64);
-    wrapper
-}
+// #7577: `make_method_wrapper(state_id, original, func)` used to live here. Its
+// signature was the defect — taking `original` as a parameter forced every
+// caller to bind that pointer BEFORE the `js_closure_alloc` inside, so the
+// capture store wrote a pre-collection address. The one caller now allocates
+// the wrapper first and reads `original` out of its handle afterwards, which
+// leaves no correct way to call this helper; per CLAUDE.md's kill-policy the
+// losing shape is deleted rather than left for a future caller to reach for.
 
 fn make_settle_wrapper(
     state_id: usize,

--- a/crates/perry-runtime/src/object/global_this/generator.rs
+++ b/crates/perry-runtime/src/object/global_this/generator.rs
@@ -88,18 +88,32 @@ pub(crate) fn generator_function_prototype_of(closure_ptr: usize) -> Option<f64>
         return Some(f64::from_bits(existing.to_bits()));
     }
     ensure_generator_intrinsics();
-    let gen_proto = generator_prototype_ptr(matches!(kind, GeneratorKind::Async));
+    // #7577: `js_object_alloc` below can run a copying minor, which moves both
+    // `%Generator.prototype%` (an ordinary heap object reached through a
+    // GC-rooted atomic the collector rewrites) and, once it exists, `obj`
+    // itself. `object_set_static_prototype` allocates too — `object_meta_ensure`
+    // mints a meta record — so `obj` was stale again by the time it was
+    // NaN-boxed for `closure_set_dynamic_prop`, and the `g.prototype` this
+    // returned was a from-space address. So: allocate first, root, and re-read
+    // the prototype from its rooted slot rather than caching it across.
     let obj = js_object_alloc(0, 0);
     if obj.is_null() {
         return None;
     }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(obj as i64));
+
+    let gen_proto = generator_prototype_ptr(matches!(kind, GeneratorKind::Async));
     if !gen_proto.is_null() {
         let proto_bits = crate::value::js_nanbox_pointer(gen_proto as i64).to_bits();
-        super::super::prototype_chain::object_set_static_prototype(obj as usize, proto_bits);
+        super::super::prototype_chain::object_set_static_prototype(
+            handle_object_ptr(&obj_h) as usize,
+            proto_bits,
+        );
     }
-    let obj_value = crate::value::js_nanbox_pointer(obj as i64);
+    let obj_value = obj_h.get_nanbox_f64();
     crate::closure::closure_set_dynamic_prop(closure_ptr, "prototype", obj_value);
-    Some(obj_value)
+    Some(obj_h.get_nanbox_f64())
 }
 
 /// `%Generator.prototype%` / `%AsyncGenerator.prototype%` pointer (the object
@@ -377,43 +391,101 @@ fn mark_generator_step_closures_no_rebind(obj: f64) {
 /// GC: both links go through `object_set_static_prototype`, whose side-table is
 /// traced + pointer-rewritten by the collector (see `prototype_chain.rs`), so
 /// the intermediate stays live as long as the instance does and dies with it.
+///
+/// # Rooting (#7577)
+///
+/// **This frame owns the only reference to the receiver.** Codegen nulls the
+/// statepoint slot immediately before the call:
+///
+/// ```llvm
+/// %r67 = bitcast i64 %r66 to double
+/// store ptr addrspace(1) null, ptr %r28              ; the caller's root, dropped
+/// %r68 = call double @js_generator_attach_prototype(double %r67, i32 0)
+/// ```
+///
+/// That is the ordinary contract — a runtime helper roots its own arguments —
+/// but every call below allocates, so the entry-time address goes stale inside
+/// this function and nothing else can rewrite it:
+///
+/// * `wrap_async_generator_instance` allocates three closures and sets three
+///   fields;
+/// * `generator_prototype_ptr` lazily builds the entire generator intrinsic
+///   tower on its first call;
+/// * `js_object_alloc` is an allocation by definition;
+/// * `object_set_static_prototype` allocates too — `object_meta_ensure` mints
+///   the object's meta record out of the arena.
+///
+/// Pre-fix, a copying minor in any of those windows produced *two* wrong
+/// answers with no diagnostic: the `[[Prototype]]` link was installed on the
+/// **pre-move** address, so `Object.getPrototypeOf(gen())` on the live object
+/// found nothing; and the function **returned** that pre-move address, so the
+/// caller's generator was a dangling pointer into retired from-space. That is
+/// the SIGBUS in #7577, and without the instruments it is a wrong answer and
+/// exit 0.
+///
+/// Every pointer below is therefore re-read from a handle after the call that
+/// could have moved it, per `docs/src/internals/gc-rooting-invariant.md`.
+/// `generator_prototype_ptr` is deliberately called a second time rather than
+/// cached: it reads a GC-rooted atomic slot the collector rewrites, so a fresh
+/// call is the re-read.
 #[no_mangle]
 pub extern "C" fn js_generator_attach_prototype(obj: f64, is_async: i32) -> f64 {
     let jv = JSValue::from_bits(obj.to_bits());
     if !jv.is_pointer() {
         return obj;
     }
-    let obj_ptr = jv.as_pointer::<u8>() as usize;
-    if obj_ptr == 0 {
+    if jv.as_pointer::<u8>() as usize == 0 {
         return obj;
     }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_nanbox_f64(obj);
+
     // Pin each step closure's lexical generator-body `this` so `yield*`
     // delegation (`next.call(iter, v)`) can't rebind it to the iterator object.
-    mark_generator_step_closures_no_rebind(obj);
+    mark_generator_step_closures_no_rebind(obj_h.get_nanbox_f64());
     if is_async != 0 {
-        super::super::async_generator_queue::wrap_async_generator_instance(
-            obj_ptr as *mut ObjectHeader,
-        );
+        let async_target = handle_object_ptr(&obj_h);
+        super::super::async_generator_queue::wrap_async_generator_instance(async_target);
     }
-    let gen_proto = generator_prototype_ptr(is_async != 0);
-    if gen_proto.is_null() {
-        return obj;
+    // First call may build the whole tower; only its NULL-ness is used here, so
+    // the pointer itself is re-read after the allocation below.
+    if generator_prototype_ptr(is_async != 0).is_null() {
+        return obj_h.get_nanbox_f64();
     }
     // Intermediate object stands in for `g.prototype`: own `[[Prototype]]` is
     // `%Generator.prototype%`, carries no own methods (the instance inherits
     // `next`/`return`/`throw` from the brand-checked prototype two hops up).
     let intermediate = js_object_alloc(0, 0);
     if intermediate.is_null() {
-        return obj;
+        return obj_h.get_nanbox_f64();
     }
-    let gen_proto_bits = crate::value::js_nanbox_pointer(gen_proto as i64).to_bits();
+    let intermediate_h =
+        scope.root_nanbox_f64(crate::value::js_nanbox_pointer(intermediate as i64));
+
+    let gen_proto_bits =
+        crate::value::js_nanbox_pointer(generator_prototype_ptr(is_async != 0) as i64).to_bits();
     super::super::prototype_chain::object_set_static_prototype(
-        intermediate as usize,
+        handle_object_ptr(&intermediate_h) as usize,
         gen_proto_bits,
     );
-    let intermediate_bits = crate::value::js_nanbox_pointer(intermediate as i64).to_bits();
-    super::super::prototype_chain::object_set_static_prototype(obj_ptr, intermediate_bits);
-    obj
+    // `object_set_static_prototype` above allocated the intermediate's meta
+    // record, so BOTH operands are re-read here.
+    let intermediate_bits = intermediate_h.get_nanbox_u64();
+    super::super::prototype_chain::object_set_static_prototype(
+        handle_object_ptr(&obj_h) as usize,
+        intermediate_bits,
+    );
+    obj_h.get_nanbox_f64()
+}
+
+/// The current address of a NaN-boxed object held in `handle`.
+///
+/// #7577: reading it through this helper rather than binding a `usize` at the
+/// top of a function is the point — the pre-collection address is never
+/// nameable. See `RuntimeHandle::across_mut`'s docs.
+#[inline]
+fn handle_object_ptr(handle: &crate::gc::RuntimeHandle<'_>) -> *mut ObjectHeader {
+    crate::value::js_nanbox_get_pointer(handle.get_nanbox_f64()) as *mut ObjectHeader
 }
 
 /// Link a generator/async-generator instance to the concrete generator
@@ -421,6 +493,14 @@ pub extern "C" fn js_generator_attach_prototype(obj: f64, is_async: i32) -> f64 
 /// Node exposes for `Object.getPrototypeOf(g()) === g.prototype`; the
 /// fallback `js_generator_attach_prototype` above is used when codegen cannot
 /// see the owning closure.
+/// # Rooting (#7577)
+///
+/// Same hazard, same shape as [`js_generator_attach_prototype`]: the caller has
+/// already dropped its root by the time this is entered, and both
+/// `wrap_async_generator_instance` and `generator_function_prototype_of`
+/// allocate — the latter mints a fresh `g.prototype` object on its first call
+/// per generator function. Binding `obj_ptr` at entry and using it at the tail
+/// linked the prototype onto a pre-move address and returned it.
 #[no_mangle]
 pub extern "C" fn js_generator_attach_closure_prototype(
     obj: f64,
@@ -430,18 +510,19 @@ pub extern "C" fn js_generator_attach_closure_prototype(
     if !jv.is_pointer() {
         return obj;
     }
-    let obj_ptr = jv.as_pointer::<u8>() as usize;
-    if obj_ptr == 0 {
+    if jv.as_pointer::<u8>() as usize == 0 {
         return obj;
     }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_nanbox_f64(obj);
 
     // Pin the step closures' lexical generator-body `this` (see the fallback
     // `js_generator_attach_prototype`); this is the closure-identity wiring path.
-    mark_generator_step_closures_no_rebind(obj);
+    mark_generator_step_closures_no_rebind(obj_h.get_nanbox_f64());
 
     let closure = crate::closure::clean_closure_ptr(closure_ptr);
     if closure.is_null() || crate::closure::get_valid_func_ptr(closure).is_null() {
-        return obj;
+        return obj_h.get_nanbox_f64();
     }
 
     // Async-generator instances need the request-queue wrapper installed on
@@ -454,21 +535,24 @@ pub extern "C" fn js_generator_attach_closure_prototype(
     if crate::closure::is_registered_async_generator_function(crate::closure::get_valid_func_ptr(
         closure,
     )) {
-        super::super::async_generator_queue::wrap_async_generator_instance(
-            obj_ptr as *mut ObjectHeader,
-        );
+        let async_target = handle_object_ptr(&obj_h);
+        super::super::async_generator_queue::wrap_async_generator_instance(async_target);
     }
 
+    // Allocates a fresh `g.prototype` on the first call for this function, so
+    // the receiver is re-read from its handle AFTER it, not before.
     let Some(proto) = generator_function_prototype_of(closure as usize) else {
-        return obj;
+        return obj_h.get_nanbox_f64();
     };
-    let proto_jv = JSValue::from_bits(proto.to_bits());
-    if !proto_jv.is_pointer() {
-        return obj;
+    if !JSValue::from_bits(proto.to_bits()).is_pointer() {
+        return obj_h.get_nanbox_f64();
     }
 
-    super::super::prototype_chain::object_set_static_prototype(obj_ptr, proto.to_bits());
-    obj
+    super::super::prototype_chain::object_set_static_prototype(
+        handle_object_ptr(&obj_h) as usize,
+        proto.to_bits(),
+    );
+    obj_h.get_nanbox_f64()
 }
 
 /// Build one generator-intrinsic tower (sync or async) and store its three

--- a/test-files/test_gap_7577_generator_prototype_rooting.ts
+++ b/test-files/test_gap_7577_generator_prototype_rooting.ts
@@ -1,0 +1,72 @@
+// #7577: `js_generator_attach_prototype` held the generator instance's address
+// across its own allocations. A copying minor in that window meant the
+// `[[Prototype]]` link was recorded against the pre-move address and the
+// pre-move address was RETURNED to the caller as the generator object.
+//
+// Without the GC instruments that is not a crash — it is a silently wrong
+// prototype chain and a dangling handle, so this test pins the observable half:
+// `Object.getPrototypeOf(gen())` and its identity, over enough constructions
+// and enough allocation churn that the window is crossed thousands of times.
+
+function* small(n: number): Generator<number, void, undefined> {
+  for (let k = 0; k < n; k++) yield k + n;
+}
+
+async function* asmall(n: number): AsyncGenerator<number, void, undefined> {
+  for (let k = 0; k < n; k++) yield k + n;
+}
+
+function churn(i: number): string {
+  return "pad-" + i + "-" + (i * 7919) + "-" + (i % 13);
+}
+
+// --- the chain, on a single instance ---
+const g0 = small(2);
+const p0 = Object.getPrototypeOf(g0);
+console.log("A proto is object:", typeof p0 === "object" && p0 !== null);
+console.log("A proto === g.prototype:", p0 === small.prototype);
+console.log("A proto !== instance:", (p0 as unknown) !== (g0 as unknown));
+
+// `g.prototype` identity is stable across reads.
+console.log("B stable:", small.prototype === small.prototype);
+
+// Every instance of the same generator function shares one `g.prototype`.
+console.log("C shared:", Object.getPrototypeOf(small(1)) === Object.getPrototypeOf(small(1)));
+
+// --- the same, under construction + allocation churn ---
+// Every iteration builds a generator, drains it, and allocates. The chain must
+// still resolve on every instance, and the accumulated sum must be right — a
+// returned-from-space generator would produce neither reliably.
+const live: string[] = [];
+let acc = 0;
+let chainOk = 0;
+for (let i = 0; i < 4000; i++) {
+  const g = small(4);
+  let gs = g.next();
+  while (!gs.done) {
+    acc += gs.value as number;
+    gs = g.next();
+  }
+  if (Object.getPrototypeOf(g) === small.prototype) chainOk++;
+  live.push(churn(i));
+  if (live.length > 64) live.shift();
+}
+console.log("D acc:", acc);
+console.log("D chainOk:", chainOk);
+console.log("D live:", live.length);
+
+// --- async generators take the queue-wrapper path on the same call ---
+async function main(): Promise<void> {
+  let asum = 0;
+  let achainOk = 0;
+  for (let i = 0; i < 200; i++) {
+    const ag = asmall(3);
+    for await (const v of ag) asum += v;
+    if (Object.getPrototypeOf(asmall(1)) === asmall.prototype) achainOk++;
+    churn(i);
+  }
+  console.log("E asum:", asum);
+  console.log("E achainOk:", achainOk);
+}
+
+await main();


### PR DESCRIPTION
Closes #7577.

## Root cause: an ordering bug, not a missing root

`js_generator_attach_prototype` (`crates/perry-runtime/src/object/global_this/generator.rs:381`)
bound the receiver's address at function entry and used it at the tail:

```rust
let obj_ptr = jv.as_pointer::<u8>() as usize;         // entry
...
let intermediate = js_object_alloc(0, 0);             // ALLOCATES
object_set_static_prototype(intermediate as usize, gen_proto_bits);   // ALLOCATES
object_set_static_prototype(obj_ptr, intermediate_bits);              // stale
obj                                                                    // stale
```

**This frame owns the only reference.** Codegen drops the caller's root
immediately before the call — from the emitted IR for the issue's own
reproducer, in `perry_fn_..._small`, the frame the fault report names:

```llvm
%r65.rs4p = load ptr addrspace(1), ptr %r28
%r66 = or i64 %r65, POINTER_TAG
%r67 = bitcast i64 %r66 to double
store ptr addrspace(1) null, ptr %r28              ; <-- the caller's root, dropped
%r68 = call double @js_generator_attach_prototype(double %r67, i32 0)
ret double %r68
```

That is the ordinary contract (a runtime helper roots its own arguments) and
this one did not. Every call it makes allocates:

| call | allocation |
|---|---|
| `wrap_async_generator_instance` | three closures + three `js_object_set_field_by_name` keys-array transitions |
| `generator_prototype_ptr` | lazily builds the **entire** generator intrinsic tower on its first call |
| `js_object_alloc` | by definition |
| `object_set_static_prototype` | `object_meta_ensure` mints the object's meta record out of the arena |

A copying minor in any of those windows gave **two** wrong answers with no
diagnostic:

1. the `[[Prototype]]` link was recorded against the **pre-move** address, so
   `Object.getPrototypeOf(gen())` on the live object found nothing;
2. the function **returned** that pre-move address — the caller's generator was
   a dangling pointer into retired from-space.

That is #7577's SIGBUS. Without the instruments it is a wrong answer and exit 0,
which is the expensive half.

Same shape, same fix, in three more places reachable from that call:
`js_generator_attach_closure_prototype`, `generator_function_prototype_of`, and
`wrap_async_generator_instance` / `set_method` below them. Fixing only the named
function would have handed a freshly re-read receiver to a callee that lets it
go stale again.

Every pointer is now re-read from a `RuntimeHandleScope` handle **after** the
call that could have moved it. `generator_prototype_ptr` is deliberately called
a second time rather than cached: it reads a GC-rooted atomic the collector
rewrites, so a fresh call *is* the re-read.

`make_method_wrapper` is **deleted** rather than fixed. Its signature was the
defect — taking `original` as a parameter forces every caller to bind that
pointer before the `js_closure_alloc` inside, so the capture store writes a
pre-collection address. Its one caller now allocates the wrapper first and reads
`original` out of its handle afterwards, which leaves no correct way to call the
helper; per CLAUDE.md's kill-policy the losing shape stops compiling rather than
waiting for a future caller.

No new runtime cache of a heap pointer, so no `gc_register_mutable_root_scanner`
entry is required — the handles are covered by the existing runtime-handle
scanner.

## Reproduction: deterministic, not zeal-dependent

The issue's end-to-end reproducer does **not** fault reliably on `main` as of
1e971d269, and I want to be explicit about that rather than claim a repro I did
not get. A moving collection needs a **safepoint**, and there is none inside
`js_generator_attach_prototype` — allocation-triggered minors force a
conservative stack scan, which makes the copying minor ineligible. Measured, with
the instrument proven live:

```
[gc-fromspace-protect] mode=ProtectPages retired_set=#0 blocks=2
                       sets_held=1/800 bytes_protected=2097152
copied_objects up to 6053           # real evacuation, subject was moving
exit 0, no FAULT
```

(The issue's own version of the program is worse than that: `churn(i)`'s result
is discarded and dead-code-eliminated, so every minor reports
`copied_objects=0` — the instrument is live and the collector is moving
*nothing*. The `--pressure` failure mode from #7024, in miniature.)

So the tests here **inject the collection into the window** instead of hoping
one lands there. `force_next_general_arena_alloc_slow()` +
`GcTriggerThresholdTestGuard::make_arena_trigger_due()` arm the next arena block
allocation to collect, and the next one is the callee's own. Pre-fix, measured:

```
before=0x20001280008  after=0x200014c0008  moved=true
ret=0x20001280008     ret_is_current=false
proto_on_after=None   proto_on_before=Some(...)
```

The receiver moved during the call; the link went to the dead address and the
dead address came back.

## Coverage

**`crates/perry-runtime/src/gc/tests/runtime_roots/generator_attach_prototype.rs`**
— two `cargo test -p perry-runtime` tests, one per entry point. Two details that
are load-bearing rather than decorative:

- each asserts **its subject was live** (the receiver actually moved) before
  asserting anything else, per CLAUDE.md's "a gate must assert its subject was
  live" — a run in which nothing moved says so instead of passing;
- each calls `register_runtime_handle_root_scanner_for_tests()`. Without it the
  `RuntimeHandleScope` inside the function under test is decorative
  (`CopyingNurseryTestGuard` `mem::take`s the thread's mutable-root scanners),
  and I hit exactly that: the first run of the fixed code still reported
  `ret_is_current=false`, and the fix looked absent.

**`test-files/test_gap_7577_generator_prototype_rooting.ts`** — the observable
half: `Object.getPrototypeOf(gen())`, its identity across reads, and its
stability over 4000 sync + 200 async constructions with allocation churn.
Byte-identical to `node --experimental-strip-types` on the pinned 26.5.1, and
clean under `PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_ZEAL=1
PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` with the
instrument printing `mode=ProtectPages retired_set=#0 blocks=2
bytes_protected=2097152` and `copied_objects` up to 6053.

### Sabotage evidence

Restoring the entry-bound `obj_ptr` in both functions (the pre-#7577 shape)
turns both tests red on the precise defect:

```
attach_closure_prototype_survives_a_copying_minor_inside_the_call ... FAILED
attach_prototype_survives_a_copying_minor_inside_the_call ... FAILED
assertion `left == right` failed: js_generator_attach_prototype: must return
the receiver's CURRENT address; returning the pre-move one hands the caller a
dangling generator object
  left: 2199036952584
 right: 2199039311880
```

## Validation

Local; CI has a deep backlog and has not reported.

- `cargo test -p perry-runtime --no-fail-fast` — **1820 passed, 0 failed**.
- 24 generator / yield* / async-generator / iterator gap tests byte-compared
  against Node: **24/24 pass**. (A 25th, `test_gap_iterator_helpers_2874`, is a
  standing known failure fixed by #7583 on a separate branch.)
- `python3 scripts/raw_handle_debt.py` → 998 (baseline 998) — the fix uses
  NaN-boxed handles throughout, so the ledger does not move.
- `scripts/check_file_size.sh` → OK.
- `cargo fmt --all -- --check` → clean.
- `python3 scripts/addr_class_inventory.py` → **fails, pre-existing**: it flags
  `crates/perry-runtime/src/iter_result.rs:139` (a `gcheader-cast` introduced by
  #7579), and I verified it fails identically on a clean tree at `origin/main`
  1e971d269. Not touched here. It needs a *mutable* header write, so
  `try_read_gc_header` (which returns `&'static`) is not a drop-in — it wants an
  allowlist entry or a `gc_flags` setter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generator and async-generator prototype handling during garbage collection.
  * Preserved generator prototype links, closure identity, and receiver references when objects move in memory.
  * Improved reliability for synchronous and asynchronous generator creation and iteration under memory pressure.

* **Tests**
  * Added runtime and TypeScript regression coverage for generator prototype attachment and garbage-collection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->