### PR TITLE
docs(plan): retract the unsound typed-shape inlining remedy (#7578)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1332
+**Current Version:** 0.5.1333
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1332"
+version = "0.5.1333"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1332"
+version = "0.5.1333"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1332"
+version = "0.5.1333"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1332"
+version = "0.5.1333"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1332"
+version = "0.5.1333"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7588-retract-unsound-typed-shape-remedy.md
+++ b/changelog.d/7588-retract-unsound-typed-shape-remedy.md
@@ -1,0 +1,47 @@
+### Documentation
+
+- **Retracts an unsound optimisation the plan was recommending (#7588).** Docs
+  only, but the retracted text pointed the next reader at a use-after-free.
+
+  #7581 proposed emitting the typed-shape install's hit path inline at the `new`
+  site, by analogy with #7566 — every argument but the object pointer is a
+  compile-time constant for the class, so it looked like the same win. #7586
+  tested both halves of that reasoning and **both are wrong**.
+
+  **The frame is not the lever; inlining it is a regression.** The prologue does
+  match #7566's shape — `sub sp, sp, #0x150`, six `stp` pairs, a 336-byte frame
+  and twelve callee-saved spills per construction, sized by LLVM for a descriptor
+  build that runs once per shape. Outlining it behind `#[cold] #[inline(never)]`
+  cut the frame to 80 bytes and the spills to zero and made it **slower**:
+  `push_cls` 0.72 → 0.75 s, `churn_alloc` 0.72 → 0.79 s. Those spills are cheap
+  dual-issued stores off the critical path, and keeping six arguments live to
+  forward to the outlined call costs more in register moves than the prologue
+  saves. The function is bound by **instruction count, not frame size** — which
+  is why #7586's shipped fix attacks instruction count and gets 1.091×.
+
+  **⛔ The codegen half is a use-after-free factory**, and it is dangerous
+  precisely because it is free: `declare`-path classes must have an empty pointer
+  mask, so since #7566 the inline `new` already writes its `GcHeader` as one i64
+  constant, and OR-ing `GC_OBJ_TYPED_LAYOUT_INTACT` into it costs +0 instructions
+  and +0 bytes.
+
+  It breaks the unwritten invariant **"intact ⟹ a descriptor is reachable"**,
+  which `layout_note_slot` silently depends on. On a contradicting store to an
+  intact-but-descriptor-less object the probe resolves `None`, and
+  `layout_set_typed_unknown` — the only thing that clears the intact bit — is
+  reachable **only from the `Some(verdict)` arm** (`gc/layout.rs:782–788`). So
+  control falls through to the pointer-mask path and the bit is never cleared.
+  The object is thereafter `SIDE_MASK` to the collector and *intact* to the
+  class-field inline guard, which consults no map by design; the raw-store fast
+  path then writes a double over a pointer slot with no barrier and no layout
+  note, and the next collection walks it as a heap pointer.
+
+  Flagged for whoever reads that code next: the comment at `gc/layout.rs:742`
+  says a `None` verdict "can only cost an extra fall-through, never mis-track a
+  slot". That is true **only while the invariant holds** — it is a consequence of
+  the invariant, not an independent guarantee, and it reads as reassurance to
+  exactly the person about to break it.
+
+  Both are now recorded in `docs/engine-plan.md` as ⛔ entries carrying their
+  measurements, so the next person re-deriving the same obvious idea meets the
+  result rather than repeating the experiment.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -95,11 +95,57 @@ levers and should not be worked.
 path (confirmed in the emitted IR — one call to `declare`, zero to `init`), so
 #7515/#7532 are working. It is the install itself, whose hit path
 `layout.rs:1022` documents as reducing to "the two header bit-writes
-`shape_install_shared` would have performed". Every argument to that call but the
-object pointer is a **compile-time constant for the class** — which is exactly
-the shape #7566 just won 1.81× on, so the same remedy (emit the hit path inline,
-keep the call as the slow path, gate it so non-hot sites pay no bytes) is the
-obvious first thing to try.
+`shape_install_shared` would have performed".
+
+**Partly addressed by #7586** (v0.5.1332): `push_cls` **1.091×**, `churn_alloc`
+1.075×, `churn` 1.042×, at **+0 bytes by construction** (no codegen crate is
+touched, so emitted IR cannot change). `deeplist` pays 0.7–1.3%, reproducible —
+pointer fields put it on the validating entry point. The cost was never the call
+overhead: **~30 of the ~70 hit-path instructions re-derived compile-time
+constants of the class**, because the FFI boundary makes them opaque — 12
+normalising two `(pointer, length)` pairs into slices only ever compared as
+integers, ~11 of `words_intersect` setup over two immutable globals, ~6
+recomputing the slot kind.
+
+### ⛔ Two remedies that look obvious and are wrong. Do not rebuild them.
+
+An earlier revision of this section proposed inlining the hit path at the `new`
+site, reasoning that every argument but the object pointer is a compile-time
+constant and that this is the shape #7566 won 1.81× on. **Both halves of that
+were tested in #7586 and both are wrong.**
+
+1. **Outlining/inlining the frame is not the lever — it is a regression.** The
+   prologue does look like #7566's shape (`sub sp, sp, #0x150`, six `stp` pairs
+   — a 336-byte frame and twelve callee-saved spills per construction, sized by
+   LLVM for a descriptor build that runs once per shape). Outlining it behind
+   `#[cold] #[inline(never)]` cut the frame to 80 bytes and the spills to zero,
+   and made things **slower**: `push_cls` 0.72 → 0.75 s, `churn_alloc`
+   0.72 → 0.79 s. Those spills are cheap dual-issued stores off the critical
+   path, and keeping six arguments live to forward to the outlined call costs
+   more in register moves than the prologue saves. **This function is bound by
+   instruction count, not frame size.**
+
+2. **⛔ Having codegen OR `GC_OBJ_TYPED_LAYOUT_INTACT` into the inline `new`'s
+   header word is a use-after-free factory.** It is seductive because it is
+   genuinely free — `declare`-path classes must have an empty pointer mask, so
+   since #7566 the inline `new` already writes its `GcHeader` as one i64
+   constant, and OR-ing one more bit costs +0 instructions and +0 bytes.
+
+   It breaks the unwritten invariant **"intact ⟹ a descriptor is reachable"**,
+   which `layout_note_slot` silently depends on. On a contradicting store to an
+   object that is intact but descriptor-less, the probe resolves `None`;
+   `layout_set_typed_unknown` — the only thing that clears the intact bit — is
+   reached **only from the `Some(verdict)` arm** (`gc/layout.rs:782–788`), so
+   control falls through to the pointer-mask path and **the bit is never
+   cleared**. The object is thereafter `SIDE_MASK` to the collector and *intact*
+   to the class-field inline guard, which consults no map by design. The raw-store
+   fast path then writes a double over a pointer slot with no barrier and no
+   layout note, and the next collection walks it as a heap pointer.
+
+   Note the comment at `layout.rs:742` says a `None` verdict "can only cost an
+   extra fall-through, never mis-track a slot". That is true **only while the
+   invariant holds** — it is a consequence of it, not an independent guarantee,
+   and it reads like reassurance to anyone implementing this.
 
 **A declared class is no longer slower than an object literal.** #7512 is
 **closed**: `churn_alloc` and `push_cls` both measure 0.75 s. The cause was not


### PR DESCRIPTION
Docs only, but time-sensitive: **the plan currently tells the next reader to build a use-after-free**, and I put it there.

In #7581 I wrote that the typed-shape install's hit path should be emitted inline at the `new` site, reasoning that every argument but the object pointer is a compile-time constant and that this is exactly the shape #7566 won 1.81× on. #7586 tested both halves of that reasoning. **Both are wrong.**

## 1. The frame is not the lever — inlining it is a regression

The prologue really does look like #7566's shape: `sub sp, sp, #0x150`, six `stp` pairs — a 336-byte frame and twelve callee-saved spills per construction, sized by LLVM for a descriptor build that runs once per shape. Outlining it behind `#[cold] #[inline(never)]` cut the frame to 80 bytes and the spills to zero, and made it **slower**:

| bench | main | outlined |
|---|--:|--:|
| `push_cls` | 0.72 s | 0.75 s |
| `churn_alloc` | 0.72 s | 0.79 s |

Those spills are cheap dual-issued stores off the critical path; keeping six arguments live to forward to the outlined call costs more in register moves than the prologue saves. **The function is bound by instruction count, not frame size** — which is why the shipped fix attacks instruction count instead and gets 1.091×.

## 2. ⛔ The codegen half is a use-after-free factory

This is the part worth reading, because it is *genuinely free* and therefore very tempting. `declare`-path classes must have an empty pointer mask, so since #7566 the inline `new` already writes its `GcHeader` as a single i64 constant. OR-ing `GC_OBJ_TYPED_LAYOUT_INTACT` into it costs **+0 instructions and +0 bytes**.

It breaks an unwritten invariant that `layout_note_slot` depends on: **intact ⟹ a descriptor is reachable.**

I verified the mechanism directly. On a contradicting store to an object that is intact but descriptor-less, the probe resolves `None` — and `layout_set_typed_unknown`, the only thing that clears the intact bit, is reachable **only from the `Some(verdict)` arm** (`gc/layout.rs:782–788`). Control falls through to the pointer-mask path and the bit is never cleared. The object is then `SIDE_MASK` to the collector and *intact* to the class-field inline guard, which consults no map by design. The raw-store fast path writes a double over a pointer slot with no barrier and no layout note, and the next collection walks it as a heap pointer.

Worth flagging for whoever reads that code next: the comment at `layout.rs:742` says a `None` verdict "can only cost an extra fall-through, never mis-track a slot". That is true **only while the invariant holds** — it is a consequence of the invariant, not an independent guarantee. It reads as reassurance precisely to the person about to break it.

Both are now written into the plan as ⛔ entries with the measurements, so they are not rediscovered by someone re-deriving the same "obvious" idea.

`check_file_size.sh` clean. No code touched.
