### PR TITLE
gate(gc): make the root-dominance corpus floor a two-sided ratchet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1405
+**Current Version:** 0.5.1406
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1405"
+version = "0.5.1406"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1405"
+version = "0.5.1406"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1405"
+version = "0.5.1406"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1405"
+version = "0.5.1406"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1405"
+version = "0.5.1406"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7706-corpus-skip-ratchet.md
+++ b/changelog.d/7706-corpus-skip-ratchet.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`gc_root_dominance_corpus.sh` tolerated 41 sources failing to compile and still exited 0.** The compile floor was the constant `MIN_COMPILED=90`, hand-synced to the `PATTERNS` list by a comment reading *"Keep this list in sync with MIN_COMPILED below when you add a prefix."* The comment drifted: `PATTERNS` grew to discover **131** sources while the floor stayed at 90. A run in which 41 sources failed to compile printed the failures to a log and exited 0.
+
+  That is CLAUDE.md's hazard 4 — "the gate runs but its subject never did" — with a twist that makes it worse than a skipped test: a source that fails to compile emits **no IR**, and IR that was never emitted reads to the dominance checker exactly like IR with no violations in it. The absence is indistinguishable from a pass at every downstream floor in the script.
+
+  A floor expressed as an absolute count cannot track a corpus that grows. Both numbers are now ratchets against the corpus **as discovered**, and both are checked in **both directions**:
+
+  - `MIN_SOURCES` (131) — how many files `PATTERNS` must still match. Falls only when sources are deleted or renamed. That is the "corpus shrank" finding, which the old single floor conflated with "sources failed to compile" — two different failures with two different fixes, now reported separately.
+  - `MAX_SKIPPED` (0) — how many discovered sources may fail to compile. Zero is the measured truth on both lowerings, not an aspiration: shadow and native each report `131/131 sources compiled, 0 skipped` as of v0.5.1402. Over budget is a regression; **under** budget also fails, naming the number to write down, so the budget can never drift above reality the way `MIN_COMPILED` did.
+
+  The derived compile floor (`MIN_SOURCES - MAX_SKIPPED`) removes the hand-sync entirely — there is nothing left to keep in step with `PATTERNS`.
+
+  All three arms are sabotage-verified rather than assumed: planting an uncompilable `test_gap_gc_*.ts` gives `1 of 132 sources failed to compile (budget: 0)`, exit 1; `MAX_SKIPPED=3` against a reality of 0 gives *"the budget is stale and would absorb the next real failure silently"*, exit 1; `MIN_SOURCES=999` gives *"PATTERNS matched only 131 sources"*, exit 1.

--- a/scripts/gc_root_dominance_corpus.sh
+++ b/scripts/gc_root_dominance_corpus.sh
@@ -14,10 +14,12 @@
 # Requires target/release/perry plus the runtime archives (see the workflow, or
 # `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`).
 #
-# Exit status is non-zero if fewer than MIN_COMPILED sources produced IR. A
-# source that stops compiling is allowed -- test-files/ churns, and this gate is
-# not the gap suite -- but the corpus is NOT allowed to quietly shrink to
-# nothing, because "0 violations over 3 files" and "0 violations over 300 files"
+# Exit status is non-zero if PATTERNS matches fewer than MIN_SOURCES files, or
+# if more than MAX_SKIPPED (= 0) of them fail to produce IR. A source that stops
+# compiling is NOT allowed to pass quietly: it emits no IR, and IR that was
+# never emitted reads to the checker exactly like IR with no violations in it.
+# Nor is the corpus allowed to shrink, because "0 violations over 3 files" and
+# "0 violations over 300 files"
 # print the same verdict and mean opposite things.
 #
 # TWO LOWERINGS, and the corpus is not the same corpus for both (#7663)
@@ -100,7 +102,6 @@ PERRY_BIN="${PERRY_BIN:-target/release/perry}"
 #   spread     - spread/rest, which allocate per element
 #   map/set    - collection literals
 #
-# Keep this list in sync with MIN_COMPILED below when you add a prefix.
 PATTERNS=(
   'test_gap_gc_*.ts'
   'test_gap_repsel*.ts'
@@ -117,9 +118,33 @@ PATTERNS=(
   'test_gap_set*.ts'
 )
 
-# The floor, not a target. Raise it when the corpus grows; never lower it to
-# make a run pass -- a shrinking corpus is the finding, not the obstacle.
-MIN_COMPILED="${MIN_COMPILED:-90}"
+# --- the two ratchets, and why a lone MIN_COMPILED could not fail -----------
+#
+# This used to be `MIN_COMPILED=90`, hand-synced to PATTERNS by a comment. The
+# comment drifted: PATTERNS grew to discover **131** sources while the floor
+# stayed at 90, so the run tolerated **41 sources failing to compile** and still
+# exited 0, printing the failures to a log nobody reads. That is CLAUDE.md's
+# hazard 4 in its purest form -- the gate ran, 41 of its subjects need not have.
+#
+# A floor expressed as an absolute count cannot track a corpus that grows. Both
+# numbers below are therefore ratchets against the corpus as DISCOVERED, and
+# both are checked in BOTH directions, so neither can drift above reality again:
+#
+#   MIN_SOURCES   how many files PATTERNS must still match. Falls only if
+#                 sources were deleted or renamed -- the "corpus shrank"
+#                 finding, which the old floor conflated with "sources failed
+#                 to compile". Two different failures, two different messages.
+#   MAX_SKIPPED   how many discovered sources may fail to compile. It is 0, and
+#                 0 is the measured truth on both lowerings, not an aspiration:
+#                 shadow and native each report 131/131, 0 skipped as of
+#                 v0.5.1402. A skip is a finding, not a tolerance.
+#
+# Raise MIN_SOURCES when you add a prefix; there is nothing else to keep in
+# sync, because the compile floor is now DERIVED (MIN_SOURCES - MAX_SKIPPED)
+# rather than restated. Lowering either to make a run pass is the thing this
+# comment exists to stop.
+MIN_SOURCES="${MIN_SOURCES:-131}"
+MAX_SKIPPED="${MAX_SKIPPED:-0}"
 
 if [ ! -x "$PERRY_BIN" ]; then
   echo "error: $PERRY_BIN not found or not executable." >&2
@@ -316,10 +341,37 @@ if [ "$LOWERING" = "native" ]; then
   fi
 fi
 
-if [ "$compiled" -lt "$MIN_COMPILED" ]; then
-  echo "::error::only $compiled sources compiled, need at least $MIN_COMPILED." >&2
-  echo "The corpus shrank. Either fix the sources that stopped compiling, or -- if" >&2
-  echo "they were removed on purpose -- adjust PATTERNS and MIN_COMPILED together" >&2
-  echo "in this file, in the same PR, so the reduction is reviewable." >&2
+# --- ratchet 1: did PATTERNS still find the corpus? -------------------------
+#
+# Separate from the skip check below on purpose. "13 sources vanished" and "13
+# sources failed to compile" are different findings with different fixes, and
+# the single floor this replaced reported both as the same thing.
+if [ "${#sources[@]}" -lt "$MIN_SOURCES" ]; then
+  echo "::error::PATTERNS matched only ${#sources[@]} sources, expected at least $MIN_SOURCES." >&2
+  echo "The corpus shrank -- sources were deleted or renamed out from under it." >&2
+  echo "If that was deliberate, lower MIN_SOURCES in this file in the SAME PR so" >&2
+  echo "the reduction is reviewable." >&2
+  exit 1
+fi
+
+# --- ratchet 2: every discovered source must compile ------------------------
+#
+# Two-sided. Over budget is a regression; UNDER budget means the budget is
+# stale and would silently absorb the next real failure, so it fails too and
+# names the number to write down. With MAX_SKIPPED=0 the second arm is
+# unreachable today -- it is what keeps the number honest if anyone ever
+# raises it, which is precisely how MIN_COMPILED=90 came to tolerate 41.
+if [ "$skipped" -gt "$MAX_SKIPPED" ]; then
+  echo "::error::$skipped of ${#sources[@]} sources failed to compile (budget: $MAX_SKIPPED)." >&2
+  echo "  ${skipped_names[*]}" >&2
+  echo "Fix them. Raising MAX_SKIPPED hides a compiler regression from every" >&2
+  echo "downstream floor in this script -- IR that was never emitted reads as" >&2
+  echo "clean to the checker." >&2
+  exit 1
+fi
+if [ "$skipped" -lt "$MAX_SKIPPED" ]; then
+  echo "::error::only $skipped sources skipped, but MAX_SKIPPED is $MAX_SKIPPED." >&2
+  echo "The budget is stale and would absorb the next real failure silently." >&2
+  echo "Lower MAX_SKIPPED to $skipped in this file." >&2
   exit 1
 fi


### PR DESCRIPTION
- **`gc_root_dominance_corpus.sh` tolerated 41 sources failing to compile and still exited 0.** The compile floor was the constant `MIN_COMPILED=90`, hand-synced to the `PATTERNS` list by a comment reading *"Keep this list in sync with MIN_COMPILED below when you add a prefix."* The comment drifted: `PATTERNS` grew to discover **131** sources while the floor stayed at 90. A run in which 41 sources failed to compile printed the failures to a log and exited 0.

  That is CLAUDE.md's hazard 4 — "the gate runs but its subject never did" — with a twist that makes it worse than a skipped test: a source that fails to compile emits **no IR**, and IR that was never emitted reads to the dominance checker exactly like IR with no violations in it. The absence is indistinguishable from a pass at every downstream floor in the script.

  A floor expressed as an absolute count cannot track a corpus that grows. Both numbers are now ratchets against the corpus **as discovered**, and both are checked in **both directions**:

  - `MIN_SOURCES` (131) — how many files `PATTERNS` must still match. Falls only when sources are deleted or renamed. That is the "corpus shrank" finding, which the old single floor conflated with "sources failed to compile" — two different failures with two different fixes, now reported separately.
  - `MAX_SKIPPED` (0) — how many discovered sources may fail to compile. Zero is the measured truth on both lowerings, not an aspiration: shadow and native each report `131/131 sources compiled, 0 skipped` as of v0.5.1402. Over budget is a regression; **under** budget also fails, naming the number to write down, so the budget can never drift above reality the way `MIN_COMPILED` did.

  The derived compile floor (`MIN_SOURCES - MAX_SKIPPED`) removes the hand-sync entirely — there is nothing left to keep in step with `PATTERNS`.

  All three arms are sabotage-verified rather than assumed: planting an uncompilable `test_gap_gc_*.ts` gives `1 of 132 sources failed to compile (budget: 0)`, exit 1; `MAX_SKIPPED=3` against a reality of 0 gives *"the budget is stale and would absorb the next real failure silently"*, exit 1; `MIN_SOURCES=999` gives *"PATTERNS matched only 131 sources"*, exit 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corpus validation to distinguish missing sources from compilation failures.
  * Added checks that prevent sources from being silently skipped during validation.
  * Validation now detects both insufficient and outdated skip limits.
  * Failure reports now clearly identify missing sources, excessive skips, and stale budgets.

* **Documentation**
  * Documented the updated corpus validation rules and failure scenarios.
  * Updated the documented project version to 0.5.1406.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->