### PR TITLE
perf(gc): break the survivor-promotion handoff livelock (#7592)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1337
+**Current Version:** 0.5.1338
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1337"
+version = "0.5.1338"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1337"
+version = "0.5.1338"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1337"
+version = "0.5.1338"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1337"
+version = "0.5.1338"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1337"
+version = "0.5.1338"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7594-survivor-promotion-handoff-livelock.md
+++ b/changelog.d/7594-survivor-promotion-handoff-livelock.md
@@ -1,0 +1,31 @@
+**perf(gc): break the survivor-promotion handoff livelock (#7592)**
+
+`copied_minor_promotion_handoff_due` replaces a minor collection with a full
+mark-sweep to make room in old-gen for survivors about to be promoted. But a
+full mark-sweep is non-moving — it promotes nothing — so it cannot relieve the
+pressure that scheduled it: the survivor space still holds the same bytes, the
+reclaim baseline it resets does not count them, and the predicate is true again
+at the very next minor. The copying minor that would have performed the
+promotion never ran.
+
+Measured on `json_pipeline` at 200k records: 19 of 22 collections were
+`survivor_promotion_bytes` fulls, each freeing 0.0 MB at ~400 ms — 7.6 s of an
+8.6 s phase, with peak RSS the same whether they ran or not.
+
+Latched to one handoff per copying minor: the handoff makes room, the copying
+minor performs the promotion that consumes it. The latch clears only on a
+*copying* minor, since a non-moving minor fallback promotes nothing and would
+reinstate the livelock at half rate. The guard precedes the
+`copied_minor_promotable_active_survivor_bytes()` walk, so a suppressed handoff
+also skips that O(n) survivor pass.
+
+The same workload now runs 6 collections instead of 22, with the copying minor
+promoting 110 MB. `build_out` at 500k records goes 57,242 ms → 10,551 ms
+(5.4×), output hash identical; peak RSS rises 17–24 % at the large sizes,
+because the run performs fewer collections.
+
+Confined to workloads that hit the livelock: measuring both arms back to back on
+one host (the pinned ratchet baseline is from 0.5.1315 on another machine and
+cannot separate this change from drift), all 12 probes agree on every semantic
+counter across 144 metric medians, with only ungated RSS/wall cells moving, all
+≤ 0.12 %.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1276,6 +1276,9 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
         trace.pause_us = start.elapsed().as_micros() as u64;
         trace.capture_layout_scans();
     }
+    // #7592: this is the promotion the survivor-promotion handoff exists to
+    // enable, so it releases the latch that suppressed a repeat handoff.
+    note_copying_minor_completed();
     maybe_schedule_old_reclaim_after_copied_minor();
     retune_after_scavenge(
         collector.stats.eden_live_bytes,

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -176,6 +176,11 @@ pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCol
         prev & GC_FLAG_IN_ALLOC
     });
     if copied_minor_promotion_handoff_due(trigger.kind) {
+        // #7592: latch before running it. This full is non-moving and promotes
+        // nothing, so it cannot relieve the survivor pressure that scheduled
+        // it; without the latch the predicate is still true at the next minor
+        // and the collector livelocks on fulls that free nothing.
+        note_survivor_promotion_handoff_full();
         let outcome = gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(
             GcTriggerKind::SurvivorPromotionBytes,
         ));

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -778,6 +778,9 @@ thread_local! {
     /// it was scheduled for has not. See
     /// `survivor_promotion_handoff_awaiting_minor`.
     static SURVIVOR_HANDOFF_AWAITING_MINOR: Cell<bool> = const { Cell::new(false) };
+    /// Count of handoffs the latch has suppressed — see
+    /// `survivor_promotion_handoff_suppressions`.
+    static SURVIVOR_HANDOFF_SUPPRESSIONS: Cell<u64> = const { Cell::new(0) };
     /// Phase 2/3 of the moving-GC project: set when an alloc-point nursery
     /// trigger fires while moving mode is on, deferring the collection to the
     /// next precise-root safepoint (event-loop boundary or a codegen loop
@@ -1241,6 +1244,16 @@ pub(super) fn note_survivor_promotion_handoff_full() {
     SURVIVOR_HANDOFF_AWAITING_MINOR.with(|flag| flag.set(true));
 }
 
+/// How many handoffs the latch has suppressed. Every one of these was a full
+/// mark-sweep that would have freed nothing — on `main` this counter would have
+/// read 18 for #7592's 200k `json_pipeline` run. It exists so the suppression
+/// itself is observable: the latch short-circuits before the arena inspection,
+/// so a test with an empty heap cannot otherwise distinguish "suppressed" from
+/// "there was no pressure anyway".
+pub(super) fn survivor_promotion_handoff_suppressions() -> u64 {
+    SURVIVOR_HANDOFF_SUPPRESSIONS.with(Cell::get)
+}
+
 /// Clear the latch — called only when a *copying* minor completes, since only
 /// that collector promotes. A non-moving minor fallback promotes nothing, so
 /// re-arming on one would reinstate the livelock at half rate.
@@ -1256,8 +1269,10 @@ pub(super) fn copied_minor_promotion_handoff_due(trigger_kind: GcTriggerKind) ->
         return false;
     }
     // A handoff full has already run and promoted nothing; let the copying
-    // minor it was scheduled for actually happen (#7592).
+    // minor it was scheduled for actually happen (#7592). Placed before the
+    // survivor walk below so a suppressed handoff also skips that O(n) pass.
     if survivor_promotion_handoff_awaiting_minor() {
+        SURVIVOR_HANDOFF_SUPPRESSIONS.with(|n| n.set(n.get().saturating_add(1)));
         return false;
     }
     if crate::arena::copying_active_survivor_in_use_bytes()

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -774,6 +774,10 @@ thread_local! {
     /// `gc_check_trigger`: the full collection must not recursively trigger
     /// another reclaim if a hook it runs allocates.
     pub(super) static GC_OLD_RECLAIM_IN_PROGRESS: Cell<bool> = const { Cell::new(false) };
+    /// #7592: a survivor-promotion handoff full has run and the copying minor
+    /// it was scheduled for has not. See
+    /// `survivor_promotion_handoff_awaiting_minor`.
+    static SURVIVOR_HANDOFF_AWAITING_MINOR: Cell<bool> = const { Cell::new(false) };
     /// Phase 2/3 of the moving-GC project: set when an alloc-point nursery
     /// trigger fires while moving mode is on, deferring the collection to the
     /// next precise-root safepoint (event-loop boundary or a codegen loop
@@ -1214,11 +1218,46 @@ pub(super) fn copied_minor_promotable_active_survivor_bytes() -> usize {
     promotable
 }
 
+/// #7592: whether a survivor-promotion handoff full has run without the copying
+/// minor it exists to enable having run since.
+///
+/// The handoff replaces a minor with a full mark-sweep to make room in old-gen
+/// for survivors that are about to be promoted. But a full mark-sweep is
+/// **non-moving — it promotes nothing**, so it cannot itself relieve the
+/// pressure it was scheduled for: the survivor space still holds the same
+/// bytes, the reclaim baseline it resets does not count them, and the predicate
+/// is immediately true again. Without this latch the next minor is intercepted
+/// too, and the collector livelocks on full collections that free nothing —
+/// measured on #7592's `json_pipeline` as 19 consecutive fulls, each freeing
+/// 0.0 MB at ~400 ms, which was 7.6 s of an 8.6 s phase.
+///
+/// One handoff per copying minor is the invariant: the handoff makes room, the
+/// minor does the promotion that consumes it.
+pub(super) fn survivor_promotion_handoff_awaiting_minor() -> bool {
+    SURVIVOR_HANDOFF_AWAITING_MINOR.with(Cell::get)
+}
+
+pub(super) fn note_survivor_promotion_handoff_full() {
+    SURVIVOR_HANDOFF_AWAITING_MINOR.with(|flag| flag.set(true));
+}
+
+/// Clear the latch — called only when a *copying* minor completes, since only
+/// that collector promotes. A non-moving minor fallback promotes nothing, so
+/// re-arming on one would reinstate the livelock at half rate.
+pub(super) fn note_copying_minor_completed() {
+    SURVIVOR_HANDOFF_AWAITING_MINOR.with(|flag| flag.set(false));
+}
+
 pub(super) fn copied_minor_promotion_handoff_due(trigger_kind: GcTriggerKind) -> bool {
     if !matches!(
         trigger_kind,
         GcTriggerKind::ArenaBytes | GcTriggerKind::MallocCount
     ) {
+        return false;
+    }
+    // A handoff full has already run and promoted nothing; let the copying
+    // minor it was scheduled for actually happen (#7592).
+    if survivor_promotion_handoff_awaiting_minor() {
         return false;
     }
     if crate::arena::copying_active_survivor_in_use_bytes()

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -224,6 +224,62 @@ fn test_copying_minor_promotion_handoff_uses_predicted_old_pressure() {
     ));
 }
 
+/// #7592: a handoff full must not repeat without the copying minor it exists to
+/// enable.
+///
+/// The handoff replaces a minor with a full mark-sweep to make room for
+/// survivors about to be promoted, but a full mark-sweep is non-moving and
+/// promotes nothing — so it cannot relieve the pressure that scheduled it, and
+/// the predicate is true again at the next minor. Without the latch that is a
+/// livelock: json_pipeline at 200k records ran 19 consecutive
+/// `survivor_promotion_bytes` fulls, each freeing 0.0 MB at ~400 ms.
+///
+/// The latch short-circuits before any arena inspection, so this asserts the
+/// suppression itself rather than reproducing the heap state that arms it.
+#[test]
+fn test_survivor_promotion_handoff_waits_for_the_copying_minor() {
+    let _guard = GcTestIsolationGuard::new();
+
+    note_copying_minor_completed();
+    assert!(
+        !survivor_promotion_handoff_awaiting_minor(),
+        "latch must start clear"
+    );
+
+    note_survivor_promotion_handoff_full();
+    assert!(survivor_promotion_handoff_awaiting_minor());
+    // Assert the SUPPRESSION, not just the `false`. With an empty heap the
+    // predicate returns false at the survivor-occupancy check regardless, so a
+    // bare `assert!(!due)` passes with the latch deleted — it would be a test
+    // that cannot fail. The counter only moves if the latch branch ran.
+    for kind in [GcTriggerKind::ArenaBytes, GcTriggerKind::MallocCount] {
+        let before = survivor_promotion_handoff_suppressions();
+        assert!(
+            !copied_minor_promotion_handoff_due(kind),
+            "a second handoff must be suppressed while the first still awaits \
+             its copying minor ({kind:?})"
+        );
+        assert_eq!(
+            survivor_promotion_handoff_suppressions(),
+            before + 1,
+            "the latch branch must be what rejected it ({kind:?})"
+        );
+    }
+    // A trigger kind the handoff never applies to must not be counted as a
+    // latch suppression — it is rejected earlier, on its own merits.
+    let before = survivor_promotion_handoff_suppressions();
+    assert!(!copied_minor_promotion_handoff_due(GcTriggerKind::Direct));
+    assert_eq!(survivor_promotion_handoff_suppressions(), before);
+
+    // Only a COPYING minor clears it: a non-moving minor fallback promotes
+    // nothing and would reinstate the livelock at half rate.
+    note_copying_minor_completed();
+    assert!(
+        !survivor_promotion_handoff_awaiting_minor(),
+        "the copying minor consumes the handoff"
+    );
+}
+
 // 2026-07-09 audit (device-blind policy): budget-scaled threshold math.
 #[test]
 fn test_budget_scaled_clamps_only_under_budget() {


### PR DESCRIPTION
Fixes the `build_out` half of #7592.

## The bug is a livelock, and it is not in JSON

#7592 reported `json_pipeline` at 500k records being 97.6× bun. Splitting the phases first, as the issue insists:

| phase | time | share |
|---|--:|--:|
| readFileSync | 89 ms | 0.1% |
| JSON.parse | 742 ms | 1.2% |
| **build_out** | **57,409 ms** | **94.1%** |
| JSON.stringify | 1,451 ms | 2.4% |
| fnv1a | 1,250 ms | 2.0% |

`JSON.parse` handles 107 MB in 742 ms and scales linearly. `build_out` — the `out.push({...})` loop — is **~100 % GC pause** (8,840 ms of traced pause against 8,633 ms of phase at 100k) and grows quadratically.

The GC trace says exactly what is happening. At 200k records, of 22 collections:

```
 19 x full/survivor_promotion_bytes     each freeing 0.0 MB at ~400 ms
  1 x full/old_gen_bytes
  1 x full/arena_bytes
  1 x minor/arena_bytes                 promoted: 0.0 MB
```

`copied_minor_promotion_handoff_due` replaces a minor with a full mark-sweep to make room in old-gen for survivors that are about to be promoted. But **a full mark-sweep is non-moving — it promotes nothing**. So it cannot relieve the pressure it was scheduled for: the survivor space still holds the same 108 MB, the reclaim baseline it resets does not count those bytes, and the predicate is true again at the very next minor. The copying minor that would have done the promotion never gets to run.

That is 7.6 s of an 8.6 s phase spent on collections that free nothing. Peak RSS is the same whether those 19 collections run or not.

## Fix

Latch it: **one handoff per copying minor.** The handoff makes room; the copying minor performs the promotion that consumes it. The latch clears only on a *copying* minor, because a non-moving minor fallback promotes nothing and would reinstate the livelock at half rate.

The guard sits before the `copied_minor_promotable_active_survivor_bytes()` walk, so a suppressed handoff also skips that O(n) survivor pass.

Same workload, after:

| | cycles | pause | `survivor_promotion` fulls | promoted |
|---|--:|--:|--:|--:|
| main | 22 | 8,782 ms | **19** | **0.0 MB** |
| this PR | 6 | 2,828 ms | **1** | **110.0 MB** |

## Measurements

Both arms built from the same package set and linked against a pinned `PERRY_RUNTIME_DIR`, interleaved, output hash checked every row:

| records | main | this PR | speedup | main RSS | PR RSS |
|--:|--:|--:|--:|--:|--:|
| 25,000 | 48 ms | 48 ms | 1.0× | 81 MB | 81 MB |
| 50,000 | 499 ms | 459 ms | 1.1× | 163 MB | 163 MB |
| 100,000 | 2,095 ms | 1,437 ms | 1.5× | 245 MB | 318 MB |
| 200,000 | 8,654 ms | 2,858 ms | 3.0× | 484 MB | 572 MB |
| 500,000 | 57,242 ms | **10,551 ms** | **5.4×** | 1,064 MB | 1,325 MB |

Output hash identical on every row.

**The RSS cost is real and I am not hiding it**: +17–24 % at the large sizes, because the run now does 6 collections instead of 22. It is a genuine trade, not a free win. It is confined to workloads that actually hit this livelock — see below.

## GC ratchet

Checking against the pinned baseline reports 29 regressions, but that baseline is from 0.5.1315 on a different host, so it cannot separate this change from drift. I measured **both arms back to back on one host with an identical package set** instead — 144 metric medians across all 12 probes:

- **Every semantic counter is identical**, except `12_large_live_set.heap_used_bytes` at −0.01 % (2,232 B). That cell is the one the harness itself documents as ungated and sample-dependent (conservative-scan residue, observed spread 9,072 B over 36 runs), so 2,232 B is inside its own noise.
- Everything else that moved is RSS/wall — ungated, and ≤ 0.12 % on RSS.

That is the expected shape: the latch can only fire after a survivor-promotion handoff has occurred, so a workload that never hits the livelock is unaffected.

`cargo test -p perry-runtime`: 1,843 passed, 0 failed. `cargo fmt --check` and `scripts/check_file_size.sh` clean.

## Test

`test_survivor_promotion_handoff_waits_for_the_copying_minor`.

The obvious version of this test cannot fail: with an empty heap `copied_minor_promotion_handoff_due` returns `false` at the survivor-occupancy check regardless, so asserting the verdict passes with the latch deleted. The test therefore counts suppressions and asserts **the latch branch is what rejected it** — and checks that a trigger kind the handoff never applies to is *not* counted, so the counter cannot pass by incrementing everywhere.

Verified by deleting the latch and watching it go red:

```
assertion `left == right` failed: the latch branch must be what rejected it (ArenaBytes)
```

## What this does not fix

`build_out` is still ~28,500 ns/record and not yet flat, so #7592 stays open. With a nursery large enough to avoid collecting during the loop the same phase runs at 764 ns/record, so there is roughly another order of magnitude available. That remainder is the collection-budget question — the cap is a constant (16 MB × `NURSERY_CAP_SCALE_MAX`), so cadence is independent of live-set size. I tried a live-proportional cap and it is structurally wrong as written: the cap gates *from-space occupancy*, and here from-space is nearly all of live, so `cap = live` is a fixed point that stops scavenging entirely. Details are in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated garbage-collection cycles caused by survivor-promotion pressure.
  * Suppressed redundant full collections until a copying minor collection completes.
  * Preserved expected behavior for direct collection triggers.

* **Performance**
  * Reduced unnecessary full collections and related overhead.
  * Improved affected workloads, with a measured RSS tradeoff.

* **Tests**
  * Added regression coverage for suppression, counting, and reset behavior.

* **Documentation**
  * Documented the fix, performance impact, RSS tradeoff, and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->