### PR TITLE
fix(codegen): stop typing a symbol-keyed element read as a number (#7796)

### DIFF
--- a/changelog.d/7796-symbol-keyed-element-truthiness.md
+++ b/changelog.d/7796-symbol-keyed-element-truthiness.md
@@ -1,0 +1,36 @@
+Fixed a wrong branch on a symbol-keyed property read.
+
+Reading a symbol-keyed property off an array gave a value that every other
+test agreed was a function — `typeof` said `"function"`, `Boolean()` said
+`true`, `=== undefined` said `false` — but that an `if` treated as falsy:
+
+```ts
+const a = [1];
+const f = (a as any)[Symbol.iterator];
+if (f) { /* never ran */ }
+```
+
+The inline form `if ((a as any)[Symbol.iterator])` was correct; only storing
+the value in a local first went wrong, which is what made it look so strange.
+
+The compiler types an element read of a `number[]` as a number, and it was
+doing that no matter what the index was. `a[Symbol.iterator]` is not an
+element read at all — it reads a property of the array object, and the answer
+is a function. So the local holding it was recorded as a number.
+
+That mistake is expensive rather than merely imprecise. A value believed to be
+a number is tested for truthiness with a floating-point comparison against
+zero, and Perry stores objects, strings and functions as NaN-boxed doubles —
+which really are NaN. Every comparison against a NaN is false, so the test
+reported "falsy" for every function, object and string that reached it.
+
+Both places that infer an element type now require the index to be a number
+first. Requiring proof rather than just the absence of contrary evidence is
+deliberate: an index the compiler cannot type may hold anything at runtime,
+and the cost of answering "not a number" is one missed fast path, while the
+cost of answering "number" is a branch that goes the wrong way.
+
+Ordinary numeric indexing is untouched — `a[i]` in a loop keeps the same
+inline comparison it had before, which a companion test pins down.
+
+Closes #7796.

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -358,6 +358,40 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // load in `js_number_coerce` which blocks LLVM's vectorizer
         // and adds a function call per iteration.
         Expr::IndexGet { object, index } => {
+            // #6750 follow-up: a masked-index read covered by an ACTIVE
+            // masked-window fact (dense range-loop / straight-line-region
+            // fast copy) is a guard-proven numeric element load, even when
+            // the receiver's STATIC type is erased (`any` parameter).
+            // Without this, `n ^= S[x & 0xff]` inside a fast copy still
+            // routed through the BigInt-aware dynamic helpers. Facts are
+            // scope-managed by the versioned lowerings, so the answer is
+            // only `true` while a fast copy that proved the window is being
+            // lowered. The fact itself proves the index is an integer, so it
+            // stands ahead of the index check below.
+            if let Expr::LocalGet(arr_id) = object.as_ref() {
+                if crate::expr::masked_window_fact_for_index(ctx, *arr_id, index).is_some() {
+                    return true;
+                }
+            }
+            // #7796: an element type only describes reads at a NUMERIC index.
+            // `a[sym]` on a `number[]` is not an element read at all — it is a
+            // property read on the array OBJECT, and `a[Symbol.iterator]`
+            // answers with a function.
+            //
+            // Getting this wrong is not merely a missed optimization. The
+            // caller acts on "this is a number" by testing the raw double with
+            // `fcmp one %v, 0.0`, and every NaN-boxed pointer IS a NaN, so that
+            // comparison is false for every object, string and function alive.
+            // `if (a[Symbol.iterator])` therefore took the FALSE branch on a
+            // value that `Boolean()` and `typeof` both agreed was a function.
+            //
+            // Proof is required rather than merely the absence of counter-
+            // evidence: an index we cannot type may hold anything at runtime,
+            // and answering `false` here costs a fast path while answering
+            // `true` costs a wrong branch.
+            if !is_numeric_expr(ctx, index) {
+                return false;
+            }
             if receiver_class_name(ctx, object)
                 .as_deref()
                 .is_some_and(is_numeric_typed_array_class)
@@ -367,18 +401,6 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             let Expr::LocalGet(arr_id) = object.as_ref() else {
                 return false;
             };
-            // #6750 follow-up: a masked-index read covered by an ACTIVE
-            // masked-window fact (dense range-loop / straight-line-region
-            // fast copy) is a guard-proven numeric element load, even when
-            // the receiver's STATIC type is erased (`any` parameter).
-            // Without this, `n ^= S[x & 0xff]` inside a fast copy still
-            // routed through the BigInt-aware dynamic helpers. Facts are
-            // scope-managed by the versioned lowerings, so the answer is
-            // only `true` while a fast copy that proved the window is being
-            // lowered.
-            if crate::expr::masked_window_fact_for_index(ctx, *arr_id, index).is_some() {
-                return true;
-            }
             match ctx.local_types.get(arr_id) {
                 Some(HirType::Array(elem)) => {
                     matches!(**elem, HirType::Number | HirType::Int32)

--- a/crates/perry-codegen/src/type_analysis/numeric/tests.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric/tests.rs
@@ -544,3 +544,125 @@ fn only_number_returning_string_methods_are_claimed_numeric() {
         );
     }
 }
+
+/// #7796 — an element read at a NON-numeric index is not a numeric read.
+///
+/// `a[Symbol.iterator]` on a `number[]` is a property read on the array
+/// object, and it answers with a function. Typing the local that holds it as
+/// `number` made the truthiness test lower to `fcmp one %v, 0.0` — and every
+/// NaN-boxed pointer IS a NaN, so that comparison is false for every function,
+/// object and string alive. `if (f)` took the false branch on a value that
+/// `typeof` called a function and `Boolean()` called true.
+mod symbol_keyed_element_reads {
+    use super::*;
+
+    /// Slice out the probe function so an assertion cannot be satisfied by
+    /// some unrelated part of the module.
+    fn probe_body(ir: &str) -> String {
+        let start = ir
+            .find("__probe(")
+            .map(|i| ir[..i].rfind("define").expect("define before probe"))
+            .expect("probe function must be emitted");
+        let end = ir[start..].find("\n}").expect("probe must terminate") + start;
+        ir[start..end].to_string()
+    }
+
+    fn array_of_numbers(id: u32) -> Stmt {
+        Stmt::Let {
+            id,
+            name: "a".to_string(),
+            ty: Type::Array(Box::new(Type::Number)),
+            mutable: false,
+            init: Some(Expr::Array(vec![Expr::Integer(1)])),
+        }
+    }
+
+    fn truthy_return(local: u32) -> Stmt {
+        Stmt::Return(Some(Expr::Conditional {
+            condition: Box::new(Expr::LocalGet(local)),
+            then_expr: Box::new(Expr::Integer(1)),
+            else_expr: Box::new(Expr::Integer(0)),
+        }))
+    }
+
+    #[test]
+    fn a_symbol_indexed_element_is_tested_with_js_is_truthy() {
+        // const a: number[] = [1];
+        // const sym = Symbol.iterator;
+        // const f = a[sym];
+        // return f ? 1 : 0;
+        let ir = emitted_ir(probe_module(
+            "symbol_keyed_element_read.ts",
+            Vec::new(),
+            vec![
+                array_of_numbers(1),
+                Stmt::Let {
+                    id: 2,
+                    name: "sym".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::SymbolFor(Box::new(Expr::String(
+                        "@@__perry_wk_iterator".to_string(),
+                    )))),
+                },
+                Stmt::Let {
+                    id: 3,
+                    name: "f".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(1)),
+                        index: Box::new(Expr::LocalGet(2)),
+                    }),
+                },
+                truthy_return(3),
+            ],
+        ));
+        let body = probe_body(&ir);
+        assert!(
+            body.contains("js_is_truthy"),
+            "a symbol-keyed read must go through the general truthiness \
+             helper, or a NaN-boxed function reads as false:\n{body}"
+        );
+        assert!(
+            !body.contains("fcmp one"),
+            "the numeric fast path must not fire for a non-numeric index:\n{body}"
+        );
+    }
+
+    #[test]
+    fn a_numeric_index_keeps_the_inline_fast_path() {
+        // The guard against over-correcting: requiring a numeric index must
+        // not cost the ordinary `a[i]` element read its inline comparison.
+        let ir = emitted_ir(probe_module(
+            "numeric_element_read.ts",
+            Vec::new(),
+            vec![
+                array_of_numbers(1),
+                Stmt::Let {
+                    id: 2,
+                    name: "i".to_string(),
+                    ty: Type::Number,
+                    mutable: false,
+                    init: Some(Expr::Integer(0)),
+                },
+                Stmt::Let {
+                    id: 3,
+                    name: "v".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(1)),
+                        index: Box::new(Expr::LocalGet(2)),
+                    }),
+                },
+                truthy_return(3),
+            ],
+        ));
+        let body = probe_body(&ir);
+        assert!(
+            body.contains("fcmp one"),
+            "a numeric index must keep the inline truthiness comparison:\n{body}"
+        );
+    }
+}

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -336,11 +336,23 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
                 None
             }
         }
-        Expr::IndexGet { object, .. } => {
+        Expr::IndexGet { object, index } => {
             // arr[i] where arr is Array<T> → element type T.
             // Handles both LocalGet(arr) and PropertyGet(this, "field")
             // — the latter lets `this.parts[i]` get the right type
             // when `parts: string[]`.
+            //
+            // #7796: only at a NUMERIC index. `a[Symbol.iterator]` on a
+            // `number[]` reads a property of the array OBJECT and answers with
+            // a function, so typing the local as `number` is simply false — and
+            // it is a costly kind of false, because a local believed numeric is
+            // tested for truthiness with `fcmp one %v, 0.0`. Every NaN-boxed
+            // pointer is a NaN, so that comparison says false for every
+            // function, object and string, and `if (f)` took the wrong branch
+            // on a value `typeof` and `Boolean()` both called a function.
+            if !is_numeric_expr(ctx, index) {
+                return None;
+            }
             if let Expr::LocalGet(arr_id) = object.as_ref() {
                 if let Some(HirType::Array(elem_ty)) = ctx.local_types.get(arr_id) {
                     return Some((**elem_ty).clone());


### PR DESCRIPTION
Closes [#7796](https://github.com/PerryTS/perry/issues/7796).

A symbol-keyed property read off an array produced a value that every test agreed was a function — `typeof` said `"function"`, `Boolean()` said `true`, `=== undefined` said `false` — but that a plain `if` treated as falsy. Only when the value was stored in a local first, which is what made it look so strange.

```ts
const a = [1];
console.log((a as any)[Symbol.iterator] ? "truthy" : "FALSY");  // truthy  ✅
const f = (a as any)[Symbol.iterator];
console.log(f ? "truthy" : "FALSY");                            // FALSY   ❌ (node: truthy)
```

<details>
<summary><b>Why it happened</b></summary>

Perry types an element read of a `number[]` as a number, and it was doing that regardless of what the index actually was. Two places do this inference — `refine_type_from_init` (which decides the type of `const f = ...`) and `is_numeric_expr` (which answers "is this expression a number?") — and both destructured the index and then ignored it.

But `a[Symbol.iterator]` is not an element read. It reads a property of the array *object*, and the answer is `Array.prototype[Symbol.iterator]`, a function. So the local holding it was recorded as a number.

That is where it turns from imprecise into wrong. A value believed to be a number gets its truthiness tested with a floating-point comparison:

```llvm
%r75 = fcmp one double %r74, 0.0
```

Perry stores objects, strings and functions as NaN-boxed doubles, which really are NaN — and every comparison against a NaN is false. So the test answered "falsy" for every function, object and string that reached it. The inline form was correct only because it never went through a local, so the bad type was never recorded.

</details>

<details>
<summary><b>The fix, and why it asks for proof</b></summary>

Both inference sites now require the index to be provably numeric before taking the array's element type.

Requiring proof, rather than just checking for a known-bad index like a symbol, is deliberate. An index the compiler cannot type may hold anything at runtime, so "I have no evidence this is a symbol" is not evidence that it is a number. The two possible mistakes are not equal either: answering "not a number" costs one missed fast path, while answering "number" costs a branch that silently goes the wrong way.

The masked-window fast-copy case keeps its early exit, since that fact already proves the index is an integer.

</details>

<details>
<summary><b>Tests</b></summary>

Two unit tests in `crates/perry-codegen/src/type_analysis/numeric/tests.rs`, both asserting on the emitted IR for the function under test rather than the whole module:

| Test | Asserts |
|---|---|
| `a_symbol_indexed_element_is_tested_with_js_is_truthy` | The symbol-keyed read reaches the general truthiness helper and does **not** get the `fcmp one` fast path |
| `a_numeric_index_keeps_the_inline_fast_path` | The guard against over-correcting: ordinary `a[i]` still gets its inline comparison |

Reverting just the two source changes and keeping the tests turns the first one red, so it fails for the reason it claims.

Also checked by hand that a hot loop is unaffected: `for (let i = 0; ...) { const v = a[i]; if (v) acc += v; }` still emits two `fcmp one` and zero `js_is_truthy` calls in the loop body, and returns the right answer.

`cargo test -p perry-codegen --lib`: 853 passing. `cargo test -p perry-hir --lib`: 293 passing. The issue's reproducer now matches `node --experimental-strip-types` line for line.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect truthiness results when accessing arrays with symbol or other non-numeric keys.
  * Preserved optimized behavior for standard numeric array and typed-array indexing.
  * Non-numeric property accesses are now evaluated using general truthiness handling instead of numeric comparisons.
* **Tests**
  * Added regression coverage for numeric and symbol-keyed array accesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->