### PR TITLE
fix(hir): salt class-capture names on the module name, not the absolute path (#7177)

### DIFF
--- a/changelog.d/7806-cap-salt-reproducible.md
+++ b/changelog.d/7806-cap-salt-reproducible.md
@@ -1,0 +1,15 @@
+**Class-capture symbol names no longer depend on the working directory** (#7177) — the same source compiled from two different directories now produces byte-identical IR.
+
+The per-module salt in `__perry_cap_<id>m<salt>` was an FNV hash of the **canonical absolute source path**, so it changed with the checkout location. Reproducible builds were impossible by construction, and every IR/object A/B harness had to independently discover the dependency and pin cwd — #7176's byte-neutrality harness measured **29 of 29 same-compiler control runs differing** once it used per-run `mkdtemp` directories.
+
+Reproduced before touching anything: the same 8-line source compiled from two directories differed in exactly **4 lines of IR**, all of them the salt string (`m000059ddd802` vs `m0000f0a10f23`). Everything else — including the `prog_ts` module prefix on every other symbol — was already identical, which is the tell: the module NAME was reproducible all along, and only the salt reached past it to the filesystem.
+
+So the salt now keys on the module name. That is not merely convenient, it is the identity that already satisfies all three properties the salt needs:
+
+* **Reproducible** — it is what every other emitted symbol is prefixed with (`perry_fn_<mod>__…`, `perry_global_<mod>__…`), so it cannot vary with the checkout without breaking far more than this.
+* **Unique per module** — it carries directory components, so `a/util.ts` and `b/util.ts` become `a_util_ts` and `b_util_ts`. Verified with two same-basename modules whose capture stashes must not merge: distinct salts, correct output.
+* **Equal within a module** — same module ⇒ same salt, so same-module inheritance keeps sharing the parent's capture stash, which is the bug the salt was introduced for.
+
+`with_class_id_start` keeps its old path-based behaviour for the `#[cfg(test)]` lowering entry points that have no module name; the production path uses the new `with_class_id_start_salted`.
+
+Verified: IR byte-identical across two working directories (was: 4 lines differing); same-basename modules keep distinct salts and match Node; `test_gap_cap_salt_reproducible_7177.ts` passes byte-for-byte. The gap test deliberately covers the *properties* rather than the reproducibility itself — a `.ts` test cannot compile itself from two directories — pinning cross-module isolation, same-module inheritance sharing, and two distinct captures in one module, so a future re-keying that is too coarse or too fine fails rather than silently merging stashes. `cargo test -p perry-hir` 293 passed, `cargo test -p perry` 902 passed, `test_gap_class` 24/24.

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -10,9 +10,25 @@ use std::collections::{HashMap, HashSet};
 use super::*;
 use crate::ir::*;
 
-fn stable_tagged_template_site_salt(source_file_path: &str) -> u64 {
+/// #7177: the per-module salt must be CHECKOUT-INVARIANT.
+///
+/// It used to hash the canonical ABSOLUTE source path, so the same source
+/// compiled from two different directories produced different
+/// `__perry_cap_<id>m<salt>` names — and therefore different IR and different
+/// objects. Measured: 29 of 29 same-compiler control runs differed once the
+/// harness used per-run `mkdtemp` working directories, and every IR/object A/B
+/// campaign had to independently discover it and pin cwd.
+///
+/// The module NAME is the right key. It is already what every other emitted
+/// symbol is prefixed with (`perry_fn_<mod>__…`, `perry_global_<mod>__…`), so
+/// it is already reproducible by construction, and it keeps the property the
+/// salt exists for: it carries directory components, so `a/util.ts` and
+/// `b/util.ts` are `a_util_ts` and `b_util_ts` — distinct salts, and
+/// cross-module capture chains stay isolated exactly as before. Same module ⇒
+/// same salt ⇒ same-module inheritance keeps sharing parent stashes.
+fn stable_module_salt(module_identity: &str) -> u64 {
     let mut h: u64 = 0xcbf29ce484222325;
-    for b in source_file_path.as_bytes() {
+    for b in module_identity.as_bytes() {
         h ^= u64::from(*b);
         h = h.wrapping_mul(0x100000001b3);
     }
@@ -32,8 +48,26 @@ impl LoweringContext {
         source_file_path: impl Into<String>,
         start_class_id: ClassId,
     ) -> Self {
+        // No module name available (the `#[cfg(test)]` lowering entry points).
+        // Salting on the path preserves the pre-#7177 behaviour for those; the
+        // production path below passes the module name.
         let source_file_path = source_file_path.into();
-        let tagged_template_site_salt = stable_tagged_template_site_salt(&source_file_path);
+        let identity = source_file_path.clone();
+        Self::with_class_id_start_salted(source_file_path, identity, start_class_id)
+    }
+
+    /// #7177: as [`Self::with_class_id_start`], but salts the module's
+    /// `__perry_cap_*` names on `salt_identity` — the module NAME — instead of
+    /// its absolute source path, so the emitted symbols do not change with the
+    /// checkout location.
+    pub fn with_class_id_start_salted(
+        source_file_path: impl Into<String>,
+        salt_identity: impl Into<String>,
+        start_class_id: ClassId,
+    ) -> Self {
+        let source_file_path = source_file_path.into();
+        let module_identity = salt_identity.into();
+        let tagged_template_site_salt = stable_module_salt(&module_identity);
         Self {
             next_local_id: 0,
             next_global_id: 0,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -479,7 +479,11 @@ pub fn lower_module_full(
     // modules without candidates) lowers the original with no clone.
     let folded = super::builder_fold::fold_builder_sequences(ast_module);
     let ast_module = folded.as_ref().unwrap_or(ast_module);
-    let mut ctx = LoweringContext::with_class_id_start(source_file_path, start_class_id);
+    // #7177: salt on the module NAME (checkout-invariant), not the absolute
+    // source path, so the same source compiled from two directories emits the
+    // same `__perry_cap_*` symbols.
+    let mut ctx =
+        LoweringContext::with_class_id_start_salted(source_file_path, name, start_class_id);
     // #6812 (w16): scan the module lowering actually consumes (post-fold) for
     // constant-bounded dynamic-key builder widths; `lower_object` attaches
     // them to the per-site empty-literal classes as alloc_width_hint.

--- a/test-files/cap_salt_helper_a.ts
+++ b/test-files/cap_salt_helper_a.ts
@@ -1,0 +1,12 @@
+// Support module for test_gap_cap_salt_reproducible_7177.ts (#7177).
+// Deliberately mirrors cap_salt_helper_b.ts: same shape, same local names, so
+// the only thing distinguishing their capture stashes is the module salt.
+export function makeA(seed: number): number {
+  const captured = seed + 1;
+  class Holder {
+    get(): number {
+      return captured;
+    }
+  }
+  return new Holder().get();
+}

--- a/test-files/cap_salt_helper_b.ts
+++ b/test-files/cap_salt_helper_b.ts
@@ -1,0 +1,11 @@
+// Support module for test_gap_cap_salt_reproducible_7177.ts (#7177).
+// See cap_salt_helper_a.ts — identical shape, different module identity.
+export function makeB(seed: number): number {
+  const captured = seed + 2;
+  class Holder {
+    get(): number {
+      return captured;
+    }
+  }
+  return new Holder().get();
+}

--- a/test-files/test_gap_cap_salt_reproducible_7177.ts
+++ b/test-files/test_gap_cap_salt_reproducible_7177.ts
@@ -1,0 +1,65 @@
+// Gap: class-capture field names must not depend on the working directory
+// (#7177).
+//
+// The per-module salt in `__perry_cap_<id>m<salt>` used to be an FNV hash of
+// the CANONICAL ABSOLUTE source path, so the same source compiled from two
+// different directories produced different symbol names, different IR, and
+// different objects. Measured when it was found: 29 of 29 same-compiler
+// control runs differed once the harness used per-run `mkdtemp` working
+// directories, and three separate measurement campaigns each had to discover
+// the cwd dependency and pin around it.
+//
+// This test is a BEHAVIOURAL cover, not the reproducibility check — a `.ts`
+// gap test cannot compile itself twice from two directories. What it pins is
+// the property the salt exists for, which any future re-keying must preserve:
+// two modules that share a basename (`a/util.ts` and `b/util.ts`) must get
+// DISTINCT salts, so their capture stashes stay isolated; and a subclass
+// declared in the same module as its base must keep SHARING the parent stash,
+// which requires their salts to be equal.
+//
+// Both directions matter. A salt that is too coarse (one constant) silently
+// merges cross-module stashes; a salt that is too fine (per-class) breaks
+// same-module inheritance. The absolute-path salt satisfied both and failed
+// reproducibility; the module name satisfies all three.
+
+import { makeA } from "./cap_salt_helper_a.ts";
+import { makeB } from "./cap_salt_helper_b.ts";
+
+// Same basename, different directories-worth of identity: distinct captures.
+console.log("a:", makeA(10));
+console.log("b:", makeB(10));
+console.log("a-again:", makeA(1));
+console.log("b-again:", makeB(1));
+
+// Same-module inheritance: the subclass must see the parent's captured stash.
+function sameModuleChain(seed: number): string {
+  const captured = seed * 7;
+  class Base {
+    base(): number {
+      return captured + 1;
+    }
+  }
+  class Sub extends Base {
+    sub(): number {
+      return this.base() + captured;
+    }
+  }
+  const s = new Sub();
+  return s.base() + "/" + s.sub();
+}
+console.log("chain:", sameModuleChain(3));
+console.log("chain2:", sameModuleChain(0));
+
+// A capture reached through two nested classes in one module — same salt, two
+// distinct outer ids, so the id half of the name still has to disambiguate.
+function twoCaptures(x: number, y: number): string {
+  const first = x + 100;
+  const second = y + 200;
+  class Holder {
+    both(): string {
+      return first + "," + second;
+    }
+  }
+  return new Holder().both();
+}
+console.log("two:", twoCaptures(1, 2));


### PR DESCRIPTION
**Class-capture symbol names no longer depend on the working directory** (#7177) — the same source compiled from two different directories now produces byte-identical IR.

The per-module salt in `__perry_cap_<id>m<salt>` was an FNV hash of the **canonical absolute source path**, so it changed with the checkout location. Reproducible builds were impossible by construction, and every IR/object A/B harness had to independently discover the dependency and pin cwd — #7176's byte-neutrality harness measured **29 of 29 same-compiler control runs differing** once it used per-run `mkdtemp` directories.

Reproduced before touching anything: the same 8-line source compiled from two directories differed in exactly **4 lines of IR**, all of them the salt string (`m000059ddd802` vs `m0000f0a10f23`). Everything else — including the `prog_ts` module prefix on every other symbol — was already identical, which is the tell: the module NAME was reproducible all along, and only the salt reached past it to the filesystem.

So the salt now keys on the module name. That is not merely convenient, it is the identity that already satisfies all three properties the salt needs:

* **Reproducible** — it is what every other emitted symbol is prefixed with (`perry_fn_<mod>__…`, `perry_global_<mod>__…`), so it cannot vary with the checkout without breaking far more than this.
* **Unique per module** — it carries directory components, so `a/util.ts` and `b/util.ts` become `a_util_ts` and `b_util_ts`. Verified with two same-basename modules whose capture stashes must not merge: distinct salts, correct output.
* **Equal within a module** — same module ⇒ same salt, so same-module inheritance keeps sharing the parent's capture stash, which is the bug the salt was introduced for.

`with_class_id_start` keeps its old path-based behaviour for the `#[cfg(test)]` lowering entry points that have no module name; the production path uses the new `with_class_id_start_salted`.

Verified: IR byte-identical across two working directories (was: 4 lines differing); same-basename modules keep distinct salts and match Node; `test_gap_cap_salt_reproducible_7177.ts` passes byte-for-byte. The gap test deliberately covers the *properties* rather than the reproducibility itself — a `.ts` test cannot compile itself from two directories — pinning cross-module isolation, same-module inheritance sharing, and two distinct captures in one module, so a future re-keying that is too coarse or too fine fails rather than silently merging stashes. `cargo test -p perry-hir` 293 passed, `cargo test -p perry` 902 passed, `test_gap_class` 24/24.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated capability names are now reproducible across different checkout locations.
  * Captures from distinct modules remain isolated, while inherited captures within the same module continue to work correctly.

* **Tests**
  * Added coverage for reproducible output, same-basename module isolation, inheritance, and nested captures.

* **Documentation**
  * Documented the improved reproducibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->