### PR TITLE
fix(runtime): dispatch inherited Array statics on a subclass constructor (#7541)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1343
+**Current Version:** 0.5.1344
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1343"
+version = "0.5.1344"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1343"
+version = "0.5.1344"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1343"
+version = "0.5.1344"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1343"
+version = "0.5.1344"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1343"
+version = "0.5.1344"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7605-array-subclass-inherited-statics.md
+++ b/changelog.d/7605-array-subclass-inherited-statics.md
@@ -1,0 +1,37 @@
+### fix(runtime): dispatch inherited Array statics on a subclass constructor (#7541)
+
+`[...MyArr.from([1, 2, 3])]` (where `class MyArr extends Array {}`) threw
+`TypeError: value is not iterable`. The spread was never at fault — a
+directly-constructed subclass instance has always spread correctly. **`MyArr.from`
+resolved to nothing**: `Array.from` / `Array.of` / `Array.isArray` are folded in
+the HIR on the *literal identifier* `Array`, so a subclass receiver matched no
+fold, fell through to `js_class_static_method_call`, and hit its documented
+miss-fallback — which returns the RECEIVER. The call therefore evaluated to the
+class ref, which is genuinely not iterable. Same "keyed on a literal `extends`
+name" weak area as the instance-side native-base gaps, on the static side.
+
+`js_class_static_method_call` now has an Array arm beside the existing
+`class X extends Promise` and `class X extends Buffer` ones, gated on the same
+bounded class-chain walk (`is_array_subclass_class_id`). Both spec statics were
+already implemented constructor-aware — `array_from_full` / `array_of_full` run
+`Construct(C, …)` when `IsConstructor(this)`, and a class ref answers true — so
+passing the subclass receiver through builds a real subclass instance, matching
+`Array.from.call(MyArr, x)` in node rather than degrading to a plain `Array`.
+
+Depends on #7574's funnel: `array_from_full` installs elements through
+`CreateDataPropertyOrThrow`, which branches on `js_array_is_array` — true for a
+subclass instance — and so reaches `js_array_set_f64_extend` on what is
+physically an `ObjectHeader`. Without that fix this change would construct the
+right object and then write into its header.
+
+Validated by `test-files/test_gap_7541_array_subclass_inherited_statics.ts`
+(byte-identical to node, exit 0; covers `from` with a mapFn / from a `Set` /
+from an array-like, `of`, `isArray`, an indirect subclass, and the full
+iteration surface on a static-produced instance), plus a full runtime revert
+reproducing the reported `TypeError` verbatim.
+
+Still open, deliberately: the property-GET form (`typeof MyArr.from` reports
+`undefined` — only the call form is dispatched, as is already the case for the
+Promise/Buffer subclass statics), `sub instanceof MyArr` (the class-registry
+parent-edge gap, Array sibling of #7575), and `ArraySpeciesCreate` on
+`sub.map(f)`.

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -1523,6 +1523,48 @@ pub unsafe extern "C" fn js_class_static_method_call(
             return result;
         }
     }
+    // #7541: `class X extends Array` — inherited builtin static
+    // (`X.from(...)`, `X.of(...)`, `X.isArray(...)`).
+    //
+    // `Array.from` / `Array.of` are folded in the HIR on the LITERAL identifier
+    // `Array` (`lower/expr_call/array_only_methods.rs`), so a subclass receiver
+    // never matched and `MyArr.from([1, 2, 3])` resolved to nothing. The
+    // fallback at the end of this function returns the RECEIVER unchanged, so
+    // the call evaluated to the class ref — and `[...MyArr.from([1,2,3])]` threw
+    // `TypeError: value is not iterable` (#7541's report), which looked like a
+    // spread bug but is a missing static.
+    //
+    // Both spec statics are already implemented constructor-aware
+    // (`array::{array_from_full, array_of_full}` run `Construct(C, …)` when
+    // `IsConstructor(this)`, and `class_ref_id` makes a class ref answer true),
+    // so passing the subclass receiver as `this` builds a subclass instance —
+    // matching `Array.from.call(MyArr, …)`. Mirrors the Promise arm above.
+    if crate::array::is_array_subclass_class_id(class_id) {
+        let arg = |i: usize| -> f64 {
+            if i < args_len && !args_ptr.is_null() {
+                *args_ptr.add(i)
+            } else {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            }
+        };
+        match name {
+            "from" => {
+                return crate::array::array_from_full(receiver, arg(0), arg(1), arg(2));
+            }
+            "of" => {
+                let vals: &[f64] = if args_ptr.is_null() || args_len == 0 {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(args_ptr, args_len)
+                };
+                return crate::array::array_of_full(receiver, vals);
+            }
+            "isArray" => {
+                return crate::array::js_array_is_array(arg(0));
+            }
+            _ => {}
+        }
+    }
     // #6475: `class X extends <function value>() {}` — a static member
     // INHERITED from the parent FUNCTION's own properties, invoked as a call
     // (`X.use(f)`, effect's `HttpRouter.Tag(id)().use`/`unwrap`/`serve`). The

--- a/test-files/test_gap_7541_array_subclass_inherited_statics.ts
+++ b/test-files/test_gap_7541_array_subclass_inherited_statics.ts
@@ -1,0 +1,63 @@
+// #7541 — `[...MyArr.from([1,2,3])]` threw `TypeError: value is not iterable`.
+//
+// The spread was never the problem: `Array.from` / `Array.of` / `Array.isArray`
+// are folded in the HIR on the LITERAL identifier `Array`, so a SUBCLASS
+// receiver matched nothing, and `js_class_static_method_call`'s miss-fallback
+// returns the RECEIVER — making `MyArr.from([1,2,3])` evaluate to the class ref,
+// which is genuinely not iterable. Directly-constructed instances always
+// spread fine; only the inherited-static-produced ones failed.
+//
+// KNOWN GAP, deliberately not asserted here: the property-GET form
+// (`typeof MyArr.from`) still reports `undefined` — only the CALL form is
+// dispatched. Same for `sub instanceof MyArr`, a pre-existing class-registry
+// parent-edge gap (#7575's Map/Set sibling).
+
+class MyArr extends Array {}
+class Indirect extends MyArr {}
+
+// The issue's exact repro.
+const sub = MyArr.from([1, 2, 3]);
+console.log([...sub]);
+console.log(Array.isArray([...sub]));
+
+// The statics themselves.
+console.log("from     ", Array.isArray(sub), sub.length, sub.join(","));
+const mapped = MyArr.from([1, 2, 3], (v: number) => v * 10);
+console.log("from+map ", mapped.length, mapped.join(","));
+const fromSet = MyArr.from(new Set([4, 5, 6]));
+console.log("from set ", fromSet.length, fromSet.join(","));
+const fromLike = MyArr.from({ length: 2, 0: "a", 1: "b" } as ArrayLike<string>);
+console.log("from like", fromLike.length, fromLike.join(","));
+const ofd = MyArr.of(7, 8, 9);
+console.log("of       ", ofd.length, ofd.join(","));
+console.log("isArray  ", MyArr.isArray([]), MyArr.isArray(1));
+
+// An INDIRECT subclass resolves through the same chain walk.
+const ind = Indirect.from([1, 2]);
+console.log("indirect ", Array.isArray(ind), ind.length, ind.join(","));
+
+// Every iteration surface on a static-produced instance.
+const it = MyArr.from([10, 20, 30]);
+const acc: number[] = [];
+for (const v of it) {
+  acc.push(v);
+}
+console.log("for-of   ", acc.join(","));
+console.log("spread   ", [...it].join(","));
+console.log("Array.from", Array.from(it).join(","));
+const [a0, a1] = it;
+console.log("destr    ", a0, a1);
+console.log("map      ", it.map((v) => v + 1).join(","));
+console.log("index    ", it[0], it[2], it.length);
+
+// Controls: the base intrinsic and a non-Array class are untouched.
+console.log("base from", Array.from([1, 2]).join(","));
+console.log("base of  ", Array.of(3, 4).join(","));
+class Other {
+  static make(): string {
+    return "other";
+  }
+}
+class OtherSub extends Other {}
+console.log("user stat", OtherSub.make());
+console.log("done");


### PR DESCRIPTION
Fixes #7541.

**Stacked on #7603** (`fix/7574-array-subclass-raw-paths`), and not by
convenience — see *Why this is stacked* below. Review the top commit only.

## The bug is not in spread

```ts
class MyArr extends Array {}
const sub = MyArr.from([1, 2, 3]);
console.log([...sub]);                // node: [ 1, 2, 3 ]   perry: TypeError: value is not iterable
console.log(Array.isArray([...sub])); // node: true          perry: TypeError
```

The issue guessed that `array_from_spread_value`'s subclass arm
(`is_array_subclass_instance` / `array_subclass_has_iterator_override`) was
answering wrong. It is not — a **directly constructed** instance spreads
correctly today, and did before this PR:

```
typeof MyArr.from  = undefined      <-- node: function
const d = new MyArr(); d.push(1,2,3);
[...d]                              -> [ 1, 2, 3 ]   (already correct)
```

`MyArr.from` resolves to **nothing**. `Array.from` / `Array.of` /
`Array.isArray` are folded in the HIR on the **literal identifier `Array`**
(`perry-hir/src/lower/expr_call/array_only_methods.rs:293`), so a subclass
receiver matches no fold and the call falls through to
`js_class_static_method_call`, whose documented miss-fallback *returns the
receiver*. `MyArr.from([1,2,3])` therefore evaluates to the class ref — which
is genuinely not iterable, so the spread throws exactly where the issue saw it.
This is the CLAUDE.md *"native base-class subclassing… keying any of that on a
literal `extends` name loses it"* weak area, on the STATIC side.

## Fix

`js_class_static_method_call` already has arms for inherited builtin statics on
a `class X extends Promise` (`X.all` / `X.resolve`) and on a
`class X extends Buffer` (`nm_static_buffer_proto_chain`). Add the Array one
beside them, gated on `is_array_subclass_class_id(class_id)` — the same bounded
class-chain walk the instance-side dispatch already uses.

Both spec statics are **already implemented constructor-aware**:
`array::array_from_full(c, items, mapfn, thisArg)` and
`array::array_of_full(c, vals)` run `Construct(C, …)` whenever
`IsConstructor(this)`, and `is_constructor_value` recognizes an INT32 class ref.
So passing the subclass receiver through as `this` builds a **real subclass
instance** — `MyArr.from(x)` behaves as `Array.from.call(MyArr, x)` does in
node, rather than degrading to a plain `Array`. `isArray` needs no receiver and
routes to `js_array_is_array`.

## Why this is stacked on #7603 (not merely convenient)

`array_from_full`'s element install is `CreateDataPropertyOrThrow`, whose
implementation branches on `jsv_is_array(result)` — and `js_array_is_array`
answers **true** for an Array-subclass instance. So it calls
`js_array_set_f64_extend` on what is physically an `ObjectHeader`. On `main`
that is precisely the #7574 corruption this PR would newly start triggering:
without #7603 the fix half-works and then writes into the object header —

```
isArr true        <-- constructed a MyArr
len undefined     <-- elements and `length` never landed
[]
```

With #7603's funnel underneath, the same code is correct. Shipping this against
`main` alone would trade one wrong answer for a memory-safety hazard, so it
must land after #7603.

## Validation (local; CI has a deep backlog, so local is what this rests on)

- **`test-files/test_gap_7541_array_subclass_inherited_statics.ts` —
  byte-identical to `node --experimental-strip-types` (v26.5.1), exit 0**, 19
  lines. Covers the issue's exact repro plus `from` with a mapFn, from a `Set`,
  from an array-like, `of`, `isArray`, an **indirect** subclass
  (`class Indirect extends MyArr`), and the whole iteration surface on a
  static-produced instance (`for…of`, spread, `Array.from`, destructuring,
  `map`, indexing, `length`). Controls: the base `Array.from`/`Array.of`
  intrinsics and an ordinary user-class inherited static are unchanged.
- **Sabotage**: with `crates/perry-runtime/` reverted *in full* to this PR's
  base (i.e. #7603 present, this change absent) and the test file untouched,
  the same file exits **1** with `TypeError: value is not iterable` — the
  reported symptom, verbatim. Restored, it exits **0**, byte-identical.
- `test_gap_7574_array_subclass_declared_base_type.ts` still byte-identical on
  this branch.
- `cargo test -p perry-runtime`: **1853 passed, 0 failed**.
- `python3 scripts/raw_handle_debt.py`: **998 (baseline 998)**.
  `python3 scripts/addr_class_inventory.py`,
  `python3 scripts/class_id_collisions.py`, `./scripts/check_file_size.sh`,
  `cargo fmt --all -- --check`: all clean.

## Scope — deliberately NOT fixed here

- **The property-GET form.** `typeof MyArr.from` still reports `undefined`;
  only the CALL form is dispatched (the GET path is a different resolver, and
  the same is true today for the `Promise`/`Buffer` subclass statics that
  already work as calls). Called out inline in the test file.
- **`sub instanceof MyArr`** is false for a static-produced instance — the
  pre-existing class-registry parent-edge gap, the Array sibling of #7575.
- **`ArraySpeciesCreate`** on `sub.map(f)` still yields a plain `Array` (node:
  `MyArr`). Pre-existing, identical on the unannotated path, noted in #7603.

No version bump (maintainer bumps at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited `Array.from`, `Array.of`, and `Array.isArray` behavior for `Array` subclasses.
  * `Array.from` and `Array.of` now correctly create instances of the subclass, including indirect subclasses.
  * Improved support for iterable, array-like, mapped, and empty-input scenarios.

* **Tests**
  * Added regression coverage for subclass inheritance, iteration, destructuring, and related array operations.

* **Chores**
  * Updated the project version to `0.5.1344`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->