### PR TITLE
fix(codegen): spread method call dispatches on an imported-value receiver (#7191)

### DIFF
--- a/changelog.d/7801-spread-call-imported-receiver.md
+++ b/changelog.d/7801-spread-call-imported-receiver.md
@@ -1,0 +1,19 @@
+**A spread method call on an imported receiver now dispatches the receiver's method** (#7191).
+
+```ts
+import { arr, nums } from "./lib.ts";
+arr.map(...[cb])        // was: TypeError
+arr.slice(...[1, 3])    // was: [3,1,2]  — the whole array
+nums.join(...["-"])     // was: TypeError
+nums.includes(...[20])  // was: false
+```
+
+Four cases, four wrong, and two of them wrong *silently* — which is why it lasted. The spread argument list was arriving as a single array in the builtin's first slot, so `slice` saw one non-numeric argument and `includes` compared against an array.
+
+`Expr::ExternFuncRef` is not one shape. It covers an imported **function**, where a method-apply dispatch would be wrong — which is why the generic `CallSpread` tail skips it — and an imported **value**, where method-apply is exactly what is needed. The skip did not distinguish the two, so a spread call on any imported receiver declined to dispatch. `ctx.imported_vars` already records precisely this distinction ("names of imports that are exported variables, not functions"), so the arm consults it instead of declining the whole family.
+
+The imported-array fold that used to cover part of this was papering over the same gap, and papering badly — `slice` and `includes` were already returning wrong values through it.
+
+`test_gap_spread_call_imported_receiver_7191.ts` asserts both halves, because the risk here is fixing one by breaking the other: the imported-value receivers that were broken (arrays via `map`/`slice`/`join`/`includes`/`indexOf`/`concat`/`at`, including a spread argument that is itself an array so "the args collapsed into one array" cannot pass by accident), and the imported-function/object/class receivers the skip exists to protect (`fn.call(...)`, `fn.apply(...)`, a direct `fn(...)`, an imported object's method, an imported class's static and instance methods). A local receiver is asserted unchanged.
+
+The existing `test_gap_6718_spread_call_native_method` covers inline literals, local receivers and `queueMicrotask` — not imported receivers — which is why this shape had never been under test. It stays green, as do `test_gap_import` and the class/static families.

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -278,9 +278,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 object, property, ..
             } = callee.as_ref()
             {
+                // #7191: `ExternFuncRef` is not one shape. It covers an
+                // imported FUNCTION (`import { fn }` — a method-apply dispatch
+                // on it would be wrong, which is why this skip exists) and an
+                // imported VALUE (`import { arr }; arr.map(...args)` — where
+                // method-apply is exactly right). Skipping both meant a spread
+                // method call on any imported receiver never dispatched the
+                // receiver's method: `arr.slice(...[1,3])` returned the whole
+                // array and `nums.includes(...[20])` returned false, because
+                // the spread list arrived as a single array in the builtin's
+                // first slot. `ctx.imported_vars` is the existing discriminator
+                // — "names of imports that are exported variables, not
+                // functions" — so consult it rather than declining the family.
                 let mut skip = matches!(
                     object.as_ref(),
-                    Expr::GlobalGet(_) | Expr::NativeModuleRef(_) | Expr::ExternFuncRef { .. }
+                    Expr::GlobalGet(_) | Expr::NativeModuleRef(_)
+                ) || matches!(
+                    object.as_ref(),
+                    Expr::ExternFuncRef { name, .. } if !ctx.imported_vars.contains(name.as_str())
                 );
                 // `recv.prop(...args)` where `prop` is an instance ACCESSOR
                 // (`get prop()`) is NOT a method call: it must READ the accessor

--- a/test-files/spread_call_imported_receiver_7191_helper.ts
+++ b/test-files/spread_call_imported_receiver_7191_helper.ts
@@ -1,0 +1,21 @@
+// Support module for test_gap_spread_call_imported_receiver_7191.ts (#7191).
+// The receivers must be IMPORTED — that is the whole subject of the test.
+export const arr = [3, 1, 2];
+export const nums: number[] = [10, 20, 30];
+export function fn(a: number, b: number) {
+  return a + b;
+}
+export const obj = {
+  m(x: number) {
+    return x * 3;
+  },
+  v: 7,
+};
+export class K {
+  static s(x: number) {
+    return x + 100;
+  }
+  m(x: number) {
+    return x - 1;
+  }
+}

--- a/test-files/test_gap_spread_call_imported_receiver_7191.ts
+++ b/test-files/test_gap_spread_call_imported_receiver_7191.ts
@@ -1,0 +1,54 @@
+// Gap: a spread method call whose RECEIVER is an imported binding (#7191).
+//
+// `arr.map(...[cb])` where `arr` comes from another module was wrong four ways
+// out of four — and two of them were silently wrong rather than throwing, which
+// is why it survived: `arr.slice(...[1,3])` returned the whole array and
+// `nums.includes(...[20])` returned false, because the spread argument list
+// arrived as a single array sitting in the builtin's first slot.
+//
+// The cause is that `Expr::ExternFuncRef` is not one shape. It is both an
+// imported FUNCTION — where a method-apply dispatch would be wrong, which is
+// why the generic `CallSpread` tail skips it — and an imported VALUE, where
+// method-apply is exactly what is needed. The skip did not distinguish them, so
+// a spread call on any imported receiver never dispatched the receiver's
+// method. `ctx.imported_vars` already records which imports are variables
+// rather than functions.
+//
+// `test_gap_6718_spread_call_native_method` covers inline literals, local
+// receivers and `queueMicrotask` — not imported receivers — so this shape had
+// never been under test. Both halves are asserted here: the imported-value
+// receivers that were broken, and the imported-function/class/object receivers
+// the skip exists to protect, which must keep working.
+
+import { arr, nums, fn, obj, K } from "./spread_call_imported_receiver_7191_helper.ts";
+
+const cb = (x: number) => x * 2;
+
+// The four cases from the report, in their original order.
+console.log(JSON.stringify(arr.map(...([cb] as [any]))));
+console.log(JSON.stringify(arr.slice(...([1, 3] as [any, any]))));
+console.log(JSON.stringify(nums.join(...(["-"] as [any]))));
+console.log(JSON.stringify(nums.includes(...([20] as [any]))));
+
+// More imported-array receivers, including one whose spread arg is itself an
+// array (so "the args became one array" cannot pass by accident).
+console.log("indexOf:", arr.indexOf(...([2] as [any])));
+console.log("concat:", JSON.stringify(arr.concat(...([[9]] as [any]))));
+console.log("at:", nums.at(...([-1] as [any])));
+
+// The shapes the skip protects: an imported FUNCTION reached through
+// `.call` / `.apply`, and a direct spread call on it.
+console.log("fn.call:", fn.call(...([null, 1, 2] as [any, any, any])));
+console.log("fn.apply:", fn.apply(...([null, [3, 4]] as [any, any])));
+console.log("fn direct:", fn(...([5, 6] as [any, any])));
+
+// An imported object's method, and an imported class's static and instance
+// methods — all reached with a spread argument list.
+console.log("obj.m:", obj.m(...([2] as [any])));
+console.log("K.s:", K.s(...([1] as [any])));
+console.log("K#m:", new K().m(...([10] as [any])));
+
+// A local receiver must be unaffected by any of this.
+const local = [3, 1, 2];
+console.log("local-map:", JSON.stringify(local.map(...([cb] as [any]))));
+console.log("local-slice:", JSON.stringify(local.slice(...([1, 3] as [any, any]))));


### PR DESCRIPTION
**A spread method call on an imported receiver now dispatches the receiver's method** (#7191).

```ts
import { arr, nums } from "./lib.ts";
arr.map(...[cb])        // was: TypeError
arr.slice(...[1, 3])    // was: [3,1,2]  — the whole array
nums.join(...["-"])     // was: TypeError
nums.includes(...[20])  // was: false
```

Four cases, four wrong, and two of them wrong *silently* — which is why it lasted. The spread argument list was arriving as a single array in the builtin's first slot, so `slice` saw one non-numeric argument and `includes` compared against an array.

`Expr::ExternFuncRef` is not one shape. It covers an imported **function**, where a method-apply dispatch would be wrong — which is why the generic `CallSpread` tail skips it — and an imported **value**, where method-apply is exactly what is needed. The skip did not distinguish the two, so a spread call on any imported receiver declined to dispatch. `ctx.imported_vars` already records precisely this distinction ("names of imports that are exported variables, not functions"), so the arm consults it instead of declining the whole family.

The imported-array fold that used to cover part of this was papering over the same gap, and papering badly — `slice` and `includes` were already returning wrong values through it.

`test_gap_spread_call_imported_receiver_7191.ts` asserts both halves, because the risk here is fixing one by breaking the other: the imported-value receivers that were broken (arrays via `map`/`slice`/`join`/`includes`/`indexOf`/`concat`/`at`, including a spread argument that is itself an array so "the args collapsed into one array" cannot pass by accident), and the imported-function/object/class receivers the skip exists to protect (`fn.call(...)`, `fn.apply(...)`, a direct `fn(...)`, an imported object's method, an imported class's static and instance methods). A local receiver is asserted unchanged.

The existing `test_gap_6718_spread_call_native_method` covers inline literals, local receivers and `queueMicrotask` — not imported receivers — which is why this shape had never been under test. It stays green, as do `test_gap_import` and the class/static families.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spread method calls on imported values, including arrays, objects, and class instances.
  * Preserved correct behavior for imported functions and direct, `.call`, and `.apply` invocations.
  * Improved handling of nested spread arguments and local receivers.

* **Tests**
  * Added regression coverage for imported values, functions, objects, classes, and existing spread-call scenarios.

* **Documentation**
  * Added a changelog entry describing the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->