### PR TITLE
fix(gc): root the JSON.stringify shape template's three raw pointers (#7268)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1393
+**Current Version:** 0.5.1394
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1393"
+version = "0.5.1394"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1393"
+version = "0.5.1394"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1393"
+version = "0.5.1394"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1393"
+version = "0.5.1394"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1393"
+version = "0.5.1394"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7694-json-shape-template-rooting.md
+++ b/changelog.d/7694-json-shape-template-rooting.md
@@ -1,0 +1,41 @@
+### Fixed
+
+- **`JSON.stringify`'s shape template no longer reads its element through a
+  pre-collection address (#7268).** `try_emit_shape_element` derived the element
+  header and its inline `fields_ptr` once, then looped over the fields calling
+  `stringify_value_depth` for the pointer-valued ones — a call that can run a user
+  `toJSON`, allocate, reach a safepoint and take an evacuating minor with it. Three
+  holders were exposed: the bare `elem_ptr`/`fields_ptr` locals, the template's raw
+  `keys_arr` (used as the shape identity *and* dereferenced to read the
+  property-name strings back out), and `SHAPE_CACHE` itself — whose doc comment
+  asserted the invariant that made the last two safe, *"within one top-level
+  stringify call no GC runs over the user object graph"*. `toJSON` is user JS; the
+  invariant is false, and the comment now says so instead of asserting it.
+
+  All three are closed, because rooting any one leaves the others. In particular
+  rooting the cache is **not** sufficient: `stringify_array_depth` builds its
+  template into a plain `Option<ShapeTemplate>` Rust local that no scanner can see.
+  So `try_emit_shape_element` roots the element (re-deriving `fields_ptr` on every
+  access, the `cur_obj()` pattern `stringify_object_inner` already used) *and* roots
+  `template.keys_arr`, writing the refreshed address back; and `SHAPE_CACHE` is
+  visited by the already-registered `json_parse_mutable_root_scanner`, marked and
+  rewritten on every frame.
+
+  Two supporting changes each remove a way for the fix to be undone. `keys_arr`
+  becomes a `Cell`: `try_emit_shape_element` holds `&ShapeTemplate` across the
+  collection, and behind a shared reference the field is `noalias` and immutable to
+  LLVM, so the post-call read could legally have been folded into the pre-call one
+  — the fix would have compiled away. And reentrancy save/restore now pushes and
+  pops a *frame* instead of `mem::take`ing the cache into a Rust local, where it sat
+  outside the collector's reach for the whole of the inner call — the call that runs
+  `toJSON`. The duplicated tuple key (`Vec<(*mut ArrayHeader, Box<ShapeTemplate>)>`
+  stored the same pointer twice) is gone; one copy cannot drift from itself.
+
+  Witness: `gc/tests/runtime_roots/json_shape_template.rs`, knob-free. A `Date`
+  field is enough to reach the window — `stringify_value_depth`'s
+  `is_date_cell_addr` branch calls `js_date_to_json`, which allocates — so no
+  closure plumbing or `.ts` witness is needed. Probe shape
+  `{ when: Date, answer: 42, also: Date }`, and the order is load-bearing.
+  Sabotage-verified both halves; hoisting `fields_ptr` back above the loop produces
+  `"answer":42.000010751275454` and the wrong ISO string for `also` — **silent data
+  corruption, not a crash**, which is what shipped.

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -6,6 +6,7 @@ mod generator_attach_prototype;
 mod hook_dispatch_handles;
 mod interned_string_caches;
 mod iter_result_keys;
+mod json_shape_template;
 mod prototype_addr_cache;
 mod side_table_scanners;
 mod string_slice;

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/json_shape_template.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/json_shape_template.rs
@@ -1,0 +1,210 @@
+//! #7268 — `JSON.stringify`'s homogeneous-array shape template held three raw
+//! heap pointers across a collection point, and the collection point is user
+//! code.
+//!
+//! `json/stringify_shape_template.rs::try_emit_shape_element` derived the
+//! element header and its inline `fields_ptr` **once**, then looped over the
+//! fields calling `stringify_value_depth` for the pointer-valued ones. That
+//! call can run a user `toJSON`, allocate, and take an evacuating minor with
+//! it. Three holders were exposed:
+//!
+//!   1. `elem_ptr` / `fields_ptr` — a bare Rust local, so every later
+//!      `fields_ptr.add(f)` read a forwarded or swept address;
+//!   2. `ShapeTemplate::keys_arr` — the raw `ArrayHeader*` used as the shape
+//!      identity AND dereferenced by `set_to_json_key_for_template_field` to
+//!      read the property-name strings back out;
+//!   3. `SHAPE_CACHE` itself, whose doc comment asserted the invariant that
+//!      made (2) safe — *"within one top-level stringify call no GC runs over
+//!      the user object graph"* — which `toJSON` falsifies.
+//!
+//! ## The collection point needs no user JS to reach
+//!
+//! A `Date` field is enough: `stringify_value_depth`'s `is_date_cell_addr`
+//! branch calls `js_date_to_json`, which **allocates a `StringHeader`**. That
+//! makes the hazard reachable from a pure-runtime unit test — no closure
+//! plumbing, no `.ts` witness, no knob. The issue's suggested shape (a later
+//! element carrying an allocating `toJSON`) is the same window reached the hard
+//! way.
+//!
+//! ## Element order is load-bearing
+//!
+//! The probe object is `{ when: Date, answer: 42, also: Date }`. `when` is the
+//! allocation; `answer` is read from `fields_ptr` AFTER it (hazard 1); `also`
+//! runs `set_to_json_key_for_template_field`, which dereferences `keys_arr`,
+//! after it (hazard 2). A two-field object would exercise neither.
+
+use super::*;
+
+/// `{ when: <date>, answer: 42, also: <date> }` — see the module header for why
+/// this exact shape.
+///
+/// Built under suppressed triggers: `js_object_set_field_by_name` allocates the
+/// keys array and each `alloc_date_cell` allocates, and a collection landing
+/// there would move `obj` — a bare local here — out from under the setup.
+unsafe fn probe_object(_trigger_guard: &GcTriggerThresholdTestGuard) -> *mut crate::ObjectHeader {
+    let obj = crate::object::js_object_alloc(0, 3);
+    let when = crate::date::alloc_date_cell(0.0);
+    let also = crate::date::alloc_date_cell(86_400_000.0);
+    let when_key = crate::string::js_string_from_bytes(b"when".as_ptr(), 4);
+    crate::object::js_object_set_field_by_name(obj, when_key, when);
+    let answer_key = crate::string::js_string_from_bytes(b"answer".as_ptr(), 6);
+    crate::object::js_object_set_field_by_name(obj, answer_key, 42.0);
+    let also_key = crate::string::js_string_from_bytes(b"also".as_ptr(), 4);
+    crate::object::js_object_set_field_by_name(obj, also_key, also);
+    obj
+}
+
+fn string_contents(ptr: *const crate::StringHeader) -> String {
+    unsafe {
+        let len = (*ptr).byte_len as usize;
+        let data = (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+    }
+}
+
+/// The end-to-end witness. An array of two same-shape objects goes through the
+/// template emit path; the `Date` in field 0 of each element allocates, the
+/// armed trigger turns that allocation into an evacuating minor, and fields 1
+/// and 2 must still read correctly afterwards.
+///
+/// Note which template this exercises: `stringify_array_depth` builds its
+/// template into a plain `Option<ShapeTemplate>` **Rust local**, not into
+/// `SHAPE_CACHE`. No root scanner can ever see that one — which is why the fix
+/// roots `keys_arr` inside `try_emit_shape_element` rather than relying on the
+/// cache scanner alone. The cache scanner is covered by the sibling test below.
+#[test]
+fn shape_template_element_survives_the_date_field_allocation() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+    crate::json::test_clear_parse_roots();
+
+    let (arr_bits, expected) = unsafe {
+        let a = probe_object(&trigger_guard);
+        let b = probe_object(&trigger_guard);
+        let arr = crate::array::js_array_alloc(2);
+        let arr = crate::array::js_array_push_f64(arr, f64::from_bits(ptr_bits(a as usize)));
+        let arr = crate::array::js_array_push_f64(arr, f64::from_bits(ptr_bits(b as usize)));
+
+        // Establish the expected bytes with NO collection in flight, so the
+        // assertion below compares against this build's own rendering rather
+        // than a hard-coded ISO string that a date-formatting change would
+        // silently invalidate.
+        let baseline = crate::json::js_json_stringify(f64::from_bits(ptr_bits(arr as usize)), 0);
+        (ptr_bits(arr as usize), string_contents(baseline))
+    };
+    assert!(
+        expected.contains("\"answer\":42"),
+        "the probe never reached the template emit path (got {expected}) — \
+         without `answer` in the output this test proves nothing"
+    );
+
+    // Liveness witness: a rooted sentinel must relocate, or the cycle below
+    // moved nothing and a green result is meaningless.
+    let sentinel_scope = RuntimeHandleScope::new();
+    let sentinel = sentinel_scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
+    let sentinel_before = sentinel.get_raw_mut_ptr::<crate::object::ObjectHeader>() as usize;
+
+    // Keep the array reachable across the collection the way generated code
+    // would, so the SUBJECT of the test is the template path's own rooting and
+    // not the caller's.
+    let arr_scope = RuntimeHandleScope::new();
+    let arr_root = arr_scope.root_nanbox_u64(arr_bits);
+
+    force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+    let before = gc_collection_count();
+
+    let out = unsafe { crate::json::js_json_stringify(arr_root.get_nanbox_f64(), 0) };
+    let out_scope = RuntimeHandleScope::new();
+    let out_root = out_scope.root_string_ptr(out);
+    drain_scheduled_minor_gc(before, "Date field stringification");
+    let actual = string_contents(out_root.get_raw_const_ptr::<crate::StringHeader>());
+
+    assert_ne!(
+        sentinel.get_raw_mut_ptr::<crate::object::ObjectHeader>() as usize,
+        sentinel_before,
+        "the minor did not evacuate — nothing here was exercised"
+    );
+    assert_eq!(
+        actual, expected,
+        "the shape-template emit path read a field through an address it \
+         computed BEFORE the Date allocation collected"
+    );
+}
+
+/// The cache half. `SHAPE_CACHE` is a registered GC root now
+/// (`json::scan_parse_roots_mut`), and both halves have to hold: MARKING keeps
+/// the keys array off the sweep list, and REWRITING keeps the identity key —
+/// and the property-name strings read out of it — pointing at the object rather
+/// than at whatever gets recycled into the from-space address.
+///
+/// A scanner a test calls directly is a no-op in production until `gc_init`
+/// names it, so registration is asserted too.
+#[test]
+fn stringify_shape_cache_keys_array_is_marked_and_rewritten() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    crate::json::test_clear_parse_roots();
+
+    clear_marks();
+    clear_mark_seeds();
+
+    let keys_arr = unsafe {
+        let obj = crate::object::js_object_alloc(0, 1);
+        let key = crate::string::js_string_from_bytes(b"id".as_ptr(), 2);
+        crate::object::js_object_set_field_by_name(obj, key, 1.0);
+        let keys = (*obj).keys_array;
+        assert!(!keys.is_null(), "probe object must have a keys array");
+        assert!(
+            crate::arena::pointer_in_nursery(keys as usize),
+            "the keys array must be movable or the rewrite half tests nothing"
+        );
+        crate::json::test_seed_stringify_shape_cache(keys);
+        keys
+    };
+
+    // MARK. The cache is a root, so a live cache entry must survive a cycle
+    // that has no other reference to the keys array.
+    let valid_ptrs = build_valid_pointer_set();
+    crate::json::scan_parse_roots_mut(&mut RuntimeRootVisitor::for_mark(&valid_ptrs));
+    assert_marked_user_ptr(keys_arr as usize, "shape-cache keys array");
+
+    // REWRITE. Marking alone is not enough: an un-rewritten cache hands out a
+    // pre-move address forever, which is the whole failure.
+    let moved = unsafe {
+        let to = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_ARRAY);
+        set_forwarding_address(header_from_user_ptr(keys_arr as *const u8), to);
+        to as usize
+    };
+    crate::json::scan_parse_roots_mut(&mut RuntimeRootVisitor::for_rewrite(&valid_ptrs));
+    assert_eq!(
+        crate::json::test_stringify_shape_cache_keys(),
+        vec![moved],
+        "scan_parse_roots_mut must rewrite SHAPE_CACHE's keys_array through \
+         the forwarding address"
+    );
+
+    crate::json::test_clear_parse_roots();
+}
+
+/// A scanner that is not in the registry is documentation. `scan_parse_roots_mut`
+/// rides on the registered `json_parse_mutable_root_scanner`; this asserts the
+/// shape cache is covered by a REGISTERED scanner rather than by one only this
+/// file calls.
+#[test]
+fn stringify_shape_cache_scanner_is_registered() {
+    crate::gc::gc_init();
+    let registered = crate::gc::roots::MUTABLE_ROOT_SCANNERS.with(|scanners| {
+        scanners.borrow().iter().any(|entry| {
+            entry.scanner as usize
+                == crate::gc::roots::json_parse_mutable_root_scanner as MutableRootScanner as usize
+        })
+    });
+    assert!(
+        registered,
+        "json_parse_mutable_root_scanner (which owns SHAPE_CACHE since #7268) \
+         is not in the mutable root scanner registry — the cache would be \
+         unrooted in production no matter what the scanner body says"
+    );
+}

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -89,19 +89,43 @@ thread_local! {
     pub(crate) static STRINGIFY_BUF: std::cell::Cell<Option<String>> =
         std::cell::Cell::new(Some(String::with_capacity(4096)));
 
-    /// Per-call shape-template cache (#64 follow-up). Keys on `keys_array`
-    /// raw pointer — within one top-level stringify call no GC runs over
-    /// the user object graph (the buffer/result allocations don't move
-    /// keys arrays), so pointer identity is a stable shape ID. Cleared
-    /// (saved+restored) at the entry of each `js_json_stringify` /
-    /// `js_json_stringify_full` / `..with_replacer` call so reentrant
-    /// `toJSON` callbacks don't return stale templates.
+    /// Per-call shape-template cache (#64 follow-up), as a STACK of frames.
+    /// Each template is keyed on its `keys_array` raw pointer, which is a
+    /// **GC-managed `ArrayHeader*`** — so `scan_parse_roots_mut` visits every
+    /// frame's every key as a real (marking AND rewriting) root.
+    ///
+    /// ★ #7268: this comment used to assert the invariant that made the raw
+    /// key safe —
+    ///
+    /// > within one top-level stringify call no GC runs over the user object
+    /// > graph (the buffer/result allocations don't move keys arrays), so
+    /// > pointer identity is a stable shape ID
+    ///
+    /// — and `toJSON` falsifies it. A `toJSON` is user JS: it allocates, it
+    /// can reach a safepoint, and the minor there is evacuating. A stale key
+    /// then either misses (merely slow) or, worse, **collides with a
+    /// newly-allocated array at the recycled address and matches the wrong
+    /// shape**; and `set_to_json_key_for_template_field` reads the property
+    /// NAME strings out of `keys_arr`, i.e. dereferences retired from-space.
+    ///
+    /// ★ Why a stack rather than a moved-out `Vec`. Reentrancy used to be
+    /// handled by `take_shape_cache()` moving the whole cache into a Rust
+    /// local for the duration of the inner call. While it sat there the root
+    /// scanner could not see it, so the inner call — the `toJSON`, i.e.
+    /// precisely the code that moves things — left every saved key stale, and
+    /// the outer call resumed using them. Keeping the frames in the TLS is
+    /// what makes the scanner's coverage complete; `take`/`restore` now push
+    /// and pop a frame instead of moving the storage out of the collector's
+    /// reach.
+    ///
+    /// Frame 0 always exists (the top-level call's), so the emit path never
+    /// has to check for an empty stack.
     ///
     /// `Box<ShapeTemplate>` lives on the heap so its address is stable
-    /// even when the cache `Vec` reallocates — we hand out raw pointers
+    /// even when a frame `Vec` reallocates — we hand out raw pointers
     /// to the templates and they must outlive the borrow.
-    pub(crate) static SHAPE_CACHE: RefCell<Vec<(*mut crate::ArrayHeader, Box<ShapeTemplate>)>> =
-        const { RefCell::new(Vec::new()) };
+    pub(crate) static SHAPE_CACHE: RefCell<Vec<Vec<Box<ShapeTemplate>>>> =
+        RefCell::new(vec![Vec::new()]);
 
     /// Key string intern cache for JSON.parse (issue #51 follow-up).
     /// Maps key bytes → already-allocated StringHeader pointer.
@@ -421,26 +445,80 @@ pub(crate) fn json_string_from_output_bytes(bytes: &[u8]) -> *mut StringHeader {
     }
 }
 
-/// Save & clear the shape cache for the duration of a top-level stringify
-/// call. Reentrant `toJSON` callbacks would otherwise inherit the outer
-/// call's templates and (worse) clear them on exit, dangling pointers we
-/// already handed out. Mirrors `take_stringify_buf` in spirit.
+/// Receipt for a pushed shape-cache frame. Consumed by `restore_shape_cache`.
+///
+/// It is not `Copy` and carries a `Drop` that pops the frame, so a JS exception
+/// unwinding past the matching `restore_shape_cache` cannot leave the stack one
+/// frame deep forever. (`clear_shape_cache` truncates to frame 0 as a second
+/// line of defence, for the `longjmp`-style exits that skip `Drop` entirely.)
+pub(crate) struct SavedShapeCache {
+    restored: bool,
+}
+
+impl Drop for SavedShapeCache {
+    fn drop(&mut self) {
+        if !self.restored {
+            SHAPE_CACHE.with(|c| {
+                let mut stack = c.borrow_mut();
+                if stack.len() > 1 {
+                    stack.pop();
+                }
+            });
+        }
+    }
+}
+
+/// Push a fresh shape-cache frame for the duration of a nested stringify call.
+/// A reentrant `toJSON` callback would otherwise inherit the outer call's
+/// templates and (worse) clear them on exit, dangling pointers we already
+/// handed out. Mirrors `take_stringify_buf` in spirit.
+///
+/// #7268: this used to `mem::take` the cache into a Rust local. The storage
+/// then sat outside the TLS — and therefore outside `scan_parse_roots_mut`'s
+/// reach — for the whole of the inner call, which is the call that runs user
+/// `toJSON` code and moves things. Pushing a frame keeps every saved key
+/// visible to the collector.
 #[inline]
-pub(crate) fn take_shape_cache() -> Vec<(*mut crate::ArrayHeader, Box<ShapeTemplate>)> {
-    SHAPE_CACHE.with(|c| std::mem::take(&mut *c.borrow_mut()))
+pub(crate) fn take_shape_cache() -> SavedShapeCache {
+    SHAPE_CACHE.with(|c| c.borrow_mut().push(Vec::new()));
+    SavedShapeCache { restored: false }
 }
 
 #[inline]
-pub(crate) fn restore_shape_cache(saved: Vec<(*mut crate::ArrayHeader, Box<ShapeTemplate>)>) {
-    SHAPE_CACHE.with(|c| *c.borrow_mut() = saved);
+pub(crate) fn restore_shape_cache(mut saved: SavedShapeCache) {
+    saved.restored = true;
+    SHAPE_CACHE.with(|c| {
+        let mut stack = c.borrow_mut();
+        if stack.len() > 1 {
+            stack.pop();
+        }
+    });
 }
 
-/// Clear cache without allocating a fresh Vec (keeps capacity, drops entries).
-/// Used in place of restore when we know the cache was empty at call entry —
-/// the outermost stringify call in a tight loop skips the save entirely.
+/// Clear the cache without allocating a fresh Vec (keeps capacity, drops
+/// entries). Used in place of restore when we know the cache was empty at call
+/// entry — the outermost stringify call in a tight loop skips the save
+/// entirely.
+///
+/// It also truncates the frame stack back to one, which is what re-establishes
+/// the invariant after a JS exception unwound past a `restore_shape_cache`.
 #[inline]
 pub(crate) fn clear_shape_cache() {
-    SHAPE_CACHE.with(|c| c.borrow_mut().clear());
+    SHAPE_CACHE.with(|c| {
+        let mut stack = c.borrow_mut();
+        stack.truncate(1);
+        stack[0].clear();
+    });
+}
+
+/// The live shape-cache frame — the innermost stringify call's.
+#[inline]
+pub(crate) fn with_shape_cache_frame<R>(f: impl FnOnce(&mut Vec<Box<ShapeTemplate>>) -> R) -> R {
+    SHAPE_CACHE.with(|c| {
+        let mut stack = c.borrow_mut();
+        let frame = stack.last_mut().expect("shape cache always has frame 0");
+        f(frame)
+    })
 }
 
 #[inline]
@@ -473,6 +551,25 @@ pub fn scan_parse_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
             visitor.visit_raw_mut_ptr_slot(&mut entry.keys_array);
             for key in entry.keys.iter_mut() {
                 visitor.visit_tagged_raw_const_ptr_slot(key, crate::value::STRING_TAG);
+            }
+        }
+    });
+    // #7268: the STRINGIFY-side shape cache keys every template on a raw
+    // `ArrayHeader*` and reads the property-name strings back out of it. Its
+    // doc comment used to claim no GC could run over the user object graph
+    // during one stringify call; `toJSON` is user JS and falsifies that. Marked
+    // AND rewritten, on EVERY frame — the reentrancy save is a pushed frame
+    // rather than a moved-out `Vec` precisely so that "every frame" is
+    // reachable from here (see `SHAPE_CACHE`).
+    SHAPE_CACHE.with(|c| {
+        for frame in c.borrow_mut().iter_mut() {
+            for template in frame.iter_mut() {
+                let mut keys_arr = template.keys_arr.get();
+                if keys_arr.is_null() {
+                    continue;
+                }
+                visitor.visit_raw_mut_ptr_slot(&mut keys_arr);
+                template.keys_arr.set(keys_arr);
             }
         }
     });
@@ -514,12 +611,44 @@ pub(crate) fn test_seed_parse_roots(value: f64, key_ptr: *const StringHeader) {
     });
 }
 
+/// Seed the stringify-side shape cache with a template keyed on `keys_arr`,
+/// so #7268's scanner tests can exercise the mark/rewrite halves without
+/// having to drive a whole `JSON.stringify` to populate it.
+#[cfg(test)]
+pub(crate) fn test_seed_stringify_shape_cache(keys_arr: *mut crate::ArrayHeader) {
+    clear_shape_cache();
+    with_shape_cache_frame(|frame| {
+        frame.push(Box::new(ShapeTemplate {
+            keys_arr: std::cell::Cell::new(keys_arr),
+            prefixes: vec![String::from("{\"id\":")],
+            shape_fields: 1,
+            primitive_only: true,
+        }));
+    });
+}
+
+/// Every frame's every `keys_arr`, in order — what the scanner is expected to
+/// have rewritten.
+#[cfg(test)]
+pub(crate) fn test_stringify_shape_cache_keys() -> Vec<usize> {
+    SHAPE_CACHE.with(|c| {
+        c.borrow()
+            .iter()
+            .flat_map(|frame| frame.iter().map(|t| t.keys_arr.get() as usize))
+            .collect()
+    })
+}
+
 #[cfg(test)]
 pub(crate) fn test_clear_parse_roots() {
     PARSE_ROOTS.with(|r| r.borrow_mut().clear());
     PARSE_KEY_CACHE.with(|c| c.borrow_mut().clear());
     PARSE_KEY_RING.with(|ring| ring.borrow_mut().clear());
     PARSE_SHAPE_CACHE.with(|cache| cache.borrow_mut().clear());
+    // #7268: the stringify-side cache is a GC root now, so a template left
+    // behind by an earlier test on this thread would hand the next test's
+    // collector a pointer into an arena that no longer exists.
+    clear_shape_cache();
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/json/stringify_shape_template.rs
+++ b/crates/perry-runtime/src/json/stringify_shape_template.rs
@@ -21,7 +21,18 @@ use crate::{JSValue, StringHeader};
 
 /// Cached shape template for a homogeneous array of objects.
 pub(crate) struct ShapeTemplate {
-    pub(crate) keys_arr: *mut crate::ArrayHeader,
+    /// The shape identity: the shared `keys_array` of every element that
+    /// matches this template. A **GC-managed pointer**, visited (marked and
+    /// rewritten) by `json::scan_parse_roots_mut` — see `SHAPE_CACHE`.
+    ///
+    /// `Cell`, not a bare pointer, and the choice is load-bearing rather than
+    /// stylistic. `try_emit_shape_element` holds `&ShapeTemplate` across
+    /// `stringify_value_depth`, which can run a user `toJSON` and therefore a
+    /// collection that rewrites this slot. A plain field behind a shared
+    /// reference is `noalias` + immutable to LLVM, so the read after the call
+    /// could legally be folded into the read before it — the fix would compile
+    /// away. `Cell`'s `UnsafeCell` withdraws exactly that permission.
+    pub(crate) keys_arr: std::cell::Cell<*mut crate::ArrayHeader>,
     pub(crate) prefixes: Vec<String>,
     pub(crate) shape_fields: u32,
     /// True when element 0's fields are all primitives (no POINTER_TAG /
@@ -45,33 +56,42 @@ pub(crate) unsafe fn shape_template_for(obj_ptr: *const u8) -> Option<*const Sha
         return None;
     }
 
-    SHAPE_CACHE.with(|c| {
-        // Fast path: linear scan from the back — recently-used entries
-        // cluster there for typical traversal orders (shape A's elements
-        // recurse into shape B repeatedly).
-        {
-            let cache = c.borrow();
-            for entry in cache.iter().rev() {
-                if entry.0 == keys_arr {
-                    return Some(&*entry.1 as *const ShapeTemplate);
-                }
-            }
-            if cache.len() >= SHAPE_CACHE_CAP {
-                return None;
+    // Fast path: linear scan from the back — recently-used entries
+    // cluster there for typical traversal orders (shape A's elements
+    // recurse into shape B repeatedly).
+    //
+    // #7268: the cache key is read out of the `Cell` rather than stored
+    // alongside the template. There used to be TWO copies of this pointer per
+    // entry — the tuple key and `ShapeTemplate::keys_arr` — which is one more
+    // slot for a root scanner to miss than the design needs. One copy cannot
+    // drift from itself.
+    let hit = with_shape_cache_frame(|frame| {
+        for template in frame.iter().rev() {
+            if template.keys_arr.get() == keys_arr {
+                return Some(&**template as *const ShapeTemplate);
             }
         }
+        None
+    });
+    if hit.is_some() {
+        return hit;
+    }
+    if with_shape_cache_frame(|frame| frame.len() >= SHAPE_CACHE_CAP) {
+        return None;
+    }
 
-        // Miss — build, insert, return raw pointer to the boxed template.
-        let elem_bits = make_pointer_bits(obj_ptr);
-        let template = build_shape_prefix_template(elem_bits)?;
-        let mut cache = c.borrow_mut();
-        // Re-check cap after the borrow round-trip (a recursive call
-        // during template build could have filled the cache).
-        if cache.len() >= SHAPE_CACHE_CAP {
+    // Miss — build, insert, return raw pointer to the boxed template. The
+    // build runs OUTSIDE the cache borrow: it allocates and can recurse.
+    let elem_bits = make_pointer_bits(obj_ptr);
+    let template = build_shape_prefix_template(elem_bits)?;
+    with_shape_cache_frame(|frame| {
+        // Re-check the cap after the build (a recursive call during the build
+        // could have filled the frame).
+        if frame.len() >= SHAPE_CACHE_CAP {
             return None;
         }
-        cache.push((keys_arr, Box::new(template)));
-        Some(&*cache.last().unwrap().1 as *const ShapeTemplate)
+        frame.push(Box::new(template));
+        Some(&**frame.last().unwrap() as *const ShapeTemplate)
     })
 }
 
@@ -206,7 +226,7 @@ pub(crate) unsafe fn build_shape_prefix_template(first_elem_bits: u64) -> Option
     }
 
     Some(ShapeTemplate {
-        keys_arr,
+        keys_arr: std::cell::Cell::new(keys_arr),
         prefixes,
         shape_fields,
         primitive_only,
@@ -246,9 +266,19 @@ unsafe fn template_field_bits(obj: *const crate::ObjectHeader, f: u32) -> u64 {
 /// `keys_arr`) as the pending `toJSON` key before recursing into that field
 /// (#5909). Mirrors the key decode in `build_shape_prefix_template`.
 #[inline]
-unsafe fn set_to_json_key_for_template_field(template: &ShapeTemplate, f: usize) {
-    let keys_elements = (template.keys_arr as *const u8)
-        .add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
+unsafe fn set_to_json_key_for_template_field(keys_arr: *mut crate::ArrayHeader, f: usize) {
+    // #7268: `keys_arr` is passed in from the caller's ROOTED handle, freshly
+    // read. It used to be `template.keys_arr` — a copy captured before
+    // `stringify_value_depth` ran a user `toJSON`, i.e. before the collection
+    // that moved the array. This function dereferences it (`str_from_header` on
+    // each key), so a stale value is a read of retired from-space, not merely a
+    // wrong identity.
+    if keys_arr.is_null() {
+        set_to_json_key_str("");
+        return;
+    }
+    let keys_elements =
+        (keys_arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
     let key_bits = (*keys_elements.add(f)).to_bits();
     let key_tag = key_bits & 0xFFFF_0000_0000_0000;
     let key_ptr = if key_tag == STRING_TAG || key_tag == POINTER_TAG {
@@ -282,22 +312,65 @@ pub(crate) unsafe fn try_emit_shape_element(
         return false;
     }
     let obj = elem_ptr as *const crate::ObjectHeader;
-    if (*obj).keys_array != template.keys_arr {
+    if (*obj).keys_array != template.keys_arr.get() {
         return false;
     }
 
-    let fields_ptr =
-        (elem_ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
+    // ★ #7268: ROOT THE ELEMENT. The emit loops below call
+    // `stringify_value_depth` for every pointer-valued field, and that can run
+    // a user `toJSON` — allocating, reaching a safepoint, and taking an
+    // evacuating minor with it. `elem_ptr` is a bare Rust local: no shadow
+    // slot, no temp root, no registered scanner, and production resolves the
+    // conservative native-stack scan to `SkipDisabled`. So every later
+    // `fields_ptr.add(f)` in the SAME loop was a read of a forwarded or swept
+    // address.
+    //
+    // `stringify_object_inner` (json/stringify.rs) has done this correctly
+    // since #6519's rework — handle + a `cur_obj()` re-derivation on every
+    // access. The template path never got the same treatment; this is that
+    // treatment.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let elem_handle = scope.root_raw_const_ptr(elem_ptr);
+    let cur_obj = || elem_handle.get_raw_const_ptr::<crate::ObjectHeader>();
+
+    // ★ #7268, second holder: the TEMPLATE'S OWN `keys_arr`.
+    //
+    // Rooting the shape cache is not sufficient, because not every template
+    // lives in the cache: `stringify_array_depth` builds one into a plain
+    // `Option<ShapeTemplate>` Rust local and holds it across the whole element
+    // loop. That local is invisible to every scanner. Rooting the pointer HERE
+    // covers both holders with one mechanism, and writing the refreshed address
+    // back into the `Cell` keeps whichever holder owns this template correct
+    // for the next element too.
+    //
+    // `set_to_json_key_for_template_field` reads the property-name strings out
+    // of this array AFTER `stringify_value_depth` has run — that read is the
+    // one that dereferences retired from-space.
+    let keys_handle = scope.root_raw_mut_ptr(template.keys_arr.get());
+    let cur_keys = || {
+        let keys = keys_handle.get_raw_mut_ptr::<crate::ArrayHeader>();
+        template.keys_arr.set(keys);
+        keys
+    };
+
     let shape_fields = template.shape_fields;
     let prefixes = template.prefixes.as_slice();
     // Per ELEMENT, not per template: two objects can share a `keys_array`
     // (same shape) while one was pre-sized and the other grown by name, so the
     // inline/overflow split has to be re-derived from this element's own
-    // header. Hoisted out of the emit loops — the common case is
-    // `shape_fields <= alloc_limit` and the branch never taken.
+    // header. Still hoisted out of the emit loops — the common case is
+    // `shape_fields <= alloc_limit` and the branch is never taken. Hoisting it
+    // stays sound across a collection because it is a COUNT, not an address:
+    // `field_count` is copied verbatim when the object moves.
     let alloc_limit = object_alloc_limit(obj);
     let field_bits_at = |f: usize| -> u64 {
+        // Re-derived per access, deliberately. The pre-#7268 code hoisted
+        // `fields_ptr` above the loop, which is exactly the address a `toJSON`
+        // in an earlier field invalidates.
+        let obj = cur_obj();
         if (f as u32) < alloc_limit {
+            let fields_ptr =
+                (obj as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
             (*fields_ptr.add(f)).to_bits()
         } else {
             crate::object::js_object_get_field(obj, f as u32).bits()
@@ -359,13 +432,13 @@ pub(crate) unsafe fn try_emit_shape_element(
                     buf.push_str("null");
                 }
             } else if vtag == POINTER_TAG || is_raw_pointer(fb) {
-                set_to_json_key_for_template_field(template, f);
+                set_to_json_key_for_template_field(cur_keys(), f);
                 stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
             } else {
                 // A BigInt field reaches `serialize_bigint` via `write_number`,
                 // which reads the pending `toJSON` key — record it first (#5909).
                 if vtag == BIGINT_TAG {
-                    set_to_json_key_for_template_field(template, f);
+                    set_to_json_key_for_template_field(cur_keys(), f);
                 }
                 write_number(buf, field_val);
             }
@@ -391,7 +464,10 @@ pub(crate) unsafe fn try_emit_shape_element(
         }
     }
     if has_pointer_fields {
-        if let Some(to_json_val) = object_get_to_json(elem_ptr) {
+        // Through the handle: the pre-scan above is allocation-free today, but
+        // `elem_ptr` is the pre-collection address and there is no reason for a
+        // second name for this object to exist (#7268).
+        if let Some(to_json_val) = object_get_to_json(cur_obj() as *const u8) {
             arm_to_json_result_guard(to_json_val);
             stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth + 1);
             SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
@@ -426,13 +502,13 @@ pub(crate) unsafe fn try_emit_shape_element(
                 buf.push_str("null");
             }
         } else if vtag == POINTER_TAG || is_raw_pointer(fb) {
-            set_to_json_key_for_template_field(template, f);
+            set_to_json_key_for_template_field(cur_keys(), f);
             stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
         } else {
             // A BigInt field reaches `serialize_bigint` via `write_number`,
             // which reads the pending `toJSON` key — record it first (#5909).
             if vtag == BIGINT_TAG {
-                set_to_json_key_for_template_field(template, f);
+                set_to_json_key_for_template_field(cur_keys(), f);
             }
             write_number(buf, field_val);
         }


### PR DESCRIPTION
Closes #7268.

The issue asked for a decision before an implementation. The decision:
**`SHAPE_CACHE`'s invariant is false**, and rooting the cache alone would not
have closed the hazard either.

## What was exposed

`try_emit_shape_element` derived the element header and its inline `fields_ptr`
**once**, then looped over the fields calling `stringify_value_depth` for the
pointer-valued ones. That call can run a user `toJSON` — allocating, reaching a
safepoint, taking an evacuating minor with it. Three holders:

1. **`elem_ptr` / `fields_ptr`** — a bare Rust local. Every later
   `fields_ptr.add(f)` in the *same loop* read a forwarded or swept address.
2. **`ShapeTemplate::keys_arr`** — the raw `ArrayHeader*` used as the shape
   identity *and* dereferenced by `set_to_json_key_for_template_field` to read
   the property-name strings back out. This one is a real deref of retired
   from-space, not merely a wrong identity.
3. **`SHAPE_CACHE`** — whose doc comment asserted the invariant that made (2)
   safe: *"within one top-level stringify call no GC runs over the user object
   graph"*. `toJSON` is user JS. The comment now says why the invariant is
   false instead of asserting it.

## Why all three

Rooting any one leaves the others. In particular, **rooting the cache is not
sufficient**: `stringify_array_depth` builds its template into a plain
`Option<ShapeTemplate>` **Rust local** and holds it across the whole element
loop. No root scanner can ever see that one. So:

- `try_emit_shape_element` roots the element and re-derives `fields_ptr` on
  every access — `stringify_object_inner`'s `cur_obj()` pattern, which the
  template path never got;
- it *also* roots `template.keys_arr` and writes the refreshed address back
  into the template. One mechanism, both holders (cache-owned and local);
- `SHAPE_CACHE` is visited by `json::scan_parse_roots_mut` — already registered
  as `json_parse_mutable_root_scanner` — marking **and** rewriting every
  frame's every key, which is what covers a template sitting idle across a
  nested call.

## Two supporting changes, each removing a way for the fix to be undone

- **`keys_arr` becomes a `Cell`.** `try_emit_shape_element` holds
  `&ShapeTemplate` across the collection. Behind a shared reference the field is
  `noalias` and immutable to LLVM, so the post-call read could legally be folded
  into the pre-call one — the fix would compile away. `Cell`'s `UnsafeCell`
  withdraws exactly that permission.
- **Reentrancy save/restore pushes and pops a FRAME** instead of `mem::take`ing
  the cache into a Rust local. The old shape put the storage outside the
  scanner's reach for the whole of the inner call — and the inner call is the
  `toJSON`, i.e. precisely the code that moves things. `SavedShapeCache` carries
  a `Drop` that pops, and `clear_shape_cache` truncates to frame 0, so a JS
  exception unwinding past the restore cannot leave the stack permanently deep.

The tuple key is gone: `SHAPE_CACHE` was `Vec<(*mut ArrayHeader,
Box<ShapeTemplate>)>` with the same pointer in both halves — one more slot for a
scanner to miss than the design needs. One copy cannot drift from itself.

## Witness

`crates/perry-runtime/src/gc/tests/runtime_roots/json_shape_template.rs`,
knob-free, three tests.

The issue's suggested reproducer needs "a later element carrying a `toJSON` that
allocates heavily". **A `Date` field reaches the same window with no user JS at
all**: `stringify_value_depth`'s `is_date_cell_addr` branch calls
`js_date_to_json`, which allocates a `StringHeader`. That makes it a pure
runtime unit test.

Probe shape `{ when: Date, answer: 42, also: Date }` — and the order is
load-bearing: `when` is the allocation, `answer` is read from `fields_ptr`
*after* it (holder 1), `also` runs `set_to_json_key_for_template_field`, which
dereferences `keys_arr`, *after* it (holder 2). A two-field object exercises
neither.

Per CLAUDE.md's "a gate must assert its subject was live", the end-to-end test
asserts a separately rooted **sentinel relocated**, and the expected bytes come
from a baseline stringify of the same array taken with no collection in flight
(so a date-formatting change cannot silently invalidate the assertion). It also
asserts `"answer":42` is in the baseline at all — without it the probe never
reached the template path.

## Sabotage — both halves

**Element rooting** (hoist `fields_ptr` back above the loop):

```
left:  [{"when":"1970-01-01T00:00:00.000Z","answer":42.000010751275454,"also":"1970-01-01T00:00:00.000Z"},…]
right: [{"when":"1970-01-01T00:00:00.000Z","answer":42,                 "also":"1970-01-02T00:00:00.000Z"},…]
```

Note what that is: **silent data corruption, not a crash.** A garbage double
where `42` belongs, and the wrong date for `also` — read out of retired
from-space. This is what shipped.

**Cache scanner** (delete the `SHAPE_CACHE` walk from `scan_parse_roots_mut`):
`stringify_shape_cache_keys_array_is_marked_and_rewritten` fails on the MARK
assertion.

## Gates run locally

`cargo fmt --all -- --check`, `cargo test -p perry-runtime --lib --no-fail-fast`
(1940 passed / 0 failed), `check_file_size.sh`, `check_test_registration.py`,
`global_sink_isolation.py` — all green.
