### PR TITLE
fix(test-isolation): the stream constructor tests read a side table the GC guards clear

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1380
+**Current Version:** 0.5.1381
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1380"
+version = "0.5.1381"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1380"
+version = "0.5.1381"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1380"
+version = "0.5.1381"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1380"
+version = "0.5.1381"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1380"
+version = "0.5.1381"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7671-stream-static-methods-side-table-race.md
+++ b/changelog.d/7671-stream-static-methods-side-table-race.md
@@ -1,0 +1,17 @@
+**`fix(test-isolation)`: the stream constructor tests read a side table the GC guards clear.**
+
+`stream_constructors_expose_static_method_values` asserts a static method value is not `TAG_UNDEFINED`, and intermittently it was — `assertion left != right failed, left: 9222246136947933185, right: 9222246136947933185`, i.e. both sides `0x7FFC_0000_0000_0001`.
+
+`CLOSURE_PROPS` is a **process-global `Mutex<HashMap<usize, HashMap<String, f64>>>`** keyed by closure address, and the GC test guards' state reset (`test_clear_closure_side_tables`) clears it from whatever thread runs them. `gc/tests/support.rs` documents this in its own comment, and three tests in `closure/dynamic_props.rs` already take `crate::gc::global_side_table_test_lock()` for exactly this reason. The two `native_module_stream` tests did not.
+
+0/16 on `main`, 1/12 on #7664's branch — the third time in two days that a branch has *exposed* a pre-existing global-sink race by changing the parallel schedule rather than introducing one (#7665 fixed the other two: `opt_report` and `ext_registry`). Verified 0/20 after.
+
+**The class is wider than this fix.** A survey of files that read closure dynamic props in tests:
+
+| guarded | file |
+|---|---|
+| 3 of 4 | `closure/dynamic_props.rs` |
+| 2 of 9 | `object/global_this_webassembly.rs` |
+| **0** | `array/tests.rs` (65), `node_stream_tests.rs` (42), `node_submodules/tests.rs` (33), `object/instanceof.rs` (5), `value/to_string.rs` (4), `object/native_module/constants.rs` (4), and ~14 more |
+
+Blanket-locking several hundred tests would serialise a large part of the suite for a hazard that only bites a test reading a *persisted* prop across a window, so this change fixes the observed instance and the exposure is filed with the survey rather than guessed at.

--- a/crates/perry-runtime/src/object/native_module_stream.rs
+++ b/crates/perry-runtime/src/object/native_module_stream.rs
@@ -267,6 +267,11 @@ mod tests {
 
     #[test]
     fn legacy_stream_prototype_is_event_emitter_instanceof_candidate() {
+        // CLOSURE_PROPS is PROCESS-global and the gc test guards' state reset
+        // (`test_clear_closure_side_tables`) clears it from parallel test
+        // threads, so a static method value read here comes back
+        // TAG_UNDEFINED. Serialize against those guards.
+        let _global = crate::gc::global_side_table_test_lock();
         let stream_ctor = bound_native_callable_export_value("stream", "Stream");
         let stream_ptr = (stream_ctor.to_bits() & crate::value::POINTER_MASK) as usize;
         let stream_proto = crate::closure::closure_get_dynamic_prop(stream_ptr, "prototype");
@@ -285,6 +290,11 @@ mod tests {
 
     #[test]
     fn stream_constructors_expose_static_method_values() {
+        // CLOSURE_PROPS is PROCESS-global and the gc test guards' state reset
+        // (`test_clear_closure_side_tables`) clears it from parallel test
+        // threads, so a static method value read here comes back
+        // TAG_UNDEFINED. Serialize against those guards.
+        let _global = crate::gc::global_side_table_test_lock();
         let readable = bound_native_callable_export_value("stream", "Readable");
         let writable = bound_native_callable_export_value("stream", "Writable");
         let duplex = bound_native_callable_export_value("stream", "Duplex");


### PR DESCRIPTION
**`fix(test-isolation)`: the stream constructor tests read a side table the GC guards clear.**

`stream_constructors_expose_static_method_values` asserts a static method value is not `TAG_UNDEFINED`, and intermittently it was — `assertion left != right failed, left: 9222246136947933185, right: 9222246136947933185`, i.e. both sides `0x7FFC_0000_0000_0001`.

`CLOSURE_PROPS` is a **process-global `Mutex<HashMap<usize, HashMap<String, f64>>>`** keyed by closure address, and the GC test guards' state reset (`test_clear_closure_side_tables`) clears it from whatever thread runs them. `gc/tests/support.rs` documents this in its own comment, and three tests in `closure/dynamic_props.rs` already take `crate::gc::global_side_table_test_lock()` for exactly this reason. The two `native_module_stream` tests did not.

0/16 on `main`, 1/12 on #7664's branch — the third time in two days that a branch has *exposed* a pre-existing global-sink race by changing the parallel schedule rather than introducing one (#7665 fixed the other two: `opt_report` and `ext_registry`). Verified 0/20 after.

**The class is wider than this fix.** A survey of files that read closure dynamic props in tests:

| guarded | file |
|---|---|
| 3 of 4 | `closure/dynamic_props.rs` |
| 2 of 9 | `object/global_this_webassembly.rs` |
| **0** | `array/tests.rs` (65), `node_stream_tests.rs` (42), `node_submodules/tests.rs` (33), `object/instanceof.rs` (5), `value/to_string.rs` (4), `object/native_module/constants.rs` (4), and ~14 more |

Blanket-locking several hundred tests would serialise a large part of the suite for a hazard that only bites a test reading a *persisted* prop across a window, so this change fixes the observed instance and the exposure is filed with the survey rather than guessed at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an intermittent test race that could cause stream static method lookups to return `undefined`.
  * Improved test isolation when garbage-collection checks run concurrently.

* **Documentation**
  * Added a changelog entry describing the resolved stream test race.

* **Chores**
  * Updated the application version from 0.5.1380 to 0.5.1381.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->