### PR TITLE
fix(gc-ratchet): record a rebase-stable provenance field (#7666 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1379
+**Current Version:** 0.5.1380
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1379"
+version = "0.5.1380"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1379"
+version = "0.5.1380"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1379"
+version = "0.5.1380"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1379"
+version = "0.5.1380"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1379"
+version = "0.5.1380"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
+++ b/benchmarks/gc_ratchet/baseline/gc-ratchet-v1.json
@@ -4,6 +4,7 @@
   "artifact_id": "gc-ratchet-v1",
   "not_the_public_baseline": "Internal Perry-vs-Perry GC ratchet. The public Node/Bun evidence is benchmarks/results/public-node-bun-v1.json, owned by benchmarks/run_public_baseline.sh. Never regenerate one from the other.",
   "commit": "a8f73122d08b64b030f9e34e868cdea1bdee59a4",
+  "code_tree": "dd8020788eedd362689719e47a819939a9203951",
   "generated_at": "2026-08-08T22:03:20+00:00",
   "platform": "darwin-arm64",
   "host": {

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -235,6 +235,26 @@ class ArtifactDefect:
 # ---------------------------------------------------------------------------
 
 
+def code_tree_hash() -> str:
+    """Tree hash of `crates/` — the code whose behaviour a probe measures.
+
+    Rebase- and version-bump-stable, unlike the commit hash. Returns
+    `"unknown"` rather than raising when git is unavailable, because a missing
+    provenance note must not fail a measurement run.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD:crates"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return out.stdout.strip() if out.returncode == 0 and out.stdout.strip() else "unknown"
+    except OSError:
+        return "unknown"
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
@@ -1197,6 +1217,20 @@ def assemble(
             "benchmarks/run_public_baseline.sh. Never regenerate one from the other."
         ),
         "commit": commit,
+        # Rebase-stable companion to `commit`. A gc-ratchet re-pin is written on
+        # a branch and REBASED at merge time (the maintainer adds the version
+        # bump), which orphans the commit the pin recorded: #7666's artifact
+        # named `a8f73122d`, a hash that is not in `main`'s history. Provenance
+        # stayed single and uniform -- this is not #7652's substance -- but a
+        # future reader attributing a moved cell looks up a commit that does not
+        # exist, and that recurs on EVERY pin.
+        #
+        # `crates/`'s tree hash identifies exactly the code that was measured. It
+        # survives both the rebase and the version bump (which touches only
+        # Cargo.toml / Cargo.lock / CLAUDE.md), so it still resolves after the
+        # branch is gone: `git rev-parse <any-commit>:crates` on a candidate
+        # commit either matches or does not.
+        "code_tree": code_tree_hash(),
         "generated_at": utc_now(),
         "platform": measurement["platform"],
         "host": measurement["host"],

--- a/changelog.d/7667-ratchet-rebase-stable-provenance.md
+++ b/changelog.d/7667-ratchet-rebase-stable-provenance.md
@@ -1,0 +1,11 @@
+**`fix(gc-ratchet)`: record a rebase-stable provenance field (#7666 follow-up).**
+
+A gc-ratchet re-pin is written on a branch and **rebased at merge time** (the maintainer adds the version bump), which orphans the commit the pin recorded. #7666's artifact names `a8f73122d` — the object still resolves in a local clone, but `git merge-base --is-ancestor a8f73122d origin/main` is false, so it is not in the history a future reader will search.
+
+This is not #7652's substance (that was 143 cells from one commit and one from another; provenance here is single and uniform). It is #7652's **shape**, and unlike #7652 it recurs on *every* pin rather than on one surgical edit.
+
+The artifact now also records `code_tree` — the tree hash of `crates/`, i.e. exactly the code whose behaviour a probe measures. It survives the rebase **and** the version bump, which touches only `Cargo.toml` / `Cargo.lock` / `CLAUDE.md`. Resolving it is a one-liner against any candidate commit: `git rev-parse <commit>:crates` either matches or does not.
+
+Backfilled on the shipped baseline as `dd8020788…`, verified identical at both the orphaned `a8f73122d` and the measurement commit `7bde3de24` — which is itself the check that the field means what it claims.
+
+Two tests, both sabotage-verified: the shipped artifact must carry a 40-hex `code_tree` (removing it reddens), and `code_tree_hash()` must return `HEAD:crates` rather than `HEAD` — a commit hash there would be the very field it replaces and would change on every version bump, which is half of what makes `commit` useless for this. `code_tree_hash()` returns `"unknown"` rather than raising when git is unavailable: a missing provenance note must not fail a measurement run.

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -16,10 +16,12 @@ import json
 import stat
 import sys
 import tempfile
+import subprocess
 import unittest
 from pathlib import Path
 
 from benchmarks.gc_ratchet.gc_ratchet import (
+    code_tree_hash,
     ALL_METRICS,
     DEFAULT_ARTIFACT,
     DETERMINISTIC_METRICS,
@@ -1316,3 +1318,55 @@ class ProbeRunEnvGateTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class RebaseStableProvenanceTests(unittest.TestCase):
+    """#7666 follow-up: `commit` alone does not survive the merge that ships it.
+
+    A gc-ratchet re-pin is written on a branch and REBASED at merge time (the
+    maintainer adds the version bump), which orphans the commit the pin
+    recorded. #7666's artifact named `a8f73122d`; that object still resolves
+    locally but is NOT an ancestor of `main`, so a future reader attributing a
+    moved cell looks up a commit that is not in the history. This recurs on
+    every pin, so the artifact also records the tree hash of `crates/` — the
+    code whose behaviour a probe measures, stable across both the rebase and
+    the version bump (which touches only Cargo.toml / Cargo.lock / CLAUDE.md).
+    """
+
+    def test_the_shipped_baseline_records_a_code_tree(self):
+        baseline = Path(__file__).resolve().parents[1] / "benchmarks" / "gc_ratchet" / "baseline" / "gc-ratchet-v1.json"
+        artifact = json.loads(baseline.read_text())
+        self.assertIn(
+            "code_tree",
+            artifact,
+            "the pinned artifact must carry a rebase-stable provenance field; "
+            "`commit` alone is orphaned by the merge that ships the pin",
+        )
+        self.assertRegex(
+            artifact["code_tree"],
+            r"^[0-9a-f]{40}$",
+            "code_tree must be a full git tree hash",
+        )
+
+    def test_code_tree_hash_is_a_tree_not_a_commit(self):
+        """It must name `HEAD:crates`, not `HEAD`.
+
+        A commit hash here would be exactly the field it replaces, and would
+        change on every version bump — which is half of what makes `commit`
+        useless for this.
+        """
+        value = code_tree_hash()
+        if value == "unknown":
+            self.skipTest("git unavailable")
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        self.assertNotEqual(
+            value, head, "code_tree must be a TREE hash, not the commit hash"
+        )
+        expected = subprocess.run(
+            ["git", "rev-parse", "HEAD:crates"],
+            cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        self.assertEqual(value, expected)
+


### PR DESCRIPTION
**`fix(gc-ratchet)`: record a rebase-stable provenance field (#7666 follow-up).**

A gc-ratchet re-pin is written on a branch and **rebased at merge time** (the maintainer adds the version bump), which orphans the commit the pin recorded. #7666's artifact names `a8f73122d` — the object still resolves in a local clone, but `git merge-base --is-ancestor a8f73122d origin/main` is false, so it is not in the history a future reader will search.

This is not #7652's substance (that was 143 cells from one commit and one from another; provenance here is single and uniform). It is #7652's **shape**, and unlike #7652 it recurs on *every* pin rather than on one surgical edit.

The artifact now also records `code_tree` — the tree hash of `crates/`, i.e. exactly the code whose behaviour a probe measures. It survives the rebase **and** the version bump, which touches only `Cargo.toml` / `Cargo.lock` / `CLAUDE.md`. Resolving it is a one-liner against any candidate commit: `git rev-parse <commit>:crates` either matches or does not.

Backfilled on the shipped baseline as `dd8020788…`, verified identical at both the orphaned `a8f73122d` and the measurement commit `7bde3de24` — which is itself the check that the field means what it claims.

Two tests, both sabotage-verified: the shipped artifact must carry a 40-hex `code_tree` (removing it reddens), and `code_tree_hash()` must return `HEAD:crates` rather than `HEAD` — a commit hash there would be the very field it replaces and would change on every version bump, which is half of what makes `commit` useless for this. `code_tree_hash()` returns `"unknown"` rather than raising when git is unavailable: a missing provenance note must not fail a measurement run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GC ratchet baseline data now records the source code tree version used for measurements.
  - Provenance tracking falls back gracefully when Git information is unavailable.

- **Bug Fixes**
  - Improved stability and accuracy when rebasing GC ratchet measurement data.

- **Documentation**
  - Updated the documented release version and added changelog details.

- **Tests**
  - Added validation for code tree hashes and Git fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->