### PR TITLE
fix(instanceof): #7575 — a monomorphized generic class is an instance of the generic it came from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1358
+**Current Version:** 0.5.1359
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1358"
+version = "0.5.1359"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1358"
+version = "0.5.1359"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1358"
+version = "0.5.1359"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1358"
+version = "0.5.1359"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1358"
+version = "0.5.1359"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7631-generic-class-instanceof.md
+++ b/changelog.d/7631-generic-class-instanceof.md
@@ -43,5 +43,5 @@
   specializations still do not match one another.
 
   Known and deliberately separate: `constructor.name` still reports the mangled
-  `Gen$num`. Same root cause, different surface, and it can move error-message
-  text, so it needs its own parity sweep.
+  `Gen$num` (#7632). Same root cause, different surface, and it can move
+  error-message text, so it needs its own parity sweep.

--- a/changelog.d/7631-generic-class-instanceof.md
+++ b/changelog.d/7631-generic-class-instanceof.md
@@ -1,0 +1,47 @@
+### Fixed
+
+- **`instanceof` was false for a monomorphized generic class (#7575).**
+  `m instanceof MyMap` was `false` for a `class MyMap<K, V> extends Map<K, V>`
+  instance while `m instanceof Map` was `true`.
+
+  Filed as a Map/Set subclass / prototype-chain defect; it is neither. The
+  mechanism is **monomorphization**. Perry specializes generic classes, so
+  `class Gen<T> {}` plus `new Gen<number>()` emits a second class `Gen$num`
+  (`monomorph::mangle::generate_specialized_name`) with its own class id, and the
+  instance is stamped with THAT id — while `x instanceof Gen` resolves the RHS to
+  the GENERIC's id, which appears nowhere in the specialization's parent chain.
+  A generic class over a plain base, and one over no base at all, failed
+  identically; `class MyMap<K, V> extends Map<K, V>` is just the idiomatic
+  spelling, which is why it surfaced there.
+
+  HIR now records `Class::specialized_from`, codegen emits one
+  `js_register_class_generic_origin(spec, generic)` per specialization next to
+  the parent edges, and `instanceof`'s chain walk — now a single shared,
+  depth-bounded `class_chain_reaches` used by both the static and the
+  dynamic-RHS path, which previously had two hand-rolled copies (one uncapped) —
+  follows that edge as well as `extends`. It is deliberately a SEPARATE edge:
+  `CLASS_REGISTRY`'s chain also resolves `super()` construction, static-method
+  lookup and vtable dispatch, so splicing the generic in between a specialization
+  and its real base would re-run the wrong constructor.
+
+  This also covers the Array-side sibling #7603 left open — but the note about it
+  was stale. Measured on pristine `main`, every NON-generic Array-subclass
+  `instanceof` already held (`new MyArr()`, `new Indirect()`,
+  `MyArr.from([1,2,3])`); only `new GenArr<number>() instanceof GenArr` was
+  broken, and that is fixed here. The stale comment in
+  `test_gap_7541_array_subclass_inherited_statics.ts` is corrected in place.
+
+  `test_gap_6325_map_set_subclass.ts` and
+  `test_gap_7570_map_set_declared_base_type.ts` are tightened to assert the
+  subclass edge, which is why the bug had survived them. New coverage in
+  `test-files/test_gap_7575_map_set_subclass_instanceof.ts` (subclass, native
+  base, unrelated class, three-level chain, explicit-`super()` subclass,
+  iterable-seeded instance, `Symbol.hasInstance` both ways, dynamic RHS, untyped
+  parameter, and the generic-over-plain / over-nothing / over-Array shapes with
+  their non-generic controls and sibling negatives) plus 4 runtime unit tests
+  over the walk — two of which assert the new edge stays DIRECTIONAL, so sibling
+  specializations still do not match one another.
+
+  Known and deliberately separate: `constructor.name` still reports the mangled
+  `Gen$num`. Same root cause, different surface, and it can move error-message
+  text, so it needs its own parity sweep.

--- a/crates/perry-codegen/src/codegen/emission_order_tests.rs
+++ b/crates/perry-codegen/src/codegen/emission_order_tests.rs
@@ -297,6 +297,7 @@ fn plain_class(id: u32, name: &str, method: Function) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -479,6 +479,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             // #6812: width hints don't cross module metadata; imported stubs
             // fall back to runtime learned sizing.
             alloc_width_hint: 0,
+            // #7575: monomorphization is per-module, so an imported stub never
+            // stands in for a specialization — its defining module registers
+            // the origin edge itself.
+            specialized_from: None,
             type_params: Vec::new(),
             extends: None,
             extends_name: ic.parent_name.clone(),

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -515,6 +515,38 @@ pub(super) fn emit_string_pool(
         );
     }
 
+    // #7575: register the GENERIC class a monomorphized specialization came
+    // from. `class Gen<T> {}` + `new Gen<number>()` emits a second class
+    // `Gen$num` carrying its own class id, and the instance is stamped with
+    // that id — but `x instanceof Gen` resolves the RHS to the GENERIC's id,
+    // which is in no parent chain, so the walk answered `false` for the class
+    // the user wrote. This is a distinct edge from the parent one on purpose:
+    // `CLASS_REGISTRY`'s chain also resolves `super()`, static-method lookup
+    // and vtable dispatch, so it must keep pointing at the real base.
+    let mut origin_pairs: Vec<(u32, u32)> = Vec::new();
+    for (name, &cid) in class_ids.iter() {
+        let Some(class) = classes.get(name) else {
+            continue;
+        };
+        let Some(generic_name) = &class.specialized_from else {
+            continue;
+        };
+        if let Some(&generic_cid) = class_ids.get(generic_name) {
+            if generic_cid != 0 && generic_cid != cid {
+                origin_pairs.push((cid, generic_cid));
+            }
+        }
+    }
+    origin_pairs.sort_unstable();
+    for (cid, generic_cid) in origin_pairs {
+        chunker.roll_if_full();
+        let blk = chunker.current_block();
+        blk.call_void(
+            "js_register_class_generic_origin",
+            &[(I32, &cid.to_string()), (I32, &generic_cid.to_string())],
+        );
+    }
+
     // Issue #392: register every user class method in the runtime
     // VTABLE_REGISTRY so cross-module callers can dispatch via
     // `js_native_call_method` even when the codegen of the calling

--- a/crates/perry-codegen/src/codegen/typed_abi/tests.rs
+++ b/crates/perry-codegen/src/codegen/typed_abi/tests.rs
@@ -61,6 +61,7 @@ fn class(id: u32, name: &str, extends: Option<u32>, extends_name: Option<&str>) 
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/src/collectors/cjs_scaffolding.rs
+++ b/crates/perry-codegen/src/collectors/cjs_scaffolding.rs
@@ -904,6 +904,7 @@ mod tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             static_accessor_names: Vec::new(),
             static_accessor_fn_ids: Vec::new(),
         }

--- a/crates/perry-codegen/src/collectors/class_accessors.rs
+++ b/crates/perry-codegen/src/collectors/class_accessors.rs
@@ -110,6 +110,7 @@ mod tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             static_accessor_names: Vec::new(),
             static_accessor_fn_ids: Vec::new(),
         }

--- a/crates/perry-codegen/src/collectors/proven_this_routing_tests.rs
+++ b/crates/perry-codegen/src/collectors/proven_this_routing_tests.rs
@@ -157,6 +157,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>, methods: Vec<Function>) -
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
@@ -49,6 +49,7 @@ fn class_c() -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         static_accessor_names: Vec::new(),
         static_accessor_fn_ids: Vec::new(),
     }

--- a/crates/perry-codegen/src/collectors/ptr_shape_opt_report_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_opt_report_tests.rs
@@ -54,6 +54,7 @@ fn class_with_fields(name: &str, fields: &[&str]) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         static_accessor_names: Vec::new(),
         static_accessor_fn_ids: Vec::new(),
     }

--- a/crates/perry-codegen/src/collectors/ptr_shape_returns_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_returns_tests.rs
@@ -46,6 +46,7 @@ fn class_c() -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         static_accessor_names: Vec::new(),
         static_accessor_fn_ids: Vec::new(),
     }

--- a/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
+++ b/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
@@ -614,6 +614,7 @@ mod tests {
             is_exported: false,
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             aliases: Vec::new(),
         }
     }

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -537,6 +537,7 @@ mod tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             static_accessor_names: Vec::new(),
             static_accessor_fn_ids: Vec::new(),
         }

--- a/crates/perry-codegen/src/lower_call/buffer_intrinsic.rs
+++ b/crates/perry-codegen/src/lower_call/buffer_intrinsic.rs
@@ -570,6 +570,7 @@ mod shadow_scan_tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
         }
     }
 

--- a/crates/perry-codegen/src/lower_call/field_init/tests.rs
+++ b/crates/perry-codegen/src/lower_call/field_init/tests.rs
@@ -77,6 +77,7 @@ fn class(fields: Vec<ClassField>, constructor: Option<Function>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         static_accessor_names: Vec::new(),
         static_accessor_fn_ids: Vec::new(),
     }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1275,6 +1275,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // allocators register on every alloc; the inline allocator skips
     // the alloc-site call and relies on this one-time registration.
     module.declare_function("js_register_class_parent", VOID, &[I32, I32]);
+    // #7575: specialization -> generic edge for monomorphized generic classes.
+    // A SEPARATE edge from the parent one: the parent chain also resolves
+    // `super()`, static-method lookup and vtable dispatch, so only `instanceof`
+    // may follow this one.
+    module.declare_function("js_register_class_generic_origin", VOID, &[I32, I32]);
     // Issue #711: dynamic parent registration for `class X extends fn(...)`
     // shapes. Codegen emits at the class-declaration source position in
     // module.init (lower.rs); the runtime helper extracts the parent

--- a/crates/perry-codegen/src/stmt/class_field_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/class_field_loop_tests.rs
@@ -117,6 +117,7 @@ fn counter_class() -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -118,6 +118,7 @@ fn node_class(extends_name: Option<&str>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/src/type_analysis_tests.rs
+++ b/crates/perry-codegen/src/type_analysis_tests.rs
@@ -215,6 +215,7 @@ fn hir_inferred_types_reuse_codegen_contextual_class_facts() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     };
     let widget = perry_hir::Class {
@@ -286,6 +287,7 @@ fn hir_inferred_types_reuse_codegen_contextual_class_facts() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     };
     let classes = HashMap::from([("Base".to_string(), &base), ("Widget".to_string(), &widget)]);

--- a/crates/perry-codegen/tests/class_field_store_pointer_test.rs
+++ b/crates/perry-codegen/tests/class_field_store_pointer_test.rs
@@ -156,6 +156,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>, constructor: Option<Funct
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/class_keys_gc_root.rs
+++ b/crates/perry-codegen/tests/class_keys_gc_root.rs
@@ -121,6 +121,7 @@ fn module_with_declared_field_class() -> Module {
             is_exported: false,
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             aliases: Vec::new(),
         }],
         interfaces: Vec::new(),

--- a/crates/perry-codegen/tests/constructor_recursion.rs
+++ b/crates/perry-codegen/tests/constructor_recursion.rs
@@ -123,6 +123,7 @@ fn module_with_recursive_constructor_return() -> Module {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
         }],
         interfaces: Vec::new(),
         type_aliases: Vec::new(),

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -247,6 +247,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -236,6 +236,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/private_guard_declaring_class.rs
+++ b/crates/perry-codegen/tests/private_guard_declaring_class.rs
@@ -56,6 +56,7 @@ fn class(id: u32, name: &str) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/static_symbol_hygiene.rs
+++ b/crates/perry-codegen/tests/static_symbol_hygiene.rs
@@ -118,6 +118,7 @@ fn class_with_static(id: u32, value: f64) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
+++ b/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
@@ -309,6 +309,7 @@ fn module_with_new(name: &str, args: Vec<Expr>) -> Module {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }];
     module
 }

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -185,6 +185,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_declared_at_allocation.rs
+++ b/crates/perry-codegen/tests/typed_shape_declared_at_allocation.rs
@@ -160,6 +160,7 @@ fn class(name: &str, fields: Vec<ClassField>, constructor: Option<Function>) -> 
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-codegen/tests/typed_shape_descriptor.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptor.rs
@@ -92,6 +92,7 @@ fn class(id: u32, name: &str, fields: Vec<ClassField>) -> Class {
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     }
 }
 

--- a/crates/perry-hir/src/analysis/value_types_tests.rs
+++ b/crates/perry-hir/src/analysis/value_types_tests.rs
@@ -623,6 +623,7 @@ fn seeds_contextual_class_and_enum_facts_from_module() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     });
 
@@ -696,6 +697,7 @@ fn infers_named_class_and_interface_property_facts() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     });
     module.classes.push(Class {
@@ -721,6 +723,7 @@ fn infers_named_class_and_interface_property_facts() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     });
     module.interfaces.push(Interface {
@@ -1665,6 +1668,7 @@ fn resolves_this_and_super_in_class_context() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     });
     module.classes.push(Class {
@@ -1690,6 +1694,7 @@ fn resolves_this_and_super_in_class_context() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     });
 

--- a/crates/perry-hir/src/ir/decl.rs
+++ b/crates/perry-hir/src/ir/decl.rs
@@ -268,6 +268,19 @@ pub struct Class {
     /// site. Pure capacity: does not add fields, keys, or enumeration
     /// entries. 0 = no hint.
     pub alloc_width_hint: u32,
+    /// #7575: the GENERIC class this one was monomorphized from, when it is a
+    /// specialization. `class Gen<T> {}` + `new Gen<number>()` produces a second
+    /// class named `Gen$num` (`monomorph::mangle::generate_specialized_name`)
+    /// carrying its own class id, and the instance is stamped with THAT id —
+    /// while `x instanceof Gen` resolves the RHS to the generic's id, which no
+    /// longer appears anywhere in the instance's chain.
+    ///
+    /// The runtime learns the edge from here (`js_register_class_generic_origin`)
+    /// and consults it during the `instanceof` chain walk ONLY. It deliberately
+    /// is not folded into `extends`/`extends_name`: the runtime parent chain also
+    /// resolves `super()`, static-method lookup and vtable dispatch, so splicing
+    /// the generic in as a parent would re-run the wrong constructor.
+    pub specialized_from: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -1101,6 +1101,7 @@ impl LoweringContext {
             // timing is irrelevant.
             is_nested: false,
             alloc_width_hint,
+            specialized_from: None,
         });
 
         self.anon_shape_classes

--- a/crates/perry-hir/src/lower/module_decl/namespace.rs
+++ b/crates/perry-hir/src/lower/module_decl/namespace.rs
@@ -110,6 +110,7 @@ pub(crate) fn lower_namespace_as_class(
                 aliases: Vec::new(),
                 is_nested: false,
                 alloc_width_hint: 0,
+                specialized_from: None,
             });
         }
     };
@@ -409,5 +410,6 @@ pub(crate) fn lower_namespace_as_class(
         aliases: Vec::new(),
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     })
 }

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -1304,6 +1304,7 @@ pub fn lower_class_decl(
         // initializers must run on class evaluation, not at module init.
         is_nested: ctx.scope_depth > 0 || ctx.inside_block_scope > 0,
         alloc_width_hint: 0,
+        specialized_from: None,
     })
 }
 
@@ -1911,5 +1912,6 @@ pub fn lower_class_from_ast(
         // initializers must run on class evaluation, not at module init.
         is_nested: ctx.scope_depth > 0 || ctx.inside_block_scope > 0,
         alloc_width_hint: 0,
+        specialized_from: None,
     })
 }

--- a/crates/perry-hir/src/monomorph/specialize.rs
+++ b/crates/perry-hir/src/monomorph/specialize.rs
@@ -268,5 +268,13 @@ pub fn specialize_class(class: &Class, type_args: &[Type], new_id: ClassId) -> C
         aliases: class.aliases.clone(),
         is_nested: class.is_nested,
         alloc_width_hint: class.alloc_width_hint,
+        // #7575: `new Gen<number>()` constructs `Gen$num`, whose class id is
+        // what the instance carries — while `x instanceof Gen` resolves the RHS
+        // to the GENERIC's id, which appears nowhere in that chain. Record the
+        // origin so the runtime can answer the specialization as an instance of
+        // the class the user actually wrote. Nested specializations chain
+        // through the generic (`class Gen2<T> extends Gen<T>` copies
+        // `extends_name = "Gen"`), so one edge per class is enough.
+        specialized_from: Some(class.name.clone()),
     }
 }

--- a/crates/perry-hir/src/stable_hash/decls.rs
+++ b/crates/perry-hir/src/stable_hash/decls.rs
@@ -34,6 +34,7 @@ impl SH for Class {
             aliases,
             is_nested,
             alloc_width_hint,
+            specialized_from,
         } = self;
         id.hash(h);
         name.hash(h);
@@ -58,6 +59,9 @@ impl SH for Class {
         aliases.hash(h);
         is_nested.hash(h);
         alloc_width_hint.hash(h);
+        // #7575: drives an extra module-init registration, so it is part of
+        // what the object cache keys on.
+        specialized_from.hash(h);
     }
 }
 

--- a/crates/perry-hir/src/stable_hash/tests.rs
+++ b/crates/perry-hir/src/stable_hash/tests.rs
@@ -282,6 +282,7 @@ fn module_metadata_affects_hash() {
         aliases: vec![],
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
     });
     assert_ne!(base_hash, hash_module(&m_class));
 

--- a/crates/perry-runtime/src/object/class_meta_registry.rs
+++ b/crates/perry-runtime/src/object/class_meta_registry.rs
@@ -33,6 +33,57 @@ pub(crate) fn fetch_parent_kind(class_id: u32) -> Option<u8> {
     g.as_ref()?.get(&class_id).copied()
 }
 
+/// #7575: specialized class_id -> the GENERIC class_id it was monomorphized
+/// from.
+///
+/// Perry monomorphizes generic classes: `class Gen<T> {}` plus
+/// `new Gen<number>()` emits a second class `Gen$num`
+/// (`perry_hir::monomorph::mangle::generate_specialized_name`) with its own
+/// class id, and the instance is stamped with THAT id. `x instanceof Gen`
+/// resolves the RHS to the generic's id, which appears nowhere in the
+/// specialization's parent chain — so `new Gen<number>() instanceof Gen` was
+/// `false` while `instanceof` against a non-generic base stayed `true`. The
+/// issue surfaced as a Map/Set-subclass bug (`m instanceof MyMap`) because
+/// `class MyMap<K, V> extends Map<K, V>` is the idiomatic spelling, but the
+/// mechanism has nothing to do with Map/Set: a plain `class Gen<T> extends
+/// Base {}` fails identically.
+///
+/// This is deliberately a SEPARATE table rather than a `CLASS_REGISTRY` parent
+/// edge. That chain also resolves `super()` construction
+/// (`object/class_constructors.rs`), static-method lookup and vtable dispatch,
+/// so splicing the generic in between a specialization and its real base would
+/// re-run the wrong constructor. Only `instanceof` consults this one.
+static CLASS_GENERIC_ORIGIN: RwLock<Option<HashMap<u32, u32>>> = RwLock::new(None);
+
+/// Record that `class_id` is a monomorphized specialization of `generic_id`.
+///
+/// Emitted once per specialized class in the module-init prelude, next to the
+/// `js_register_class_parent` edges.
+#[no_mangle]
+pub extern "C" fn js_register_class_generic_origin(class_id: u32, generic_id: u32) {
+    if class_id == 0 || generic_id == 0 || class_id == generic_id {
+        return;
+    }
+    let mut g = CLASS_GENERIC_ORIGIN.write().unwrap();
+    if g.is_none() {
+        *g = Some(HashMap::new());
+    }
+    g.as_mut().unwrap().insert(class_id, generic_id);
+}
+
+/// Keepalive anchor: emitted only from generated module-init code, so the
+/// whole-program auto-optimize bitcode pass would otherwise dead-strip it.
+#[cfg(feature = "keepalive-anchors")]
+#[used]
+static KEEP_REGISTER_CLASS_GENERIC_ORIGIN: extern "C" fn(u32, u32) =
+    js_register_class_generic_origin;
+
+/// The generic class `class_id` was specialized from, if any (no chain walk).
+pub(crate) fn class_generic_origin(class_id: u32) -> Option<u32> {
+    let g = CLASS_GENERIC_ORIGIN.read().ok()?;
+    g.as_ref()?.get(&class_id).copied()
+}
+
 /// Global registry of class IDs that extend the built-in Error class
 static EXTENDS_ERROR_REGISTRY: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -885,6 +885,70 @@ pub extern "C" fn js_instanceof_noncallable_rhs() -> f64 {
     throw_type_error(b"Right-hand side of 'instanceof' is not callable");
 }
 
+/// Does the class-id chain starting at `start` reach `want`?
+///
+/// Walks two edges at every step, both bounded by the same depth budget:
+///
+/// * the **parent** edge (`CLASS_REGISTRY`), i.e. `extends`; and
+/// * the **generic-origin** edge (#7575), i.e. "this class is
+///   `monomorph`'s `Gen$num`, written by the user as `Gen`".
+///
+/// The second one exists because Perry monomorphizes generic classes. `new
+/// Gen<number>()` stamps the instance with `Gen$num`'s id, while `x instanceof
+/// Gen` resolves the RHS to the GENERIC's id — an id that is in no parent chain,
+/// so the walk answered `false` for the class the user actually wrote. It is
+/// checked at each hop rather than only at the start because a specialization's
+/// ancestors can be specializations too.
+///
+/// The origin edge is NOT a parent edge: `CLASS_REGISTRY`'s chain also resolves
+/// `super()` construction, static-method lookup and vtable dispatch, and
+/// splicing `Gen` in between `Gen$num` and its real base would re-run the wrong
+/// constructor. See `object/class_meta_registry.rs`.
+pub(crate) fn class_chain_reaches(start: u32, want: u32) -> bool {
+    if start == 0 || want == 0 {
+        return false;
+    }
+    let mut cur = start;
+    let mut depth = 0;
+    loop {
+        if cur == want {
+            return true;
+        }
+        if depth > 64 {
+            return false;
+        }
+        if let Some(gid) = crate::object::class_generic_origin(cur) {
+            if gid == want || class_chain_reaches_parents_only(gid, want, depth + 1) {
+                return true;
+            }
+        }
+        match get_parent_class_id(cur) {
+            Some(pid) if pid != 0 && pid != cur => cur = pid,
+            _ => return false,
+        }
+        depth += 1;
+    }
+}
+
+/// The parent-only half of [`class_chain_reaches`], used to continue a walk that
+/// has already stepped onto a generic origin. Separate so the two edges cannot
+/// recurse into each other without bound.
+fn class_chain_reaches_parents_only(start: u32, want: u32, depth0: usize) -> bool {
+    let mut cur = start;
+    let mut depth = depth0;
+    while depth <= 64 {
+        if cur == want {
+            return true;
+        }
+        match get_parent_class_id(cur) {
+            Some(pid) if pid != 0 && pid != cur => cur = pid,
+            _ => return false,
+        }
+        depth += 1;
+    }
+    false
+}
+
 /// Check if a value is an instance of a class with the given class_id
 /// Walks the inheritance chain to check parent classes
 /// Returns NaN-boxed TAG_TRUE / TAG_FALSE so the result identifies as a boolean.
@@ -975,22 +1039,9 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
                     (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader
                 };
                 if unsafe { (*gc_header).obj_type } == crate::gc::GC_TYPE_OBJECT {
-                    let mut cur = unsafe { (*obj).class_id };
-                    if cur != 0 {
-                        if cur == class_id {
-                            return true_val;
-                        }
-                        let mut depth = 0;
-                        while let Some(pid) = get_parent_class_id(cur) {
-                            if pid == 0 || depth > 64 {
-                                break;
-                            }
-                            if pid == class_id {
-                                return true_val;
-                            }
-                            cur = pid;
-                            depth += 1;
-                        }
+                    let cur = unsafe { (*obj).class_id };
+                    if class_chain_reaches(cur, class_id) {
+                        return true_val;
                     }
                 }
             }
@@ -1556,20 +1607,12 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         {
             return true_val;
         }
-        if obj_class_id == class_id {
+        // Walk up the inheritance chain using the class registry. #7575: the
+        // walk also follows the generic-origin edge, so a dynamic RHS holding a
+        // generic class (`const C = Gen; x instanceof C`) matches an instance of
+        // one of its specializations.
+        if class_chain_reaches(obj_class_id, class_id) {
             return true_val;
-        }
-
-        // Walk up the inheritance chain using the class registry
-        let mut current_class = obj_class_id;
-        while let Some(parent_id) = get_parent_class_id(current_class) {
-            if parent_id == 0 {
-                break;
-            }
-            if parent_id == class_id {
-                return true_val;
-            }
-            current_class = parent_id;
         }
 
         false_val
@@ -1611,5 +1654,86 @@ mod null_lhs_tests {
                 lhs.to_bits()
             );
         }
+    }
+}
+
+/// #7575 — the generic-origin edge in [`class_chain_reaches`].
+///
+/// Perry monomorphizes generic classes, so `new Gen<number>()` stamps its
+/// instance with `Gen$num`'s id while `x instanceof Gen` asks about the
+/// GENERIC's id. These exercise the walk directly over synthetic ids: the
+/// gap test proves the end-to-end behaviour, this proves the walk's shape,
+/// including that the new edge does not make unrelated classes match.
+#[cfg(test)]
+mod generic_origin_chain_tests {
+    use super::class_chain_reaches;
+    use crate::object::{js_register_class_generic_origin, js_register_class_parent};
+
+    // Ids well outside the reserved 0xFFFF00xx band and outside any range a
+    // compiled module hands out in a test run.
+    const BASE: u32 = 0x0757_5000;
+    const GENERIC: u32 = 0x0757_5001;
+    const SPECIALIZED: u32 = 0x0757_5002;
+    const OTHER_SPECIALIZED: u32 = 0x0757_5003;
+    const SUB_GENERIC: u32 = 0x0757_5004;
+    const SUB_SPECIALIZED: u32 = 0x0757_5005;
+    const UNRELATED: u32 = 0x0757_5006;
+
+    fn wire() {
+        // class Base {}
+        // class Generic<T> extends Base {}        -> Specialized, OtherSpecialized
+        // class SubGeneric<T> extends Generic<T> {} -> SubSpecialized
+        js_register_class_parent(GENERIC, BASE);
+        js_register_class_parent(SPECIALIZED, BASE);
+        js_register_class_generic_origin(SPECIALIZED, GENERIC);
+        js_register_class_parent(OTHER_SPECIALIZED, BASE);
+        js_register_class_generic_origin(OTHER_SPECIALIZED, GENERIC);
+        js_register_class_parent(SUB_GENERIC, GENERIC);
+        js_register_class_parent(SUB_SPECIALIZED, GENERIC);
+        js_register_class_generic_origin(SUB_SPECIALIZED, SUB_GENERIC);
+    }
+
+    #[test]
+    fn a_specialization_is_an_instance_of_its_generic_and_of_the_real_base() {
+        wire();
+        // The bug: this was false, because GENERIC is in no parent chain.
+        assert!(class_chain_reaches(SPECIALIZED, GENERIC));
+        assert!(class_chain_reaches(SPECIALIZED, BASE));
+        assert!(class_chain_reaches(SPECIALIZED, SPECIALIZED));
+    }
+
+    #[test]
+    fn the_origin_edge_walks_the_generics_own_parents() {
+        wire();
+        // SubSpecialized -> (origin) SubGeneric -> (parent) Generic -> Base.
+        assert!(class_chain_reaches(SUB_SPECIALIZED, SUB_GENERIC));
+        assert!(class_chain_reaches(SUB_SPECIALIZED, GENERIC));
+        assert!(class_chain_reaches(SUB_SPECIALIZED, BASE));
+    }
+
+    /// The edge must not make everything match everything: two specializations
+    /// of the same generic are siblings, not ancestors of one another, and the
+    /// generic is not an instance of its own specialization.
+    #[test]
+    fn the_origin_edge_stays_directional_and_does_not_widen_matches() {
+        wire();
+        assert!(!class_chain_reaches(SPECIALIZED, OTHER_SPECIALIZED));
+        assert!(!class_chain_reaches(OTHER_SPECIALIZED, SPECIALIZED));
+        assert!(!class_chain_reaches(GENERIC, SPECIALIZED));
+        assert!(!class_chain_reaches(BASE, GENERIC));
+        assert!(!class_chain_reaches(SPECIALIZED, UNRELATED));
+        assert!(!class_chain_reaches(UNRELATED, GENERIC));
+        assert!(!class_chain_reaches(SPECIALIZED, 0));
+        assert!(!class_chain_reaches(0, GENERIC));
+    }
+
+    /// A self-edge or a cycle must terminate rather than hang: the walk is
+    /// depth-bounded and refuses `cur -> cur`.
+    #[test]
+    fn a_self_referential_registration_terminates() {
+        js_register_class_generic_origin(0x0757_50FF, 0x0757_50FF); // rejected
+        js_register_class_parent(0x0757_50FE, 0x0757_50FE); // self parent
+        assert!(!class_chain_reaches(0x0757_50FE, GENERIC));
+        assert!(class_chain_reaches(0x0757_50FE, 0x0757_50FE));
     }
 }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -175,12 +175,12 @@ pub use with_env::*;
 // named re-exports keep existing `crate::object::X` / bare-name call sites in
 // the object submodules resolving unchanged.
 pub(crate) use class_meta_registry::{
-    extends_builtin_error, fetch_parent_kind, lookup_has_instance_hook, lookup_to_string_tag_hook,
-    register_fetch_parent_kind, CLASS_REGISTRY,
+    class_generic_origin, extends_builtin_error, fetch_parent_kind, lookup_has_instance_hook,
+    lookup_to_string_tag_hook, register_fetch_parent_kind, CLASS_REGISTRY,
 };
 pub use class_meta_registry::{
-    js_register_class_extends_error, js_register_class_has_instance,
-    js_register_class_to_string_tag,
+    js_register_class_extends_error, js_register_class_generic_origin,
+    js_register_class_has_instance, js_register_class_to_string_tag,
 };
 pub use descriptor_state::PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED;
 pub(crate) use descriptor_state::{

--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -1868,6 +1868,7 @@ mod computed_and_field_async_tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
         }
     }
 

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -353,6 +353,7 @@ fn deforests_producer_called_from_class_method() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     };
 
@@ -472,6 +473,7 @@ fn rejects_deforest_when_class_method_uses_super() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     };
 
@@ -563,6 +565,7 @@ fn still_deforests_when_method_has_no_super() {
         is_exported: false,
         is_nested: false,
         alloc_width_hint: 0,
+        specialized_from: None,
         aliases: Vec::new(),
     };
 

--- a/crates/perry-transform/src/generator/id_scan.rs
+++ b/crates/perry-transform/src/generator/id_scan.rs
@@ -630,6 +630,7 @@ mod tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
         }
     }
 

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -701,6 +701,7 @@ mod tests {
             aliases: Vec::new(),
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
         }
     }
 

--- a/crates/perry/src/commands/compile/helpers.rs
+++ b/crates/perry/src/commands/compile/helpers.rs
@@ -291,6 +291,7 @@ mod tests {
             is_exported: true,
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             aliases: Vec::new(),
         };
         let project_root = PathBuf::from("/repo");
@@ -344,6 +345,7 @@ mod tests {
             is_exported: true,
             is_nested: false,
             alloc_width_hint: 0,
+            specialized_from: None,
             aliases: Vec::new(),
         };
         let project_root = PathBuf::from("/repo");

--- a/test-files/test_gap_6325_map_set_subclass.ts
+++ b/test-files/test_gap_6325_map_set_subclass.ts
@@ -25,7 +25,9 @@ s.add("x");
 console.log("set subclass has:", s.has("x"), "size:", s.size);
 
 // ── the registry parent edge is wired, so `instanceof` holds ──
+// #7575 tightened this to assert the SUBCLASS edge as well as the base one.
 console.log("instanceof:", m instanceof Map, s instanceof Set);
+console.log("instanceof subclass:", m instanceof M, s instanceof S);
 
 // ── explicit-ctor control (this path already worked — must keep working) ──
 class WithCtor extends Map {

--- a/test-files/test_gap_7541_array_subclass_inherited_statics.ts
+++ b/test-files/test_gap_7541_array_subclass_inherited_statics.ts
@@ -9,8 +9,15 @@
 //
 // KNOWN GAP, deliberately not asserted here: the property-GET form
 // (`typeof MyArr.from`) still reports `undefined` — only the CALL form is
-// dispatched. Same for `sub instanceof MyArr`, a pre-existing class-registry
-// parent-edge gap (#7575's Map/Set sibling).
+// dispatched.
+//
+// The note that used to sit here claiming `sub instanceof MyArr` was also a gap
+// was STALE and is removed: #7575 measured it on pristine `main` and every
+// NON-generic Array-subclass `instanceof` — `new MyArr()`, `new Indirect()`,
+// and `MyArr.from([...])` — already held. Only the GENERIC spelling
+// (`class GenArr<T> extends Array<T>`) was broken, because Perry monomorphizes
+// generics and the instance carried `GenArr$num`'s class id; that is fixed in
+// #7575 and asserted in test_gap_7575_map_set_subclass_instanceof.ts.
 
 class MyArr extends Array {}
 class Indirect extends MyArr {}

--- a/test-files/test_gap_7570_map_set_declared_base_type.ts
+++ b/test-files/test_gap_7570_map_set_declared_base_type.ts
@@ -141,16 +141,16 @@ const m7: Map<string, number> = new MyMap<string, number>();
 console.log("7 set returns receiver:", m7.set("a", 1) === m7);
 m7.set("b", 2).set("c", 3);
 console.log("7 chained:", m7.size, m7.get("b"), m7.get("c"));
-// NOTE: only the BASE `instanceof` is asserted here. `m7 instanceof MyMap` is
-// a separate, pre-existing gap — it is false for a Map/Set subclass instance
-// with or without the annotation, so it is not part of this fix.
-console.log("7 still a Map:", m7 instanceof Map);
+// The SUBCLASS edge is asserted too since #7575: `MyMap<K, V>` is generic, so
+// `new MyMap<string, number>()` constructs the monomorphized `MyMap$str_num`
+// and `instanceof MyMap` used to miss the class the user actually wrote.
+console.log("7 still a Map:", m7 instanceof Map, m7 instanceof MyMap);
 
 const s7: Set<number> = new MySet<number>();
 console.log("7 add returns receiver:", s7.add(1) === s7);
 s7.add(2).add(3);
 console.log("7 set chained:", s7.size, s7.has(2), s7.has(3));
-console.log("7 still a Set:", s7 instanceof Set);
+console.log("7 still a Set:", s7 instanceof Set, s7 instanceof MySet);
 
 // ── 8. `clear()` through an annotated binding ──
 const m8: Map<string, number> = new MyMap<string, number>([["z", 1]]);

--- a/test-files/test_gap_7575_map_set_subclass_instanceof.ts
+++ b/test-files/test_gap_7575_map_set_subclass_instanceof.ts
@@ -1,0 +1,111 @@
+// #7575: `m instanceof MyMap` was `false` for a `class MyMap extends Map {}`
+// instance while `m instanceof Map` was `true` — the LEAF/intermediate class
+// edge was lost and only the native base edge survived.
+//
+// Sibling of #7573/#7603 but a different mechanism: not header branding, but
+// which class id ends up stamped on the instance and what the class-registry
+// parent chain looks like from there. `js_instanceof` walks
+// `ObjectHeader.class_id` up through `get_parent_class_id`; if the instance
+// carries the NATIVE BASE's reserved id rather than the subclass's, the walk
+// can only ever answer for the base.
+//
+// `test_gap_6325_map_set_subclass.ts` and `test_gap_7570_map_set_declared_base_type.ts`
+// both asserted only `instanceof Map` / `instanceof Set`, which is why this
+// survived them.
+
+class MyMap<K, V> extends Map<K, V> {}
+class MySet<T> extends Set<T> {}
+class Plain {}
+class SubPlain extends Plain {}
+class Unrelated {}
+
+// ── 1. the issue's exact repro ──
+const a = new MyMap<string, number>();
+console.log("1 unannotated:", a instanceof MyMap, a instanceof Map);
+
+const b: Map<string, number> = new MyMap<string, number>();
+console.log("1 annotated  :", b instanceof MyMap, b instanceof Map);
+
+const sa = new MySet<number>();
+console.log("1 set unann  :", sa instanceof MySet, sa instanceof Set);
+const sb: Set<number> = new MySet<number>();
+console.log("1 set ann    :", sb instanceof MySet, sb instanceof Set);
+
+// ── 2. control: an ordinary hierarchy was never affected ──
+const c: Plain = new SubPlain();
+console.log("2 plain:", c instanceof SubPlain, c instanceof Plain);
+
+// ── 3. negatives must stay negative ──
+console.log("3 unrelated:", a instanceof Unrelated, a instanceof Set, sa instanceof Map);
+console.log("3 base only:", new Map() instanceof MyMap, new Set() instanceof MySet);
+console.log("3 real base:", new Map() instanceof Map, new Set() instanceof Set);
+
+// ── 4. multi-level: the chain must be walked, not just its first edge ──
+class A extends Map<string, number> {}
+class B extends A {}
+class C extends B {}
+const bb = new B();
+console.log("4 two level:", bb instanceof B, bb instanceof A, bb instanceof Map, bb instanceof C);
+const cc = new C();
+console.log("4 three lvl:", cc instanceof C, cc instanceof B, cc instanceof A, cc instanceof Map);
+
+class SA extends Set<number> {}
+class SB extends SA {}
+const sbb = new SB();
+console.log("4 set level:", sbb instanceof SB, sbb instanceof SA, sbb instanceof Set);
+
+// ── 5. a subclass WITH its own constructor (explicit `super()` path) ──
+class Tagged extends Map<string, number> {
+  tag: string;
+  constructor(tag: string) {
+    super();
+    this.tag = tag;
+  }
+}
+const t = new Tagged("t");
+console.log("5 explicit ctor:", t instanceof Tagged, t instanceof Map, t.tag);
+
+class TaggedSub extends Tagged {}
+const ts = new TaggedSub("u");
+console.log("5 sub of ctor  :", ts instanceof TaggedSub, ts instanceof Tagged, ts instanceof Map);
+
+// ── 6. seeded from an iterable — the surface must survive the branding fix ──
+const seeded = new MyMap<string, number>([
+  ["x", 1],
+  ["y", 2],
+]);
+console.log("6 seeded:", seeded instanceof MyMap, seeded instanceof Map, seeded.size, seeded.get("x"));
+seeded.set("z", 3);
+console.log("6 mutate:", seeded.size, seeded.has("z"), seeded.get("z"), [...seeded.keys()].join(","));
+
+const seededSet = new MySet<number>([1, 2, 2, 3]);
+console.log("6 set    :", seededSet instanceof MySet, seededSet instanceof Set, seededSet.size, seededSet.has(2));
+
+// ── 7. `Symbol.hasInstance` still takes precedence over the chain walk ──
+class Never extends Map<string, number> {
+  static [Symbol.hasInstance](_v: unknown): boolean {
+    return false;
+  }
+}
+const n = new Never();
+console.log("7 hasInstance:", n instanceof Never, n instanceof Map);
+
+class Always extends Map<string, number> {
+  static [Symbol.hasInstance](_v: unknown): boolean {
+    return true;
+  }
+}
+console.log("7 always:", 42 instanceof Always, new Map() instanceof Always);
+
+// ── 8. the dynamic RHS (`x instanceof ctorVar`) resolves the same way ──
+const ctor: unknown = MyMap;
+// deno-lint-ignore no-explicit-any
+console.log("8 dynamic:", a instanceof (ctor as any), b instanceof (ctor as any));
+
+// ── 9. `instanceof` inside a function, over a parameter (no local type proof) ──
+function isMine(v: unknown): string {
+  return `${v instanceof MyMap} ${v instanceof Map} ${v instanceof MySet}`;
+}
+console.log("9 param:", isMine(a));
+console.log("9 param:", isMine(sa));
+console.log("9 param:", isMine(new Map()));

--- a/test-files/test_gap_7575_map_set_subclass_instanceof.ts
+++ b/test-files/test_gap_7575_map_set_subclass_instanceof.ts
@@ -2,12 +2,16 @@
 // instance while `m instanceof Map` was `true` — the LEAF/intermediate class
 // edge was lost and only the native base edge survived.
 //
-// Sibling of #7573/#7603 but a different mechanism: not header branding, but
-// which class id ends up stamped on the instance and what the class-registry
-// parent chain looks like from there. `js_instanceof` walks
-// `ObjectHeader.class_id` up through `get_parent_class_id`; if the instance
-// carries the NATIVE BASE's reserved id rather than the subclass's, the walk
-// can only ever answer for the base.
+// The mechanism turned out to have nothing to do with Map/Set, or with native
+// bases, or with prototype chains: it is MONOMORPHIZATION. Perry specializes
+// generic classes, so `new MyMap<string, number>()` constructs a second class
+// `MyMap$str_num` (`monomorph::mangle::generate_specialized_name`) carrying its
+// own class id, and the instance is stamped with THAT id — while
+// `x instanceof MyMap` resolves the RHS to the GENERIC's id, which appears
+// nowhere in the specialization's parent chain. `class MyMap<K, V> extends
+// Map<K, V>` is just the idiomatic spelling, which is why it surfaced there;
+// section 9 below shows a generic class with a plain base, and one with NO
+// base, failing identically before the fix.
 //
 // `test_gap_6325_map_set_subclass.ts` and `test_gap_7570_map_set_declared_base_type.ts`
 // both asserted only `instanceof Map` / `instanceof Set`, which is why this
@@ -102,10 +106,35 @@ const ctor: unknown = MyMap;
 // deno-lint-ignore no-explicit-any
 console.log("8 dynamic:", a instanceof (ctor as any), b instanceof (ctor as any));
 
-// ── 9. `instanceof` inside a function, over a parameter (no local type proof) ──
+// ── 9. it was never about Map/Set: a generic subclass of ANY base, and of no
+//       base at all, failed identically. This is the real shape of the bug. ──
+class PlainBase {}
+class GenPlain<T> extends PlainBase {}
+class GenNoBase<T> {}
+class GenArr<T> extends Array<T> {}
+
+const gp = new GenPlain<number>();
+console.log("9 gen plain :", gp instanceof GenPlain, gp instanceof PlainBase);
+const gn = new GenNoBase<number>();
+console.log("9 gen nobase:", gn instanceof GenNoBase, gn instanceof PlainBase);
+const ga = new GenArr<number>();
+console.log("9 gen array :", ga instanceof GenArr, ga instanceof Array);
+// ...and the NON-generic spellings, which already worked and must keep working.
+class ConcPlain extends PlainBase {}
+class ConcArr extends Array {}
+console.log("9 concrete  :", new ConcPlain() instanceof ConcPlain, new ConcArr() instanceof ConcArr);
+// The same generic class instantiated without type arguments takes a different
+// specialization (none at all), and must answer the same way.
+console.log("9 no-typearg:", new GenPlain() instanceof GenPlain, new GenArr() instanceof GenArr);
+// Two specializations of one generic are siblings, not ancestors: `instanceof`
+// must not have been widened into "shares a generic origin".
+const gs = new GenPlain<string>();
+console.log("9 siblings  :", gs instanceof GenPlain, gp instanceof GenPlain, gs instanceof PlainBase);
+
+// ── 10. `instanceof` inside a function, over a parameter (no local type proof) ──
 function isMine(v: unknown): string {
   return `${v instanceof MyMap} ${v instanceof Map} ${v instanceof MySet}`;
 }
-console.log("9 param:", isMine(a));
-console.log("9 param:", isMine(sa));
-console.log("9 param:", isMine(new Map()));
+console.log("10 param:", isMine(a));
+console.log("10 param:", isMine(sa));
+console.log("10 param:", isMine(new Map()));


### PR DESCRIPTION
Closes #7575.

## Root cause: it is not Map/Set, and it is not the prototype chain

The issue reads `m instanceof MyMap === false` as a native-base-subclassing /
class-registry-parentage defect, and points at CLAUDE.md's *Native base-class
subclassing* and *Two prototype-resolution paths* entries. Both are the wrong
tree. The mechanism is **monomorphization**.

Perry specializes generic classes. `class Gen<T> {}` plus `new Gen<number>()`
emits a SECOND class named `Gen$num`
(`crates/perry-hir/src/monomorph/mangle.rs:14`, `specialize.rs:50`) carrying its
own class id, and the instance is stamped with **that** id — while
`x instanceof Gen` resolves the RHS through `ctx.class_ids` to the **generic's**
id (`crates/perry-codegen/src/expr/instance_misc1.rs:346`), which appears nowhere
in the specialization's parent chain. `js_instanceof`'s walk therefore answers
`false` for the class the user actually wrote, and `true` for the base — exactly
the "only the native base edge survives" symptom.

The bisect that identifies it, measured on pristine `main`:

```
class GenMap<K,V> extends Map<K,V> {}  new GenMap<string,number>()  false true
class ConcMap     extends Map<...>  {}  new ConcMap()                true  true
class BareMap     extends Map       {}  new BareMap()                true  true
class GenMap<K,V> extends Map<K,V> {}  new GenMap()   /* no args */  true  true
class GenPlain<T> extends PlainBase {}  new GenPlain<number>()       false true   <-- no Map anywhere
class GenNoBase<T>                  {}  new GenNoBase<number>()      false        <-- no BASE anywhere
```

The last two rows settle it: a generic class with an ordinary base, and one with
no base at all, fail identically. `class MyMap<K, V> extends Map<K, V>` is simply
the idiomatic spelling, which is why it surfaced there. `constructor.name` on the
same instances reports `Gen$num` — the same leak on a different surface.

## The fix

* HIR records `Class::specialized_from` (the generic's name), set by
  `specialize_class`.
* Codegen emits one `js_register_class_generic_origin(spec, generic)` per
  specialization in the module-init prelude, next to the existing
  `js_register_class_parent` edges.
* `instanceof`'s chain walk — now a single shared, depth-bounded
  `class_chain_reaches`, used by both the static and the dynamic-RHS path, which
  previously had two hand-rolled copies (one of them uncapped) — follows the
  origin edge as well as `extends`.

It is deliberately a **separate edge, not a parent edge**. `CLASS_REGISTRY`'s
chain also resolves `super()` construction
(`object/class_constructors.rs:652`), static-method lookup and vtable dispatch,
so splicing `Gen` in between `Gen$num` and its real base would re-run the wrong
constructor. Only `instanceof` may follow this one, and the runtime module says
so at the declaration.

## Did the fix need rooting discipline?

No. The whole change is `u32 -> u32` class-id bookkeeping — no heap pointers, no
new cache of a `*mut`, so nothing to register with
`gc_register_mutable_root_scanner` and nothing for `raw_handle_debt.py` to count
(it is unchanged at 998). The gap test is nevertheless byte-identical under
`PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1`.

## The Array-side sibling #7603 left unfixed

One mechanism covers both families, **and the note about it was stale**. Measured
on pristine `main`:

```
new MyArr()                  instanceof MyArr    true    (already worked)
new Indirect()               instanceof MyArr    true    (already worked)
MyArr.from([1,2,3])          instanceof MyArr    true    (already worked)
new GenArr<number>()         instanceof GenArr   FALSE   <-- fixed here
```

So the only broken Array case was the generic spelling, and this PR fixes it. The
comment in `test_gap_7541_array_subclass_inherited_statics.ts` that named
`sub instanceof MyArr` as a pre-existing gap was wrong; it is corrected in place
rather than left to mislead the next reader. Nothing is left to file on the
Array side.

## Sabotage, both ways

* Making `class_generic_origin` return `None` turns two of the four new runtime
  unit tests red and turns the gap test red at 8 lines
  (`1 unannotated: false true`, `6 seeded: false true`, `8 dynamic`, `9/10 ...`).
* The other two unit tests stay green under that sabotage **by design** — they
  assert the edge is directional and does not widen matches (sibling
  specializations must not match each other, a generic is not an instance of its
  own specialization), so they would catch the opposite mistake.

## Validation (local; CI backlog is deep, so this is the evidence)

* `test-files/test_gap_7575_map_set_subclass_instanceof.ts` — byte-identical to
  `node --experimental-strip-types` on the pinned 26.5.1, exit 0. Covers
  `instanceof` against the subclass, the native base, an unrelated class, a
  multi-level chain (`class A extends Map {}; class B extends A {}; class C
  extends B {}`), an explicit-`super()` subclass and a subclass of it, an
  iterable-seeded instance, `Symbol.hasInstance` in both directions (it still
  takes precedence over the chain walk), the dynamic RHS, `instanceof` over an
  untyped parameter, and the generic-over-plain / generic-over-nothing /
  generic-over-Array shapes plus their non-generic controls and sibling
  negatives.
* Same test byte-identical under `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1
  PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, compiled with
  `PERRY_GC_MOVING_LOOP_POLLS=1`.
* `test_gap_6325_map_set_subclass.ts` and
  `test_gap_7570_map_set_declared_base_type.ts` **tightened** to assert the
  subclass edge, as #7575 asked — both still byte-identical.
* No regressions: `test_gap_7541`, `test_gap_7574`, `test_gap_7563`,
  `test_gap_6232`, `test_gap_4099`, `test_gap_5592`, `test_edge_generics`,
  `test_generic_class`, `test_edge_class_advanced`, `test_edge_complex_patterns`,
  `test_edge_interfaces`, `test_data_pipeline`,
  `test_gap_repsel_element_shape_loop_clone`,
  `test_gap_intl_rtf_auto_instanceof_6960` all byte-identical to node.
* 4 new `perry-runtime` unit tests over the walk. `cargo test -p perry-runtime`
  1890 passed / 0 failed; `-p perry-hir` and `-p perry-transform` all green.
* Lint: `cargo fmt --all -- --check`, `check_file_size.sh`,
  `addr_class_inventory.py`, `raw_handle_debt.py` (998, unchanged),
  `class_id_collisions.py`, `check_test_registration.py`,
  `gc_store_site_inventory.py`, `workspace_architecture.py`,
  `gap_snapshot.py --self-test` all pass.

Pre-existing failures untouched by this PR, each A/B'd against pristine
`origin/main` in this worktree:

* `perry-codegen`'s integration suites (`crates/perry-codegen/tests/*.rs`, which
  do not run per-PR) fail **the same 23 tests, byte-identical list**, on both
  arms.
* `test_harness_class_mixins`, `test_issue_562_stream_subclass` and
  `test_issue_806_curried_factory_extends_capture` produce **byte-identical Perry
  output** on both arms.
* `cargo clippy` errors in `crates/perry-ffi/src/jsvalue.rs` (`approx_constant`
  on `3.14`) are pre-existing in a file this PR does not touch.

## Known, deliberately not folded in

`constructor.name` still reports the mangled `Gen$num` rather than `Gen`. Same
root cause (monomorphized identity leaking to a user-visible surface), different
surface (the class display-name registry), and it can move error-message text —
so it belongs in its own change with its own parity sweep, not bundled into an
`instanceof` fix. Filed as #7632.

---

## Rebased onto v0.5.1357 (#7627) — clean as text, but it did NOT compile

Rebasing this onto current main produced **zero conflicts**, and
`git merge-tree origin/main <this>` exits 0. That verdict was wrong in the way
that matters: **the merge does not build.**

#7627 added a new `perry_hir::Class` literal in
`crates/perry-codegen/src/codegen/emission_order_tests.rs`, and this PR *widens*
that struct with `Class::specialized_from`. Neither side touches a line the
other side touches, so there is nothing for a textual merge to flag — but the
result is `E0063: missing field specialized_from`. Fixed here in its own commit.

Worth stating plainly because it generalises: **textual mergeability is not a
merge check when one branch widens a struct another branch constructs.** The
only reliable check is `cargo check --all-targets` on the merge result, and
`--all-targets` is load-bearing — the offending literal is in a `#[cfg(test)]`
fixture, so a plain `cargo check` stays green and the break surfaces later, in a
job that does build tests.

This PR does not touch `expr/instance_misc1.rs`, `logical_collections.rs` or
`map_set.rs`, so it has no overlap with #7627's rooting migration itself.

### Re-verified after the rebase, not before

* `test_gap_7575_map_set_subclass_instanceof.ts` byte-identical to node 26.5.1,
  exit 0; byte-identical again under `PERRY_GC_ZEAL=1
  PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, compiled
  with `PERRY_GC_MOVING_LOOP_POLLS=1`.
* `test_gap_7570`, `test_gap_6325` (both tightened by this PR) and
  `test_gap_7541` all byte-identical.
* `cargo check --all-targets` over the workspace: clean.
* 4 runtime unit tests over the walk green; `-p perry-runtime` 1890 passed / 0
  failed; `-p perry-codegen --lib` 694 / 0 (ledger tests included);
  `-p perry-hir` 281 / 0; `-p perry-transform` 56 / 0.
* **Root-dominance corpus, both gated modes** (this PR changes codegen emission,
  so it was re-run rather than reasoned about): 129/129 sources, 149 `.ll`,
  2452 functions / 9846 root stores, **0 violations** in dominance mode with
  **40/40 seeded caught**, and **0** `--unrooted-allocas` violations.
* Full lint set from `.github/workflows/test.yml` green, including
  `raw_handle_debt.py` at **998** (unchanged — this PR is `u32 → u32`
  bookkeeping, no heap pointers).

Conflict-free against #7626 (`git merge-tree` of the two heads exits 0), and
#7626 adds no `Class` literal, so this PR's struct widening cannot break it in
either merge order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `instanceof` checks for monomorphized generic classes and their inheritance chains.
  * Improved behavior for generic `Map`, `Set`, and other specialized subclasses, including dynamic constructor checks.
  * Preserved correct behavior for negative matches, sibling specializations, and custom `Symbol.hasInstance` implementations.

* **Tests**
  * Added comprehensive regression coverage for generic inheritance and built-in collection subclasses.

* **Chores**
  * Updated the application version to 0.5.1359.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->