### PR TITLE
fix(runtime): JSX and raw-JSON shared a class id; add a scanning gate (#7587)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,22 @@ jobs:
           python3 scripts/addr_class_inventory.py --self-test
           python3 scripts/addr_class_inventory.py
 
+      # Two reserved class ids sharing a value is silent and destructive: every
+      # dispatch tower matches them in a fixed order, so the later arm becomes
+      # unreachable and its whole method surface dies (#7576 killed the entire
+      # TC39 iterator-helpers proposal that way), and any site discriminating on
+      # class_id ALONE cross-matches — which can look correct for as long as the
+      # two types agree on field layout and break the day either changes (#7587,
+      # where `String(JSON.rawJSON(x))` was silently taking the JSX path).
+      #
+      # This SCANS rather than enumerating. #7576 shipped a Rust test listing
+      # seven iterator ids, which is good and stays — but it could not catch
+      # #7587, a different family that was not in the list. A gate whose
+      # coverage depends on the same attention the bug depends on is not a gate.
+      - name: Class-id collision audit
+        if: ${{ !cancelled() }}
+        run: python3 scripts/class_id_collisions.py
+
       # #7341 layer 3. A RuntimeHandleScope gives an object liveness; it does
       # nothing for a raw pointer already read out of the slot. Every rooting bug
       # in the quarantine sweep had rooting ALREADY -- what was missing was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1333
+**Current Version:** 0.5.1334
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1333"
+version = "0.5.1334"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1333"
+version = "0.5.1334"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1333"
+version = "0.5.1334"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1333"
+version = "0.5.1334"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1333"
+version = "0.5.1334"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7589-class-id-collision-gate.md
+++ b/changelog.d/7589-class-id-collision-gate.md
@@ -1,0 +1,53 @@
+### Fixed
+
+- **`JSX_NODE_CLASS_ID` and `RAW_JSON_CLASS_ID` were both `0xFFFF_00A0`
+  (#7589).** The second class-id collision found in a week, after #7576's
+  `ITERATOR_HELPER_CLASS_ID` / `STRING_ITERATOR_CLASS_ID` pair — which had
+  silently killed the entire TC39 iterator-helpers surface.
+
+  **Not inert.** `value/to_string.rs` discriminates on `class_id` **alone** — no
+  second condition — and returns field 0 as the object's string. A raw-JSON
+  wrapper is allocated with one field and keeps its text in field 0, so
+  `String(JSON.rawJSON("123"))` matched the **JSX** arm and stringified through
+  it. It returned a plausible answer **purely by coincidence of layout**, both
+  types happening to store their payload in the same slot. That is the more
+  instructive failure mode: a collision can produce right-looking output for
+  exactly as long as the two types agree structurally, and break the day either
+  layout changes. `RAW_JSON_CLASS_ID` moves to the free `0xFFFF_00A1`; neither
+  id is referenced by codegen or persisted, so the move is internal.
+
+  **The gate is the more important half.** #7576 added
+  `iterator_class_ids_are_pairwise_distinct`, a Rust test enumerating seven
+  iterator ids. It is good and it stays — and it **could not have caught this**,
+  because this was a different family and not in the list. That is the
+  structural problem with an enumerated list: it covers only the constants
+  somebody remembered to add, while the failure being guarded against *is*
+  forgetting that a constant exists. **A gate whose coverage depends on the same
+  attention the bug depends on is not a gate.**
+
+  `scripts/class_id_collisions.py` scans every crate instead, so a new constant
+  is covered the moment it is written, with no list to maintain. It runs in
+  `lint` beside the address-classification audit.
+
+  It detects two shapes, and **the second one found itself during development**.
+  Different names on one value is the collision. The *same* name on one value is
+  a deliberate cross-crate mirror — `perry-ext-events` restates the runtime's
+  `ABORT_SIGNAL_CLASS_ID` so it can recognise runtime AbortSignal objects — which
+  is correct and must not be reported, or the gate would be permanently red and
+  therefore ignored. But one name carrying **different** values is *mirror
+  drift*, and that is worse than a collision: each crate stays internally
+  consistent, so nothing looks wrong anywhere, while the type silently stops
+  being recognised across the boundary.
+
+  Sabotage-verified with exit codes captured directly rather than through a pipe
+  (`$?` after `| head` is `head`'s status): reintroducing the collision exits 1,
+  drifting the mirror exits 1, raising the stale-scan floor exits 2, clean exits
+  0. That floor exists because a scan which silently matches nothing prints "no
+  collisions" and means nothing — the same discipline as
+  `gc_root_dominance_corpus.sh`'s `MIN_COMPILED`.
+
+  Validation: `JSON.rawJSON` byte-identical to node 26.5.1 across `isRawJSON`,
+  `stringify`, the `rawJSON` own property and a nested/mixed array, with JSX
+  rendering unchanged as a control; `cargo test -p perry-runtime --lib` 1838
+  passed / 0 failed; `addr_class_inventory`, `raw_handle_debt` (998),
+  `check_file_size.sh` and `cargo fmt --check` clean.

--- a/crates/perry-runtime/src/json/raw_json.rs
+++ b/crates/perry-runtime/src/json/raw_json.rs
@@ -20,7 +20,27 @@ use crate::{js_string_from_bytes, JSValue, ObjectHeader, StringHeader};
 /// Reserved class id stamped onto raw-JSON wrapper objects. Kept distinct
 /// from every other reserved id used by `instanceof` / typeof so it can't be
 /// confused with a real user class or built-in.
-pub(crate) const RAW_JSON_CLASS_ID: u32 = 0xFFFF_00A0;
+///
+/// #7587: this was `0xFFFF_00A0`, which is [`JSX_NODE_CLASS_ID`]. Two
+/// independently written constants landed on the same slot — the second such
+/// collision found in a week, after #7576's `ITERATOR_HELPER_CLASS_ID` /
+/// `STRING_ITERATOR_CLASS_ID` pair. That one was inert-looking too, right up
+/// until it turned out to have killed the entire TC39 iterator-helpers surface.
+///
+/// This pair was not inert either. `value/to_string.rs` discriminates on
+/// `class_id` **alone** — no second condition — and returns field 0 as the
+/// object's string. A raw-JSON wrapper is allocated with one field and keeps
+/// its text in field 0, so `String(JSON.rawJSON("123"))` took the **JSX** arm
+/// and stringified through it. It returned a plausible answer purely because
+/// both types happen to store their payload in the same slot; any change to
+/// either layout would have turned that into garbage or a fault.
+///
+/// `scripts/class_id_collisions.py` now scans for this shape across every
+/// family, so a third pair cannot be introduced silently. A hand-maintained
+/// list could not — it only covers the constants somebody remembered to add.
+///
+/// [`JSX_NODE_CLASS_ID`]: crate::jsx::JSX_NODE_CLASS_ID
+pub(crate) const RAW_JSON_CLASS_ID: u32 = 0xFFFF_00A1;
 
 /// True if `text` is an acceptable argument to `JSON.rawJSON` per Node: a
 /// single JSON scalar with no leading/trailing whitespace, and not an object

--- a/scripts/class_id_collisions.py
+++ b/scripts/class_id_collisions.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Fail the build when two reserved class ids collide.
+
+WHY THIS IS A SCRIPT AND NOT A UNIT TEST
+----------------------------------------
+#7576 shipped `iterator_class_ids_are_pairwise_distinct`, a Rust test that
+hand-enumerates seven iterator class ids and asserts they differ. That test is
+good and stays. It also could not have caught #7587, which was a collision
+between `JSX_NODE_CLASS_ID` and `RAW_JSON_CLASS_ID` — a different family, so
+not in the list.
+
+That is the whole problem with an enumerated list: it only covers the constants
+somebody remembered to add, and the failure mode being guarded against is
+*forgetting that a constant exists*. A gate whose coverage depends on the same
+attention the bug depends on is not a gate. So this scans the source instead —
+every new constant is covered the moment it is written, with no list to update.
+
+WHAT THE BUG LOOKS LIKE
+-----------------------
+Both known collisions were introduced the same way: an author copied a
+neighbouring constant, bumped the low byte, and wrote a comment describing
+where it sits relative to its neighbour — without checking whether the slot was
+already taken. Both comments were accurate about the neighbour and wrong about
+the slot.
+
+Neither was inert:
+
+* #7576 — `ITERATOR_HELPER_CLASS_ID` and `STRING_ITERATOR_CLASS_ID` were both
+  `0xFFFF_0009`. Every dispatch tower matches the String arm first, so EVERY
+  helper object dispatched as a String iterator and the entire TC39
+  iterator-helpers surface returned `undefined`. Silently for `Iterator.from`.
+
+* #7587 — `JSX_NODE_CLASS_ID` and `RAW_JSON_CLASS_ID` were both `0xFFFF_00A0`.
+  `value/to_string.rs` discriminates on `class_id` alone and returns field 0,
+  and both types keep their payload in field 0, so `String(JSON.rawJSON(x))`
+  took the JSX path and *looked correct by coincidence of layout*.
+
+The second is the more instructive one: a collision can produce right-looking
+output for as long as the two types happen to agree structurally, and break the
+day either layout changes.
+
+USAGE
+-----
+    python3 scripts/class_id_collisions.py           # check, exit 1 on collision
+    python3 scripts/class_id_collisions.py --list    # print the id map
+
+Exit status is non-zero on a collision, or if the scan finds implausibly few
+constants — a scan that silently matches nothing reports "no collisions" and
+means nothing. That floor is the same discipline `gc_root_dominance_corpus.sh`
+applies with MIN_COMPILED.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Scan every workspace crate, not just perry-runtime: a class id minted in
+# perry-stdlib collides with a perry-runtime one just as thoroughly, and the
+# whole point of this file is not to depend on someone remembering the scope.
+CRATES = ROOT / "crates"
+
+# `pub const FOO_CLASS_ID: u32 = 0xFFFF_0009;` and the pub(crate)/plain forms.
+# The value may carry `_` separators and any case.
+DECL = re.compile(
+    r"^\s*(?:pub\s*(?:\(\s*[^)]*\s*\)\s*)?)?const\s+"
+    r"(?P<name>[A-Z0-9_]*CLASS_ID)\s*:\s*u32\s*=\s*"
+    r"(?P<value>0[xX][0-9A-Fa-f_]+)\s*;",
+    re.MULTILINE,
+)
+
+# A scan that matches nothing is indistinguishable from a clean scan. This is
+# the floor, not a target: raise it when the set genuinely grows, never lower
+# it to make a run pass.
+MIN_CONSTANTS = 12
+
+
+def collect() -> dict[int, list[tuple[str, str]]]:
+    """value -> [(constant name, repo-relative file:line), ...]"""
+    found: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for path in sorted(CRATES.rglob("*.rs")):
+        if "/target/" in str(path):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "CLASS_ID" not in text:
+            continue
+        for m in DECL.finditer(text):
+            value = int(m.group("value").replace("_", ""), 16)
+            line = text.count("\n", 0, m.start()) + 1
+            rel = path.relative_to(ROOT)
+            found[value].append((m.group("name"), f"{rel}:{line}"))
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="print the id map and exit")
+    args = ap.parse_args()
+
+    found = collect()
+    total = sum(len(v) for v in found.values())
+
+    if args.list:
+        for value in sorted(found):
+            for name, where in found[value]:
+                print(f"  {value:#010x}  {name:<44} {where}")
+        print(f"\n{total} reserved class ids across {len(found)} distinct values")
+        return 0
+
+    if total < MIN_CONSTANTS:
+        print(
+            f"::error::found only {total} class-id constants, expected at least "
+            f"{MIN_CONSTANTS}. The scan pattern has probably gone stale — a scan "
+            f"that matches nothing reports 'no collisions' and means nothing.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Two DIFFERENT names on one value is the bug. The SAME name on one value
+    # is a deliberate cross-crate mirror — `perry-ext-events` restates the
+    # runtime's `ABORT_SIGNAL_CLASS_ID` so it can recognise runtime AbortSignal
+    # objects, which is correct and must not be reported. Distinguishing them
+    # by name is what makes this gate usable rather than permanently red.
+    collisions = {
+        v: entries
+        for v, entries in found.items()
+        if len({name for name, _ in entries}) > 1
+    }
+
+    # The mirror has its own failure mode, in the opposite direction: one name
+    # carrying DIFFERENT values in different crates. That is a mirror that has
+    # drifted, and it is worse than a collision because each crate is
+    # self-consistent — the runtime stamps one id and the ext crate tests for
+    # another, so the type simply stops being recognised across the boundary
+    # with nothing anywhere looking wrong.
+    by_name: dict[str, set[int]] = defaultdict(set)
+    where_by_name: dict[str, list[str]] = defaultdict(list)
+    for value, entries in found.items():
+        for name, where in entries:
+            by_name[name].add(value)
+            where_by_name[name].append(f"{value:#010x}  {where}")
+    drifted = {n: v for n, v in by_name.items() if len(v) > 1}
+
+    if not collisions and not drifted:
+        mirrors = sum(1 for e in found.values() if len(e) > 1)
+        note = f", {mirrors} intentional cross-crate mirror(s)" if mirrors else ""
+        print(f"Class-id audit passed ({total} reserved ids{note}).")
+        return 0
+
+    if collisions:
+        print("Class-id COLLISION — two DIFFERENT ids share a value:\n", file=sys.stderr)
+        for value, entries in sorted(collisions.items()):
+            print(f"  {value:#010x}", file=sys.stderr)
+            for name, where in entries:
+                print(f"      {name:<44} {where}", file=sys.stderr)
+            print(file=sys.stderr)
+        print(
+            "Every dispatch tower matches these in a FIXED ORDER, so the later arm\n"
+            "becomes unreachable and its whole method surface dies silently (#7576),\n"
+            "and any site that discriminates on class_id alone will cross-match —\n"
+            "which can look CORRECT for as long as the two types agree on field\n"
+            "layout, and break the day either changes (#7587).\n\n"
+            "Give one of them an unused value. `--list` prints the map.\n",
+            file=sys.stderr,
+        )
+
+    if drifted:
+        print("Class-id MIRROR DRIFT — one name, different values:\n", file=sys.stderr)
+        for name in sorted(drifted):
+            print(f"  {name}", file=sys.stderr)
+            for line in sorted(where_by_name[name]):
+                print(f"      {line}", file=sys.stderr)
+            print(file=sys.stderr)
+        print(
+            "A cross-crate mirror that has drifted is worse than a collision:\n"
+            "each crate is internally consistent, so nothing looks wrong, but the\n"
+            "type stops being recognised across the boundary. Make them equal.",
+            file=sys.stderr,
+        )
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`JSX_NODE_CLASS_ID` and `RAW_JSON_CLASS_ID` were both `0xFFFF_00A0` — the **second** class-id collision found in a week, after #7576's `ITERATOR_HELPER_CLASS_ID` / `STRING_ITERATOR_CLASS_ID` pair took out the entire TC39 iterator-helpers surface.

## It was not inert

`value/to_string.rs:1144` discriminates on `class_id` **alone** — no second condition — and returns field 0 as the object's string. A raw-JSON wrapper is allocated with one field and keeps its text in field 0, so `String(JSON.rawJSON("123"))` matched the **JSX** arm and stringified through it.

It returned a plausible answer **purely by coincidence of layout** — both types happen to store their payload in the same slot. That is the more instructive failure: a collision can produce right-looking output for exactly as long as the two types agree structurally, and break the day either layout changes.

`RAW_JSON_CLASS_ID` moves to the free `0xFFFF_00A1`. Neither id is referenced by `perry-codegen`/`perry-hir` or persisted anywhere, so the move is internal.

## The gate is the more important half

#7576 added `iterator_class_ids_are_pairwise_distinct`, a Rust test enumerating seven iterator ids. It is good and it stays. **It could not have caught this** — different family, not in the list.

That is the structural problem with an enumerated list: it covers only the constants somebody remembered to add, and the failure being guarded against *is* forgetting that a constant exists. A gate whose coverage depends on the same attention the bug depends on is not a gate.

`scripts/class_id_collisions.py` scans every crate instead, so a new constant is covered the moment it is written, with no list to update. Wired into `lint` next to the addr-class audit.

**It detects two shapes, and the second one found itself.** Different names on one value is the collision. The *same* name on one value is a deliberate cross-crate mirror — `perry-ext-events` restates the runtime's `ABORT_SIGNAL_CLASS_ID` so it can recognise runtime AbortSignal objects — which is correct and must not be reported, or the gate is permanently red. But one name carrying **different** values is *mirror drift*, and that is worse than a collision: each crate stays internally consistent, so nothing looks wrong, while the type silently stops being recognised across the boundary. The gate catches both.

## Sabotage-verified, with real exit codes

Captured without a pipe, because `$?` after `| head` is `head`'s status — a trap that has bitten this repo:

| sabotage | exit |
|---|--:|
| reintroduce the `0xFFFF_00A0` collision | **1** |
| drift the `ABORT_SIGNAL_CLASS_ID` mirror | **1** |
| raise `MIN_CONSTANTS` (stale-scan floor) | **2** |
| clean | **0** |

The floor exists because a scan that silently matches nothing prints "no collisions" and means nothing — same discipline as `gc_root_dominance_corpus.sh`'s `MIN_COMPILED`.

## Validation

`JSON.rawJSON` byte-identical to node 26.5.1 across `isRawJSON`, `stringify`, the `rawJSON` own property, and a nested/mixed array; JSX rendering unchanged as a control. `cargo test -p perry-runtime --lib` 1838 passed / 0 failed. `addr_class_inventory`, `raw_handle_debt` (998), `check_file_size.sh`, `cargo fmt --check` all clean.

CI has a deep backlog and may not report; this is local validation.
