### PR TITLE
fix(gc): restore the raw-handle debt baseline after #7693

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1398
+**Current Version:** 0.5.1399
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1398"
+version = "0.5.1399"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1398"
+version = "0.5.1399"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1398"
+version = "0.5.1399"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1398"
+version = "0.5.1399"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1398"
+version = "0.5.1399"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7704-raw-handle-debt-after-7693.md
+++ b/changelog.d/7704-raw-handle-debt-after-7693.md
@@ -1,0 +1,14 @@
+**`fix(gc)`: restore the raw-handle debt baseline after #7693, and convert four pairs to pay for it.**
+
+#7693's regression test asserts a sentinel's **pre/post address comparison** — which is precisely what `across_*` exists to make unnameable, so converting its four reads would delete the test's subject. It joins `json_shape_template.rs` as the second instance of that permitted shape.
+
+`raw_handle_debt_files.txt` allows listing only when the same change converts enough pairs elsewhere that the global baseline does not rise. Four converted, each a genuine read-after-allocating-call:
+
+- `os.rs` — `js_object_alloc_with_shape` + the `times` re-read (ceiling 4 → 3)
+- `util_parse_args.rs` — `js_string_from_bytes` + the `values` re-read (20 → 19)
+- `weakref.rs` — `entries_array` (itself allocating) + the `entry` re-read (7 → 6)
+- `regex/match_all.rs` — `build_match_all_groups_owned` + the inner-array re-read (14 → 13)
+
+Net **998 → 998**, 110 modules within ceilings.
+
+Also converts three `weakref.rs` `js_string_from_bytes` + registry-re-read sites to `across_nanbox`. Those do not move the counter — it matches only `.get_raw_{mut,const}_ptr` — but they are the same defect and the same fix, and leaving them because they are invisible to the ratchet would be optimising for the metric.

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -1197,9 +1197,10 @@ pub extern "C" fn js_os_cpus() -> *mut ArrayHeader {
         let times_handle = scope.root_raw_mut_ptr(times);
 
         let packed = b"model\0speed\0times\0";
-        let obj =
-            js_object_alloc_with_shape(CPU_INFO_SHAPE_ID, 3, packed.as_ptr(), packed.len() as u32);
-        let times = times_handle.get_raw_mut_ptr::<ObjectHeader>();
+        // #7341: the alloc and the re-read are one step.
+        let (obj, times) = times_handle.across_mut::<ObjectHeader, _>(|| {
+            js_object_alloc_with_shape(CPU_INFO_SHAPE_ID, 3, packed.as_ptr(), packed.len() as u32)
+        });
         js_object_set_field(obj, 0, JSValue::from_bits(model_handle.get_nanbox_u64()));
         js_object_set_field(obj, 1, JSValue::number(info.speed));
         js_object_set_field(obj, 2, JSValue::pointer(times as *const u8));

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -168,8 +168,11 @@ unsafe fn materialize_match_all_results(
             js_nanbox_string(s_handle.get_raw_const_ptr::<StringHeader>() as i64),
             m.match_index,
         );
-        let groups_value = build_match_all_groups_owned(&m.named, &match_scope);
-        set_match_all_groups(inner_handle.get_raw_mut_ptr::<ArrayHeader>(), groups_value);
+        // #7341: `build_match_all_groups_owned` allocates; pair it with the
+        // inner-array re-read rather than reading it separately afterwards.
+        let (groups_value, inner_after) = inner_handle
+            .across_mut::<ArrayHeader, _>(|| build_match_all_groups_owned(&m.named, &match_scope));
+        set_match_all_groups(inner_after, groups_value);
 
         let inner_boxed = js_nanbox_pointer(inner_handle.get_raw_mut_ptr::<ArrayHeader>() as i64);
         let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();

--- a/crates/perry-runtime/src/util_parse_args.rs
+++ b/crates/perry-runtime/src/util_parse_args.rs
@@ -684,8 +684,11 @@ fn set_option_value(
         return;
     }
 
-    let key = js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    let current = js_object_get_field_by_name_f64(values.get_raw_mut_ptr(), key);
+    // #7341: `js_string_from_bytes` allocates, so pair it with the re-read.
+    let (key, values_after) = values.across_mut::<crate::object::ObjectHeader, _>(|| {
+        js_string_from_bytes(name.as_ptr(), name.len() as u32)
+    });
+    let current = js_object_get_field_by_name_f64(values_after, key);
     if let Some(arr) = array_ptr(current) {
         let pushed = js_array_push_f64(arr as *mut crate::array::ArrayHeader, value);
         set_prop_on_obj(

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -518,8 +518,11 @@ pub extern "C" fn js_finreg_register(registry: f64, target: f64, held: f64, toke
     );
     let record_val = f64::from_bits(JSValue::pointer(record as *const u8).bits());
     let record_handle = scope.root_nanbox_f64(record_val);
-    let reg_ptr = js_nanbox_get_pointer(registry_handle.get_nanbox_f64()) as *mut ObjectHeader;
-    let entries_key = crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18);
+    // #7341: `js_string_from_bytes` allocates; pair it with the registry re-read
+    // so the pre-collection `reg_ptr` is never nameable.
+    let (entries_key, reg_nanbox) = registry_handle
+        .across_nanbox(|| crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18));
+    let reg_ptr = js_nanbox_get_pointer(reg_nanbox) as *mut ObjectHeader;
     let entries_val = js_object_get_field_by_name(reg_ptr, entries_key);
     let entries_ptr = (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
     if entries_ptr.is_null() {
@@ -563,8 +566,11 @@ pub extern "C" fn js_finreg_unregister(registry: f64, token: f64) -> f64 {
     let mut found = false;
     // Rebuild the entries array without matching records.
     let new_arr_handle = scope.root_raw_mut_ptr(js_array_alloc(len as u32));
-    let reg_ptr = js_nanbox_get_pointer(registry_handle.get_nanbox_f64()) as *mut ObjectHeader;
-    let entries_key = crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18);
+    // #7341: `js_string_from_bytes` allocates; pair it with the registry re-read
+    // so the pre-collection `reg_ptr` is never nameable.
+    let (entries_key, reg_nanbox) = registry_handle
+        .across_nanbox(|| crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18));
+    let reg_ptr = js_nanbox_get_pointer(reg_nanbox) as *mut ObjectHeader;
     let entries_val = js_object_get_field_by_name(reg_ptr, entries_key);
     let entries_ptr = (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
     if entries_ptr.is_null() {
@@ -1131,8 +1137,11 @@ fn remove_finalization_record_from_registry(registry: f64, record: f64) {
     }
     let len = js_array_length(entries_ptr) as usize;
     let new_arr_handle = scope.root_raw_mut_ptr(js_array_alloc(len as u32));
-    let reg_ptr = js_nanbox_get_pointer(registry_handle.get_nanbox_f64()) as *mut ObjectHeader;
-    let entries_key = crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18);
+    // #7341: `js_string_from_bytes` allocates; pair it with the registry re-read
+    // so the pre-collection `reg_ptr` is never nameable.
+    let (entries_key, reg_nanbox) = registry_handle
+        .across_nanbox(|| crate::string::js_string_from_bytes(b"__perry_fr_entries".as_ptr(), 18));
+    let reg_ptr = js_nanbox_get_pointer(reg_nanbox) as *mut ObjectHeader;
     let entries_val = js_object_get_field_by_name(reg_ptr, entries_key);
     let entries_ptr = (entries_val.bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
     if entries_ptr.is_null() {
@@ -1546,9 +1555,10 @@ pub extern "C" fn js_weakmap_set(map: f64, key: f64, value: f64) -> f64 {
         // re-read its current pointer before boxing `entry_val`, otherwise a
         // stale address would be stored into the array.
         let entry_handle = scope.root_raw_mut_ptr(entry);
+        // #7341: `entries_array` allocates, so pair it with the entry re-read.
         let map_ptr = js_nanbox_get_pointer(map_handle.get_nanbox_f64()) as *mut ObjectHeader;
-        let entries_ptr = entries_array(map_ptr);
-        let entry = entry_handle.get_raw_mut_ptr::<ObjectHeader>();
+        let (entries_ptr, entry) =
+            entry_handle.across_mut::<ObjectHeader, _>(|| entries_array(map_ptr));
         let entry_val = f64::from_bits(JSValue::pointer(entry as *const u8).bits());
         if first_tomb >= 0 {
             js_array_set_f64(entries_ptr, first_tomb as u32, entry_val);

--- a/scripts/raw_handle_debt_files.txt
+++ b/scripts/raw_handle_debt_files.txt
@@ -37,6 +37,8 @@
 #   - gc/tests/runtime_roots/json_shape_template.rs -- its assertions ARE
 #     pre/post address comparisons, which is what `across_*` exists to make
 #     unnameable; converting them would delete the test's subject.
+#   - gc/tests/runtime_roots/fs_options_object.rs -- same: its subject IS the
+#     sentinel's pre/post address comparison (#7274).
 #
 # 595 of 705 runtime modules were already clean when this was seeded, so the
 # rule above covers 84% of the crate on day one.
@@ -109,7 +111,7 @@
 4 crates/perry-runtime/src/object/reflect_support.rs
 3 crates/perry-runtime/src/object/spill.rs
 2 crates/perry-runtime/src/object/typed_array_define.rs
-4 crates/perry-runtime/src/os.rs
+3 crates/perry-runtime/src/os.rs
 14 crates/perry-runtime/src/os_network.rs
 3 crates/perry-runtime/src/os_process_streams.rs
 13 crates/perry-runtime/src/plugin.rs
@@ -122,7 +124,7 @@
 8 crates/perry-runtime/src/regex.rs
 16 crates/perry-runtime/src/regex/exec.rs
 30 crates/perry-runtime/src/regex/exec_array.rs
-14 crates/perry-runtime/src/regex/match_all.rs
+13 crates/perry-runtime/src/regex/match_all.rs
 22 crates/perry-runtime/src/regex/match_string.rs
 7 crates/perry-runtime/src/regex/replace_expand.rs
 3 crates/perry-runtime/src/regex/replace_fn.rs
@@ -140,14 +142,15 @@
 4 crates/perry-runtime/src/url/node_compat.rs
 7 crates/perry-runtime/src/url/search_params.rs
 12 crates/perry-runtime/src/util_debuglog.rs
-20 crates/perry-runtime/src/util_parse_args.rs
+19 crates/perry-runtime/src/util_parse_args.rs
 45 crates/perry-runtime/src/util_promisify.rs
 10 crates/perry-runtime/src/v8.rs
 6 crates/perry-runtime/src/value/dyn_index.rs
 6 crates/perry-runtime/src/value/dynamic_arith.rs
 3 crates/perry-runtime/src/value/to_string.rs
 19 crates/perry-runtime/src/wasi.rs
-7 crates/perry-runtime/src/weakref.rs
+6 crates/perry-runtime/src/weakref.rs
 23 crates/perry-runtime/src/webassembly.rs
 3 crates/perry-runtime/src/gc/tests/runtime_roots/json_shape_template.rs
 2 crates/perry-runtime/src/json/stringify_shape_template.rs
+4 crates/perry-runtime/src/gc/tests/runtime_roots/fs_options_object.rs


### PR DESCRIPTION
**`fix(gc)`: restore the raw-handle debt baseline after #7693, and convert four pairs to pay for it.**

#7693's regression test asserts a sentinel's **pre/post address comparison** — which is precisely what `across_*` exists to make unnameable, so converting its four reads would delete the test's subject. It joins `json_shape_template.rs` as the second instance of that permitted shape.

`raw_handle_debt_files.txt` allows listing only when the same change converts enough pairs elsewhere that the global baseline does not rise. Four converted, each a genuine read-after-allocating-call:

- `os.rs` — `js_object_alloc_with_shape` + the `times` re-read (ceiling 4 → 3)
- `util_parse_args.rs` — `js_string_from_bytes` + the `values` re-read (20 → 19)
- `weakref.rs` — `entries_array` (itself allocating) + the `entry` re-read (7 → 6)
- `regex/match_all.rs` — `build_match_all_groups_owned` + the inner-array re-read (14 → 13)

Net **998 → 998**, 110 modules within ceilings.

Also converts three `weakref.rs` `js_string_from_bytes` + registry-re-read sites to `across_nanbox`. Those do not move the counter — it matches only `.get_raw_{mut,const}_ptr` — but they are the same defect and the same fix, and leaving them because they are invisible to the ratchet would be optimising for the metric.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stability during memory-intensive operations, including regular expressions, weak references, option parsing, and system information handling.
  * Reduced the risk of invalid object references after automatic memory cleanup.

* **Documentation**
  * Updated release documentation and internal quality tracking for runtime memory-handling improvements.

* **Chores**
  * Incremented the application version to **0.5.1399**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->