### PR TITLE
test(gc-ratchet): pin the large-Eden copying-minor cadence (#7481) and re-derive the #7056 RSS numbers under statepoints

### DIFF
--- a/.github/workflows/gc-ratchet.yml
+++ b/.github/workflows/gc-ratchet.yml
@@ -81,9 +81,9 @@ jobs:
       #
       # `--scope structural` is load-bearing and is the #7554 repair. This step
       # runs BEFORE the measurement step, so anything it fails on costs the
-      # entire run's coverage — twelve probes that never execute. That price is
-      # correct for "this artifact is unreadable or tampered with" and badly
-      # wrong for "one of its 144 cells is not bit-identical", which is what
+      # entire run's coverage — thirteen probes that never execute. That price
+      # is correct for "this artifact is unreadable or tampered with" and badly
+      # wrong for "one of its 156 cells is not bit-identical", which is what
       # actually happened: one cell's 6,768-byte spread failed this step and the
       # ratchet measured NOTHING on any branch for three days, while two GC
       # pacing changes (#7594, #7596) merged with hand-run A/Bs in its place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1378
+**Current Version:** 0.5.1379
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1378"
+version = "0.5.1379"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1378"
+version = "0.5.1379"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1378"
+version = "0.5.1379"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1378"
+version = "0.5.1379"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1378"
+version = "0.5.1379"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -143,9 +143,14 @@ The fix is the retained set, which holds the pacing baseline high enough that a
 | 131,072 | 1 | 14 |
 | 262,144 (shipped) | **4** | 12 |
 
-At `KEEP = 262,144` the four minors free 37, 36, 68 and 68 MB and the first
-copies 532,482 objects (32 MB) in one cycle, against ~16 MB per minor for every
-default-cap probe. The guard that keeps this honest is `check`'s existing
+At `KEEP = 262,144` the four minors free 37, 36, 68 and 68 MB (49.7 MB per
+minor) and the first copies 532,482 objects — 32 MB — in one cycle. Against the
+rest of the suite: **14.6–16.6 MB per minor on eleven of the twelve default-cap
+probes**, and 21.8 MB on `12_large_live_set`, whose tenured-proportional cap
+term (`gc/tenuring.rs`, `max(influx x scale, tenured/2)`) already raises its
+Eden a little. That last row is worth noticing — it is the shipped path by which
+a large Eden is reached without any knob, and it tops out around 22 MB on the
+biggest workload the suite has. The guard that keeps this honest is `check`'s existing
 liveness rule (`minor_cycles > 0` and `copied_objects + promoted_objects > 0`):
 a future change that stops reaching the copying minor at this cadence cannot be
 pinned, it fails.

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -467,6 +467,23 @@ python3 benchmarks/gc_ratchet/gc_ratchet.py measure \
 python3 benchmarks/gc_ratchet/gc_ratchet.py check --current /tmp/current.json
 ```
 
+★ **`--probes-dir` pointed at a copy outside the repo is a different
+compilation, and its retention is not comparable to the pinned artifact.** A
+probe compiled with a `package.json` in scope retains one more 1 MiB arena block
+at `gc()` than the same source compiled without one, and `09_try_catch_roots`
+sits on that boundary: 5,825,256 from the repo directory, 4,777,624 from any of
+three `/tmp` directories, and 5,825,256 again from `/tmp` **with a
+`package.json` copied in** — each stable across repeats. Read against the
+baseline that is a −17.98% "improvement" in a probe nothing touched, and it cost
+real time before it was localised. The driver and CI always compile from
+`benchmarks/gc_ratchet/probes`, so the gate is self-consistent; *ratios between
+arms measured in the same directory* are unaffected, which is what makes a
+copied directory usable for an A/B and not for a comparison against the pin.
+
+(This is not build non-determinism, which was ruled out in the same session: two
+builds of one probe from one directory differ byte-for-byte and report the
+identical retention.)
+
 ## What `heap_used_bytes` actually contains (#7559, #7558)
 
 **A retention row is not evidence of a collector regression until it has been

--- a/benchmarks/gc_ratchet/README.md
+++ b/benchmarks/gc_ratchet/README.md
@@ -31,14 +31,16 @@ because it is good discipline, not because the artifacts are related.
 
 ## What is measured
 
-Twelve probes in `probes/`, each a deterministic TypeScript workload that
+Thirteen probes in `probes/`, each a deterministic TypeScript workload that
 drives a different part of the collector: nursery churn with a zero live set,
 survivor aging and promotion, old-to-young stores and the remembered set, dead
 objects left under a deep stack high-water mark, closure environments, heap
 strings, array element-storage growth, Map/Set side tables, try/catch rooting,
-receiver stores across allocation points, collection under stack depth, and a
+receiver stores across allocation points, collection under stack depth, a
 ~100 MB live set held across many collections (the shape that catches
-survivor-space saturation — every other probe's live set is small).
+survivor-space saturation — every other probe's live set is small), and a
+survivor cohort carried across large, infrequent copying minors (the *cadence*
+every other probe misses — see below).
 
 Every probe parks its allocations in a heap container before dropping them. This
 is load-bearing. An earlier draft allocated into locals that never escaped, LLVM
@@ -76,6 +78,77 @@ gate on really are deterministic.
 Retention and GC accounting are semantic: they are a function of the allocation
 sequence and collector policy, not of CPU speed, core count, or machine load.
 That is why they can be gated on a shared CI runner and memory and time cannot.
+
+## A probe may declare the collector it is a probe *of* (the large-Eden arm)
+
+Twelve of the thirteen probes run the shipped configuration, so every copying
+minor this matrix had ever exercised was small (~16 MB of Eden) and frequent.
+Two faults arrived from the other end of that axis and neither was reachable
+from here: #7472, and #7481, which is deterministic at
+`PERRY_GC_SCAVENGE_NURSERY_MB=64` and absent at 1, 4, 16 and 32 MB. #7481 names
+the gap itself — "a live copying-minor correctness signal at exactly the cadence
+the ratchet probes never exercise".
+
+A cadence is a property of the *run*, not of the source, so a probe may state
+the run it is a probe of, in its own source:
+
+```ts
+// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64
+```
+
+`13_large_eden_survivors.ts` carries exactly that one directive. It lives in the
+probe source rather than in `tolerances.json` because it is not possible to read
+the workload without reading the arm.
+
+Deliberate properties:
+
+- **The declaration reaches every run of that probe** — warmup, the timed
+  repeats, both traced runs, and both of `classify`'s scan modes — and is
+  asserted to, by a test whose stub probe *reports* whether the variable
+  arrived. A `run_env` the harness recorded but never exported would be an arm
+  that is documented, gated, and inert: CLAUDE.md's fourth failure mode.
+- **It does not reach `compile_probe`.** These are runtime knobs read through
+  `OnceLock`; Perry's object cache keys on every codegen env var (#6394), so
+  passing them at compile time would move the cache key without moving a byte
+  of emitted code.
+- **Only `PERRY_*`, never a variable the harness owns.**
+  `PERRY_CONSERVATIVE_STACK_SCAN` is `classify`'s axis and `PERRY_GC_DIAG`
+  separates the traced pass from the timed one; a probe setting either would be
+  contradicting the measurement rather than describing itself. A repeated key is
+  refused too — the losing line would look effective.
+- **The arm is pinned in the artifact and compared like a metric.** `check`
+  fails a probe whose run declares a different configuration from the one the
+  baseline recorded, *before* any band arithmetic. This is the check that
+  matters: delete the directive and every band is still satisfied, because the
+  numbers would have been re-pinned by the same act that lost the arm. `check`
+  also lists every armed probe above its table, so a reader of CI output does
+  not have to open the probe to know which rows answer a different question.
+
+### Why the probe is shaped the way it is
+
+A large Eden on top of a *small* retained set runs **zero** copying minors, and
+the first draft of this probe did exactly that. `gc/policy.rs`'s
+`arena_growth_full_escalation_due` escalates a minor to a full mark-sweep once
+arena in-use clears 32 MB *and* exceeds twice the post-full baseline; with a
+64 MB Eden and a ~1 MB retained set, every collection satisfies both and the
+copying minor is never reached. The probe would have been pinned on a collector
+it never ran — the #7024 shape, inside the arm added to close it.
+
+The fix is the retained set, which holds the pacing baseline high enough that a
+64 MB Eden is not a doubling. Measured on the pinned host at v0.5.1376:
+
+| `KEEP` | copying minors at 64 MB | at the shipped default |
+|---|---:|---:|
+| 8,192 | **0** | 15 |
+| 131,072 | 1 | 14 |
+| 262,144 (shipped) | **4** | 12 |
+
+At `KEEP = 262,144` the four minors free 37, 36, 68 and 68 MB and the first
+copies 532,482 objects (32 MB) in one cycle, against ~16 MB per minor for every
+default-cap probe. The guard that keeps this honest is `check`'s existing
+liveness rule (`minor_cycles > 0` and `copied_objects + promoted_objects > 0`):
+a future change that stops reaching the copying minor at this cadence cannot be
+pinned, it fails.
 
 ## Why wall time is excluded from the shared-CI gate
 
@@ -502,6 +575,12 @@ Adding or removing a probe changes the baseline's probe set, and the checker
 fails on a set mismatch rather than silently ignoring the new one. So a new
 probe requires a deliberate re-pin, which is the intended friction. The probe
 must trigger at least one minor collection or the harness refuses to pin it.
+
+If the probe is a probe of a *configuration* rather than only of a workload,
+declare it with a `// gc-ratchet-env:` directive (see the large-Eden arm above)
+and check that the resulting run still reaches the collector you meant: a knob
+that quietly moves a workload off the path it was chosen to exercise is the
+failure this suite has paid for most often.
 
 ## Files
 

--- a/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
+++ b/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
@@ -3,8 +3,8 @@
   "kind": "gc-ratchet-baseline",
   "artifact_id": "gc-ratchet-v1",
   "not_the_public_baseline": "Internal Perry-vs-Perry GC ratchet. The public Node/Bun evidence is benchmarks/results/public-node-bun-v1.json, owned by benchmarks/run_public_baseline.sh. Never regenerate one from the other.",
-  "commit": "59d522052a12c4b35061750c5e790a97e5fd1b80",
-  "generated_at": "2026-08-08T17:41:39+00:00",
+  "commit": "a8f73122d08b64b030f9e34e868cdea1bdee59a4",
+  "generated_at": "2026-08-08T22:03:20+00:00",
   "platform": "darwin-arm64",
   "host": {
     "platform": "darwin-arm64",
@@ -14,16 +14,16 @@
     "machine": "arm64",
     "cpu_count": 8,
     "load_average": {
-      "1m": 4.35,
-      "5m": 3.3,
-      "15m": 2.87
+      "1m": 1.62,
+      "5m": 1.6,
+      "15m": 1.75
     },
     "cpu_brand": "Apple M1",
     "memory_bytes": 8589934592,
     "product_version": "26.5.1"
   },
   "toolchain": {
-    "perry_version": "perry 0.5.1370",
+    "perry_version": "perry 0.5.1376",
     "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
     "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
     "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)",
@@ -36,20 +36,20 @@
     },
     "binaries": {
       "perry": {
-        "path": "~/tgt7558fix/release/perry",
-        "size": 109801328,
-        "sha256": "a81089d8d9a8559acebdf33c9f13a493a828cd2bc03e52700cac467e2d55899f"
+        "path": "~/tgt7056/release/perry",
+        "size": 109817776,
+        "sha256": "351abf2c9f346f2d3a9266db522cec36b0bd4523f7ecb7729bb41c205e144036"
       },
-      "runtime_dir": "~/tgt7558fix/release",
+      "runtime_dir": "~/tgt7056/release",
       "libperry_runtime.a": {
-        "path": "~/tgt7558fix/release/libperry_runtime.a",
-        "size": 28908416,
-        "sha256": "cb436b8d78e36460adc19f052c1e253c5338f5d86e38e232bfa8b8c3cc3a6f0a"
+        "path": "~/tgt7056/release/libperry_runtime.a",
+        "size": 28912096,
+        "sha256": "a1484f7e8a2cde41b1eac8ae0505d2e1883bb3cd1aff3ea3fc6b11e32f2e4d73"
       },
       "libperry_stdlib.a": {
-        "path": "~/tgt7558fix/release/libperry_stdlib.a",
-        "size": 78752112,
-        "sha256": "9ab8deb67e493b42d2ce9e5ef6a48d47c37a305e772917bf793969935249d518"
+        "path": "~/tgt7056/release/libperry_stdlib.a",
+        "size": 78758480,
+        "sha256": "a181d24c732b82f07a4666c9bc202dec654c2cc570e0637ef3cd25a3b5a69522"
       }
     }
   },
@@ -69,7 +69,8 @@
       "09_try_catch_roots",
       "10_store_receiver_across_alloc",
       "11_collect_at_depth",
-      "12_large_live_set"
+      "12_large_live_set",
+      "13_large_eden_survivors"
     ]
   },
   "tolerances": {
@@ -295,7 +296,7 @@
     },
     "probe_overrides": {}
   },
-  "notes": "RE-PIN REQUIRED BY #7558, not a re-pin to make a red gate green. Explicit gc() no longer forces the conservative native-stack scan (crates/perry-runtime/src/gc/policy.rs::manual_gc_collect_now); it now consumes the same precise root set every automatic collection in a production binary already uses. Two consequences are in these numbers. (1) RETENTION: every probe reports its precise retention instead of precise-plus-stack-residue. gc_ratchet.py classify on main 961777904 measured that residue at 28.63/28.24/29.71/31.03 percent on probes 01/05/06/11, 13.80 percent on 12, and 0.00 on 07/08/10; on this build classify reports excess 0.00 percent and spread 0 on all twelve. That is why benchmarks/gc_ratchet/tolerances.json probe_overrides is now EMPTY: 12_large_live_set.heap_used_bytes is bit-identical again and gates again, so the #7554 entry was deleted rather than left to outlive its reason. (2) TENURING: gc/tenuring.rs deliberately refuses to seed the adaptive threshold from a cycle that ran the conservative scan, so on gc()-driven workloads the seed had never fired and tenuring_survivals stayed at its power-on 4. It fires now. On 09_try_catch_roots and 11_collect_at_depth the threshold falls 4 -> 1 and every survivor is promoted on first copy: copied_objects 5823 -> 0 with promoted_objects 0 -> 6077 (09) and 5830 -> 0 with 0 -> 6150 (11). The copying minor still ran (eligible=true, [gc-copy-minor] ran, PERRY_GC_DIAG verified on both arms) and moved MORE objects, to old-gen instead of survivor space; heap_total_bytes and freed_bytes are unchanged and heap_used_bytes falls on both. The liveness rule in gc_ratchet.py check was widened to copied_objects+promoted_objects in the same PR so that pinning copied_objects=0 here does not disarm it. CONTROL: the same host, same toolchain, same probe set, running main 961777904 built identically, reproduced the previous pinned artifact and exited gc-ratchet: OK before this was taken -- so every delta above is this change and not accumulated drift. This also gives the artifact single provenance again (#7652: 143 cells were from 26b9c9d59 and one from c8394bfdb).",
+  "notes": "RE-PIN REQUIRED BY THE NEW PROBE, not a re-pin to make a red gate green. 13_large_eden_survivors is added, so the probe set changed and check fails on a set mismatch by design; nothing else in this artifact moved. CONTROL, taken on this host with this binary BEFORE the pin: run_gc_ratchet_baseline.sh --check against the previous artifact (59d522052, #7558/#7657) reported every one of its 144 cells ok, and FAILED on exactly one line - \"probes present now but absent from the baseline: 13_large_eden_survivors\". So every number carried over here is the previous pin reproduced, not accumulated drift, and the only new rows are the new probe.\n\nWHAT THE NEW PROBE IS FOR (#7481). Twelve probes ran the shipped 16 MB nursery cap, so every copying minor this matrix had ever exercised was small and frequent. #7481 names that gap: \"a live copying-minor correctness signal at exactly the cadence the ratchet probes never exercise\". 13_large_eden_survivors declares PERRY_GC_SCAVENGE_NURSERY_MB=64 through the new per-probe gc-ratchet-env directive, which is recorded in run_env and compared by check like a metric - deleting the directive leaves every band satisfied, so the arm itself has to be gated or it is not an arm.\n\nWHY THE PROBE HOLDS A 262,144-OBJECT COHORT. A large Eden on a small retained set runs ZERO copying minors: arena_growth_full_escalation_due escalates every minor to a full mark-sweep once arena in-use clears 32 MB and exceeds twice the post-full baseline, which a 64 MB Eden over a ~1 MB live set does every time. The first draft did exactly that and would have been pinned on a collector it never reached. Measured on this host: KEEP 8,192 -> 0 copying minors, 131,072 -> 1, 262,144 -> 4, freeing 37/36/68/68 MB with 532,482 objects copied in the first cycle, against ~16 MB per minor for every default-cap probe. checks liveness rule (minor_cycles > 0 and copied+promoted > 0) is what keeps that honest.\n\nMEASUREMENT-CONTEXT NOTE, recorded because it looks exactly like drift. A probe compiled with a package.json in scope retains one more 1 MiB arena block at gc() than the same source compiled without one, and 09_try_catch_roots sits on that boundary: 5,825,256 from the repo probes directory, 4,777,624 from any of three /tmp directories, 5,825,256 again from /tmp with a package.json copied in, each stable across repeats and unmoved by Perrys known build non-determinism. An ad-hoc measure --probes-dir <copy> therefore reports 09 at -17.98% against this artifact and it is not a collector change. The driver and CI always compile from benchmarks/gc_ratchet/probes, so the gate is self-consistent.\n\nPROVENANCE. perry-macos (Mac mini, 8-core M1, 8 GB, macOS 26.5.1), CPU-active gate satisfied by the driver before each phase and 94.6-95.8% idle with zero rustc and zero cargo for the whole session. Binary built at 7bde3de24 with cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static into an isolated CARGO_TARGET_DIR; this commit changes no Rust at all (git diff --name-only 7bde3de24 <this> matches zero .rs files), so the binary is the right one for this tree. PERRY_RUNTIME_DIR pinned, PERRY_NO_AUTO_OPTIMIZE=1, node oracle v26.5.1.",
   "probes": {
     "01_nursery_churn": {
       "stdout": "probe:01_nursery_churn\nchecksum:-1399701504\n",
@@ -304,6 +305,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -343,57 +345,57 @@
         },
         "rss_bytes": {
           "samples": [
-            30212096,
-            30228480,
-            30212096,
-            30244864,
-            30212096,
-            30228480,
-            30244864
+            30113792,
+            30130176,
+            30130176,
+            30113792,
+            30146560,
+            30130176,
+            30130176
           ],
           "sample_count": 7,
-          "median": 30228480,
-          "min": 30212096,
-          "max": 30244864,
-          "stdev": 13647.759406,
+          "median": 30130176,
+          "min": 30113792,
+          "max": 30146560,
+          "stdev": 10467.353641,
           "spread": 32768,
-          "spread_pct": 0.108401
+          "spread_pct": 0.108755
         },
         "peak_rss_bytes": {
           "samples": [
-            30654464,
-            30670848,
-            30654464,
-            30687232,
-            30654464,
-            30670848,
-            30687232
+            30523392,
+            30539776,
+            30539776,
+            30523392,
+            30556160,
+            30539776,
+            30539776
           ],
           "sample_count": 7,
-          "median": 30670848,
-          "min": 30654464,
-          "max": 30687232,
-          "stdev": 13647.759406,
+          "median": 30539776,
+          "min": 30523392,
+          "max": 30556160,
+          "stdev": 10467.353641,
           "spread": 32768,
-          "spread_pct": 0.106838
+          "spread_pct": 0.107296
         },
         "wall_ms": {
           "samples": [
-            85.043375,
-            97.00575,
-            89.604125,
-            108.686584,
-            94.642625,
-            115.964375,
-            147.536667
+            66.729542,
+            66.330875,
+            66.838167,
+            67.433875,
+            66.537916,
+            66.554,
+            66.694
           ],
           "sample_count": 7,
-          "median": 97.00575,
-          "min": 85.043375,
-          "max": 147.536667,
-          "stdev": 19.813149,
-          "spread": 62.493292,
-          "spread_pct": 64.422255
+          "median": 66.694,
+          "min": 66.330875,
+          "max": 67.433875,
+          "stdev": 0.324169,
+          "spread": 1.103,
+          "spread_pct": 1.653822
         },
         "minor_cycles": {
           "samples": [
@@ -495,6 +497,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -534,57 +537,57 @@
         },
         "rss_bytes": {
           "samples": [
-            36978688,
-            36995072,
-            36978688,
-            36978688,
-            36962304,
-            36962304,
-            36978688
+            36929536,
+            36945920,
+            36945920,
+            36929536,
+            36913152,
+            36913152,
+            36929536
           ],
           "sample_count": 7,
-          "median": 36978688,
-          "min": 36962304,
-          "max": 36995072,
-          "stdev": 10467.353641,
+          "median": 36929536,
+          "min": 36913152,
+          "max": 36945920,
+          "stdev": 12385.139852,
           "spread": 32768,
-          "spread_pct": 0.088613
+          "spread_pct": 0.088731
         },
         "peak_rss_bytes": {
           "samples": [
-            37404672,
-            37421056,
-            37404672,
-            37404672,
-            37388288,
-            37388288,
-            37404672
+            37339136,
+            37355520,
+            37355520,
+            37339136,
+            37322752,
+            37322752,
+            37339136
           ],
           "sample_count": 7,
-          "median": 37404672,
-          "min": 37388288,
-          "max": 37421056,
-          "stdev": 10467.353641,
+          "median": 37339136,
+          "min": 37322752,
+          "max": 37355520,
+          "stdev": 12385.139852,
           "spread": 32768,
-          "spread_pct": 0.087604
+          "spread_pct": 0.087758
         },
         "wall_ms": {
           "samples": [
-            76.431458,
-            122.621875,
-            80.482125,
-            89.997375,
-            84.627167,
-            84.477708,
-            85.485792
+            65.143125,
+            65.224375,
+            64.863917,
+            64.96475,
+            65.381625,
+            64.48575,
+            65.059083
           ],
           "sample_count": 7,
-          "median": 84.627167,
-          "min": 76.431458,
-          "max": 122.621875,
-          "stdev": 14.211111,
-          "spread": 46.190417,
-          "spread_pct": 54.581074
+          "median": 65.059083,
+          "min": 64.48575,
+          "max": 65.381625,
+          "stdev": 0.267801,
+          "spread": 0.895875,
+          "spread_pct": 1.377018
         },
         "minor_cycles": {
           "samples": [
@@ -686,6 +689,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -725,57 +729,57 @@
         },
         "rss_bytes": {
           "samples": [
-            25870336,
-            25870336,
-            25853952,
-            25853952,
-            25853952,
-            25870336,
-            25853952
+            25772032,
+            25755648,
+            25755648,
+            25772032,
+            25772032,
+            25755648,
+            25755648
           ],
           "sample_count": 7,
-          "median": 25853952,
-          "min": 25853952,
-          "max": 25870336,
+          "median": 25755648,
+          "min": 25755648,
+          "max": 25772032,
           "stdev": 8107.977266,
           "spread": 16384,
-          "spread_pct": 0.063371
+          "spread_pct": 0.063613
         },
         "peak_rss_bytes": {
           "samples": [
-            29343744,
-            29343744,
-            29327360,
-            29343744,
-            29327360,
-            29343744,
-            29327360
+            29163520,
+            29147136,
+            29147136,
+            29163520,
+            29163520,
+            29163520,
+            29147136
           ],
           "sample_count": 7,
-          "median": 29343744,
-          "min": 29327360,
-          "max": 29343744,
+          "median": 29163520,
+          "min": 29147136,
+          "max": 29163520,
           "stdev": 8107.977266,
           "spread": 16384,
-          "spread_pct": 0.055835
+          "spread_pct": 0.05618
         },
         "wall_ms": {
           "samples": [
-            77.696625,
-            49.955584,
-            55.726458,
-            62.503833,
-            55.915834,
-            56.499084,
-            61.742166
+            46.105292,
+            45.57425,
+            45.534417,
+            45.290625,
+            45.273167,
+            45.395292,
+            45.485291
           ],
           "sample_count": 7,
-          "median": 56.499084,
-          "min": 49.955584,
-          "max": 77.696625,
-          "stdev": 8.198997,
-          "spread": 27.741041,
-          "spread_pct": 49.099984
+          "median": 45.485291,
+          "min": 45.273167,
+          "max": 46.105292,
+          "stdev": 0.260759,
+          "spread": 0.832125,
+          "spread_pct": 1.829438
         },
         "minor_cycles": {
           "samples": [
@@ -877,6 +881,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -916,57 +921,57 @@
         },
         "rss_bytes": {
           "samples": [
-            25313280,
-            25329664,
-            25329664,
-            25313280,
-            25313280,
-            25329664,
-            25329664
+            25247744,
+            25247744,
+            25264128,
+            25247744,
+            25247744,
+            25247744,
+            25264128
           ],
           "sample_count": 7,
-          "median": 25329664,
-          "min": 25313280,
-          "max": 25329664,
-          "stdev": 8107.977266,
+          "median": 25247744,
+          "min": 25247744,
+          "max": 25264128,
+          "stdev": 7401.536741,
           "spread": 16384,
-          "spread_pct": 0.064683
+          "spread_pct": 0.064893
         },
         "peak_rss_bytes": {
           "samples": [
+            28803072,
+            28819456,
             28819456,
             28819456,
             28819456,
             28803072,
-            28819456,
-            28819456,
             28819456
           ],
           "sample_count": 7,
           "median": 28819456,
           "min": 28803072,
           "max": 28819456,
-          "stdev": 5733.205707,
+          "stdev": 7401.536741,
           "spread": 16384,
           "spread_pct": 0.05685
         },
         "wall_ms": {
           "samples": [
-            56.174416,
-            55.607958,
-            68.584333,
-            56.135125,
-            60.992792,
-            70.304917,
-            72.330292
+            44.944791,
+            44.528917,
+            44.215292,
+            44.351792,
+            44.3925,
+            44.136291,
+            44.35625
           ],
           "sample_count": 7,
-          "median": 60.992792,
-          "min": 55.607958,
-          "max": 72.330292,
-          "stdev": 6.80209,
-          "spread": 16.722334,
-          "spread_pct": 27.416902
+          "median": 44.35625,
+          "min": 44.136291,
+          "max": 44.944791,
+          "stdev": 0.244689,
+          "spread": 0.8085,
+          "spread_pct": 1.822742
         },
         "minor_cycles": {
           "samples": [
@@ -1068,6 +1073,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -1107,57 +1113,57 @@
         },
         "rss_bytes": {
           "samples": [
-            57147392,
-            57147392,
-            57131008,
-            57147392,
-            57131008,
-            57131008,
-            57131008
+            56967168,
+            56967168,
+            56950784,
+            56950784,
+            56950784,
+            56950784,
+            56950784
           ],
           "sample_count": 7,
-          "median": 57131008,
-          "min": 57131008,
-          "max": 57147392,
-          "stdev": 8107.977266,
+          "median": 56950784,
+          "min": 56950784,
+          "max": 56967168,
+          "stdev": 7401.536741,
           "spread": 16384,
-          "spread_pct": 0.028678
+          "spread_pct": 0.028769
         },
         "peak_rss_bytes": {
           "samples": [
-            59457536,
-            59457536,
-            59457536,
-            59457536,
-            59441152,
-            59441152,
-            59441152
+            59359232,
+            59359232,
+            59342848,
+            59342848,
+            59359232,
+            59342848,
+            59342848
           ],
           "sample_count": 7,
-          "median": 59457536,
-          "min": 59441152,
-          "max": 59457536,
+          "median": 59342848,
+          "min": 59342848,
+          "max": 59359232,
           "stdev": 8107.977266,
           "spread": 16384,
-          "spread_pct": 0.027556
+          "spread_pct": 0.027609
         },
         "wall_ms": {
           "samples": [
-            91.914708,
-            93.175917,
-            110.650167,
-            156.141209,
-            145.213667,
-            158.056291,
-            135.166792
+            73.369958,
+            73.676042,
+            72.9625,
+            73.521334,
+            72.860834,
+            73.135459,
+            72.97475
           ],
           "sample_count": 7,
-          "median": 135.166792,
-          "min": 91.914708,
-          "max": 158.056291,
-          "stdev": 26.333716,
-          "spread": 66.141583,
-          "spread_pct": 48.933308
+          "median": 73.135459,
+          "min": 72.860834,
+          "max": 73.676042,
+          "stdev": 0.288753,
+          "spread": 0.815208,
+          "spread_pct": 1.114655
         },
         "minor_cycles": {
           "samples": [
@@ -1259,6 +1265,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -1298,57 +1305,57 @@
         },
         "rss_bytes": {
           "samples": [
-            30818304,
-            30638080,
-            30654464,
-            30703616,
-            30654464,
-            30621696,
-            30687232
+            30720000,
+            30769152,
+            30769152,
+            30883840,
+            30785536,
+            30720000,
+            30932992
           ],
           "sample_count": 7,
-          "median": 30654464,
-          "min": 30621696,
-          "max": 30818304,
-          "stdev": 61124.326463,
-          "spread": 196608,
-          "spread_pct": 0.641368
+          "median": 30769152,
+          "min": 30720000,
+          "max": 30932992,
+          "stdev": 75190.287936,
+          "spread": 212992,
+          "spread_pct": 0.692226
         },
         "peak_rss_bytes": {
           "samples": [
+            31211520,
+            31260672,
+            31260672,
+            31375360,
             31277056,
-            31096832,
-            31113216,
-            31309824,
-            31113216,
-            31080448,
-            31145984
+            31211520,
+            31424512
           ],
           "sample_count": 7,
-          "median": 31113216,
-          "min": 31080448,
-          "max": 31309824,
-          "stdev": 85358.685758,
-          "spread": 229376,
-          "spread_pct": 0.73723
+          "median": 31260672,
+          "min": 31211520,
+          "max": 31424512,
+          "stdev": 75190.287936,
+          "spread": 212992,
+          "spread_pct": 0.681342
         },
         "wall_ms": {
           "samples": [
-            75.005292,
-            75.720042,
-            75.914458,
-            76.426583,
-            75.940375,
-            75.808584,
-            75.840875
+            70.311208,
+            70.373583,
+            70.449917,
+            69.179208,
+            70.401875,
+            70.205541,
+            69.38425
           ],
           "sample_count": 7,
-          "median": 75.840875,
-          "min": 75.005292,
-          "max": 76.426583,
-          "stdev": 0.389993,
-          "spread": 1.421291,
-          "spread_pct": 1.874044
+          "median": 70.311208,
+          "min": 69.179208,
+          "max": 70.449917,
+          "stdev": 0.490204,
+          "spread": 1.270709,
+          "spread_pct": 1.807264
         },
         "minor_cycles": {
           "samples": [
@@ -1450,6 +1457,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -1489,57 +1497,57 @@
         },
         "rss_bytes": {
           "samples": [
-            31277056,
-            31277056,
-            31260672,
-            31293440,
-            31277056,
-            31260672,
-            31293440
+            31424512,
+            31408128,
+            31408128,
+            31424512,
+            31424512,
+            31391744,
+            31408128
           ],
           "sample_count": 7,
-          "median": 31277056,
-          "min": 31260672,
-          "max": 31293440,
-          "stdev": 12385.139852,
+          "median": 31408128,
+          "min": 31391744,
+          "max": 31424512,
+          "stdev": 11466.411413,
           "spread": 32768,
-          "spread_pct": 0.104767
+          "spread_pct": 0.10433
         },
         "peak_rss_bytes": {
           "samples": [
-            31801344,
-            31801344,
-            31784960,
-            31817728,
-            31801344,
-            31784960,
-            31817728
+            31948800,
+            31932416,
+            31932416,
+            31948800,
+            31948800,
+            31916032,
+            31932416
           ],
           "sample_count": 7,
-          "median": 31801344,
-          "min": 31784960,
-          "max": 31817728,
-          "stdev": 12385.139852,
+          "median": 31932416,
+          "min": 31916032,
+          "max": 31948800,
+          "stdev": 11466.411413,
           "spread": 32768,
-          "spread_pct": 0.10304
+          "spread_pct": 0.102617
         },
         "wall_ms": {
           "samples": [
-            53.750708,
-            52.972334,
-            52.982958,
-            53.211167,
-            53.247208,
-            53.010708,
-            53.281
+            49.216333,
+            48.861709,
+            48.78975,
+            48.888333,
+            48.949709,
+            48.774958,
+            48.843
           ],
           "sample_count": 7,
-          "median": 53.211167,
-          "min": 52.972334,
-          "max": 53.750708,
-          "stdev": 0.252563,
-          "spread": 0.778374,
-          "spread_pct": 1.462802
+          "median": 48.861709,
+          "min": 48.774958,
+          "max": 49.216333,
+          "stdev": 0.138924,
+          "spread": 0.441375,
+          "spread_pct": 0.903315
         },
         "minor_cycles": {
           "samples": [
@@ -1641,6 +1649,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -1680,57 +1689,57 @@
         },
         "rss_bytes": {
           "samples": [
+            25247744,
+            25247744,
+            25247744,
             25231360,
-            25214976,
-            25214976,
-            25214976,
+            25247744,
             25231360,
-            25231360,
-            25231360
+            25247744
           ],
           "sample_count": 7,
-          "median": 25231360,
-          "min": 25214976,
-          "max": 25231360,
-          "stdev": 8107.977266,
+          "median": 25247744,
+          "min": 25231360,
+          "max": 25247744,
+          "stdev": 7401.536741,
           "spread": 16384,
-          "spread_pct": 0.064935
+          "spread_pct": 0.064893
         },
         "peak_rss_bytes": {
           "samples": [
-            28753920,
-            28753920,
             28737536,
-            28753920,
-            28753920,
-            28753920,
-            28753920
+            28737536,
+            28737536,
+            28737536,
+            28737536,
+            28721152,
+            28737536
           ],
           "sample_count": 7,
-          "median": 28753920,
-          "min": 28737536,
-          "max": 28753920,
+          "median": 28737536,
+          "min": 28721152,
+          "max": 28737536,
           "stdev": 5733.205707,
           "spread": 16384,
-          "spread_pct": 0.05698
+          "spread_pct": 0.057013
         },
         "wall_ms": {
           "samples": [
-            197.793125,
-            197.928625,
-            197.780458,
-            197.495375,
-            197.671541,
-            197.481041,
-            197.505083
+            183.285458,
+            183.73125,
+            183.627375,
+            183.620042,
+            183.350625,
+            183.575542,
+            183.392875
           ],
           "sample_count": 7,
-          "median": 197.671541,
-          "min": 197.481041,
-          "max": 197.928625,
-          "stdev": 0.163652,
-          "spread": 0.447584,
-          "spread_pct": 0.226428
+          "median": 183.575542,
+          "min": 183.285458,
+          "max": 183.73125,
+          "stdev": 0.155217,
+          "spread": 0.445792,
+          "spread_pct": 0.242838
         },
         "minor_cycles": {
           "samples": [
@@ -1832,6 +1841,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -1871,57 +1881,57 @@
         },
         "rss_bytes": {
           "samples": [
-            34750464,
-            34701312,
+            34816000,
+            34848768,
             34766848,
-            34750464,
             34766848,
-            34668544,
+            34766848,
+            34848768,
             34766848
           ],
           "sample_count": 7,
-          "median": 34750464,
-          "min": 34668544,
-          "max": 34766848,
-          "stdev": 35803.858162,
-          "spread": 98304,
-          "spread_pct": 0.282885
+          "median": 34766848,
+          "min": 34766848,
+          "max": 34848768,
+          "stdev": 36560.894483,
+          "spread": 81920,
+          "spread_pct": 0.235627
         },
         "peak_rss_bytes": {
           "samples": [
-            35061760,
-            35012608,
-            35078144,
-            35061760,
-            35078144,
-            34979840,
-            35078144
+            35094528,
+            35127296,
+            35045376,
+            35045376,
+            35045376,
+            35127296,
+            35045376
           ],
           "sample_count": 7,
-          "median": 35061760,
-          "min": 34979840,
-          "max": 35078144,
-          "stdev": 35803.858162,
-          "spread": 98304,
-          "spread_pct": 0.280374
+          "median": 35045376,
+          "min": 35045376,
+          "max": 35127296,
+          "stdev": 36560.894483,
+          "spread": 81920,
+          "spread_pct": 0.233754
         },
         "wall_ms": {
           "samples": [
-            1055.899083,
-            1055.983083,
-            1063.417333,
-            1057.897708,
-            1052.694,
-            1055.093292,
-            1063.825417
+            975.950417,
+            976.082916,
+            968.384084,
+            968.44025,
+            969.880875,
+            975.399125,
+            974.515459
           ],
           "sample_count": 7,
-          "median": 1055.983083,
-          "min": 1052.694,
-          "max": 1063.825417,
-          "stdev": 3.931112,
-          "spread": 11.131417,
-          "spread_pct": 1.054128
+          "median": 974.515459,
+          "min": 968.384084,
+          "max": 976.082916,
+          "stdev": 3.323119,
+          "spread": 7.698832,
+          "spread_pct": 0.790016
         },
         "minor_cycles": {
           "samples": [
@@ -2023,6 +2033,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -2062,57 +2073,57 @@
         },
         "rss_bytes": {
           "samples": [
-            30261248,
-            30244864,
-            30261248,
-            30261248,
-            30244864,
-            30244864,
-            30244864
+            30277632,
+            30294016,
+            30277632,
+            30277632,
+            30294016,
+            30294016,
+            30294016
           ],
           "sample_count": 7,
-          "median": 30244864,
-          "min": 30244864,
-          "max": 30261248,
+          "median": 30294016,
+          "min": 30277632,
+          "max": 30294016,
           "stdev": 8107.977266,
           "spread": 16384,
-          "spread_pct": 0.054171
+          "spread_pct": 0.054083
         },
         "peak_rss_bytes": {
           "samples": [
-            30720000,
+            30687232,
             30703616,
-            30720000,
-            30720000,
+            30687232,
+            30687232,
             30703616,
             30703616,
             30703616
           ],
           "sample_count": 7,
           "median": 30703616,
-          "min": 30703616,
-          "max": 30720000,
+          "min": 30687232,
+          "max": 30703616,
           "stdev": 8107.977266,
           "spread": 16384,
           "spread_pct": 0.053362
         },
         "wall_ms": {
           "samples": [
-            61.469875,
-            60.643042,
-            60.630292,
-            61.885958,
-            62.408084,
-            60.288083,
-            61.713834
+            56.005542,
+            55.698542,
+            56.565375,
+            55.731208,
+            56.083,
+            56.962958,
+            55.58
           ],
           "sample_count": 7,
-          "median": 61.469875,
-          "min": 60.288083,
-          "max": 62.408084,
-          "stdev": 0.724555,
-          "spread": 2.120001,
-          "spread_pct": 3.448845
+          "median": 56.005542,
+          "min": 55.58,
+          "max": 56.962958,
+          "stdev": 0.468628,
+          "spread": 1.382958,
+          "spread_pct": 2.469323
         },
         "minor_cycles": {
           "samples": [
@@ -2214,6 +2225,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -2253,57 +2265,57 @@
         },
         "rss_bytes": {
           "samples": [
-            31113216,
-            31096832,
-            31096832,
-            31096832,
-            31113216,
-            31096832,
-            31096832
+            31178752,
+            31145984,
+            31178752,
+            31195136,
+            31162368,
+            31178752,
+            31195136
           ],
           "sample_count": 7,
-          "median": 31096832,
-          "min": 31096832,
-          "max": 31113216,
-          "stdev": 7401.536741,
-          "spread": 16384,
-          "spread_pct": 0.052687
+          "median": 31178752,
+          "min": 31145984,
+          "max": 31195136,
+          "stdev": 16215.954532,
+          "spread": 49152,
+          "spread_pct": 0.157646
         },
         "peak_rss_bytes": {
           "samples": [
+            31571968,
+            31539200,
+            31571968,
+            31588352,
             31555584,
-            31539200,
-            31539200,
-            31539200,
-            31555584,
-            31539200,
-            31539200
+            31571968,
+            31588352
           ],
           "sample_count": 7,
-          "median": 31539200,
+          "median": 31571968,
           "min": 31539200,
-          "max": 31555584,
-          "stdev": 7401.536741,
-          "spread": 16384,
-          "spread_pct": 0.051948
+          "max": 31588352,
+          "stdev": 16215.954532,
+          "spread": 49152,
+          "spread_pct": 0.155682
         },
         "wall_ms": {
           "samples": [
-            80.509541,
-            80.194333,
-            80.5105,
-            80.533291,
-            80.768959,
-            80.818375,
-            79.00475
+            74.037292,
+            74.6475,
+            73.411042,
+            74.281292,
+            73.738833,
+            74.605916,
+            74.41625
           ],
           "sample_count": 7,
-          "median": 80.5105,
-          "min": 79.00475,
-          "max": 80.818375,
-          "stdev": 0.574693,
-          "spread": 1.813625,
-          "spread_pct": 2.252656
+          "median": 74.281292,
+          "min": 73.411042,
+          "max": 74.6475,
+          "stdev": 0.425978,
+          "spread": 1.236458,
+          "spread_pct": 1.664562
         },
         "minor_cycles": {
           "samples": [
@@ -2405,6 +2417,7 @@
         "oracle_version": "v26.5.1",
         "reason": ""
       },
+      "run_env": {},
       "metrics": {
         "heap_used_bytes": {
           "samples": [
@@ -2444,57 +2457,57 @@
         },
         "rss_bytes": {
           "samples": [
-            168214528,
-            168198144,
-            168198144,
             167182336,
+            168247296,
             167247872,
-            167231488,
-            167018496
+            167133184,
+            167297024,
+            169885696,
+            168247296
           ],
           "sample_count": 7,
-          "median": 167247872,
-          "min": 167018496,
-          "max": 168214528,
-          "stdev": 516084.058171,
-          "spread": 1196032,
-          "spread_pct": 0.715125
+          "median": 167297024,
+          "min": 167133184,
+          "max": 169885696,
+          "stdev": 931635.636886,
+          "spread": 2752512,
+          "spread_pct": 1.645284
         },
         "peak_rss_bytes": {
           "samples": [
-            168689664,
-            168673280,
-            168673280,
-            167657472,
-            167723008,
-            167706624,
-            167493632
+            167575552,
+            168640512,
+            167641088,
+            167526400,
+            167690240,
+            170278912,
+            168640512
           ],
           "sample_count": 7,
-          "median": 167723008,
-          "min": 167493632,
-          "max": 168689664,
-          "stdev": 516084.058171,
-          "spread": 1196032,
-          "spread_pct": 0.7131
+          "median": 167690240,
+          "min": 167526400,
+          "max": 170278912,
+          "stdev": 931635.636886,
+          "spread": 2752512,
+          "spread_pct": 1.641426
         },
         "wall_ms": {
           "samples": [
-            2840.680542,
-            2852.78125,
-            2846.144458,
-            2847.809417,
-            2848.065834,
-            2846.187541,
-            2801.629375
+            2656.394917,
+            2652.941625,
+            2653.512125,
+            2657.891833,
+            2658.362709,
+            2651.4755,
+            2653.817625
           ],
           "sample_count": 7,
-          "median": 2846.187541,
-          "min": 2801.629375,
-          "max": 2852.78125,
-          "stdev": 16.198143,
-          "spread": 51.151875,
-          "spread_pct": 1.797207
+          "median": 2653.817625,
+          "min": 2651.4755,
+          "max": 2658.362709,
+          "stdev": 2.444675,
+          "spread": 6.887209,
+          "spread_pct": 0.259521
         },
         "minor_cycles": {
           "samples": [
@@ -2588,12 +2601,206 @@
           "spread_pct": 0
         }
       }
+    },
+    "13_large_eden_survivors": {
+      "stdout": "probe:13_large_eden_survivors\nchecksum:1846988256\nhits:3000000\ntagChars:1722368\npeerIds:-131072\nnotes:11719\nnoteSum:22499072\n",
+      "correctness": {
+        "status": "pass",
+        "oracle_version": "v26.5.1",
+        "reason": ""
+      },
+      "run_env": {
+        "PERRY_GC_SCAVENGE_NURSERY_MB": "64"
+      },
+      "metrics": {
+        "heap_used_bytes": {
+          "samples": [
+            7685768,
+            7685768,
+            7685768,
+            7685768,
+            7685768,
+            7685768,
+            7685768
+          ],
+          "sample_count": 7,
+          "median": 7685768,
+          "min": 7685768,
+          "max": 7685768,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "heap_total_bytes": {
+          "samples": [
+            77594624,
+            77594624,
+            77594624,
+            77594624,
+            77594624,
+            77594624,
+            77594624
+          ],
+          "sample_count": 7,
+          "median": 77594624,
+          "min": 77594624,
+          "max": 77594624,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "rss_bytes": {
+          "samples": [
+            193478656,
+            193478656,
+            193150976,
+            193462272,
+            193167360,
+            193478656,
+            193462272
+          ],
+          "sample_count": 7,
+          "median": 193462272,
+          "min": 193150976,
+          "max": 193478656,
+          "stdev": 141599.735455,
+          "spread": 327680,
+          "spread_pct": 0.169377
+        },
+        "peak_rss_bytes": {
+          "samples": [
+            193888256,
+            193888256,
+            193560576,
+            193871872,
+            193576960,
+            193888256,
+            193871872
+          ],
+          "sample_count": 7,
+          "median": 193871872,
+          "min": 193560576,
+          "max": 193888256,
+          "stdev": 141599.735455,
+          "spread": 327680,
+          "spread_pct": 0.169019
+        },
+        "wall_ms": {
+          "samples": [
+            3087.762667,
+            3161.676333,
+            3121.287541,
+            3097.011584,
+            3168.160708,
+            3141.31725,
+            3021.68925
+          ],
+          "sample_count": 7,
+          "median": 3121.287541,
+          "min": 3021.68925,
+          "max": 3168.160708,
+          "stdev": 47.062143,
+          "spread": 146.471458,
+          "spread_pct": 4.692661
+        },
+        "minor_cycles": {
+          "samples": [
+            4,
+            4
+          ],
+          "sample_count": 2,
+          "median": 4,
+          "min": 4,
+          "max": 4,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "step_cycles": {
+          "samples": [
+            5,
+            5
+          ],
+          "sample_count": 2,
+          "median": 5,
+          "min": 5,
+          "max": 5,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_objects": {
+          "samples": [
+            532482,
+            532482
+          ],
+          "sample_count": 2,
+          "median": 532482,
+          "min": 532482,
+          "max": 532482,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "copied_bytes": {
+          "samples": [
+            32039696,
+            32039696
+          ],
+          "sample_count": 2,
+          "median": 32039696,
+          "min": 32039696,
+          "max": 32039696,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_objects": {
+          "samples": [
+            541898,
+            541898
+          ],
+          "sample_count": 2,
+          "median": 541898,
+          "min": 541898,
+          "max": 541898,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "promoted_bytes": {
+          "samples": [
+            32597416,
+            32597416
+          ],
+          "sample_count": 2,
+          "median": 32597416,
+          "min": 32597416,
+          "max": 32597416,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        },
+        "freed_bytes": {
+          "samples": [
+            208566616,
+            208566616
+          ],
+          "sample_count": 2,
+          "median": 208566616,
+          "min": 208566616,
+          "max": 208566616,
+          "stdev": 0,
+          "spread": 0,
+          "spread_pct": 0
+        }
+      }
     }
   },
   "suite": {
     "schema_version": 2,
-    "commit": "59d522052",
-    "generated_at": "2026-08-08T17:41:39Z",
+    "commit": "a8f73122d",
+    "generated_at": "2026-08-08T22:03:20Z",
     "run_config": {
       "requested_samples": 5,
       "expected_benchmarks": [
@@ -2626,12 +2833,12 @@
     "runtimes": {
       "perry": {
         "available": true,
-        "version": "perry 0.5.1370",
+        "version": "perry 0.5.1376",
         "command": [
           "<compiled-binary>"
         ],
         "compile_command": [
-          "~/tgt7558fix/release/perry",
+          "~/tgt7056/release/perry",
           "<source.ts>",
           "-o",
           "<compiled-binary>"
@@ -2661,33 +2868,33 @@
           "perry": {
             "wall_ms": {
               "samples": [
-                107,
-                97,
-                97,
-                98,
-                98
+                136,
+                94,
+                93,
+                93,
+                94
               ],
               "sample_count": 5,
-              "median": 98,
-              "p95": 107,
-              "min": 97,
-              "max": 107,
+              "median": 94,
+              "p95": 136,
+              "min": 93,
+              "max": 136,
               "mad": 1,
-              "stdev": 3.826225
+              "stdev": 17.005881
             },
             "rss_kb": {
               "samples": [
-                4272,
-                4272,
-                4272,
-                4272,
-                4272
+                4288,
+                4288,
+                4288,
+                4288,
+                4288
               ],
               "sample_count": 5,
-              "median": 4272,
-              "p95": 4272,
-              "min": 4272,
-              "max": 4272,
+              "median": 4288,
+              "p95": 4288,
+              "min": 4288,
+              "max": 4288,
               "mad": 0,
               "stdev": 0
             }
@@ -2695,393 +2902,9 @@
           "node": {
             "wall_ms": {
               "samples": [
-                67,
-                53,
-                54,
-                54,
-                53
-              ],
-              "sample_count": 5,
-              "median": 54,
-              "p95": 67,
-              "min": 53,
-              "max": 67,
-              "mad": 1,
-              "stdev": 5.418487
-            },
-            "rss_kb": {
-              "samples": [
-                82288,
-                82416,
-                82240,
-                82416,
-                82432
-              ],
-              "sample_count": 5,
-              "median": 82416,
-              "p95": 82432,
-              "min": 82240,
-              "max": 82432,
-              "mad": 16,
-              "stdev": 78.774615
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 1.814815,
-            "rss": 0.051835
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "sum:100000000"
-          ],
-          "expected_lines": [
-            "sum:100000000"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 98,
-        "perry_rss_kb": 4272,
-        "node_ms": 54,
-        "node_rss_kb": 82416,
-        "speed_ratio": 1.814815,
-        "memory_ratio": 0.051835
-      },
-      "03_array_write": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                2,
-                1,
-                1,
-                1,
-                1
-              ],
-              "sample_count": 5,
-              "median": 1,
-              "p95": 2,
-              "min": 1,
-              "max": 2,
-              "mad": 0,
-              "stdev": 0.4
-            },
-            "rss_kb": {
-              "samples": [
-                98272,
-                98272,
-                98272,
-                98272,
-                98288
-              ],
-              "sample_count": 5,
-              "median": 98272,
-              "p95": 98288,
-              "min": 98272,
-              "max": 98288,
-              "mad": 0,
-              "stdev": 6.4
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                8,
-                9,
-                8,
-                9,
-                8
-              ],
-              "sample_count": 5,
-              "median": 8,
-              "p95": 9,
-              "min": 8,
-              "max": 9,
-              "mad": 0,
-              "stdev": 0.489898
-            },
-            "rss_kb": {
-              "samples": [
-                386640,
-                386768,
-                386688,
-                386752,
-                386560
-              ],
-              "sample_count": 5,
-              "median": 386688,
-              "p95": 386768,
-              "min": 386560,
-              "max": 386768,
-              "mad": 64,
-              "stdev": 76.130414
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 0.125,
-            "rss": 0.254138
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "checksum:9999999"
-          ],
-          "expected_lines": [
-            "checksum:9999999"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 1,
-        "perry_rss_kb": 98272,
-        "node_ms": 8,
-        "node_rss_kb": 386688,
-        "speed_ratio": 0.125,
-        "memory_ratio": 0.254138
-      },
-      "04_array_read": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                24,
-                25,
-                24,
-                31,
-                31
-              ],
-              "sample_count": 5,
-              "median": 25,
-              "p95": 31,
-              "min": 24,
-              "max": 31,
-              "mad": 1,
-              "stdev": 3.286335
-            },
-            "rss_kb": {
-              "samples": [
-                98272,
-                98272,
-                98272,
-                98272,
-                98288
-              ],
-              "sample_count": 5,
-              "median": 98272,
-              "p95": 98288,
-              "min": 98272,
-              "max": 98288,
-              "mad": 0,
-              "stdev": 6.4
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                14,
-                21,
-                25,
-                15,
-                14
-              ],
-              "sample_count": 5,
-              "median": 15,
-              "p95": 25,
-              "min": 14,
-              "max": 25,
-              "mad": 1,
-              "stdev": 4.445222
-            },
-            "rss_kb": {
-              "samples": [
-                387952,
-                388352,
-                387792,
-                388512,
-                387808
-              ],
-              "sample_count": 5,
-              "median": 387952,
-              "p95": 388512,
-              "min": 387792,
-              "max": 388512,
-              "mad": 160,
-              "stdev": 294.573862
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 1.666667,
-            "rss": 0.25331
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "sum:49999995000000"
-          ],
-          "expected_lines": [
-            "sum:49999995000000"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 25,
-        "perry_rss_kb": 98272,
-        "node_ms": 15,
-        "node_rss_kb": 387952,
-        "speed_ratio": 1.666667,
-        "memory_ratio": 0.25331
-      },
-      "05_fibonacci": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                428,
-                419,
-                433,
-                501,
-                554
-              ],
-              "sample_count": 5,
-              "median": 433,
-              "p95": 554,
-              "min": 419,
-              "max": 554,
-              "mad": 14,
-              "stdev": 52.35647
-            },
-            "rss_kb": {
-              "samples": [
-                4384,
-                4368,
-                4368,
-                4368,
-                4368
-              ],
-              "sample_count": 5,
-              "median": 4368,
-              "p95": 4384,
-              "min": 4368,
-              "max": 4384,
-              "mad": 0,
-              "stdev": 6.4
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                1266,
-                1038,
-                1037,
-                1036,
-                1036
-              ],
-              "sample_count": 5,
-              "median": 1037,
-              "p95": 1266,
-              "min": 1036,
-              "max": 1266,
-              "mad": 1,
-              "stdev": 91.702999
-            },
-            "rss_kb": {
-              "samples": [
-                82448,
-                82160,
-                82016,
-                82160,
-                82224
-              ],
-              "sample_count": 5,
-              "median": 82160,
-              "p95": 82448,
-              "min": 82016,
-              "max": 82448,
-              "mad": 64,
-              "stdev": 140.8
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 0.417551,
-            "rss": 0.053165
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "fib(40):102334155"
-          ],
-          "expected_lines": [
-            "fib(40):102334155"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 433,
-        "perry_rss_kb": 4368,
-        "node_ms": 1037,
-        "node_rss_kb": 82160,
-        "speed_ratio": 0.417551,
-        "memory_ratio": 0.053165
-      },
-      "06_math_intensive": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                65,
-                53,
                 52,
-                53,
-                52
-              ],
-              "sample_count": 5,
-              "median": 53,
-              "p95": 65,
-              "min": 52,
-              "max": 65,
-              "mad": 1,
-              "stdev": 5.01996
-            },
-            "rss_kb": {
-              "samples": [
-                4400,
-                4400,
-                4400,
-                4400,
-                4400
-              ],
-              "sample_count": 5,
-              "median": 4400,
-              "p95": 4400,
-              "min": 4400,
-              "max": 4400,
-              "mad": 0,
-              "stdev": 0
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
                 52,
                 51,
-                52,
                 51,
                 52
               ],
@@ -3095,26 +2918,26 @@
             },
             "rss_kb": {
               "samples": [
-                83776,
-                83760,
-                83776,
-                83792,
-                83552
+                82352,
+                82256,
+                82384,
+                82432,
+                82224
               ],
               "sample_count": 5,
-              "median": 83776,
-              "p95": 83792,
-              "min": 83552,
-              "max": 83792,
-              "mad": 16,
-              "stdev": 90.169618
+              "median": 82352,
+              "p95": 82432,
+              "min": 82224,
+              "max": 82432,
+              "mad": 80,
+              "stdev": 78.121956
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 1.019231,
-            "rss": 0.052521
+            "wall_time": 1.807692,
+            "rss": 0.052069
           },
           "perry_to_bun": null
         },
@@ -3122,52 +2945,340 @@
           "status": "pass",
           "reference": "node",
           "actual_lines": [
-            "result:19.30474921829397"
+            "sum:100000000"
           ],
           "expected_lines": [
-            "result:19.30474921829397"
+            "sum:100000000"
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 53,
-        "perry_rss_kb": 4400,
+        "perry_ms": 94,
+        "perry_rss_kb": 4288,
         "node_ms": 52,
-        "node_rss_kb": 83776,
-        "speed_ratio": 1.019231,
-        "memory_ratio": 0.052521
+        "node_rss_kb": 82352,
+        "speed_ratio": 1.807692,
+        "memory_ratio": 0.052069
       },
-      "07_object_create": {
+      "03_array_write": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                12,
                 2,
-                3,
+                1,
                 2,
-                3
+                2,
+                2
               ],
               "sample_count": 5,
-              "median": 3,
-              "p95": 12,
-              "min": 2,
-              "max": 12,
-              "mad": 1,
-              "stdev": 3.826225
+              "median": 2,
+              "p95": 2,
+              "min": 1,
+              "max": 2,
+              "mad": 0,
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                5232,
-                5232,
-                5232,
-                5232,
-                5248
+                98192,
+                98176,
+                98192,
+                98192,
+                98176
               ],
               "sample_count": 5,
-              "median": 5232,
-              "p95": 5248,
-              "min": 5232,
-              "max": 5248,
+              "median": 98192,
+              "p95": 98192,
+              "min": 98176,
+              "max": 98192,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                7,
+                7,
+                7,
+                7,
+                8
+              ],
+              "sample_count": 5,
+              "median": 7,
+              "p95": 8,
+              "min": 7,
+              "max": 8,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                386544,
+                386384,
+                386464,
+                386544,
+                386592
+              ],
+              "sample_count": 5,
+              "median": 386544,
+              "p95": 386592,
+              "min": 386384,
+              "max": 386592,
+              "mad": 48,
+              "stdev": 73.391008
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.285714,
+            "rss": 0.254025
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:9999999"
+          ],
+          "expected_lines": [
+            "checksum:9999999"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 2,
+        "perry_rss_kb": 98192,
+        "node_ms": 7,
+        "node_rss_kb": 386544,
+        "speed_ratio": 0.285714,
+        "memory_ratio": 0.254025
+      },
+      "04_array_read": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                38,
+                23,
+                22,
+                22,
+                23
+              ],
+              "sample_count": 5,
+              "median": 23,
+              "p95": 38,
+              "min": 22,
+              "max": 38,
+              "mad": 1,
+              "stdev": 6.216108
+            },
+            "rss_kb": {
+              "samples": [
+                98176,
+                98176,
+                98176,
+                98176,
+                98176
+              ],
+              "sample_count": 5,
+              "median": 98176,
+              "p95": 98176,
+              "min": 98176,
+              "max": 98176,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                13,
+                12,
+                12,
+                12,
+                12
+              ],
+              "sample_count": 5,
+              "median": 12,
+              "p95": 13,
+              "min": 12,
+              "max": 13,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                387120,
+                387232,
+                387296,
+                387280,
+                387392
+              ],
+              "sample_count": 5,
+              "median": 387280,
+              "p95": 387392,
+              "min": 387120,
+              "max": 387392,
+              "mad": 48,
+              "stdev": 88.796396
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.916667,
+            "rss": 0.253501
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "sum:49999995000000"
+          ],
+          "expected_lines": [
+            "sum:49999995000000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 23,
+        "perry_rss_kb": 98176,
+        "node_ms": 12,
+        "node_rss_kb": 387280,
+        "speed_ratio": 1.916667,
+        "memory_ratio": 0.253501
+      },
+      "05_fibonacci": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                433,
+                390,
+                390,
+                390,
+                389
+              ],
+              "sample_count": 5,
+              "median": 390,
+              "p95": 433,
+              "min": 389,
+              "max": 433,
+              "mad": 0,
+              "stdev": 17.304335
+            },
+            "rss_kb": {
+              "samples": [
+                4432,
+                4432,
+                4432,
+                4432,
+                4432
+              ],
+              "sample_count": 5,
+              "median": 4432,
+              "p95": 4432,
+              "min": 4432,
+              "max": 4432,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                968,
+                968,
+                969,
+                969,
+                969
+              ],
+              "sample_count": 5,
+              "median": 969,
+              "p95": 969,
+              "min": 968,
+              "max": 969,
+              "mad": 0,
+              "stdev": 0.489898
+            },
+            "rss_kb": {
+              "samples": [
+                81712,
+                81760,
+                81856,
+                81792,
+                81792
+              ],
+              "sample_count": 5,
+              "median": 81792,
+              "p95": 81856,
+              "min": 81712,
+              "max": 81856,
+              "mad": 32,
+              "stdev": 47.030203
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.402477,
+            "rss": 0.054186
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "fib(40):102334155"
+          ],
+          "expected_lines": [
+            "fib(40):102334155"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 390,
+        "perry_rss_kb": 4432,
+        "node_ms": 969,
+        "node_rss_kb": 81792,
+        "speed_ratio": 0.402477,
+        "memory_ratio": 0.054186
+      },
+      "06_math_intensive": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                93,
+                49,
+                49,
+                49,
+                49
+              ],
+              "sample_count": 5,
+              "median": 49,
+              "p95": 93,
+              "min": 49,
+              "max": 93,
+              "mad": 0,
+              "stdev": 17.6
+            },
+            "rss_kb": {
+              "samples": [
+                4384,
+                4384,
+                4400,
+                4384,
+                4384
+              ],
+              "sample_count": 5,
+              "median": 4384,
+              "p95": 4400,
+              "min": 4384,
+              "max": 4400,
               "mad": 0,
               "stdev": 6.4
             }
@@ -3175,42 +3286,138 @@
           "node": {
             "wall_ms": {
               "samples": [
-                8,
-                9,
-                9,
-                8,
-                9
+                48,
+                48,
+                48,
+                48,
+                48
               ],
               "sample_count": 5,
-              "median": 9,
-              "p95": 9,
-              "min": 8,
-              "max": 9,
+              "median": 48,
+              "p95": 48,
+              "min": 48,
+              "max": 48,
               "mad": 0,
-              "stdev": 0.489898
+              "stdev": 0
             },
             "rss_kb": {
               "samples": [
-                85360,
-                85360,
-                85280,
-                85072,
-                85344
+                83728,
+                83600,
+                83728,
+                83680,
+                83776
               ],
               "sample_count": 5,
-              "median": 85344,
-              "p95": 85360,
-              "min": 85072,
-              "max": 85360,
-              "mad": 16,
-              "stdev": 109.643787
+              "median": 83728,
+              "p95": 83776,
+              "min": 83600,
+              "max": 83776,
+              "mad": 48,
+              "stdev": 59.523441
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.333333,
-            "rss": 0.061305
+            "wall_time": 1.020833,
+            "rss": 0.05236
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "result:19.30474921829397"
+          ],
+          "expected_lines": [
+            "result:19.30474921829397"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 49,
+        "perry_rss_kb": 4384,
+        "node_ms": 48,
+        "node_rss_kb": 83728,
+        "speed_ratio": 1.020833,
+        "memory_ratio": 0.05236
+      },
+      "07_object_create": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                11,
+                2,
+                2,
+                2,
+                2
+              ],
+              "sample_count": 5,
+              "median": 2,
+              "p95": 11,
+              "min": 2,
+              "max": 11,
+              "mad": 0,
+              "stdev": 3.6
+            },
+            "rss_kb": {
+              "samples": [
+                5200,
+                5200,
+                5200,
+                5200,
+                5200
+              ],
+              "sample_count": 5,
+              "median": 5200,
+              "p95": 5200,
+              "min": 5200,
+              "max": 5200,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                9,
+                8,
+                8,
+                8,
+                8
+              ],
+              "sample_count": 5,
+              "median": 8,
+              "p95": 9,
+              "min": 8,
+              "max": 9,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                85328,
+                85072,
+                85072,
+                85152,
+                85200
+              ],
+              "sample_count": 5,
+              "median": 85152,
+              "p95": 85328,
+              "min": 85072,
+              "max": 85328,
+              "mad": 80,
+              "stdev": 95.14284
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.25,
+            "rss": 0.061067
           },
           "perry_to_bun": null
         },
@@ -3225,12 +3432,12 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 3,
-        "perry_rss_kb": 5232,
-        "node_ms": 9,
-        "node_rss_kb": 85344,
-        "speed_ratio": 0.333333,
-        "memory_ratio": 0.061305
+        "perry_ms": 2,
+        "perry_rss_kb": 5200,
+        "node_ms": 8,
+        "node_rss_kb": 85152,
+        "speed_ratio": 0.25,
+        "memory_ratio": 0.061067
       },
       "08_string_concat": {
         "runtimes": {
@@ -3241,37 +3448,37 @@
                 2,
                 1,
                 1,
-                1
+                2
               ],
               "sample_count": 5,
-              "median": 1,
+              "median": 2,
               "p95": 8,
               "min": 1,
               "max": 8,
-              "mad": 0,
-              "stdev": 2.727636
+              "mad": 1,
+              "stdev": 2.638181
             },
             "rss_kb": {
               "samples": [
-                4688,
-                4704,
-                4688,
-                4688,
-                4688
+                4672,
+                4672,
+                4672,
+                4672,
+                4672
               ],
               "sample_count": 5,
-              "median": 4688,
-              "p95": 4704,
-              "min": 4688,
-              "max": 4704,
+              "median": 4672,
+              "p95": 4672,
+              "min": 4672,
+              "max": 4672,
               "mad": 0,
-              "stdev": 6.4
+              "stdev": 0
             }
           },
           "node": {
             "wall_ms": {
               "samples": [
-                4,
+                3,
                 4,
                 4,
                 4,
@@ -3280,33 +3487,33 @@
               "sample_count": 5,
               "median": 4,
               "p95": 4,
-              "min": 4,
+              "min": 3,
               "max": 4,
               "mad": 0,
-              "stdev": 0
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                89056,
-                88944,
+                88976,
+                88960,
+                88896,
                 89040,
-                88944,
-                88896
+                89040
               ],
               "sample_count": 5,
-              "median": 88944,
-              "p95": 89056,
+              "median": 88976,
+              "p95": 89040,
               "min": 88896,
-              "max": 89056,
-              "mad": 48,
-              "stdev": 61.553229
+              "max": 89040,
+              "mad": 64,
+              "stdev": 54.11691
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.25,
-            "rss": 0.052707
+            "wall_time": 0.5,
+            "rss": 0.052509
           },
           "perry_to_bun": null
         },
@@ -3321,88 +3528,88 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 1,
-        "perry_rss_kb": 4688,
+        "perry_ms": 2,
+        "perry_rss_kb": 4672,
         "node_ms": 4,
-        "node_rss_kb": 88944,
-        "speed_ratio": 0.25,
-        "memory_ratio": 0.052707
+        "node_rss_kb": 88976,
+        "speed_ratio": 0.5,
+        "memory_ratio": 0.052509
       },
       "09_method_calls": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
+                24,
                 10,
-                10,
-                10,
+                9,
                 10,
                 10
               ],
               "sample_count": 5,
               "median": 10,
-              "p95": 10,
-              "min": 10,
-              "max": 10,
+              "p95": 24,
+              "min": 9,
+              "max": 24,
               "mad": 0,
-              "stdev": 0
+              "stdev": 5.713143
             },
             "rss_kb": {
               "samples": [
-                9840,
-                9840,
-                9840,
-                9840,
-                9840
+                9984,
+                9984,
+                10000,
+                9984,
+                9984
               ],
               "sample_count": 5,
-              "median": 9840,
-              "p95": 9840,
-              "min": 9840,
-              "max": 9840,
+              "median": 9984,
+              "p95": 10000,
+              "min": 9984,
+              "max": 10000,
               "mad": 0,
-              "stdev": 0
+              "stdev": 6.4
             }
           },
           "node": {
             "wall_ms": {
               "samples": [
+                10,
                 11,
-                12,
-                11,
+                10,
                 11,
                 11
               ],
               "sample_count": 5,
               "median": 11,
-              "p95": 12,
-              "min": 11,
-              "max": 12,
+              "p95": 11,
+              "min": 10,
+              "max": 11,
               "mad": 0,
-              "stdev": 0.4
+              "stdev": 0.489898
             },
             "rss_kb": {
               "samples": [
-                82992,
-                82912,
-                83008,
-                82880,
-                83088
+                82768,
+                82704,
+                82688,
+                82656,
+                82752
               ],
               "sample_count": 5,
-              "median": 82992,
-              "p95": 83088,
-              "min": 82880,
-              "max": 83088,
-              "mad": 80,
-              "stdev": 73.669532
+              "median": 82704,
+              "p95": 82768,
+              "min": 82656,
+              "max": 82768,
+              "mad": 48,
+              "stdev": 41.229116
             }
           }
         },
         "ratios": {
           "perry_to_node": {
             "wall_time": 0.909091,
-            "rss": 0.118566
+            "rss": 0.12072
           },
           "perry_to_bun": null
         },
@@ -3418,44 +3625,44 @@
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
         "perry_ms": 10,
-        "perry_rss_kb": 9840,
+        "perry_rss_kb": 9984,
         "node_ms": 11,
-        "node_rss_kb": 82992,
+        "node_rss_kb": 82704,
         "speed_ratio": 0.909091,
-        "memory_ratio": 0.118566
+        "memory_ratio": 0.12072
       },
       "10_nested_loops": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                43,
-                42,
-                43,
-                42,
-                42
+                69,
+                40,
+                40,
+                40,
+                39
               ],
               "sample_count": 5,
-              "median": 42,
-              "p95": 43,
-              "min": 42,
-              "max": 43,
+              "median": 40,
+              "p95": 69,
+              "min": 39,
+              "max": 69,
               "mad": 0,
-              "stdev": 0.489898
+              "stdev": 11.706409
             },
             "rss_kb": {
               "samples": [
-                10112,
-                10112,
-                10128,
-                10112,
-                10112
+                10032,
+                10016,
+                10016,
+                10016,
+                10016
               ],
               "sample_count": 5,
-              "median": 10112,
-              "p95": 10128,
-              "min": 10112,
-              "max": 10128,
+              "median": 10016,
+              "p95": 10032,
+              "min": 10016,
+              "max": 10032,
               "mad": 0,
               "stdev": 6.4
             }
@@ -3463,42 +3670,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                17,
-                17,
-                17,
-                17,
-                19
+                18,
+                16,
+                18,
+                16,
+                16
               ],
               "sample_count": 5,
-              "median": 17,
-              "p95": 19,
-              "min": 17,
-              "max": 19,
+              "median": 16,
+              "p95": 18,
+              "min": 16,
+              "max": 18,
               "mad": 0,
-              "stdev": 0.8
+              "stdev": 0.979796
             },
             "rss_kb": {
               "samples": [
-                83904,
-                84064,
-                83888,
-                83904,
-                84880
+                84672,
+                83776,
+                84624,
+                83776,
+                83856
               ],
               "sample_count": 5,
-              "median": 83904,
-              "p95": 84880,
-              "min": 83888,
-              "max": 84880,
-              "mad": 16,
-              "stdev": 381.458255
+              "median": 83856,
+              "p95": 84672,
+              "min": 83776,
+              "max": 84672,
+              "mad": 80,
+              "stdev": 415.43346
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 2.470588,
-            "rss": 0.120519
+            "wall_time": 2.5,
+            "rss": 0.119443
           },
           "perry_to_bun": null
         },
@@ -3513,45 +3720,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 42,
-        "perry_rss_kb": 10112,
-        "node_ms": 17,
-        "node_rss_kb": 83904,
-        "speed_ratio": 2.470588,
-        "memory_ratio": 0.120519
+        "perry_ms": 40,
+        "perry_rss_kb": 10016,
+        "node_ms": 16,
+        "node_rss_kb": 83856,
+        "speed_ratio": 2.5,
+        "memory_ratio": 0.119443
       },
       "11_prime_sieve": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                33,
-                32,
-                32,
-                31,
-                32
+                38,
+                28,
+                28,
+                28,
+                28
               ],
               "sample_count": 5,
-              "median": 32,
-              "p95": 33,
-              "min": 31,
-              "max": 33,
+              "median": 28,
+              "p95": 38,
+              "min": 28,
+              "max": 38,
               "mad": 0,
-              "stdev": 0.632456
+              "stdev": 4
             },
             "rss_kb": {
               "samples": [
-                28304,
-                28304,
-                28304,
-                28304,
-                28288
+                28320,
+                28336,
+                28336,
+                28336,
+                28336
               ],
               "sample_count": 5,
-              "median": 28304,
-              "p95": 28304,
-              "min": 28288,
-              "max": 28304,
+              "median": 28336,
+              "p95": 28336,
+              "min": 28320,
+              "max": 28336,
               "mad": 0,
               "stdev": 6.4
             }
@@ -3559,42 +3766,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                7,
-                7,
-                7,
-                7,
-                7
+                6,
+                6,
+                6,
+                6,
+                6
               ],
               "sample_count": 5,
-              "median": 7,
-              "p95": 7,
-              "min": 7,
-              "max": 7,
+              "median": 6,
+              "p95": 6,
+              "min": 6,
+              "max": 6,
               "mad": 0,
               "stdev": 0
             },
             "rss_kb": {
               "samples": [
-                114368,
-                114208,
-                114256,
-                114352,
-                114240
+                113728,
+                113776,
+                113696,
+                113600,
+                114000
               ],
               "sample_count": 5,
-              "median": 114256,
-              "p95": 114368,
-              "min": 114208,
-              "max": 114368,
+              "median": 113728,
+              "p95": 114000,
+              "min": 113600,
+              "max": 114000,
               "mad": 48,
-              "stdev": 63.518186
+              "stdev": 133.09846
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 4.571429,
-            "rss": 0.247724
+            "wall_time": 4.666667,
+            "rss": 0.249156
           },
           "perry_to_bun": null
         },
@@ -3609,12 +3816,12 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 32,
-        "perry_rss_kb": 28304,
-        "node_ms": 7,
-        "node_rss_kb": 114256,
-        "speed_ratio": 4.571429,
-        "memory_ratio": 0.247724
+        "perry_ms": 28,
+        "perry_rss_kb": 28336,
+        "node_ms": 6,
+        "node_rss_kb": 113728,
+        "speed_ratio": 4.666667,
+        "memory_ratio": 0.249156
       },
       "12_binary_trees": {
         "runtimes": {
@@ -3622,32 +3829,32 @@
             "wall_ms": {
               "samples": [
                 16,
+                3,
                 4,
                 4,
-                4,
-                4
+                3
               ],
               "sample_count": 5,
               "median": 4,
               "p95": 16,
-              "min": 4,
+              "min": 3,
               "max": 16,
-              "mad": 0,
-              "stdev": 4.8
+              "mad": 1,
+              "stdev": 5.01996
             },
             "rss_kb": {
               "samples": [
-                5152,
-                5152,
-                5152,
-                5152,
-                5152
+                5184,
+                5184,
+                5184,
+                5184,
+                5184
               ],
               "sample_count": 5,
-              "median": 5152,
-              "p95": 5152,
-              "min": 5152,
-              "max": 5152,
+              "median": 5184,
+              "p95": 5184,
+              "min": 5184,
+              "max": 5184,
               "mad": 0,
               "stdev": 0
             }
@@ -3655,42 +3862,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                11,
-                11,
-                11,
-                10,
-                11
+                9,
+                9,
+                9,
+                9,
+                10
               ],
               "sample_count": 5,
-              "median": 11,
-              "p95": 11,
-              "min": 10,
-              "max": 11,
+              "median": 9,
+              "p95": 10,
+              "min": 9,
+              "max": 10,
               "mad": 0,
               "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                85296,
-                85120,
-                85200,
-                85248,
-                85184
+                85152,
+                85104,
+                85104,
+                85168,
+                85056
               ],
               "sample_count": 5,
-              "median": 85200,
-              "p95": 85296,
-              "min": 85120,
-              "max": 85296,
+              "median": 85104,
+              "p95": 85168,
+              "min": 85056,
+              "max": 85168,
               "mad": 48,
-              "stdev": 59.523441
+              "stdev": 39.710956
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.363636,
-            "rss": 0.060469
+            "wall_time": 0.444444,
+            "rss": 0.060914
           },
           "perry_to_bun": null
         },
@@ -3706,87 +3913,87 @@
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
         "perry_ms": 4,
-        "perry_rss_kb": 5152,
-        "node_ms": 11,
-        "node_rss_kb": 85200,
-        "speed_ratio": 0.363636,
-        "memory_ratio": 0.060469
+        "perry_rss_kb": 5184,
+        "node_ms": 9,
+        "node_rss_kb": 85104,
+        "speed_ratio": 0.444444,
+        "memory_ratio": 0.060914
       },
       "13_factorial": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                115,
-                100,
-                101,
-                100,
-                101
+                135,
+                94,
+                95,
+                94,
+                94
               ],
               "sample_count": 5,
-              "median": 101,
-              "p95": 115,
-              "min": 100,
-              "max": 115,
-              "mad": 1,
-              "stdev": 5.817216
+              "median": 94,
+              "p95": 135,
+              "min": 94,
+              "max": 135,
+              "mad": 0,
+              "stdev": 16.304601
             },
             "rss_kb": {
               "samples": [
-                4288,
-                4304,
-                4288,
-                4288,
-                4288
+                4352,
+                4352,
+                4352,
+                4352,
+                4352
               ],
               "sample_count": 5,
-              "median": 4288,
-              "p95": 4304,
-              "min": 4288,
-              "max": 4304,
+              "median": 4352,
+              "p95": 4352,
+              "min": 4352,
+              "max": 4352,
               "mad": 0,
-              "stdev": 6.4
+              "stdev": 0
             }
           },
           "node": {
             "wall_ms": {
               "samples": [
-                620,
-                619,
-                620,
-                618,
-                613
+                580,
+                579,
+                579,
+                579,
+                579
               ],
               "sample_count": 5,
-              "median": 619,
-              "p95": 620,
-              "min": 613,
-              "max": 620,
-              "mad": 1,
-              "stdev": 2.607681
+              "median": 579,
+              "p95": 580,
+              "min": 579,
+              "max": 580,
+              "mad": 0,
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                84560,
-                84624,
-                84592,
-                84560,
-                84560
+                84080,
+                84048,
+                84016,
+                84080,
+                84112
               ],
               "sample_count": 5,
-              "median": 84560,
-              "p95": 84624,
-              "min": 84560,
-              "max": 84624,
-              "mad": 0,
-              "stdev": 25.6
+              "median": 84080,
+              "p95": 84112,
+              "min": 84016,
+              "max": 84112,
+              "mad": 32,
+              "stdev": 32.633725
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.163166,
-            "rss": 0.05071
+            "wall_time": 0.162349,
+            "rss": 0.05176
           },
           "perry_to_bun": null
         },
@@ -3801,45 +4008,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 101,
-        "perry_rss_kb": 4288,
-        "node_ms": 619,
-        "node_rss_kb": 84560,
-        "speed_ratio": 0.163166,
-        "memory_ratio": 0.05071
+        "perry_ms": 94,
+        "perry_rss_kb": 4352,
+        "node_ms": 579,
+        "node_rss_kb": 84080,
+        "speed_ratio": 0.162349,
+        "memory_ratio": 0.05176
       },
       "14_closure": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                61,
-                50,
-                50,
-                51,
-                51
+                84,
+                47,
+                47,
+                47,
+                47
               ],
               "sample_count": 5,
-              "median": 51,
-              "p95": 61,
-              "min": 50,
-              "max": 61,
-              "mad": 1,
-              "stdev": 4.223742
+              "median": 47,
+              "p95": 84,
+              "min": 47,
+              "max": 84,
+              "mad": 0,
+              "stdev": 14.8
             },
             "rss_kb": {
               "samples": [
-                4464,
-                4464,
-                4464,
-                4464,
-                4464
+                4544,
+                4544,
+                4544,
+                4544,
+                4544
               ],
               "sample_count": 5,
-              "median": 4464,
-              "p95": 4464,
-              "min": 4464,
-              "max": 4464,
+              "median": 4544,
+              "p95": 4544,
+              "min": 4544,
+              "max": 4544,
               "mad": 0,
               "stdev": 0
             }
@@ -3847,42 +4054,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                319,
-                318,
-                319,
-                318,
-                319
+                297,
+                297,
+                297,
+                297,
+                296
               ],
               "sample_count": 5,
-              "median": 319,
-              "p95": 319,
-              "min": 318,
-              "max": 319,
+              "median": 297,
+              "p95": 297,
+              "min": 296,
+              "max": 297,
               "mad": 0,
-              "stdev": 0.489898
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                84256,
-                84000,
-                84240,
-                84352,
-                84208
+                83856,
+                83952,
+                84128,
+                84208,
+                83968
               ],
               "sample_count": 5,
-              "median": 84240,
-              "p95": 84352,
-              "min": 84000,
-              "max": 84352,
-              "mad": 32,
-              "stdev": 115.997241
+              "median": 83968,
+              "p95": 84208,
+              "min": 83856,
+              "max": 84208,
+              "mad": 112,
+              "stdev": 127.43877
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.159875,
-            "rss": 0.052991
+            "wall_time": 0.158249,
+            "rss": 0.054116
           },
           "perry_to_bun": null
         },
@@ -3897,211 +4104,19 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 51,
-        "perry_rss_kb": 4464,
-        "node_ms": 319,
-        "node_rss_kb": 84240,
-        "speed_ratio": 0.159875,
-        "memory_ratio": 0.052991
+        "perry_ms": 47,
+        "perry_rss_kb": 4544,
+        "node_ms": 297,
+        "node_rss_kb": 83968,
+        "speed_ratio": 0.158249,
+        "memory_ratio": 0.054116
       },
       "15_mandelbrot": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                40,
-                23,
-                23,
-                23,
-                23
-              ],
-              "sample_count": 5,
-              "median": 23,
-              "p95": 40,
-              "min": 23,
-              "max": 40,
-              "mad": 0,
-              "stdev": 6.8
-            },
-            "rss_kb": {
-              "samples": [
-                4256,
-                4256,
-                4256,
-                4256,
-                4256
-              ],
-              "sample_count": 5,
-              "median": 4256,
-              "p95": 4256,
-              "min": 4256,
-              "max": 4256,
-              "mad": 0,
-              "stdev": 0
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                26,
-                25,
-                25,
-                25,
-                25
-              ],
-              "sample_count": 5,
-              "median": 25,
-              "p95": 26,
-              "min": 25,
-              "max": 26,
-              "mad": 0,
-              "stdev": 0.4
-            },
-            "rss_kb": {
-              "samples": [
-                84672,
-                84064,
-                84000,
-                83856,
-                84016
-              ],
-              "sample_count": 5,
-              "median": 84016,
-              "p95": 84672,
-              "min": 83856,
-              "max": 84672,
-              "mad": 48,
-              "stdev": 283.809514
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 0.92,
-            "rss": 0.050657
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "total_iter:8011148"
-          ],
-          "expected_lines": [
-            "total_iter:8011148"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 23,
-        "perry_rss_kb": 4256,
-        "node_ms": 25,
-        "node_rss_kb": 84016,
-        "speed_ratio": 0.92,
-        "memory_ratio": 0.050657
-      },
-      "16_matrix_multiply": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                106,
-                91,
-                90,
-                91,
-                91
-              ],
-              "sample_count": 5,
-              "median": 91,
-              "p95": 106,
-              "min": 90,
-              "max": 106,
-              "mad": 0,
-              "stdev": 6.112283
-            },
-            "rss_kb": {
-              "samples": [
-                8096,
-                8096,
-                8096,
-                8096,
-                8096
-              ],
-              "sample_count": 5,
-              "median": 8096,
-              "p95": 8096,
-              "min": 8096,
-              "max": 8096,
-              "mad": 0,
-              "stdev": 0
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                35,
-                35,
-                35,
-                35,
-                35
-              ],
-              "sample_count": 5,
-              "median": 35,
-              "p95": 35,
-              "min": 35,
-              "max": 35,
-              "mad": 0,
-              "stdev": 0
-            },
-            "rss_kb": {
-              "samples": [
-                89568,
-                89680,
-                89632,
-                89600,
-                89408
-              ],
-              "sample_count": 5,
-              "median": 89600,
-              "p95": 89680,
-              "min": 89408,
-              "max": 89680,
-              "mad": 32,
-              "stdev": 92.523727
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 2.6,
-            "rss": 0.090357
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "checksum:41079519680"
-          ],
-          "expected_lines": [
-            "checksum:41079519680"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 91,
-        "perry_rss_kb": 8096,
-        "node_ms": 35,
-        "node_rss_kb": 89600,
-        "speed_ratio": 2.6,
-        "memory_ratio": 0.090357
-      },
-      "bench_gc_pressure": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                35,
+                58,
                 22,
                 22,
                 22,
@@ -4109,22 +4124,214 @@
               ],
               "sample_count": 5,
               "median": 22,
-              "p95": 35,
+              "p95": 58,
               "min": 22,
-              "max": 35,
+              "max": 58,
               "mad": 0,
-              "stdev": 5.2
+              "stdev": 14.4
+            },
+            "rss_kb": {
+              "samples": [
+                4288,
+                4288,
+                4288,
+                4288,
+                4288
+              ],
+              "sample_count": 5,
+              "median": 4288,
+              "p95": 4288,
+              "min": 4288,
+              "max": 4288,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                23,
+                23,
+                23,
+                23,
+                24
+              ],
+              "sample_count": 5,
+              "median": 23,
+              "p95": 24,
+              "min": 23,
+              "max": 24,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                83904,
+                83872,
+                83616,
+                83584,
+                83712
+              ],
+              "sample_count": 5,
+              "median": 83712,
+              "p95": 83904,
+              "min": 83584,
+              "max": 83904,
+              "mad": 128,
+              "stdev": 130.220736
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.956522,
+            "rss": 0.051223
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "total_iter:8011148"
+          ],
+          "expected_lines": [
+            "total_iter:8011148"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 22,
+        "perry_rss_kb": 4288,
+        "node_ms": 23,
+        "node_rss_kb": 83712,
+        "speed_ratio": 0.956522,
+        "memory_ratio": 0.051223
+      },
+      "16_matrix_multiply": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                130,
+                84,
+                84,
+                85,
+                85
+              ],
+              "sample_count": 5,
+              "median": 85,
+              "p95": 130,
+              "min": 84,
+              "max": 130,
+              "mad": 1,
+              "stdev": 18.205494
+            },
+            "rss_kb": {
+              "samples": [
+                8160,
+                8176,
+                8160,
+                8160,
+                8160
+              ],
+              "sample_count": 5,
+              "median": 8160,
+              "p95": 8176,
+              "min": 8160,
+              "max": 8176,
+              "mad": 0,
+              "stdev": 6.4
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                33,
+                33,
+                33,
+                32,
+                33
+              ],
+              "sample_count": 5,
+              "median": 33,
+              "p95": 33,
+              "min": 32,
+              "max": 33,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                89680,
+                89552,
+                89536,
+                89616,
+                89680
+              ],
+              "sample_count": 5,
+              "median": 89616,
+              "p95": 89680,
+              "min": 89536,
+              "max": 89680,
+              "mad": 64,
+              "stdev": 61.052109
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 2.575758,
+            "rss": 0.091055
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:41079519680"
+          ],
+          "expected_lines": [
+            "checksum:41079519680"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 85,
+        "perry_rss_kb": 8160,
+        "node_ms": 33,
+        "node_rss_kb": 89616,
+        "speed_ratio": 2.575758,
+        "memory_ratio": 0.091055
+      },
+      "bench_gc_pressure": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                62,
+                21,
+                20,
+                21,
+                20
+              ],
+              "sample_count": 5,
+              "median": 21,
+              "p95": 62,
+              "min": 20,
+              "max": 62,
+              "mad": 1,
+              "stdev": 16.606023
             },
             "rss_kb": {
               "samples": [
                 24224,
+                24224,
                 24240,
-                24240,
-                24240,
-                24224
+                24224,
+                24240
               ],
               "sample_count": 5,
-              "median": 24240,
+              "median": 24224,
               "p95": 24240,
               "min": 24224,
               "max": 24240,
@@ -4135,42 +4342,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                15,
-                16,
-                16,
-                16,
+                12,
+                12,
+                13,
+                13,
                 14
               ],
               "sample_count": 5,
-              "median": 16,
-              "p95": 16,
-              "min": 14,
-              "max": 16,
-              "mad": 0,
-              "stdev": 0.8
+              "median": 13,
+              "p95": 14,
+              "min": 12,
+              "max": 14,
+              "mad": 1,
+              "stdev": 0.748331
             },
             "rss_kb": {
               "samples": [
-                92176,
-                91232,
-                92064,
-                91232,
-                91408
+                91328,
+                91360,
+                91312,
+                91264,
+                91264
               ],
               "sample_count": 5,
-              "median": 91408,
-              "p95": 92176,
-              "min": 91232,
-              "max": 92176,
-              "mad": 176,
-              "stdev": 412.862011
+              "median": 91312,
+              "p95": 91360,
+              "min": 91264,
+              "max": 91360,
+              "mad": 48,
+              "stdev": 37.318092
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 1.375,
-            "rss": 0.265185
+            "wall_time": 1.615385,
+            "rss": 0.265288
           },
           "perry_to_bun": null
         },
@@ -4185,45 +4392,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 22,
-        "perry_rss_kb": 24240,
-        "node_ms": 16,
-        "node_rss_kb": 91408,
-        "speed_ratio": 1.375,
-        "memory_ratio": 0.265185
+        "perry_ms": 21,
+        "perry_rss_kb": 24224,
+        "node_ms": 13,
+        "node_rss_kb": 91312,
+        "speed_ratio": 1.615385,
+        "memory_ratio": 0.265288
       },
       "bench_json_roundtrip": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                189,
-                189,
-                188,
-                188,
-                189
+                177,
+                172,
+                172,
+                172,
+                173
               ],
               "sample_count": 5,
-              "median": 189,
-              "p95": 189,
-              "min": 188,
-              "max": 189,
+              "median": 172,
+              "p95": 177,
+              "min": 172,
+              "max": 177,
               "mad": 0,
-              "stdev": 0.489898
+              "stdev": 1.939072
             },
             "rss_kb": {
               "samples": [
-                89296,
-                89296,
-                89296,
-                89280,
-                89296
+                89200,
+                89200,
+                89200,
+                89184,
+                89200
               ],
               "sample_count": 5,
-              "median": 89296,
-              "p95": 89296,
-              "min": 89280,
-              "max": 89296,
+              "median": 89200,
+              "p95": 89200,
+              "min": 89184,
+              "max": 89200,
               "mad": 0,
               "stdev": 6.4
             }
@@ -4231,42 +4438,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                278,
-                270,
-                272,
-                271,
-                275
+                255,
+                242,
+                251,
+                244,
+                242
               ],
               "sample_count": 5,
-              "median": 272,
-              "p95": 278,
-              "min": 270,
-              "max": 278,
+              "median": 244,
+              "p95": 255,
+              "min": 242,
+              "max": 255,
               "mad": 2,
-              "stdev": 2.925748
+              "stdev": 5.268776
             },
             "rss_kb": {
               "samples": [
-                164240,
-                164128,
-                164256,
-                164112,
-                164192
+                163968,
+                164032,
+                163936,
+                164000,
+                164112
               ],
               "sample_count": 5,
-              "median": 164192,
-              "p95": 164256,
-              "min": 164112,
-              "max": 164256,
-              "mad": 64,
-              "stdev": 57.777504
+              "median": 164000,
+              "p95": 164112,
+              "min": 163936,
+              "max": 164112,
+              "mad": 32,
+              "stdev": 60.377479
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 0.694853,
-            "rss": 0.543851
+            "wall_time": 0.704918,
+            "rss": 0.543902
           },
           "perry_to_bun": null
         },
@@ -4281,45 +4488,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 189,
-        "perry_rss_kb": 89296,
-        "node_ms": 272,
-        "node_rss_kb": 164192,
-        "speed_ratio": 0.694853,
-        "memory_ratio": 0.543851
+        "perry_ms": 172,
+        "perry_rss_kb": 89200,
+        "node_ms": 244,
+        "node_rss_kb": 164000,
+        "speed_ratio": 0.704918,
+        "memory_ratio": 0.543902
       },
       "bench_object_property": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                130,
-                130,
-                130,
-                130,
-                130
+                148,
+                121,
+                121,
+                120,
+                120
               ],
               "sample_count": 5,
-              "median": 130,
-              "p95": 130,
-              "min": 130,
-              "max": 130,
-              "mad": 0,
-              "stdev": 0
+              "median": 121,
+              "p95": 148,
+              "min": 120,
+              "max": 148,
+              "mad": 1,
+              "stdev": 11.009087
             },
             "rss_kb": {
               "samples": [
-                23824,
-                23824,
-                23824,
-                23808,
-                23808
+                23904,
+                23904,
+                23920,
+                23920,
+                23904
               ],
               "sample_count": 5,
-              "median": 23824,
-              "p95": 23824,
-              "min": 23808,
-              "max": 23824,
+              "median": 23904,
+              "p95": 23920,
+              "min": 23904,
+              "max": 23920,
               "mad": 0,
               "stdev": 7.838367
             }
@@ -4327,42 +4534,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                14,
-                14,
-                14,
-                14,
+                12,
+                13,
+                13,
+                13,
                 14
               ],
               "sample_count": 5,
-              "median": 14,
+              "median": 13,
               "p95": 14,
-              "min": 14,
+              "min": 12,
               "max": 14,
               "mad": 0,
-              "stdev": 0
+              "stdev": 0.632456
             },
             "rss_kb": {
               "samples": [
-                84896,
-                84736,
-                84496,
-                84736,
-                84688
+                84784,
+                84832,
+                84800,
+                84768,
+                84848
               ],
               "sample_count": 5,
-              "median": 84736,
-              "p95": 84896,
-              "min": 84496,
-              "max": 84896,
-              "mad": 48,
-              "stdev": 128.239775
+              "median": 84800,
+              "p95": 84848,
+              "min": 84768,
+              "max": 84848,
+              "mad": 32,
+              "stdev": 29.675579
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 9.285714,
-            "rss": 0.281156
+            "wall_time": 9.307692,
+            "rss": 0.281887
           },
           "perry_to_bun": null
         },
@@ -4377,141 +4584,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 130,
-        "perry_rss_kb": 23824,
-        "node_ms": 14,
-        "node_rss_kb": 84736,
-        "speed_ratio": 9.285714,
-        "memory_ratio": 0.281156
+        "perry_ms": 121,
+        "perry_rss_kb": 23904,
+        "node_ms": 13,
+        "node_rss_kb": 84800,
+        "speed_ratio": 9.307692,
+        "memory_ratio": 0.281887
       },
       "bench_int_arithmetic": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                397,
-                395,
-                395,
-                395,
-                395
+                398,
+                368,
+                370,
+                371,
+                368
               ],
               "sample_count": 5,
-              "median": 395,
-              "p95": 397,
-              "min": 395,
-              "max": 397,
-              "mad": 0,
-              "stdev": 0.8
+              "median": 370,
+              "p95": 398,
+              "min": 368,
+              "max": 398,
+              "mad": 2,
+              "stdev": 11.558547
             },
             "rss_kb": {
               "samples": [
-                4608,
-                4608,
-                4624,
-                4608,
-                4608
+                4672,
+                4672,
+                4672,
+                4672,
+                4672
               ],
               "sample_count": 5,
-              "median": 4608,
-              "p95": 4624,
-              "min": 4608,
-              "max": 4624,
-              "mad": 0,
-              "stdev": 6.4
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                67,
-                68,
-                68,
-                69,
-                71
-              ],
-              "sample_count": 5,
-              "median": 68,
-              "p95": 71,
-              "min": 67,
-              "max": 71,
-              "mad": 1,
-              "stdev": 1.356466
-            },
-            "rss_kb": {
-              "samples": [
-                83312,
-                83520,
-                83392,
-                83360,
-                83312
-              ],
-              "sample_count": 5,
-              "median": 83360,
-              "p95": 83520,
-              "min": 83312,
-              "max": 83520,
-              "mad": 48,
-              "stdev": 76.666551
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 5.808824,
-            "rss": 0.055278
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "checksum:5760000"
-          ],
-          "expected_lines": [
-            "checksum:5760000"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 395,
-        "perry_rss_kb": 4608,
-        "node_ms": 68,
-        "node_rss_kb": 83360,
-        "speed_ratio": 5.808824,
-        "memory_ratio": 0.055278
-      },
-      "bench_buffer_readwrite": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                109,
-                97,
-                97,
-                97,
-                97
-              ],
-              "sample_count": 5,
-              "median": 97,
-              "p95": 109,
-              "min": 97,
-              "max": 109,
-              "mad": 0,
-              "stdev": 4.8
-            },
-            "rss_kb": {
-              "samples": [
-                5584,
-                5584,
-                5584,
-                5584,
-                5584
-              ],
-              "sample_count": 5,
-              "median": 5584,
-              "p95": 5584,
-              "min": 5584,
-              "max": 5584,
+              "median": 4672,
+              "p95": 4672,
+              "min": 4672,
+              "max": 4672,
               "mad": 0,
               "stdev": 0
             }
@@ -4519,42 +4630,42 @@
           "node": {
             "wall_ms": {
               "samples": [
-                85,
-                85,
-                84,
-                84,
-                84
+                63,
+                63,
+                63,
+                63,
+                64
               ],
               "sample_count": 5,
-              "median": 84,
-              "p95": 85,
-              "min": 84,
-              "max": 85,
+              "median": 63,
+              "p95": 64,
+              "min": 63,
+              "max": 64,
               "mad": 0,
-              "stdev": 0.489898
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                82976,
-                83040,
-                82816,
-                82896,
-                82960
+                83424,
+                83264,
+                83312,
+                83424,
+                83408
               ],
               "sample_count": 5,
-              "median": 82960,
-              "p95": 83040,
-              "min": 82816,
-              "max": 83040,
-              "mad": 64,
-              "stdev": 76.130414
+              "median": 83408,
+              "p95": 83424,
+              "min": 83264,
+              "max": 83424,
+              "mad": 16,
+              "stdev": 66.047256
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 1.154762,
-            "rss": 0.06731
+            "wall_time": 5.873016,
+            "rss": 0.056014
           },
           "perry_to_bun": null
         },
@@ -4562,150 +4673,52 @@
           "status": "pass",
           "reference": "node",
           "actual_lines": [
-            "checksum:12749385600"
+            "checksum:5760000"
           ],
           "expected_lines": [
-            "checksum:12749385600"
+            "checksum:5760000"
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 97,
-        "perry_rss_kb": 5584,
-        "node_ms": 84,
-        "node_rss_kb": 82960,
-        "speed_ratio": 1.154762,
-        "memory_ratio": 0.06731
+        "perry_ms": 370,
+        "perry_rss_kb": 4672,
+        "node_ms": 63,
+        "node_rss_kb": 83408,
+        "speed_ratio": 5.873016,
+        "memory_ratio": 0.056014
       },
-      "bench_array_grow": {
+      "bench_buffer_readwrite": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                17,
-                8,
-                8,
-                8,
-                8
+                136,
+                94,
+                94,
+                94,
+                94
               ],
               "sample_count": 5,
-              "median": 8,
-              "p95": 17,
-              "min": 8,
-              "max": 17,
+              "median": 94,
+              "p95": 136,
+              "min": 94,
+              "max": 136,
               "mad": 0,
-              "stdev": 3.6
+              "stdev": 16.8
             },
             "rss_kb": {
               "samples": [
-                43216,
-                43200,
-                43216,
-                43216,
-                43216
+                5600,
+                5616,
+                5600,
+                5600,
+                5616
               ],
               "sample_count": 5,
-              "median": 43216,
-              "p95": 43216,
-              "min": 43200,
-              "max": 43216,
-              "mad": 0,
-              "stdev": 6.4
-            }
-          },
-          "node": {
-            "wall_ms": {
-              "samples": [
-                13,
-                12,
-                12,
-                12,
-                11
-              ],
-              "sample_count": 5,
-              "median": 12,
-              "p95": 13,
-              "min": 11,
-              "max": 13,
-              "mad": 0,
-              "stdev": 0.632456
-            },
-            "rss_kb": {
-              "samples": [
-                146112,
-                145936,
-                145888,
-                141408,
-                145872
-              ],
-              "sample_count": 5,
-              "median": 145888,
-              "p95": 146112,
-              "min": 141408,
-              "max": 146112,
-              "mad": 48,
-              "stdev": 1819.598901
-            }
-          }
-        },
-        "ratios": {
-          "perry_to_node": {
-            "wall_time": 0.666667,
-            "rss": 0.296227
-          },
-          "perry_to_bun": null
-        },
-        "correctness": {
-          "status": "pass",
-          "reference": "node",
-          "actual_lines": [
-            "length:2000000",
-            "checksum:2998500000"
-          ],
-          "expected_lines": [
-            "length:2000000",
-            "checksum:2998500000"
-          ],
-          "reason": "all 5 Perry sample(s) matched node semantic output"
-        },
-        "perry_ms": 8,
-        "perry_rss_kb": 43216,
-        "node_ms": 12,
-        "node_rss_kb": 145888,
-        "speed_ratio": 0.666667,
-        "memory_ratio": 0.296227
-      },
-      "bench_string_heavy": {
-        "runtimes": {
-          "perry": {
-            "wall_ms": {
-              "samples": [
-                70,
-                51,
-                53,
-                51,
-                51
-              ],
-              "sample_count": 5,
-              "median": 51,
-              "p95": 70,
-              "min": 51,
-              "max": 70,
-              "mad": 0,
-              "stdev": 7.44043
-            },
-            "rss_kb": {
-              "samples": [
-                24144,
-                24160,
-                24144,
-                24144,
-                24160
-              ],
-              "sample_count": 5,
-              "median": 24144,
-              "p95": 24160,
-              "min": 24144,
-              "max": 24160,
+              "median": 5600,
+              "p95": 5616,
+              "min": 5600,
+              "max": 5616,
               "mad": 0,
               "stdev": 7.838367
             }
@@ -4713,33 +4726,33 @@
           "node": {
             "wall_ms": {
               "samples": [
-                43,
-                43,
-                43,
-                46,
-                45
+                82,
+                81,
+                81,
+                81,
+                81
               ],
               "sample_count": 5,
-              "median": 43,
-              "p95": 46,
-              "min": 43,
-              "max": 46,
+              "median": 81,
+              "p95": 82,
+              "min": 81,
+              "max": 82,
               "mad": 0,
-              "stdev": 1.264911
+              "stdev": 0.4
             },
             "rss_kb": {
               "samples": [
-                82496,
-                82512,
-                82528,
-                82448,
-                82496
+                83056,
+                83008,
+                83008,
+                83056,
+                82992
               ],
               "sample_count": 5,
-              "median": 82496,
-              "p95": 82528,
-              "min": 82448,
-              "max": 82528,
+              "median": 83008,
+              "p95": 83056,
+              "min": 82992,
+              "max": 83056,
               "mad": 16,
               "stdev": 26.773121
             }
@@ -4747,8 +4760,202 @@
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 1.186047,
-            "rss": 0.292669
+            "wall_time": 1.160494,
+            "rss": 0.067463
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "checksum:12749385600"
+          ],
+          "expected_lines": [
+            "checksum:12749385600"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 94,
+        "perry_rss_kb": 5600,
+        "node_ms": 81,
+        "node_rss_kb": 83008,
+        "speed_ratio": 1.160494,
+        "memory_ratio": 0.067463
+      },
+      "bench_array_grow": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                20,
+                7,
+                7,
+                7,
+                8
+              ],
+              "sample_count": 5,
+              "median": 7,
+              "p95": 20,
+              "min": 7,
+              "max": 20,
+              "mad": 0,
+              "stdev": 5.114685
+            },
+            "rss_kb": {
+              "samples": [
+                43216,
+                43216,
+                43216,
+                43216,
+                43216
+              ],
+              "sample_count": 5,
+              "median": 43216,
+              "p95": 43216,
+              "min": 43216,
+              "max": 43216,
+              "mad": 0,
+              "stdev": 0
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                10,
+                11,
+                11,
+                11,
+                11
+              ],
+              "sample_count": 5,
+              "median": 11,
+              "p95": 11,
+              "min": 10,
+              "max": 11,
+              "mad": 0,
+              "stdev": 0.4
+            },
+            "rss_kb": {
+              "samples": [
+                145904,
+                145968,
+                145936,
+                141232,
+                141424
+              ],
+              "sample_count": 5,
+              "median": 145904,
+              "p95": 145968,
+              "min": 141232,
+              "max": 145968,
+              "mad": 64,
+              "stdev": 2258.356783
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 0.636364,
+            "rss": 0.296195
+          },
+          "perry_to_bun": null
+        },
+        "correctness": {
+          "status": "pass",
+          "reference": "node",
+          "actual_lines": [
+            "length:2000000",
+            "checksum:2998500000"
+          ],
+          "expected_lines": [
+            "length:2000000",
+            "checksum:2998500000"
+          ],
+          "reason": "all 5 Perry sample(s) matched node semantic output"
+        },
+        "perry_ms": 7,
+        "perry_rss_kb": 43216,
+        "node_ms": 11,
+        "node_rss_kb": 145904,
+        "speed_ratio": 0.636364,
+        "memory_ratio": 0.296195
+      },
+      "bench_string_heavy": {
+        "runtimes": {
+          "perry": {
+            "wall_ms": {
+              "samples": [
+                97,
+                49,
+                48,
+                49,
+                49
+              ],
+              "sample_count": 5,
+              "median": 49,
+              "p95": 97,
+              "min": 48,
+              "max": 97,
+              "mad": 0,
+              "stdev": 19.303886
+            },
+            "rss_kb": {
+              "samples": [
+                24208,
+                24192,
+                24208,
+                24208,
+                24192
+              ],
+              "sample_count": 5,
+              "median": 24208,
+              "p95": 24208,
+              "min": 24192,
+              "max": 24208,
+              "mad": 0,
+              "stdev": 7.838367
+            }
+          },
+          "node": {
+            "wall_ms": {
+              "samples": [
+                43,
+                43,
+                43,
+                43,
+                43
+              ],
+              "sample_count": 5,
+              "median": 43,
+              "p95": 43,
+              "min": 43,
+              "max": 43,
+              "mad": 0,
+              "stdev": 0
+            },
+            "rss_kb": {
+              "samples": [
+                82336,
+                82432,
+                82480,
+                82320,
+                82368
+              ],
+              "sample_count": 5,
+              "median": 82368,
+              "p95": 82480,
+              "min": 82320,
+              "max": 82480,
+              "mad": 48,
+              "stdev": 60.207641
+            }
+          }
+        },
+        "ratios": {
+          "perry_to_node": {
+            "wall_time": 1.139535,
+            "rss": 0.293901
           },
           "perry_to_bun": null
         },
@@ -4763,88 +4970,88 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 51,
-        "perry_rss_kb": 24144,
+        "perry_ms": 49,
+        "perry_rss_kb": 24208,
         "node_ms": 43,
-        "node_rss_kb": 82496,
-        "speed_ratio": 1.186047,
-        "memory_ratio": 0.292669
+        "node_rss_kb": 82368,
+        "speed_ratio": 1.139535,
+        "memory_ratio": 0.293901
       },
       "bench_numeric_array_numeric": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                90,
-                95,
-                144,
-                132,
-                98
+                70,
+                67,
+                67,
+                68,
+                68
               ],
               "sample_count": 5,
-              "median": 98,
-              "p95": 144,
-              "min": 90,
-              "max": 144,
-              "mad": 8,
-              "stdev": 21.876014
+              "median": 68,
+              "p95": 70,
+              "min": 67,
+              "max": 70,
+              "mad": 1,
+              "stdev": 1.095445
             },
             "rss_kb": {
               "samples": [
-                28176,
-                28192,
-                28192,
-                28176,
-                28176
+                28304,
+                28288,
+                28304,
+                28304,
+                28304
               ],
               "sample_count": 5,
-              "median": 28176,
-              "p95": 28192,
-              "min": 28176,
-              "max": 28192,
+              "median": 28304,
+              "p95": 28304,
+              "min": 28288,
+              "max": 28304,
               "mad": 0,
-              "stdev": 7.838367
+              "stdev": 6.4
             }
           },
           "node": {
             "wall_ms": {
               "samples": [
-                6,
-                6,
+                4,
                 5,
-                6,
-                5
+                5,
+                4,
+                4
               ],
               "sample_count": 5,
-              "median": 6,
-              "p95": 6,
-              "min": 5,
-              "max": 6,
+              "median": 4,
+              "p95": 5,
+              "min": 4,
+              "max": 5,
               "mad": 0,
               "stdev": 0.489898
             },
             "rss_kb": {
               "samples": [
-                102896,
-                103056,
+                102720,
                 102976,
-                103184,
-                102944
+                102912,
+                102848,
+                102928
               ],
               "sample_count": 5,
-              "median": 102976,
-              "p95": 103184,
-              "min": 102896,
-              "max": 103184,
-              "mad": 80,
-              "stdev": 100.88885
+              "median": 102912,
+              "p95": 102976,
+              "min": 102720,
+              "max": 102976,
+              "mad": 64,
+              "stdev": 88.44976
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 16.333333,
-            "rss": 0.273617
+            "wall_time": 17.0,
+            "rss": 0.275031
           },
           "perry_to_bun": null
         },
@@ -4859,45 +5066,45 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 98,
-        "perry_rss_kb": 28176,
-        "node_ms": 6,
-        "node_rss_kb": 102976,
-        "speed_ratio": 16.333333,
-        "memory_ratio": 0.273617
+        "perry_ms": 68,
+        "perry_rss_kb": 28304,
+        "node_ms": 4,
+        "node_rss_kb": 102912,
+        "speed_ratio": 17.0,
+        "memory_ratio": 0.275031
       },
       "bench_numeric_array_downgrade": {
         "runtimes": {
           "perry": {
             "wall_ms": {
               "samples": [
-                19,
-                20,
-                19,
-                25,
-                19
+                17,
+                17,
+                17,
+                18,
+                18
               ],
               "sample_count": 5,
-              "median": 19,
-              "p95": 25,
-              "min": 19,
-              "max": 25,
+              "median": 17,
+              "p95": 18,
+              "min": 17,
+              "max": 18,
               "mad": 0,
-              "stdev": 2.332381
+              "stdev": 0.489898
             },
             "rss_kb": {
               "samples": [
-                23968,
                 23984,
+                24000,
                 23984,
-                23968,
-                23968
+                24000,
+                24000
               ],
               "sample_count": 5,
-              "median": 23968,
-              "p95": 23984,
-              "min": 23968,
-              "max": 23984,
+              "median": 24000,
+              "p95": 24000,
+              "min": 23984,
+              "max": 24000,
               "mad": 0,
               "stdev": 7.838367
             }
@@ -4906,41 +5113,41 @@
             "wall_ms": {
               "samples": [
                 5,
-                12,
                 5,
-                5,
-                7
+                4,
+                4,
+                5
               ],
               "sample_count": 5,
               "median": 5,
-              "p95": 12,
-              "min": 5,
-              "max": 12,
+              "p95": 5,
+              "min": 4,
+              "max": 5,
               "mad": 0,
-              "stdev": 2.712932
+              "stdev": 0.489898
             },
             "rss_kb": {
               "samples": [
+                103296,
+                103184,
                 103200,
-                103120,
-                103040,
-                103008,
-                103520
+                103152,
+                103088
               ],
               "sample_count": 5,
-              "median": 103120,
-              "p95": 103520,
-              "min": 103008,
-              "max": 103520,
-              "mad": 80,
-              "stdev": 183.714561
+              "median": 103184,
+              "p95": 103296,
+              "min": 103088,
+              "max": 103296,
+              "mad": 32,
+              "stdev": 67.882251
             }
           }
         },
         "ratios": {
           "perry_to_node": {
-            "wall_time": 3.8,
-            "rss": 0.232428
+            "wall_time": 3.4,
+            "rss": 0.232594
           },
           "perry_to_bun": null
         },
@@ -4955,12 +5162,12 @@
           ],
           "reason": "all 5 Perry sample(s) matched node semantic output"
         },
-        "perry_ms": 19,
-        "perry_rss_kb": 23968,
+        "perry_ms": 17,
+        "perry_rss_kb": 24000,
         "node_ms": 5,
-        "node_rss_kb": 103120,
-        "speed_ratio": 3.8,
-        "memory_ratio": 0.232428
+        "node_rss_kb": 103184,
+        "speed_ratio": 3.4,
+        "memory_ratio": 0.232594
       }
     }
   }

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -98,6 +98,10 @@ DEFAULT_TOLERANCES = HERE / "tolerances.json"
 
 GCMETRIC_RE = re.compile(r"^#gcmetric\s+([a-z0-9_]+)=(-?[0-9]+)\s*$")
 COPY_MINOR_RE = re.compile(r"^\[gc-copy-minor\]\s+ran\s+(.*)$")
+SCAN_FALLBACK_RE = re.compile(
+    r"^\[gc-scan-fallback\]\s+site=(\w+)\s+automatic=(true|false)\s+count=(\d+)\s*$"
+)
+GC_STEP_PREFIX = "[gc-step]"
 
 #: A probe may declare the collector configuration it is a probe *of*, as
 #: ``// gc-ratchet-env: KEY=VALUE`` comment lines in its own source. See
@@ -110,10 +114,6 @@ PROBE_ENV_RE = re.compile(r"^//\s*gc-ratchet-env:\s*([A-Za-z_][A-Za-z0-9_]*)=(\S
 #: ``classify`` sweeps; ``PERRY_GC_DIAG`` is what separates the traced pass from
 #: the timed one.
 RESERVED_PROBE_ENV = frozenset(("PERRY_CONSERVATIVE_STACK_SCAN", "PERRY_GC_DIAG"))
-SCAN_FALLBACK_RE = re.compile(
-    r"^\[gc-scan-fallback\]\s+site=(\w+)\s+automatic=(true|false)\s+count=(\d+)\s*$"
-)
-GC_STEP_PREFIX = "[gc-step]"
 
 #: Runtime knob that turns the conservative native-stack scan off. See
 #: ``classify`` for why this harness cares.
@@ -593,7 +593,13 @@ def probe_run_env(source: Path) -> dict[str, str]:
 def _with_probe_env(
     probe_env: Mapping[str, str], extra: Mapping[str, str] | None = None
 ) -> dict[str, str]:
-    """The probe's declared env, plus whatever the harness is adding this pass."""
+    """The probe's declared env, plus whatever the harness is adding this pass.
+
+    Layered over ``os.environ`` by ``run_once``, so a knob exported into the
+    shell applies to every probe that does *not* declare it and is overridden
+    for the one that does — which is what makes an ad-hoc sweep over a knob
+    still leave an armed probe measuring its own arm.
+    """
     merged = dict(probe_env)
     if extra:
         merged.update(extra)

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -98,6 +98,18 @@ DEFAULT_TOLERANCES = HERE / "tolerances.json"
 
 GCMETRIC_RE = re.compile(r"^#gcmetric\s+([a-z0-9_]+)=(-?[0-9]+)\s*$")
 COPY_MINOR_RE = re.compile(r"^\[gc-copy-minor\]\s+ran\s+(.*)$")
+
+#: A probe may declare the collector configuration it is a probe *of*, as
+#: ``// gc-ratchet-env: KEY=VALUE`` comment lines in its own source. See
+#: ``probe_run_env``.
+PROBE_ENV_RE = re.compile(r"^//\s*gc-ratchet-env:\s*([A-Za-z_][A-Za-z0-9_]*)=(\S+)\s*$")
+
+#: Env names a probe may not declare, because the harness itself sets them and
+#: a probe that also set them would be silently fighting the measurement rather
+#: than describing itself. ``PERRY_CONSERVATIVE_STACK_SCAN`` is the axis
+#: ``classify`` sweeps; ``PERRY_GC_DIAG`` is what separates the traced pass from
+#: the timed one.
+RESERVED_PROBE_ENV = frozenset(("PERRY_CONSERVATIVE_STACK_SCAN", "PERRY_GC_DIAG"))
 SCAN_FALLBACK_RE = re.compile(
     r"^\[gc-scan-fallback\]\s+site=(\w+)\s+automatic=(true|false)\s+count=(\d+)\s*$"
 )
@@ -510,6 +522,84 @@ def probe_sources(probes_dir: Path) -> list[Path]:
     return sources
 
 
+def probe_run_env(source: Path) -> dict[str, str]:
+    """The collector configuration a probe declares for its own *runs*.
+
+    A probe states this in its own source, as ``// gc-ratchet-env: KEY=VALUE``
+    comment lines::
+
+        // gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64
+
+    WHY A PROBE MAY NEED ONE
+    ------------------------
+    Twelve of the thirteen probes run at the shipped 16 MB nursery cap, so every
+    copying minor this matrix has ever exercised is small and frequent. Both
+    #7472 and #7481 faulted at a *larger* Eden and neither was reachable from
+    here; #7481 says so directly ("a live copying-minor correctness signal at
+    exactly the cadence the ratchet probes never exercise"). A cadence is a
+    property of the run, not of the source, so the only way to pin it is to let
+    a probe name the run it is a probe of.
+
+    WHY IT LIVES IN THE PROBE SOURCE
+    -------------------------------
+    Because it is not possible to read the workload without reading the arm.
+    ``tolerances.json`` was the alternative and it separates the two files a
+    reader has to hold together to know what a row means.
+
+    WHAT IS REFUSED, AND WHY EACH
+    -----------------------------
+    * A name outside ``PERRY_*`` — a probe declares collector configuration, not
+      ``PATH`` or ``DYLD_*``. The probe set is reviewed as workloads; it must not
+      become a way to change the process the harness runs.
+    * ``PERRY_CONSERVATIVE_STACK_SCAN`` / ``PERRY_GC_DIAG`` — the harness sets
+      both (the first is ``classify``'s axis, the second separates the traced
+      pass from the timed one). A probe that also set them would silently
+      contradict the measurement instead of describing itself.
+    * A repeated key — two directives disagreeing about one variable has no
+      defensible reading, and picking the last would make the losing line look
+      effective.
+
+    The declaration deliberately does **not** reach ``compile_probe``. These are
+    runtime knobs read through ``OnceLock`` in ``perry-runtime``, and Perry's
+    object cache keys on every codegen env var (#6394), so passing them at
+    compile time would change the cache key without changing a byte of emitted
+    code — a difference that looks like a difference and is not one.
+    """
+    declared: dict[str, str] = {}
+    for lineno, line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1):
+        match = PROBE_ENV_RE.match(line.strip())
+        if not match:
+            continue
+        name, value = match.group(1), match.group(2)
+        if not name.startswith("PERRY_"):
+            raise RatchetError(
+                f"{source.name}:{lineno}: gc-ratchet-env may only set PERRY_* variables, "
+                f"got {name!r}"
+            )
+        if name in RESERVED_PROBE_ENV:
+            raise RatchetError(
+                f"{source.name}:{lineno}: {name} is set by the harness itself, so a probe "
+                "declaring it would contradict the measurement rather than describe it"
+            )
+        if name in declared:
+            raise RatchetError(
+                f"{source.name}:{lineno}: gc-ratchet-env sets {name} twice "
+                f"({declared[name]!r} then {value!r})"
+            )
+        declared[name] = value
+    return declared
+
+
+def _with_probe_env(
+    probe_env: Mapping[str, str], extra: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """The probe's declared env, plus whatever the harness is adding this pass."""
+    merged = dict(probe_env)
+    if extra:
+        merged.update(extra)
+    return merged
+
+
 def compile_probe(perry: Path, source: Path, out_dir: Path) -> Path:
     binary = out_dir / source.stem
     completed = subprocess.run(
@@ -575,14 +665,15 @@ def measure(
         for source in sources:
             name = source.stem
             binary = compile_probe(perry, source, out_dir)
+            probe_env = probe_run_env(source)
 
             for _ in range(warmup):
-                run_once([str(binary)])
+                run_once([str(binary)], extra_env=_with_probe_env(probe_env))
 
             samples: dict[str, list[float]] = {metric: [] for metric in SAMPLED_METRICS}
             stdouts: list[str] = []
             for _ in range(repeats):
-                run = run_once([str(binary)])
+                run = run_once([str(binary)], extra_env=_with_probe_env(probe_env))
                 if run["returncode"] != 0:
                     raise RatchetError(f"{name}: probe exited {run['returncode']}\n{run['stderr']}")
                 emitted = parse_gcmetrics(run["stderr"])
@@ -606,7 +697,10 @@ def measure(
             # counters it is about to gate on are actually deterministic.
             traced = [
                 parse_gc_diag(
-                    run_once([str(binary)], extra_env={"PERRY_GC_DIAG": "1"})["stderr"]
+                    run_once(
+                        [str(binary)],
+                        extra_env=_with_probe_env(probe_env, {"PERRY_GC_DIAG": "1"}),
+                    )["stderr"]
                 )
                 for _ in range(2)
             ]
@@ -631,6 +725,13 @@ def measure(
             results[name] = {
                 "stdout": stdouts[0],
                 "correctness": _check_against_node(node, source, stdouts[0]),
+                # Recorded per probe, and compared cell-for-cell by `evaluate`.
+                # Without this the arm would be invisible in the artifact: a
+                # deleted directive would silently retarget the probe at the
+                # default cadence and every row would still be inside its band,
+                # because the numbers would have been re-pinned to the new
+                # configuration by the same act that lost the old one.
+                "run_env": dict(probe_env),
                 "metrics": metrics,
             }
 
@@ -715,15 +816,16 @@ def classify(
         for source in sources:
             name = source.stem
             binary = compile_probe(perry, source, out_dir)
+            probe_env = probe_run_env(source)
             for _ in range(warmup):
-                run_once([str(binary)])
+                run_once([str(binary)], extra_env=_with_probe_env(probe_env))
 
             modes: dict[str, list[dict[str, int]]] = {}
             stdouts: dict[str, str] = {}
             for label, env in (("conservative", None), ("precise", {SCAN_MODE_ENV: "off"})):
                 seen: list[dict[str, int]] = []
                 for _ in range(repeats):
-                    run = run_once([str(binary)], extra_env=env)
+                    run = run_once([str(binary)], extra_env=_with_probe_env(probe_env, env))
                     if run["returncode"] != 0:
                         raise RatchetError(
                             f"{name}: probe exited {run['returncode']} with "
@@ -753,7 +855,10 @@ def classify(
                 )
 
             sites = parse_scan_fallbacks(
-                run_once([str(binary)], extra_env={"PERRY_GC_DIAG": "1"})["stderr"]
+                run_once(
+                    [str(binary)],
+                    extra_env=_with_probe_env(probe_env, {"PERRY_GC_DIAG": "1"}),
+                )["stderr"]
             )
             conservative_samples = [sample["heap_used_bytes"] for sample in modes["conservative"]]
             conservative = int(statistics.median(conservative_samples))
@@ -761,6 +866,7 @@ def classify(
             rows.append(
                 {
                     "probe": name,
+                    "run_env": dict(probe_env),
                     "heap_used_bytes": conservative,
                     "heap_used_samples": conservative_samples,
                     "heap_used_spread_bytes": max(conservative_samples) - min(conservative_samples),
@@ -1198,6 +1304,17 @@ def inspect_artifact(artifact: Mapping[str, Any]) -> list[ArtifactDefect]:
             artifact_defect(f"{name}: no metrics recorded")
             continue
 
+        # `run_env` is what tells a reader which collector these numbers came
+        # from, and `evaluate` compares it. An unreadable one would compare
+        # unequal against every well-formed run and read as a regression in the
+        # collector rather than as corruption of the artifact, so it is fatal
+        # for the same reason a tampered summary is.
+        recorded_env = entry.get("run_env", {})
+        if not isinstance(recorded_env, Mapping) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in recorded_env.items()
+        ):
+            artifact_defect(f"{name}: run_env is not a string-to-string mapping")
+
         # Integrity of the recorded numbers. A missing metric or a summary that
         # disagrees with its own samples is tampering or corruption, not
         # unfitness: it stays fatal, because a partially-trusted artifact is not
@@ -1283,6 +1400,13 @@ def validate_artifact(artifact: Mapping[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 # Regression check
 # ---------------------------------------------------------------------------
+
+
+def _render_run_env(env: Mapping[str, str]) -> str:
+    """A probe's declared arm, printable. ``<default>`` when it declares none."""
+    if not env:
+        return "<default>"
+    return " ".join(f"{key}={value}" for key, value in sorted(env.items()))
 
 
 @dataclass
@@ -1377,6 +1501,23 @@ def evaluate(
 
         if cur_entry.get("stdout") != base_entry.get("stdout"):
             failures.append(f"{name}: observable output changed since the baseline")
+
+        # The arm is part of what the row means. `13_large_eden_survivors` is
+        # pinned at `PERRY_GC_SCAVENGE_NURSERY_MB=64` because its whole subject
+        # is the large-Eden cadence (#7481); at the default 16 MB it is a
+        # perfectly healthy probe of something else, and every band would still
+        # be satisfied by the re-pin that lost the arm. So the declared
+        # environment is compared like a metric: a run under a different one is
+        # not a comparison, it is two measurements of two collectors.
+        base_env = base_entry.get("run_env") or {}
+        cur_env = cur_entry.get("run_env") or {}
+        if base_env != cur_env:
+            failures.append(
+                f"{name}: ran under a different collector configuration than the baseline "
+                f"pinned ({_render_run_env(cur_env)} vs {_render_run_env(base_env)}); the "
+                "rows below compare two different collectors. Restore the probe's "
+                "`gc-ratchet-env` directive, or re-pin deliberately."
+            )
 
         # "unchecked" is a failure, not a pass. A run that could not reach the
         # Node oracle has not verified that the probe still computes anything;
@@ -1524,6 +1665,23 @@ def render(rows: Iterable[Row], baseline: Mapping[str, Any], profile: str) -> st
         "Only rows marked gating can fail the job. Non-gating rows are recorded so a",
         "drift that is real but unmeasurable on this runner is still visible.",
         "",
+    ]
+    # Named where the numbers are read, not only in the probe source: a row from
+    # a non-default arm answers a different question from its neighbours, and
+    # the reader of a CI table has no other way to know which.
+    armed = {
+        name: entry["run_env"]
+        for name, entry in sorted(baseline.get("probes", {}).items())
+        if entry.get("run_env")
+    }
+    if armed:
+        lines += [
+            "Probes pinned under a non-default collector configuration:",
+            "",
+            *(f"- `{name}` — `{_render_run_env(env)}`" for name, env in armed.items()),
+            "",
+        ]
+    lines += [
         "| Probe | Metric | Baseline | Current | Δ | Allowance | Gating | Status |",
         "|-------|--------|---------:|--------:|---:|----------:|:------:|--------|",
     ]

--- a/benchmarks/gc_ratchet/probes/13_large_eden_survivors.ts
+++ b/benchmarks/gc_ratchet/probes/13_large_eden_survivors.ts
@@ -37,8 +37,9 @@
 //   * `tag` is a heap string, so a survivor carries a pointer the rewrite must
 //     follow into a different object kind;
 //   * the verification phase reads all four back and folds them into the
-//     checksum, which is diffed byte-for-byte against Node. A missed rewrite
-//     therefore has to either fault or produce a wrong number; it cannot pass.
+//     `hits`/`tagChars`/`peerIds`/`notes`/`noteSum` lines, every one of which
+//     is diffed byte-for-byte against Node. A missed rewrite therefore has to
+//     either fault or produce a wrong number; it cannot pass quietly.
 //
 // Metric contract as everywhere else: stdout carries only `probe:`/`checksum:`
 // style lines, `#gcmetric` goes to stderr.
@@ -52,10 +53,11 @@ declare function gc(): void;
 // runs zero copying minors — the arm would be pinned on a collector it never
 // reached. A ~30 MB retained set holds the baseline high enough that a 64 MB
 // Eden is not a doubling, which is what leaves the copying minor reachable.
-// Measured on the pinned host at v0.5.1376: KEEP 131,072 -> 1 copying minor,
-// KEEP 262,144 -> 3 (freed 36 MB, 36 MB, 68 MB per minor, against 16 MB per
-// minor for the default-cap probes). `check`'s liveness rule is what keeps that
-// honest: a shape that stopped reaching the copying minor cannot be pinned.
+// Measured on the pinned host at v0.5.1376: KEEP 8,192 -> 0 copying minors,
+// 131,072 -> 1, 262,144 -> 4 (freeing 37, 36, 68 and 68 MB; 49.7 MB per minor,
+// against 14.6-16.6 MB on eleven of the twelve default-cap probes and 21.8 MB
+// on 12_large_live_set). `check`'s liveness rule is what keeps that honest: a
+// shape that stopped reaching the copying minor cannot be pinned.
 const KEEP = 262144;
 const RING = 512;
 const CHURN = 3000000;

--- a/benchmarks/gc_ratchet/probes/13_large_eden_survivors.ts
+++ b/benchmarks/gc_ratchet/probes/13_large_eden_survivors.ts
@@ -1,0 +1,152 @@
+// GC ratchet probe: a survivor cohort carried across LARGE, INFREQUENT
+// copying minors.
+//
+// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64
+//
+// Every other probe in this suite runs at the shipped 16 MB nursery cap, so
+// every copying minor they exercise is small and frequent. #7472/#7481 both
+// faulted at a *non-default* cap and neither was reachable from this matrix:
+// #7481 is deterministic at `PERRY_GC_SCAVENGE_NURSERY_MB=64`, absent at 1, 4,
+// 16 and 32, and its own issue names the missing coverage — "a live
+// copying-minor correctness signal at exactly the cadence the ratchet probes
+// never exercise". This probe is that cadence, pinned.
+//
+// Why the cadence is a different collector, not merely a slower one:
+//
+//   * a minor at 64 MB has ~4x the Eden to scan and copies a survivor cohort
+//     that has had ~4x as long to accumulate, so the copy loop, the survivor
+//     semispace sizing and the promotion decision all run at magnitudes the
+//     16 MB probes never reach;
+//   * `gc/tenuring.rs` sizes the target survivor occupancy as a fraction of
+//     the *effective* cap and scales that cap from measured influx, so a
+//     larger base lands on a different point of both policies;
+//   * a reference that survives N collections at 16 MB survives ~N/4 at 64 MB,
+//     which is what moves a missed reference rewrite from "faults on the next
+//     cycle" to "faults much later, somewhere else".
+//
+// What the workload holds across those minors, in the shape the two faults
+// took — a slot in a long-lived object pointing at a young object that the
+// copying minor relocates:
+//
+//   * `keep` is a survivor cohort that outlives every collection;
+//   * `keep[j].note` takes a pointer to a *freshly allocated* object every
+//     256th iteration, so the remembered set and the old-to-young rewrite are
+//     exercised at every minor rather than only at the start;
+//   * `keep[j].peer` is an intra-cohort edge, so the cohort is a graph and not
+//     a flat array the collector can walk in allocation order;
+//   * `tag` is a heap string, so a survivor carries a pointer the rewrite must
+//     follow into a different object kind;
+//   * the verification phase reads all four back and folds them into the
+//     checksum, which is diffed byte-for-byte against Node. A missed rewrite
+//     therefore has to either fault or produce a wrong number; it cannot pass.
+//
+// Metric contract as everywhere else: stdout carries only `probe:`/`checksum:`
+// style lines, `#gcmetric` goes to stderr.
+
+declare function gc(): void;
+
+// KEEP is sized for the *pacing*, not for the workload. `gc/policy.rs`'s
+// `arena_growth_full_escalation_due` escalates a minor to a full mark-sweep
+// once arena in-use clears 32 MB AND exceeds twice the post-full baseline, so a
+// large Eden on top of a *small* retained set escalates every collection and
+// runs zero copying minors — the arm would be pinned on a collector it never
+// reached. A ~30 MB retained set holds the baseline high enough that a 64 MB
+// Eden is not a doubling, which is what leaves the copying minor reachable.
+// Measured on the pinned host at v0.5.1376: KEEP 131,072 -> 1 copying minor,
+// KEEP 262,144 -> 3 (freed 36 MB, 36 MB, 68 MB per minor, against 16 MB per
+// minor for the default-cap probes). `check`'s liveness rule is what keeps that
+// honest: a shape that stopped reaching the copying minor cannot be pinned.
+const KEEP = 262144;
+const RING = 512;
+const CHURN = 3000000;
+const NOTE_EVERY = 256;
+const NOTE_SHIFT = 8;
+
+class Row {
+  id: number;
+  tag: string;
+  hits: number;
+  peer: Row | null;
+  note: { a: number; b: number } | null;
+  constructor(id: number) {
+    this.id = id;
+    this.tag = "row-" + (id & 255);
+    this.hits = 0;
+    this.peer = null;
+    this.note = null;
+  }
+}
+
+const keep: Row[] = [];
+for (let i = 0; i < KEEP; i++) {
+  keep.push(new Row(i));
+}
+for (let i = 0; i < KEEP; i++) {
+  keep[i].peer = keep[(i * 7 + 3) & (KEEP - 1)];
+}
+
+// The ring is load-bearing for the same reason it is in 01_nursery_churn: an
+// object that never escapes gets scalar-replaced and the probe measures a
+// collector that never ran.
+const ring: ({ a: number; b: number } | null)[] = [];
+for (let i = 0; i < RING; i++) {
+  ring.push(null);
+}
+
+let checksum = 0;
+for (let i = 0; i < CHURN; i++) {
+  const t = { a: i, b: (i * 3) & 4095 };
+  ring[i & (RING - 1)] = t;
+  const k = keep[i & (KEEP - 1)];
+  k.hits = (k.hits + 1) | 0;
+  if ((i & (NOTE_EVERY - 1)) === 0) {
+    // Old-to-young pointer store into a cohort member that has already
+    // survived collections: the remembered-set entry and the reference
+    // rewrite this probe exists to exercise. The target walks the cohort
+    // rather than reusing the same few slots, so the notes still reachable at
+    // the end are spread across it instead of being 32 repeatedly-overwritten
+    // entries.
+    keep[(i >> NOTE_SHIFT) & (KEEP - 1)].note = t;
+  }
+  checksum = (checksum + t.b) | 0;
+}
+
+for (let i = 0; i < RING; i++) {
+  ring[i] = null;
+}
+
+// Verification phase. Every field read here has crossed every copying minor
+// the run performed.
+let hits = 0;
+let tagChars = 0;
+let peerIds = 0;
+let notes = 0;
+let noteSum = 0;
+for (let i = 0; i < KEEP; i++) {
+  const k = keep[i];
+  hits = (hits + k.hits) | 0;
+  tagChars = (tagChars + k.tag.length) | 0;
+  const p = k.peer;
+  if (p !== null) {
+    peerIds = (peerIds + p.id) | 0;
+  }
+  const n = k.note;
+  if (n !== null) {
+    notes = (notes + 1) | 0;
+    noteSum = (noteSum + n.b) | 0;
+  }
+}
+
+gc();
+const mu = process.memoryUsage();
+
+console.log("probe:13_large_eden_survivors");
+console.log("checksum:" + checksum);
+console.log("hits:" + hits);
+console.log("tagChars:" + tagChars);
+console.log("peerIds:" + peerIds);
+console.log("notes:" + notes);
+console.log("noteSum:" + noteSum);
+console.error("#gcmetric heap_used_bytes=" + mu.heapUsed);
+console.error("#gcmetric heap_total_bytes=" + mu.heapTotal);
+console.error("#gcmetric rss_bytes=" + mu.rss);

--- a/changelog.d/7666-gc-ratchet-large-eden-arm-and-7056-rss-rederivation.md
+++ b/changelog.d/7666-gc-ratchet-large-eden-arm-and-7056-rss-rederivation.md
@@ -1,0 +1,128 @@
+**GC ratchet: the large-Eden copying-minor cadence is pinned and gated (#7481), and #7056's RSS numbers are re-derived under the statepoint default.**
+
+Two halves of one job — they share the pinned quiet host and the same harness.
+
+### The arm (#7481)
+
+Twelve probes all ran the shipped 16 MB nursery cap, so every copying minor this
+matrix had ever exercised was small and frequent. #7481 named the gap itself —
+"a live copying-minor correctness signal at exactly the cadence the ratchet
+probes never exercise" — and its own reproducer is deterministic at
+`PERRY_GC_SCAVENGE_NURSERY_MB=64` and absent at 1, 4, 16 and 32 MB.
+
+A probe may now declare the collector it is a probe *of*, in its own source:
+
+```ts
+// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64
+```
+
+`13_large_eden_survivors.ts` carries exactly that. The declaration reaches every
+run of that probe — warmup, the timed repeats, both traced runs, and both of
+`classify`'s scan modes — and deliberately not `compile_probe`, because these are
+`OnceLock` runtime knobs and Perry's object cache keys on every codegen env var
+(#6394). Only `PERRY_*`; never `PERRY_CONSERVATIVE_STACK_SCAN` or
+`PERRY_GC_DIAG`, which the harness owns; never a repeated key.
+
+**The arm is pinned in the artifact and compared like a metric**, before any band
+arithmetic — and that is not ceremony. With the directive deleted the probe's
+retention, RSS and wall all read as *improvements* (−80.27%, −37.33%, −27.07%),
+so the deletion looks like a win from every one-sided band. Only the arm check
+and the two-sided evacuation counters say what actually happened.
+
+**A large Eden on a small retained set runs zero copying minors.**
+`arena_growth_full_escalation_due` escalates a minor to a full mark-sweep once
+arena in-use clears 32 MB *and* exceeds twice the post-full baseline; a 64 MB
+Eden over a ~1 MB live set satisfies both every time. The first draft of this
+probe did exactly that — 0 copying minors, 4 full sweeps — and would have been
+pinned on a collector it never reached. So `PERRY_GC_SCAVENGE_NURSERY_MB` is not
+on its own a "larger Eden" knob: above ~32 MB it is a "no copying minor" knob
+unless the workload also holds a live set. Measured on the pinned host:
+
+| `KEEP` | copying minors at 64 MB | at the shipped default |
+|---|---:|---:|
+| 8,192 | **0** | 15 |
+| 131,072 | 1 | 14 |
+| 262,144 (shipped) | **4** | 12 |
+
+At the shipped size the four minors free 37, 36, 68 and 68 MB and the first
+copies **532,482 objects (32 MB)** in one cycle, against ~16 MB per minor for
+every default-cap probe.
+
+**Shown able to fail**, each arm measured with the real harness and scored by
+`check` against the freshly pinned artifact:
+
+| perturbation | verdict | why |
+|---|---|---|
+| control, nothing changed | `OK` | the pin reproduces on an independent session; probe 13's wall median 3,137 vs 3,121 ms, retention and counters bit-identical |
+| `gc-ratchet-env` directive deleted | **FAILED** | arm mismatch, plus `minor_cycles` 4 → 12, `copied_objects` 532,482 → 286,246 |
+| `PERRY_GC_SCAVENGE=0` | **FAILED** | the liveness rule fires: `minor_cycles` 4 → 0, `copied + promoted` 1,074,380 → 0, retention +3135% |
+| `PERRY_GEN_GC_EVACUATE=0` | `OK` | **the perturbation was inert, not the gate** — see below |
+
+That last row is kept because it is the lesson, not a footnote.
+`PERRY_GEN_GC_EVACUATE=0` does **not** gate the copying minor: 4 copying minors
+with it set, 4 without. It gates the C4b old-gen policy evacuation and
+`gc_force_evacuate_enabled`. A green gate under a knob whose name promises
+otherwise reads as "the gate cannot fail"; the correct reading was "nothing was
+perturbed", and the discriminator was counting copying minors before trusting
+the verdict.
+
+`wt-scavtenure` is **subsumed**: #7432 is merged, its worktree exists on neither
+host, and the quiet-host driver's `--check` at this commit against the #7657
+artifact reported every one of its 144 cells `ok`, failing on exactly one line —
+the new probe's absence. There was no pending re-pin.
+
+### The re-derivation (#7056)
+
+#7056's numbers were taken under the shadow-stack root lowering, which stopped
+being the default in #7370. 2x2 over root lowering x nursery cap, 12 probes,
+7 repeats, **3 interleaved rotations**, all 72 probe-runs byte-identical to the
+pinned Node oracle:
+
+| | statepoint (default) | shadow stack (`PERRY_RS4GC=0`) | ratio |
+|---|--:|--:|--:|
+| peak RSS, 12 probes | 544,210,944 B | 545,144,832 B | **1.002** |
+| retained heap after `gc()` | 114,594,904 B | 114,596,520 B | **1.000** |
+| wall | 4,808 ms | 4,894 ms | 1.018 |
+
+**The root lowering is not an RSS lever.** 104 of 108 deterministic cells are
+bit-identical; all four that move are on `10_store_receiver_across_alloc` and are
+≤0.31% (the shadow stack keeps 7 more objects live at that collection point).
+Between-rotation spread: retention 0.000%, peak RSS max 0.621%, wall max 2.779%.
+The arms were shown to differ per probe before they were compared —
+`statepoint-example` + `addrspace(1)` roots on 12/12 under the default, 0 of both
+under `PERRY_RS4GC=0`.
+
+What *did* invalidate parts of #7056 is everything else that shipped since:
+
+- §9's recommendation shipped (#7377); the poll has been default-off since #7161,
+  so none of its five arms names anything that ships.
+- The cap is still the whole footprint lever, now on 12 probes rather than 8: at
+  `PERRY_GC_SCAVENGE_NURSERY_MB=128`, peak RSS **1.911x**, retained heap
+  **2.475x**, wall **0.947x** — up to 5.005x and 6.350x per probe. Identical to
+  within 0.6% under both lowerings, so it is a pacing result, not a rooting one.
+- §7's 4.6x–54.8x false-retention table is **gone, not shrunk**: `classify`
+  reports excess 0.00% and spread 0 on all twelve, with no `manual_collect` scan
+  site — #7657 removed the cause.
+- §6's finding survives: a conservative scan does not degrade the copying minor,
+  it **disables** it. `PERRY_CONSERVATIVE_STACK_SCAN=full` under statepoints
+  takes `minor_cycles` to 0 on all twelve probes, for 1.98x retention and 1.46x
+  peak RSS.
+- #7481 no longer reproduces (5/5 runs exit 0 with identical checksums), and does
+  run 6 copying minors at cap 64, so the arm is not vacuous.
+
+Not re-derived and stated rather than hidden: #7056's largest RSS numbers
+(§3–§5) came from three server-shaped workloads it wrote and never landed.
+
+### One trap worth the four lines
+
+An ad-hoc `measure --probes-dir <copy>` reported
+`09_try_catch_roots.heap_used_bytes` at **−17.98%** against the pin, which reads
+exactly like drift. It is not: a probe compiled with a `package.json` in scope
+retains one more 1 MiB arena block at `gc()` than the same source compiled
+without one, and 09 sits on that boundary. Reproduced three ways — repo dir
+5,825,256; three separate `/tmp` directories 4,777,624; `/tmp` **plus a copied
+`package.json`** 5,825,256 — each stable across repeats, and unmoved by Perry's
+known build non-determinism (two builds from one directory differ byte-wise and
+report the identical number). The driver and CI always compile from the repo, so
+the gate is self-consistent; a copied probes directory outside the repo is a
+different compilation, and `benchmarks/gc_ratchet/README.md` now says so.

--- a/changelog.d/7666-gc-ratchet-large-eden-arm-and-7056-rss-rederivation.md
+++ b/changelog.d/7666-gc-ratchet-large-eden-arm-and-7056-rss-rederivation.md
@@ -44,9 +44,11 @@ unless the workload also holds a live set. Measured on the pinned host:
 | 131,072 | 1 | 14 |
 | 262,144 (shipped) | **4** | 12 |
 
-At the shipped size the four minors free 37, 36, 68 and 68 MB and the first
-copies **532,482 objects (32 MB)** in one cycle, against ~16 MB per minor for
-every default-cap probe.
+At the shipped size the four minors free 37, 36, 68 and 68 MB — 49.7 MB per
+minor — and the first copies **532,482 objects (32 MB)** in one cycle. The rest
+of the suite runs 14.6–16.6 MB per minor on eleven of twelve, and 21.8 MB on
+`12_large_live_set`, whose tenured-proportional cap term already raises its Eden
+without any knob.
 
 **Shown able to fail**, each arm measured with the real harness and scored by
 `check` against the freshly pinned artifact:

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -512,10 +512,90 @@ already working, on a workload that happens to reach it through `JSON.parse`.
    107-module ceiling list toward empty; same end state, same reason.
 8. **Statepoint-side static checker** — teach `gc_root_dominance_check.py` to
    read relocation bundles, closing the gap the #7452/#7460 repairs named.
-9. **RSS re-derivation under the statepoint default** (#7056) — the earlier
-   numbers were measured under the shadow stack.
-10. **Ratchet large-Eden probe arm** (#7481's lesson), plus the pending
-   quiet-host re-pins (`wt-scavtenure` baseline).
+9. ~~**RSS re-derivation under the statepoint default** (#7056)~~ — **done, and
+   the answer is that the root lowering is not an RSS lever.** Re-derived at
+   `7bde3de24` on the pinned quiet mini (95% idle, zero `rustc`/`cargo`
+   throughout), 12 ratchet probes x 7 repeats x **3 interleaved rotations**,
+   every probe byte-identical to the pinned Node oracle in all 72 probe-runs:
+
+   | | statepoint (default) | shadow stack (`PERRY_RS4GC=0`) | ratio |
+   |---|--:|--:|--:|
+   | peak RSS, 12 probes | 544.2 MB | 545.1 MB | **1.002** |
+   | retained heap after `gc()` | 114,594,904 B | 114,596,520 B | **1.000** |
+   | wall | 4,808 ms | 4,894 ms | 1.018 |
+
+   **104 of 108 deterministic cells are bit-identical between the two
+   lowerings.** All four that move are on `10_store_receiver_across_alloc` and
+   are ≤0.31% — the shadow stack keeps 7 more objects live at that collection
+   point than the statepoint map does. Between-rotation spread: retention
+   **0.000%**, peak RSS max 0.621% (median 0.000%), wall max 2.779%. The arms
+   were shown to differ before they were compared, per probe, not per suite:
+   `statepoint-example` + `addrspace(1)` roots present on 12/12 under the
+   default and **0 of both** under `PERRY_RS4GC=0`, with `js_shadow_frame_enter`
+   rising to match.
+
+   So #7056's RSS numbers were not invalidated by #7370. What *did* invalidate
+   parts of it is everything else that shipped since, and the re-derivation
+   should be read for those:
+
+   - **§9's recommendation shipped** (#7377): the 16 MB cap no longer hangs off
+     `gc_moving_loop_polls_enabled()`, and the poll has been default-off since
+     #7161. The five arms #7056 tabulates (`on`/`off`/`off_rt`/`on_cap128`/
+     `off_scav`) no longer name anything that ships.
+   - **The cap is still the whole footprint lever, and now measured on 12
+     probes rather than 8**: at `PERRY_GC_SCAVENGE_NURSERY_MB=128`, peak RSS is
+     **1.911x** and retained heap **2.475x** the shipped cap, for **0.947x** the
+     wall — up to 5.005x peak RSS on `04_dead_after_deep_stack` and 6.350x
+     retention on `07_array_grow_evacuate`. Identical to 0.6% under both root
+     lowerings, so this is a pacing result and not a rooting one.
+   - **§7's false-retention table is gone, not shrunk.** It recorded a
+     4.6x–54.8x conservative-vs-precise band on probes 01–08. `classify` at
+     `7bde3de24` reports **excess 0.00% and spread 0 on all twelve**, with no
+     `manual_collect` scan site anywhere — #7657 removed the forced scan at
+     `gc()` rather than the reading.
+   - **§6's real finding survives intact**: a conservative scan does not
+     degrade the copying minor, it **disables** it. Forcing
+     `PERRY_CONSERVATIVE_STACK_SCAN=full` under statepoints takes
+     `minor_cycles` to **0 on all twelve probes** (`copied + promoted` 0 on
+     all twelve), costs 1.98x retained heap (0.70x–6.35x) and 1.46x peak RSS
+     (0.93x–3.47x). Smaller than the +364%..+5371% #7056 recorded, same sign,
+     same mechanism.
+
+   Not re-derived, and stated rather than hidden: #7056's largest RSS numbers
+   (§3–§5, 272 MB -> 421 MB) came from three server-shaped workloads it wrote
+   and never landed, so there is nothing in the tree to re-run. The 12 probes
+   are what replaced them.
+10. ~~**Ratchet large-Eden probe arm** (#7481's lesson), plus the pending
+   quiet-host re-pins (`wt-scavtenure` baseline)~~ — **both done.**
+
+    `13_large_eden_survivors` pins the cadence the matrix had no coverage of,
+    via a per-probe `// gc-ratchet-env:` declaration that `check` compares like
+    a metric (delete the directive and every band is still satisfied, which is
+    exactly why the arm itself has to be gated). Full rationale and the
+    perturbations that turn it red: `benchmarks/gc_ratchet/README.md`.
+
+    **The finding that shaped it is worth carrying forward.** A large Eden on a
+    small retained set runs **zero copying minors** —
+    `arena_growth_full_escalation_due` escalates every minor to a full
+    mark-sweep once arena in-use clears its 32 MB floor and exceeds twice the
+    post-full baseline, which a 64 MB Eden over a ~1 MB live set does every
+    time. The first draft of the probe did precisely that and would have been
+    pinned on a collector it never reached. So `PERRY_GC_SCAVENGE_NURSERY_MB`
+    is not, on its own, a "larger Eden" knob: above ~32 MB it is a "no
+    copying minor" knob unless the workload also holds a live set. Sizing the
+    retained set to 262,144 objects buys 4 copying minors freeing 37/36/68/68 MB
+    (the first copies 532,482 objects in one cycle) against ~16 MB per minor
+    for every default-cap probe.
+
+    **`wt-scavtenure` is subsumed, measured rather than assumed.** #7432 is
+    merged, its worktree exists on neither host, and the baseline has been
+    re-pinned five times since — most recently in full by #7657 at `59d522052`
+    on the pinned host, which also closed #7652's mixed provenance. Running
+    `check` at `7bde3de24` against that artifact on the pinned host: **`OK`**,
+    12/12 probes, `pinned_host` profile. The only cell outside its band is
+    `09_try_catch_roots.heap_used_bytes` at **−17.98%**, which is an
+    *improvement* (one 1 MiB block of #7559-shaped residue) and is folded into
+    this re-pin.
 
 ---
 

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -584,8 +584,10 @@ already working, on a workload that happens to reach it through `JSON.parse`.
     is not, on its own, a "larger Eden" knob: above ~32 MB it is a "no
     copying minor" knob unless the workload also holds a live set. Sizing the
     retained set to 262,144 objects buys 4 copying minors freeing 37/36/68/68 MB
-    (the first copies 532,482 objects in one cycle) against ~16 MB per minor
-    for every default-cap probe.
+    — 49.7 MB per minor, the first copying 532,482 objects in one cycle —
+    against 14.6–16.6 MB per minor on eleven of the twelve default-cap probes
+    and 21.8 MB on `12_large_live_set`, whose tenured-proportional cap term is
+    the shipped path to a larger Eden and tops out around 22 MB here.
 
     **`wt-scavtenure` is subsumed, measured rather than assumed.** #7432 is
     merged, its worktree exists on neither host, and the baseline has been

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -590,12 +590,27 @@ already working, on a workload that happens to reach it through `JSON.parse`.
     **`wt-scavtenure` is subsumed, measured rather than assumed.** #7432 is
     merged, its worktree exists on neither host, and the baseline has been
     re-pinned five times since — most recently in full by #7657 at `59d522052`
-    on the pinned host, which also closed #7652's mixed provenance. Running
-    `check` at `7bde3de24` against that artifact on the pinned host: **`OK`**,
-    12/12 probes, `pinned_host` profile. The only cell outside its band is
-    `09_try_catch_roots.heap_used_bytes` at **−17.98%**, which is an
-    *improvement* (one 1 MiB block of #7559-shaped residue) and is folded into
-    this re-pin.
+    on the pinned host, which also closed #7652's mixed provenance. Running the
+    quiet-host driver's `--check` at this PR's commit against that artifact:
+    **every one of the 144 pinned cells `ok`**, the only failure being the new
+    probe's absence from the baseline, which is the friction adding a probe is
+    supposed to cost. There is no pending re-pin.
+
+    ★ **One trap found the hard way, and it is worth the four lines.** An
+    ad-hoc `measure --probes-dir <copy>` first reported
+    `09_try_catch_roots.heap_used_bytes` **−17.98%** against the pin, which
+    reads exactly like drift since `59d522052`. It is not drift: a probe
+    compiled with a `package.json` in scope retains one more 1 MiB arena block
+    at `gc()` than the same source compiled without one, and 09 sits on that
+    block boundary. Reproduced three ways — repo dir 5,825,256; any of three
+    `/tmp` directories 4,777,624; `/tmp` **plus a copied `package.json`**
+    5,825,256 — each stable 3/3, and unmoved by Perry's known build
+    non-determinism (two builds from the same directory differ byte-wise and
+    report the identical number). The driver and CI always compile from the
+    repo, so the gate is self-consistent; **a copied probes directory outside
+    the repo is a different compilation and its absolute retention is not
+    comparable to the artifact.** Ratios between arms measured in the same
+    directory are unaffected, which is why item 9's 2x2 stands.
 
 ---
 

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -34,10 +34,12 @@ from benchmarks.gc_ratchet.gc_ratchet import (
     gated_anywhere,
     inspect_artifact,
     main,
+    measure,
     parse_gc_diag,
     parse_gcmetrics,
     parse_scan_fallbacks,
     probe_overrides_from_json,
+    probe_run_env,
     render,
     render_classification,
     tolerances_from_json,
@@ -300,7 +302,7 @@ class GateFailTests(unittest.TestCase):
     def test_a_probe_that_stopped_collecting_fails(self):
         """The bands alone could not catch this, which is why it is asserted.
 
-        Six of the twelve shipped probes pin ``minor_cycles`` at 1 and the
+        Six of the thirteen shipped probes pin ``minor_cycles`` at 1 and the
         allowance floor is also 1, so a collapse from 1 to 0 lands exactly on
         ``delta == -allowance`` and scored "ok". A collector that stopped
         running copying minors — the largest regression this ratchet exists to
@@ -1054,6 +1056,261 @@ class FailOpenPerCellTests(unittest.TestCase):
             [defect.describe() for defect in inspect_artifact(artifact)],
             [],
             "the pinned artifact should be fit, not merely tolerated",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-probe run environment — the large-Eden arm (#7481)
+# ---------------------------------------------------------------------------
+
+#: A stand-in for `perry` that also records the environment it was *compiled*
+#: under, so a test can assert the probe's declared knobs did not leak into the
+#: compile step. Perry's object cache keys on every codegen env var (#6394), so
+#: a runtime knob passed at compile time would change the cache key without
+#: changing a byte of emitted code.
+_STUB_PERRY_RECORDING_COMPILE_ENV = """#!{python}
+import json, os, stat, sys
+source = sys.argv[1]
+out = sys.argv[sys.argv.index("-o") + 1]
+here = os.path.dirname(os.path.abspath(source)) or "."
+with open(os.path.join(here, "compile-env.json"), "w") as handle:
+    json.dump({{k: v for k, v in os.environ.items() if k.startswith("PERRY_")}}, handle)
+body = open(os.path.join(here, source)).read()
+with open(out, "w") as handle:
+    handle.write("#!{python}\\n" + body)
+os.chmod(out, os.stat(out).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+"""
+
+#: A stub probe whose retention depends on the arm. This is what makes the
+#: delivery testable: if the harness merely *recorded* `run_env` without passing
+#: it to the child, `heap_used_bytes` would come back at the unarmed value and
+#: the assertion below would fail. A test that only checked the recorded dict
+#: would pass in exactly that broken state.
+_STUB_ARMED_PROBE = """
+import os, sys
+armed = os.environ.get("PERRY_GC_SCAVENGE_NURSERY_MB") == "64"
+sys.stdout.write("probe:stub\\nchecksum:1\\n")
+sys.stderr.write("#gcmetric heap_used_bytes=%d\\n" % (6000000 if armed else 5000000))
+sys.stderr.write("#gcmetric heap_total_bytes=20971520\\n")
+sys.stderr.write("#gcmetric rss_bytes=30000000\\n")
+if os.environ.get("PERRY_GC_DIAG"):
+    sys.stderr.write(
+        "[gc-copy-minor] ran copied_objects=%d copied_bytes=64 promoted_objects=0 "
+        "promoted_bytes=0 freed_bytes=128\\n" % (11 if armed else 7)
+    )
+"""
+
+#: The directive, wrapped in a module docstring so the stub probe — which is
+#: Python, because these tests must run without a compiler — stays executable
+#: while carrying a line the harness reads as TypeScript.
+_ARM_DIRECTIVE = '"""\n// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64\n"""\n'
+
+
+class ProbeRunEnvParsingTests(unittest.TestCase):
+    """A probe declares the collector configuration it is a probe *of*."""
+
+    def _source(self, tmp, text):
+        path = Path(tmp) / "13_stub.ts"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_a_probe_with_no_directive_declares_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(probe_run_env(self._source(tmp, "// just a comment\n")), {})
+
+    def test_directives_are_read_in_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = self._source(
+                tmp,
+                "// header\n"
+                "// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64\n"
+                "// gc-ratchet-env: PERRY_GC_SCAVENGE=1\n"
+                "const x = 1;\n",
+            )
+            self.assertEqual(
+                probe_run_env(source),
+                {"PERRY_GC_SCAVENGE_NURSERY_MB": "64", "PERRY_GC_SCAVENGE": "1"},
+            )
+
+    def test_a_non_perry_variable_is_refused(self):
+        # The probe set is reviewed as workloads. It must not double as a way to
+        # change the process the harness runs.
+        with tempfile.TemporaryDirectory() as tmp:
+            source = self._source(tmp, "// gc-ratchet-env: PATH=/tmp/evil\n")
+            with self.assertRaises(RatchetError) as caught:
+                probe_run_env(source)
+        self.assertIn("PERRY_*", str(caught.exception))
+
+    def test_a_variable_the_harness_owns_is_refused(self):
+        for name, value in (
+            ("PERRY_CONSERVATIVE_STACK_SCAN", "off"),
+            ("PERRY_GC_DIAG", "1"),
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                source = self._source(tmp, f"// gc-ratchet-env: {name}={value}\n")
+                with self.assertRaises(RatchetError) as caught:
+                    probe_run_env(source)
+                self.assertIn("harness", str(caught.exception))
+
+    def test_a_repeated_variable_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = self._source(
+                tmp,
+                "// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64\n"
+                "// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=32\n",
+            )
+            with self.assertRaises(RatchetError) as caught:
+                probe_run_env(source)
+        self.assertIn("twice", str(caught.exception))
+
+    def test_the_shipped_large_eden_probe_still_declares_its_arm(self):
+        # The subject of `13_large_eden_survivors` is the large-Eden cadence.
+        # Without the directive it is a healthy probe of something else, and
+        # nothing else in the tree would say so. Same discipline as
+        # `gc_root_dominance_allowlist.json`: the claim has to keep matching.
+        source = (
+            REPO_ROOT
+            / "benchmarks"
+            / "gc_ratchet"
+            / "probes"
+            / "13_large_eden_survivors.ts"
+        )
+        self.assertEqual(probe_run_env(source), {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"})
+
+
+class ProbeRunEnvDeliveryTests(unittest.TestCase):
+    """The declared arm must reach the child process, not merely the artifact.
+
+    #7024 and #7025 are the shape this guards against: a knob that disabled the
+    path it was measuring, and a counter that summed two collectors so a cell
+    could pass having run zero copying minors. A `run_env` the harness records
+    but never exports would be exactly that — an arm that is documented, gated,
+    and inert.
+    """
+
+    def _fixture(self, tmp, *, armed):
+        root = Path(tmp)
+        perry = root / "stub-perry"
+        perry.write_text(
+            _STUB_PERRY_RECORDING_COMPILE_ENV.format(python=sys.executable), encoding="utf-8"
+        )
+        perry.chmod(perry.stat().st_mode | stat.S_IEXEC)
+        probes_dir = root / "probes"
+        probes_dir.mkdir()
+        (probes_dir / "13_stub.ts").write_text(
+            (_ARM_DIRECTIVE if armed else "") + _STUB_ARMED_PROBE, encoding="utf-8"
+        )
+        return perry, probes_dir
+
+    def test_the_declared_arm_reaches_the_probe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            perry, probes_dir = self._fixture(tmp, armed=True)
+            payload = measure(perry=perry, probes_dir=probes_dir, repeats=3, node=None, warmup=0)
+        entry = payload["probes"]["13_stub"]
+        self.assertEqual(entry["run_env"], {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"})
+        self.assertEqual(entry["metrics"]["heap_used_bytes"]["median"], 6_000_000)
+        self.assertEqual(entry["metrics"]["copied_objects"]["median"], 11)
+
+    def test_removing_the_directive_moves_the_numbers(self):
+        # The perturbation that proves the arm is load-bearing rather than
+        # decorative: same workload, directive deleted, different collector,
+        # different numbers.
+        with tempfile.TemporaryDirectory() as tmp:
+            perry, probes_dir = self._fixture(tmp, armed=False)
+            payload = measure(perry=perry, probes_dir=probes_dir, repeats=3, node=None, warmup=0)
+        entry = payload["probes"]["13_stub"]
+        self.assertEqual(entry["run_env"], {})
+        self.assertEqual(entry["metrics"]["heap_used_bytes"]["median"], 5_000_000)
+        self.assertEqual(entry["metrics"]["copied_objects"]["median"], 7)
+
+    def test_the_arm_does_not_leak_into_the_compile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            perry, probes_dir = self._fixture(tmp, armed=True)
+            measure(perry=perry, probes_dir=probes_dir, repeats=3, node=None, warmup=0)
+            seen = json.loads((probes_dir / "compile-env.json").read_text(encoding="utf-8"))
+        self.assertNotIn("PERRY_GC_SCAVENGE_NURSERY_MB", seen)
+
+    def test_classify_runs_both_scan_modes_under_the_declared_arm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            perry, probes_dir = self._fixture(tmp, armed=True)
+            payload = classify(perry=perry, probes_dir=probes_dir, repeats=3, warmup=0)
+        (row,) = payload["probes"]
+        self.assertEqual(row["run_env"], {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"})
+        # Both arms saw the armed value, so the split is 6,000,000 / 6,000,000
+        # and the residue is zero — not 6,000,000 against an unarmed 5,000,000,
+        # which is what a `classify` that dropped the arm would report as a
+        # 1 MB false-root excess that does not exist.
+        self.assertEqual(row["heap_used_bytes"], 6_000_000)
+        self.assertEqual(row["heap_used_precise_bytes"], 6_000_000)
+        self.assertEqual(row["false_root_excess_bytes"], 0)
+
+
+class ProbeRunEnvGateTests(unittest.TestCase):
+    """A run under a different arm is not a comparison."""
+
+    def _armed_pair(self):
+        baseline = _baseline(_pair())
+        baseline["probes"]["01_probe"]["run_env"] = {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"}
+        current = _measurement(copy.deepcopy(_pair()))
+        current["probes"]["01_probe"]["run_env"] = {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"}
+        return baseline, current
+
+    def test_matching_arms_pass(self):
+        baseline, current = self._armed_pair()
+        _, failures = evaluate(baseline, current, profile="pinned_host")
+        self.assertEqual(_hard(failures), [])
+
+    def test_a_dropped_arm_fails_even_though_every_band_is_satisfied(self):
+        # This is the failure mode the check exists for. Every metric is
+        # byte-identical to the baseline; the only thing that changed is which
+        # collector produced them.
+        baseline, current = self._armed_pair()
+        current["probes"]["01_probe"]["run_env"] = {}
+        _, failures = evaluate(baseline, current, profile="pinned_host")
+        self.assertTrue(
+            any("different collector configuration" in failure for failure in _hard(failures)),
+            _hard(failures),
+        )
+
+    def test_a_changed_arm_value_fails(self):
+        baseline, current = self._armed_pair()
+        current["probes"]["01_probe"]["run_env"] = {"PERRY_GC_SCAVENGE_NURSERY_MB": "32"}
+        _, failures = evaluate(baseline, current, profile="pinned_host")
+        self.assertTrue(
+            any("different collector configuration" in failure for failure in _hard(failures)),
+            _hard(failures),
+        )
+
+    def test_an_added_arm_fails(self):
+        # The mirror image: the baseline pinned the default and the run armed
+        # itself. Also a comparison of two collectors.
+        baseline, current = self._armed_pair()
+        current["probes"]["02_other"]["run_env"] = {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"}
+        _, failures = evaluate(baseline, current, profile="pinned_host")
+        self.assertTrue(
+            any("02_other" in failure and "different collector" in failure for failure in _hard(failures)),
+            _hard(failures),
+        )
+
+    def test_an_unreadable_run_env_is_a_fatal_artifact_defect(self):
+        baseline, current = self._armed_pair()
+        baseline["probes"]["01_probe"]["run_env"] = {"PERRY_GC_SCAVENGE_NURSERY_MB": 64}
+        self.assertTrue(any(defect.fatal for defect in inspect_artifact(baseline)))
+        with self.assertRaises(RatchetError):
+            evaluate(baseline, current, profile="pinned_host")
+
+    def test_the_rendered_table_names_the_armed_probes(self):
+        baseline, current = self._armed_pair()
+        rows, _ = evaluate(baseline, current, profile="pinned_host")
+        text = render(rows, baseline, "pinned_host")
+        self.assertIn("non-default collector configuration", text)
+        self.assertIn("PERRY_GC_SCAVENGE_NURSERY_MB=64", text)
+
+    def test_the_shipped_artifact_pins_the_large_eden_arm(self):
+        artifact = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+        self.assertEqual(
+            artifact["probes"]["13_large_eden_survivors"]["run_env"],
+            {"PERRY_GC_SCAVENGE_NURSERY_MB": "64"},
         )
 
 


### PR DESCRIPTION
Closes plan items 9 and 10 of `docs/engine-plan.md`. They share the pinned quiet host and the same harness, so they are one PR.

Provenance for **every** number below: `perry-macos` (Mac mini, 8-core M1, 8 GB, macOS 26.5.1). Binary built at `7bde3de24` with `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static` into an isolated `CARGO_TARGET_DIR`; the `.a` mtimes were confirmed to move after that build, and this PR changes **zero** `.rs` files (`git diff --name-only 7bde3de24 <head> | grep -c '\.rs$'` = 0), so it is the right binary for this tree. `PERRY_RUNTIME_DIR` pinned, `PERRY_NO_AUTO_OPTIMIZE=1`, node oracle `v26.5.1`. Host quiet was re-checked before every arm and every phase: **94.6–95.8% idle, zero `rustc`, zero `cargo`** throughout. No other agent was building on the box.

---

## Item 10 — the large-Eden probe arm

#7481 named the gap itself: "a live copying-minor correctness signal at exactly the cadence the ratchet probes never exercise". All twelve probes ran the shipped 16 MB nursery cap, so every copying minor this matrix had ever exercised was small (~16 MB of Eden) and frequent.

### A probe may now declare the collector it is a probe *of*

```ts
// gc-ratchet-env: PERRY_GC_SCAVENGE_NURSERY_MB=64
```

It lives in the probe source because it is not possible to read the workload without reading the arm. It reaches every run of that probe — warmup, the timed repeats, both traced runs, and both of `classify`'s scan modes — and deliberately **not** `compile_probe` (these are `OnceLock` runtime knobs, and Perry's object cache keys on every codegen env var, #6394, so a compile-time pass would move the cache key without moving a byte of code). Only `PERRY_*`; never `PERRY_CONSERVATIVE_STACK_SCAN` or `PERRY_GC_DIAG`, which the harness owns; never a repeated key.

The arm is pinned in the artifact and **compared like a metric**, before any band arithmetic. That is the check that matters: delete the directive and every band is still satisfied, because the numbers would have been re-pinned by the same act that lost the arm.

### The finding that shaped the probe

**A large Eden on a *small* retained set runs zero copying minors.** `gc/policy.rs`'s `arena_growth_full_escalation_due` escalates a minor to a full mark-sweep once arena in-use clears 32 MB *and* exceeds twice the post-full baseline; a 64 MB Eden over a ~1 MB live set satisfies both, every time. The first draft of this probe did exactly that — 0 copying minors, 4 full sweeps — and would have been pinned on a collector it never reached, the #7024 shape inside the arm added to close it.

So `PERRY_GC_SCAVENGE_NURSERY_MB` is not on its own a "larger Eden" knob: above ~32 MB it is a "no copying minor" knob unless the workload also holds a live set. Sizing the retained set is the fix:

| `KEEP` | copying minors at 64 MB | at the shipped default |
|---|---:|---:|
| 8,192 | **0** | 15 |
| 131,072 | 1 | 14 |
| 262,144 (shipped) | **4** | 12 |

At the shipped size the four minors free 37, 36, 68 and 68 MB — **49.7 MB per minor** — and the first copies **532,482 objects (32 MB) in one cycle**. The rest of the suite runs **14.6–16.6 MB per minor on eleven of twelve**, and 21.8 MB on `12_large_live_set`, whose tenured-proportional cap term (`max(influx x scale, tenured/2)`) is the shipped path to a larger Eden and tops out around 22 MB even on the biggest workload the suite has. Traced counters are byte-identical across traced runs, and probe stdout is byte-identical to Node 26.5.1.

### Shown able to fail

Three perturbations, each measured with the real harness and scored by `check` against the freshly pinned artifact:

| perturbation | `check` verdict | what it reported |
|---|---|---|
| control — nothing changed | `gc-ratchet: OK` | the pin reproduces on an independent 7-repeat session; probe 13's wall median 3,137 vs 3,121 ms, retention and every counter bit-identical |
| `gc-ratchet-env` directive deleted | **`FAILED`** | the arm-mismatch line, plus `minor_cycles` 4 -> 12, `step_cycles` 5 -> 13, `copied_objects` 532,482 -> 286,246, `copied_bytes` -45.56% |
| `PERRY_GC_SCAVENGE=0` | **`FAILED`** | the liveness rule fires on probe 13 — `minor_cycles` 4 -> 0 and `copied + promoted` 1,074,380 -> 0 — plus 11 REGRESSION rows including retention **+3135%** |
| `PERRY_GEN_GC_EVACUATE=0` | `OK` | **the perturbation was inert, not the gate.** See below. |

The directive-deleted row is the one that justifies gating the arm at all: with the directive gone, retention **-80.27%**, peak RSS **-37.33%** and wall **-27.07%** all read as *improvements*, because those bands are one-sided. Only the arm check and the two-sided evacuation counters say what actually happened.

The `PERRY_GEN_GC_EVACUATE=0` row is kept because it is the lesson rather than a footnote. That knob does **not** gate the copying minor — 4 copying minors with it set, 4 without; it gates the C4b old-gen policy evacuation and `gc_force_evacuate_enabled`. A green gate under a knob whose name promises otherwise reads as "this gate cannot fail". The correct reading was "nothing was perturbed", and the discriminator was counting copying minors before trusting the verdict, not re-reading the harness.

Plus unit-level, in `tests/test_gc_ratchet.py`: the arm reaching the child is asserted by a stub probe that *reports* whether the variable arrived (a `run_env` recorded but never exported would be an arm that is documented, gated and inert); dropping, changing or adding an arm each fails `check`; an unreadable `run_env` is a fatal artifact defect; the shipped probe is asserted to still carry its directive, so deleting it turns a unit test red rather than silently retargeting the probe.

### `wt-scavtenure`

**Subsumed. Measured, not assumed.** #7432 is merged, its worktree exists on neither host, and the baseline has been re-pinned five times since — most recently in full by #7657 at `59d522052` on this same host, which also closed #7652's mixed provenance. The quiet-host driver's `--check` at this PR's first commit, against that artifact: **every one of its 144 pinned cells `ok`**, failing on exactly one line — `probes present now but absent from the baseline: 13_large_eden_survivors`, which is the friction adding a probe is supposed to cost. There is no pending re-pin.

★ **One trap, found the hard way, and it is why this section says 144/144 and not something else.** An earlier ad-hoc `measure --probes-dir <copy>` reported `09_try_catch_roots.heap_used_bytes` at **−17.98%**, which reads exactly like drift since `59d522052`. It is not drift. **A probe compiled with a `package.json` in scope retains one more 1 MiB arena block at `gc()` than the same source compiled without one**, and 09 sits on that boundary. Reproduced three ways, each stable 3/3: repo directory 5,825,256; three separate `/tmp` directories 4,777,624; `/tmp` **plus a copied `package.json`** 5,825,256. Ruled out as build non-determinism in the same session — two builds of one probe from one directory differ byte-for-byte and report the identical number. The driver and CI always compile from `benchmarks/gc_ratchet/probes`, so the gate is self-consistent, and *ratios between arms measured in the same directory* are unaffected, which is what leaves item 9's 2x2 standing. `README.md` now carries the warning.

---

## Item 9 — the #7056 RSS numbers, re-derived under the statepoint default

#7056's numbers were taken under the shadow-stack root lowering. Statepoints became the default in #7370, so the question is whether that invalidates them. 2x2 over root lowering x nursery cap, 12 probes, 7 repeats, **3 interleaved rotations** (rotation *i* runs every arm before *i+1*, so drift perturbs all four equally), every probe byte-identical to the pinned Node oracle in all 72 probe-runs.

### The root lowering is not an RSS lever

| | statepoint (default) | shadow stack (`PERRY_RS4GC=0`) | ratio |
|---|--:|--:|--:|
| peak RSS, 12 probes | 544,210,944 B | 545,144,832 B | **1.002** |
| retained heap after `gc()` | 114,594,904 B | 114,596,520 B | **1.000** |
| wall | 4,808 ms | 4,894 ms | 1.018 |

**104 of 108 deterministic cells are bit-identical.** All four that move are on `10_store_receiver_across_alloc`, all ≤0.31%: the shadow stack keeps 7 more objects live at that collection point than the statepoint map does (`copied_objects` 8,056 → 8,063).

Between-rotation spread: retention **0.000%**, peak RSS max **0.621%** (median 0.000%), wall max 2.779% (median 0.449%). Every claim above clears its spread by an order of magnitude or is explicitly a null result.

**The arms were shown to differ before they were compared — per probe, not per suite.** `--trace llvm` census over all 12: `statepoint-example` + `addrspace(1)` root allocas present on 12/12 under the default (168–514 `addrspace(1)` sites each) and **0 of both** under `PERRY_RS4GC=0`, where `js_shadow_frame_enter` rises to match. This is #7056's own poll-site-count discipline: differing bytes are not a differing configuration.

### What actually invalidated parts of #7056, and it is not #7370

- **§9's recommendation shipped** (#7377). The 16 MB cap no longer hangs off `gc_moving_loop_polls_enabled()`, and the poll has been default-off since #7161. The five arms #7056 tabulates (`on`/`off`/`off_rt`/`on_cap128`/`off_scav`) no longer name anything that ships.
- **The cap is still the whole footprint lever**, now on 12 probes rather than 8. At `PERRY_GC_SCAVENGE_NURSERY_MB=128`: peak RSS **1.911x**, retained heap **2.475x**, wall **0.947x** — up to **5.005x** peak RSS on `04_dead_after_deep_stack` and **6.350x** retention on `07_array_grow_evacuate`. Identical to within 0.6% under both root lowerings, so it is a pacing result and not a rooting one.
- **§7's false-retention table is gone, not shrunk.** It recorded a 4.6x–54.8x conservative-vs-precise band on probes 01–08. `classify` at `7bde3de24` reports **excess 0.00% and spread 0 on all twelve**, with no `manual_collect` scan site anywhere — #7657 removed the forced scan at `gc()` rather than the reading.
- **§6's real finding survives intact.** A conservative scan does not degrade the copying minor, it **disables** it. Forcing `PERRY_CONSERVATIVE_STACK_SCAN=full` under statepoints takes `minor_cycles` to **0 on all twelve probes** (`copied + promoted` = 0 on all twelve), for 1.98x retained heap (0.70x–6.35x) and 1.46x peak RSS (0.93x–3.47x). Smaller than #7056's +364%..+5371%, same sign, same mechanism.
- **#7481 no longer reproduces.** Its own reproducer (`benchmarks/json_polyglot/bench_field_access.ts` under `PERRY_GC_SCAVENGE_NURSERY_MB=64`) exits 0 with an identical checksum on 5/5 runs at `7bde3de24`, and does run 6 copying minors there, so the arm is not vacuous. The probe added here is what keeps that cadence covered rather than the issue's specific fault.

### Not re-derived, stated rather than hidden

#7056's largest RSS numbers (§3–§5, 272 MB → 421 MB on `w1_srv_pump`/`w2_srv_pump_while`/`w3_mono_sync`) came from three server-shaped workloads it wrote and never landed. There is nothing in the tree to re-run and a fresh reimplementation would not be comparable to them. The 12 probes are what replaced them.

Also not measured: probe 13's counters cross-host. They are deterministic across repeats, traced runs and rotations on this host, and nothing they depend on is host-derived above 2 GB of RAM (`gc_heap_budget_bytes` returns `None` for any budget ≥ 1 GB, so both this host and a GitHub runner take the historical constant path) — but the `shared_ci` profile gates them and that has not been demonstrated on a second machine.

---

## Verification

All green on this branch.

- **The 22 `lint`-job commands**, enumerated from `.github/workflows/test.yml` rather than by hand (fewer than 5 would mean the extraction failed): 22 ran, 0 failed, each command's own `$?` read directly and the runner exiting non-zero if fewer than 22 executed.
- `rustup run stable cargo fmt --all -- --check` — clean (it is the first of the 22).
- `python3 -m unittest tests.test_gc_ratchet` — **89 tests, OK** (17 new).
- `python3 benchmarks/gc_ratchet/gc_ratchet.py validate --scope all` — structurally valid.
- `python3 scripts/gc_gate_wiring_check.py` (+ `--self-test`) — clean.
- `cargo check --all-targets` — exit 0, 0 `error` lines. `cargo test -p perry-runtime --lib --no-fail-fast` — **1,917 passed, 0 failed**, exit 0. (Both run on the pinned host against this branch; this PR changes no Rust, so they are a no-regression check rather than a subject.)
- The quiet-host driver itself: `--check` before the pin (control), `--pin` after, `validate` after that.

**Host contention: none.** `rustc` and `cargo` counts were checked at 0 before every arm and every phase, CPU idle stayed in 94.6–95.8% for the whole session, and no other agent was building on the box. One correction to the brief's quiet gate: **1-minute load average on this mini idles at 1.3–1.8**, above the "< 1.5" bar, because a `WallpaperAerialsExtension` screensaver holds ~14% of one core continuously. `rustc == 0 && cargo == 0 && CPU idle >= 90%` is the predicate that actually discriminates here, and it is what the repo's own driver already gates on (`cpu_active <= 25%`).
