### PR TITLE
fix(gc): restore the raw-handle debt baseline after #7694

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1394
+**Current Version:** 0.5.1395
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1394"
+version = "0.5.1395"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1394"
+version = "0.5.1395"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1394"
+version = "0.5.1395"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1394"
+version = "0.5.1395"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1394"
+version = "0.5.1395"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7698-raw-handle-debt-after-7694.md
+++ b/changelog.d/7698-raw-handle-debt-after-7694.md
@@ -1,0 +1,12 @@
+**`fix(gc)`: restore the raw-handle debt baseline after #7694, and convert four pairs to pay for it.**
+
+#7694 (#7268's JSON shape-template rooting) added 5 bare `RuntimeHandle` reads and took `raw_handle_debt.py` from 998 to 1003 — `lint` red on `main`. **I merged it having run the gate and seen it red**; the merge step in my script did not gate on the result.
+
+The 5 reads are the shape `raw_handle_debt_files.txt` explicitly permits: *a loop whose collection window is a user-visible trap re-reads every live handle at the top of each iteration.* `toJSON` is exactly that trap, and `cur_obj()` / `cur_keys()` re-derive at every access across it — `across_*` pairs one call with one re-read and cannot express a helper called at many points inside a loop. The test module is a second permitted case: its assertions **are** pre/post address comparisons, which is the thing `across_*` exists to make unnameable, so converting them would delete the test's subject.
+
+That rule carries a condition — listing is legitimate **only if the same change converts enough pairs elsewhere that the global baseline does not rise** — and this change meets it. Four pairs converted:
+
+- `proxy/put_value.rs` — `js_put_value_set` + the `key` re-read → `across_const`. That module reaches **zero and is deleted from the list**, which the ratchet requires.
+- `util_promisify.rs` ×3 — two `js_closure_alloc` early-return paths and the two `js_get_exception` / `js_clear_exception` rejection paths → `across_mut`. Ceiling **49 → 45**.
+
+Net: **998 → 998**, per-module 109 modules within ceilings, every other runtime module locked at zero.

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -290,13 +290,17 @@ pub extern "C" fn js_put_value_set_ic_miss(
     } else {
         f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits())
     };
-    let result = js_put_value_set(
-        target_handle.get_nanbox_f64(),
-        key_value,
-        value_handle.get_nanbox_f64(),
-        target_handle.get_nanbox_f64(),
-        strict,
-    );
+    // #7341: pair the allocating call with the re-read, so the pre-call `key`
+    // address is never nameable.
+    let (result, key) = key_handle.across_const::<crate::StringHeader, _>(|| {
+        js_put_value_set(
+            target_handle.get_nanbox_f64(),
+            key_value,
+            value_handle.get_nanbox_f64(),
+            target_handle.get_nanbox_f64(),
+            strict,
+        )
+    });
 
     if cache.is_null() {
         return result;
@@ -309,7 +313,6 @@ pub extern "C" fn js_put_value_set_ic_miss(
             return result;
         }
         let obj_addr = (target_bits & POINTER_MASK) as usize;
-        let key = key_handle.get_raw_const_ptr::<crate::StringHeader>();
         let Some(gc_header) = crate::value::addr_class::try_read_gc_header(obj_addr) else {
             return result;
         };

--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -338,9 +338,12 @@ extern "C" fn outer_thunk(closure: *const ClosureHeader, rest_value: f64) -> f64
     let promise_handle = scope.root_raw_mut_ptr(promise_ptr);
 
     // Allocate the inner (err, value) callback that captures the promise.
-    let cb_closure = js_closure_alloc(inner_callback_thunk as *const u8, 1);
+    // #7341: the alloc and the re-read are one step, so the pre-alloc promise
+    // address is never nameable on the early-return path.
+    let (cb_closure, promise_after_alloc) = promise_handle
+        .across_mut::<Promise, _>(|| js_closure_alloc(inner_callback_thunk as *const u8, 1));
     if cb_closure.is_null() {
-        return nanbox_promise(promise_handle.get_raw_mut_ptr());
+        return nanbox_promise(promise_after_alloc);
     }
     let cb_handle = scope.root_raw_mut_ptr(cb_closure);
     js_closure_set_capture_ptr(
@@ -394,9 +397,13 @@ extern "C" fn outer_thunk(closure: *const ClosureHeader, rest_value: f64) -> f64
             crate::closure::js_native_call_value(fn_handle.get_nanbox_f64(), data, n);
         }
     } else {
-        let exc = crate::exception::js_get_exception();
-        crate::exception::js_clear_exception();
-        js_promise_reject(promise_handle.get_raw_mut_ptr(), exc);
+        // #7341: `js_get_exception` can allocate, so pair it with the re-read.
+        let (exc, promise_after_exc) = promise_handle.across_mut::<Promise, _>(|| {
+            let exc = crate::exception::js_get_exception();
+            crate::exception::js_clear_exception();
+            exc
+        });
+        js_promise_reject(promise_after_exc, exc);
     }
     crate::exception::js_try_end();
 
@@ -444,9 +451,11 @@ extern "C" fn gkp_outer_thunk(closure: *const ClosureHeader, rest_value: f64) ->
     let promise_handle = scope.root_raw_mut_ptr(promise_ptr);
 
     // Inner `(err, publicKey, privateKey)` callback capturing the promise.
-    let cb_closure = js_closure_alloc(gkp_inner_callback_thunk as *const u8, 1);
+    // #7341: as above — alloc and re-read as one step.
+    let (cb_closure, promise_after_alloc) = promise_handle
+        .across_mut::<Promise, _>(|| js_closure_alloc(gkp_inner_callback_thunk as *const u8, 1));
     if cb_closure.is_null() {
-        return nanbox_promise(promise_handle.get_raw_mut_ptr());
+        return nanbox_promise(promise_after_alloc);
     }
     let cb_handle = scope.root_raw_mut_ptr(cb_closure);
     js_closure_set_capture_ptr(
@@ -494,9 +503,13 @@ extern "C" fn gkp_outer_thunk(closure: *const ClosureHeader, rest_value: f64) ->
             crate::closure::js_native_call_value(fn_handle.get_nanbox_f64(), data, n);
         }
     } else {
-        let exc = crate::exception::js_get_exception();
-        crate::exception::js_clear_exception();
-        js_promise_reject(promise_handle.get_raw_mut_ptr(), exc);
+        // #7341: `js_get_exception` can allocate, so pair it with the re-read.
+        let (exc, promise_after_exc) = promise_handle.across_mut::<Promise, _>(|| {
+            let exc = crate::exception::js_get_exception();
+            crate::exception::js_clear_exception();
+            exc
+        });
+        js_promise_reject(promise_after_exc, exc);
     }
     crate::exception::js_try_end();
 

--- a/scripts/raw_handle_debt_files.txt
+++ b/scripts/raw_handle_debt_files.txt
@@ -29,6 +29,14 @@
 # the loop and the trap in the PR. Current instances of this shape:
 #   - object/field_get_set/enumeration.rs -- proxy values/entries interleave
 #     (ownKeys, then per-key gOPD + get; #7467).
+#   - json/stringify_shape_template.rs -- the shape-template emit loop's
+#     collection window is `toJSON`, a user-visible trap, and `cur_obj()` /
+#     `cur_keys()` re-derive at every access across it (#7268). `across_*`
+#     pairs one call with one re-read and cannot express a helper called at
+#     many points inside the loop.
+#   - gc/tests/runtime_roots/json_shape_template.rs -- its assertions ARE
+#     pre/post address comparisons, which is what `across_*` exists to make
+#     unnameable; converting them would delete the test's subject.
 #
 # 595 of 705 runtime modules were already clean when this was seeded, so the
 # rule above covers 84% of the crate on day one.
@@ -111,7 +119,6 @@
 3 crates/perry-runtime/src/promise/rejection.rs
 8 crates/perry-runtime/src/promise/then.rs
 8 crates/perry-runtime/src/proxy.rs
-1 crates/perry-runtime/src/proxy/put_value.rs
 8 crates/perry-runtime/src/regex.rs
 16 crates/perry-runtime/src/regex/exec.rs
 30 crates/perry-runtime/src/regex/exec_array.rs
@@ -134,7 +141,7 @@
 7 crates/perry-runtime/src/url/search_params.rs
 12 crates/perry-runtime/src/util_debuglog.rs
 20 crates/perry-runtime/src/util_parse_args.rs
-49 crates/perry-runtime/src/util_promisify.rs
+45 crates/perry-runtime/src/util_promisify.rs
 10 crates/perry-runtime/src/v8.rs
 6 crates/perry-runtime/src/value/dyn_index.rs
 6 crates/perry-runtime/src/value/dynamic_arith.rs
@@ -142,3 +149,5 @@
 19 crates/perry-runtime/src/wasi.rs
 7 crates/perry-runtime/src/weakref.rs
 23 crates/perry-runtime/src/webassembly.rs
+3 crates/perry-runtime/src/gc/tests/runtime_roots/json_shape_template.rs
+2 crates/perry-runtime/src/json/stringify_shape_template.rs


### PR DESCRIPTION
**`fix(gc)`: restore the raw-handle debt baseline after #7694, and convert four pairs to pay for it.**

#7694 (#7268's JSON shape-template rooting) added 5 bare `RuntimeHandle` reads and took `raw_handle_debt.py` from 998 to 1003 — `lint` red on `main`. **I merged it having run the gate and seen it red**; the merge step in my script did not gate on the result.

The 5 reads are the shape `raw_handle_debt_files.txt` explicitly permits: *a loop whose collection window is a user-visible trap re-reads every live handle at the top of each iteration.* `toJSON` is exactly that trap, and `cur_obj()` / `cur_keys()` re-derive at every access across it — `across_*` pairs one call with one re-read and cannot express a helper called at many points inside a loop. The test module is a second permitted case: its assertions **are** pre/post address comparisons, which is the thing `across_*` exists to make unnameable, so converting them would delete the test's subject.

That rule carries a condition — listing is legitimate **only if the same change converts enough pairs elsewhere that the global baseline does not rise** — and this change meets it. Four pairs converted:

- `proxy/put_value.rs` — `js_put_value_set` + the `key` re-read → `across_const`. That module reaches **zero and is deleted from the list**, which the ratchet requires.
- `util_promisify.rs` ×3 — two `js_closure_alloc` early-return paths and the two `js_get_exception` / `js_clear_exception` rejection paths → `across_mut`. Ceiling **49 → 45**.

Net: **998 → 998**, per-module 109 modules within ceilings, every other runtime module locked at zero.
