### PR TITLE
refactor(codegen): migrate the computed read/write modules onto the Layer 1 rooting API (#7615)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1363
+**Current Version:** 0.5.1364
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1363"
+version = "0.5.1364"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1363"
+version = "0.5.1364"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1363"
+version = "0.5.1364"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1363"
+version = "0.5.1364"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1363"
+version = "0.5.1364"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7642-layer1-slice4-computed-reads-writes.md
+++ b/changelog.d/7642-layer1-slice4-computed-reads-writes.md
@@ -1,0 +1,73 @@
+### Layer 1 slice 4 — the computed read/write lowerings move onto the rooting API
+
+Slice 4 of the Layer 1 campaign (#7615). Nine modules — `expr/index_get.rs`,
+`expr/index_get/guarded_array.rs`, `expr/index_get/inline_dyn_typed_array.rs`,
+`expr/index_set.rs`, `expr/index_set_typed_array.rs`, `expr/property_get.rs`,
+`expr/property_get/globalget.rs`, `expr/property_get/helpers.rs` and
+`expr/property_set.rs` — are migrated end to end and listed in
+`MIGRATED_MODULES`. No module is left half-migrated and none names
+`expr::temp_root` any more.
+
+**One shape, no new combinator.** Every rooting decision in this slice was the
+`StoreOperandGuard` family — lower the receiver, guard it, lower the rest,
+re-read, store, release — and that is exactly what
+`rooting::with_operands_rooted` and `rooting::with_operands_rooted_across`
+already express. The `across` form is needed wherever the value is lowered by
+`lower_value_for_dynamic_{index,property}_set` or
+`lower_value_for_optional_barrier`, which produce native representations the
+operand list cannot.
+
+**Three live bugs, fixed here** — each the same window every sibling arm has
+guarded since #7154, each on an arm whose store already routes through a runtime
+helper, so the root is noise beside the call:
+
+- **#7637** — `arr.length = f()` had no guard at all. The receiver is lowered
+  first (spec order), `f()` allocates, and `js_array_set_length_strict` then
+  truncates the abandoned from-space copy.
+- **#7638** — two array element stores held a heap-string KEY across the value.
+  `arr[k] = f()` with a non-numeric index rooted the receiver but not the key,
+  on the one arm whose whole purpose is keys that are not proven numeric; and
+  `arr[stringKey] = f()` guarded neither operand.
+- **#7639** — the polymorphic `o[k] = f()` fallback guarded neither operand,
+  and it is the arm reached precisely when nothing about receiver or key is
+  known, so both are heap values by default. Separately, the dynamic-string-key
+  arm derived the receiver's window from `value` alone — the half-measure #7201
+  named in prose — so `o[f()] = 1` was unguarded.
+
+The last one is the argument for the combinator rather than for a better flag:
+`with_operands_rooted_window` computes each operand's window as
+`across_collects || any_may_trigger_gc(exprs[i+1..])`, so "the receiver is live
+across everything after it" is a property of the operand list instead of
+something the author has to restate at each site. The dynamic-string-key arm's
+two nested guards also collapse to one group, retiring the release-inner-to-outer
+obligation that `temp_root_truncate`'s stack-cut semantics imposed.
+
+**What the migration surfaced and did NOT fix — #7640.** Translating the guarded
+arms made visible that about twenty arms in the same files make *no* rooting
+decision at all: the bounded-index array store, the `#5525` inline typed-array
+stores, `globalThis[k] = v`, ten read-side arms of `index_get.rs` where the base
+is live across the key, an unsubstantiated "statepoint re-read" claim above the
+class-field store, and a `unbox_str_handle` ordering hazard that no temp root can
+express. Those sit on inline fast paths where a root is a measured cost, so they
+are filed with a repro and a suggested order rather than smuggled into a
+behaviour-preserving refactor.
+
+That gap is now stated in the ledger itself, because it is the campaign's most
+misreadable result: **a module listed in `MIGRATED_MODULES` is not an audited
+module.** The ledger asserts that every rooting decision a module makes goes
+through `crate::rooting`; a window with no decision at all is invisible to it.
+
+**Verification.** Emitted IR byte-identical on all 149 modules of the curated
+root-dominance corpus and all 81 of the dependency-scale (zod) corpus, with each
+migrated arm's call sites counted in the emitted IR first so the A/B is not
+green over a corpus containing none of the subject. Both gated modes green on
+both corpora with an empty allowlist, `--seeded-violations 40` at 40/40. The
+ledger sabotage was run per module — a real, compiling `temp_root_push_double` /
+`temp_root_truncate` pair planted in each of the nine in turn, each recorded red
+and naming its own file and lines.
+
+The three repaired arms get differential HIR-built unit tests rather than gap
+tests, because they are not reachable from ordinary TypeScript: an assignment
+statement in those shapes lowers to `Expr::PutValueSet` and reaches the dynamic
+IC, not these arms. Measured, not assumed — `js_array_set_length_strict` is
+called zero times across the whole curated corpus.

--- a/crates/perry-codegen/src/expr/computed_store_rooting_tests.rs
+++ b/crates/perry-codegen/src/expr/computed_store_rooting_tests.rs
@@ -1,0 +1,222 @@
+//! Rooting coverage for the three computed-store arms slice 4 repaired
+//! (#7637, #7638, #7639), built from HIR rather than from TypeScript.
+//!
+//! # Why these are unit tests and not gap tests
+//!
+//! Counted, not assumed. Over the whole `gc-root-dominance` curated corpus (129
+//! sources, 149 modules) `js_array_set_length_strict` is **called zero times**,
+//! and the two arms that are reached — `js_typed_feedback_array_set_string_key`
+//! and `js_typed_feedback_object_set_index_polymorphic` — are reached once each,
+//! by a source whose operands provably cannot collect, so the emitted IR is
+//! identical with and without the repair.
+//!
+//! Hand-written probes did not close the gap either, and the reason is
+//! structural rather than a failure of imagination: an ordinary
+//! `o.k = v` / `o[k] = v` assignment statement lowers to `Expr::PutValueSet`
+//! and reaches the dynamic IC (`js_put_value_set_dyn_ic`), NOT the
+//! `Expr::PropertySet` / `Expr::IndexSet` arms in these two modules. Six probe
+//! shapes were tried — module-const and parameter receivers, string / symbol /
+//! `any` keys, inside and outside a function — and every one of them routed
+//! past the subject. That is slice 3's finding 4 again: *a branch the corpora
+//! cannot reach needs a unit test, and the way to find out is to count, not to
+//! read.*
+//!
+//! # What each test asserts, and why it cannot pass vacuously
+//!
+//! Each builds the SAME store twice, changing one thing: the right-hand side is
+//! either an allocating `Expr::Object` or an inert `Expr::Number`. Then it
+//! compares the shadow-frame width the function reserves.
+//!
+//! - `Expr::Number` ⇒ `expr_may_trigger_gc` is false ⇒ `operand_protection`
+//!   returns `Reuse` ⇒ the combinator emits nothing at all, which is the
+//!   property that keeps this slice's IR byte-identical on the corpus.
+//! - `Expr::Object` ⇒ the window collects ⇒ the operands take slots.
+//!
+//! So the assertion is a DIFFERENCE between two runs of the same code path,
+//! which no amount of corpus drift can turn into a tautology, and deleting the
+//! operand group collapses the two counts and turns each test red. Every test
+//! also asserts the arm it is about was actually reached, by name — a frame
+//! width measured over a store that never got emitted would be hazard 4.
+
+use perry_hir::types::Type;
+use perry_hir::{Expr, Function, Module as HirModule, Stmt};
+
+/// Compile a one-function module and return its LLVM IR.
+fn compile_body(name: &str, body: Vec<Stmt>) -> String {
+    let mut hir = HirModule::new(name);
+    hir.functions.push(Function {
+        id: 0,
+        name: "build".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Any,
+        body,
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    });
+    let opts = crate::CompileOptions {
+        emit_ir_only: true,
+        ..Default::default()
+    };
+    let bytes = crate::compile_module(&hir, opts).expect("test module compiles");
+    String::from_utf8(bytes).expect("LLVM IR is UTF-8")
+}
+
+/// How many root slots the module's code reserves.
+///
+/// Counted under BOTH root lowerings on purpose, because which one runs is an
+/// env decision (`PERRY_RS4GC`) and a test that silently measured zero under the
+/// other would be a gate that cannot fail. Under the statepoint lowering — the
+/// default since #7370 — a root slot is an `alloca ptr addrspace(1)`; under the
+/// shadow-stack lowering it is a `js_shadow_slot_bind`. Both arms of each
+/// comparison are compiled in the same process with the same settings, so only
+/// the difference is read.
+fn root_slots(ir: &str) -> usize {
+    ir.matches("alloca ptr addrspace(1)").count() + ir.matches("@js_shadow_slot_bind(").count()
+}
+
+/// An allocating RHS (`{ a: 1 }`) and an inert one (`1`), so each test can
+/// compare the same store under a collecting and a non-collecting window.
+fn allocating_value() -> Expr {
+    Expr::Object(vec![("a".to_string(), Expr::Number(1.0))])
+}
+
+fn inert_value() -> Expr {
+    Expr::Number(1.0)
+}
+
+/// Assert the store arm named by `callee` was emitted, then that an allocating
+/// RHS costs strictly more root slots than an inert one.
+fn assert_operands_rooted_only_when_the_window_collects(
+    label: &str,
+    callee: &str,
+    build: impl Fn(Expr) -> Vec<Stmt>,
+) {
+    let hot = compile_body(&format!("{label}_hot"), build(allocating_value()));
+    let cold = compile_body(&format!("{label}_cold"), build(inert_value()));
+
+    // Subject liveness first: a frame width measured over a store that never
+    // got emitted proves nothing (CLAUDE.md hazard 4).
+    assert!(
+        hot.contains(&format!("@{callee}(")),
+        "{label}: the arm under test was not reached — no call to @{callee}:\n{hot}"
+    );
+    assert!(
+        cold.contains(&format!("@{callee}(")),
+        "{label}: the inert arm took a different path, so the two runs are not \
+         comparable — no call to @{callee}:\n{cold}"
+    );
+
+    let hot_slots = root_slots(&hot);
+    let cold_slots = root_slots(&cold);
+    assert!(
+        hot_slots > cold_slots,
+        "{label}: an allocating RHS must put the store's operands in root slots. \
+         The module reserved {hot_slots} root slots with an allocating RHS and \
+         {cold_slots} with an inert one — equal means the operand group is gone \
+         and the receiver (and key) are live in bare registers across the RHS \
+         again."
+    );
+}
+
+/// #7637 — `arr.length = f()`. The receiver is lowered first because
+/// `Set(O, "length", v, true)` evaluates the reference before the value, and
+/// `js_array_set_length_strict` then truncates through whatever address the
+/// register still holds.
+#[test]
+fn arr_length_store_roots_the_receiver_across_an_allocating_rhs() {
+    assert_operands_rooted_only_when_the_window_collects(
+        "arr_length",
+        "js_array_set_length_strict",
+        |value| {
+            vec![
+                Stmt::Let {
+                    id: 1,
+                    name: "arr".to_string(),
+                    ty: Type::Array(Box::new(Type::Number)),
+                    mutable: false,
+                    init: Some(Expr::Array(vec![Expr::Number(1.0), Expr::Number(2.0)])),
+                },
+                Stmt::Expr(Expr::PropertySet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    property: "length".to_string(),
+                    value: Box::new(value),
+                }),
+            ]
+        },
+    );
+}
+
+/// #7638 arm 2 — `arr[stringKey] = f()`. The key is a heap string by
+/// construction on this arm and `unbox_str_handle` below the RHS would hand the
+/// setter a pre-move `StringHeader*`.
+#[test]
+fn array_string_key_store_roots_both_operands_across_an_allocating_rhs() {
+    assert_operands_rooted_only_when_the_window_collects(
+        "array_string_key",
+        "js_typed_feedback_array_set_string_key",
+        |value| {
+            vec![
+                Stmt::Let {
+                    id: 1,
+                    name: "arr".to_string(),
+                    ty: Type::Array(Box::new(Type::Any)),
+                    mutable: false,
+                    init: Some(Expr::Array(vec![Expr::Number(1.0)])),
+                },
+                Stmt::Let {
+                    id: 2,
+                    name: "key".to_string(),
+                    ty: Type::String,
+                    mutable: false,
+                    init: Some(Expr::String("k".to_string())),
+                },
+                Stmt::Expr(Expr::IndexSet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    index: Box::new(Expr::LocalGet(2)),
+                    value: Box::new(value),
+                }),
+            ]
+        },
+    );
+}
+
+/// #7639 arm 1 — the polymorphic `o[k] = f()` fallback, reached when nothing
+/// about the receiver or the key is statically known. It guarded neither
+/// operand, and it is the arm where both are heap values by default.
+#[test]
+fn polymorphic_index_store_roots_both_operands_across_an_allocating_rhs() {
+    assert_operands_rooted_only_when_the_window_collects(
+        "polymorphic_index",
+        "js_typed_feedback_object_set_index_polymorphic",
+        |value| {
+            vec![
+                Stmt::Let {
+                    id: 1,
+                    name: "recv".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::Object(Vec::new())),
+                },
+                Stmt::Let {
+                    id: 2,
+                    name: "key".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::Object(Vec::new())),
+                },
+                Stmt::Expr(Expr::IndexSet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    index: Box::new(Expr::LocalGet(2)),
+                    value: Box::new(value),
+                }),
+            ]
+        },
+    );
+}

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -3,6 +3,20 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Migrated onto [`crate::rooting`]; this module names no `expr::temp_root`
+//! symbol. Both windows here are the READ counterpart of the store-operand
+//! guard — `o[f()]` evaluates the base before the key, so the base is live in
+//! an SSA register while arbitrary user code runs — and both are one call to
+//! [`crate::rooting::with_operands_rooted`] over `[base, key]`. The key needs
+//! no protection of its own because it is lowered last, which the operand list
+//! derives rather than asserts.
+//!
+//! The remaining `js_*` calls in this file return `DOUBLE` (NaN-boxed) or are
+//! consumed in the block that produced them, so there is no raw-pointer
+//! register to root: `call_rooted` has no site here.
 
 use anyhow::Result;
 use perry_hir::types::Type as HirType;
@@ -12,6 +26,7 @@ use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
+use crate::rooting;
 use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
 use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
@@ -1225,7 +1240,6 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // it as `*StringHeader`. Issue #214 SSO bug class.
                 let preserve_class_ref_bits =
                     index_object_is_class_or_proto_ref(ctx, object.as_ref());
-                let obj_box = lower_expr(ctx, object)?;
                 // #7154: `o[f()]` evaluates the base first and the key second,
                 // leaving the base in a bare SSA register while `f()` runs. An
                 // evacuating minor inside `f()` relocates the base; the location
@@ -1239,157 +1253,158 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // `PERRY_GC_MOVING_LOOP_POLLS=1`: `numericOriginMap` is a module
                 // global (a registered root the collector rewrites) and the key
                 // `typeof def.value` is a property get that can collect.
-                let recv_guard =
-                    super::temp_root::guard_store_operand(ctx, object, &obj_box, index);
-                let key_box = lower_expr(ctx, index)?;
-                let obj_box =
-                    super::temp_root::reread_store_operand(ctx, &recv_guard, object, &obj_box)?;
-                let blk = ctx.block();
-                let obj_bits = blk.bitcast_double_to_i64(&obj_box);
-                let obj_handle =
-                    classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
-                let key_handle = unbox_str_handle(blk, &key_box);
-                let site_id = emit_typed_feedback_register_site(
-                    ctx,
-                    TypedFeedbackKind::PropertyGet,
-                    "object[index]",
-                    TypedFeedbackContract::object_get_by_name(),
-                );
-                let out = ctx.block().call(
-                    DOUBLE,
-                    "js_typed_feedback_object_get_field_by_name_f64",
-                    &[(I64, &site_id), (I64, &obj_handle), (I64, &key_handle)],
-                );
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(out);
+                //
+                // The base and the key are one operand group: the base's window
+                // is the key's lowering, the key's window is empty (it is
+                // lowered last), and `operand_protection` derives both from the
+                // list rather than from a hand-written `collects` flag.
+                return rooting::with_operands_rooted(ctx, &[object, index], |ctx, vals| {
+                    let (obj_box, key_box) = (&vals[0], &vals[1]);
+                    let blk = ctx.block();
+                    let obj_bits = blk.bitcast_double_to_i64(obj_box);
+                    let obj_handle =
+                        classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
+                    let key_handle = unbox_str_handle(blk, key_box);
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::PropertyGet,
+                        "object[index]",
+                        TypedFeedbackContract::object_get_by_name(),
+                    );
+                    Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_typed_feedback_object_get_field_by_name_f64",
+                        &[(I64, &site_id), (I64, &obj_handle), (I64, &key_handle)],
+                    ))
+                });
             }
             // Last-resort fallback with runtime tag checks on the index.
             // First runtime-check whether the index is a Symbol; if so,
             // dispatch to the symbol-property side table — mirrors the
             // IndexSet branch. Otherwise fall through to string/numeric.
             let preserve_class_ref_bits = index_object_is_class_or_proto_ref(ctx, object.as_ref());
-            let obj_box = lower_expr(ctx, object)?;
             // #7154: same window as the dynamic-string-key arm above — the base
             // is live in a register while the key expression is lowered, and an
             // evacuating minor inside the key relocates it.
-            let recv_guard = super::temp_root::guard_store_operand(ctx, object, &obj_box, index);
-            let idx_box = lower_expr(ctx, index)?;
-            let obj_box =
-                super::temp_root::reread_store_operand(ctx, &recv_guard, object, &obj_box)?;
-            // RequireObjectCoercible(base): `null[k]` / `undefined[k]` must throw
-            // a TypeError per spec, NOT silently return undefined. The dotted
-            // PropertyGet path already guards nullish receivers; the computed
-            // form fell through to the by-name runtime helper (masked handle
-            // `2`/`1`) which returned undefined. The check fires here — after
-            // both the base and the property-key *expression* are evaluated but
-            // before ToPropertyKey (key coercion / `toString`) — matching the
-            // ECMAScript evaluation order (test262 compound-assignment S11.13.2_A7.*,
-            // prefix/postfix increment A6). A non-nullish receiver passes through
-            // unchanged. (#4918 non-class language remnant.)
-            let obj_box =
-                ctx.block()
-                    .call(DOUBLE, "js_require_object_coercible", &[(DOUBLE, &obj_box)]);
-            let blk = ctx.block();
-            let obj_bits = blk.bitcast_double_to_i64(&obj_box);
-            let obj_handle = classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
-            let is_sym_i32 = blk.call(I32, "js_is_symbol", &[(DOUBLE, &idx_box)]);
-            let is_sym_bit = blk.icmp_ne(I32, &is_sym_i32, "0");
-            let sym_idx = ctx.new_block("iget.sym");
-            let nonsym_idx = ctx.new_block("iget.nonsym");
-            let str_idx = ctx.new_block("iget.str");
-            let num_idx = ctx.new_block("iget.num");
-            let merge_idx = ctx.new_block("iget.merge");
-            let sym_lbl = ctx.block_label(sym_idx);
-            let nonsym_lbl = ctx.block_label(nonsym_idx);
-            let str_lbl = ctx.block_label(str_idx);
-            let num_lbl = ctx.block_label(num_idx);
-            let merge_lbl = ctx.block_label(merge_idx);
-            ctx.block().cond_br(&is_sym_bit, &sym_lbl, &nonsym_lbl);
-            // Symbol key → side-table get.
-            ctx.current_block = sym_idx;
-            let v_sym = ctx.block().call(
-                DOUBLE,
-                "js_object_get_symbol_property",
-                &[(DOUBLE, &obj_box), (DOUBLE, &idx_box)],
-            );
-            let sym_end_lbl = ctx.block().label.clone();
-            ctx.block().br(&merge_lbl);
-            // Not a symbol → recompute idx_bits in this block.
-            ctx.current_block = nonsym_idx;
-            let blk = ctx.block();
-            let idx_bits = blk.bitcast_double_to_i64(&idx_box);
-            let top16 = blk.lshr(I64, &idx_bits, "48");
-            // STRING_TAG (0x7FFF = 32767): heap StringHeader pointer.
-            let is_str_tag_heap = blk.icmp_eq(I64, &top16, "32767");
-            let lower48 = blk.and(I64, &idx_bits, POINTER_MASK_I64);
-            let is_valid_ptr = blk.icmp_ugt(I64, &lower48, "4095");
-            let is_str_heap = blk.and(crate::types::I1, &is_str_tag_heap, &is_valid_ptr);
-            // SHORT_STRING_TAG (0x7FF9 = 32761): inline SSO from JSON.parse,
-            // .slice, etc. Lower 48 encode length+bytes, NOT a pointer, so we
-            // can't AND-mask to a StringHeader; route through unbox_str_handle
-            // which materializes SSO to a heap StringHeader (issue #434).
-            let is_str_tag_sso = blk.icmp_eq(I64, &top16, "32761");
-            let is_str = blk.or(crate::types::I1, &is_str_heap, &is_str_tag_sso);
-            ctx.block().cond_br(&is_str, &str_lbl, &num_lbl);
-            // String key → object field access.
-            ctx.current_block = str_idx;
-            let key_handle = {
+            //
+            // The group is released after `body` returns, which lands the
+            // truncate in the merge block — below every arm's getter, any of
+            // which can run a user getter and therefore collect.
+            rooting::with_operands_rooted(ctx, &[object, index], |ctx, vals| {
+                let (obj_box, idx_box) = (vals[0].clone(), vals[1].clone());
+                // RequireObjectCoercible(base): `null[k]` / `undefined[k]` must throw
+                // a TypeError per spec, NOT silently return undefined. The dotted
+                // PropertyGet path already guards nullish receivers; the computed
+                // form fell through to the by-name runtime helper (masked handle
+                // `2`/`1`) which returned undefined. The check fires here — after
+                // both the base and the property-key *expression* are evaluated but
+                // before ToPropertyKey (key coercion / `toString`) — matching the
+                // ECMAScript evaluation order (test262 compound-assignment S11.13.2_A7.*,
+                // prefix/postfix increment A6). A non-nullish receiver passes through
+                // unchanged. (#4918 non-class language remnant.)
+                let obj_box =
+                    ctx.block()
+                        .call(DOUBLE, "js_require_object_coercible", &[(DOUBLE, &obj_box)]);
                 let blk = ctx.block();
-                unbox_str_handle(blk, &idx_box)
-            };
-            let site_id = emit_typed_feedback_register_site(
-                ctx,
-                TypedFeedbackKind::PropertyGet,
-                "object[index]",
-                TypedFeedbackContract::object_get_by_name(),
-            );
-            let v_str = ctx.block().call(
-                DOUBLE,
-                "js_typed_feedback_object_get_field_by_name_f64",
-                &[(I64, &site_id), (I64, &obj_handle), (I64, &key_handle)],
-            );
-            let str_end_lbl = ctx.block().label.clone();
-            ctx.block().br(&merge_lbl);
-            // Numeric key → polymorphic dispatch.
-            //
-            // Closes #471 (read side, paired with the IndexSet polymorphic
-            // fix above): the previous fallback emitted an inline
-            // `obj_handle + 8 + idx*8` load on the assumption that the
-            // receiver had an ArrayHeader (8-byte header) layout. Once the
-            // IndexSet path stopped writing through that layout for plain
-            // objects, the read side had to follow — `constMap[i] = v;
-            // constMap[i]` would otherwise set via the object setter
-            // (key stringified into the keys_array) and read from
-            // `obj+8+i*8` (stale ObjectHeader fields), returning garbage
-            // f64 values.
-            //
-            // Route through the runtime which checks the receiver's GC
-            // type and dispatches: arrays/lazy/buffers/typed-arrays
-            // through js_array_get_f64 (handles forwarding-chain follow
-            // + lazy-materialize + per-kind reads), plain objects
-            // through stringify-the-index + js_object_get_field_by_name_f64.
-            ctx.current_block = num_idx;
-            let v_num = ctx.block().call(
-                DOUBLE,
-                "js_object_get_index_polymorphic",
-                &[(I64, &obj_handle), (DOUBLE, &idx_box)],
-            );
-            let num_end_lbl = ctx.block().label.clone();
-            ctx.block().br(&merge_lbl);
-            // Merge.
-            ctx.current_block = merge_idx;
-            let merged = ctx.block().phi(
-                DOUBLE,
-                &[
-                    (&v_sym, &sym_end_lbl),
-                    (&v_str, &str_end_lbl),
-                    (&v_num, &num_end_lbl),
-                ],
-            );
-            // Released in the merge block so every arm's getter (any of which
-            // can run a user getter and therefore collect) is still covered.
-            super::temp_root::release_store_operand(ctx, recv_guard);
-            Ok(merged)
+                let obj_bits = blk.bitcast_double_to_i64(&obj_box);
+                let obj_handle =
+                    classref_preserving_handle(blk, &obj_bits, preserve_class_ref_bits);
+                let is_sym_i32 = blk.call(I32, "js_is_symbol", &[(DOUBLE, &idx_box)]);
+                let is_sym_bit = blk.icmp_ne(I32, &is_sym_i32, "0");
+                let sym_idx = ctx.new_block("iget.sym");
+                let nonsym_idx = ctx.new_block("iget.nonsym");
+                let str_idx = ctx.new_block("iget.str");
+                let num_idx = ctx.new_block("iget.num");
+                let merge_idx = ctx.new_block("iget.merge");
+                let sym_lbl = ctx.block_label(sym_idx);
+                let nonsym_lbl = ctx.block_label(nonsym_idx);
+                let str_lbl = ctx.block_label(str_idx);
+                let num_lbl = ctx.block_label(num_idx);
+                let merge_lbl = ctx.block_label(merge_idx);
+                ctx.block().cond_br(&is_sym_bit, &sym_lbl, &nonsym_lbl);
+                // Symbol key → side-table get.
+                ctx.current_block = sym_idx;
+                let v_sym = ctx.block().call(
+                    DOUBLE,
+                    "js_object_get_symbol_property",
+                    &[(DOUBLE, &obj_box), (DOUBLE, &idx_box)],
+                );
+                let sym_end_lbl = ctx.block().label.clone();
+                ctx.block().br(&merge_lbl);
+                // Not a symbol → recompute idx_bits in this block.
+                ctx.current_block = nonsym_idx;
+                let blk = ctx.block();
+                let idx_bits = blk.bitcast_double_to_i64(&idx_box);
+                let top16 = blk.lshr(I64, &idx_bits, "48");
+                // STRING_TAG (0x7FFF = 32767): heap StringHeader pointer.
+                let is_str_tag_heap = blk.icmp_eq(I64, &top16, "32767");
+                let lower48 = blk.and(I64, &idx_bits, POINTER_MASK_I64);
+                let is_valid_ptr = blk.icmp_ugt(I64, &lower48, "4095");
+                let is_str_heap = blk.and(crate::types::I1, &is_str_tag_heap, &is_valid_ptr);
+                // SHORT_STRING_TAG (0x7FF9 = 32761): inline SSO from JSON.parse,
+                // .slice, etc. Lower 48 encode length+bytes, NOT a pointer, so we
+                // can't AND-mask to a StringHeader; route through unbox_str_handle
+                // which materializes SSO to a heap StringHeader (issue #434).
+                let is_str_tag_sso = blk.icmp_eq(I64, &top16, "32761");
+                let is_str = blk.or(crate::types::I1, &is_str_heap, &is_str_tag_sso);
+                ctx.block().cond_br(&is_str, &str_lbl, &num_lbl);
+                // String key → object field access.
+                ctx.current_block = str_idx;
+                let key_handle = {
+                    let blk = ctx.block();
+                    unbox_str_handle(blk, &idx_box)
+                };
+                let site_id = emit_typed_feedback_register_site(
+                    ctx,
+                    TypedFeedbackKind::PropertyGet,
+                    "object[index]",
+                    TypedFeedbackContract::object_get_by_name(),
+                );
+                let v_str = ctx.block().call(
+                    DOUBLE,
+                    "js_typed_feedback_object_get_field_by_name_f64",
+                    &[(I64, &site_id), (I64, &obj_handle), (I64, &key_handle)],
+                );
+                let str_end_lbl = ctx.block().label.clone();
+                ctx.block().br(&merge_lbl);
+                // Numeric key → polymorphic dispatch.
+                //
+                // Closes #471 (read side, paired with the IndexSet polymorphic
+                // fix above): the previous fallback emitted an inline
+                // `obj_handle + 8 + idx*8` load on the assumption that the
+                // receiver had an ArrayHeader (8-byte header) layout. Once the
+                // IndexSet path stopped writing through that layout for plain
+                // objects, the read side had to follow — `constMap[i] = v;
+                // constMap[i]` would otherwise set via the object setter
+                // (key stringified into the keys_array) and read from
+                // `obj+8+i*8` (stale ObjectHeader fields), returning garbage
+                // f64 values.
+                //
+                // Route through the runtime which checks the receiver's GC
+                // type and dispatches: arrays/lazy/buffers/typed-arrays
+                // through js_array_get_f64 (handles forwarding-chain follow
+                // + lazy-materialize + per-kind reads), plain objects
+                // through stringify-the-index + js_object_get_field_by_name_f64.
+                ctx.current_block = num_idx;
+                let v_num = ctx.block().call(
+                    DOUBLE,
+                    "js_object_get_index_polymorphic",
+                    &[(I64, &obj_handle), (DOUBLE, &idx_box)],
+                );
+                let num_end_lbl = ctx.block().label.clone();
+                ctx.block().br(&merge_lbl);
+                // Merge.
+                ctx.current_block = merge_idx;
+                let merged = ctx.block().phi(
+                    DOUBLE,
+                    &[
+                        (&v_sym, &sym_end_lbl),
+                        (&v_str, &str_end_lbl),
+                        (&v_num, &num_end_lbl),
+                    ],
+                );
+                Ok(merged)
+            })
         }
 
         // Phase H err: `agg.errors.length` — receiver is

--- a/crates/perry-codegen/src/expr/index_get/guarded_array.rs
+++ b/crates/perry-codegen/src/expr/index_get/guarded_array.rs
@@ -4,6 +4,17 @@
 //! Pure mechanical move — the items below are verbatim copies (only the
 //! visibility of the three entry points is widened to `pub(super)` so the
 //! trunk's call sites keep compiling).
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion. The audit that earned it: every entry point here takes operands
+//! its caller has already lowered, and lowers no user expression of its own, so
+//! there is no window for a root to span. `js_array_refresh_local_head` and the
+//! `*_index_get_guard` helpers are the only calls in the receiver's live range,
+//! and neither re-enters user code.
 
 use anyhow::Result;
 

--- a/crates/perry-codegen/src/expr/index_get/inline_dyn_typed_array.rs
+++ b/crates/perry-codegen/src/expr/index_get/inline_dyn_typed_array.rs
@@ -4,6 +4,16 @@
 //! Pure mechanical move — the items below are verbatim copies (only the
 //! visibility of the entry point is widened to `pub(super)` so the trunk's
 //! call sites keep compiling).
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion. The audit that earned it: the entry point receives the receiver
+//! and index already lowered, lowers no user expression, and emits only pure
+//! IR (guards, GEPs, loads) plus the out-of-line `js_dyn_index_get` fallback —
+//! so no register of a GC value spans a lowering here.
 
 use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8};
 

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -20,7 +20,7 @@
 //! window rather than restating it: #7201's disjunction — the receiver is live
 //! across BOTH the key and the value — falls out of the list order instead of
 //! being a hand-written `recv_collects`, and the two arms that got that flag
-//! wrong are exactly the two bugs this slice fixed (#7646, #7647).
+//! wrong are exactly the two bugs this slice fixed (#7638, #7639).
 //!
 //! Nesting note that no longer applies: the dynamic-string-key arm used to push
 //! two guards and release them inner-to-outer, because `temp_root_truncate` is a
@@ -980,7 +980,7 @@ pub(crate) fn lower(
             // to `js_array_set_f64_extend`, falling back to object-property
             // set on non-numeric keys per spec.
             if is_array_expr(ctx, object) && is_string_expr(ctx, index) {
-                // #7646: neither operand was guarded. The receiver AND the key
+                // #7638: neither operand was guarded. The receiver AND the key
                 // are lowered before the value, and the key is a heap string by
                 // construction on this arm (`is_string_expr`) with no
                 // registered root of its own — `unbox_str_handle` below would
@@ -1041,7 +1041,7 @@ pub(crate) fn lower(
             if is_array_expr(ctx, object) && !is_numeric_expr(ctx, index) {
                 // #7341: receiver live across `index` and `value` lowering.
                 //
-                // #7646: the KEY was live across `value` too, and was not
+                // #7638: the KEY was live across `value` too, and was not
                 // rooted. This arm fires exactly when the index is NOT
                 // statically numeric — a `forEach` callback's `(item, k)` where
                 // `k` came from a for-in over object keys, say — so `idx_double`
@@ -1607,7 +1607,7 @@ pub(crate) fn lower(
                 // `unbox_str_handle` below would hand the setter a pre-move
                 // `StringHeader*` and the field would land under a garbage key.
                 //
-                // #7647: the receiver's window used to be derived from `value`
+                // #7639: the receiver's window used to be derived from `value`
                 // ALONE, which is the half-measure #7201 named. The receiver is
                 // lowered before the KEY as well, so `o[f()] = 1` — a literal
                 // RHS that cannot collect, an allocating key that can — left it
@@ -1681,7 +1681,7 @@ pub(crate) fn lower(
             // symbol-property side table. Otherwise fall through to the
             // string/numeric dispatch.
             //
-            // #7647: this arm had NO store-operand guard on either operand,
+            // #7639: this arm had NO store-operand guard on either operand,
             // while every sibling arm above has had one since #7154. It is the
             // most exposed of them all — it is reached precisely when NOTHING
             // about the receiver or the key is statically known, so both are

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -3,6 +3,29 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Migrated onto [`crate::rooting`]; this module names no `expr::temp_root`
+//! symbol. Every arm is the same window — `o[k] = v` evaluates the reference
+//! before the value (spec order), so the receiver, and on the dynamic arms the
+//! key too, sit in SSA registers while arbitrary user code runs.
+//!
+//! Each arm is one call to [`crate::rooting::with_operands_rooted`] over
+//! `[object, index, value]` (the value is lowered by `lower_expr`) or to
+//! [`crate::rooting::with_operands_rooted_across`] over `[object]` / `[object,
+//! index]` with `[index, value]` as the window (the value is lowered by
+//! `lower_value_for_dynamic_index_set`, which the operand list cannot produce).
+//! The point of the operand-list form is that it *derives* the per-operand
+//! window rather than restating it: #7201's disjunction — the receiver is live
+//! across BOTH the key and the value — falls out of the list order instead of
+//! being a hand-written `recv_collects`, and the two arms that got that flag
+//! wrong are exactly the two bugs this slice fixed (#7646, #7647).
+//!
+//! Nesting note that no longer applies: the dynamic-string-key arm used to push
+//! two guards and release them inner-to-outer, because `temp_root_truncate` is a
+//! stack CUT. One operand group has one guard, so that ordering obligation is
+//! gone rather than merely documented.
 
 use anyhow::Result;
 use perry_hir::{BinaryOp, Expr};
@@ -12,6 +35,7 @@ use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
+use crate::rooting;
 use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
 use crate::types::{DOUBLE, I32, I64};
 
@@ -228,60 +252,69 @@ fn lower_array_index_set_via_runtime_key(
     value: &Expr,
     source_label: &str,
 ) -> Result<String> {
-    let arr_box = lower_expr(ctx, object)?;
     // #7341, same hazard as the packed path: the receiver is live across both
     // `index` and `value` lowering, and an allocating RHS is a collection
     // point. Without this the store writes through a pre-evacuation address.
-    let recv_collects = super::temp_root::expr_may_trigger_gc(ctx, index)
-        || super::temp_root::expr_may_trigger_gc(ctx, value);
-    let recv_guard =
-        super::temp_root::guard_store_operand_across(ctx, object, &arr_box, recv_collects);
-    let idx_double = lower_expr(ctx, index)?;
-    let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
-    let (val_double, val_bits) = lower_value_for_dynamic_index_set(
+    //
+    // `across` rather than the plain operand form: the value is lowered by
+    // `lower_value_for_dynamic_index_set`, a native-rep lowering the operand
+    // list cannot produce. Passing `[index, value]` as the window keeps its
+    // extent answered by `operand_protection` — the #7201 disjunction — rather
+    // than by a `recv_collects` flag this function re-derives.
+    rooting::with_operands_rooted_across(
         ctx,
-        value,
-        "index_set.array_runtime_key_value_bits",
-        "array_runtime_key_set_helper_edge",
-    )?;
-    let arr_box = super::temp_root::reread_store_operand(ctx, &recv_guard, object, &arr_box)?;
-    let arr_handle = {
-        let blk = ctx.block();
-        unbox_to_i64(blk, &arr_box)
-    };
-    let site_id = emit_typed_feedback_register_site(
-        ctx,
-        TypedFeedbackKind::ArrayElement,
-        source_label,
-        TypedFeedbackContract::array_set_index_or_string(),
-    );
-    let new_handle = ctx.block().call(
-        I64,
-        "js_typed_feedback_array_set_index_or_string",
-        &[
-            (I64, &site_id),
-            (I64, &arr_handle),
-            (DOUBLE, &idx_double),
-            (DOUBLE, &val_double),
-        ],
-    );
-    if let Expr::LocalGet(id) = object {
-        if let Some(slot) = ctx.locals.get(id).cloned() {
-            let new_box = nanbox_pointer_inline(ctx.block(), &new_handle);
-            ctx.block().store(DOUBLE, &new_box, &slot);
-        } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
-            let new_box = nanbox_pointer_inline(ctx.block(), &new_handle);
-            let g_ref = format!("@{}", global_name);
-            emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
-        }
-    }
-    if value_needs_barrier {
-        let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
-        emit_write_barrier(ctx, &arr_bits, &val_bits);
-    }
-    // After the store: the helper itself can grow the element array.
-    super::temp_root::release_store_operand(ctx, recv_guard);
-    Ok(val_double)
+        &[object],
+        &[index, value],
+        |ctx| {
+            let idx_double = lower_expr(ctx, index)?;
+            let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
+            let (val_double, val_bits) = lower_value_for_dynamic_index_set(
+                ctx,
+                value,
+                "index_set.array_runtime_key_value_bits",
+                "array_runtime_key_set_helper_edge",
+            )?;
+            Ok((idx_double, value_needs_barrier, val_double, val_bits))
+        },
+        |ctx, vals, (idx_double, value_needs_barrier, val_double, val_bits)| {
+            let arr_box = &vals[0];
+            let arr_handle = {
+                let blk = ctx.block();
+                unbox_to_i64(blk, arr_box)
+            };
+            let site_id = emit_typed_feedback_register_site(
+                ctx,
+                TypedFeedbackKind::ArrayElement,
+                source_label,
+                TypedFeedbackContract::array_set_index_or_string(),
+            );
+            let new_handle = ctx.block().call(
+                I64,
+                "js_typed_feedback_array_set_index_or_string",
+                &[
+                    (I64, &site_id),
+                    (I64, &arr_handle),
+                    (DOUBLE, &idx_double),
+                    (DOUBLE, &val_double),
+                ],
+            );
+            if let Expr::LocalGet(id) = object {
+                if let Some(slot) = ctx.locals.get(id).cloned() {
+                    let new_box = nanbox_pointer_inline(ctx.block(), &new_handle);
+                    ctx.block().store(DOUBLE, &new_box, &slot);
+                } else if let Some(global_name) = ctx.module_globals.get(id).cloned() {
+                    let new_box = nanbox_pointer_inline(ctx.block(), &new_handle);
+                    let g_ref = format!("@{}", global_name);
+                    emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
+                }
+            }
+            if value_needs_barrier {
+                let arr_bits = ctx.block().bitcast_double_to_i64(arr_box);
+                emit_write_barrier(ctx, &arr_bits, &val_bits);
+            }
+            Ok(val_double)
+        },
+    )
 }
 
 fn lower_packed_f64_loop_store_value(
@@ -947,40 +980,52 @@ pub(crate) fn lower(
             // to `js_array_set_f64_extend`, falling back to object-property
             // set on non-numeric keys per spec.
             if is_array_expr(ctx, object) && is_string_expr(ctx, index) {
-                let arr_box = lower_expr(ctx, object)?;
-                let key_box = lower_expr(ctx, index)?;
+                // #7646: neither operand was guarded. The receiver AND the key
+                // are lowered before the value, and the key is a heap string by
+                // construction on this arm (`is_string_expr`) with no
+                // registered root of its own — `unbox_str_handle` below would
+                // hand the setter a pre-move `StringHeader*`. `for (const i in
+                // src) out[i] = mk();` is the shape, which is the very pattern
+                // the arm was added for (#637).
                 let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
-                let (val_double, val_bits) =
-                    lower_value_for_optional_barrier(ctx, value, value_needs_barrier)?;
-                let (arr_handle, key_handle) = {
-                    let blk = ctx.block();
-                    let arr_handle = unbox_to_i64(blk, &arr_box);
-                    let key_handle = unbox_str_handle(blk, &key_box);
-                    (arr_handle, key_handle)
-                };
-                let site_id = emit_typed_feedback_register_site(
+                return rooting::with_operands_rooted_across(
                     ctx,
-                    TypedFeedbackKind::ArrayElement,
-                    "array[string_index]",
-                    TypedFeedbackContract::array_set_string_key(),
+                    &[object.as_ref(), index.as_ref()],
+                    &[value.as_ref()],
+                    |ctx| lower_value_for_optional_barrier(ctx, value, value_needs_barrier),
+                    |ctx, vals, (val_double, val_bits)| {
+                        let (arr_box, key_box) = (vals[0].clone(), vals[1].clone());
+                        let (arr_handle, key_handle) = {
+                            let blk = ctx.block();
+                            let arr_handle = unbox_to_i64(blk, &arr_box);
+                            let key_handle = unbox_str_handle(blk, &key_box);
+                            (arr_handle, key_handle)
+                        };
+                        let site_id = emit_typed_feedback_register_site(
+                            ctx,
+                            TypedFeedbackKind::ArrayElement,
+                            "array[string_index]",
+                            TypedFeedbackContract::array_set_string_key(),
+                        );
+                        ctx.block().call(
+                            I64,
+                            "js_typed_feedback_array_set_string_key",
+                            &[
+                                (I64, &site_id),
+                                (I64, &arr_handle),
+                                (I64, &key_handle),
+                                (DOUBLE, &val_double),
+                            ],
+                        );
+                        if value_needs_barrier {
+                            let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
+                            let val_bits = val_bits
+                                .unwrap_or_else(|| ctx.block().bitcast_double_to_i64(&val_double));
+                            emit_write_barrier(ctx, &arr_bits, &val_bits);
+                        }
+                        Ok(val_double)
+                    },
                 );
-                ctx.block().call(
-                    I64,
-                    "js_typed_feedback_array_set_string_key",
-                    &[
-                        (I64, &site_id),
-                        (I64, &arr_handle),
-                        (I64, &key_handle),
-                        (DOUBLE, &val_double),
-                    ],
-                );
-                if value_needs_barrier {
-                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
-                    let val_bits =
-                        val_bits.unwrap_or_else(|| ctx.block().bitcast_double_to_i64(&val_double));
-                    emit_write_barrier(ctx, &arr_bits, &val_bits);
-                }
-                return Ok(val_double);
             }
             // Issue #637 followup: `arr[k] = X` where receiver is array
             // but index is dynamically-typed (Any) — most commonly a
@@ -994,48 +1039,54 @@ pub(crate) fn lower(
             // the existing fast path is correct and avoids the runtime
             // dispatch overhead).
             if is_array_expr(ctx, object) && !is_numeric_expr(ctx, index) {
-                let arr_box = lower_expr(ctx, object)?;
                 // #7341: receiver live across `index` and `value` lowering.
-                let recv_collects = super::temp_root::expr_may_trigger_gc(ctx, index)
-                    || super::temp_root::expr_may_trigger_gc(ctx, value);
-                let recv_guard = super::temp_root::guard_store_operand_across(
-                    ctx,
-                    object,
-                    &arr_box,
-                    recv_collects,
-                );
-                let idx_double = lower_expr(ctx, index)?;
+                //
+                // #7646: the KEY was live across `value` too, and was not
+                // rooted. This arm fires exactly when the index is NOT
+                // statically numeric — a `forEach` callback's `(item, k)` where
+                // `k` came from a for-in over object keys, say — so `idx_double`
+                // is routinely a NaN-boxed heap string, and
+                // `js_typed_feedback_array_set_index_or_string` parses it as a
+                // key. An evacuating minor inside the RHS therefore left the
+                // store reading a from-space `StringHeader*` and the element
+                // landed under a garbage key. The dynamic-string-key arm below
+                // has guarded exactly this since #7154; this one was missed
+                // because its key is not *statically* a string.
+                //
+                // One operand group derives both windows rather than restating
+                // either: the receiver's spans `index` and `value`, the key's
+                // spans `value`, and `value` is lowered last so it takes
+                // nothing.
                 let value_needs_barrier = array_store_needs_write_barrier(ctx, value);
-                let val_double = lower_expr(ctx, value)?;
-                let arr_box =
-                    super::temp_root::reread_store_operand(ctx, &recv_guard, object, &arr_box)?;
-                let arr_handle = {
-                    let blk = ctx.block();
-                    unbox_to_i64(blk, &arr_box)
-                };
-                let site_id = emit_typed_feedback_register_site(
-                    ctx,
-                    TypedFeedbackKind::ArrayElement,
-                    "array[dynamic_index]",
-                    TypedFeedbackContract::array_set_index_or_string(),
-                );
-                ctx.block().call(
-                    I64,
-                    "js_typed_feedback_array_set_index_or_string",
-                    &[
-                        (I64, &site_id),
-                        (I64, &arr_handle),
-                        (DOUBLE, &idx_double),
-                        (DOUBLE, &val_double),
-                    ],
-                );
-                if value_needs_barrier {
-                    let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                    let arr_bits = ctx.block().bitcast_double_to_i64(&arr_box);
-                    emit_write_barrier(ctx, &arr_bits, &val_bits);
-                }
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(val_double);
+                return rooting::with_operands_rooted(ctx, &[object, index, value], |ctx, vals| {
+                    let (arr_box, idx_double, val_double) = (&vals[0], &vals[1], &vals[2]);
+                    let arr_handle = {
+                        let blk = ctx.block();
+                        unbox_to_i64(blk, arr_box)
+                    };
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::ArrayElement,
+                        "array[dynamic_index]",
+                        TypedFeedbackContract::array_set_index_or_string(),
+                    );
+                    ctx.block().call(
+                        I64,
+                        "js_typed_feedback_array_set_index_or_string",
+                        &[
+                            (I64, &site_id),
+                            (I64, &arr_handle),
+                            (DOUBLE, idx_double),
+                            (DOUBLE, val_double),
+                        ],
+                    );
+                    if value_needs_barrier {
+                        let val_bits = ctx.block().bitcast_double_to_i64(val_double);
+                        let arr_bits = ctx.block().bitcast_double_to_i64(arr_box);
+                        emit_write_barrier(ctx, &arr_bits, &val_bits);
+                    }
+                    Ok(val_double.clone())
+                });
             }
             if is_array_expr(ctx, object)
                 && numeric_index_needs_runtime_key(ctx, object.as_ref(), index.as_ref())
@@ -1314,7 +1365,11 @@ pub(crate) fn lower(
                 let value_is_numeric = is_numeric_expr(ctx, value);
                 let require_numeric_layout =
                     value_is_numeric && expr_has_numeric_pointer_free_array_layout(ctx, object);
-                let arr_box = lower_expr(ctx, object)?;
+                let local_id = if let Expr::LocalGet(id) = object.as_ref() {
+                    Some(*id)
+                } else {
+                    None
+                };
                 // #7341: this array path skipped the store-operand guard the
                 // generic object paths below already apply (#7154). `a[i] = v`
                 // evaluates the receiver first and the value last — spec order
@@ -1335,107 +1390,127 @@ pub(crate) fn lower(
                 // all, so neither lowering could have covered it.
                 //
                 // The window is the disjunction over `index` and `value`
-                // (#7201): the receiver is live across both.
-                let recv_collects = super::temp_root::expr_may_trigger_gc(ctx, index)
-                    || super::temp_root::expr_may_trigger_gc(ctx, value);
-                let recv_guard = super::temp_root::guard_store_operand_across(
-                    ctx,
-                    object,
-                    &arr_box,
-                    recv_collects,
-                );
-                let idx_double = lower_expr(ctx, index)?;
-                let val_double = lower_expr(ctx, value)?;
-                let arr_box =
-                    super::temp_root::reread_store_operand(ctx, &recv_guard, object, &arr_box)?;
-                let local_id = if let Expr::LocalGet(id) = object.as_ref() {
-                    Some(*id)
-                } else {
-                    None
-                };
-                let feedback_site_id = emit_typed_feedback_register_site(
-                    ctx,
-                    TypedFeedbackKind::ArrayElement,
-                    "array[index]=",
-                    if require_numeric_layout {
-                        TypedFeedbackContract::numeric_array_set_index()
-                    } else {
-                        TypedFeedbackContract::array_set_index()
-                    },
-                );
-                // Use the fast inlined IndexSet path only when the
-                // receiver is a local that's actually in ctx.locals
-                // (stack slot). Module-level arrays accessed from inside
-                // a function are in ctx.module_globals instead — for
-                // those we use js_array_set_f64_extend (the realloc-
-                // capable variant) and write the new pointer back to
-                // the global slot. Issue #221: the previous code
-                // funneled module globals through js_array_set_f64
-                // which returns silently when `index >= length` — so
-                // every `arr[i] = v` against a `const A: T[] = []`
-                // declared empty was a silent no-op, both the value
-                // and the implicit length update vanishing.
-                if let Some(id) = local_id {
-                    if ctx.locals.contains_key(&id) {
-                        let value_is_canonical_raw_f64 =
-                            crate::type_analysis::expr_produces_canonical_raw_f64(ctx, value);
-                        lower_index_set_fast(
-                            ctx,
-                            &arr_box,
-                            &idx_double,
-                            &val_double,
-                            id,
-                            layout_note_needed,
-                            write_barrier_needed,
-                            value_is_numeric,
-                            require_numeric_layout,
-                            value_is_canonical_raw_f64,
-                            &feedback_site_id,
-                        )?;
-                    } else if let Some(global_name) = ctx.module_globals.get(&id).cloned() {
-                        let blk = ctx.block();
-                        let arr_bits = blk.bitcast_double_to_i64(&arr_box);
-                        let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
-                        let new_handle = blk.call(
-                            I64,
-                            "js_typed_feedback_array_set_f64_extend",
-                            &[
-                                (I64, &feedback_site_id),
-                                (I64, &arr_handle),
-                                (I32, &idx_i32),
-                                (DOUBLE, &val_double),
-                            ],
-                        );
-                        let new_box = nanbox_pointer_inline(blk, &new_handle);
-                        let g_ref = format!("@{}", global_name);
-                        // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
-                        emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
-                        // Gen-GC Phase C2: write barrier on array element store.
-                        if write_barrier_needed {
-                            let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                            emit_write_barrier(ctx, &arr_bits, &val_bits);
+                // (#7201): the receiver is live across both. The operand group
+                // derives that from the list order; the index is numeric on
+                // this path, so it takes no slot and the IR is unchanged.
+                return rooting::with_operands_rooted(ctx, &[object, index, value], |ctx, vals| {
+                    let (arr_box, idx_double, val_double) =
+                        (vals[0].clone(), vals[1].clone(), vals[2].clone());
+                    let feedback_site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::ArrayElement,
+                        "array[index]=",
+                        if require_numeric_layout {
+                            TypedFeedbackContract::numeric_array_set_index()
+                        } else {
+                            TypedFeedbackContract::array_set_index()
+                        },
+                    );
+                    // Use the fast inlined IndexSet path only when the
+                    // receiver is a local that's actually in ctx.locals
+                    // (stack slot). Module-level arrays accessed from inside
+                    // a function are in ctx.module_globals instead — for
+                    // those we use js_array_set_f64_extend (the realloc-
+                    // capable variant) and write the new pointer back to
+                    // the global slot. Issue #221: the previous code
+                    // funneled module globals through js_array_set_f64
+                    // which returns silently when `index >= length` — so
+                    // every `arr[i] = v` against a `const A: T[] = []`
+                    // declared empty was a silent no-op, both the value
+                    // and the implicit length update vanishing.
+                    if let Some(id) = local_id {
+                        if ctx.locals.contains_key(&id) {
+                            let value_is_canonical_raw_f64 =
+                                crate::type_analysis::expr_produces_canonical_raw_f64(ctx, value);
+                            lower_index_set_fast(
+                                ctx,
+                                &arr_box,
+                                &idx_double,
+                                &val_double,
+                                id,
+                                layout_note_needed,
+                                write_barrier_needed,
+                                value_is_numeric,
+                                require_numeric_layout,
+                                value_is_canonical_raw_f64,
+                                &feedback_site_id,
+                            )?;
+                        } else if let Some(global_name) = ctx.module_globals.get(&id).cloned() {
+                            let blk = ctx.block();
+                            let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                            let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                            let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
+                            let new_handle = blk.call(
+                                I64,
+                                "js_typed_feedback_array_set_f64_extend",
+                                &[
+                                    (I64, &feedback_site_id),
+                                    (I64, &arr_handle),
+                                    (I32, &idx_i32),
+                                    (DOUBLE, &val_double),
+                                ],
+                            );
+                            let new_box = nanbox_pointer_inline(blk, &new_handle);
+                            let g_ref = format!("@{}", global_name);
+                            // GC_STORE_AUDIT(ROOT): module global array slot is a registered mutable GC root.
+                            emit_root_nanbox_store_on_block(ctx.block(), &new_box, &g_ref);
+                            // Gen-GC Phase C2: write barrier on array element store.
+                            if write_barrier_needed {
+                                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                                emit_write_barrier(ctx, &arr_bits, &val_bits);
+                            }
+                        } else {
+                            // Closure-captured array, or local without a
+                            // stack slot (rare). Issue #637 followup / hono r2:
+                            // pre-fix this called `js_array_set_f64` (non-
+                            // extending), which silently returned when `index
+                            // >= length` (matching `js_array_set_f64`'s in-
+                            // bounds gate at array.rs:571). For an empty
+                            // captured array (common pattern: closure body
+                            // does `arr[++i] = X` to populate from outer
+                            // scope), this dropped every write. Switch to
+                            // `js_array_set_f64_extend` — the forwarding-
+                            // pointer mechanism (issue #233) handles realloc
+                            // visibility for the caller, so we don't need a
+                            // writeback target here. Discard the returned
+                            // pointer; downstream reads via clean_arr_ptr
+                            // follow the forwarding chain to the new head.
+                            let blk = ctx.block();
+                            let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                            let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                            let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
+                            blk.call(
+                                I64,
+                                "js_typed_feedback_array_set_f64_extend",
+                                &[
+                                    (I64, &feedback_site_id),
+                                    (I64, &arr_handle),
+                                    (I32, &idx_i32),
+                                    (DOUBLE, &val_double),
+                                ],
+                            );
+                            // Gen-GC Phase C2: write barrier on array element store.
+                            if write_barrier_needed {
+                                let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
+                                emit_write_barrier(ctx, &arr_bits, &val_bits);
+                            }
                         }
                     } else {
-                        // Closure-captured array, or local without a
-                        // stack slot (rare). Issue #637 followup / hono r2:
-                        // pre-fix this called `js_array_set_f64` (non-
-                        // extending), which silently returned when `index
-                        // >= length` (matching `js_array_set_f64`'s in-
-                        // bounds gate at array.rs:571). For an empty
-                        // captured array (common pattern: closure body
-                        // does `arr[++i] = X` to populate from outer
-                        // scope), this dropped every write. Switch to
-                        // `js_array_set_f64_extend` — the forwarding-
-                        // pointer mechanism (issue #233) handles realloc
-                        // visibility for the caller, so we don't need a
-                        // writeback target here. Discard the returned
-                        // pointer; downstream reads via clean_arr_ptr
-                        // follow the forwarding chain to the new head.
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
                         let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
+                        // Issue #637 followup / hono r2: use the extend variant
+                        // so `arr[i] = X` for i >= length grows the array per
+                        // JS spec, instead of silently no-op'ing (which the
+                        // non-extend `js_array_set_f64` did via `if index >=
+                        // length { return; }`). The hono Trie's
+                        // `indexReplacementMap[++captureIndex] = N` pattern
+                        // (sparse-extend from a closure capturing the array)
+                        // was the load-bearing site — pre-fix the array stayed
+                        // length 0 inside the closure, so `for (const i in
+                        // indexReplacementMap)` outside the closure iterated
+                        // zero times and `handlerMap` ended up empty.
                         blk.call(
                             I64,
                             "js_typed_feedback_array_set_f64_extend",
@@ -1452,300 +1527,311 @@ pub(crate) fn lower(
                             emit_write_barrier(ctx, &arr_bits, &val_bits);
                         }
                     }
-                } else {
-                    let blk = ctx.block();
-                    let arr_bits = blk.bitcast_double_to_i64(&arr_box);
-                    let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                    let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
-                    // Issue #637 followup / hono r2: use the extend variant
-                    // so `arr[i] = X` for i >= length grows the array per
-                    // JS spec, instead of silently no-op'ing (which the
-                    // non-extend `js_array_set_f64` did via `if index >=
-                    // length { return; }`). The hono Trie's
-                    // `indexReplacementMap[++captureIndex] = N` pattern
-                    // (sparse-extend from a closure capturing the array)
-                    // was the load-bearing site — pre-fix the array stayed
-                    // length 0 inside the closure, so `for (const i in
-                    // indexReplacementMap)` outside the closure iterated
-                    // zero times and `handlerMap` ended up empty.
-                    blk.call(
-                        I64,
-                        "js_typed_feedback_array_set_f64_extend",
-                        &[
-                            (I64, &feedback_site_id),
-                            (I64, &arr_handle),
-                            (I32, &idx_i32),
-                            (DOUBLE, &val_double),
-                        ],
-                    );
-                    // Gen-GC Phase C2: write barrier on array element store.
-                    if write_barrier_needed {
-                        let val_bits = ctx.block().bitcast_double_to_i64(&val_double);
-                        emit_write_barrier(ctx, &arr_bits, &val_bits);
-                    }
-                }
-                // After the store, never before: every branch above ends in a
-                // helper that can itself allocate (element-array growth, the
-                // extend path's realloc).
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(val_double);
+                    // The group is released after `body` returns, never before:
+                    // every branch above ends in a helper that can itself allocate
+                    // (element-array growth, the extend path's realloc).
+                    Ok(val_double)
+                });
             }
             if let Expr::String(literal) = index.as_ref() {
-                let obj_box = lower_expr(ctx, object)?;
                 // #7154: the value expression can collect, and an evacuating
                 // minor inside it relocates the receiver out from under
                 // `obj_box`. Root it across the evaluation and re-read below.
-                let recv_guard =
-                    super::temp_root::guard_store_operand(ctx, object, &obj_box, value);
-                let (val_double, _val_bits) = lower_value_for_dynamic_index_set(
+                // The key is a literal, so it is not an operand here at all —
+                // it is interned into the string pool below.
+                return rooting::with_operands_rooted_across(
                     ctx,
-                    value,
-                    "index_set.literal_string_value_bits",
-                    "literal_string_index_set_helper_edge",
-                )?;
-                let obj_box =
-                    super::temp_root::reread_store_operand(ctx, &recv_guard, object, &obj_box)?;
-                let key_idx = ctx.strings.intern(literal);
-                let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
-                let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
-                super::property_set::emit_nullish_write_guard(
-                    ctx,
-                    &obj_bits,
-                    literal,
-                    "iset.literal",
+                    &[object.as_ref()],
+                    &[value.as_ref()],
+                    |ctx| {
+                        lower_value_for_dynamic_index_set(
+                            ctx,
+                            value,
+                            "index_set.literal_string_value_bits",
+                            "literal_string_index_set_helper_edge",
+                        )
+                    },
+                    |ctx, vals, (val_double, _val_bits)| {
+                        let obj_box = vals[0].clone();
+                        let key_idx = ctx.strings.intern(literal);
+                        let key_handle_global =
+                            format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                        let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
+                        super::property_set::emit_nullish_write_guard(
+                            ctx,
+                            &obj_bits,
+                            literal,
+                            "iset.literal",
+                        );
+                        let static_classref = super::index_get::index_object_is_class_or_proto_ref(
+                            ctx,
+                            object.as_ref(),
+                        );
+                        let (obj_handle, key_raw) = {
+                            let blk = ctx.block();
+                            let obj_handle = super::index_get::classref_preserving_handle(
+                                blk,
+                                &obj_bits,
+                                static_classref,
+                            );
+                            let key_box = blk.load(DOUBLE, &key_handle_global);
+                            let key_bits = blk.bitcast_double_to_i64(&key_box);
+                            let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+                            (obj_handle, key_raw)
+                        };
+                        let site_id = emit_typed_feedback_register_site(
+                            ctx,
+                            TypedFeedbackKind::PropertySet,
+                            literal,
+                            TypedFeedbackContract::object_set_by_name(),
+                        );
+                        ctx.block().call_void(
+                            "js_typed_feedback_object_set_field_by_name",
+                            &[
+                                (I64, &site_id),
+                                (I64, &obj_handle),
+                                (I64, &key_raw),
+                                (DOUBLE, &val_double),
+                            ],
+                        );
+                        Ok(val_double)
+                    },
                 );
-                let static_classref =
-                    super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
-                let (obj_handle, key_raw) = {
-                    let blk = ctx.block();
-                    let obj_handle = super::index_get::classref_preserving_handle(
-                        blk,
-                        &obj_bits,
-                        static_classref,
-                    );
-                    let key_box = blk.load(DOUBLE, &key_handle_global);
-                    let key_bits = blk.bitcast_double_to_i64(&key_box);
-                    let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
-                    (obj_handle, key_raw)
-                };
-                let site_id = emit_typed_feedback_register_site(
-                    ctx,
-                    TypedFeedbackKind::PropertySet,
-                    literal,
-                    TypedFeedbackContract::object_set_by_name(),
-                );
-                ctx.block().call_void(
-                    "js_typed_feedback_object_set_field_by_name",
-                    &[
-                        (I64, &site_id),
-                        (I64, &obj_handle),
-                        (I64, &key_raw),
-                        (DOUBLE, &val_double),
-                    ],
-                );
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(val_double);
             }
             if is_string_expr(ctx, index) {
-                let obj_box = lower_expr(ctx, object)?;
-                // #7154: see the literal-key arm above.
-                let recv_guard =
-                    super::temp_root::guard_store_operand(ctx, object, &obj_box, value);
-                let key_box = lower_expr(ctx, index)?;
-                // #7154: the KEY sits in the same window as the receiver. A
-                // non-literal string key is an ordinary heap string with no
-                // registered root of its own, so an evacuating minor inside the
-                // value's evaluation relocates it and leaves `key_box` naming
-                // from-space — `unbox_str_handle` below would hand the setter a
-                // pre-move `StringHeader*` and the field would land under a
-                // garbage key. Pushed AFTER `recv_guard` so the two cuts nest:
-                // `temp_root_truncate` drops everything above its index, so the
-                // key must be released first.
-                let key_guard = super::temp_root::guard_store_operand(ctx, index, &key_box, value);
-                let (val_double, _val_bits) = lower_value_for_dynamic_index_set(
+                // #7154: see the literal-key arm above, plus the KEY, which
+                // sits in the same window. A non-literal string key is an
+                // ordinary heap string with no registered root of its own, so
+                // an evacuating minor inside the value's evaluation relocates
+                // it and leaves the register naming from-space —
+                // `unbox_str_handle` below would hand the setter a pre-move
+                // `StringHeader*` and the field would land under a garbage key.
+                //
+                // #7647: the receiver's window used to be derived from `value`
+                // ALONE, which is the half-measure #7201 named. The receiver is
+                // lowered before the KEY as well, so `o[f()] = 1` — a literal
+                // RHS that cannot collect, an allocating key that can — left it
+                // unguarded. As one operand group the receiver's window is the
+                // disjunction over everything after it, which is what #7201
+                // established and what `guard_store_operand`'s two-argument
+                // form structurally could not say.
+                return rooting::with_operands_rooted_across(
                     ctx,
-                    value,
-                    "index_set.string_value_bits",
-                    "string_index_set_helper_edge",
-                )?;
-                let key_box =
-                    super::temp_root::reread_store_operand(ctx, &key_guard, index, &key_box)?;
-                let obj_box =
-                    super::temp_root::reread_store_operand(ctx, &recv_guard, object, &obj_box)?;
-                let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
-                super::property_set::emit_nullish_write_guard(
-                    ctx,
-                    &obj_bits,
-                    "index",
-                    "iset.string",
+                    &[object.as_ref(), index.as_ref()],
+                    &[value.as_ref()],
+                    |ctx| {
+                        lower_value_for_dynamic_index_set(
+                            ctx,
+                            value,
+                            "index_set.string_value_bits",
+                            "string_index_set_helper_edge",
+                        )
+                    },
+                    |ctx, vals, (val_double, _val_bits)| {
+                        let (obj_box, key_box) = (vals[0].clone(), vals[1].clone());
+                        let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
+                        super::property_set::emit_nullish_write_guard(
+                            ctx,
+                            &obj_bits,
+                            "index",
+                            "iset.string",
+                        );
+                        let static_classref = super::index_get::index_object_is_class_or_proto_ref(
+                            ctx,
+                            object.as_ref(),
+                        );
+                        let (obj_handle, key_handle) = {
+                            let blk = ctx.block();
+                            let obj_handle = super::index_get::classref_preserving_handle(
+                                blk,
+                                &obj_bits,
+                                static_classref,
+                            );
+                            // SSO-safe key unbox — see IndexGet branch above for rationale.
+                            let key_handle = unbox_str_handle(blk, &key_box);
+                            (obj_handle, key_handle)
+                        };
+                        let site_id = emit_typed_feedback_register_site(
+                            ctx,
+                            TypedFeedbackKind::PropertySet,
+                            "object[string_index]",
+                            TypedFeedbackContract::object_set_by_name(),
+                        );
+                        ctx.block().call_void(
+                            "js_typed_feedback_object_set_field_by_name",
+                            &[
+                                (I64, &site_id),
+                                (I64, &obj_handle),
+                                (I64, &key_handle),
+                                (DOUBLE, &val_double),
+                            ],
+                        );
+                        // One group, one release, below the store. The inner-to-outer
+                        // ordering obligation the two hand-written guards carried —
+                        // `temp_root_truncate` is a stack CUT, so releasing the
+                        // receiver first silently dropped the key's slot as well — is
+                        // gone rather than merely documented.
+                        Ok(val_double)
+                    },
                 );
-                let static_classref =
-                    super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
-                let (obj_handle, key_handle) = {
-                    let blk = ctx.block();
-                    let obj_handle = super::index_get::classref_preserving_handle(
-                        blk,
-                        &obj_bits,
-                        static_classref,
-                    );
-                    // SSO-safe key unbox — see IndexGet branch above for rationale.
-                    let key_handle = unbox_str_handle(blk, &key_box);
-                    (obj_handle, key_handle)
-                };
-                let site_id = emit_typed_feedback_register_site(
-                    ctx,
-                    TypedFeedbackKind::PropertySet,
-                    "object[string_index]",
-                    TypedFeedbackContract::object_set_by_name(),
-                );
-                ctx.block().call_void(
-                    "js_typed_feedback_object_set_field_by_name",
-                    &[
-                        (I64, &site_id),
-                        (I64, &obj_handle),
-                        (I64, &key_handle),
-                        (DOUBLE, &val_double),
-                    ],
-                );
-                // Inner-to-outer: `temp_root_truncate` drops every slot at and
-                // above its index, so releasing the receiver first would drop
-                // the key's as a side effect. Correct today, wrong the moment
-                // the push order changes — and #7207's `proxy_reflect` sibling
-                // spells both out for exactly that reason.
-                super::temp_root::release_store_operand(ctx, key_guard);
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(val_double);
             }
             // Fallback with runtime STRING_TAG check, matching IndexGet.
             // Layout: first runtime-check whether the index is a Symbol
             // (POINTER_TAG with SYMBOL_MAGIC). If so, dispatch to the
             // symbol-property side table. Otherwise fall through to the
             // string/numeric dispatch.
-            let obj_box = lower_expr(ctx, object)?;
-            let idx_box = lower_expr(ctx, index)?;
-            let (val_double, _val_bits) = lower_value_for_dynamic_index_set(
-                ctx,
-                value,
-                "index_set.dynamic_value_bits",
-                "polymorphic_index_set_helper_edge",
-            )?;
-            let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
-            super::property_set::emit_nullish_write_guard(ctx, &obj_bits, "index", "iset");
-            let static_classref =
-                super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
-            let obj_handle = {
-                let blk = ctx.block();
-                super::index_get::classref_preserving_handle(blk, &obj_bits, static_classref)
-            };
-            let feedback_site_id = emit_typed_feedback_register_site(
-                ctx,
-                TypedFeedbackKind::ArrayElement,
-                "index_set",
-                TypedFeedbackContract::polymorphic_index_set(),
-            );
-            // Symbol check: js_is_symbol returns 1 if idx_box is a Symbol.
-            let is_sym_i32 = ctx.block().call(I32, "js_is_symbol", &[(DOUBLE, &idx_box)]);
-            let is_sym_bit = ctx.block().icmp_ne(I32, &is_sym_i32, "0");
-            let sym_set = ctx.new_block("iset.sym");
-            let nonsym_set = ctx.new_block("iset.nonsym");
-            let str_set = ctx.new_block("iset.str");
-            let num_set = ctx.new_block("iset.num");
-            let set_merge = ctx.new_block("iset.merge");
-            let sym_lbl = ctx.block_label(sym_set);
-            let nonsym_lbl = ctx.block_label(nonsym_set);
-            let str_lbl = ctx.block_label(str_set);
-            let num_lbl = ctx.block_label(num_set);
-            let merge_lbl = ctx.block_label(set_merge);
-            ctx.block().cond_br(&is_sym_bit, &sym_lbl, &nonsym_lbl);
-            // Symbol key → side-table set.
-            ctx.current_block = sym_set;
-            ctx.block().call(
-                DOUBLE,
-                "js_object_set_symbol_property",
-                &[
-                    (DOUBLE, &obj_box),
-                    (DOUBLE, &idx_box),
-                    (DOUBLE, &val_double),
-                ],
-            );
-            ctx.block().br(&merge_lbl);
-            // Not a symbol — recompute idx_bits in this block (LLVM SSA, no
-            // dominance issue: each branch starts fresh).
-            ctx.current_block = nonsym_set;
-            let blk = ctx.block();
-            let idx_bits = blk.bitcast_double_to_i64(&idx_box);
-            let top16 = blk.lshr(I64, &idx_bits, "48");
-            // STRING_TAG (0x7FFF) heap pointer + SHORT_STRING_TAG (0x7FF9) SSO.
-            // See IndexGet path comment / issue #434 for the SSO rationale.
-            let is_str_tag_heap = blk.icmp_eq(I64, &top16, "32767");
-            let lower48 = blk.and(I64, &idx_bits, POINTER_MASK_I64);
-            let is_valid_ptr = blk.icmp_ugt(I64, &lower48, "4095");
-            let is_str_heap = blk.and(crate::types::I1, &is_str_tag_heap, &is_valid_ptr);
-            let is_str_tag_sso = blk.icmp_eq(I64, &top16, "32761");
-            let is_str = blk.or(crate::types::I1, &is_str_heap, &is_str_tag_sso);
-            ctx.block().cond_br(&is_str, &str_lbl, &num_lbl);
-            // String key → polymorphic helper that detects array receivers
-            // and parses numeric-string keys as array indices, falling
-            // through to `js_object_set_field_by_name` for Object/Closure
-            // receivers. Issue #637: pre-fix this called the object setter
-            // unconditionally, which silently no-op'd `arr[stringKey] = X`
-            // on captured arrays whose static type was lost across the
-            // closure boundary (forEach callbacks, replace callbacks, etc.).
-            ctx.current_block = str_set;
-            let key_handle = {
-                let blk = ctx.block();
-                unbox_str_handle(blk, &idx_box)
-            };
-            ctx.block().call(
-                I64,
-                "js_typed_feedback_array_set_string_key",
-                &[
-                    (I64, &feedback_site_id),
-                    (I64, &obj_handle),
-                    (I64, &key_handle),
-                    (DOUBLE, &val_double),
-                ],
-            );
-            ctx.block().br(&merge_lbl);
-            // Numeric key → polymorphic dispatch.
             //
-            // Closes #471: the previous fallback emitted an inline
-            // `obj_handle + 8 + idx*8` store on the assumption that the
-            // receiver had an ArrayHeader (8-byte header) layout. That's
-            // a load-bearing assumption for `arr[i] = v` against an
-            // unknown-typed receiver where `is_array_expr` couldn't
-            // narrow it statically — but the header spans object_header_size_bytes(...) bytes, then inline slots, plus
-            // `max(field_count, 8)` inline slots, so writing at offset
-            // `8 + idx*8` for any `idx ≥ 7` overflows the object's
-            // allocation and corrupts the adjacent heap object. The
-            // @perryts/mongodb #471 repro hit this with `idMap[i] = …`
-            // (a `Record<number, unknown>`) and trampled the keys_array
-            // of an unrelated object that the BSON encoder later read
-            // as an empty doc, producing structurally-truncated wire data.
-            //
-            // Route through the runtime which checks the receiver's GC
-            // type and dispatches: arrays/buffers/typed-arrays through
-            // js_array_set_f64_extend (handles forwarding + per-kind
-            // stores), plain objects through stringify-the-index +
-            // js_object_set_field_by_name. The forwarding-chain handling
-            // that the previous code's inline-vs-fwd branch did is now
-            // inside js_array_set_f64_extend's clean_arr_ptr_mut.
-            ctx.current_block = num_set;
-            {
-                let blk = ctx.block();
-                blk.call_void(
-                    "js_typed_feedback_object_set_index_polymorphic",
-                    &[
-                        (I64, &feedback_site_id),
-                        (I64, &obj_handle),
-                        (DOUBLE, &idx_box),
-                        (DOUBLE, &val_double),
-                    ],
-                );
-            }
-            ctx.block().br(&merge_lbl);
-            ctx.current_block = set_merge;
-            Ok(val_double)
+            // #7647: this arm had NO store-operand guard on either operand,
+            // while every sibling arm above has had one since #7154. It is the
+            // most exposed of them all — it is reached precisely when NOTHING
+            // about the receiver or the key is statically known, so both are
+            // ordinary heap values by default, and both are consumed after
+            // `lower_value_for_dynamic_index_set` has lowered arbitrary user
+            // code. `js_object_set_symbol_property` takes the receiver box
+            // directly and the string arm masks the key to a `StringHeader*`,
+            // so an evacuating minor in the RHS lands the write on a stale
+            // object under a stale key. `m[k] = f()` on an `any`-typed `m`
+            // reaches it.
+            return rooting::with_operands_rooted_across(
+                ctx,
+                &[object.as_ref(), index.as_ref()],
+                &[value.as_ref()],
+                |ctx| {
+                    lower_value_for_dynamic_index_set(
+                        ctx,
+                        value,
+                        "index_set.dynamic_value_bits",
+                        "polymorphic_index_set_helper_edge",
+                    )
+                },
+                |ctx, vals, (val_double, _val_bits)| {
+                    let (obj_box, idx_box) = (vals[0].clone(), vals[1].clone());
+                    let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
+                    super::property_set::emit_nullish_write_guard(ctx, &obj_bits, "index", "iset");
+                    let static_classref =
+                        super::index_get::index_object_is_class_or_proto_ref(ctx, object.as_ref());
+                    let obj_handle = {
+                        let blk = ctx.block();
+                        super::index_get::classref_preserving_handle(
+                            blk,
+                            &obj_bits,
+                            static_classref,
+                        )
+                    };
+                    let feedback_site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::ArrayElement,
+                        "index_set",
+                        TypedFeedbackContract::polymorphic_index_set(),
+                    );
+                    // Symbol check: js_is_symbol returns 1 if idx_box is a Symbol.
+                    let is_sym_i32 = ctx.block().call(I32, "js_is_symbol", &[(DOUBLE, &idx_box)]);
+                    let is_sym_bit = ctx.block().icmp_ne(I32, &is_sym_i32, "0");
+                    let sym_set = ctx.new_block("iset.sym");
+                    let nonsym_set = ctx.new_block("iset.nonsym");
+                    let str_set = ctx.new_block("iset.str");
+                    let num_set = ctx.new_block("iset.num");
+                    let set_merge = ctx.new_block("iset.merge");
+                    let sym_lbl = ctx.block_label(sym_set);
+                    let nonsym_lbl = ctx.block_label(nonsym_set);
+                    let str_lbl = ctx.block_label(str_set);
+                    let num_lbl = ctx.block_label(num_set);
+                    let merge_lbl = ctx.block_label(set_merge);
+                    ctx.block().cond_br(&is_sym_bit, &sym_lbl, &nonsym_lbl);
+                    // Symbol key → side-table set.
+                    ctx.current_block = sym_set;
+                    ctx.block().call(
+                        DOUBLE,
+                        "js_object_set_symbol_property",
+                        &[
+                            (DOUBLE, &obj_box),
+                            (DOUBLE, &idx_box),
+                            (DOUBLE, &val_double),
+                        ],
+                    );
+                    ctx.block().br(&merge_lbl);
+                    // Not a symbol — recompute idx_bits in this block (LLVM SSA, no
+                    // dominance issue: each branch starts fresh).
+                    ctx.current_block = nonsym_set;
+                    let blk = ctx.block();
+                    let idx_bits = blk.bitcast_double_to_i64(&idx_box);
+                    let top16 = blk.lshr(I64, &idx_bits, "48");
+                    // STRING_TAG (0x7FFF) heap pointer + SHORT_STRING_TAG (0x7FF9) SSO.
+                    // See IndexGet path comment / issue #434 for the SSO rationale.
+                    let is_str_tag_heap = blk.icmp_eq(I64, &top16, "32767");
+                    let lower48 = blk.and(I64, &idx_bits, POINTER_MASK_I64);
+                    let is_valid_ptr = blk.icmp_ugt(I64, &lower48, "4095");
+                    let is_str_heap = blk.and(crate::types::I1, &is_str_tag_heap, &is_valid_ptr);
+                    let is_str_tag_sso = blk.icmp_eq(I64, &top16, "32761");
+                    let is_str = blk.or(crate::types::I1, &is_str_heap, &is_str_tag_sso);
+                    ctx.block().cond_br(&is_str, &str_lbl, &num_lbl);
+                    // String key → polymorphic helper that detects array receivers
+                    // and parses numeric-string keys as array indices, falling
+                    // through to `js_object_set_field_by_name` for Object/Closure
+                    // receivers. Issue #637: pre-fix this called the object setter
+                    // unconditionally, which silently no-op'd `arr[stringKey] = X`
+                    // on captured arrays whose static type was lost across the
+                    // closure boundary (forEach callbacks, replace callbacks, etc.).
+                    ctx.current_block = str_set;
+                    let key_handle = {
+                        let blk = ctx.block();
+                        unbox_str_handle(blk, &idx_box)
+                    };
+                    ctx.block().call(
+                        I64,
+                        "js_typed_feedback_array_set_string_key",
+                        &[
+                            (I64, &feedback_site_id),
+                            (I64, &obj_handle),
+                            (I64, &key_handle),
+                            (DOUBLE, &val_double),
+                        ],
+                    );
+                    ctx.block().br(&merge_lbl);
+                    // Numeric key → polymorphic dispatch.
+                    //
+                    // Closes #471: the previous fallback emitted an inline
+                    // `obj_handle + 8 + idx*8` store on the assumption that the
+                    // receiver had an ArrayHeader (8-byte header) layout. That's
+                    // a load-bearing assumption for `arr[i] = v` against an
+                    // unknown-typed receiver where `is_array_expr` couldn't
+                    // narrow it statically — but the header spans object_header_size_bytes(...) bytes, then inline slots, plus
+                    // `max(field_count, 8)` inline slots, so writing at offset
+                    // `8 + idx*8` for any `idx ≥ 7` overflows the object's
+                    // allocation and corrupts the adjacent heap object. The
+                    // @perryts/mongodb #471 repro hit this with `idMap[i] = …`
+                    // (a `Record<number, unknown>`) and trampled the keys_array
+                    // of an unrelated object that the BSON encoder later read
+                    // as an empty doc, producing structurally-truncated wire data.
+                    //
+                    // Route through the runtime which checks the receiver's GC
+                    // type and dispatches: arrays/buffers/typed-arrays through
+                    // js_array_set_f64_extend (handles forwarding + per-kind
+                    // stores), plain objects through stringify-the-index +
+                    // js_object_set_field_by_name. The forwarding-chain handling
+                    // that the previous code's inline-vs-fwd branch did is now
+                    // inside js_array_set_f64_extend's clean_arr_ptr_mut.
+                    ctx.current_block = num_set;
+                    {
+                        let blk = ctx.block();
+                        blk.call_void(
+                            "js_typed_feedback_object_set_index_polymorphic",
+                            &[
+                                (I64, &feedback_site_id),
+                                (I64, &obj_handle),
+                                (DOUBLE, &idx_box),
+                                (DOUBLE, &val_double),
+                            ],
+                        );
+                    }
+                    ctx.block().br(&merge_lbl);
+                    // The group is released after `body` returns, which lands the
+                    // truncate in the merge block — below every arm's setter, each of
+                    // which can run a user setter and therefore collect.
+                    ctx.current_block = set_merge;
+                    Ok(val_double)
+                },
+            );
         }
 
         // `obj.field = v` — generic object field write.

--- a/crates/perry-codegen/src/expr/index_set_typed_array.rs
+++ b/crates/perry-codegen/src/expr/index_set_typed_array.rs
@@ -15,7 +15,7 @@
 //! out-of-line `js_dyn_index_set` fallback — no user expression is lowered
 //! here, so no window opens. The receiver's exposure across the VALUE's
 //! lowering is the caller's to close, and `index_set.rs`'s `#5525` arm is one
-//! of the sites #7647 records as still open.
+//! of the sites #7640 records as still open.
 
 use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8};
 

--- a/crates/perry-codegen/src/expr/index_set_typed_array.rs
+++ b/crates/perry-codegen/src/expr/index_set_typed_array.rs
@@ -4,6 +4,18 @@
 //! (#7342 pushed it to 2035). Pure mechanical move — the two functions below
 //! are verbatim, and `index_set.rs` calls them through a `use super::` path
 //! exactly as it called them locally before.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion. The audit that earned it: both functions take the receiver, index
+//! and value already lowered by the caller, and emit only pure IR plus the
+//! out-of-line `js_dyn_index_set` fallback — no user expression is lowered
+//! here, so no window opens. The receiver's exposure across the VALUE's
+//! lowering is the caller's to close, and `index_set.rs`'s `#5525` arm is one
+//! of the sites #7647 records as still open.
 
 use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8};
 

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1848,6 +1848,10 @@ mod ptr_numarray_access;
 mod ta_param_f64_read;
 pub(crate) use index_get::packed_f64_loop_index_parts;
 pub(crate) use masked_window::masked_window_fact_for_index;
+/// Rooting coverage for the computed-store arms the TS corpora cannot reach
+/// (#7637, #7638, #7639) — see the module header for why they cannot.
+#[cfg(test)]
+mod computed_store_rooting_tests;
 mod index_set;
 mod index_set_typed_array;
 mod instance_misc1;

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -3,6 +3,25 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion. Say what it is rather than banking the count.
+//!
+//! The audit that earned it. A dotted `obj.k` has exactly ONE user expression
+//! to lower — the receiver — and the property name is a compile-time string
+//! interned into the pool, not an operand. So the sibling-window shape that
+//! `index_get.rs` has (base lowered, then key lowered, then base used) cannot
+//! arise: the receiver is lowered LAST and nothing follows it.
+//!
+//! The three `.call(I64, "js_*")` sites the campaign map counts —
+//! `js_error_get_errors`, `js_process_version`, `js_closure_alloc_singleton` —
+//! each hand their raw pointer straight to a `nanbox_*_inline` in the same
+//! block, with no emission in between. `call_rooted` has no site here: rooting
+//! them would add temp-root traffic to close a window that does not exist.
 
 use anyhow::Result;
 use perry_hir::types::Type as HirType;

--- a/crates/perry-codegen/src/expr/property_get/globalget.rs
+++ b/crates/perry-codegen/src/expr/property_get/globalget.rs
@@ -3,6 +3,23 @@
 //! Pure mechanical move — body is the verbatim contents of the
 //! `if matches!(object.as_ref(), Expr::GlobalGet(_)) { ... }` block from the
 //! general catch-all arm, lifted into its own function.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion.
+//!
+//! The audit that earned it, and it is the one worth reading twice: the
+//! campaign map credits this file with **6 hazard sites** and all six are the
+//! same false positive. Each is `js_get_global_this_builtin_value` →
+//! `ctx.strings.intern(property)` → `unbox_to_i64` → `load` → the by-name
+//! getter. `intern` and `format!` are compile-time bookkeeping that emit NO IR,
+//! and the rest are loads, bitcasts and masks, none of which can collect. The
+//! `haz` heuristic counts source distance between a binding and its use; a
+//! window is measured in *emissions*, and there are none here. This module
+//! lowers no user expression at all.
 
 use super::*;
 

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -3,6 +3,19 @@
 //! Pure mechanical move — bodies are verbatim. Visibility widened to
 //! `pub(crate)` so both the trunk's guarded arms and the sibling general
 //! dispatch can reach them.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Listed in `crate::rooting`'s `MIGRATED_MODULES`, and the listing is
+//! **vacuous on the committed source**: this module has never named an
+//! `expr::temp_root` symbol, so only the sabotage arm makes the line an
+//! assertion. The audit that earned it: these helpers receive the receiver
+//! already lowered and lower no user expression, so no operand window opens
+//! inside them. The class-field guard diamond does hold a derived
+//! `obj_bits`/`obj_handle` across `js_typed_feedback_class_field_get_guard`;
+//! that shape is a *derived raw pointer*, which no temp root can name and which
+//! `crate::rooting` therefore cannot express — it is recorded in #7648, not
+//! papered over here.
 
 use super::*;
 

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -14,7 +14,7 @@
 //! inside them. The class-field guard diamond does hold a derived
 //! `obj_bits`/`obj_handle` across `js_typed_feedback_class_field_get_guard`;
 //! that shape is a *derived raw pointer*, which no temp root can name and which
-//! `crate::rooting` therefore cannot express — it is recorded in #7648, not
+//! `crate::rooting` therefore cannot express — it is recorded in #7640, not
 //! papered over here.
 
 use super::*;

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -16,7 +16,7 @@
 //! `lower_value_for_dynamic_property_set`, which this API cannot produce).
 //!
 //! The migration found one arm that had no guard at all: `arr.length = f()`
-//! (#7645). It is the same #7154 window every sibling arm already closed, and
+//! (#7637). It is the same #7154 window every sibling arm already closed, and
 //! it is closed here by putting the receiver in an operand group rather than by
 //! a fourth hand-written guard.
 
@@ -398,7 +398,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // an array). Deliberately out of scope here; the static-typed
             // case covers the issue's repro.
             if property == "length" && crate::type_analysis::is_array_expr(ctx, object) {
-                // #7645: this arm had NO store-operand guard, while every other
+                // #7637: this arm had NO store-operand guard, while every other
                 // `PropertySet` arm in this file has had one since #7154. It is
                 // the same window: `arr.length = f()` lowers the receiver first
                 // (spec order), `f()` allocates and can drive an evacuating

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -3,6 +3,22 @@
 //! Extracted from `expr/mod.rs` to keep that file under the 2000-line cap.
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
+//!
+//! # Rooting (Layer 1, slice 4)
+//!
+//! Migrated onto [`crate::rooting`]; this module names no `expr::temp_root`
+//! symbol. Every store here is the same shape — the receiver is lowered first
+//! because `Set(O, k, v)` evaluates the reference before the value, so it sits
+//! in an SSA register while arbitrary user code runs — and that shape is
+//! exactly one call to [`crate::rooting::with_operands_rooted`] (the value is
+//! lowered by `lower_expr`) or
+//! [`crate::rooting::with_operands_rooted_across`] (the value is lowered by
+//! `lower_value_for_dynamic_property_set`, which this API cannot produce).
+//!
+//! The migration found one arm that had no guard at all: `arr.length = f()`
+//! (#7645). It is the same #7154 window every sibling arm already closed, and
+//! it is closed here by putting the receiver in an operand group rather than by
+//! a fourth hand-written guard.
 
 use anyhow::Result;
 use perry_hir::types::Type as HirType;
@@ -13,6 +29,7 @@ use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
+use crate::rooting;
 use crate::type_analysis::{
     expr_may_return_boxed_value_from_raw_f64_fallback, is_numeric_expr, receiver_class_name,
 };
@@ -266,22 +283,22 @@ fn lower_runtime_property_set_by_name(
     property: &str,
     value: &Expr,
 ) -> Result<String> {
-    let recv_box = lower_expr(ctx, object)?;
     // #7154: root the receiver across the value's evaluation, which allocates.
-    let recv_guard = super::temp_root::guard_store_operand(ctx, object, &recv_box, value);
-    let val_double = lower_expr(ctx, value)?;
-    let recv_box = super::temp_root::reread_store_operand(ctx, &recv_guard, object, &recv_box)?;
-    let key_idx = ctx.strings.intern(property);
-    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
-    let blk = ctx.block();
-    let obj_bits = blk.bitcast_double_to_i64(&recv_box);
-    let property_id = crate::strings::emit_static_dispatch_id(blk, &dispatch_global);
-    blk.call_void(
-        "js_object_set_field_by_property_id",
-        &[(I64, &obj_bits), (I64, &property_id), (DOUBLE, &val_double)],
-    );
-    super::temp_root::release_store_operand(ctx, recv_guard);
-    Ok(val_double)
+    // The group re-reads it as part of emitting the store, so no register of
+    // the receiver exists across the window.
+    rooting::with_operands_rooted(ctx, &[object, value], |ctx, vals| {
+        let (recv_box, val_double) = (&vals[0], &vals[1]);
+        let key_idx = ctx.strings.intern(property);
+        let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
+        let blk = ctx.block();
+        let obj_bits = blk.bitcast_double_to_i64(recv_box);
+        let property_id = crate::strings::emit_static_dispatch_id(blk, &dispatch_global);
+        blk.call_void(
+            "js_object_set_field_by_property_id",
+            &[(I64, &obj_bits), (I64, &property_id), (DOUBLE, val_double)],
+        );
+        Ok(val_double.clone())
+    })
 }
 
 fn lower_value_for_dynamic_property_set(
@@ -381,19 +398,28 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // an array). Deliberately out of scope here; the static-typed
             // case covers the issue's repro.
             if property == "length" && crate::type_analysis::is_array_expr(ctx, object) {
-                let arr_box = lower_expr(ctx, object)?;
-                let val_double = lower_expr(ctx, value)?;
-                let blk = ctx.block();
-                let arr_bits = blk.bitcast_double_to_i64(&arr_box);
-                let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                // `arr.length = v` is a strict `Set(O,"length",v,true)`: a frozen
-                // array's `length` is non-writable, so route to the throwing
-                // variant instead of the silent internal helper.
-                blk.call_void(
-                    "js_array_set_length_strict",
-                    &[(I64, &arr_handle), (DOUBLE, &val_double)],
-                );
-                return Ok(val_double);
+                // #7645: this arm had NO store-operand guard, while every other
+                // `PropertySet` arm in this file has had one since #7154. It is
+                // the same window: `arr.length = f()` lowers the receiver first
+                // (spec order), `f()` allocates and can drive an evacuating
+                // minor, and `js_array_set_length_strict` then truncates through
+                // a pre-move `ArrayHeader*` — the array the program keeps is
+                // left at its old length. The receiver's own slot is a root the
+                // collector rewrites; the register is not.
+                return rooting::with_operands_rooted(ctx, &[object, value], |ctx, vals| {
+                    let (arr_box, val_double) = (&vals[0], &vals[1]);
+                    let blk = ctx.block();
+                    let arr_bits = blk.bitcast_double_to_i64(arr_box);
+                    let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                    // `arr.length = v` is a strict `Set(O,"length",v,true)`: a
+                    // frozen array's `length` is non-writable, so route to the
+                    // throwing variant instead of the silent internal helper.
+                    blk.call_void(
+                        "js_array_set_length_strict",
+                        &[(I64, &arr_handle), (DOUBLE, val_double)],
+                    );
+                    Ok(val_double.clone())
+                });
             }
             // #1344: `process.env.X = v` must persist to the real OS
             // environment, not just a cached ProcessEnv object backing.
@@ -1250,62 +1276,72 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     }
                 }
             }
-            let obj_box = lower_expr(ctx, object)?;
             // #7154: the value expression can collect, and an evacuating minor
             // inside it relocates the receiver out from under `obj_box` --
             // `obj.k = f()` then writes `k` into abandoned from-space memory
             // and the field never appears on the object the program keeps.
-            let recv_guard = super::temp_root::guard_store_operand(ctx, object, &obj_box, value);
-            let (val_double, _val_bits) = lower_value_for_dynamic_property_set(
+            //
+            // `across` rather than the plain form because the value is lowered
+            // by `lower_value_for_dynamic_property_set` (an
+            // `ExpectedNativeRep::JsValueBits` lowering plus a recorded
+            // materialisation), which the operand list cannot produce.
+            rooting::with_operands_rooted_across(
                 ctx,
-                value,
-                "property_set.dynamic_value_bits",
-                "dynamic_property_set_helper_edge",
-            )?;
-            let obj_box =
-                super::temp_root::reread_store_operand(ctx, &recv_guard, object, &obj_box)?;
-            // Intern the field name in the StringPool (same one the
-            // matching getter uses, so they share the global string).
-            let key_idx = ctx.strings.intern(property);
-            let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
-            let obj_bits = ctx.block().bitcast_double_to_i64(&obj_box);
-            emit_nullish_write_guard(ctx, &obj_bits, property, "pset");
-            // Issue #618-followup: pass the FULL bits (including NaN-box
-            // tag) so the runtime can detect INT32-tagged class refs
-            // (`SQL.Aliased = Aliased` IIFE-static-property pattern from
-            // drizzle-orm). Pre-fix the AND-with-POINTER_MASK_I64 stripped
-            // the 0x7FFE tag, leaving the runtime with a small integer
-            // (the class id) — which fell into the small-handle dispatch
-            // path and silently dropped the assignment. The runtime now
-            // checks for top16 == 0x7FFE and routes to CLASS_DYNAMIC_PROPS.
-            let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-            let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
-            let key_raw = ctx.block().and(I64, &key_bits, POINTER_MASK_I64);
-            if matches!(property.as_str(), "caller" | "arguments") {
-                ctx.block().call_void(
-                    "js_object_set_field_by_name",
-                    &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
-                );
-                super::temp_root::release_store_operand(ctx, recv_guard);
-                return Ok(val_double);
-            }
-            let site_id = emit_typed_feedback_register_site(
-                ctx,
-                TypedFeedbackKind::PropertySet,
-                property,
-                TypedFeedbackContract::object_set_by_name(),
-            );
-            ctx.block().call_void(
-                "js_typed_feedback_object_set_field_by_name_fast",
-                &[
-                    (I64, &site_id),
-                    (I64, &obj_bits),
-                    (I64, &key_raw),
-                    (DOUBLE, &val_double),
-                ],
-            );
-            super::temp_root::release_store_operand(ctx, recv_guard);
-            Ok(val_double)
+                &[object.as_ref()],
+                &[value.as_ref()],
+                |ctx| {
+                    lower_value_for_dynamic_property_set(
+                        ctx,
+                        value,
+                        "property_set.dynamic_value_bits",
+                        "dynamic_property_set_helper_edge",
+                    )
+                },
+                |ctx, vals, (val_double, _val_bits)| {
+                    let obj_box = &vals[0];
+                    // Intern the field name in the StringPool (same one the
+                    // matching getter uses, so they share the global string).
+                    let key_idx = ctx.strings.intern(property);
+                    let key_handle_global =
+                        format!("@{}", ctx.strings.entry(key_idx).handle_global);
+                    let obj_bits = ctx.block().bitcast_double_to_i64(obj_box);
+                    emit_nullish_write_guard(ctx, &obj_bits, property, "pset");
+                    // Issue #618-followup: pass the FULL bits (including NaN-box
+                    // tag) so the runtime can detect INT32-tagged class refs
+                    // (`SQL.Aliased = Aliased` IIFE-static-property pattern from
+                    // drizzle-orm). Pre-fix the AND-with-POINTER_MASK_I64 stripped
+                    // the 0x7FFE tag, leaving the runtime with a small integer
+                    // (the class id) — which fell into the small-handle dispatch
+                    // path and silently dropped the assignment. The runtime now
+                    // checks for top16 == 0x7FFE and routes to CLASS_DYNAMIC_PROPS.
+                    let key_box = ctx.block().load(DOUBLE, &key_handle_global);
+                    let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
+                    let key_raw = ctx.block().and(I64, &key_bits, POINTER_MASK_I64);
+                    if matches!(property.as_str(), "caller" | "arguments") {
+                        ctx.block().call_void(
+                            "js_object_set_field_by_name",
+                            &[(I64, &obj_bits), (I64, &key_raw), (DOUBLE, &val_double)],
+                        );
+                        return Ok(val_double);
+                    }
+                    let site_id = emit_typed_feedback_register_site(
+                        ctx,
+                        TypedFeedbackKind::PropertySet,
+                        property,
+                        TypedFeedbackContract::object_set_by_name(),
+                    );
+                    ctx.block().call_void(
+                        "js_typed_feedback_object_set_field_by_name_fast",
+                        &[
+                            (I64, &site_id),
+                            (I64, &obj_bits),
+                            (I64, &key_raw),
+                            (DOUBLE, &val_double),
+                        ],
+                    );
+                    Ok(val_double)
+                },
+            )
         }
 
         // `obj.field` — generic object field read. We get the key string

--- a/crates/perry-codegen/src/rooting.rs
+++ b/crates/perry-codegen/src/rooting.rs
@@ -837,9 +837,9 @@ pub(crate) fn with_rooted_accumulator<'f, R>(
 /// bounded-index array store and ten arms of `index_get.rs` lower a receiver,
 /// then lower more user code, then use the receiver — and root nothing. Three
 /// of those were adjacent to arms this slice was already rewriting and are
-/// fixed here (#7645, #7646, #7647); the rest are filed (#7647, #7648) rather
-/// than fixed, because they sit on inline fast paths where a temp root is a
-/// measured cost rather than plumbing.
+/// fixed here (#7637, #7638, #7639); the rest are filed as #7640 rather than
+/// fixed, because they sit on inline fast paths where a temp root is a measured
+/// cost rather than plumbing.
 ///
 /// So do not read a ledger line as "this module has no rooting bugs". It says
 /// the module cannot make an ORDERING mistake against the raw API, because it

--- a/crates/perry-codegen/src/rooting.rs
+++ b/crates/perry-codegen/src/rooting.rs
@@ -813,6 +813,38 @@ pub(crate) fn with_rooted_accumulator<'f, R>(
 /// committed source — the sabotage arm is the only thing that makes it an
 /// assertion, exactly as for both slice-1 modules, and the audit that earned
 /// the listing is written into that file's header rather than into this one.
+///
+/// Slice 4 is three load-bearing and six vacuous. `index_get.rs`,
+/// `index_set.rs` and `property_set.rs` all named the `StoreOperandGuard`
+/// family (`guard_store_operand`, `guard_store_operand_across`,
+/// `reread_store_operand`, `release_store_operand`, `expr_may_trigger_gc`)
+/// before the migration, so their lines hold on the committed source. The other
+/// six — `index_get/guarded_array.rs`, `index_get/inline_dyn_typed_array.rs`,
+/// `index_set_typed_array.rs`, `property_get.rs`, `property_get/globalget.rs`,
+/// `property_get/helpers.rs` — named none, and each carries the audit that
+/// earned its listing in its own file header.
+///
+/// ★ **A listed module is not an audited module, and slice 4 is where that
+/// distinction became load-bearing.** These two properties are not the same:
+///
+///   1. every rooting decision the module makes goes through `crate::rooting`
+///      — which is what this ledger checks, and what the listing means;
+///   2. every window in the module HAS a rooting decision.
+///
+/// `index_set.rs` and `index_get.rs` satisfy (1) and do not satisfy (2). The
+/// migration itself surfaced the gap: translating the six guarded arms of
+/// `index_set.rs` made it obvious that its `#5525` typed-array arm, its
+/// bounded-index array store and ten arms of `index_get.rs` lower a receiver,
+/// then lower more user code, then use the receiver — and root nothing. Three
+/// of those were adjacent to arms this slice was already rewriting and are
+/// fixed here (#7645, #7646, #7647); the rest are filed (#7647, #7648) rather
+/// than fixed, because they sit on inline fast paths where a temp root is a
+/// measured cost rather than plumbing.
+///
+/// So do not read a ledger line as "this module has no rooting bugs". It says
+/// the module cannot make an ORDERING mistake against the raw API, because it
+/// no longer names it. A window with no decision at all is invisible to this
+/// check, and the only instrument for it is reading the module.
 #[cfg(test)]
 const MIGRATED_MODULES: &[(&str, &str)] = &[
     (
@@ -858,6 +890,42 @@ const MIGRATED_MODULES: &[(&str, &str)] = &[
     (
         "crates/perry-codegen/src/expr/array_push.rs",
         include_str!("expr/array_push.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/index_get.rs",
+        include_str!("expr/index_get.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/index_get/guarded_array.rs",
+        include_str!("expr/index_get/guarded_array.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/index_get/inline_dyn_typed_array.rs",
+        include_str!("expr/index_get/inline_dyn_typed_array.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/index_set.rs",
+        include_str!("expr/index_set.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/index_set_typed_array.rs",
+        include_str!("expr/index_set_typed_array.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/property_get.rs",
+        include_str!("expr/property_get.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/property_get/globalget.rs",
+        include_str!("expr/property_get/globalget.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/property_get/helpers.rs",
+        include_str!("expr/property_get/helpers.rs"),
+    ),
+    (
+        "crates/perry-codegen/src/expr/property_set.rs",
+        include_str!("expr/property_set.rs"),
     ),
 ];
 


### PR DESCRIPTION
Slice 4 of the Layer 1 campaign (#7615): the computed read/write lowerings.

**Nine modules, all migrated end to end and listed in `MIGRATED_MODULES`** —
`expr/index_get.rs`, `expr/index_get/guarded_array.rs`,
`expr/index_get/inline_dyn_typed_array.rs`, `expr/index_set.rs`,
`expr/index_set_typed_array.rs`, `expr/property_get.rs`,
`expr/property_get/globalget.rs`, `expr/property_get/helpers.rs`,
`expr/property_set.rs`. Nothing names `expr::temp_root` after this, and no
module is left half-migrated.

## One shape, no fourth combinator

Every rooting decision in this slice was the `StoreOperandGuard` family — lower
the receiver, guard it, lower the rest, re-read, store, release — and that is
exactly what `with_operands_rooted` / `with_operands_rooted_across` already say.
The `across` form is needed wherever the value is lowered by
`lower_value_for_dynamic_{index,property}_set` or
`lower_value_for_optional_barrier`, native-rep lowerings the operand list cannot
produce; everywhere else the plain form serves.

## Honest scoping: three load-bearing, six vacuous

`index_get.rs`, `index_set.rs` and `property_set.rs` named the escape hatch
before the migration (`guard_store_operand`, `guard_store_operand_across`,
`reread_store_operand`, `release_store_operand`, `expr_may_trigger_gc`), so
their ledger lines hold on the committed source.

The other six named nothing, so **their lines are vacuous** and only the
sabotage arm makes them assertions. Each carries the audit that earned it in its
own file header rather than banking the count here. The one worth repeating:
the campaign map credits `property_get/globalget.rs` with **6 hazard sites** and
all six are the same false positive — `js_get_global_this_builtin_value` →
`ctx.strings.intern` → `unbox_to_i64` → `load`. `intern` and `format!` emit no
IR. A window is measured in *emissions*, and there are none. That module lowers
no user expression at all.

`property_get.rs`'s three `.call(I64, "js_*")` sites each hand their raw pointer
to a `nanbox_*_inline` in the same block, so `call_rooted` has no site there —
rooting them would add temp-root traffic to close a window that does not exist.

## Three live bugs, fixed here

Each is the same window every sibling arm has guarded since #7154, and each is
on an arm whose store already routes through a runtime helper, so the root is
noise beside the call.

- **#7637** — `arr.length = f()` had no guard at all. Receiver lowered first
  (spec order), `f()` allocates, and `js_array_set_length_strict` then truncates
  the abandoned from-space copy.
- **#7638** — two array element stores held a heap-string KEY across the value.
  `arr[k] = f()` with a non-numeric index rooted the receiver but not the key —
  on the one arm whose entire purpose is keys that are *not* proven numeric —
  and `arr[stringKey] = f()` guarded neither operand.
- **#7639** — the polymorphic `o[k] = f()` fallback guarded neither operand,
  and it is reached precisely when nothing about receiver or key is known, so
  both are heap values by default. Separately the dynamic-string-key arm derived
  the receiver's window from `value` **alone** — the half-measure #7201 named in
  prose — leaving `o[f()] = 1` unguarded.

That last one is the argument for the combinator rather than for a better flag.
`with_operands_rooted_window` computes each operand's window as
`across_collects || any_may_trigger_gc(exprs[i+1..])`, so "the receiver is live
across everything after it" becomes a property of the operand list instead of
something an author restates per site. `guard_store_operand`'s two-argument form
structurally could not say it. The same arm's two nested guards also collapse to
one group, retiring the release-inner-to-outer obligation that
`temp_root_truncate`'s stack-cut semantics imposed.

## What the migration surfaced and did NOT fix — #7640

Translating the guarded arms made visible that ~20 arms in the same files make
**no rooting decision at all**: the bounded-index array store (which sits
immediately above the arm #7341 fixed, and whose loop predicate explicitly
accepts allocating object/array RHSs), the `#5525` inline typed-array stores,
`globalThis[k] = v`, ten read-side arms of `index_get.rs` where the base is live
across the key, an unsubstantiated "statepoint re-read" claim above the
class-field store, and a `unbox_str_handle` ordering hazard that is #7280's
case (a) — a raw `i64` no temp root can name.

Filed with repros and a suggested order rather than fixed, because they sit on
inline fast paths and guard diamonds where a root is a **measured** cost, and
this slice was not permitted to benchmark. Slice 3's `arr.push` precedent
(#7634) is the standard: a behaviour-preserving refactor does not smuggle in a
change whose cost nobody measured.

That gap is now written into the ledger itself, because it is the campaign's
most misreadable result:

> **A listed module is not an audited module.** The ledger asserts that every
> rooting decision a module makes goes through `crate::rooting`. A window with
> no decision at all is invisible to it.

## Verification

**IR identity.** Byte-identical on all 149 modules of the curated corpus. On the
dependency-scale (zod) corpus, 80 of 81 byte-identical; the single difference is
one function, `perry_closure_..._schemas_ts__126`, and it is root-plumbing only:
the dynamic-string-key `IndexSet` arm's two operands are now re-read and
released in **operand-list order** (receiver, key) instead of the hand-written
inner-to-outer order (key, receiver). Same two slots, same set of clears, no
root added or removed — 32 diff lines, all register renumbering downstream of
that swap.

**Probe vacuity checked before trusting the A/B.** Every migrated arm's call
sites were counted in the emitted IR first: 543 `object_get_field_by_name_f64`,
37 `object_set_field_by_name`, 16 `object_get_index_polymorphic`, 10
`array_set_index_or_string`, and so on. The one arm the curated corpus never
calls is `js_array_set_length_strict` — **zero calls across all 129 sources** —
which is why the repairs get unit tests instead.

**Gates.** Both gated modes green on both corpora with an **empty allowlist**;
`--seeded-violations 40` at 40/40 on each; `--unrooted-allocas --moving-only` at
0 over 7867 (curated) and 15242 (dep) gc-capable allocas; stale-register ratchet
unchanged at 23 / 115. Checker `--self-test`, `--audit-alloc-re`,
`--audit-poll-capable`, `--audit-immovable-sources` all clean.

**Ledger sabotage, per module.** A real, compiling `temp_root_push_double` /
`temp_root_truncate` pair was planted in each of the nine in turn — the assert
stops at the first offender, so one run cannot speak for nine — and each was
recorded red naming its own file and lines. Two of the nested submodules needed
`crate::expr::temp_root::` rather than `super::temp_root::`; with `super::` the
plant did not compile, which is a build failure and not a sabotage, so those two
were re-run with the resolving path.

**Tests.** `-p perry-codegen --lib` 702 passed; `--doc` 3 passed (both
`compile_fail` doctests still reject); `-p perry-runtime --no-fail-fast` 1902
passed, 0 failed, no rerun needed. `cargo check --all-targets` clean — the
`#[cfg(test)]` check #7631 asked for.

**Gap families**, both arms, `PERRY_NO_AUTO_OPTIMIZE=1`, prebuilt release
binaries per arm: `test_gap_computed` (5), `test_gap_prop` (1),
`test_gap_array` (13), `test_gap_object` (9), `test_gap_gc_` (30). **Verdict sets
identical on both arms**, including the two pre-existing failures —
`test_gap_prop_plan_cache_invalidation` (parity) and
`test_gap_gc_same_module_call_argument_rooting` (crash) — which reproduce on a
baseline build of `e4b298946` and are not this PR's.

**Lint**: 23 of 24 enumerated steps pass. The one red is
`benchmarks/ci_public_baseline_check.py`, red on pristine `main` since
2026-07-29 and reported by #7618, #7620, #7627 and #7636 alike.

## Coverage for the repaired arms

They are not reachable from ordinary TypeScript, and that was measured rather
than assumed. Six probe shapes — module-const and parameter receivers, string /
symbol / `any` keys, inside and outside a function — all routed past the
subject, because an ordinary `o.k = v` / `o[k] = v` assignment lowers to
`Expr::PutValueSet` and reaches the dynamic IC, not the `Expr::PropertySet` /
`Expr::IndexSet` arms in these modules.

So the coverage is built from HIR, and each test is **differential**: the same
store compiled twice, once with an allocating RHS and once with an inert one,
asserting the allocating one reserves strictly more root slots. An inert RHS
makes `operand_protection` return `Reuse` and the combinator emit nothing —
which is the property keeping this slice byte-identical on the corpus — so the
two runs bracket the repair and no corpus drift can make the assertion vacuous.
Each test also asserts by name that its arm was reached, and the slot count is
read under both root lowerings so it cannot silently measure zero. Sabotaging
the `arr.length` repair turns exactly that one test red, and only it.

Closes #7637, closes #7638, closes #7639. Map comment on #7615 follows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for computed property reads and writes, including array indexing, dynamic keys, and array-length updates.
  - Prevented potential instability during operations that trigger memory allocation.
  - Preserved correct runtime behavior for numeric, string, and symbol-based property access.

- **Tests**
  - Added coverage for computed stores and allocation-sensitive scenarios across supported runtime paths.

- **Documentation**
  - Expanded release documentation covering the completed memory-safety improvements and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->