### PR TITLE
Fix a crash when reading a method off a Buffer without calling it

### DIFF
--- a/changelog.d/7747-buffer-bound-method-name-lifetime.md
+++ b/changelog.d/7747-buffer-bound-method-name-lifetime.md
@@ -1,0 +1,49 @@
+### Fixed
+
+**A bound Buffer-method closure captured a pointer to memory it did not own,
+and dispatched on it later.** `typeof buf.readUInt8`, `const f = buf.readUInt8`
+and `buf[k]` each produced a closure whose method-name pointer was already
+dangling; the call then resolved the method from freed or relocated bytes.
+
+`js_class_method_bind` stores the method-name POINTER in the closure and
+`dispatch_bound_method` re-reads it at CALL time. Its own doc states the
+contract — *"Method-name pointer is expected to be stable for the closure's
+lifetime; codegen emits it from the per-module `.str.N.bytes` rodata global"* —
+and codegen honours it. Two runtime callers on the Buffer path did not:
+
+* `get_field_by_name_tail` derived `key_ptr` as
+  `key + size_of::<StringHeader>()` — the **interior of a movable GC heap
+  string** — and passed it through `buffer_own_prop_or_method`. The key string
+  is unreachable the moment the read returns, so a copying minor could relocate
+  or reclaim it out from under a closure that outlives it.
+* `polymorphic_index`'s computed-key arm bound `name.as_bytes().as_ptr()` where
+  `name` is a local `String`. That one dangles on return with no collector
+  involvement at all.
+
+Both now bind a `'static` literal. `buffer_dispatch`'s method-name list becomes
+a single macro-generated source for both `is_buffer_method_name` and a new
+`buffer_method_name_static`, which returns the literal out of that list rather
+than a borrow of its argument — so there is one list to keep current, not two.
+
+**Why it read as flaky.** Whether the stale bytes still spell the method name
+is a property of the allocator, not of the bug, so the same code passed locally
+and took a SIGSEGV on conformance-smoke: `test_gap_buffer_own_prop_shadow_intrinsic_6405`
+on shard 7, joined by `test_gap_buffer_own_props` on shard 8 once collections
+got denser. Neither test is in `gap_snapshot.json`; both are expected to pass.
+
+**Tests** — `gc/tests/buffer_bound_method_name.rs`, in the required per-PR
+`cargo-test` gate, asserting the contract structurally rather than asking
+whether a given run happens to survive it:
+
+* the closure's captured name must not alias the key string's interior;
+* the computed-key arm's captured name must not come from a temporary;
+* `buffer_method_name_static` must not return a borrow of its argument, and
+  every caller must get the same literal whatever storage its own copy lives in.
+
+Verified by sabotage: with the two call sites reverted and the tests unchanged,
+the first two fail — the second on garbage bytes, i.e. the use-after-free
+reproduced deterministically in-process on a host where the end-to-end tests
+still passed.
+
+`cargo test -p perry-runtime --lib`: 1979 passed, 0 failed. All 12
+buffer/DataView gap tests byte-match Node 26.5.1, including both crashers.

--- a/crates/perry-runtime/src/gc/tests/buffer_bound_method_name.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_bound_method_name.rs
@@ -1,0 +1,130 @@
+//! A bound Buffer-method closure must not capture a pointer into the key
+//! string, or into any other storage the caller owns.
+//!
+//! `js_class_method_bind` stores the method-name POINTER in the closure and
+//! `dispatch_bound_method` re-reads it at CALL time. Its contract says so:
+//! "Method-name pointer is expected to be stable for the closure's lifetime;
+//! codegen emits it from the per-module `.str.N.bytes` rodata global." Two
+//! runtime callers on the Buffer path did not honour it:
+//!
+//! * `get_field_by_name_tail` derived `key_ptr` as `key + size_of::<StringHeader>()`
+//!   — the INTERIOR of a movable GC heap string — and passed it straight
+//!   through `buffer_own_prop_or_method`. Every `typeof buf.readUInt8` /
+//!   `const f = buf.readUInt8` read produced a closure pointing into the
+//!   nursery. Once that string moved under a copying minor (or was reclaimed,
+//!   the string being unreachable after the read), the closure named freed or
+//!   relocated bytes and the call dispatched on garbage.
+//! * `polymorphic_index`'s computed-key arm (`buf[k]`) bound
+//!   `name.as_bytes().as_ptr()` where `name` is a local `String` — freed on
+//!   return, so the closure dangled before any collection was involved.
+//!
+//! The failure is invisible on a host whose allocator happens to leave the old
+//! bytes intact, which is why it surfaced as a conformance-smoke SIGSEGV on
+//! Linux while the same tests passed locally. So the assertions here are
+//! STRUCTURAL — the captured pointer must not alias the key string at all —
+//! rather than "does it happen to still read correctly after a collection",
+//! which is exactly the question a lucky allocator answers wrong.
+
+use super::super::*;
+use super::support::*;
+
+/// The name bytes a bound closure keeps, as raw parts.
+unsafe fn captured_name(bound: crate::value::JSValue) -> (*const u8, usize) {
+    let closure = crate::value::js_nanbox_get_pointer(f64::from_bits(bound.bits())) as *const crate::ClosureHeader;
+    assert!(!closure.is_null(), "the read must produce a bound closure");
+    let ptr = crate::closure::js_closure_get_capture_ptr(closure, 1) as *const u8;
+    let len = crate::closure::js_closure_get_capture_ptr(closure, 2) as usize;
+    (ptr, len)
+}
+
+/// ★ The regression. Reading a Buffer method as a VALUE must not hand the
+/// closure the key string's interior.
+#[test]
+fn a_bound_buffer_method_never_captures_the_key_strings_interior() {
+    let _guard = GcTestIsolationGuard::new();
+
+    unsafe {
+        let buf = crate::buffer::buffer_alloc(8);
+        let key = crate::string::js_string_from_bytes(b"readUInt8".as_ptr(), 9);
+        let key_interior = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+
+        let bound = crate::object::js_object_get_field_by_name(buf as *const crate::ObjectHeader, key);
+        let (name_ptr, name_len) = captured_name(bound);
+
+        assert_ne!(
+            name_ptr, key_interior,
+            "the closure captured the KEY STRING's interior — that allocation \
+             is movable and unreachable after this read, so the name it \
+             dispatches on is freed or relocated bytes"
+        );
+        assert_eq!(name_len, 9, "the captured name must still be `readUInt8`");
+        assert_eq!(
+            std::slice::from_raw_parts(name_ptr, name_len),
+            b"readUInt8",
+            "and it must spell the method"
+        );
+    }
+}
+
+/// The same contract for the computed-key arm (`buf[k]`), whose name came from
+/// a local `String` — dangling on return with no collection required.
+#[test]
+fn a_computed_key_buffer_method_never_captures_a_temporary() {
+    let _guard = GcTestIsolationGuard::new();
+
+    unsafe {
+        let buf = crate::buffer::buffer_alloc(8);
+        let key = crate::string::js_string_from_bytes(b"readUInt8".as_ptr(), 9);
+        let key_interior = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let key_value = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+
+        let obj_handle = crate::value::js_nanbox_pointer(buf as i64).to_bits() as i64;
+        let bound = crate::value::JSValue::from_bits(
+            crate::object::js_object_get_index_polymorphic(obj_handle, key_value).to_bits(),
+        );
+        let (name_ptr, name_len) = captured_name(bound);
+
+        assert_ne!(
+            name_ptr, key_interior,
+            "the computed-key arm captured the key string's interior"
+        );
+        assert_eq!(
+            std::slice::from_raw_parts(name_ptr, name_len),
+            b"readUInt8",
+            "the captured name must spell the method"
+        );
+    }
+}
+
+/// LIVENESS for the two above: they only mean something if the captured
+/// pointer is genuinely stable, so pin the property the fix relies on — the
+/// `'static` lookup returns the LITERAL out of its own list, never a borrow of
+/// the caller's bytes. A future edit that "simplifies" it to `Some(name)`
+/// compiles and passes every behavioural test on a lucky allocator; it fails
+/// here.
+#[test]
+fn the_static_method_name_lookup_does_not_borrow_its_argument() {
+    let owned = String::from("readUInt8");
+    let found = crate::object::buffer_method_name_static(&owned)
+        .expect("readUInt8 is a Buffer method");
+
+    assert_ne!(
+        found.as_ptr(),
+        owned.as_ptr(),
+        "the lookup returned a borrow of its argument — the whole point is a \
+         pointer that outlives the caller's storage"
+    );
+    assert_eq!(found, "readUInt8");
+    assert_eq!(
+        found.as_ptr(),
+        crate::object::buffer_method_name_static("readUInt8")
+            .unwrap()
+            .as_ptr(),
+        "every caller must get the SAME static literal, whatever storage its \
+         own copy of the name lives in"
+    );
+    assert!(
+        crate::object::buffer_method_name_static("notAMethod").is_none(),
+        "and a non-method must not resolve"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/buffer_bound_method_name.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_bound_method_name.rs
@@ -51,6 +51,13 @@ fn a_bound_buffer_method_never_captures_the_key_strings_interior() {
         let bound = crate::object::js_object_get_field_by_name(buf as *const crate::ObjectHeader, key);
         let (name_ptr, name_len) = captured_name(bound);
 
+        let static_name = crate::object::buffer_method_name_static("readUInt8")
+            .expect("readUInt8 is a Buffer method");
+        assert_eq!(
+            name_ptr,
+            static_name.as_ptr(),
+            "the closure must capture the 'static literal"
+        );
         assert_ne!(
             name_ptr, key_interior,
             "the closure captured the KEY STRING's interior — that allocation \
@@ -84,9 +91,23 @@ fn a_computed_key_buffer_method_never_captures_a_temporary() {
         );
         let (name_ptr, name_len) = captured_name(bound);
 
+        // Pointer IDENTITY with the static literal, not merely "not the key
+        // string". The broken version of this path captured a local `String`'s
+        // bytes, which are neither the key's interior nor the literal — so an
+        // inequality against the key would pass with the bug fully present, and
+        // comparing the BYTES only fails on a host where the freed memory has
+        // already been reused. Identity is the assertion that cannot be lucky.
+        let static_name = crate::object::buffer_method_name_static("readUInt8")
+            .expect("readUInt8 is a Buffer method");
+        assert_eq!(
+            name_ptr,
+            static_name.as_ptr(),
+            "the computed-key arm must capture the 'static literal — anything \
+             else is storage the caller owns and the closure outlives"
+        );
         assert_ne!(
             name_ptr, key_interior,
-            "the computed-key arm captured the key string's interior"
+            "and in particular not the key string's interior"
         );
         assert_eq!(
             std::slice::from_raw_parts(name_ptr, name_len),

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -3,6 +3,7 @@ mod barrier;
 mod barrier_arming;
 mod barrier_decoded_parent;
 mod budgeted_step_api;
+mod buffer_bound_method_name;
 mod buffer_side_tables;
 mod clone_keys_array_init;
 mod contract;

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -78,151 +78,172 @@ fn validate_buffer_target(value: f64, name: &str) {
 /// is the raw heap pointer (already stripped of NaN-box tags). Routes
 /// the Node-style numeric read/write/search/swap method family through
 /// `crate::buffer` helpers; unknown methods return undefined.
-/// Issue #639 followup: list of method names recognized by `dispatch_buffer_method`.
-/// Used by `js_object_get_field_by_name`'s Buffer arm to decide whether a
-/// non-length property read should synthesize a bound-method closure (so
-/// duck-type tests like `typeof v.readUInt8 === "function"` pass and a
+/// Issue #639 followup: the method names `dispatch_buffer_method` recognizes,
+/// kept as ONE list that generates both the predicate and the `'static` lookup.
+/// `js_object_get_field_by_name`'s Buffer arm uses the predicate to decide
+/// whether a non-length property read should synthesize a bound-method closure
+/// (so duck-type tests like `typeof v.readUInt8 === "function"` pass and a
 /// subsequent call dispatches through `js_native_call_method`).
 ///
 /// Keep this list aligned with the `match method_name` arms below — every
 /// arm there should be reachable from a method-as-value read.
-pub fn is_buffer_method_name(name: &str) -> bool {
-    matches!(
-        name,
-        "toString"
-            | "inspect"
-            | "slice"
-            | "subarray"
-            | "set"
-            | "copy"
-            | "write"
-            | "toJSON"
-            | "export"
-            | "toCryptoKey"
-            | "fill"
-            | "equals"
-            | "compare"
-            | "indexOf"
-            | "lastIndexOf"
-            | "includes"
-            | "at"
-            | "swap16"
-            | "swap32"
-            | "swap64"
-            // Issue #1206: explicit iterator-protocol surface.
-            | "values"
-            | "keys"
-            | "entries"
-            // Object.prototype methods exposed on Buffer instances so
-            // safer-buffer's `if (buffer.hasOwnProperty(...))` probe (and
-            // similar duck-type tests in express / body-parser dependents)
-            // resolve to a callable, not undefined. Without these,
-            // `typeof buf.hasOwnProperty` is `"undefined"` and the
-            // subsequent invocation throws "buffer.hasOwnProperty is not
-            // a function" at express startup.
-            | "hasOwnProperty"
-            | "propertyIsEnumerable"
-            | "valueOf"
-            | "isPrototypeOf"
-            | "toLocaleString"
-            | "readUInt8"
-            | "readUint8"
-            | "readInt8"
-            | "readUInt16BE"
-            | "readUint16BE"
-            | "readUInt16LE"
-            | "readUint16LE"
-            | "readInt16BE"
-            | "readInt16LE"
-            | "readUInt32BE"
-            | "readUint32BE"
-            | "readUInt32LE"
-            | "readUint32LE"
-            | "readInt32BE"
-            | "readInt32LE"
-            | "readFloatBE"
-            | "readFloatLE"
-            | "readDoubleBE"
-            | "readDoubleLE"
-            | "readBigInt64BE"
-            | "readBigInt64LE"
-            | "readBigUInt64BE"
-            | "readBigUint64BE"
-            | "readBigUInt64LE"
-            | "readBigUint64LE"
-            | "readUIntBE"
-            | "readUintBE"
-            | "readUIntLE"
-            | "readUintLE"
-            | "readIntBE"
-            | "readIntLE"
-            | "writeUInt8"
-            | "writeUint8"
-            | "writeInt8"
-            | "writeUInt16BE"
-            | "writeUint16BE"
-            | "writeUInt16LE"
-            | "writeUint16LE"
-            | "writeInt16BE"
-            | "writeInt16LE"
-            | "writeUInt32BE"
-            | "writeUint32BE"
-            | "writeUInt32LE"
-            | "writeUint32LE"
-            | "writeInt32BE"
-            | "writeInt32LE"
-            | "writeFloatBE"
-            | "writeFloatLE"
-            | "writeDoubleBE"
-            | "writeDoubleLE"
-            | "writeBigInt64BE"
-            | "writeBigInt64LE"
-            | "writeBigUInt64BE"
-            | "writeBigUint64BE"
-            | "writeBigUInt64LE"
-            | "writeBigUint64LE"
-            | "writeUIntBE"
-            | "writeUintBE"
-            | "writeUIntLE"
-            | "writeUintLE"
-            | "writeIntBE"
-            | "writeIntLE"
-            // #2901: TC39 Uint8Array base64/hex instance conversion APIs.
-            | "toBase64"
-            | "toHex"
-            | "setFromBase64"
-            | "setFromHex"
-            // #2879: typed-array mutators that reach buffer dispatch for the
-            // Uint8Array/Buffer shape.
-            | "copyWithin"
-            // #2878: DataView numeric accessors. These resolve as bound-method
-            // values on a DataView-marked buffer (so `typeof dv.getUint8 ===
-            // "function"`); the call routes through `dispatch_buffer_method`.
-            | "getInt8"
-            | "getUint8"
-            | "getInt16"
-            | "getUint16"
-            | "getInt32"
-            | "getUint32"
-            | "getFloat32"
-            | "getFloat64"
-            | "setInt8"
-            | "setUint8"
-            | "setInt16"
-            | "setUint16"
-            | "setInt32"
-            | "setUint32"
-            | "setFloat32"
-            | "setFloat64"
-            // #4365: DataView BigInt64/BigUint64 accessors (8-byte BigInt
-            // read/write). Route through `dispatch_buffer_method` like the
-            // other DataView numeric methods.
-            | "getBigInt64"
-            | "getBigUint64"
-            | "setBigInt64"
-            | "setBigUint64"
-    )
+macro_rules! buffer_method_names {
+    ($($name:literal),+ $(,)?) => {
+        pub fn is_buffer_method_name(name: &str) -> bool {
+            matches!(name, $($name)|+)
+        }
+
+        /// The matched name as a `'static` string: the literal out of this
+        /// list, never a borrow of `name`.
+        ///
+        /// `js_class_method_bind` captures the name *pointer* into the bound
+        /// closure and `dispatch_bound_method` re-reads it at CALL time, so a
+        /// caller that hands it bytes the caller owns gives the closure a
+        /// pointer that outlives them. Codegen satisfies that contract with
+        /// per-module rodata globals; runtime callers satisfy it with this.
+        pub fn buffer_method_name_static(name: &str) -> Option<&'static str> {
+            match name {
+                $($name => Some($name),)+
+                _ => None,
+            }
+        }
+    };
 }
+
+buffer_method_names!(
+    "toString",
+    "inspect",
+    "slice",
+    "subarray",
+    "set",
+    "copy",
+    "write",
+    "toJSON",
+    "export",
+    "toCryptoKey",
+    "fill",
+    "equals",
+    "compare",
+    "indexOf",
+    "lastIndexOf",
+    "includes",
+    "at",
+    "swap16",
+    "swap32",
+    "swap64",
+    // Issue #1206: explicit iterator-protocol surface.
+    "values",
+    "keys",
+    "entries",
+    // Object.prototype methods exposed on Buffer instances so
+    // safer-buffer's `if (buffer.hasOwnProperty(...))` probe (and
+    // similar duck-type tests in express / body-parser dependents)
+    // resolve to a callable, not undefined. Without these,
+    // `typeof buf.hasOwnProperty` is `"undefined"` and the
+    // subsequent invocation throws "buffer.hasOwnProperty is not
+    // a function" at express startup.
+    "hasOwnProperty",
+    "propertyIsEnumerable",
+    "valueOf",
+    "isPrototypeOf",
+    "toLocaleString",
+    "readUInt8",
+    "readUint8",
+    "readInt8",
+    "readUInt16BE",
+    "readUint16BE",
+    "readUInt16LE",
+    "readUint16LE",
+    "readInt16BE",
+    "readInt16LE",
+    "readUInt32BE",
+    "readUint32BE",
+    "readUInt32LE",
+    "readUint32LE",
+    "readInt32BE",
+    "readInt32LE",
+    "readFloatBE",
+    "readFloatLE",
+    "readDoubleBE",
+    "readDoubleLE",
+    "readBigInt64BE",
+    "readBigInt64LE",
+    "readBigUInt64BE",
+    "readBigUint64BE",
+    "readBigUInt64LE",
+    "readBigUint64LE",
+    "readUIntBE",
+    "readUintBE",
+    "readUIntLE",
+    "readUintLE",
+    "readIntBE",
+    "readIntLE",
+    "writeUInt8",
+    "writeUint8",
+    "writeInt8",
+    "writeUInt16BE",
+    "writeUint16BE",
+    "writeUInt16LE",
+    "writeUint16LE",
+    "writeInt16BE",
+    "writeInt16LE",
+    "writeUInt32BE",
+    "writeUint32BE",
+    "writeUInt32LE",
+    "writeUint32LE",
+    "writeInt32BE",
+    "writeInt32LE",
+    "writeFloatBE",
+    "writeFloatLE",
+    "writeDoubleBE",
+    "writeDoubleLE",
+    "writeBigInt64BE",
+    "writeBigInt64LE",
+    "writeBigUInt64BE",
+    "writeBigUint64BE",
+    "writeBigUInt64LE",
+    "writeBigUint64LE",
+    "writeUIntBE",
+    "writeUintBE",
+    "writeUIntLE",
+    "writeUintLE",
+    "writeIntBE",
+    "writeIntLE",
+    // #2901: TC39 Uint8Array base64/hex instance conversion APIs.
+    "toBase64",
+    "toHex",
+    "setFromBase64",
+    "setFromHex",
+    // #2879: typed-array mutators that reach buffer dispatch for the
+    // Uint8Array/Buffer shape.
+    "copyWithin",
+    // #2878: DataView numeric accessors. These resolve as bound-method
+    // values on a DataView-marked buffer (so `typeof dv.getUint8 ===
+    // "function"`); the call routes through `dispatch_buffer_method`.
+    "getInt8",
+    "getUint8",
+    "getInt16",
+    "getUint16",
+    "getInt32",
+    "getUint32",
+    "getFloat32",
+    "getFloat64",
+    "setInt8",
+    "setUint8",
+    "setInt16",
+    "setUint16",
+    "setInt32",
+    "setUint32",
+    "setFloat32",
+    "setFloat64",
+    // #4365: DataView BigInt64/BigUint64 accessors (8-byte BigInt
+    // read/write). Route through `dispatch_buffer_method` like the
+    // other DataView numeric methods.
+    "getBigInt64",
+    "getBigUint64",
+    "setBigInt64",
+    "setBigUint64",
+);
 
 unsafe fn buffer_secret_export_format(bits: f64) -> Option<String> {
     let raw = bits.to_bits();

--- a/crates/perry-runtime/src/object/field_get_set/buffer_own_prop.rs
+++ b/crates/perry-runtime/src/object/field_get_set/buffer_own_prop.rs
@@ -23,18 +23,20 @@ use super::*;
 pub(super) fn buffer_own_prop_or_method(
     obj: *const ObjectHeader,
     key_bytes: &[u8],
-    key_ptr: *const u8,
-    key_len: usize,
 ) -> Option<JSValue> {
     let name = std::str::from_utf8(key_bytes).ok()?;
     if let Some(v) = crate::buffer::buffer_get_own_prop(obj as usize, name) {
         return Some(JSValue::from_bits(v.to_bits()));
     }
-    if crate::object::buffer_dispatch::is_buffer_method_name(name) {
+    // The bound closure keeps the name POINTER and re-reads it at call time
+    // (`dispatch_bound_method`), so it must not point into the key string:
+    // that is a movable GC heap allocation, and `key_bytes` borrows its
+    // interior. Bind the `'static` literal instead.
+    if let Some(method) = crate::object::buffer_dispatch::buffer_method_name_static(name) {
         let bound = crate::object::js_class_method_bind(
             crate::value::js_nanbox_pointer(obj as i64),
-            key_ptr,
-            key_len,
+            method.as_ptr(),
+            method.len(),
         );
         return Some(JSValue::from_bits(bound.to_bits()));
     }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -257,9 +257,9 @@ pub(crate) fn get_field_by_name_object_tail(
                 }
                 // An own property on the Buffer shadows the same-named prototype
                 // method; both reads live in `buffer_own_prop`.
-                if let Some(v) = super::buffer_own_prop::buffer_own_prop_or_method(
-                    obj, key_bytes, key_ptr, key_len,
-                ) {
+                if let Some(v) =
+                    super::buffer_own_prop::buffer_own_prop_or_method(obj, key_bytes)
+                {
                     return v;
                 }
                 // ArrayBuffer.prototype `resizable` / `maxByteLength` getters.

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -185,12 +185,16 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
                 if let Some(v) = crate::buffer::buffer_get_own_prop(raw as usize, &name) {
                     return v;
                 }
-                if crate::object::buffer_dispatch::is_buffer_method_name(&name) {
-                    let bytes = name.as_bytes();
+                // The bound closure keeps the name POINTER and re-reads it at
+                // call time, so it must not borrow from `name` — a local
+                // `String` freed the moment this returns.
+                if let Some(method) =
+                    crate::object::buffer_dispatch::buffer_method_name_static(&name)
+                {
                     return crate::object::js_class_method_bind(
                         crate::value::js_nanbox_pointer(raw as i64),
-                        bytes.as_ptr(),
-                        bytes.len(),
+                        method.as_ptr(),
+                        method.len(),
                     );
                 }
             }


### PR DESCRIPTION
## Fixing a crash when you read a method off a Buffer

Reading a method from a Buffer without calling it — `typeof buf.readUInt8`, `const f = buf.readUInt8`, or `buf[someKey]` — produced a function that pointed at memory which had already been freed or moved. Calling it later read whatever happened to be sitting there.

This fixes the segmentation fault on `test_gap_buffer_own_props` and `test_gap_buffer_own_prop_shadow_intrinsic_6405` in the conformance test suite. Neither test is listed in `gap_snapshot.json`, meaning both are expected to pass.

### What was wrong

When you read a method off a Buffer but do not call it, Perry has to hand you back something callable. It builds a small object that remembers two things: which Buffer you read it from, and the **name** of the method. When you eventually call it, that name is looked up and the real method runs.

The catch is that it remembers the name as a *pointer* — an address in memory — rather than copying the text. So whatever it points at has to stay valid and unchanged for as long as that callable object might be used. The function's own documentation says exactly this:

> Method-name pointer is expected to be stable for the closure's lifetime; codegen emits it from the per-module `.str.N.bytes` rodata global.

The compiler holds up its end: the names it passes live in a read-only section of the executable and never move. Two places in the runtime did not:

| where | what it pointed at | why that breaks |
|---|---|---|
| `get_field_by_name_tail` | inside the key string on the garbage-collected heap | that string becomes unreachable the moment the read returns, so the collector is free to reclaim it or relocate it while the callable is still around |
| `polymorphic_index`, the `buf[key]` path | inside a temporary Rust `String` local | that memory is freed when the function returns, so the pointer is dangling immediately — no garbage collector involved at all |

In both cases you got back something that looked like a working function and was, in fact, pointing at memory nobody owned any more.

### The fix

Both places now pass a pointer to a string literal baked into the executable, which is never freed and never moves — the same guarantee the compiler already provides.

To make that possible without maintaining a second copy of the list of Buffer method names, the existing list in `buffer_dispatch` now generates two things from one source: the existing yes/no check, and a new lookup that returns the matching literal. The yes/no check compiles to exactly what it did before, and the new lookup is only reached on the path that was already about to allocate, so nothing on a hot path got slower.

I checked the other callers of the same function while I was in there. The ones in `symbol/get.rs` pass byte-string literals, which already live in read-only memory, and the three in `descriptors.rs` and the class registry already make a permanent copy. These two were the only ones getting it wrong.

<details>
<summary><b>Why this looked like a flaky test rather than a bug</b></summary>

Whether reading freed memory *actually goes wrong* depends on whether anything has reused that memory yet. That is a property of the memory allocator on the machine you happen to be running on — not a property of the program.

So this passed consistently on macOS while segfaulting on Linux in CI. Worse, it looked like unrelated changes were causing it: an in-flight pull request that made the garbage collector run more often flipped `test_gap_buffer_own_props` from passing to crashing without touching a single line of Buffer code. More collections meant more churn, which meant the freed bytes were more likely to have been reused by the time anything read them.

That is exactly the kind of bug that gets triaged as "flaky, re-run it".
</details>

<details>
<summary><b>The tests, and why they check the shape rather than the symptom</b></summary>

The obvious test — call the method after forcing a collection and see whether it still works — is a bad test here, because it asks the machine's allocator a question rather than asking the program one. It would pass on a lucky host with the bug fully present, which is the failure mode that let this ship in the first place.

So the three tests in `gc/tests/buffer_bound_method_name.rs` check the underlying rule instead:

1. The callable's remembered name must not point inside the key string.
2. The `buf[key]` path's remembered name must not point at a temporary.
3. The new lookup must not return a borrow of what you passed it, and two callers looking up the same name must get back the identical pointer, no matter where their own copy of the text lives.

These live under `gc/tests/` so they run in the required per-pull-request `cargo-test` job, rather than the nightly-only tier where a regression could sit red for days.

**They were checked by deliberately breaking the fix.** With the two corrected call sites reverted and the tests left alone, the first two fail — and the second one fails because the remembered name had already turned into garbage bytes. So the use-after-free reproduces deterministically, in-process, on the same machine where the end-to-end tests were happily passing.
</details>

<details>
<summary><b>How this was verified</b></summary>

- `cargo test -p perry-runtime --lib` — **1979 passed, 0 failed**, 4 ignored.
- All **12** Buffer and DataView conformance tests produce byte-identical output to Node 26.5.1, including the two that were crashing.
- `scripts/check_file_size.sh` passes.
</details>

No version bump — the maintainer bumps that at merge time, per the external-contributor flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Buffer bound methods to remain reliable when accessed directly or through computed property names.
  * Prevented failures caused by temporary or changing property-name storage.
  * Preserved expected Buffer method behavior while continuing to reject unknown method names.

* **Tests**
  * Added regression coverage for method-name stability and Buffer method lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->