### PR TITLE
perf(repsel): resolve object-literal element types in the element-shape loop clone (#7480)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1382
+**Current Version:** 0.5.1383
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1382"
+version = "0.5.1383"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1382"
+version = "0.5.1383"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1382"
+version = "0.5.1383"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1382"
+version = "0.5.1383"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1382"
+version = "0.5.1383"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7669-repsel-object-literal-element-shape.md
+++ b/changelog.d/7669-repsel-object-literal-element-shape.md
@@ -1,0 +1,78 @@
+### repsel: object-literal element types reach the element-shape loop clone (#7480)
+
+`for (let j = 0; j < n; j++) sum += keep[j].v` over a **`keep: {v, w}[]`** —
+#7480's own kernel — went from **408 ms to 12 ms** on the pinned quiet mini
+(200k elements × 50 sweeps, 7 interleaved rounds, checksums equal in every
+cell). That is **parity with node (12 ms) and bun (12 ms)**, down from 34×
+node. The named-class arm the #7612 consumer already covered is unchanged at
+13 ms, and the region-local arm `collectors/ptr_shape_elements.rs` (#7034 §3)
+already covered is unchanged at 14–15 ms.
+
+**Root cause.** `stmt/element_shape_loop.rs::element_class_name` resolved
+`Array(Named(C))` only, so a declared object-literal element type never
+produced a class id and #7480's kernel never reached the clone. It now also
+resolves the declared object type to the `__AnonShape_<hash>` class its
+literals allocate, by matching the declared property order against the module's
+anon shapes. The name cannot be recomputed — `mint_anon_shape_class` keys its
+FNV hash on the literal's *inferred value* types (`{v: 1}` tags `i`, not `n`)
+while the annotation says `number` — so the class is looked up, not derived,
+and an ambiguous field-name list **declines** rather than guessing (`ctx.classes`
+is a `HashMap`; "first match wins" would make the emitted code depend on
+iteration order).
+
+**`receiver_class_name` is deliberately unchanged.** Widening it to type an
+`Object`-typed element read is the #6377 blast radius #7612 refused. The clone
+was made self-contained instead: its `ElementShapeLoopFact` already carried the
+class name and packed slot index, so the three sites that would otherwise
+re-derive the class from the receiver now consult one predicate,
+`expr::element_shape_loop_fact_for_property_get` — the raw-f64 field lowering
+(its interception moved *above* the `receiver_class_name` gate),
+`type_analysis::is_numeric_expr`'s `PropertyGet` arm, and `expr::binary`'s
+arithmetic-operand router. All three are scoped to the fast clone, so
+`keep[j].v` anywhere else is byte-for-byte what it was. The predicate includes
+the canonical-i32 counter slot, because answering `yes` is a promise that the
+read takes the bare-load lowering and `is_numeric_expr` bets a raw `double` on
+that promise.
+
+**The issue's cost model was wrong, and the correction is the design point.**
+#7480 recorded "no out-of-line guard *calls*, the cost is stacked inline
+diamonds"; the object-literal arm actually carried three calls per iteration,
+the third being `js_dynamic_string_or_number_add` — with no resolvable class
+the accumulator also loses its numeric proof, so `+` is not an `fadd`. That was
+recorded as "a second, separable lever". It is not one: the clone is admitted
+only if it is provably call-free (`LlBlock::contains_gc_unsafe_call` counts
+every non-`llvm.` call), so resolving the element class *without* restoring the
+numeric proof emits the clone, fails the call-free test, branches
+unconditionally to the slow arm and buys zero at a cost in code size. Anything
+gated on call-freeness has this shape. The numeric claim inside the clone is
+also stronger than the annotation it replaces: the residual per-element check
+already proves `GC_OBJ_TYPED_LAYOUT_INTACT`, i.e. that the slot holds a raw
+double.
+
+**An existing gate that could not fail.** `fast_clone_slice` in
+`element_shape_loop_tests.rs` sliced from the first *substring* match of
+`for.element_shape_fast.cond`, which is the `br label %…` terminator of the
+fast preheader — four lines above the slow preheader — and every assertion made
+against the result is a negative (`!fast.contains(" call ")`, …). The IR census
+that exists to prove the clone is call-free had therefore been **vacuous since
+#7612**, on the code that then shipped the #7660 SIGBUS. It now finds the block
+*definition* and asserts the slice contains the cloned body and its element
+load, so it cannot pass on an empty subject again (#7024/#7025 family).
+
+**Coverage.** Seven new IR-census tests: one positive that asserts the clone is
+reached, call-free, and `fadd`-accumulating (all three together, because any
+one alone is inert), plus sabotage cases for an ambiguous shape, a tie a field
+type *can* break, an optional property, a shape no literal allocates, a
+reordered shape, and a read outside the clone that must stay on the by-name
+path. `test-files/test_gap_repsel_element_shape_loop_clone.ts` gains an
+object-literal section covering the #7660 growth-forwarding shapes on this arm
+(callee-built, callee-filled, a 17-element prefix, and a module-global array
+read from inside a function), an inline `rows.length` bound the matcher rejects,
+a layout downgrade that forces the residual check's side exit mid-loop, two
+anon shapes sharing field names, and a mixed numeric/string shape the matcher
+must decline — byte-identical to the Node 26.5.1 oracle.
+
+`docs/engine-plan.md` item 6 is closed. What remains of Route A — a `Ptr<Shape>`
+element representation that survives *outside* a loop for the parameter/global
+case — needs the type-visibility change above with its own gap-suite A/B, and
+is scoped against the region-local case already being covered.

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -58,7 +58,19 @@ fn lower_arithmetic_operand(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<(String,
             return Ok((value, true));
         }
     }
-    if expr_may_return_boxed_value_from_raw_f64_fallback(ctx, expr) {
+    // repsel #7480 step 3: a tracked `arr[i].field` read inside an
+    // element-shape fast clone routes to the raw-f64 lowering WITHOUT the
+    // boxed-fallback test below. That test asks `receiver_class_name`, which
+    // by design does not resolve an object-literal element type, so the read
+    // would otherwise fall through to `lower_expr` — a generic diamond, whose
+    // calls then fail the clone's call-free admission and cost the clone
+    // entirely. The predicate is left alone rather than widened: this read has
+    // no boxed fallback at all (the residual per-element check proves the slot
+    // is a raw double before the load), so claiming one here would be a lie
+    // that other consumers of that predicate would read.
+    let in_element_shape_clone = matches!(expr, Expr::PropertyGet { object, property, .. }
+        if crate::expr::element_shape_loop_fact_for_property_get(ctx, object, property).is_some());
+    if in_element_shape_clone || expr_may_return_boxed_value_from_raw_f64_fallback(ctx, expr) {
         if let Some(value) =
             super::property_get::lower_raw_f64_class_field_get_for_number_context(ctx, expr)?
         {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1605,21 +1605,56 @@ pub(crate) struct ElementShapeLoopFact {
     pub max_field_index: u32,
 }
 
-/// Find the innermost active element-shape loop fact covering
-/// `(array_local_id, index_local_id, class_name, property)`. Returns the fact
-/// and the packed slot index of the field.
-pub(crate) fn element_shape_loop_fact_lookup<'f>(
-    facts: &'f [ElementShapeLoopFact],
-    array_local_id: u32,
-    index_local_id: u32,
-    class_name: &str,
+/// Find the innermost active element-shape loop fact covering a
+/// `PropertyGet`'s receiver: answers `Some((fact, packed_slot_index))` exactly
+/// when `object.property` is a tracked `arr[counter].field` read inside an
+/// element-shape fast clone.
+///
+/// The single entry point for the three sites that must agree about that read
+/// — the field lowering itself
+/// (`expr::property_get::lower_raw_f64_class_field_get_for_number_context`),
+/// `type_analysis::is_numeric_expr`, and `expr::binary`'s arithmetic-operand
+/// router. #7480 step 3 made the clone self-contained by routing all three
+/// through the fact instead of through `receiver_class_name`, which by design
+/// does not resolve an object-literal element type; the fact's own
+/// `class_name` is therefore the authoritative answer rather than a filter on
+/// one the caller supplies.
+///
+/// `(array, counter)` already identifies one loop — a counter local is minted
+/// per `for`, and the matcher admits exactly one array per loop. Cheap
+/// early-out first: outside a fast clone the fact vector is empty.
+///
+/// The **canonical-i32 counter slot is part of the predicate**, not a
+/// precondition the caller re-checks. Answering `Some` is a promise that the
+/// read really does take the bare-load lowering, and `is_numeric_expr` bets a
+/// raw `double` on that promise: if the field lowering declined for want of an
+/// i32 slot while the numeric predicate still said yes, the operand would be
+/// consumed as a real double while the generic lowering handed back a NaN-boxed
+/// value. The matcher declines the whole loop without that slot
+/// (`lower_element_shape_versioned_for`), so today the two can't disagree —
+/// asking here keeps them unable to disagree if the matcher is ever widened.
+pub(crate) fn element_shape_loop_fact_for_property_get<'f>(
+    ctx: &'f FnCtx<'_>,
+    object: &perry_hir::Expr,
     property: &str,
 ) -> Option<(&'f ElementShapeLoopFact, u32)> {
-    facts.iter().rev().find_map(|fact| {
-        if fact.array_local_id != array_local_id
-            || fact.index_local_id != index_local_id
-            || fact.class_name != class_name
-        {
+    use perry_hir::Expr;
+    if ctx.element_shape_loop_facts.is_empty() {
+        return None;
+    }
+    let Expr::IndexGet { object, index } = object else {
+        return None;
+    };
+    let (Expr::LocalGet(array_local_id), Expr::LocalGet(index_local_id)) =
+        (object.as_ref(), index.as_ref())
+    else {
+        return None;
+    };
+    if !ctx.i32_counter_slots.contains_key(index_local_id) {
+        return None;
+    }
+    ctx.element_shape_loop_facts.iter().rev().find_map(|fact| {
+        if fact.array_local_id != *array_local_id || fact.index_local_id != *index_local_id {
             return None;
         }
         fact.fields.get(property).map(|idx| (fact, *idx))

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -331,6 +331,81 @@ pub(crate) fn lower_raw_f64_class_field_get_for_number_context(
         }
     }
 
+    // repsel #7480 / #5093: inside the fast clone of an ELEMENT-shape
+    // versioned loop, `arr[i].field` in number context lowers to a bare
+    // element load plus the residual per-element check, with no element-read
+    // tier and no guard call (see stmt/element_shape_loop.rs).
+    //
+    // #7480 step 3: this sits ABOVE the `receiver_class_name` gate on purpose.
+    // The clone's element class can be one that resolver does not answer for —
+    // an object-literal element type (`keep: {v: number}[]`) resolves to its
+    // `__AnonShape_<hash>` only inside the matcher, which is where that
+    // resolution is kept so it cannot un-gate anything else (#6377). Every
+    // fact this consults was validated by the matcher when the fact was built:
+    // the class has no computed members and no base, the property is not an
+    // accessor and is not denylisted, and its declared type is a raw-f64
+    // candidate at the packed slot index carried here. So the lowering needs
+    // nothing from the receiver's static type, and asking for it would have
+    // made the whole clone dead IR.
+    if let Some((fact, field_index)) =
+        crate::expr::element_shape_loop_fact_for_property_get(ctx, object, property)
+            .map(|(fact, idx)| (fact.clone(), idx))
+    {
+        if let Expr::IndexGet { object: array, .. } = object.as_ref() {
+            if let Expr::LocalGet(arr_id) = array.as_ref() {
+                // The counter's canonical i32 slot is what the matcher
+                // required; without it there is nothing to index with.
+                if let Some(slot) = ctx.i32_counter_slots.get(&fact.index_local_id).cloned() {
+                    let idx_i32 = ctx.block().load(I32, &slot);
+                    let value = crate::expr::element_shape_guard::emit_element_shape_field_load(
+                        ctx,
+                        &fact,
+                        &idx_i32,
+                        field_index,
+                    );
+                    let lowered = LoweredValue {
+                        semantic: SemanticKind::JsNumber,
+                        rep: NativeRep::F64,
+                        llvm_ty: DOUBLE,
+                        value: value.clone(),
+                    };
+                    ctx.record_lowered_value_with_access_mode_and_facts(
+                        "ElementShapeFieldGet",
+                        Some(*arr_id),
+                        "element_shape_loop.raw_f64_load",
+                        &lowered,
+                        Some(BoundsState::Guarded {
+                            guard_id: "element_shape_loop_preheader_check".to_string(),
+                        }),
+                        None,
+                        Some(BufferAccessMode::CheckedNative),
+                        None,
+                        None,
+                        None,
+                        vec![raw_f64_layout_fact(
+                            Some(*arr_id),
+                            "consumed",
+                            "element_shape_loop_preheader_check",
+                            None,
+                        )],
+                        Vec::new(),
+                        false,
+                        false,
+                        vec![
+                            format!("field={property}"),
+                            format!("class={}", fact.class_name),
+                            "loop_versioning=element_shape".to_string(),
+                            "index_range=nonnegative_i32".to_string(),
+                            "length_range=guarded_i32".to_string(),
+                            "element_shape=homogeneous_class".to_string(),
+                        ],
+                    );
+                    return Ok(Some(value));
+                }
+            }
+        }
+    }
+
     let Some(class_name) = receiver_class_name(ctx, object) else {
         return Ok(None);
     };
@@ -367,80 +442,6 @@ pub(crate) fn lower_raw_f64_class_field_get_for_number_context(
     ) else {
         return Ok(None);
     };
-
-    // repsel #7480 / #5093: inside the fast clone of an ELEMENT-shape
-    // versioned loop, `arr[i].field` in number context lowers to a bare
-    // element load plus the residual per-element check, with no element-read
-    // tier and no guard call (see stmt/element_shape_loop.rs). Checked before
-    // the class-field fact because the receiver shapes are disjoint
-    // (`IndexGet` vs `LocalGet`) and this one is the cheaper lowering.
-    if !ctx.element_shape_loop_facts.is_empty() {
-        if let Expr::IndexGet { object, index } = object.as_ref() {
-            if let (Expr::LocalGet(arr_id), Expr::LocalGet(idx_id)) =
-                (object.as_ref(), index.as_ref())
-            {
-                let hit = crate::expr::element_shape_loop_fact_lookup(
-                    &ctx.element_shape_loop_facts,
-                    *arr_id,
-                    *idx_id,
-                    &class_name,
-                    property,
-                )
-                .filter(|(_, loop_idx)| *loop_idx == field_index)
-                .map(|(fact, _)| fact.clone());
-                if let Some(fact) = hit {
-                    // The counter's canonical i32 slot is what the matcher
-                    // required; without it there is nothing to index with.
-                    if let Some(slot) = ctx.i32_counter_slots.get(idx_id).cloned() {
-                        let idx_i32 = ctx.block().load(I32, &slot);
-                        let value = crate::expr::element_shape_guard::emit_element_shape_field_load(
-                            ctx,
-                            &fact,
-                            &idx_i32,
-                            field_index,
-                        );
-                        let lowered = LoweredValue {
-                            semantic: SemanticKind::JsNumber,
-                            rep: NativeRep::F64,
-                            llvm_ty: DOUBLE,
-                            value: value.clone(),
-                        };
-                        ctx.record_lowered_value_with_access_mode_and_facts(
-                            "ElementShapeFieldGet",
-                            Some(*arr_id),
-                            "element_shape_loop.raw_f64_load",
-                            &lowered,
-                            Some(BoundsState::Guarded {
-                                guard_id: "element_shape_loop_preheader_check".to_string(),
-                            }),
-                            None,
-                            Some(BufferAccessMode::CheckedNative),
-                            None,
-                            None,
-                            None,
-                            vec![raw_f64_layout_fact(
-                                Some(*arr_id),
-                                "consumed",
-                                "element_shape_loop_preheader_check",
-                                None,
-                            )],
-                            Vec::new(),
-                            false,
-                            false,
-                            vec![
-                                format!("field={property}"),
-                                "loop_versioning=element_shape".to_string(),
-                                "index_range=nonnegative_i32".to_string(),
-                                "length_range=guarded_i32".to_string(),
-                                "element_shape=homogeneous_class".to_string(),
-                            ],
-                        );
-                        return Ok(Some(value));
-                    }
-                }
-            }
-        }
-    }
 
     // #5093 loop versioning: inside the fast clone of a class-field versioned
     // loop, a tracked number-context field read on the proven receiver lowers

--- a/crates/perry-codegen/src/stmt/element_shape_loop.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop.rs
@@ -176,9 +176,24 @@ fn element_shape_loop_pure_expr_collect(
             array.is_none_or(|a| a != *id) && crate::type_analysis::is_numeric_expr(ctx, expr)
         }
         Expr::Number(_) | Expr::Integer(_) => true,
+        // NOTE (#7480 step 3): deliberately NOT gated on
+        // `is_numeric_expr(ctx, expr)`. `BinaryOp` is arithmetic/bitwise only
+        // (no `in`/`instanceof`), so the sole hazard the whole-expression test
+        // covered was `+` on a possibly-string operand — and every leaf this
+        // walk admits is numeric by the time the match is ACCEPTED: numeric
+        // locals and literals by their own arms, and tracked `arr[j].field`
+        // reads because the caller rejects the whole loop unless every
+        // collected property is a declared raw-f64 candidate on the resolved
+        // element class.
+        //
+        // The gate had to go for the object-literal kernel: at match time no
+        // fact is installed yet, so `is_numeric_expr` cannot see through
+        // `keep[j].v` (its `PropertyGet` arm resolves the owner through
+        // `receiver_class_name`, which by design does not type an
+        // object-literal element). Keeping it would have declined #7480's own
+        // kernel before the class resolver was ever consulted.
         Expr::Binary { left, right, .. } => {
-            crate::type_analysis::is_numeric_expr(ctx, expr)
-                && element_shape_loop_pure_expr_collect(ctx, left, counter_id, array, props)
+            element_shape_loop_pure_expr_collect(ctx, left, counter_id, array, props)
                 && element_shape_loop_pure_expr_collect(ctx, right, counter_id, array, props)
         }
         Expr::NumberCoerce(operand) => {
@@ -208,35 +223,150 @@ fn element_shape_loop_pure_expr_collect(
 /// Resolve the class every element of `array_id` must have for the clone to
 /// fire.
 ///
-/// Exactly one source: `receiver_class_name` on the `IndexGet`, i.e. a
-/// declared element type (`keep: Node[]`) — the same path Perry already uses
-/// to resolve `items[2].display()`. It does not have to be *right*: the
-/// preheader compares the class id the runtime invariant reports against this
-/// one, so a wrong answer costs the clone, never correctness.
+/// Two sources, tried in order:
 ///
-/// **Deliberately NOT resolved: object-literal element types**
-/// (`keep: {v: number}[]`), which is #7480's own kernel — an object literal
-/// lowers to `New { __AnonShape_<hash> }`, so a class id genuinely exists, and
-/// matching the declared object type's property order against this module's
-/// `__AnonShape_*` classes would find it. It is left out on purpose, because
-/// the class name alone is not enough: `receiver_class_name` returning `None`
-/// is also what makes `lower_raw_f64_class_field_get_for_number_context`
-/// decline, so the read would still lower through the generic diamond, the
-/// clone would fail its call-free check, and the only thing the wider matcher
-/// would buy is a block of dead fast-clone IR. Reaching that kernel means
-/// teaching `static_type_of` / `receiver_class_name` to type an `Object`-typed
-/// property read — which is precisely the #6377 "more type visibility un-gates
-/// latent fast paths" change, and belongs in its own PR with its own gap-suite
-/// A/B. Measured cost of the omission: the object-literal kernel stays at
-/// ~88 ms while the named-class kernel goes 43 → 16 ms.
+/// 1. `receiver_class_name` on the `IndexGet`, i.e. a declared *named* element
+///    type (`keep: Node[]`) — the same path Perry already uses to resolve
+///    `items[2].display()`.
+/// 2. #7480 step 3: an **object-literal element type** (`keep: {v: number}[]`),
+///    resolved to the `__AnonShape_<hash>` class the literals actually
+///    allocate ([`anon_shape_class_for_element_type`]). This is #7480's own
+///    kernel and the whole measured gap — 414 ms vs node's 12 on 200k × 50,
+///    where the named-class arm is already 13 ms.
+///
+/// Neither has to be *right*: the preheader compares the class id the runtime
+/// invariant reports against this one, so a wrong answer costs the clone,
+/// never correctness. The annotation stays a hint, never layout.
 fn element_class_name(ctx: &FnCtx<'_>, array_id: u32, counter_id: u32) -> Option<String> {
-    crate::type_analysis::receiver_class_name(
+    if let Some(named) = crate::type_analysis::receiver_class_name(
         ctx,
         &perry_hir::Expr::IndexGet {
             object: Box::new(perry_hir::Expr::LocalGet(array_id)),
             index: Box::new(perry_hir::Expr::LocalGet(counter_id)),
         },
-    )
+    ) {
+        return Some(named);
+    }
+    anon_shape_class_for_element_type(ctx, array_id)
+}
+
+/// Content-addressed synthetic class every closed-shape object literal lowers
+/// to (`perry-hir/src/lower/context.rs::mint_anon_shape_class`).
+const ANON_SHAPE_PREFIX: &str = "__AnonShape_";
+
+/// #7480 step 3: resolve `keep: {v: number, w: number}[]` to the
+/// `__AnonShape_<hash>` class its literals allocate.
+///
+/// **Why not widen `receiver_class_name`.** That is the #6377 blast radius
+/// #7612 deliberately refused — every consumer of the receiver-class resolver
+/// would start seeing a class for an `Object`-typed read, un-gating latent
+/// fast paths this change never measured. The resolver therefore lives here,
+/// in the matcher, and the fast clone is made self-contained instead: its
+/// field read carries its own `class_name` + packed slot index on
+/// `ElementShapeLoopFact`, and the three predicates that would otherwise have
+/// re-derived the class from the receiver
+/// (`lower_raw_f64_class_field_get_for_number_context`, `is_numeric_expr`,
+/// `lower_arithmetic_operand`'s routing test) consult that fact instead. All
+/// three are scoped to the fast clone, where the guard has already proven the
+/// element's class *and* — via the residual check's
+/// `GC_OBJ_TYPED_LAYOUT_INTACT` bit — that the slot really holds a raw double.
+///
+/// **Why the hash cannot be recomputed.** `mint_anon_shape_class` keys the
+/// FNV hash on the literal's *inferred value* types (`{v: 1}` tags `i`, not
+/// `n`), while the annotation says `number`. So the class is found by matching
+/// the declared property order against the module's anon shapes, not by
+/// recomputing the name.
+///
+/// Ambiguity declines rather than guesses: two anon shapes can share a field
+/// name list (`{v: n, w: n}` vs `{v: s, w: s}`), so candidates are narrowed by
+/// field-type compatibility and a still-ambiguous set returns `None`. That
+/// keeps the answer independent of `ctx.classes` iteration order, which is a
+/// `HashMap`'s.
+fn anon_shape_class_for_element_type(ctx: &FnCtx<'_>, array_id: u32) -> Option<String> {
+    use perry_hir::types::Type as HirType;
+
+    let elem = match ctx.local_types.get(&array_id)? {
+        HirType::Array(elem) => elem.as_ref(),
+        // `new Array<{v: number}>(n)` locals carry the generic spelling.
+        HirType::Generic { base, type_args } if base == "Array" && type_args.len() == 1 => {
+            &type_args[0]
+        }
+        _ => return None,
+    };
+    let HirType::Object(obj) = elem else {
+        return None;
+    };
+    // Only a CLOSED shape names a layout: an index signature, a method
+    // signature (which `property_order` does not record) or an optional
+    // property all mean the runtime object may not have exactly these slots.
+    if obj.index_signature.is_some() {
+        return None;
+    }
+    let order = obj.property_order.as_ref()?;
+    if order.is_empty() || order.len() != obj.properties.len() {
+        return None;
+    }
+    if obj.properties.values().any(|p| p.optional) {
+        return None;
+    }
+
+    let mut candidates: Vec<&str> = ctx
+        .classes
+        .iter()
+        .filter(|(name, class)| {
+            name.starts_with(ANON_SHAPE_PREFIX)
+                // The clone's packed slot indices describe ONE class's own
+                // fields; an inherited layout or a computed key would not be
+                // self-describing. Anon shapes never have either, so this is
+                // a belt-and-braces check that keeps the invariant local.
+                && class.extends_name.is_none()
+                && class.computed_members.is_empty()
+                && class.fields.len() == order.len()
+                && class
+                    .fields
+                    .iter()
+                    .zip(order)
+                    .all(|(f, want)| f.key_expr.is_none() && f.name == *want)
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if candidates.len() > 1 {
+        candidates.retain(|name| {
+            ctx.classes.get(*name).is_some_and(|class| {
+                class.fields.iter().all(|f| {
+                    obj.properties
+                        .get(&f.name)
+                        .is_some_and(|p| anon_shape_field_type_is_compatible(&p.ty, &f.ty))
+                })
+            })
+        });
+    }
+    match candidates.as_slice() {
+        [only] => Some((*only).to_string()),
+        _ => None,
+    }
+}
+
+/// Disambiguator for [`anon_shape_class_for_element_type`]: is a synthesized
+/// anon-shape field type (inferred from the literal's VALUES) consistent with
+/// the declared property type (an annotation)?
+///
+/// Only used to break a tie between same-named shapes, so it is deliberately
+/// coarse — `Number`/`Int32` are one bucket (`{v: 1}` infers `Int32` for a
+/// `number`-declared property), as are `String`/`StringLiteral`.
+fn anon_shape_field_type_is_compatible(
+    declared: &perry_hir::types::Type,
+    actual: &perry_hir::types::Type,
+) -> bool {
+    use perry_hir::types::Type as T;
+    match (declared, actual) {
+        (T::Number | T::Int32, T::Number | T::Int32) => true,
+        (T::String | T::StringLiteral(_), T::String | T::StringLiteral(_)) => true,
+        // An `any`/`unknown` annotation names no layout, so it rules nothing
+        // out; every other pair must agree exactly.
+        (T::Any | T::Unknown, _) => true,
+        (d, a) => d == a,
+    }
 }
 
 /// Match `for (let j = k0; j < B; j++) acc = <pure over arr[j].field>`.

--- a/crates/perry-codegen/src/stmt/element_shape_loop.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop.rs
@@ -231,8 +231,9 @@ fn element_shape_loop_pure_expr_collect(
 /// 2. #7480 step 3: an **object-literal element type** (`keep: {v: number}[]`),
 ///    resolved to the `__AnonShape_<hash>` class the literals actually
 ///    allocate ([`anon_shape_class_for_element_type`]). This is #7480's own
-///    kernel and the whole measured gap — 414 ms vs node's 12 on 200k × 50,
-///    where the named-class arm is already 13 ms.
+///    kernel and the whole measured gap: 408 ms against node's 12 on
+///    200k × 50 before this resolved, 12 ms after, where the named-class arm
+///    was already 13 ms.
 ///
 /// Neither has to be *right*: the preheader compares the class id the runtime
 /// invariant reports against this one, so a wrong answer costs the clone,

--- a/crates/perry-codegen/src/stmt/element_shape_loop.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop.rs
@@ -311,7 +311,7 @@ fn anon_shape_class_for_element_type(ctx: &FnCtx<'_>, array_id: u32) -> Option<S
         return None;
     }
 
-    let mut candidates: Vec<&str> = ctx
+    let candidates: Vec<&str> = ctx
         .classes
         .iter()
         .filter(|(name, class)| {
@@ -328,44 +328,49 @@ fn anon_shape_class_for_element_type(ctx: &FnCtx<'_>, array_id: u32) -> Option<S
                     .iter()
                     .zip(order)
                     .all(|(f, want)| f.key_expr.is_none() && f.name == *want)
-        })
-        .map(|(name, _)| name.as_str())
-        .collect();
-    if candidates.len() > 1 {
-        candidates.retain(|name| {
-            ctx.classes.get(*name).is_some_and(|class| {
-                class.fields.iter().all(|f| {
+                // Field types are checked for EVERY candidate, not only to
+                // break a tie: "the declared shape and the class agree" should
+                // mean the same thing whether or not a second shape happens to
+                // share the field names, otherwise a one-candidate module and a
+                // two-candidate one apply different rules to the same pair.
+                && class.fields.iter().all(|f| {
                     obj.properties
                         .get(&f.name)
                         .is_some_and(|p| anon_shape_field_type_is_compatible(&p.ty, &f.ty))
                 })
-            })
-        });
-    }
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
     match candidates.as_slice() {
         [only] => Some((*only).to_string()),
         _ => None,
     }
 }
 
-/// Disambiguator for [`anon_shape_class_for_element_type`]: is a synthesized
-/// anon-shape field type (inferred from the literal's VALUES) consistent with
-/// the declared property type (an annotation)?
+/// Candidate filter for [`anon_shape_class_for_element_type`]: is a
+/// synthesized anon-shape field type (inferred from the literal's VALUES)
+/// consistent with the declared property type (an annotation)?
 ///
-/// Only used to break a tie between same-named shapes, so it is deliberately
-/// coarse — `Number`/`Int32` are one bucket (`{v: 1}` infers `Int32` for a
-/// `number`-declared property), as are `String`/`StringLiteral`.
+/// Deliberately coarse, because the two sides are not the same kind of fact.
+/// `Number`/`Int32` are one bucket (`{v: 1}` infers `Int32` for a
+/// `number`-declared property), as are `String`/`StringLiteral`, and an
+/// `any`/`unknown` on EITHER side rules nothing out: a declared `any` names no
+/// layout, and an inferred `Any` just means the lowering could not type that
+/// literal's value expression (`{v: i, w: f()}`), which is not evidence of
+/// disagreement. Making that arm one-sided would have silently declined the
+/// very common `{v: <typed>, w: <untyped call>}` shape.
+///
+/// Being wrong here costs the clone and never correctness — the preheader
+/// still compares the class id the runtime invariant reports.
 fn anon_shape_field_type_is_compatible(
     declared: &perry_hir::types::Type,
     actual: &perry_hir::types::Type,
 ) -> bool {
     use perry_hir::types::Type as T;
     match (declared, actual) {
+        (T::Any | T::Unknown, _) | (_, T::Any | T::Unknown) => true,
         (T::Number | T::Int32, T::Number | T::Int32) => true,
         (T::String | T::StringLiteral(_), T::String | T::StringLiteral(_)) => true,
-        // An `any`/`unknown` annotation names no layout, so it rules nothing
-        // out; every other pair must agree exactly.
-        (T::Any | T::Unknown, _) => true,
         (d, a) => d == a,
     }
 }

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -252,9 +252,13 @@ fn object_element_module(elem: Type, classes: Vec<Class>) -> Module {
         None,
     );
     m.classes = classes;
-    if let Some(Stmt::Let { ty, .. }) = m.init.first_mut() {
-        *ty = Type::Array(Box::new(elem));
-    }
+    // A silent skip here would leave the array typed `Node[]` and every
+    // object-literal test below would quietly be re-testing the named-class
+    // path — passing for the wrong reason. Assert the shape instead.
+    let Some(Stmt::Let { ty, .. }) = m.init.first_mut() else {
+        panic!("element_shape_module's first init statement should be the array `Let`");
+    };
+    *ty = Type::Array(Box::new(elem));
     m
 }
 
@@ -818,9 +822,13 @@ fn object_literal_element_resolution_does_not_escape_the_clone() {
     // resolver had been wired into `receiver_class_name` instead, this read
     // would have become a class-field diamond too — a change this PR did not
     // measure.
-    let after = &ir[ir
-        .find("element_shape.loop.merge")
-        .expect("merge block should exist")..];
+    //
+    // Sliced from the merge block's DEFINITION, not from the first mention of
+    // its name: the earliest occurrence is a `br label %element_shape.loop.merge`
+    // inside the fast clone, and slicing from there would let the CLONE's own
+    // instructions satisfy an assertion about what follows it.
+    let after = &ir[block_def_offset(&ir, "element_shape.loop.merge")
+        .expect("the merge block should be DEFINED in the emitted IR")..];
     assert!(
         after.contains("js_object_get_field_by_name_f64")
             || after.contains("js_object_get_field_ic_miss"),

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -122,6 +122,51 @@ fn node_class(extends_name: Option<&str>) -> Class {
     }
 }
 
+/// A closed-shape object literal's synthesized class, exactly as
+/// `perry-hir`'s `mint_anon_shape_class` builds it: content-addressed name, no
+/// base, no computed members, fields in source order with `init: None`.
+fn anon_shape_class(id: u32, name: &str, fields: &[(&str, Type)]) -> Class {
+    let mut class = node_class(None);
+    class.id = id;
+    class.name = name.to_string();
+    class.fields = fields
+        .iter()
+        .map(|(field, ty)| ClassField {
+            name: (*field).to_string(),
+            key_expr: None,
+            ty: ty.clone(),
+            init: None,
+            is_private: false,
+            is_readonly: false,
+            decorators: Vec::new(),
+        })
+        .collect();
+    class
+}
+
+/// The declared element type of #7480's own kernel: `{ v: number; w: number }`.
+fn object_element_type(fields: &[(&str, Type)], optional: bool) -> Type {
+    let mut properties = std::collections::HashMap::new();
+    let mut property_order = Vec::new();
+    for (name, ty) in fields {
+        property_order.push((*name).to_string());
+        properties.insert(
+            (*name).to_string(),
+            perry_hir::types::PropertyInfo {
+                ty: ty.clone(),
+                optional,
+                readonly: false,
+            },
+        );
+    }
+    Type::Object(perry_hir::types::ObjectType {
+        name: None,
+        properties,
+        property_order: Some(property_order),
+        index_signature: None,
+    })
+}
+
 /// `keep[<index>].v`
 fn elem_field(array_id: u32, index: Expr) -> Expr {
     Expr::PropertyGet {
@@ -194,6 +239,25 @@ fn element_shape_module(body: Vec<Stmt>, extends_name: Option<&str>) -> Module {
     m
 }
 
+/// `const keep: <elem>[] = []; let sum = 0; for (let j = 0; j < N; j++) sum +=
+/// keep[j].v` with an explicit set of module classes — the object-literal
+/// twin of [`element_shape_module`] (#7480 step 3).
+fn object_element_module(elem: Type, classes: Vec<Class>) -> Module {
+    let mut m = element_shape_module(
+        vec![accumulate_stmt(
+            SUM_ID,
+            ARRAY_ID,
+            Expr::LocalGet(COUNTER_ID),
+        )],
+        None,
+    );
+    m.classes = classes;
+    if let Some(Stmt::Let { ty, .. }) = m.init.first_mut() {
+        *ty = Type::Array(Box::new(elem));
+    }
+    m
+}
+
 fn emit(m: &Module) -> String {
     String::from_utf8(compile_module(m, ir_opts()).unwrap()).expect("LLVM IR should be UTF-8")
 }
@@ -220,17 +284,47 @@ fn block_slice<'a>(ir: &'a str, label: &str) -> &'a str {
     &body[..end]
 }
 
-/// The emitted text the fast clone owns: from its cond block to the slow
-/// clone's.
+/// Byte offset of the DEFINITION of block `label` — a line that begins at
+/// column 0 with `<label>` and ends in `:`. A bare `ir.find(label)` finds the
+/// `br label %<label>` reference instead, which is a different place entirely.
+fn block_def_offset(ir: &str, label: &str) -> Option<usize> {
+    let mut offset = 0usize;
+    for line in ir.split_inclusive('\n') {
+        if line.starts_with(label) && line.trim_end().ends_with(':') {
+            return Some(offset);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+/// The emitted text the fast clone owns: from the DEFINITION of its cond block
+/// to the definition of the slow clone's. Covers `for.element_shape_fast.*`
+/// and the `element_shape.load` block the field read branches into.
+///
+/// #7480 step 3 — ANTI-VACUITY. This used to slice from the first *substring*
+/// occurrence of `for.element_shape_fast.cond`, which is the
+/// `br label %for.element_shape_fast.cond.N` terminator of
+/// `element_shape.loop.fast.preheader`, three lines above the slow
+/// preheader's own branch. Every assertion made against the result is a
+/// NEGATIVE (`!fast.contains(" call ")`, `!fast.contains("js_array_get_f64")`,
+/// …), so that four-line stub satisfied all of them: the IR census that exists
+/// to prove the clone is really call-free had never been able to fail. The
+/// liveness assertion below is what makes it a gate — CLAUDE.md's "a gate must
+/// assert its subject was live".
 fn fast_clone_slice(ir: &str) -> &str {
-    let start = ir
-        .find("for.element_shape_fast.cond")
-        .expect("fast clone cond block");
-    let end = ir[start..]
-        .find("for.element_shape_slow.cond")
-        .map(|off| start + off)
-        .unwrap_or(ir.len());
-    &ir[start..end]
+    let start = block_def_offset(ir, "for.element_shape_fast.cond")
+        .expect("the fast clone's cond block should be DEFINED in the emitted IR");
+    let end = block_def_offset(ir, "for.element_shape_slow.cond").unwrap_or(ir.len());
+    assert!(end > start, "the fast clone must precede the slow clone");
+    let slice = &ir[start..end];
+    assert!(
+        slice.contains("for.element_shape_fast.body") && slice.contains("element_shape.load"),
+        "the fast-clone slice must contain the cloned BODY and its element \
+         load, otherwise every negative assertion against it is vacuous; \
+         sliced:\n{slice}"
+    );
+    slice
 }
 
 #[test]
@@ -503,6 +597,234 @@ fn the_repaired_head_is_written_back_to_the_binding() {
             l.starts_with("%rs4gc.b") && l.contains(&format!("bitcast double {refreshed} to i64"))
         }),
         "the value stored back must be the refreshed head {refreshed}; emitted:\n{repair}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #7480 step 3: OBJECT-LITERAL element types.
+//
+// `keep: {v: number, w: number}[]` is #7480's own kernel and the whole
+// measured gap — 414 ms against node's 12 on 200k x 50, where the named-class
+// arm the clone already covered is 13 ms. The literals allocate an
+// `__AnonShape_<hash>`, so a class id genuinely exists; the matcher resolves
+// it by matching the declared property order against the module's anon shapes.
+//
+// The two halves are NOT separable, which is why the assertions below are in
+// one test: with no resolvable class the accumulator also loses its numeric
+// proof, `sum += keep[j].v` lowers through `js_dynamic_string_or_number_add`,
+// and THAT CALL fails the clone's call-free admission — so a fix that resolved
+// the class without also restoring the numeric proof would emit a block of
+// dead fast-clone IR and change nothing.
+// ---------------------------------------------------------------------------
+
+const ANON_SHAPE_VW: &str = "__AnonShape_0000000000000abc";
+
+#[test]
+fn element_shape_versioned_loop_resolves_an_object_literal_element_type() {
+    let ir = emit(&object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], false),
+        vec![anon_shape_class(
+            311,
+            ANON_SHAPE_VW,
+            &[("v", Type::Number), ("w", Type::Number)],
+        )],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            ir.contains(label),
+            "#7480's own kernel (an object-literal element type) must reach the \
+             clone, but `{label}` is absent — the matcher declined"
+        );
+    }
+    // The guard must be pinned to the ANON SHAPE's keys global, not to some
+    // other class that happened to be in scope.
+    let deref = block_slice(&ir, "element_shape.loop.preheader.deref");
+    assert!(
+        deref.contains("AnonShape"),
+        "the preheader must load the anon shape's keys global; emitted:\n{deref}"
+    );
+
+    let fast = fast_clone_slice(&ir);
+    assert!(
+        !fast.contains(" call "),
+        "the fast clone must be call-free; found a call in:\n{fast}"
+    );
+    // The second half, and the reason the first half alone would be inert: the
+    // accumulate is a real `fadd`, not the BigInt-aware dynamic add helper.
+    assert!(
+        !fast.contains("js_dynamic_string_or_number_add"),
+        "the accumulator must regain its numeric proof inside the clone; \
+         emitted:\n{fast}"
+    );
+    assert!(
+        fast.contains("fadd"),
+        "the accumulate must lower to an fadd inside the clone; emitted:\n{fast}"
+    );
+}
+
+/// SABOTAGE (resolution): two anon shapes with the same field NAMES and
+/// incompatible field types are ambiguous. `ctx.classes` is a `HashMap`, so
+/// "pick whichever came first" would make the emitted code depend on iteration
+/// order; the resolver declines instead.
+#[test]
+fn element_shape_versioned_loop_declines_an_ambiguous_object_shape() {
+    let ir = emit(&object_element_module(
+        // `any` rules nothing out, so BOTH shapes below stay compatible and
+        // the tie cannot be broken.
+        object_element_type(&[("v", Type::Any), ("w", Type::Any)], false),
+        vec![
+            anon_shape_class(
+                311,
+                ANON_SHAPE_VW,
+                &[("v", Type::Number), ("w", Type::Number)],
+            ),
+            anon_shape_class(
+                312,
+                "__AnonShape_0000000000000def",
+                &[("v", Type::String), ("w", Type::String)],
+            ),
+        ],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            !ir.contains(label),
+            "an ambiguous object shape must not be cloned, but `{label}` was \
+             emitted — the pick would depend on HashMap iteration order"
+        );
+    }
+}
+
+/// A tie that field types CAN break is resolved rather than declined: only one
+/// of the two same-named shapes is numeric, and the declaration says `number`.
+#[test]
+fn element_shape_versioned_loop_breaks_a_tie_on_field_types() {
+    let ir = emit(&object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], false),
+        vec![
+            anon_shape_class(
+                311,
+                ANON_SHAPE_VW,
+                &[("v", Type::Number), ("w", Type::Number)],
+            ),
+            anon_shape_class(
+                312,
+                "__AnonShape_0000000000000def",
+                &[("v", Type::String), ("w", Type::String)],
+            ),
+        ],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            ir.contains(label),
+            "a type-disambiguated object shape should still be cloned, but \
+             `{label}` is absent"
+        );
+    }
+}
+
+/// SABOTAGE (closedness): an OPTIONAL property means the runtime object may
+/// not have that slot at all, so the declared order names no layout.
+#[test]
+fn element_shape_versioned_loop_declines_an_optional_property() {
+    let ir = emit(&object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], true),
+        vec![anon_shape_class(
+            311,
+            ANON_SHAPE_VW,
+            &[("v", Type::Number), ("w", Type::Number)],
+        )],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            !ir.contains(label),
+            "an optional property must not be cloned, but `{label}` was emitted"
+        );
+    }
+}
+
+/// SABOTAGE (no allocation site): an object type whose shape no literal in the
+/// module allocates has no class id to guard on. The declared type is a hint,
+/// and a hint with no referent must decline rather than invent one.
+#[test]
+fn element_shape_versioned_loop_declines_an_unallocated_object_shape() {
+    let ir = emit(&object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], false),
+        vec![anon_shape_class(
+            311,
+            ANON_SHAPE_VW,
+            &[("x", Type::Number), ("y", Type::Number)],
+        )],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            !ir.contains(label),
+            "an object shape with no matching anon class must not be cloned, \
+             but `{label}` was emitted"
+        );
+    }
+}
+
+/// SABOTAGE (field order): the anon shape's slot layout is SOURCE ORDER, so a
+/// same-named-but-reordered shape is a different layout. Matching it would
+/// read `w` where the loop asked for `v`.
+#[test]
+fn element_shape_versioned_loop_declines_a_reordered_object_shape() {
+    let ir = emit(&object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], false),
+        vec![anon_shape_class(
+            311,
+            ANON_SHAPE_VW,
+            &[("w", Type::Number), ("v", Type::Number)],
+        )],
+    ));
+    for label in CLONE_LABELS {
+        assert!(
+            !ir.contains(label),
+            "a reordered object shape must not be cloned, but `{label}` was \
+             emitted — its packed slot indices describe a different layout"
+        );
+    }
+}
+
+/// The object-literal resolution must not leak out of the matcher. A read of
+/// the same array OUTSIDE any element-shape loop still has no resolvable
+/// receiver class, which is the #6377 containment `receiver_class_name` was
+/// deliberately not widened for.
+#[test]
+fn object_literal_element_resolution_does_not_escape_the_clone() {
+    let mut m = object_element_module(
+        object_element_type(&[("v", Type::Number), ("w", Type::Number)], false),
+        vec![anon_shape_class(
+            311,
+            ANON_SHAPE_VW,
+            &[("v", Type::Number), ("w", Type::Number)],
+        )],
+    );
+    // A straight-line read after the loop, at a constant index.
+    m.init.push(Stmt::Expr(Expr::LocalSet(
+        SUM_ID,
+        Box::new(Expr::Binary {
+            op: BinaryOp::Add,
+            left: Box::new(Expr::LocalGet(SUM_ID)),
+            right: Box::new(elem_field(ARRAY_ID, Expr::Integer(0))),
+        }),
+    )));
+    let ir = emit(&m);
+    assert!(
+        ir.contains("element_shape.loop.fast.preheader"),
+        "the loop must still be cloned"
+    );
+    // Outside the clone the read keeps the generic by-name lowering. If the
+    // resolver had been wired into `receiver_class_name` instead, this read
+    // would have become a class-field diamond too — a change this PR did not
+    // measure.
+    let after = &ir[ir
+        .find("element_shape.loop.merge")
+        .expect("merge block should exist")..];
+    assert!(
+        after.contains("js_object_get_field_by_name_f64")
+            || after.contains("js_object_get_field_ic_miss"),
+        "the post-loop read must stay on the by-name path; emitted:\n{after}"
     );
 }
 

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -278,6 +278,25 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             if property == "length" && expression_has_numeric_length(ctx, object) {
                 return true;
             }
+            // repsel #7480 step 3: inside an element-shape fast clone a tracked
+            // `arr[i].field` read is a GUARD-PROVEN raw double — the preheader
+            // pinned the element class and the per-element residual check
+            // requires `GC_OBJ_TYPED_LAYOUT_INTACT`, so the slot cannot hold a
+            // NaN-boxed value. This is a stronger proof than the declared-type
+            // answer below, and it is the ONLY one available for an
+            // object-literal element type, whose owner class
+            // `receiver_class_name` deliberately does not resolve.
+            //
+            // It is also load-bearing rather than a bonus: without it
+            // `sum += keep[j].v` lowers through
+            // `js_dynamic_string_or_number_add`, that call fails the clone's
+            // call-free admission test, and the clone is never entered at all.
+            // Scoped to the clone — outside one the fact vector is empty.
+            if crate::expr::element_shape_loop_fact_for_property_get(ctx, object, property)
+                .is_some()
+            {
+                return true;
+            }
             if let Expr::LocalGet(id) = object.as_ref() {
                 if ctx
                     .scalar_replaced

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -460,48 +460,71 @@ already working, on a workload that happens to reach it through `JSON.parse`.
    `gc-rooting-invariant.md` records as having already shipped broken. Today's
    ~20 rooting bugs were all found by hand with `PERRY_GC_PROTECT_FROMSPACE`
    because nothing else can find them. This is the structural fix.
-6. **Repsel** — the element-shape invariant landed (#7496) and its
-   versioned-loop consumer landed (#7612, matrix #7608, corpus #7619). What
-   remains of #7480 is **element `Ptr<Shape>` for object-literal element
-   types**, and it is the whole measured gap, not a tail: #7612's
-   `element_class_name` resolves `Array(Named(C))` only, so #7480's own kernel
-   (`keep: {v,w}[]`) never reaches the clone. Re-measured 2026-08-08 on the
-   pinned quiet host, 200k elements × 50 sweeps, checksums equal, interleaved:
+6. ~~**Repsel — element `Ptr<Shape>` for object-literal element types**~~ —
+   **closed.** The element-shape invariant landed (#7496), its versioned-loop
+   consumer landed (#7612, matrix #7608, corpus #7619) and stopped SIGBUSing
+   (#7660); the last piece of #7480 was that `element_class_name` resolved
+   `Array(Named(C))` only, so #7480's own kernel (`keep: {v,w}[]`) never
+   reached the clone at all. Re-measured on the pinned quiet host, 200k
+   elements × 50 sweeps, 7 interleaved rounds, checksums equal across all four
+   runtimes, `rustc`/`cargo` at zero and 94.6–94.9% idle throughout:
 
-   | kernel | perry | node | bun | ratio |
+   | kernel | perry before | perry after | node | bun |
    |---|--:|--:|--:|--:|
-   | `keep: {v,w}[]` — #7480's kernel | 414 ms | 12 ms | 12 ms | **34.5×** |
-   | `keep: Node[]` — what #7612 covers | 13 ms‡ | 57 ms† | 15 ms | **0.23×** |
+   | `keep: {v,w}[]` — #7480's kernel | 408 ms | **12 ms** | 12 ms | 12 ms |
+   | `keep: Node[]` — what #7612 covered | 13 ms | 13 ms | 56 ms | 12 ms |
+   | region-local `{v,w}[]` (#7034 §3) | 15 ms | 14 ms | 12 ms | — |
 
-   **The issue's recorded 93 ms / 6.2× is stale and was optimistic** — the
-   fourth time a figure in this plan has gone stale, and the first in that
-   direction. Two traps in this one table, both of which cost time to find:
+   **34× on the object-literal arm, to parity with both engines**, and the
+   named-class arm is unchanged. The recorded 93 ms / 6.2× in the issue was
+   stale in the *optimistic* direction (the real figure was 34.5× node); its
+   cost model was wrong too, and the correction is the load-bearing part:
 
-   †Node is *slower* on the named-class arm than on the literal arm (57 vs
-   12 ms). `v: number;` cannot be erased by type stripping — without the
-   annotation it is still a valid class field declaration — so V8
-   pre-initialises the slot to `undefined`, pinning the field to tagged
-   representation. **"Beat node" is therefore a different number on the two
-   arms**; re-measure the arm you are gating on, in the same run.
+   **The two levers are not separable, and that is a property of the design,
+   not of this kernel.** #7480 recorded "no out-of-line guard calls, the cost
+   is stacked inline diamonds"; the object-literal arm actually carried three
+   calls per iteration, the third being `js_dynamic_string_or_number_add` —
+   with no resolvable class the accumulator loses its numeric proof, so `+` is
+   not an `fadd`. The plan called that "a second, separable lever". It is not
+   one: the clone is admitted only if it is provably call-free
+   (`LlBlock::contains_gc_unsafe_call`, which counts every non-`llvm.` call),
+   so a fix that resolved the element class WITHOUT also restoring the numeric
+   proof emits the clone, fails the call-free test, branches unconditionally to
+   the slow arm, and buys exactly zero at a cost in code size. Anything gated
+   on call-freeness has this shape: the enabling proof and the proof that makes
+   the body cheap are the same admission test.
 
-   ‡That cell did not exist before #7660: on `main` the named-class arm
-   *SIGBUSes*, because the versioned-loop consumer derived its elements base
-   from an unresolved growth-forwarding stub for any array grown outside the
-   scope that reads it. Step 2's win was real but gated behind a crash.
+   **What was deliberately NOT taken: `receiver_class_name` is unchanged.**
+   Widening it to type an `Object`-typed element read is the #6377 blast radius
+   #7612 refused, and it is not needed — the resolver lives in the matcher, and
+   the clone was made self-contained instead (its `ElementShapeLoopFact`
+   carries the class name and packed slot index, and the field lowering,
+   `is_numeric_expr` and the arithmetic-operand router all consult that fact).
+   So `keep[j].v` OUTSIDE an element-shape loop is byte-for-byte what it was.
+   The numeric claim inside the clone is stronger than the annotation it
+   replaces: the residual per-element check already proves
+   `GC_OBJ_TYPED_LAYOUT_INTACT`, i.e. that the slot holds a raw double.
 
-   The IR does not match the issue's recorded cost model either. #7480 says
-   the body has "no out-of-line guard calls, the cost is stacked inline
-   diamonds"; the object-literal arm actually carries **three calls per
-   iteration** — `js_typed_feedback_observe_property_get`,
-   `js_typed_feedback_record_guard_pass` (on the *hit* path) and
-   `js_dynamic_string_or_number_add`, because with no resolvable class the
-   field read falls into the by-name PIC tower and the accumulator loses its
-   numeric proof. That is a second, separable lever, and it is the kind of win
-   that gets misattributed to the element-shape work.
+   **What remains, and why it is a different ticket.** Route A proper — a
+   `Ptr<Shape>` element representation that survives outside a loop — is still
+   open for the parameter/global case. It needs the type-visibility change
+   above, with its own gap-suite A/B, and it should be scoped against the fact
+   that the region-local case is already covered: `collectors/ptr_shape_elements.rs`
+   (#7034 §3, E1–E5) puts that row at 14–15 ms with no work from this change.
+   Sequencing note carried from before: element reads are 13% of `churn`, so
+   against the bookkeeping levers this stays an RSS/footprint play more than a
+   time one — but the 34× above is the kernel, and it was real.
 
-   Sequencing note carried from before: element reads are 13% of `churn` at
-   4.3×, so against the bookkeeping levers this stays an RSS/footprint play
-   more than a time one — but the 34.5× above is the kernel, and it is real.
+   Method note for the next person: the IR census that proves the clone is
+   call-free had been **vacuous since #7612**. `fast_clone_slice` sliced from
+   the first *substring* match of `for.element_shape_fast.cond`, which is the
+   `br label %…` terminator of the fast preheader — four lines above the slow
+   preheader — and every assertion made against the result is a negative
+   (`!fast.contains(" call ")`). The slicer now finds the block DEFINITION and
+   asserts the slice contains the cloned body and its element load, so it
+   cannot pass on an empty subject again. Same family as #7024/#7025: the gate
+   ran, its subject did not.
+
 7. **Layer 1** — migrate remaining lowerings onto the rooted-combinator API
    (`crates/perry-codegen/src/rooting.rs`). **#7615 is the ordered worklist**:
    88 modules, 694 raw-pointer sites, 262 hazard sites, grouped into ten

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -99,10 +99,14 @@ dead 4b prototype flag). Next gap:
 homogeneous-element-shape invariant, construction-maintained, self-healing
 like 4a's dense bit), consumed first by the #5093 versioned-loop clone, then
 by element `Ptr<Shape>`. Prerequisite and consumer both landed (#7496, #7612);
-the consumer's growth-forwarding crash is #7660. **The element `Ptr<Shape>`
-half is still open and the kernel re-measures at 34.5× node, not the 6.2×
-#7480 recorded** — see backlog item 6 for the current table and for why the
-named-class arm's node baseline is not the literal arm's.
+the consumer's growth-forwarding crash is #7660, and the consumer now resolves
+**object-literal** element types too (#7669), which took #7480's own kernel
+from 34.5× node to **parity — 12 ms against node's 12 and bun's 12**. What
+remains is element `Ptr<Shape>` *outside* a loop, which needs the type
+visibility `receiver_class_name` deliberately still does not have; see backlog
+item 6 for the closing table, for why the named-class arm's node baseline is
+not the literal arm's, and for why the element-class proof and the
+accumulator's numeric proof are one lever rather than two.
 
 ### Object construction — the dominant cost (#7469 campaign)
 

--- a/test-files/test_gap_repsel_element_shape_loop_clone.ts
+++ b/test-files/test_gap_repsel_element_shape_loop_clone.ts
@@ -315,3 +315,187 @@ function fill(rows: Node[], n: number): void {
 const callerOwned: Node[] = [];
 fill(callerOwned, 40);
 console.log("grown-callee-filled:", sumField(callerOwned, callerOwned.length));
+
+// ---------------------------------------------------------------------------
+// 11. OBJECT-LITERAL element types (#7480 step 3). `keep: {v, w}[]` is #7480's
+//     own kernel: the literals allocate an `__AnonShape_<hash>`, so a class id
+//     exists, and the matcher resolves it by matching the declared property
+//     order against the module's anon shapes. Every hazard above applies here
+//     too, and two are specific to this arm:
+//
+//     * the resolution is a HINT — the preheader still compares the class id
+//       the runtime invariant reports, so a mis-resolved shape must cost the
+//       clone and never the answer;
+//     * the clone only exists because the accumulator also regains its numeric
+//       proof (an untyped `+` lowers to a call, which fails the clone's
+//       call-free admission), so a wrong numeric claim would show up here as a
+//       wrong SUM rather than as a crash.
+// ---------------------------------------------------------------------------
+type Row = { v: number; w: number };
+
+function sumRow(rows: Row[], n: number): number {
+  let sum = 0;
+  for (let j = 0; j < n; j++) {
+    sum += rows[j].v;
+  }
+  return sum;
+}
+
+// The same loop with an INLINE `.length` bound. The matcher only accepts an
+// integer literal or a local as the bound (`rows.length` is a `PropertyGet`),
+// so this shape gets no clone at all — which is exactly why it has to be here:
+// a kernel written the obvious way must still print the same number.
+function sumRowInlineBound(rows: Row[]): number {
+  let sum = 0;
+  for (let j = 0; j < rows.length; j++) {
+    sum += rows[j].v;
+  }
+  return sum;
+}
+
+function buildRowsLocal(n: number): Row[] {
+  const out: Row[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({ v: i, w: i * 2 });
+  }
+  return out;
+}
+
+// Built in the reading scope AND grown past MIN_ARRAY_CAPACITY.
+const rowsLocal: Row[] = [];
+for (let i = 0; i < 40; i++) {
+  rowsLocal.push({ v: i, w: i * 2 });
+}
+console.log("obj-hot:", sumRow(rowsLocal, rowsLocal.length));
+console.log("obj-hot-again:", sumRow(rowsLocal, rowsLocal.length));
+console.log("obj-inline-bound:", sumRowInlineBound(rowsLocal));
+
+// The #7660 stale-head shapes, on the object-literal arm.
+const rowsReturned = buildRowsLocal(40);
+console.log("obj-grown-callee-built:", sumRow(rowsReturned, rowsReturned.length));
+let objPrefix = 0;
+for (let j = 0; j < 17; j++) {
+  objPrefix += rowsReturned[j].v;
+}
+console.log("obj-grown-prefix-17:", objPrefix);
+
+function fillRows(rows: Row[], n: number): void {
+  for (let i = 0; i < n; i++) {
+    rows.push({ v: i, w: i * 3 });
+  }
+}
+const rowsCallerOwned: Row[] = [];
+fillRows(rowsCallerOwned, 40);
+console.log(
+  "obj-grown-callee-filled:",
+  sumRow(rowsCallerOwned, rowsCallerOwned.length),
+);
+
+// Empty, and a bound past the end.
+console.log("obj-empty:", sumRow([], 0));
+const rowsShort: Row[] = [{ v: 5, w: 5 }, { v: 6, w: 6 }];
+let objOver = "";
+for (let j = 0; j < 4; j++) {
+  const row = rowsShort[j] as Row | undefined;
+  objOver += row === undefined ? "_" : String(row.v);
+}
+console.log("obj-bound-past-length:", objOver);
+
+// Heterogeneous / revoked: no proof exists, or it is retired mid-loop.
+const rowsHetero: Row[] = [{ v: 1, w: 1 }, { v: 2, w: 2 }, { v: 3, w: 3 }];
+(rowsHetero as unknown as unknown[])[1] = 40;
+let objHetero = "";
+for (let j = 0; j < rowsHetero.length; j++) {
+  objHetero += String(rowsHetero[j].v) + ",";
+}
+console.log("obj-hetero:", objHetero);
+
+const rowsRevoked: Row[] = [];
+for (let i = 0; i < 20; i++) {
+  rowsRevoked.push({ v: i, w: i });
+}
+let objRevoked = "";
+for (let j = 0; j < rowsRevoked.length; j++) {
+  objRevoked += String(rowsRevoked[j].v) + ",";
+  if (j === 2) {
+    (rowsRevoked as unknown as unknown[])[9] = 100;
+  }
+}
+console.log("obj-mid-loop-store:", objRevoked);
+
+// Residual per-element hazards: layout downgrade, `delete`, own accessor.
+const rowsDown: Row[] = [];
+for (let i = 0; i < 20; i++) {
+  rowsDown.push({ v: i, w: i });
+}
+(rowsDown[3] as unknown as Record<string, unknown>).v = "nine";
+// Through the CLONE (local bound): the residual per-element check must side
+// exit on the downgraded element and the slow clone must re-run that
+// iteration, so the accumulator turns into a string exactly where JS says it
+// does. Through the generic path (inline `.length` bound) for contrast.
+console.log("obj-layout-downgrade:", sumRow(rowsDown, rowsDown.length));
+console.log("obj-layout-downgrade-generic:", sumRowInlineBound(rowsDown));
+
+const rowsDeleted: Row[] = [];
+for (let i = 0; i < 20; i++) {
+  rowsDeleted.push({ v: i, w: i });
+}
+delete (rowsDeleted[2] as unknown as Record<string, unknown>).w;
+console.log("obj-deleted-field:", sumRow(rowsDeleted, rowsDeleted.length));
+
+const rowsAccessor: Row[] = [];
+for (let i = 0; i < 20; i++) {
+  rowsAccessor.push({ v: i, w: i });
+}
+Object.defineProperty(rowsAccessor[4], "v", {
+  get() {
+    return 99;
+  },
+  configurable: true,
+});
+console.log("obj-own-accessor:", sumRow(rowsAccessor, rowsAccessor.length));
+
+// A SECOND anon shape with the same field NAMES but different field types.
+// The two shapes are distinct classes, so a resolver that picked the wrong one
+// would guard on a class id the array never reports — costing the clone, never
+// the answer. Both loops below must still print the right thing.
+type StrRow = { v: string; w: string };
+const strRows: StrRow[] = [];
+for (let i = 0; i < 20; i++) {
+  strRows.push({ v: String(i), w: String(i) });
+}
+let strOut = "";
+for (let j = 0; j < strRows.length; j++) {
+  strOut += strRows[j].v;
+}
+console.log("obj-same-names-string-shape:", strOut);
+console.log("obj-numeric-shape-after:", sumRow(rowsLocal, rowsLocal.length));
+
+// A shape whose reads mix a numeric and a non-numeric field: the matcher must
+// decline (the non-numeric field is not a raw-f64 candidate) and the answer
+// must be JavaScript's string concatenation, not an arithmetic add.
+type MixedRow = { n: number; s: string };
+const mixed: MixedRow[] = [];
+for (let i = 0; i < 20; i++) {
+  mixed.push({ n: i, s: "x" });
+}
+let mixedAcc = "";
+for (let j = 0; j < mixed.length; j++) {
+  mixedAcc += String(mixed[j].n) + mixed[j].s;
+}
+console.log("obj-mixed-fields:", mixedAcc);
+
+// A MODULE-LEVEL array read from inside a function — the module-global arm of
+// the preheader's growth-forwarding write-back (the array was grown by a
+// callee, so the global holds the pre-growth head on first read).
+const globalRows: Row[] = buildRowsLocal(40);
+
+function sumGlobalRows(n: number): number {
+  let sum = 0;
+  for (let j = 0; j < n; j++) {
+    sum += globalRows[j].w;
+  }
+  return sum;
+}
+console.log("obj-module-global:", sumGlobalRows(globalRows.length));
+console.log("obj-module-global-again:", sumGlobalRows(globalRows.length));

--- a/test-files/test_gap_repsel_element_shape_loop_clone.ts
+++ b/test-files/test_gap_repsel_element_shape_loop_clone.ts
@@ -436,12 +436,28 @@ for (let i = 0; i < 20; i++) {
 console.log("obj-layout-downgrade:", sumRow(rowsDown, rowsDown.length));
 console.log("obj-layout-downgrade-generic:", sumRowInlineBound(rowsDown));
 
+// Deleting a field the loop does NOT read still compacts the packed slots and
+// installs a fresh keys array, so the residual `keys_array` identity check is
+// the only thing between the clone and reading `w`'s old slot as `v`.
 const rowsDeleted: Row[] = [];
 for (let i = 0; i < 20; i++) {
   rowsDeleted.push({ v: i, w: i });
 }
 delete (rowsDeleted[2] as unknown as Record<string, unknown>).w;
 console.log("obj-deleted-field:", sumRow(rowsDeleted, rowsDeleted.length));
+
+// Deleting the field the loop DOES read: the element must read `undefined`,
+// so the sum is NaN rather than a slot load of whatever compacted into
+// index 0.
+const rowsDeletedRead: Row[] = [];
+for (let i = 0; i < 20; i++) {
+  rowsDeletedRead.push({ v: i, w: i });
+}
+delete (rowsDeletedRead[2] as unknown as Record<string, unknown>).v;
+console.log(
+  "obj-deleted-read-field:",
+  sumRow(rowsDeletedRead, rowsDeletedRead.length),
+);
 
 const rowsAccessor: Row[] = [];
 for (let i = 0; i < 20; i++) {


### PR DESCRIPTION
Closes the last piece of #7480 and `docs/engine-plan.md` item 6: **element
`Ptr<Shape>` for object-literal element types**.

## Measured

Pinned quiet mini, release, 7 interleaved rounds, 200k elements x 50 sweeps,
runtime-derived bounds, checksums equal in every cell, `rustc`/`cargo` at zero
and 94.6–94.9% idle before and after.

| kernel | perry before | perry after | node | bun |
|---|--:|--:|--:|--:|
| `keep: {v, w}[]` — #7480's own kernel | 408 ms | **12 ms** | 12 ms | 12 ms |
| `keep: Node[]` — what #7612 covered | 13 ms | 13 ms | 56 ms | 12 ms |
| region-local `{v, w}[]` (#7034 §3, E1–E5) | 15 ms | 14 ms | 12 ms | — |

**34x on the object-literal arm, to parity with both engines.** The
named-class arm is unchanged, and so is the region-local arm — that one was
already covered by `collectors/ptr_shape_elements.rs`, which is why this
change extends the versioned-loop consumer (the parameter/global case) rather
than that pass.

Both arms link **byte-identical** `libperry_runtime.a` / `libperry_stdlib.a`
(sha256 equal), so this is a codegen-only change and the meaningful control is
the emitted IR, below.

## What changed

`stmt/element_shape_loop.rs::element_class_name` resolved `Array(Named(C))`
only. It now also resolves a declared object type to the `__AnonShape_<hash>`
class its literals allocate, by matching the declared property order against
the module's anon shapes. The hash cannot be recomputed — `mint_anon_shape_class`
keys it on the literal's *inferred value* types (`{v: 1}` tags `i`, not `n`)
while the annotation says `number` — so the class is found, not derived.
Ambiguity **declines** rather than guessing, because `ctx.classes` is a
`HashMap` and "first match wins" would make the emitted code depend on
iteration order.

`receiver_class_name` is **not** widened. That is the #6377 blast radius #7612
deliberately refused; instead the clone is made self-contained. Its
`ElementShapeLoopFact` already carried the class name and packed slot index, so
the three sites that would otherwise re-derive the class from the receiver now
go through one predicate,
`expr::element_shape_loop_fact_for_property_get`:

* `lower_raw_f64_class_field_get_for_number_context` — the interception moved
  **above** the `receiver_class_name` gate;
* `type_analysis::is_numeric_expr`'s `PropertyGet` arm;
* `expr::binary`'s arithmetic-operand router (as a disjunct, rather than by
  widening `expr_may_return_boxed_value_from_raw_f64_fallback`, which would
  have been a lie — this read has no boxed fallback).

All three are scoped to the fast clone: outside one the fact vector is empty,
so `keep[j].v` anywhere else is byte-for-byte what it was.

## The issue's cost model was wrong, and the correction is load-bearing

#7480 records "no out-of-line guard *calls*, the cost is stacked inline
diamonds". The object-literal arm actually carried **three calls per
iteration**, the third being `js_dynamic_string_or_number_add`: with no
resolvable class the accumulator loses its numeric proof, so `+` is not an
`fadd`. The plan called that "a second, separable lever".

**It is not separable.** The clone is admitted only if it is provably
call-free (`LlBlock::contains_gc_unsafe_call` counts every non-`llvm.` call),
so resolving the element class *without* restoring the numeric proof emits the
clone, fails the call-free test, branches unconditionally to the slow arm and
buys exactly zero at a cost in code size. Both had to land together, and the
numeric claim inside the clone is stronger than the annotation it replaces:
the residual per-element check already proves `GC_OBJ_TYPED_LAYOUT_INTACT`,
i.e. that the slot holds a raw double.

### IR evidence (`--trace llvm`, release, `PERRY_NO_AUTO_OPTIMIZE=1`)

`sweep`, object-literal kernel, before — no clone at all, zero `fadd`:

```
js_typed_feedback_observe_property_get, js_typed_feedback_record_guard_pass,
js_dynamic_string_or_number_add, js_object_get_field_by_name_f64 x2,
js_object_get_field_ic_miss, ...           element_shape blocks: 0   fadd: 0
```

After — the fast clone is `gep` + load, a three-load residual check, `fadd`:

```
for.element_shape_fast.body:  gep/load elem, hdr mask+cmp, field_count cmp,
                              keys_array cmp, one branch
element_shape.load:           gep + load double + fadd double
FAST CLONE calls: []          FAST CLONE fadd: 1
```

The remaining calls in the function are the preheader's
(`js_array_refresh_local_head`, `js_array_ensure_element_shape`) and the slow
clone's, which is unchanged.

## Correctness against the #7660 shape

Every new gap case that reads a `{v, w}[]` crosses `MIN_ARRAY_CAPACITY`, so the
growth-forwarding stub the #7660 repair exists for is live on this arm too:
callee-built-and-returned, callee-filled-caller-owned, a 17-element prefix, and
a module-global array read from inside a function (the write-back's
`module_globals` arm). No new preheader or base derivation was added — the
element-shape preheader is the one #7660 fixed, unchanged.

The gap test also pins the hazards specific to this arm:

* an inline `rows.length` bound, which the matcher **rejects** (it is a
  `PropertyGet`, not an `Integer`/`LocalGet`), so a kernel written the obvious
  way gets no clone and must still print the same number;
* a layout downgrade under the clone, so the residual check's side exit
  re-runs the current iteration and the accumulator turns into a string exactly
  where JS says it does;
* two anon shapes sharing field names (`{v: number, w: number}` vs
  `{v: string, w: string}`), so a mis-resolved shape would cost the clone and
  never the answer;
* a mixed numeric/string shape the matcher must decline.

`test_gap_repsel_element_shape_loop_clone` is byte-identical to the Node 26.5.1
oracle on **both** arms, and an IR census confirms the new sections are live:
`sumRow`, `sumRow$spec_b_i32` and `sumGlobalRows` gain the clone, where on
`main` only `sumField` and `main` had it.

## An existing gate that could not fail

`fast_clone_slice` in `element_shape_loop_tests.rs` sliced from the first
*substring* occurrence of `for.element_shape_fast.cond` — which is the
`br label %…` terminator of the fast preheader, four lines above the slow
preheader — and every assertion made against the result is a negative
(`!fast.contains(" call ")`, `!fast.contains("js_array_get_f64")`, …). So the
IR census that exists to prove the clone is call-free had been **vacuous since
#7612**, on the code that then shipped a SIGBUS. It now finds the block
*definition* and asserts the slice contains the cloned body and its element
load, so it cannot pass on an empty subject again. Same family as #7024/#7025:
the gate ran, its subject did not.

## Tests

`crates/perry-codegen/src/stmt/element_shape_loop_tests.rs`, 7 new (17 total in
the module, all green). One positive — #7480's kernel reaches the clone, the
clone is call-free, and the accumulate is an `fadd` (the two halves asserted
together, because either alone is inert) — and six sabotage cases: an ambiguous
shape, a shape a field-type tie *can* break, an optional property, a shape no
literal allocates, a reordered shape, and a read outside the clone that must
stay on the by-name path.

## Gates

Run on the pinned mini against this branch (`628db10e3`), each command's own
exit code, never a downstream `tail`'s.

| gate | result |
|---|---|
| `lint`'s extracted commands | **22 extracted, 22 ran, 0 failed** |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo check --all-targets` | exit 0 |
| `cargo test -p perry-codegen --lib --no-fail-fast` | exit 0 — 748 passed, 0 failed |
| `cargo test -p perry-runtime --lib --no-fail-fast` | exit 0 — 1917 passed, 0 failed, 4 ignored |
| `native_root_coverage` | exit 0 — **14** tests |
| dominance `--moving-only --seeded-violations 40` | exit 0 — 149 modules, 40/40 seeded caught |
| dominance `--statepoints --moving-only` | exit 1 — **and identically on `origin/main`**, see below |
| gap suite (506 tests) | 490 pass / 15 parity_fail / 1 compile_fail — 12 snapshot divergences, **none attributable**, see below |

Zero `error[` in any build log; `Running unittests` present in each test log.

### The `--statepoints` arm is red on `main`, not on this branch

`--max-unrooted 21` reads **22** here. It reads **22 on `origin/main`
(3beef03b3) in the same session, on the same host, with the same corpus** — and
the 22 reported fingerprints are a **byte-identical set** between the two arms
(`diff` clean). So this change neither adds nor removes a hazard; the budget is
simply one over on `main` today, which is what open PR #7667
(`gc/7664-native-lowering-unrooted-hazards`) addresses. The seeded control
passed in both arms (40 planted, 40 caught, 0 missed), so the checker was live
for both readings.

### Gap-suite divergences from `test-parity/gap_snapshot.json`

506 tests: 490 pass, 15 parity_fail, 1 compile_fail. The harness reports 12
divergences from the committed snapshot — 1 regression
(`test_gap_zlib_4917_level: pass -> compile_fail`), 10 status changes
(`node_fail -> parity_fail`) and 1 improvement
(`test_gap_iterator_helpers_2874: parity_fail -> pass`).

**None is attributable to this change**, and that is measured rather than
argued. Every one of the 17 tests involved was compiled and run under **both**
arms: Perry's bytes are identical in all 17 (`TESTED=17 SAME=17 DIFFERENT=0`).

* `test_gap_zlib_4917_level` is the known host-local zlib link flake: compiled
  directly with either arm's binary it exits 0 and prints the right output,
  with and without auto-optimize. The failure lives in the harness's own
  auto-optimized relink on this host.
* The 10 `node_fail -> parity_fail` moves are all oracle-side classification
  (node still refuses e.g. `test_gap_4510_enum_forward_ref` with
  `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`, exactly as its snapshot entry records) —
  a Perry-independent axis.

### Blast radius, measured

The change can only alter code inside an element-shape fast clone, so "which
files gain one" is the blast radius. Compiling with both arms and counting
`element_shape.loop.fast.preheader` sites:

* 43 assorted `test_gap_*` files: **zero clones in either arm**, zero
  compile-status differences — the change is inert there;
* 25 `test_gap_repsel_*` / `test_gap_specabi_*` files: exactly **one** file
  changes, `test_gap_repsel_element_shape_loop_clone`, **2 -> 6** clone sites.
  That file is the liveness control — a census that reports "no change" over a
  corpus with zero clones in both arms proves nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved optimized processing of numeric fields in homogeneous array loops.
  * Added support for safely optimizing compatible object-literal element types.
  * Preserved efficient fallback behavior for ambiguous, heterogeneous, or unsupported data.

* **Bug Fixes**
  * Improved handling of array growth, bounds, deleted fields, accessors, and changing element layouts.
  * Fixed validation of optimized loop regions.

* **Documentation**
  * Documented the completed element-shape optimization work and benchmark improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->