### PR TITLE
docs(plan): sync to v0.5.1345 — the 2026-08-07/08 wave

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1345
+**Current Version:** 0.5.1346
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1345"
+version = "0.5.1346"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1345"
+version = "0.5.1346"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1345"
+version = "0.5.1346"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1345"
+version = "0.5.1346"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1345"
+version = "0.5.1346"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7607-plan-sync-aug8.md
+++ b/changelog.d/7607-plan-sync-aug8.md
@@ -1,0 +1,20 @@
+### Documentation
+
+- **Engine plan synced to v0.5.1345 (#7607).** Adds the one-table summary of
+  the 2026-08-07/08 wave — twenty-two merges: the `json_pipeline` scaling cliff
+  taken 97.6× → ~8× bun across four PRs (#7594 livelock latch, #7596
+  live-proportional budgets, #7601 `charCodeAt` inlining, #7600 push-length
+  elision), the array-push write barrier gated on the parent header (#7602),
+  two subclass memory-safety families closed (#7573 Map/Set SIGBUS, #7603
+  Array SIGSEGV, #7605 inherited statics), two class-id collisions fixed with a
+  scanning `lint` gate (#7583/#7589), `known_failures.json` converted from a
+  suppression list to a self-emptying ratchet (#7599), and the public baseline
+  published for the first time in five days (#7593).
+
+  Records the named fix pattern for the *declared-type-as-layout-proof* bug
+  class — runtime-funnel brand checks **plus** codegen-tier guards, because the
+  inline-store tiers never reach the runtime — and the ordering constraint that
+  **#7554 (gc-ratchet CI repair) must precede the next GC-pacing change**:
+  #7594 and #7596 both had to substitute hand-run both-arms A/Bs for the broken
+  official gate, and a third pacing change without the gate would be the
+  "measured nothing" hazard with a paper trail.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -6,7 +6,7 @@
 every dated status section, incident narrative and superseded sequencing lives
 in [`engine-plan-history.md`](engine-plan-history.md); this file holds only the
 current state and the remaining work so it stays readable across context loads.
-Last synced **2026-08-07** (v0.5.1324). The v0.5.1299 public-baseline sweep is
+Last synced **2026-08-08** (v0.5.1345). The v0.5.1299 public-baseline sweep is
 kept as the baseline measurement event; rows fixed since are annotated in place
 rather than overwritten, because they were measured individually rather than in
 a fresh sweep.
@@ -21,6 +21,49 @@ a fresh sweep.
 ---
 
 ## Status quo
+
+### 2026-08-07/08 in one table — what closed, what opened
+
+Twenty-two merges, v0.5.1324 → v0.5.1345. The construction campaign's measured
+levers are now **all worked or retired**, and the day's dominant discovery —
+`json_pipeline` at 500k records, found by the first published baseline sweep in
+five days — went **97.6× → ~8× bun** in four PRs:
+
+| item | closed by | result |
+|---|---|--:|
+| survivor-promotion handoff livelock | #7594 | 57.2 s → 12.1 s |
+| constant pacing bands (both generations) | #7596 | → 5.8 s; 4 cycles, none futile |
+| `charCodeAt` through the dynamic-bitwise helper | #7601 | fnv1a 11.2× |
+| statement-position `push` length computation | #7600 | 2.77× pure-push |
+| array-push write barrier (parent-side gate) | #7602 | `push_cls` 1.33–1.38× |
+| typed-shape install re-derivation | #7586 | `push_cls` 1.091× |
+| **Map/Set subclass as raw header (SIGBUS)** | #7573 | memory safety |
+| **Array subclass as raw header (SIGSEGV)** | #7603 | memory safety |
+| inherited Array statics on a subclass | #7605 | `MyArr.from` works |
+| iterator-helpers surface dead (class-id collision) | #7583 | whole TC39 surface |
+| second class-id collision (JSX/rawJSON) + scanning gate | #7589 | gate in `lint` |
+| `known_failures.json` suppression → ratchet | #7599 | 37 entries → 10 |
+| public baseline unpublishable (2 independent causes) | #7593 | `check` exits 0 |
+
+**The `declared type as layout proof` bug class now has a named fix pattern**
+(#7573/#7603): brand-check on `GcHeader.obj_type` at the shared runtime
+funnels, redirect subclass receivers onto the spec-generic engine, PLUS guards
+at any codegen tier that never calls into the runtime — #7603 proved the
+runtime funnel alone cannot stop the inline-store tiers. Remaining known member
+of the family: none filed. Adjacent leftovers: `ArraySpeciesCreate` on
+subclasses, static-method GET form, `instanceof` a subclass (#7575).
+
+**Remaining top levers, in order:** the #7592 remainder (~8× bun: two-hop
+promotion copies 268 MB twice — promote-on-first-copy design is on the issue
+with the fixed-point trap named; and `JSON.parse` 742 ms); class-field-store
+barriers (the half #7602 could not reach); #7480 repsel element-shape proofs;
+Layer-1 emitter migration (not started).
+
+**Gate debt still open:** #7554 (gc-ratchet CI has measured nothing since
+2026-08-05 — REPAIR THIS BEFORE the next GC-pacing change, which needs it),
+#7502–#7507 (root-lowering suites partly vacuous), #7300 (flaky codegen tests),
+#7604 (zeal can arm without firing on compute-only benches), #7606 (two macOS
+gc-rooting gap crashes, untriaged), #6847 reopened (zlib link on macOS).
 
 ### GC correctness — the four layers
 


### PR DESCRIPTION
Docs only. Adds a one-table summary of the v0.5.1324 → v0.5.1345 wave to `docs/engine-plan.md`, updates the sync date, names the remaining top levers in priority order, and lists the open gate debt — including the ordering constraint that **#7554 (the gc-ratchet CI repair) must precede the next GC-pacing change**, since #7594/#7596 both had to substitute hand-run both-arms A/Bs for the broken official gate.

Also records the now-named fix pattern for the "declared type as layout proof" bug class (#7573/#7603): runtime-funnel brand checks alone are insufficient — #7603 proved the inline-store codegen tiers never reach the runtime, so the pattern is funnel + codegen guards, verified by family A/B.

`check_file_size.sh` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product version to 0.5.1346.

* **Documentation**
  * Added release notes covering recent engine synchronization, performance improvements, memory-safety fixes, and tooling updates.
  * Refreshed the engine plan with the latest synchronization status, measured results, completed work, and remaining items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->