### PR TITLE
refactor(codegen): migrate the literal-accumulator modules onto the Layer 1 rooting API (#7615)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1361
+**Current Version:** 0.5.1362
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1361"
+version = "0.5.1362"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1361"
+version = "0.5.1362"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1361"
+version = "0.5.1362"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1361"
+version = "0.5.1362"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1361"
+version = "0.5.1362"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7636-layer1-slice3-literal-accumulators.md
+++ b/changelog.d/7636-layer1-slice3-literal-accumulators.md
@@ -1,0 +1,89 @@
+### Layer 1 rooting migration, slice 3 — the literal accumulators (#7615)
+
+`expr/objects_arrays_lit.rs`, `expr/array_literal.rs`, `expr/object_literal.rs`
+and `expr/array_push.rs` now root through `crate::rooting` and are listed in
+`MIGRATED_MODULES`; none names `expr::temp_root`. Follows the template (#7617)
+and slices 1a (#7618), 1b (#7620) and 2 (#7627).
+
+**No new combinator, including where one looked necessary.** The spread
+literal's growing array is `with_rooted_accumulator(Repr::Ptr)` + `advance`
+(which fuses the republish to the call — the accumulator's address legitimately
+changes on every append); the array literal's element group is
+`with_operands_rooted`; the object literal's half-built handle is
+`with_rooted_accumulator` on both build paths; `arr.push(...src)`'s operand pair
+is `with_operands_rooted` over an empty window, which emits nothing.
+
+The shape that looked like a fourth combinator is a `this`-capturing method
+closure's deferred value: it is consumed by the `this` patch loop *below every
+remaining initializer*, so its root must span exactly that suffix, and the
+number of such values is data-dependent. None of the three
+`with_operands_rooted*` forms can express it — all three lower their operand
+list up front, which for an object literal would evaluate every property before
+storing any of them and reorder observable side effects. `with_rooted_accumulator`
+already *is* "a GC value held while more user code is lowered", so the answer is
+one nested scope per such property, which falls out as a small recursion over
+the property list. That replaces #6951's flat `Vec` of raw slots which were
+never released at all — correct only because `temp_root_truncate` is a stack cut
+and the object handle sat below them, i.e. correct because of an invariant
+stated in a comment, and leaked outright on a `?` from a later initializer.
+
+**Scoped honestly: three of the four modules are translations, not repairs.**
+#7280 rooted the spread accumulator correctly, #6951 rooted the array literal's
+element group and the object literal's handle correctly (including loading the
+interned key *below* the value's lowering, which is the #7627 finding already
+right in this arm). What the migration buys there is that the republish cannot
+be forgotten and the release cannot become branch-conditional (#7462's shape,
+which shipped in a sibling arm) — plus, in `array_literal.rs`, a release on the
+two paths that had none: three exits each carried their own `temp_root_release`,
+and the `?` on every element's lowering released nothing. `array_push.rs` named
+no rooting symbol before the migration and names none after, so its ledger line
+is vacuous on the committed source exactly as both slice-1 modules' were; only
+the sabotage arm makes it an assertion, and the audit that earned the listing is
+written into that file's header.
+
+**A branch no corpus can reach, so it gets its own tests.**
+`lower_object_literal`'s by-name path with a non-empty property list — the one
+carrying the `this`-patch machinery — is not reachable from TypeScript: since
+#809 every source-level literal containing a `Prop::Method` lowers to a
+source-ordered IIFE over `{}`. Measured rather than assumed — over the whole
+`gc_root_dominance_corpus.sh` corpus (129 sources, 149 modules) every emitted
+`js_object_alloc` is `(i32 0, i32 0)`. Four unit tests built directly from HIR
+now pin it: the by-name path is selected, both patches run below the last
+property store, the patches are applied in **source order** (readable off the
+reserved `this`-slot index, because the two closures deliberately reserve
+different ones), and three slots are rooted and released innermost-first with
+the object handle released last. Deleting the list's `reverse()` turns the third
+red.
+
+**Also found, filed rather than fixed: #7634.** `arr.push(f())` and
+`arr.push(...g())` evaluate the receiver *after* the argument, so an argument
+that reassigns the receiver's binding pushes onto the wrong array (node prints
+`[9]`, perry prints `[9,2]`). That order is exactly what makes the arm
+rooting-free today, so restoring spec order puts the receiver in a window and
+every pointer-valued push gains a temp root — expressible with the existing
+`with_operands_rooted_across`, but needing a measured before/after that a
+behaviour-preserving refactor has no mandate to run.
+
+**Verified locally** (the CI backlog is deep, so this is the evidence). IR A/B
+against a baseline built from `c1365ed8a`'s copies of the five touched files:
+the probes are byte-identical in both environments, the dependency-scale corpus
+(81 zod modules, 64 MB) is byte-identical, and the curated corpus is 2450/2452
+identical — the two differences being the same instruction pair in the
+iterator-result literal, where the accumulator's re-read now lands *after* the
+value's `bitcast` instead of before because it is fused to the emission that
+consumes it. Identical opcode multiset, same operands, same call.
+`gc-root-dominance` green in both gated modes on both corpora with an empty
+allowlist (curated 2452 functions / 9846 root stores → 0 violations, 40/40
+seeded, `--unrooted-allocas` 0 over 7867; dependency-scale 12899 functions /
+12908 root stores → 0, 40/40, 0 over 15242), root-store counts unchanged on
+both. `cargo test -p perry-codegen --lib` 699 pass and `--doc`'s two
+`compile_fail,E0499` arms still reject; `-p perry-runtime --no-fail-fast` 1902
+pass first run; `cargo check --all-targets` clean. 13 gap-family filters over
+both prebuilt arms produce identical 140-verdict sets. All probes byte-identical
+in stdout and exit code on both arms and again under `PERRY_GC_ZEAL=1
+PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800
+PERRY_GC_MOVING_LOOP_POLLS=1`, with `PERRY_GC_DIAG=1` confirming the instrument
+was live (5 retired from-space sets). Ledger sabotage run per module — each of
+the four turns the ledger red naming both planted lines. It also caught a real
+violation in this change's own new test, where an assertion message quoted
+`temp_root_truncate`: that is a code line, not a comment.

--- a/crates/perry-codegen/src/expr/array_literal.rs
+++ b/crates/perry-codegen/src/expr/array_literal.rs
@@ -1,14 +1,35 @@
 //! Array-literal lowering (extracted from `expr.rs`, issue #1098).
 //! Pure move — no logic changes.
+//!
+//! # Layer 1 migrated module (#7615, slice 3)
+//!
+//! Nothing here names `expr::temp_root`. The element group goes through
+//! [`crate::rooting::with_operands_rooted`], and
+//! `crate::rooting::migration_ledger` fails the build if this module reaches
+//! back into the raw API.
+//!
+//! ## What the migration found here
+//!
+//! Nothing new: #6951 already rooted the element group correctly. The
+//! migration is a *translation* and its IR is byte-identical, which is the
+//! claim this module makes — not a closed hazard.
+//!
+//! What it does buy is the release, and here that is not hypothetical. Three
+//! separate exits (the #5391 outline path, the inline bump-alloc path, the
+//! `N > 16` extern path) each carried their own `temp_root_release`, plus a
+//! `?` on every element's lowering that released nothing at all — the guard
+//! outlived a failed lowering. `with_operands_rooted` owns the release on all
+//! five paths, so "released on one arm" (#7462, which shipped in
+//! `URLSearchParams.delete`) stops being a program this arm can express.
 
 use anyhow::Result;
 use perry_hir::Expr;
 
-use super::temp_root::{lower_exprs_rooted, temp_root_release};
 use super::{
     emit_jsvalue_slot_store_on_block, expr_produces_non_pointer_bits_by_construction,
     nanbox_pointer_inline, FnCtx,
 };
+use crate::rooting;
 use crate::type_analysis::is_numeric_expr;
 use crate::types::{DOUBLE, I32, I64, I8, PTR};
 
@@ -64,205 +85,199 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
         ));
     }
     let element_refs: Vec<&Expr> = elements.iter().collect();
-    let (vals, element_guard) = lower_exprs_rooted(ctx, &element_refs)?;
-
-    // #5391: oversized modules outline array-literal construction. The inline
-    // bump-alloc + N×(store + layout-note + barrier) sequence makes minified
-    // data-table builders huge (single 18MB functions clang -O0 can't compile
-    // in practical time). Instead spill the already-evaluated element values to
-    // a per-literal stack buffer and build the array in ONE runtime call. The
-    // buffer is hoisted to the entry block (fixed size per site; bounded total
-    // stack) and consumed immediately by the call, so no GC-visible window.
-    if crate::codegen::full_outline_ic_enabled() {
-        let buf = ctx.func.alloca_entry_array(DOUBLE, n);
-        for (i, v) in vals.iter().enumerate() {
-            let slot = ctx.block().gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
-            ctx.block().store(DOUBLE, v, &slot);
+    rooting::with_operands_rooted(ctx, &element_refs, |ctx, vals| {
+        // #5391: oversized modules outline array-literal construction. The inline
+        // bump-alloc + N×(store + layout-note + barrier) sequence makes minified
+        // data-table builders huge (single 18MB functions clang -O0 can't compile
+        // in practical time). Instead spill the already-evaluated element values to
+        // a per-literal stack buffer and build the array in ONE runtime call. The
+        // buffer is hoisted to the entry block (fixed size per site; bounded total
+        // stack) and consumed immediately by the call, so no GC-visible window.
+        if crate::codegen::full_outline_ic_enabled() {
+            let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+            for (i, v) in vals.iter().enumerate() {
+                let slot = ctx.block().gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                ctx.block().store(DOUBLE, v, &slot);
+            }
+            let n_str = n.to_string();
+            let arr = ctx
+                .block()
+                .call(I64, "js_array_from_values", &[(PTR, &buf), (I32, &n_str)]);
+            return Ok(nanbox_pointer_inline(ctx.block(), &arr));
         }
-        let n_str = n.to_string();
+
+        // Inline bump-allocator path for small literals. Size threshold matches
+        // `MAX_SCALAR_ARRAY_LEN` in collectors.rs so every candidate the escape
+        // pass rejects can still benefit from the inline alloc.
+        const INLINE_MAX_ELEMENTS: usize = 16;
+        if n <= INLINE_MAX_ELEMENTS {
+            // Layout constants — must match `ArrayHeader` in array.rs and
+            // `GcHeader` in gc.rs. Duplicated here because codegen emits raw
+            // byte offsets; the runtime declarations are authoritative.
+            const GC_HEADER_SIZE: u64 = 8;
+            const ARRAY_HEADER_SIZE: u64 = 8;
+            const ELEMENT_SIZE: u64 = 8;
+            const GC_TYPE_ARRAY: u64 = 1;
+            const GC_FLAG_ARENA: u64 = 0x02;
+            // PR #1146: pointer-free hint for slot-layout tracking. The
+            // element-store loop below only suppresses per-slot notes for
+            // values whose non-pointer bits are proven by expression shape.
+            const GC_LAYOUT_POINTER_FREE: u64 = 0x4000;
+
+            let total_size = GC_HEADER_SIZE + ARRAY_HEADER_SIZE + (n as u64) * ELEMENT_SIZE;
+            let total_size_str = total_size.to_string();
+
+            // Lazy per-function slot for the arena state pointer. Reused for
+            // `new ClassName()` inline allocs; first one to hit creates it.
+            let arena_state_slot = if let Some(slot) = ctx.arena_state_slot.clone() {
+                slot
+            } else {
+                let slot = ctx.func.entry_init_call_ptr("js_inline_arena_state");
+                ctx.arena_state_slot = Some(slot.clone());
+                slot
+            };
+
+            // Load state + compute bump check. `total_size` is always a
+            // multiple of 8, every prior alloc rounds offset to 8, and blocks
+            // start 8-aligned, so no align-up step is needed.
+            let blk = ctx.block();
+            let state_ptr = blk.load(PTR, &arena_state_slot);
+            let offset_field_ptr = blk.gep(I8, &state_ptr, &[(I64, "8")]);
+            let offset_val = blk.load(I64, &offset_field_ptr);
+            let aligned_off = offset_val.clone();
+            let new_offset = blk.add(I64, &aligned_off, &total_size_str);
+            let size_field_ptr = blk.gep(I8, &state_ptr, &[(I64, "16")]);
+            let size_val = blk.load(I64, &size_field_ptr);
+            let fits = blk.icmp_ule(I64, &new_offset, &size_val);
+
+            let fast_idx = ctx.new_block("arrlit.fast");
+            let slow_idx = ctx.new_block("arrlit.slow");
+            let merge_idx = ctx.new_block("arrlit.merge");
+            let fast_label = ctx.block_label(fast_idx);
+            let slow_label = ctx.block_label(slow_idx);
+            let merge_label = ctx.block_label(merge_idx);
+
+            ctx.block().cond_br(&fits, &fast_label, &slow_label);
+
+            // Fast path: commit the bump, compute `data + offset`.
+            ctx.current_block = fast_idx;
+            let blk = ctx.block();
+            // GC_STORE_AUDIT(INIT): arena bump offset is allocator metadata, not a JS heap edge.
+            blk.store(I64, &new_offset, &offset_field_ptr);
+            let data_ptr = blk.load(PTR, &state_ptr);
+            let raw_fast = blk.gep(I8, &data_ptr, &[(I64, &aligned_off)]);
+            let fast_pred_label = blk.label.clone();
+            blk.br(&merge_label);
+
+            // Slow path: call the runtime slow-alloc (same one used by the
+            // inline `new` path). Returns a fresh raw pointer (inclusive of
+            // GcHeader space).
+            ctx.current_block = slow_idx;
+            let raw_slow = ctx.block().call(
+                PTR,
+                "js_inline_arena_slow_alloc",
+                &[(PTR, &state_ptr), (I64, &total_size_str), (I64, "8")],
+            );
+            let slow_pred_label = ctx.block().label.clone();
+            ctx.block().br(&merge_label);
+
+            // Merge: phi the raw pointer and write everything.
+            ctx.current_block = merge_idx;
+            let blk = ctx.block();
+            let raw = blk.phi(
+                PTR,
+                &[(&raw_fast, &fast_pred_label), (&raw_slow, &slow_pred_label)],
+            );
+
+            // Packed GcHeader (bits 0..7 obj_type, 8..15 gc_flags, 16..31
+            // _reserved, 32..63 size). PR #1146 packs the layout-tag in the
+            // reserved bits so the GC sees the array as pointer-free until
+            // the element-store loop overrides per-slot via
+            // `js_gc_note_slot_layout` below.
+            let gc_packed: u64 = GC_TYPE_ARRAY
+                | (GC_FLAG_ARENA << 8)
+                | (GC_LAYOUT_POINTER_FREE << 16)
+                | (total_size << 32);
+            // GC_STORE_AUDIT(INIT): freshly allocated array header starts pointer-free until slot notes below.
+            blk.store(I64, &gc_packed.to_string(), &raw);
+
+            // Packed ArrayHeader at raw+8 (length low 32 / capacity high 32).
+            let arr_header_addr = blk.gep(I8, &raw, &[(I64, "8")]);
+            let arr_header_packed = (n as u64) | ((n as u64) << 32);
+            // GC_STORE_AUDIT(INIT): freshly allocated ArrayHeader length/capacity, no child pointer.
+            blk.store(I64, &arr_header_packed.to_string(), &arr_header_addr);
+
+            // User pointer = raw + GC_HEADER_SIZE. Computed before the
+            // element loop so the per-slot layout notes target the correct
+            // user-visible address.
+            let user_ptr = blk.gep(I8, &raw, &[(I64, "8")]);
+            let user_ptr_as_i64 = blk.ptrtoint(&user_ptr, I64);
+
+            // Elements at raw+16 + i*8.
+            for (i, v) in vals.iter().enumerate() {
+                let offset = (16 + i * 8).to_string();
+                let elem_ptr = blk.gep_inbounds(I8, &raw, &[(I64, &offset)]);
+                let slot_index = i.to_string();
+                emit_jsvalue_slot_store_on_block(
+                    blk,
+                    &elem_ptr,
+                    v,
+                    &user_ptr_as_i64,
+                    &slot_index,
+                    layout_notes_needed[i],
+                    &user_ptr_as_i64,
+                    "0",
+                    false,
+                );
+            }
+
+            if all_numeric_elements {
+                blk.call(
+                    I32,
+                    "js_array_mark_numeric_f64_layout",
+                    &[(I64, &user_ptr_as_i64)],
+                );
+            }
+
+            return Ok(nanbox_pointer_inline(ctx.block(), &user_ptr_as_i64));
+        }
+
+        // Fallback for N > INLINE_MAX_ELEMENTS: keep the extern call + N inline
+        // stores. Thin-LTO already inlines this call into user IR, so the cost
+        // is ~1 inlined arena bump plus some LLVM churn around the arg pack.
+        let cap_str = n.to_string();
         let arr = ctx
             .block()
-            .call(I64, "js_array_from_values", &[(PTR, &buf), (I32, &n_str)]);
-        let boxed = nanbox_pointer_inline(ctx.block(), &arr);
-        temp_root_release(ctx, element_guard);
-        return Ok(boxed);
-    }
+            .call(I64, "js_array_alloc_literal", &[(I32, &cap_str)]);
 
-    // Inline bump-allocator path for small literals. Size threshold matches
-    // `MAX_SCALAR_ARRAY_LEN` in collectors.rs so every candidate the escape
-    // pass rejects can still benefit from the inline alloc.
-    const INLINE_MAX_ELEMENTS: usize = 16;
-    if n <= INLINE_MAX_ELEMENTS {
-        // Layout constants — must match `ArrayHeader` in array.rs and
-        // `GcHeader` in gc.rs. Duplicated here because codegen emits raw
-        // byte offsets; the runtime declarations are authoritative.
-        const GC_HEADER_SIZE: u64 = 8;
-        const ARRAY_HEADER_SIZE: u64 = 8;
-        const ELEMENT_SIZE: u64 = 8;
-        const GC_TYPE_ARRAY: u64 = 1;
-        const GC_FLAG_ARENA: u64 = 0x02;
-        // PR #1146: pointer-free hint for slot-layout tracking. The
-        // element-store loop below only suppresses per-slot notes for
-        // values whose non-pointer bits are proven by expression shape.
-        const GC_LAYOUT_POINTER_FREE: u64 = 0x4000;
-
-        let total_size = GC_HEADER_SIZE + ARRAY_HEADER_SIZE + (n as u64) * ELEMENT_SIZE;
-        let total_size_str = total_size.to_string();
-
-        // Lazy per-function slot for the arena state pointer. Reused for
-        // `new ClassName()` inline allocs; first one to hit creates it.
-        let arena_state_slot = if let Some(slot) = ctx.arena_state_slot.clone() {
-            slot
-        } else {
-            let slot = ctx.func.entry_init_call_ptr("js_inline_arena_state");
-            ctx.arena_state_slot = Some(slot.clone());
-            slot
-        };
-
-        // Load state + compute bump check. `total_size` is always a
-        // multiple of 8, every prior alloc rounds offset to 8, and blocks
-        // start 8-aligned, so no align-up step is needed.
-        let blk = ctx.block();
-        let state_ptr = blk.load(PTR, &arena_state_slot);
-        let offset_field_ptr = blk.gep(I8, &state_ptr, &[(I64, "8")]);
-        let offset_val = blk.load(I64, &offset_field_ptr);
-        let aligned_off = offset_val.clone();
-        let new_offset = blk.add(I64, &aligned_off, &total_size_str);
-        let size_field_ptr = blk.gep(I8, &state_ptr, &[(I64, "16")]);
-        let size_val = blk.load(I64, &size_field_ptr);
-        let fits = blk.icmp_ule(I64, &new_offset, &size_val);
-
-        let fast_idx = ctx.new_block("arrlit.fast");
-        let slow_idx = ctx.new_block("arrlit.slow");
-        let merge_idx = ctx.new_block("arrlit.merge");
-        let fast_label = ctx.block_label(fast_idx);
-        let slow_label = ctx.block_label(slow_idx);
-        let merge_label = ctx.block_label(merge_idx);
-
-        ctx.block().cond_br(&fits, &fast_label, &slow_label);
-
-        // Fast path: commit the bump, compute `data + offset`.
-        ctx.current_block = fast_idx;
-        let blk = ctx.block();
-        // GC_STORE_AUDIT(INIT): arena bump offset is allocator metadata, not a JS heap edge.
-        blk.store(I64, &new_offset, &offset_field_ptr);
-        let data_ptr = blk.load(PTR, &state_ptr);
-        let raw_fast = blk.gep(I8, &data_ptr, &[(I64, &aligned_off)]);
-        let fast_pred_label = blk.label.clone();
-        blk.br(&merge_label);
-
-        // Slow path: call the runtime slow-alloc (same one used by the
-        // inline `new` path). Returns a fresh raw pointer (inclusive of
-        // GcHeader space).
-        ctx.current_block = slow_idx;
-        let raw_slow = ctx.block().call(
-            PTR,
-            "js_inline_arena_slow_alloc",
-            &[(PTR, &state_ptr), (I64, &total_size_str), (I64, "8")],
-        );
-        let slow_pred_label = ctx.block().label.clone();
-        ctx.block().br(&merge_label);
-
-        // Merge: phi the raw pointer and write everything.
-        ctx.current_block = merge_idx;
-        let blk = ctx.block();
-        let raw = blk.phi(
-            PTR,
-            &[(&raw_fast, &fast_pred_label), (&raw_slow, &slow_pred_label)],
-        );
-
-        // Packed GcHeader (bits 0..7 obj_type, 8..15 gc_flags, 16..31
-        // _reserved, 32..63 size). PR #1146 packs the layout-tag in the
-        // reserved bits so the GC sees the array as pointer-free until
-        // the element-store loop overrides per-slot via
-        // `js_gc_note_slot_layout` below.
-        let gc_packed: u64 = GC_TYPE_ARRAY
-            | (GC_FLAG_ARENA << 8)
-            | (GC_LAYOUT_POINTER_FREE << 16)
-            | (total_size << 32);
-        // GC_STORE_AUDIT(INIT): freshly allocated array header starts pointer-free until slot notes below.
-        blk.store(I64, &gc_packed.to_string(), &raw);
-
-        // Packed ArrayHeader at raw+8 (length low 32 / capacity high 32).
-        let arr_header_addr = blk.gep(I8, &raw, &[(I64, "8")]);
-        let arr_header_packed = (n as u64) | ((n as u64) << 32);
-        // GC_STORE_AUDIT(INIT): freshly allocated ArrayHeader length/capacity, no child pointer.
-        blk.store(I64, &arr_header_packed.to_string(), &arr_header_addr);
-
-        // User pointer = raw + GC_HEADER_SIZE. Computed before the
-        // element loop so the per-slot layout notes target the correct
-        // user-visible address.
-        let user_ptr = blk.gep(I8, &raw, &[(I64, "8")]);
-        let user_ptr_as_i64 = blk.ptrtoint(&user_ptr, I64);
-
-        // Elements at raw+16 + i*8.
+        let arr_ptr = ctx.block().inttoptr(I64, &arr);
         for (i, v) in vals.iter().enumerate() {
-            let offset = (16 + i * 8).to_string();
-            let elem_ptr = blk.gep_inbounds(I8, &raw, &[(I64, &offset)]);
+            let offset = (8 + i * 8).to_string();
+            let elem_ptr = ctx.block().gep_inbounds(I8, &arr_ptr, &[(I64, &offset)]);
+            let elem_addr = if layout_notes_needed[i] {
+                ctx.block().ptrtoint(&elem_ptr, I64)
+            } else {
+                "0".to_string()
+            };
             let slot_index = i.to_string();
             emit_jsvalue_slot_store_on_block(
-                blk,
+                ctx.block(),
                 &elem_ptr,
                 v,
-                &user_ptr_as_i64,
+                &arr,
                 &slot_index,
                 layout_notes_needed[i],
-                &user_ptr_as_i64,
-                "0",
-                false,
+                &arr,
+                &elem_addr,
+                layout_notes_needed[i],
             );
         }
 
         if all_numeric_elements {
-            blk.call(
-                I32,
-                "js_array_mark_numeric_f64_layout",
-                &[(I64, &user_ptr_as_i64)],
-            );
+            ctx.block()
+                .call(I32, "js_array_mark_numeric_f64_layout", &[(I64, &arr)]);
         }
 
-        let boxed = nanbox_pointer_inline(ctx.block(), &user_ptr_as_i64);
-        temp_root_release(ctx, element_guard);
-        return Ok(boxed);
-    }
-
-    // Fallback for N > INLINE_MAX_ELEMENTS: keep the extern call + N inline
-    // stores. Thin-LTO already inlines this call into user IR, so the cost
-    // is ~1 inlined arena bump plus some LLVM churn around the arg pack.
-    let cap_str = n.to_string();
-    let arr = ctx
-        .block()
-        .call(I64, "js_array_alloc_literal", &[(I32, &cap_str)]);
-
-    let arr_ptr = ctx.block().inttoptr(I64, &arr);
-    for (i, v) in vals.iter().enumerate() {
-        let offset = (8 + i * 8).to_string();
-        let elem_ptr = ctx.block().gep_inbounds(I8, &arr_ptr, &[(I64, &offset)]);
-        let elem_addr = if layout_notes_needed[i] {
-            ctx.block().ptrtoint(&elem_ptr, I64)
-        } else {
-            "0".to_string()
-        };
-        let slot_index = i.to_string();
-        emit_jsvalue_slot_store_on_block(
-            ctx.block(),
-            &elem_ptr,
-            v,
-            &arr,
-            &slot_index,
-            layout_notes_needed[i],
-            &arr,
-            &elem_addr,
-            layout_notes_needed[i],
-        );
-    }
-
-    if all_numeric_elements {
-        ctx.block()
-            .call(I32, "js_array_mark_numeric_f64_layout", &[(I64, &arr)]);
-    }
-
-    let boxed = nanbox_pointer_inline(ctx.block(), &arr);
-    temp_root_release(ctx, element_guard);
-    Ok(boxed)
+        Ok(nanbox_pointer_inline(ctx.block(), &arr))
+    })
 }

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -3,6 +3,38 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Layer 1 migrated module (#7615, slice 3)
+//!
+//! Nothing here names `expr::temp_root`, and nothing here did before the
+//! migration either — so the ledger line is **vacuous on the committed source**
+//! and only means something because the slice ran the sabotage arm (a real
+//! `temp_root_push_i64` / `temp_root_truncate` pair injected here turns
+//! `migrated_modules_do_not_reach_past_the_rooting_api` red). Slices 1a and 1b
+//! carried the same caveat. `ArrayPushSpread`'s operand pair goes through
+//! [`crate::rooting::with_operands_rooted`], which is a documentation change
+//! rather than a repair: the group's window is empty, so it emits nothing.
+//!
+//! ## Why `Expr::ArrayPush` has no window — and what that rests on
+//!
+//! Both arms lower the **pushed value first and the receiver second**, and the
+//! receiver is `Expr::LocalGet`, i.e. a load from the local's alloca / box /
+//! module global. A load taken *after* the value's arbitrary user code observes
+//! whatever an evacuating cycle wrote back into that storage, so there is no
+//! stale register to repair and `operand_protection` would answer `Reuse`.
+//! Everything the arms emit below that point — `js_array_push_f64`,
+//! `js_array_concat`, the header probes, `js_gc_note_slot_layout`,
+//! `js_write_barrier_slot`, `js_array_length` — either consumes the pointer it
+//! is handed or cannot re-enter user code, so no value crosses a moving window.
+//!
+//! That safety is a **consequence of an evaluation order the spec does not
+//! permit**, which is what this audit found: `a.push(f())` must push onto the
+//! array `a.push` resolved *before* `f` ran, and perry pushes onto whatever `a`
+//! names afterwards. Reported separately rather than fixed here — the fix is to
+//! lower the receiver first and carry it across the value with
+//! `with_operands_rooted_across`, which turns a today-free arm into one that
+//! roots on every pointer-valued push, and this slice is a behaviour-preserving
+//! refactor with no mandate to measure that.
 
 use anyhow::{anyhow, Result};
 use perry_hir::Expr;
@@ -12,6 +44,7 @@ use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
+use crate::rooting;
 use crate::type_analysis::is_numeric_expr;
 use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
@@ -679,76 +712,86 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr, value_discarded: bool) -> 
         // return pointer, and write back to whichever storage backs
         // `array_id`. Issue #248.
         Expr::ArrayPushSpread { array_id, source } => {
-            let src_box = lower_expr(ctx, source)?;
-            let arr_box = lower_expr(ctx, &Expr::LocalGet(*array_id))?;
-            let blk = ctx.block();
-            let dst_handle = unbox_to_i64(blk, &arr_box);
-            let src_handle = unbox_to_i64(blk, &src_box);
-            let new_handle = blk.call(
-                I64,
-                "js_array_concat",
-                &[(I64, &dst_handle), (I64, &src_handle)],
-            );
-            let new_box = nanbox_pointer_inline(blk, &new_handle);
-            if ctx.boxed_vars.contains(array_id) {
+            let array_expr = Expr::LocalGet(*array_id);
+            // The operand pair, stated through the API instead of by statement
+            // order. The window is EMPTY and stays empty: the only thing lowered
+            // after `source` is the receiver, which is a slot read, so
+            // `operand_protection` answers `Reuse` for both and this emits no
+            // rooting IR at all. It is here so that a later edit which inserts a
+            // lowering between the two is a change to a rooted group rather than
+            // a silent reopening.
+            rooting::with_operands_rooted(ctx, &[source.as_ref(), &array_expr], |ctx, vals| {
+                let blk = ctx.block();
+                let dst_handle = unbox_to_i64(blk, &vals[1]);
+                let src_handle = unbox_to_i64(blk, &vals[0]);
+                let new_handle = blk.call(
+                    I64,
+                    "js_array_concat",
+                    &[(I64, &dst_handle), (I64, &src_handle)],
+                );
+                let new_box = nanbox_pointer_inline(blk, &new_handle);
+                if ctx.boxed_vars.contains(array_id) {
+                    if let Some(&capture_idx) = ctx.closure_captures.get(array_id) {
+                        let closure_ptr = super::current_closure_ptr_value(
+                            ctx,
+                            "ArrayPushSpread boxed captured",
+                        )?;
+                        let idx_str = capture_idx.to_string();
+                        let blk = ctx.block();
+                        let box_ptr = blk.call(
+                            I64,
+                            "js_closure_get_capture_bits",
+                            &[(I64, &closure_ptr), (I32, &idx_str)],
+                        );
+                        let new_bits = blk.bitcast_double_to_i64(&new_box);
+                        blk.call_void("js_box_set_bits", &[(I64, &box_ptr), (I64, &new_bits)]);
+                        // Gen-GC Phase C2: the realloc'd array head is a (possibly
+                        // young) heap pointer stored into an existing box — barrier
+                        // the box parent so a minor GC can't miss it.
+                        emit_write_barrier(ctx, &box_ptr, &new_bits);
+                        // Box content is the shared storage; the capture slot must keep
+                        // pointing at the box. Return so we don't fall through to the
+                        // capture-slot store, which would clobber the box pointer (see
+                        // the matching note in `Expr::ArrayPush`).
+                        return Ok(emit_array_handle_length(ctx, &new_handle, value_discarded));
+                    } else if let Some(slot) = ctx.locals.get(array_id).cloned() {
+                        let blk = ctx.block();
+                        let box_ptr = blk.load(I64, &slot);
+                        let new_bits = blk.bitcast_double_to_i64(&new_box);
+                        blk.call_void("js_box_set_bits", &[(I64, &box_ptr), (I64, &new_bits)]);
+                        // Gen-GC Phase C2: barrier the box parent (see capture path).
+                        emit_write_barrier(ctx, &box_ptr, &new_bits);
+                        return Ok(emit_array_handle_length(ctx, &new_handle, value_discarded));
+                    }
+                    // #5459: in `boxed_vars` but no box location here — a module-level
+                    // global accessed directly from a nested function. Fall through to
+                    // the module-global store-back so the relocated head reaches the
+                    // GC-root slot (see the matching note in `Expr::ArrayPush`).
+                }
                 if let Some(&capture_idx) = ctx.closure_captures.get(array_id) {
                     let closure_ptr =
-                        super::current_closure_ptr_value(ctx, "ArrayPushSpread boxed captured")?;
+                        super::current_closure_ptr_value(ctx, "ArrayPushSpread captured")?;
                     let idx_str = capture_idx.to_string();
-                    let blk = ctx.block();
-                    let box_ptr = blk.call(
-                        I64,
-                        "js_closure_get_capture_bits",
-                        &[(I64, &closure_ptr), (I32, &idx_str)],
+                    let new_bits = ctx.block().bitcast_double_to_i64(&new_box);
+                    ctx.block().call_void(
+                        "js_closure_set_capture_bits",
+                        &[(I64, &closure_ptr), (I32, &idx_str), (I64, &new_bits)],
                     );
-                    let new_bits = blk.bitcast_double_to_i64(&new_box);
-                    blk.call_void("js_box_set_bits", &[(I64, &box_ptr), (I64, &new_bits)]);
-                    // Gen-GC Phase C2: the realloc'd array head is a (possibly
-                    // young) heap pointer stored into an existing box — barrier
-                    // the box parent so a minor GC can't miss it.
-                    emit_write_barrier(ctx, &box_ptr, &new_bits);
-                    // Box content is the shared storage; the capture slot must keep
-                    // pointing at the box. Return so we don't fall through to the
-                    // capture-slot store, which would clobber the box pointer (see
-                    // the matching note in `Expr::ArrayPush`).
-                    return Ok(emit_array_handle_length(ctx, &new_handle, value_discarded));
+                    // Gen-GC Phase C2: the realloc'd array head stored into the
+                    // closure capture is a (possibly young) heap pointer — barrier
+                    // the closure parent.
+                    emit_write_barrier(ctx, &closure_ptr, &new_bits);
                 } else if let Some(slot) = ctx.locals.get(array_id).cloned() {
-                    let blk = ctx.block();
-                    let box_ptr = blk.load(I64, &slot);
-                    let new_bits = blk.bitcast_double_to_i64(&new_box);
-                    blk.call_void("js_box_set_bits", &[(I64, &box_ptr), (I64, &new_bits)]);
-                    // Gen-GC Phase C2: barrier the box parent (see capture path).
-                    emit_write_barrier(ctx, &box_ptr, &new_bits);
-                    return Ok(emit_array_handle_length(ctx, &new_handle, value_discarded));
+                    ctx.block().store(DOUBLE, &new_box, &slot);
+                } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
+                    let g_ref = format!("@{}", global_name);
+                    // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
+                    emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
+                } else {
+                    return Err(anyhow!("ArrayPushSpread({}): local not in scope", array_id));
                 }
-                // #5459: in `boxed_vars` but no box location here — a module-level
-                // global accessed directly from a nested function. Fall through to
-                // the module-global store-back so the relocated head reaches the
-                // GC-root slot (see the matching note in `Expr::ArrayPush`).
-            }
-            if let Some(&capture_idx) = ctx.closure_captures.get(array_id) {
-                let closure_ptr =
-                    super::current_closure_ptr_value(ctx, "ArrayPushSpread captured")?;
-                let idx_str = capture_idx.to_string();
-                let new_bits = ctx.block().bitcast_double_to_i64(&new_box);
-                ctx.block().call_void(
-                    "js_closure_set_capture_bits",
-                    &[(I64, &closure_ptr), (I32, &idx_str), (I64, &new_bits)],
-                );
-                // Gen-GC Phase C2: the realloc'd array head stored into the
-                // closure capture is a (possibly young) heap pointer — barrier
-                // the closure parent.
-                emit_write_barrier(ctx, &closure_ptr, &new_bits);
-            } else if let Some(slot) = ctx.locals.get(array_id).cloned() {
-                ctx.block().store(DOUBLE, &new_box, &slot);
-            } else if let Some(global_name) = ctx.module_globals.get(array_id).cloned() {
-                let g_ref = format!("@{}", global_name);
-                // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
-            } else {
-                return Err(anyhow!("ArrayPushSpread({}): local not in scope", array_id));
-            }
-            Ok(emit_array_handle_length(ctx, &new_handle, value_discarded))
+                Ok(emit_array_handle_length(ctx, &new_handle, value_discarded))
+            })
         }
 
         // -------- Closures (Phase D.1) --------

--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -1,16 +1,53 @@
 //! Object-literal lowering (extracted from `expr.rs`, issue #1098).
 //! Pure move — no logic changes.
+//!
+//! # Layer 1 migrated module (#7615, slice 3)
+//!
+//! Nothing here names `expr::temp_root`. Both build paths root the half-built
+//! object through [`crate::rooting::with_rooted_accumulator`], and so does the
+//! *other* GC value this lowering holds across user code — a `this`-capturing
+//! method closure's value, which the patch loop consumes below every remaining
+//! initializer. `crate::rooting::migration_ledger` fails the build if this
+//! module reaches back into the raw API.
+//!
+//! ## Why the closure values nest rather than sitting in a list
+//!
+//! #6951 rooted them as a flat `Vec` of raw slots and released none of them:
+//! the object handle's own `temp_root_truncate` is a stack **cut**, so cutting
+//! at the handle dropped every closure slot above it. That is correct, and it
+//! is correct only because of an invariant stated in a comment — "keep
+//! `rooted_handle_begin` ahead of this loop and the release after the patch
+//! loop". Reorder those two statements and the leak is silent.
+//!
+//! Nesting one `with_rooted_accumulator` per such property expresses the same
+//! lifetime as a scope: each value's root spans exactly the suffix of the
+//! literal that follows it, the release is owned on every path out (including a
+//! `?` from a later initializer, which the flat form leaked), and the value can
+//! only be read in `finish` — below the last initializer, above the release.
+//! No fourth combinator: the three existing `with_operands_rooted*` forms all
+//! lower their own operand list up front, which would evaluate every property
+//! before storing any of them and reorder observable side effects, and
+//! `with_rooted_accumulator` is exactly "a GC value held while more user code
+//! is lowered".
+//!
+//! ## What the migration found here
+//!
+//! Nothing new. #6951's rooting was already complete and correctly ordered —
+//! the handle is rooted immediately after its allocation, every field store
+//! re-reads it, the interned key is loaded *below* the value's lowering (the
+//! #7627 finding, already right in this arm), and the deferred closure values
+//! are re-read before the patch loop. This is a translation, and the IR differs
+//! only by instruction-order permutations with the identical opcode multiset:
+//! the re-read is now fused to the emission that consumes it, so it lands after
+//! the value's `bitcast` / the key's `and` instead of before.
 
 use anyhow::Result;
 use perry_hir::types::Type as HirType;
 use perry_hir::Expr;
 
-use super::temp_root::{
-    any_may_trigger_gc, rooted_handle_begin, rooted_handle_get, rooted_handle_release,
-    temp_root_get_double, temp_root_push_double,
-};
 use super::{lower_expr, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::POINTER_MASK_I64;
+use crate::rooting::{self, Arg, Repr, RootedAcc};
 use crate::type_analysis::compute_auto_captures;
 use crate::types::{DOUBLE, I32, I64, PTR};
 
@@ -172,6 +209,92 @@ fn emit_object_typed_shape_init(
     );
 }
 
+/// Materialize an interned key's raw `StringHeader` pointer.
+///
+/// Emitted **below** the property value's lowering, deliberately: the handle
+/// global is a registered root that an evacuating cycle *rewrites*, so a load
+/// taken above the value would name the pre-move address while the global did
+/// not — the shape #7627 found in `with (o) { x = f() }`. Interning is
+/// compile-time and stays where it was, so the string pool's numbering is
+/// untouched.
+fn emit_interned_key_raw(ctx: &mut FnCtx<'_>, key_handle_global: &str) -> String {
+    let blk = ctx.block();
+    let key_box = blk.load(DOUBLE, key_handle_global);
+    let key_bits = blk.bitcast_double_to_i64(&key_box);
+    blk.and(I64, &key_bits, POINTER_MASK_I64)
+}
+
+/// Lower the by-name path's properties from index `from` onward into the rooted
+/// object accumulator, returning the `(closure value, reserved `this` slot)`
+/// pairs the patch loop needs — innermost first, i.e. reverse source order.
+///
+/// Recursive because a `this`-capturing method closure's value has to stay
+/// rooted for the whole *suffix* of the literal that follows it, which is one
+/// `with_rooted_accumulator` scope per such property. See the module header for
+/// why that is the shape rather than a list of slots.
+fn lower_by_name_props<'f>(
+    ctx: &mut FnCtx<'f>,
+    obj: &mut RootedAcc,
+    props: &[(String, Expr)],
+    from: usize,
+    protect: bool,
+) -> Result<Vec<(String, u32)>> {
+    for (i, (key, value_expr)) in props.iter().enumerate().skip(from) {
+        let key_idx = ctx.strings.intern(key);
+        let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+
+        if let Expr::Closure {
+            params: cparams,
+            body: cbody,
+            captures: ccaps,
+            captures_this: true,
+            ..
+        } = value_expr
+        {
+            let auto_caps = compute_auto_captures(ctx, cparams, cbody, ccaps);
+            let this_idx = auto_caps.len() as u32;
+
+            let v = lower_expr(ctx, value_expr)?;
+            let key_raw = emit_interned_key_raw(ctx, &key_handle_global);
+            obj.call_void(
+                ctx,
+                "js_object_set_field_by_name",
+                &[Arg::Plain(I64, &key_raw), Arg::Plain(DOUBLE, &v)],
+            );
+
+            // The closure value is deferred: the patch loop reads it after every
+            // remaining property has been lowered, so it must survive their
+            // allocations AND be re-read afterwards (an evacuating cycle rewrote
+            // the slot; the register queued above is stale). `build` owns the
+            // rest of the literal, `finish` is the one place the value escapes,
+            // and the release happens on both paths out.
+            let mut rest: Vec<(String, u32)> = Vec::new();
+            let closure_value = rooting::with_rooted_accumulator(
+                ctx,
+                Repr::Boxed,
+                &v,
+                protect,
+                |ctx, _| {
+                    rest = lower_by_name_props(ctx, obj, props, i + 1, protect)?;
+                    Ok(())
+                },
+                |_ctx, closure_value| Ok(closure_value.to_string()),
+            )?;
+            rest.push((closure_value, this_idx));
+            return Ok(rest);
+        }
+
+        let v = lower_expr(ctx, value_expr)?;
+        let key_raw = emit_interned_key_raw(ctx, &key_handle_global);
+        obj.call_void(
+            ctx,
+            "js_object_set_field_by_name",
+            &[Arg::Plain(I64, &key_raw), Arg::Plain(DOUBLE, &v)],
+        );
+    }
+    Ok(Vec::new())
+}
+
 fn is_generator_iterator_object_literal(props: &[(String, Expr)]) -> bool {
     if props.len() != 3 {
         return false;
@@ -229,7 +352,7 @@ pub(crate) fn lower_object_literal(
     // therefore had its half-built object swept by `f`'s collection, and the
     // remaining field stores landed in recycled memory. Root the handle when any
     // initializer can collect; literals of plain locals emit no extra IR.
-    let protect_handle = any_may_trigger_gc(ctx, props.iter().map(|(_, v)| v));
+    let protect_handle = rooting::any_operand_may_collect(ctx, props.iter().map(|(_, v)| v));
     let field_count = props.len() as u32;
     let zero_str = "0".to_string();
     let n_str = field_count.to_string();
@@ -294,143 +417,104 @@ pub(crate) fn lower_object_literal(
             ],
         );
 
-        let rooted = rooted_handle_begin(ctx, &obj_handle, protect_handle);
-        for (i, (_, value_expr)) in props.iter().enumerate() {
-            let v = lower_expr(ctx, value_expr)?;
-            let idx_str = i.to_string();
-            let obj_handle = rooted_handle_get(ctx, &rooted);
-            // Issue #448: the runtime `js_object_set_field` takes its
-            // value as `JSValue` (`#[repr(transparent)] u64`), which the
-            // System V / AArch64 / Win64 ABIs all pass in a *general*-
-            // purpose register. The lowered NaN-box `v` is a `double`,
-            // which the same ABIs pass in a *floating-point* register.
-            // Without the bitcast the call sent the value in xmm0 / d0
-            // while Rust read garbage from rdx / x2, so generator iter
-            // objects (`{next, return, throw}` literals built via the
-            // shape-cache fast path) read back closure-typed fields as
-            // `0` — and the resulting `__iter.next()` dispatch never
-            // returned a real iter-result, so `for…of` over a class
-            // implementing `*[Symbol.iterator]()` hung forever
-            // allocating empty results.
-            let blk = ctx.block();
-            let v_bits = blk.bitcast_double_to_i64(&v);
-            blk.call_void(
-                "js_object_set_field",
-                &[(I64, &obj_handle), (I32, &idx_str), (I64, &v_bits)],
-            );
-        }
-        let obj_handle = rooted_handle_get(ctx, &rooted);
-        if let Some(layout) = typed_layout.as_ref() {
-            emit_object_typed_shape_init(ctx, &obj_handle, layout);
-        }
-        let boxed = nanbox_pointer_inline(ctx.block(), &obj_handle);
-        rooted_handle_release(ctx, rooted);
-        return Ok(boxed);
+        return rooting::with_rooted_accumulator(
+            ctx,
+            Repr::Ptr,
+            &obj_handle,
+            protect_handle,
+            |ctx, obj| {
+                for (i, (_, value_expr)) in props.iter().enumerate() {
+                    let v = lower_expr(ctx, value_expr)?;
+                    let idx_str = i.to_string();
+                    // Issue #448: the runtime `js_object_set_field` takes its
+                    // value as `JSValue` (`#[repr(transparent)] u64`), which the
+                    // System V / AArch64 / Win64 ABIs all pass in a *general*-
+                    // purpose register. The lowered NaN-box `v` is a `double`,
+                    // which the same ABIs pass in a *floating-point* register.
+                    // Without the bitcast the call sent the value in xmm0 / d0
+                    // while Rust read garbage from rdx / x2, so generator iter
+                    // objects (`{next, return, throw}` literals built via the
+                    // shape-cache fast path) read back closure-typed fields as
+                    // `0` — and the resulting `__iter.next()` dispatch never
+                    // returned a real iter-result, so `for…of` over a class
+                    // implementing `*[Symbol.iterator]()` hung forever
+                    // allocating empty results.
+                    let v_bits = ctx.block().bitcast_double_to_i64(&v);
+                    obj.call_void(
+                        ctx,
+                        "js_object_set_field",
+                        &[Arg::Plain(I32, &idx_str), Arg::Plain(I64, &v_bits)],
+                    );
+                }
+                Ok(())
+            },
+            |ctx, obj_handle| {
+                if let Some(layout) = typed_layout.as_ref() {
+                    emit_object_typed_shape_init(ctx, obj_handle, layout);
+                }
+                Ok(nanbox_pointer_inline(ctx.block(), obj_handle))
+            },
+        );
     }
 
     let obj_handle = ctx
         .block()
         .call(I64, "js_object_alloc", &[(I32, &zero_str), (I32, &n_str)]);
-    let rooted = rooted_handle_begin(ctx, &obj_handle, protect_handle);
 
-    // Track `(temp_root_slot, closure_value_double, reserved_this_slot_idx)`
-    // for each method closure that needs `this` patched after the object is
-    // fully built. Enables `calc.add(n) { this.value = ... }`.
+    // `(closure_value_double, reserved_this_slot_idx)` for each method closure
+    // that needs `this` patched after the object is fully built. Enables
+    // `calc.add(n) { this.value = ... }`.
     //
-    // #6951: the closure value is *deferred* — it is reused after every
-    // remaining property has been lowered, so it sits in an SSA register
-    // across all of their allocations. Root it whenever any initializer can
-    // collect, and re-read it before the patch loop.
-    let mut this_patches: Vec<(Option<String>, String, u32)> = Vec::new();
+    // A `RefCell` rather than a plain `&mut`: `build` fills it and `finish`
+    // reads it, and the two closures are handed to `with_rooted_accumulator`
+    // together — a `&mut` in one and a `&` in the other is `E0499`. Nothing
+    // here is re-entrant, so the borrow discipline is trivially satisfied.
+    let this_patches: std::cell::RefCell<Vec<(String, u32)>> = std::cell::RefCell::new(Vec::new());
 
-    for (key, value_expr) in props {
-        let key_idx = ctx.strings.intern(key);
-        let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+    rooting::with_rooted_accumulator(
+        ctx,
+        Repr::Ptr,
+        &obj_handle,
+        protect_handle,
+        |ctx, obj| {
+            let mut patches = lower_by_name_props(ctx, obj, props, 0, protect_handle)?;
+            // `lower_by_name_props` returns innermost-first, i.e. the LAST
+            // method closure in source order first, because each nesting
+            // appends its own value after the suffix it wrapped.
+            patches.reverse();
+            *this_patches.borrow_mut() = patches;
+            Ok(())
+        },
+        |ctx, obj_handle| {
+            // Patch each method closure's reserved `this` slot with the object
+            // pointer (NaN-boxed). Done AFTER all fields are set so every
+            // method sees the fully-initialized object. Every closure value
+            // reaching here was read in its own `finish`, i.e. below the last
+            // initializer that could have relocated it.
+            let this_patches = this_patches.borrow();
+            if !this_patches.is_empty() {
+                let blk = ctx.block();
+                let obj_tagged = {
+                    let tagged = blk.or(I64, obj_handle, crate::nanbox::POINTER_TAG_I64);
+                    blk.bitcast_i64_to_double(&tagged)
+                };
+                for (closure_val, this_idx) in this_patches.iter() {
+                    let bits = blk.bitcast_double_to_i64(closure_val);
+                    let closure_handle = blk.and(I64, &bits, POINTER_MASK_I64);
+                    let idx_str = this_idx.to_string();
+                    let obj_bits = blk.bitcast_double_to_i64(&obj_tagged);
+                    blk.call_void(
+                        "js_closure_set_capture_bits",
+                        &[(I64, &closure_handle), (I32, &idx_str), (I64, &obj_bits)],
+                    );
+                }
+            }
 
-        if let Expr::Closure {
-            params: cparams,
-            body: cbody,
-            captures: ccaps,
-            captures_this: true,
-            ..
-        } = value_expr
-        {
-            let auto_caps = compute_auto_captures(ctx, cparams, cbody, ccaps);
-            let this_idx = auto_caps.len() as u32;
+            if let Some(layout) = typed_layout.as_ref() {
+                emit_object_typed_shape_init(ctx, obj_handle, layout);
+            }
 
-            let v = lower_expr(ctx, value_expr)?;
-            // No explicit release for these: `js_gc_temp_root_truncate` is a
-            // stack CUT, not a pop, and `rooted` was pushed before the loop —
-            // so the single `rooted_handle_release` at the end of this function
-            // drops the object handle AND every closure root above it. That
-            // depends on the push order, so keep `rooted_handle_begin` ahead of
-            // this loop and the release after the patch loop.
-            // (`gc::tests::temp_roots::truncate_drops_every_slot_above_the_base`
-            // pins the cut semantics.)
-            let closure_root = protect_handle.then(|| temp_root_push_double(ctx, &v));
-            this_patches.push((closure_root, v.clone(), this_idx));
-
-            let obj_handle = rooted_handle_get(ctx, &rooted);
-            let blk = ctx.block();
-            let key_box = blk.load(DOUBLE, &key_handle_global);
-            let key_bits = blk.bitcast_double_to_i64(&key_box);
-            let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
-            blk.call_void(
-                "js_object_set_field_by_name",
-                &[(I64, &obj_handle), (I64, &key_raw), (DOUBLE, &v)],
-            );
-            continue;
-        }
-
-        let v = lower_expr(ctx, value_expr)?;
-        let obj_handle = rooted_handle_get(ctx, &rooted);
-        let blk = ctx.block();
-        let key_box = blk.load(DOUBLE, &key_handle_global);
-        let key_bits = blk.bitcast_double_to_i64(&key_box);
-        let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
-        blk.call_void(
-            "js_object_set_field_by_name",
-            &[(I64, &obj_handle), (I64, &key_raw), (DOUBLE, &v)],
-        );
-    }
-
-    // Patch each method closure's reserved `this` slot with the object
-    // pointer (NaN-boxed). Done AFTER all fields are set so every
-    // method sees the fully-initialized object.
-    // Refresh every deferred closure value from its root BEFORE taking the
-    // block builder — an evacuating cycle during a later property's
-    // initializer rewrote the slot, and the register queued above is stale.
-    let this_patches: Vec<(String, u32)> = this_patches
-        .into_iter()
-        .map(|(root, value, this_idx)| match root {
-            Some(idx) => (temp_root_get_double(ctx, &idx), this_idx),
-            None => (value, this_idx),
-        })
-        .collect();
-    let obj_handle = rooted_handle_get(ctx, &rooted);
-    if !this_patches.is_empty() {
-        let blk = ctx.block();
-        let obj_tagged = {
-            let tagged = blk.or(I64, &obj_handle, crate::nanbox::POINTER_TAG_I64);
-            blk.bitcast_i64_to_double(&tagged)
-        };
-        for (closure_val, this_idx) in &this_patches {
-            let bits = blk.bitcast_double_to_i64(closure_val);
-            let closure_handle = blk.and(I64, &bits, POINTER_MASK_I64);
-            let idx_str = this_idx.to_string();
-            let obj_bits = blk.bitcast_double_to_i64(&obj_tagged);
-            blk.call_void(
-                "js_closure_set_capture_bits",
-                &[(I64, &closure_handle), (I32, &idx_str), (I64, &obj_bits)],
-            );
-        }
-    }
-
-    if let Some(layout) = typed_layout.as_ref() {
-        emit_object_typed_shape_init(ctx, &obj_handle, layout);
-    }
-
-    let boxed = nanbox_pointer_inline(ctx.block(), &obj_handle);
-    rooted_handle_release(ctx, rooted);
-    Ok(boxed)
+            Ok(nanbox_pointer_inline(ctx.block(), obj_handle))
+        },
+    )
 }

--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -518,3 +518,240 @@ pub(crate) fn lower_object_literal(
         },
     )
 }
+
+#[cfg(test)]
+mod by_name_method_closure_tests {
+    use perry_hir::types::Type;
+    use perry_hir::{Expr, Function, Module as HirModule, Param, Stmt};
+
+    /// `{ add(k) {…}, tag: {}, scale(k) {…}, last: {} }` — an object literal
+    /// carrying two `this`-capturing method closures. That selects
+    /// `lower_object_literal`'s BY-NAME path and with it the deferred
+    /// `this`-patch machinery this module's nested accumulators root.
+    ///
+    /// Built from HIR rather than from TypeScript on purpose. Since #809 every
+    /// source-level object literal containing a `Prop::Method` is lowered to a
+    /// source-ordered IIFE over `{}` (`js_object_set_method_by_name`), so the
+    /// by-name path with a non-empty prop list is not reachable from
+    /// TypeScript: over the whole `gc_root_dominance_corpus.sh` corpus (129
+    /// sources, 149 modules) every emitted `js_object_alloc` is
+    /// `(i32 0, i32 0)`. A branch no corpus reaches is a branch no IR A/B can
+    /// speak for, so it gets a test of its own rather than an assumption.
+    ///
+    /// The two closures deliberately reserve DIFFERENT `this` slots — `add`
+    /// captures nothing so its slot index is 0, `scale` captures `base` so its
+    /// index is 1 — which is what lets
+    /// [`the_patches_are_applied_in_source_order`] tell the two patch calls
+    /// apart.
+    fn method_literal_ir() -> String {
+        let closure = |func_id: u32, captures: Vec<u32>| {
+            let param_id = 10 + func_id;
+            let mut body = vec![Stmt::Return(Some(Expr::LocalGet(param_id)))];
+            if !captures.is_empty() {
+                body.insert(0, Stmt::Expr(Expr::LocalGet(captures[0])));
+            }
+            Expr::Closure {
+                func_id,
+                params: vec![Param {
+                    id: param_id,
+                    name: "k".to_string(),
+                    ty: Type::Any,
+                    default: None,
+                    decorators: Vec::new(),
+                    is_rest: false,
+                    arguments_object: None,
+                }],
+                return_type: Type::Any,
+                body,
+                captures,
+                mutable_captures: Vec::new(),
+                captures_this: true,
+                captures_new_target: false,
+                enclosing_class: None,
+                is_arrow: false,
+                is_async: false,
+                is_generator: false,
+                is_strict: true,
+            }
+        };
+        let mut hir = HirModule::new("objlit_by_name_test");
+        hir.functions.push(Function {
+            id: 0,
+            name: "build".to_string(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: Type::Any,
+            body: vec![
+                Stmt::Let {
+                    id: 5,
+                    name: "base".to_string(),
+                    ty: Type::Number,
+                    mutable: false,
+                    init: Some(Expr::Number(1.0)),
+                },
+                Stmt::Return(Some(Expr::Object(vec![
+                    ("add".to_string(), closure(1, Vec::new())),
+                    // Allocating initializers AFTER each closure: that is what
+                    // makes `protect_handle` true, i.e. what puts the closure
+                    // values in a window at all.
+                    ("tag".to_string(), Expr::Object(Vec::new())),
+                    ("scale".to_string(), closure(2, vec![5])),
+                    ("last".to_string(), Expr::Object(Vec::new())),
+                ]))),
+            ],
+            is_async: false,
+            is_generator: false,
+            is_strict: true,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+        let opts = crate::CompileOptions {
+            emit_ir_only: true,
+            ..Default::default()
+        };
+        let bytes = crate::compile_module(&hir, opts).expect("test module compiles");
+        String::from_utf8(bytes).expect("LLVM IR is UTF-8")
+    }
+
+    /// The `build` function's body, and only it — the closure bodies are
+    /// separate `define`s and contain none of what is asserted below.
+    fn build_fn(ir: &str) -> String {
+        let mut body = Vec::new();
+        let mut inside = false;
+        for line in ir.lines() {
+            if line.starts_with("define ") {
+                inside = line.contains("__build(");
+                continue;
+            }
+            if inside {
+                if line == "}" {
+                    break;
+                }
+                body.push(line.trim());
+            }
+        }
+        assert!(
+            !body.is_empty(),
+            "no `build` function in the emitted IR:\n{ir}"
+        );
+        body.join("\n")
+    }
+
+    /// Everything the lowering emits after the last property store: the
+    /// deferred closure re-reads, the patch loop, and the releases.
+    fn tail_after_last_property_store(ir: &str) -> String {
+        let last_store = ir
+            .rfind("@js_object_set_field_by_name(")
+            .expect("a by-name store");
+        ir[last_store..].to_string()
+    }
+
+    /// The literal must take the BY-NAME path, or every assertion below is
+    /// about a branch that did not run.
+    #[test]
+    fn a_this_capturing_method_selects_the_by_name_path() {
+        let ir = build_fn(&method_literal_ir());
+        assert!(
+            ir.contains("@js_object_alloc(i32 0, i32 4)"),
+            "the four-property literal must allocate through the by-name path:\n{ir}"
+        );
+        assert_eq!(
+            ir.matches("@js_object_set_field_by_name(").count(),
+            4,
+            "every property is stored by name on this path:\n{ir}"
+        );
+    }
+
+    /// Each `this` patch must be emitted BELOW the last property store — the
+    /// ordering the deferral exists for ("every method sees the fully
+    /// initialized object"), and what forces the closure values to be rooted in
+    /// the first place.
+    ///
+    /// Counting patch calls over the WHOLE function would be vacuous: closure
+    /// construction emits `js_closure_set_capture_bits` too (that is how the
+    /// reserved `this` slot is seeded from `js_implicit_this_get`), so the
+    /// count only means something in the tail.
+    #[test]
+    fn the_this_patches_run_below_every_property_store() {
+        let ir = build_fn(&method_literal_ir());
+        let tail = tail_after_last_property_store(&ir);
+        assert_eq!(
+            tail.matches("@js_closure_set_capture_bits(").count(),
+            2,
+            "one patch per `this`-capturing method, all below the last store:\n{tail}"
+        );
+    }
+
+    /// The patches must be applied in SOURCE order. The nested form fills its
+    /// list innermost-first, so a dropped `reverse()` swaps the two — invisible
+    /// while both closures reserve the same `this` slot index, and a live
+    /// miscompile the moment they do not. Here `add` captures nothing (slot 0)
+    /// and `scale` captures `base` (slot 1), so the order is readable off the
+    /// `i32 <idx>` argument.
+    #[test]
+    fn the_patches_are_applied_in_source_order() {
+        let ir = build_fn(&method_literal_ir());
+        let tail = tail_after_last_property_store(&ir);
+        let idxs: Vec<&str> = tail
+            .lines()
+            .filter(|l| l.contains("@js_closure_set_capture_bits("))
+            .map(|l| {
+                l.split("i32 ")
+                    .nth(1)
+                    .and_then(|s| s.split(',').next())
+                    .expect("the reserved this-slot index")
+            })
+            .collect();
+        assert_eq!(
+            idxs,
+            vec!["0", "1"],
+            "`add` (slot 0) must be patched before `scale` (slot 1) — reverse order \
+             means the nested accumulators' list was not re-reversed:\n{tail}"
+        );
+    }
+
+    /// The rooting shape, read off the IR. Three GC values are live across the
+    /// literal — the object handle and both deferred closure values — so the
+    /// lowering must own three rooted slots and must give each back, innermost
+    /// first, with the object handle released LAST (it is still needed by the
+    /// patch loop).
+    #[test]
+    fn three_slots_are_rooted_and_released_innermost_first() {
+        let full = method_literal_ir();
+        let ir = build_fn(&full);
+        let tail = tail_after_last_property_store(&ir);
+        // Line INDEXES, not `str::find`: the slot registers are `%r3`, `%r16`
+        // and `%r38`, and `%r3` is a prefix of `%r38`, so a substring search for
+        // the object's release finds the first closure's instead — and the
+        // assertion then reads backwards while passing.
+        let releases: Vec<usize> = tail
+            .lines()
+            .enumerate()
+            .filter(|(_, l)| l.starts_with("store ptr addrspace(1) null, ptr %"))
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            releases.len(),
+            3,
+            "the object handle and both closure values must each be released \
+             exactly once below the last store:\n{tail}"
+        );
+        let release_pos = releases[2];
+        let patches: Vec<usize> = tail
+            .lines()
+            .enumerate()
+            .filter(|(_, l)| l.contains("@js_closure_set_capture_bits("))
+            .map(|(i, _)| i)
+            .collect();
+        let patch_pos = *patches.last().expect("a patch call");
+        assert!(
+            release_pos > patch_pos,
+            "the object handle's root must outlive the patch loop that reads it — the \
+             release is a stack CUT, so giving it back early drops every closure slot \
+             above it too:\n{tail}"
+        );
+    }
+}

--- a/crates/perry-codegen/src/expr/objects_arrays_lit.rs
+++ b/crates/perry-codegen/src/expr/objects_arrays_lit.rs
@@ -3,10 +3,36 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Layer 1 migrated module (#7615, slice 3)
+//!
+//! Nothing here names `expr::temp_root`. The spread-literal accumulator — the
+//! canonical shape [`crate::rooting::with_rooted_accumulator`] exists for —
+//! goes through that combinator; `crate::rooting::migration_ledger` fails the
+//! build if this module reaches back into the raw API.
+//!
+//! The other three arms delegate ([`lower_object_literal`],
+//! [`lower_array_literal`]) or lower a single operand that the very next
+//! instruction consumes, which is the template module's rule (`expr/url_main.rs`,
+//! #7617): with nothing lowered after the operand there is no window, and
+//! `operand_protection` would answer `Reuse`.
+//!
+//! ## What the migration found here
+//!
+//! Nothing new. #7280 rooted this accumulator by hand and did it correctly —
+//! push before the first element, re-read before every append, **republish the
+//! append's return value** (the address legitimately changes), read once below
+//! the last append and release above nothing. The migration is therefore a
+//! *translation*, and its IR is byte-identical; claiming it as a closed hazard
+//! would be the overclaim slices 1a/1b warned about. What it buys is that the
+//! republish can no longer be forgotten (`advance` fuses it to the call) and
+//! that the release cannot become branch-conditional — #7462's shape, which
+//! shipped in a sibling arm.
 
 use anyhow::Result;
 use perry_hir::Expr;
 
+use crate::rooting::{self, Arg, Repr};
 use crate::types::{DOUBLE, I32, I64};
 
 use super::{lower_array_literal, lower_expr, lower_object_literal, nanbox_pointer_inline, FnCtx};
@@ -54,48 +80,54 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // 29 of the 77 fatal moving stale uses on the #7280 reproducer are
             // this shape.
             //
-            // `temp_root_set_i64` rather than a fixed `RootedHandle`: the
-            // accumulator's address legitimately CHANGES on every append, so
-            // the slot must be rewritten, not just re-read. Same contract as
-            // the string-concat accumulator (#6971).
+            // `RootedAcc::advance` rather than a fixed slot that is only
+            // re-read: the accumulator's address legitimately CHANGES on every
+            // append, so the slot must be rewritten, not just re-read. Same
+            // contract as the string-concat accumulator (#6971), and the reason
+            // `advance` exists — it fuses "call the helper" to "publish what it
+            // handed back", so the republish is not a statement a later edit can
+            // drop.
             let cap_str = (elements.len() as u32).to_string();
-            let mut current_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap_str)]);
-            let root = super::temp_root::temp_root_push_i64(ctx, &current_arr);
-            for elem in elements {
-                match elem {
-                    ArrayElement::Expr(e) => {
-                        let v = lower_expr(ctx, e)?;
-                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
-                        current_arr = ctx.block().call(
-                            I64,
-                            "js_array_push_f64",
-                            &[(I64, &arr), (DOUBLE, &v)],
-                        );
+            let current_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap_str)]);
+            // `protect` is STATED, not derived from the elements. Two of the
+            // three appends can re-enter user code on their own —
+            // `js_array_spread_append` runs the iterator protocol, and a
+            // spread literal always has at least one — so deriving the window
+            // from the element expressions would answer *false* for
+            // `[...a, ...b]` over two plain locals and drop the root at the one
+            // site that provably needs it. `any_operand_may_collect` is the
+            // right predicate for an operand group, not for a window whose
+            // collection points are the lowering's own emitted calls
+            // (`with_operands_rooted_across_call` makes the same argument).
+            rooting::with_rooted_accumulator(
+                ctx,
+                Repr::Ptr,
+                &current_arr,
+                true,
+                |ctx, acc| {
+                    for elem in elements {
+                        match elem {
+                            ArrayElement::Expr(e) => {
+                                let v = lower_expr(ctx, e)?;
+                                acc.advance(ctx, "js_array_push_f64", &[Arg::Plain(DOUBLE, &v)]);
+                            }
+                            ArrayElement::Hole => {
+                                acc.advance(ctx, "js_array_push_hole", &[]);
+                            }
+                            ArrayElement::Spread(e) => {
+                                let src_box = lower_expr(ctx, e)?;
+                                acc.advance(
+                                    ctx,
+                                    "js_array_spread_append",
+                                    &[Arg::Plain(DOUBLE, &src_box)],
+                                );
+                            }
+                        }
                     }
-                    ArrayElement::Hole => {
-                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
-                        current_arr = ctx.block().call(I64, "js_array_push_hole", &[(I64, &arr)]);
-                    }
-                    ArrayElement::Spread(e) => {
-                        let src_box = lower_expr(ctx, e)?;
-                        let arr = super::temp_root::temp_root_get_i64(ctx, &root);
-                        current_arr = ctx.block().call(
-                            I64,
-                            "js_array_spread_append",
-                            &[(I64, &arr), (DOUBLE, &src_box)],
-                        );
-                    }
-                }
-                // The append may have grown the array (a new address) and may
-                // have run a collection that moved it again. The returned
-                // pointer is the live one; republish it before the next
-                // element's lowering can collect.
-                super::temp_root::temp_root_set_i64(ctx, &root, &current_arr);
-            }
-            let current_arr = super::temp_root::temp_root_get_i64(ctx, &root);
-            let boxed = nanbox_pointer_inline(ctx.block(), &current_arr);
-            super::temp_root::temp_root_truncate(ctx, &root);
-            Ok(boxed)
+                    Ok(())
+                },
+                |ctx, current_arr| Ok(nanbox_pointer_inline(ctx.block(), current_arr)),
+            )
         }
 
         // `arr[i]` index access. INLINE FAST PATH for typed-Number arrays:

--- a/crates/perry-codegen/src/rooting.rs
+++ b/crates/perry-codegen/src/rooting.rs
@@ -804,6 +804,15 @@ pub(crate) fn with_rooted_accumulator<'f, R>(
 /// committed source and not only under sabotage. The sabotage arm was still run
 /// per module — the assert stops at the first offender, so one run cannot speak
 /// for three.
+///
+/// Slice 3 is three of each. `objects_arrays_lit.rs`, `array_literal.rs` and
+/// `object_literal.rs` all named `expr::temp_root` before the migration
+/// (`temp_root_{push,get,set}_i64`, `lower_exprs_rooted`/`temp_root_release`,
+/// `rooted_handle_*`/`temp_root_{push,get}_double`), so their lines are
+/// load-bearing. `array_push.rs` named none and its line is vacuous on the
+/// committed source — the sabotage arm is the only thing that makes it an
+/// assertion, exactly as for both slice-1 modules, and the audit that earned
+/// the listing is written into that file's header rather than into this one.
 #[cfg(test)]
 const MIGRATED_MODULES: &[(&str, &str)] = &[
     (
@@ -833,6 +842,22 @@ const MIGRATED_MODULES: &[(&str, &str)] = &[
     (
         "crates/perry-codegen/src/lower_call/property_get/map_set.rs",
         include_str!("lower_call/property_get/map_set.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/objects_arrays_lit.rs",
+        include_str!("expr/objects_arrays_lit.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/array_literal.rs",
+        include_str!("expr/array_literal.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/object_literal.rs",
+        include_str!("expr/object_literal.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/array_push.rs",
+        include_str!("expr/array_push.rs"),
     ),
 ];
 


### PR DESCRIPTION
Slice 3 of the Layer 1 campaign (#7615) — the **literal accumulators**. Four
modules, 1776 lines, 18 raw sites, 7 hazard sites:
`expr/objects_arrays_lit.rs`, `expr/array_literal.rs`, `expr/object_literal.rs`,
`expr/array_push.rs`. All four are listed in `MIGRATED_MODULES`; none names
`expr::temp_root`. Follows the template (#7617) and slices 1a (#7618),
1b (#7620) and 2 (#7627).

## No new combinator

#7627 asked slice 3 to reuse `with_rooted_accumulator` rather than build a
second one. It does, and so does the one shape that looked like it needed a
fourth:

| site | combinator |
|---|---|
| `[a, ...b, c]`'s growing array (`js_array_push_f64` / `_hole` / `js_array_spread_append`) | `with_rooted_accumulator(Repr::Ptr)` + `advance` |
| `[a, b, c]`'s element group | `with_operands_rooted` |
| an object literal's half-built handle, both build paths | `with_rooted_accumulator(Repr::Ptr)` |
| a `this`-capturing method closure's deferred value | `with_rooted_accumulator(Repr::Boxed)`, **nested one per property** |
| `arr.push(...src)`'s operand pair | `with_operands_rooted` (empty window, emits nothing) |

The nesting is the interesting one. A method closure's value is consumed by the
`this` patch loop *below every remaining initializer*, so its root has to span
exactly the suffix of the literal that follows it, and the number of such values
is data-dependent. The three `with_operands_rooted*` forms cannot express that:
all three lower their own operand list **up front**, which for an object literal
would evaluate every property before storing any of them and reorder observable
side effects. `with_rooted_accumulator` *is* "a GC value held while more user
code is lowered", so the shape is one scope per such property, which falls out
as a small recursion over the property list (`lower_by_name_props`). The list it
returns is innermost-first and re-reversed, and that `reverse()` is pinned by a
test rather than by a comment.

What that replaces is #6951's flat `Vec` of raw slots that were **never
released** — correct only because `temp_root_truncate` is a stack cut and the
object handle sat below them, i.e. correct because of an invariant stated in a
comment ("keep `rooted_handle_begin` ahead of this loop and the release after
the patch loop"). It also leaked the whole group on a `?` from a later
initializer. Nested, the release is owned on every path out.

## Live bug found, and deliberately not fixed here

`arr.push(f())` and `arr.push(...g())` evaluate the **receiver after the
argument**. Per ES2024 the `MemberExpression` is evaluated to a Reference first,
so a `f` that reassigns `arr` must still push onto the array `arr.push` resolved
— node prints `[9]`, perry prints `[9,2]`. Filed as **#7634** with the
reproducer and the prescription.

It is not fixed in this slice because that evaluation order is precisely what
makes the arm rooting-free today: the receiver is an `Expr::LocalGet`, so
reading it *after* the value's arbitrary user code observes whatever an
evacuating cycle wrote back into the local's alloca / box / module global, and
`operand_protection` answers `Reuse`. Restoring spec order puts the receiver in
a window, i.e. every pointer-valued push gains a temp root — expressible with
the existing `with_operands_rooted_across` and needing no new combinator, but
needing a measured before/after on the pinned mini, which a behaviour-preserving
refactor has no mandate to run. Same rule that produced #7628 last slice.

## Scoped honestly

**Three of the four modules are translations, not repairs**, and the PR claims
them as such:

- `objects_arrays_lit.rs` — #7280 rooted the spread accumulator by hand and did
  it right: push before the first element, re-read before every append,
  **republish** the append's return value, read once below the last one. What
  the migration buys is that `advance` fuses the republish to the call, and that
  the release cannot become branch-conditional (#7462's shape, which shipped in
  a sibling arm).
- `array_literal.rs` — #6951's element group was already correct. What is new is
  the release: three exits each carried their own `temp_root_release`, and the
  `?` on every element's lowering released nothing at all.
- `object_literal.rs` — #6951's rooting was complete and correctly ordered,
  including loading the interned key *below* the value's lowering (the #7627
  finding, already right here).

**`array_push.rs`'s ledger line is vacuous on the committed source.** It named
no rooting symbol before the migration and names none after, exactly like both
slice-1 modules; only the sabotage arm makes it an assertion. The audit that
earned the listing is written into that file's header: both arms lower value
first / receiver second, and nothing they emit below that point
(`js_array_push_f64`, `js_array_concat`, the header probes,
`js_gc_note_slot_layout`, `js_write_barrier_slot`, `js_array_length`) either
holds a pointer across a moving window or fails to consume the one it is handed.

## A branch no corpus can reach

`lower_object_literal`'s by-name path with a non-empty property list — the one
carrying the `this`-patch machinery this PR restructures — **is not reachable
from TypeScript**. Since #809 every source-level literal containing a
`Prop::Method` is lowered to a source-ordered IIFE over `{}`
(`js_object_set_method_by_name`). Measured rather than assumed: over the whole
`gc_root_dominance_corpus.sh` corpus (129 sources, 149 modules) **every** emitted
`js_object_alloc` is `(i32 0, i32 0)`.

A branch no corpus reaches is a branch no IR A/B can speak for, so it gets four
unit tests built directly from HIR (`by_name_method_closure_tests`): the by-name
path is actually selected (`js_object_alloc(i32 0, i32 4)` + four
`js_object_set_field_by_name`), both patches run below the last property store,
the two patches are applied in **source order** — readable off the reserved
`this`-slot index, because the two closures deliberately reserve different ones
— and three slots are rooted and released innermost-first with the object handle
released last. Sabotage: deleting the `patches.reverse()` turns the third red
with `left: ["1", "0"] right: ["0", "1"]`.

## Verification (local — the CI backlog is deep, so this is the evidence)

**IR A/B**, both arms built from the same package set in one target dir, the
baseline arm from `c1365ed8a`'s copies of the five touched files:

| corpus | result |
|---|---|
| 4 probes × 2 environments (default; and `PERRY_RS4GC=0 PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_INLINE_SHADOW_SLOT=0`) | **byte-identical** |
| curated dominance corpus — 129 sources, 149 modules, 2452 functions | 2450 identical, **2 differ** |
| dependency-scale corpus — 81 zod modules, 64 MB of IR | **byte-identical** |

Both differences are the same one instruction pair, in the iterator-result
literal `{value, done}`:

```diff
-  %v645 = load i64, ptr %v9
-  %v646 = bitcast double %v640 to i64
-  invoke void @js_object_set_field(i64 %v645, i32 0, i64 %v646)
+  %v645 = bitcast double %v640 to i64
+  %v646 = load i64, ptr %v9
+  invoke void @js_object_set_field(i64 %v646, i32 0, i64 %v645)
```

Root-plumbing only, and in the direction the API exists to enforce: the
accumulator's re-read is now fused to the emission that consumes it, so it lands
*after* the value's `bitcast` instead of before. Identical opcode multiset, same
operands, same call. Per #7625 the emitted IR is run-to-run deterministic, so
the double-compile control is no longer needed.

The probes cover every lowering family in the four modules — verified by counting
call sites rather than by reading the source: `js_object_alloc_with_shape` 14,
`js_object_set_field` 30, `js_object_alloc` 2, `js_gc_init_typed_shape_layout`
11, `js_array_alloc_literal` 4, `js_array_from_values` 10 (`PERRY_FULL_OUTLINE_IC=1`),
`js_array_spread_append` 14, `js_array_push_hole` 2, `js_array_clone_for_spread`
2, `js_array_concat` 3, `js_array_push_f64` 94. (The first p2 probe read its
literals' fields back and every one was scalar-replaced away; the probe now makes
them escape.)

**Gates.** `gc-root-dominance` green in **both** gated modes on **both** corpora
with an empty allowlist:

- curated: 2452 functions / 149 modules / 9846 root stores → 0 violations;
  `--seeded-violations 40` at 40/40; `--unrooted-allocas` 0 over 7867 gc-capable
  allocas;
- dependency-scale: 12899 functions / 81 modules / 12908 root stores → 0
  violations; 40/40 seeded; `--unrooted-allocas` 0 over 15242.

All four checker static audits pass (`--self-test`, `--audit-alloc-re`,
`--audit-poll-capable`, `--audit-immovable-sources`). Root-store counts are
**unchanged** on both corpora, which is what a byte-identical translation should
read.

**Tests.** `cargo test -p perry-codegen --lib` 699 pass (695 + the 4 new);
`--doc` 3 pass with both `compile_fail,E0499` arms still rejecting;
`cargo test -p perry-runtime --no-fail-fast` 1902 pass, 0 failed, first run;
`cargo check --all-targets` clean.

**Gap A/B**, 13 family filters over both prebuilt arms (`PERRY_SKIP_BUILD=1`,
so the binaries are the ones the IR A/B was measured on): 140 journal verdicts
each, **identical sets** (`diff` exit 0) — 126 pass, 1 crash. The crash is
`test_gap_gc_same_module_call_argument_rooting`, a harness 10 s timeout present
identically on both arms; compiled and run directly the binary finishes in 0.5 s,
so it is the `perry-dev` profile's margin, not a fault.

**Runtime instrument.** All four probes byte-identical in stdout and exit code
on both arms, and again under `PERRY_GC_ZEAL=1 PERRY_GC_PROTECT_FROMSPACE=1
PERRY_GC_PROTECT_FROMSPACE_DEPTH=800 PERRY_GC_MOVING_LOOP_POLLS=1`. The
instrument was **live**, not merely enabled: `PERRY_GC_DIAG=1` prints 5
`[gc-fromspace-protect] retired_set=` lines, so copying minors actually ran and
quarantined from-space.

**Ledger sabotage**, per module — the assert stops at the first offender, so one
run cannot speak for four. A real, compiling `temp_root_push_i64` /
`temp_root_truncate` pair injected into each of the four turns
`migrated_modules_do_not_reach_past_the_rooting_api` red and names **both**
planted lines; restored, the ledger is green again. It also caught a genuine
violation in this PR's own new test — an assertion message quoting
`temp_root_truncate` is a code line, not a comment — which is now reworded.

**`lint`.** Every step of the job enumerated from `.github/workflows/test.yml`
was run (27 of them). All pass except `python3
benchmarks/ci_public_baseline_check.py`, which is red on pristine `origin/main`
and has been since 2026-07-29 — #7618, #7620 and #7627 each reported the same
step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory safety while creating array and object literals, including spread operations and closures that capture `this`.
  - Ensured temporary values remain properly available during complex literal construction and are released reliably on success or failure.

- **Tests**
  - Added coverage for literal construction paths, closure patching, root-release ordering, unreachable paths, and garbage-collection safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->