### PR TITLE
gc: assert the positive direction of arena-growth pacing recording, on one shared accessor (#7737 item 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1439
+**Current Version:** 0.5.1440
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,7 +5547,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "base64",
@@ -5607,14 +5607,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "cc",
  "libc",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "base64",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5721,14 +5721,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "serde",
  "serde_json",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1439"
+version = "0.5.1440"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "clap",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "block2",
  "objc2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "chrono",
  "cron",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5871,14 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bytes",
  "h2",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bson",
  "futures-util",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5993,7 +5993,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6079,14 +6079,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "brotli",
  "flate2",
@@ -6145,7 +6145,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "base64",
@@ -6226,14 +6226,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6328,14 +6328,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6344,14 +6344,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "itoa",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "block2",
@@ -6417,7 +6417,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "block2",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1439"
+version = "0.5.1440"
 
 [[package]]
 name = "perry-ui-test"
@@ -6443,11 +6443,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1439"
+version = "0.5.1440"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "block2",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "block2",
  "libc",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "base64",
  "libc",
@@ -6509,14 +6509,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "anyhow",
  "base64",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1439"
+version = "0.5.1440"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1439"
+version = "0.5.1440"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/7752-positive-pacing-recording-test.md
+++ b/changelog.d/7752-positive-pacing-recording-test.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **gc: the arena-growth pacing recording is now asserted in the POSITIVE direction, and the predicate and the recording read one accessor (#7737 item 2).**
+
+  `declining_to_escalate_records_no_pre_full_reading` proved only that a *declined* escalation leaves `pre_in_use == 0`. Nothing asserted that a `true` verdict from the real `arena_growth_full_escalation_due()` — not the `test_note_full_cycle_reclaimed` bypass, which sets the reading itself — leaves a non-zero one behind. A negative-only test cannot distinguish "declined correctly" from "the recording never ran": both produce `0`. That is precisely the first-cut bug #7733's changelog describes (the recording wired at the wrong call sites, `update_major_pacing_backoff` returning early on a zero pre-reading, every test green).
+
+  Forcing `due == true` needs an arena reading above `PERRY_GC_MAJOR_PACING_FLOOR_MB` (32 MB by default), and the floor cannot be lowered per test: `major_pacing_config` is a process-wide `OnceLock`, so an env var only takes effect if the test happens to run first. A 32 MB live heap in a unit test is what `major_pacing_escalation_threshold_for` was factored out to avoid. So the reading is injected instead, through a new `pacing_arena_in_use_bytes()` — the ONE accessor both the escalation predicate and `note_full_cycle_started` now use.
+
+  That accessor is worth more than the seam. `update_major_pacing_backoff`'s doc already claimed the two are "deliberately measured on the SAME metric ... so the two cannot disagree about whether a full helped" — but both sites called `arena_in_use_bytes()` independently, so the guarantee was a convention, not a structure. Routing an injected reading in and requiring the same value back out makes it checkable. The override is `#[cfg(test)]`, so it compiles out of every shipping build; it is not a runtime knob and so is not subject to the GC knob kill-policy.
+
+  Three tests: the positive recording, predicate/recording agreement across several readings, and the floor's inclusivity (`>=` on the floor is why `major_pacing_escalation_threshold_for` adds its `+1` to the growth boundary and not to the floor).
+
+  **All three were verified able to fail.** Sabotage 1 rewires the recording away from the predicate (the #7726 bug): all 3 go red. Sabotage 2 points `note_full_cycle_started` back at a second, independent `arena_in_use_bytes()` call (metric drift): all 3 go red. In both arms the pre-existing negative test still PASSED — which is the gap this closes, demonstrated rather than asserted.
+
+  Items 1 (prototype-registry latch) and 4 (branch-protection promotion) of #7737 are not touched here: 1 landed in #7740, and 4 is a maintainer action. Item 3 (the grow-then-churn `gc_ratchet` probe) needs the pinned bench host and is left open.

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1588,7 +1588,43 @@ fn update_major_pacing_backoff(post_in_use: usize) {
 /// nothing about arena-growth pacing, and whose repeated use would otherwise
 /// drive the shift to its cap — never moves the backoff.
 fn note_full_cycle_started() {
-    GC_FULL_CYCLE_PRE_IN_USE_BYTES.with(|bytes| bytes.set(crate::arena::arena_in_use_bytes()));
+    GC_FULL_CYCLE_PRE_IN_USE_BYTES.with(|bytes| bytes.set(pacing_arena_in_use_bytes()));
+}
+
+/// The arena reading BOTH halves of arena-growth pacing must use: the
+/// escalation predicate's comparison against the boundary, and the pre-full
+/// reading `note_full_cycle_started` records for `update_major_pacing_backoff`
+/// to price the result against.
+///
+/// `update_major_pacing_backoff`'s doc already says these are "deliberately
+/// measured on the SAME metric ... so the two cannot disagree about whether a
+/// full helped". Reading `arena_in_use_bytes()` twice made that a convention;
+/// one accessor makes it structural (#7737).
+///
+/// It is also the injection point the positive-direction test needs. Forcing a
+/// `true` verdict from the REAL predicate otherwise requires an arena above
+/// `PERRY_GC_MAJOR_PACING_FLOOR_MB` (32 MB by default), and the floor cannot be
+/// lowered per-test: `major_pacing_config` is a process-wide `OnceLock`, so an
+/// env var only takes effect if this test happens to run first. A 32 MB live
+/// heap in a unit test is what `major_pacing_escalation_threshold_for` was
+/// factored out to avoid, so the seam goes here instead — `#[cfg(test)]`, so it
+/// compiles out of every shipping build and is not a mode anything can be
+/// configured into (CLAUDE.md's GC knob kill-policy is about runtime knobs;
+/// this is not one).
+fn pacing_arena_in_use_bytes() -> usize {
+    #[cfg(test)]
+    if let Some(bytes) = TEST_PACING_ARENA_IN_USE.with(|cell| cell.get()) {
+        return bytes;
+    }
+    crate::arena::arena_in_use_bytes()
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override for [`pacing_arena_in_use_bytes`]. Thread-local, so
+    /// concurrently-running tests cannot see each other's value.
+    static TEST_PACING_ARENA_IN_USE: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
 }
 
 /// Current arena-growth escalation backoff shift.
@@ -1636,6 +1672,18 @@ pub(super) fn test_major_pacing_pre_in_use_bytes() -> usize {
 #[cfg(test)]
 pub(super) fn test_set_major_pacing_baseline(bytes: usize) -> usize {
     GC_LAST_FULL_ARENA_IN_USE_BYTES.with(|cell| {
+        let previous = cell.get();
+        cell.set(bytes);
+        previous
+    })
+}
+
+/// Override the arena reading arena-growth pacing sees, for the duration of a
+/// test. `None` restores the real `arena_in_use_bytes()`. Returns the previous
+/// value so a test can restore it rather than assume it was unset.
+#[cfg(test)]
+pub(super) fn test_set_pacing_arena_in_use(bytes: Option<usize>) -> Option<usize> {
+    TEST_PACING_ARENA_IN_USE.with(|cell| {
         let previous = cell.get();
         cell.set(bytes);
         previous
@@ -2706,7 +2754,7 @@ fn arena_growth_full_escalation_due_inner() -> bool {
         // `PERRY_GC_MAJOR_PACING_FLOOR_MB=0` disables the pacing: no reading
         // escalates, so there is no boundary to compare against.
         None => false,
-        Some(threshold) => crate::arena::arena_in_use_bytes() >= threshold,
+        Some(threshold) => pacing_arena_in_use_bytes() >= threshold,
     }
 }
 

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -778,6 +778,156 @@ fn declining_to_escalate_records_no_pre_full_reading() {
     );
 }
 
+/// #7737 item 2: the POSITIVE direction of the same recording.
+///
+/// `declining_to_escalate_records_no_pre_full_reading` proves only that a
+/// declined escalation leaves `pre_in_use == 0`. Nothing asserted that a `true`
+/// verdict from the REAL `arena_growth_full_escalation_due()` — not the
+/// `test_note_full_cycle_reclaimed` bypass, which sets the reading itself —
+/// leaves a non-zero one behind.
+///
+/// That gap is exactly the shape of the first-cut bug #7733's changelog
+/// describes: the recording wired at the wrong call sites,
+/// `update_major_pacing_backoff` silently no-op'ing on `pre_in_use == 0`, and
+/// every test still green. A negative-only test cannot see it, because the
+/// no-op and the correct decline produce the same `0`.
+///
+/// Forcing `due == true` needs the arena reading above the floor
+/// (`PERRY_GC_MAJOR_PACING_FLOOR_MB`, 32 MB by default), and the floor is not
+/// lowerable per-test — `major_pacing_config` is a process-wide `OnceLock`. So
+/// the reading is injected through `pacing_arena_in_use_bytes`, the one
+/// accessor both the predicate and the recording now share.
+#[test]
+fn escalating_records_the_pre_full_arena_reading() {
+    use super::super::policy::{
+        arena_growth_full_escalation_due, major_pacing_config, test_major_pacing_pre_in_use_bytes,
+        test_reset_major_pacing_backoff, test_set_major_pacing_baseline,
+        test_set_pacing_arena_in_use,
+    };
+
+    let (floor_bytes, _growth) = major_pacing_config();
+    if floor_bytes == 0 {
+        // `PERRY_GC_MAJOR_PACING_FLOOR_MB=0` disables pacing outright: no
+        // reading escalates, so there is no positive direction to assert.
+        return;
+    }
+
+    test_reset_major_pacing_backoff();
+    // Baseline 0 ("no full yet") makes the floor itself the boundary, so the
+    // reading below is unambiguously over it.
+    let previous_baseline = test_set_major_pacing_baseline(0);
+    let reading = floor_bytes + 1;
+    let previous_reading = test_set_pacing_arena_in_use(Some(reading));
+
+    let due = arena_growth_full_escalation_due();
+    let recorded = test_major_pacing_pre_in_use_bytes();
+
+    test_set_pacing_arena_in_use(previous_reading);
+    test_set_major_pacing_baseline(previous_baseline);
+    test_reset_major_pacing_backoff();
+
+    assert!(
+        due,
+        "an arena reading one byte over the floor ({floor_bytes}) must escalate \
+         with no prior full — `major_pacing_escalation_threshold_for` returns \
+         the floor verbatim when the baseline is 0"
+    );
+    assert_eq!(
+        recorded, reading,
+        "an ESCALATED full must leave the pre-full reading behind, and it must \
+         be the same reading the predicate decided on. A 0 here is the #7726 \
+         no-op: `update_major_pacing_backoff` returns early on a zero pre \
+         reading, so the backoff never fires and pacing silently reverts to the \
+         unconditional K× rule — with every test still green"
+    );
+}
+
+/// The predicate and the pre-full recording must read the SAME metric.
+///
+/// `update_major_pacing_backoff`'s doc asserts this in prose ("deliberately
+/// measured on the SAME metric the escalation gate reads"). Before #7737 both
+/// sites called `arena_in_use_bytes()` independently, so the guarantee was a
+/// convention two call sites happened to honour. Routing an injected reading
+/// through and requiring it to come back out the other side is what makes it
+/// checkable: if either site is re-pointed at a different metric, the recorded
+/// value stops matching what the decision was taken on.
+#[test]
+fn the_recorded_reading_is_the_one_the_predicate_decided_on() {
+    use super::super::policy::{
+        arena_growth_full_escalation_due, major_pacing_config, test_major_pacing_pre_in_use_bytes,
+        test_reset_major_pacing_backoff, test_set_major_pacing_baseline,
+        test_set_pacing_arena_in_use,
+    };
+
+    let (floor_bytes, _growth) = major_pacing_config();
+    if floor_bytes == 0 {
+        return;
+    }
+
+    for over in [1usize, 7, 4096] {
+        test_reset_major_pacing_backoff();
+        let previous_baseline = test_set_major_pacing_baseline(0);
+        let reading = floor_bytes + over;
+        let previous_reading = test_set_pacing_arena_in_use(Some(reading));
+
+        let due = arena_growth_full_escalation_due();
+        let recorded = test_major_pacing_pre_in_use_bytes();
+
+        test_set_pacing_arena_in_use(previous_reading);
+        test_set_major_pacing_baseline(previous_baseline);
+        test_reset_major_pacing_backoff();
+
+        assert!(due, "reading {reading} is over the floor {floor_bytes}");
+        assert_eq!(
+            recorded, reading,
+            "the recording must observe the same arena reading the predicate did"
+        );
+    }
+}
+
+/// A reading exactly ON the floor escalates (the clause is `>=`), and one below
+/// it does not — the boundary the positive test sits above.
+#[test]
+fn the_floor_is_inclusive_and_below_it_declines() {
+    use super::super::policy::{
+        arena_growth_full_escalation_due, major_pacing_config, test_major_pacing_pre_in_use_bytes,
+        test_reset_major_pacing_backoff, test_set_major_pacing_baseline,
+        test_set_pacing_arena_in_use,
+    };
+
+    let (floor_bytes, _growth) = major_pacing_config();
+    if floor_bytes == 0 {
+        return;
+    }
+
+    let mut verdicts = Vec::new();
+    for reading in [floor_bytes - 1, floor_bytes] {
+        test_reset_major_pacing_backoff();
+        let previous_baseline = test_set_major_pacing_baseline(0);
+        let previous_reading = test_set_pacing_arena_in_use(Some(reading));
+
+        let due = arena_growth_full_escalation_due();
+        let recorded = test_major_pacing_pre_in_use_bytes();
+
+        test_set_pacing_arena_in_use(previous_reading);
+        test_set_major_pacing_baseline(previous_baseline);
+        test_reset_major_pacing_backoff();
+        verdicts.push((due, recorded));
+    }
+    assert_eq!(
+        verdicts[0],
+        (false, 0),
+        "one byte under the floor must decline, and record nothing"
+    );
+    assert_eq!(
+        verdicts[1],
+        (true, floor_bytes),
+        "exactly on the floor must escalate — the clause is `>=`, which is why \
+         `major_pacing_escalation_threshold_for` adds the `+1` to the growth \
+         boundary and not to the floor"
+    );
+}
+
 /// The escalation boundary the GC trace reports must be the boundary the
 /// predicate takes its decision on.
 ///


### PR DESCRIPTION
Addresses **item 2** of #7737 ("No positive-direction test for the recording"). Item 1 landed in #7740; item 4 is a maintainer action; item 3 needs the pinned bench host and is left open — so this does **not** close the issue.

## The gap

`declining_to_escalate_records_no_pre_full_reading` proves only the negative: a declined escalation leaves `pre_in_use == 0`. Nothing asserted that a `true` verdict from the **real** `arena_growth_full_escalation_due()` — not the `test_note_full_cycle_reclaimed` bypass, which sets the reading itself — leaves a non-zero one behind.

A negative-only test cannot tell "declined correctly" from "the recording never ran". Both produce `0`. That is exactly the first-cut bug #7733's own changelog describes: the recording wired at the wrong call sites, `update_major_pacing_backoff` returning early on a zero pre-reading, and every test still green.

## Why it wasn't already there, and what I did instead

The issue says forcing `due=true` "needs control over `arena_in_use_bytes()`, which isn't mockable today". Confirmed, and the reason is worth recording: the boundary is `max(floor, baseline × growth + 1)`, and the floor **always dominates from below**, so no amount of baseline manipulation gets the threshold under it. `PERRY_GC_MAJOR_PACING_FLOOR_MB` can't help either — `major_pacing_config` is a process-wide `OnceLock`, so an env var only takes effect if this test happens to run first.

That leaves a 32 MB live heap, which is precisely what `major_pacing_escalation_threshold_for` was factored out to avoid ("unit-testable without a 32 MB live heap").

So the reading is injected, through a new `pacing_arena_in_use_bytes()` — **the one accessor both the escalation predicate and `note_full_cycle_started` now use.**

## The accessor is the more interesting half

`update_major_pacing_backoff`'s doc already claims:

> Deliberately measured on the SAME metric the escalation gate reads (`arena_in_use_bytes`) so the two cannot disagree about whether a full helped.

But both sites called `arena_in_use_bytes()` independently. The guarantee was a convention two call sites happened to honour, not a structure — the same shape as the snapshot-vs-predicate divergence #7733 fixed by collapsing two formulas into one. Routing an injected reading in and requiring the same value back out is what makes it checkable.

The override is `#[cfg(test)]`: it compiles out of every shipping build, so it is not a runtime knob and the GC knob kill-policy doesn't apply.

## Tests, and proof they can fail

Three, all deterministic (thread-local, no timing, no allocation):

- `escalating_records_the_pre_full_arena_reading` — the item-2 ask.
- `the_recorded_reading_is_the_one_the_predicate_decided_on` — agreement across several readings.
- `the_floor_is_inclusive_and_below_it_declines` — `floor - 1` declines and records nothing; exactly `floor` escalates. (The `>=` on the floor is why `major_pacing_escalation_threshold_for` adds its `+1` to the growth boundary and not to the floor.)

**Both sabotage arms were run:**

| sabotage | result |
|---|---|
| rewire the recording away from the predicate (the #7726 bug) | all 3 new tests FAIL |
| point `note_full_cycle_started` at a second, independent `arena_in_use_bytes()` (metric drift) | all 3 new tests FAIL |

And in **both** arms the pre-existing negative test still **passed** — so the gap this PR closes is demonstrated, not merely asserted.

## Validation

- `cargo test -p perry-runtime --lib`: 1991 passed, 0 failed.
- `cargo fmt --all --check`, `scripts/check_file_size.sh`: clean.

One thing worth flagging for #7365 rather than this PR: across four repeat runs of the full suite under CPU load I saw 0–2 failures per run, always from `promise::keyed_table::tests::{settling_many_keys,draining_a_heavily_populated_key_ahead_of_another}_is_not_quadratic` and once `gc::tests::inline_generation_gate_contract::sabotaged_parent_gate_strands_a_young_child_the_shipped_gate_keeps`. Those are wall-clock-ratio assertions, which is a plausible mechanism for "#7365: fails a different number of tests on every run". None of the three is touched by this PR, and my three new tests never appeared in any run.

No version bump (maintainer bumps at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved major garbage-collection pacing consistency by aligning escalation checks with recorded arena usage.
  * Ensured pacing behavior handles threshold values correctly, including the inclusive lower boundary.

* **Tests**
  * Added coverage for positive pacing escalation, metric consistency, and below-threshold behavior.
  * Added safeguards against metric drift and incorrect pacing wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->