### PR TITLE
test(gc): the POINTER_FREE trace-skip hazard probe that faults (#7635)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1365
+**Current Version:** 0.5.1366
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1365"
+version = "0.5.1366"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1365"
+version = "0.5.1366"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1365"
+version = "0.5.1366"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1365"
+version = "0.5.1366"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1365"
+version = "0.5.1366"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7644-pointer-free-hazard-probe.md
+++ b/changelog.d/7644-pointer-free-hazard-probe.md
@@ -1,0 +1,17 @@
+**test(gc): the POINTER_FREE trace-skip hazard probe that faults (#7635)**
+
+#7635's mystery — forcing `POINTER_FREE` on pointer-bearing parse records
+strands nothing under any instrument — was the probes, not the instruments:
+`JSON.parse` of a non-tiny blob is lazy (#7499), so probes that only read
+records back after the churn materialized the cohort after the collections
+ran. The identical shape with one pre-churn touch loop faults immediately
+(SIGSEGV under default cycles; a precise `[gc-fromspace-protect]` report
+under zeal+protect).
+
+`gc/tests/layout_pointer_free_hazard.rs` plants the hazard at unit level
+with no env knob: a lying `saw_pointer=false` finalize strands a field-only
+young string — asserted on both halves (slot unrewritten AND child in
+poisoned from-space) with subject-liveness (the object must have moved) so
+neither arm passes vacuously; the truthful twin proves evacuation+rewrite.
+Standing rule recorded: parse-cohort GC probes must defeat the lazy tape or
+state that they exercised the lazy path.

--- a/crates/perry-runtime/src/gc/tests/layout_pointer_free_hazard.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_pointer_free_hazard.rs
@@ -1,0 +1,121 @@
+//! #7635: the `POINTER_FREE` trace-skip hazard is REAL and this test is the
+//! probe that faults — the one the issue asked for.
+//!
+//! Why every earlier probe was vacuous: `JSON.parse` of a non-tiny blob is
+//! LAZY by default (#7499's tape). A probe that parses, churns, and only then
+//! reads the records back materializes the whole cohort AFTER the collections
+//! ran — there was nothing to strand. Forcing a wrong `POINTER_FREE` on such
+//! a run measures nothing, which is exactly what #7633's audit observed. The
+//! TS-level shape that discriminates is parse → touch every record →
+//! churn → read (the touch defeats the tape); this unit test plants the same
+//! hazard directly, with no env knob and no JSON in the loop.
+//!
+//! Two arms, one plant (the `fromspace_protect` convention):
+//!
+//! - **red control** — the hazard: an object whose only reference to a young
+//!   string sits in a field slot, with its layout state left claiming
+//!   `POINTER_FREE` (what a `layout_finish_deferred_boxed_object` caller
+//!   lying about `saw_pointer` would produce). The copying minor MOVES the
+//!   object but — honoring the state — never visits the field: the slot
+//!   bits survive verbatim and the child is retired with from-space.
+//! - **green arm** — the real contract: identical construction, truthful
+//!   finalize. The minor visits the field, evacuates the string, rewrites
+//!   the slot.
+//!
+//! Subject-liveness is asserted in both arms (the object must MOVE, the
+//! collection must run), so neither arm can pass vacuously.
+
+use super::super::*;
+use super::support::*;
+use crate::arena::FromSpaceProtection;
+
+const OBJECT_HEADER_SIZE: usize = std::mem::size_of::<crate::ObjectHeader>();
+
+/// Build a 1-field object through the materialiser's exact store path
+/// (`store_object_field_slot_layout_deferred`), holding a fresh young string
+/// reachable ONLY through that field. Returns `(obj_user, child_bits)`.
+unsafe fn plant_object_with_young_string_child(finalize_truthfully: bool) -> (usize, u64) {
+    let packed_keys = b"a\0";
+    let obj = crate::object::js_object_alloc_with_shape(
+        0x7635,
+        1,
+        packed_keys.as_ptr(),
+        packed_keys.len() as u32,
+    );
+    let child = string_bits(young_leaf());
+    let saw_pointer = crate::object::store_object_field_slot_layout_deferred(obj, 0, child);
+    assert!(
+        saw_pointer,
+        "premise: the stored value must be pointer-bearing"
+    );
+    // The plant: a caller lying about what it stored leaves the birth
+    // POINTER_FREE standing over a pointer-bearing payload.
+    layout_finish_deferred_boxed_object(obj as usize, finalize_truthfully);
+    (obj as usize, child)
+}
+
+unsafe fn field0_bits(obj_user: usize) -> u64 {
+    *((obj_user + OBJECT_HEADER_SIZE) as *const u64)
+}
+
+#[test]
+fn a_lying_pointer_free_finalize_strands_the_field_child() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _mode = crate::arena::ProtectionModeGuard::set(FromSpaceProtection::PoisonOnly);
+
+    let (obj, child_before) = unsafe { plant_object_with_young_string_child(false) };
+    js_shadow_slot_set(0, ptr_bits(obj));
+
+    let _ = gc_collect_minor();
+
+    // Subject-liveness: the minor must have MOVED the object.
+    let moved_obj = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_ne!(moved_obj, obj, "premise: the object must have moved");
+
+    // The hazard, observed twice over:
+    // 1. the slot was never rewritten — the collector skipped the payload;
+    let child_after = unsafe { field0_bits(moved_obj) };
+    assert_eq!(
+        child_after, child_before,
+        "a POINTER_FREE payload must not have been visited — a rewritten slot \
+         means the skip did not happen and this test is not testing it"
+    );
+    // 2. the child the slot still names was retired with from-space.
+    let child_addr = (child_after & POINTER_MASK) as usize;
+    let word = unsafe { *(child_addr as *const u64) };
+    assert_eq!(
+        word,
+        crate::arena::QUARANTINE_POISON_WORD,
+        "the stranded child must sit in poisoned from-space — anything else \
+         means something rescued it and the hazard is not being exercised"
+    );
+}
+
+#[test]
+fn a_truthful_finalize_keeps_the_field_child_alive_across_the_move() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _mode = crate::arena::ProtectionModeGuard::set(FromSpaceProtection::PoisonOnly);
+
+    let (obj, child_before) = unsafe { plant_object_with_young_string_child(true) };
+    js_shadow_slot_set(0, ptr_bits(obj));
+
+    let _ = gc_collect_minor();
+
+    let moved_obj = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_ne!(moved_obj, obj, "premise: the object must have moved");
+
+    // The truthful state (UNKNOWN) visits the payload: the string is
+    // evacuated and the slot rewritten to the live copy.
+    let child_after = unsafe { field0_bits(moved_obj) };
+    assert_ne!(
+        child_after, child_before,
+        "the child slot must have been rewritten to the evacuated copy"
+    );
+    let child_addr = (child_after & POINTER_MASK) as usize;
+    let word = unsafe { *(child_addr as *const u64) };
+    assert_ne!(
+        word,
+        crate::arena::QUARANTINE_POISON_WORD,
+        "the evacuated child must be live, not poisoned from-space"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -21,6 +21,7 @@ mod host_safepoints;
 mod incremental_sweep_reclaim;
 mod inline_generation_gate_contract;
 mod inline_pointer_bearing_contract;
+mod layout_pointer_free_hazard;
 mod layout_trace;
 mod lazy_tape_side_alloc;
 mod oldgen;


### PR DESCRIPTION
Fixes #7635 — the probe that faults, and the reason nobody could build one.

## Root cause: the probes were vacuous, not the instruments

`JSON.parse` of a non-tiny blob is **lazy by default** (#7499's tape). Every probe in this investigation — the audit's two shapes and my reproduction — parsed, churned, and only then read the records back. The materialisation happens at read-back, **after** the collections ran: the cohort did not exist while the collectors were being tested, so no sabotage could strand it and no instrument could catch anything. The instruments were fine the entire time.

Demonstrated end-to-end on an instrumented build: the identical TS shape with **one pre-churn touch loop** (defeating the tape) faults immediately under the sabotage —

| arm | result |
|--|--|
| sabotage, default cycles | **SIGSEGV** (rc=139) |
| sabotage + `ZEAL=1 PROTECT_FROMSPACE=1` | **`[gc-fromspace-protect] FAULT: signal 10 at 0x47ab075bbd0`** — precise, named address |
| no sabotage (real code) | clean, and a trace-time audit confirms zero POINTER_FREE selections over pointer-bearing payloads |

A supporting measurement that sealed it: under sabotage with the *lazy* probe, a trace-time counter saw only ~5 pointer-bearing PF selections across dozens of cycles × 4,000 records — the records simply weren't there.

## The committed regression test

`gc/tests/layout_pointer_free_hazard.rs`, in the `fromspace_protect` planted-hazard convention, **no env knobs**:

- **Red control** — an object built through the materialiser's exact deferred-store path, whose only reference to a young string sits in a field slot, finalized with a lying `saw_pointer=false`. The copying minor moves the object, honors the state, skips the payload — asserted on **both halves of the strand**: the slot bits survive unrewritten (the skip was live), and the child sits in poisoned from-space (`QUARANTINE_POISON_WORD`).
- **Green twin** — truthful finalize: the child is evacuated and the slot rewritten.
- Subject-liveness asserted in both arms (the object must have MOVED), so neither can pass vacuously.

## Consequences for the record

- The `POINTER_FREE` trace-skip is **real, observable, and load-bearing** — outcome (3) of the issue's trichotomy, with the missing shape identified.
- #7633's "zeal arm: output identical" line was indeed non-discriminating for parse-only shapes, exactly as the audit said. The discriminating form now lives in CI.
- **Standing rule for this family**: any parse-cohort GC probe must defeat the lazy tape (touch the cohort before the collections) or state explicitly that it exercised the lazy path.

`perry-runtime` suite: 1,904 passed / 0 failed (both new tests green). `cargo fmt --check` and `check_file_size.sh` clean. No production code changed — this PR is the test alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added regression coverage for garbage collection of pointer-free layouts.
  * Verified that referenced objects are correctly evacuated and rewritten during collection, preventing stranded or invalid references.

* **Documentation**
  * Documented the pointer-free tracing hazard and guidance for ensuring garbage-collection probes exercise the intended behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->