### PR TITLE
fix(json): throw instead of crashing on deeply nested JSON.parse input (#7792)

### DIFF
--- a/changelog.d/7792-json-parse-nesting-depth.md
+++ b/changelog.d/7792-json-parse-nesting-depth.md
@@ -1,0 +1,43 @@
+`JSON.parse` no longer crashes the process on deeply nested input.
+
+A document nested a few tens of thousands of levels deep did not throw — it
+killed the process with SIGSEGV and printed nothing at all, so a program had
+no way to see what happened, let alone recover:
+
+```
+node    → parses it
+scriptc → throws a catchable RangeError
+perry   → SIGSEGV, exit 139, no output
+```
+
+Deeply nested JSON is a well-known shape for untrusted input, which is what
+makes a crash the wrong answer even though such a document is unusual.
+
+Two parsers read the text, and both descend one function call per nesting
+level: the syntax-validation pass and Perry's own value parser. Deep enough
+input exhausts the stack in whichever reaches it first.
+
+`JSON.parse` now measures nesting depth first and throws a catchable
+`RangeError` when it exceeds 1,000 levels. The measurement is a single
+non-recursive scan of the text, which matters more than it sounds: a recursive
+depth check would crash on exactly the documents it exists to reject. It also
+runs *before* syntax validation, since that pass recurses too and would crash
+first otherwise — which means the scan sees malformed input and has to cope
+with it, so brackets inside strings do not count and a stray closing bracket
+clamps at zero instead of underflowing.
+
+The limit is 1,000 because it has to be safe on the *smallest* stack in the
+process, not the largest. Perry parses JSON on worker threads as well as the
+main thread, and a 2 MiB thread stack overflows far earlier than the main
+thread's 8 MB does. A first attempt used 10,000, taken from a main-thread
+measurement, and the unit test crashed the test harness at 9,999 levels — so
+the number is what a small stack can carry, not what a big one can. It matches
+the depth Python's parser settled on, and real documents are not close: JSON
+nested past a hundred levels is already unusual.
+
+This is a deliberate gap against Node, which parses far deeper because V8's
+parser is iterative and consumes no stack per level. Closing it means making
+Perry's parser iterative too, tracked separately. Until then a catchable error
+is strictly better than a crash.
+
+Refs #7792.

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -815,6 +815,61 @@ mod tests {
         }
     }
 
+    /// #7792 — deeply nested input must throw, not take the process out.
+    ///
+    /// Both parsers that read the document recurse once per nesting level, so
+    /// a deep enough document exhausted the stack: SIGSEGV, exit 139, no
+    /// output at all. The input shape here is a well-known one for untrusted
+    /// data, which is why a crash is the wrong answer even though a very deep
+    /// document is unusual.
+    mod nesting_depth {
+        use super::*;
+        use crate::json::parser::{nesting_depth_exceeds, MAX_NESTING_DEPTH};
+
+        #[test]
+        fn the_scan_counts_only_structural_brackets() {
+            assert!(!nesting_depth_exceeds(b"[[[]]]", 8));
+            assert!(nesting_depth_exceeds(b"[[[[[[[[[[]]]]]]]]]]", 4));
+            assert!(!nesting_depth_exceeds(br#"{"a":{"b":1}}"#, 4));
+            assert!(nesting_depth_exceeds(br#"{"a":{"b":1}}"#, 1));
+
+            // Brackets inside a string are text, not structure. Without this a
+            // single long string value would be rejected as deep nesting.
+            assert!(!nesting_depth_exceeds(br#"{"a":"[[[[[[[[[["}"#, 3));
+            // ...including one that ends in an escaped quote, so the scanner
+            // does not lose track of where the string closes.
+            assert!(!nesting_depth_exceeds(br#"{"a":"[[[\"[[["}"#, 3));
+
+            // The scan runs BEFORE syntax validation, so it sees malformed
+            // input. An unbalanced closer must clamp, not underflow.
+            assert!(!nesting_depth_exceeds(b"]]]]]]", 2));
+            assert!(!nesting_depth_exceeds(b"", 0));
+        }
+
+        /// The limit is the point of the change, so pin the boundary itself:
+        /// one level under passes, one level over is refused.
+        #[test]
+        fn parse_refuses_input_past_the_limit_and_accepts_input_under_it() {
+            let ok_depth = MAX_NESTING_DEPTH - 1;
+            let mut ok = vec![b'['; ok_depth];
+            ok.extend(std::iter::repeat(b']').take(ok_depth));
+            let text = js_string_from_bytes(ok.as_ptr(), ok.len() as u32);
+            assert!(
+                unsafe { js_json_parse_result(text) }.is_ok(),
+                "input inside the limit must still parse"
+            );
+
+            let deep_depth = MAX_NESTING_DEPTH + 1;
+            let mut deep = vec![b'['; deep_depth];
+            deep.extend(std::iter::repeat(b']').take(deep_depth));
+            let text = js_string_from_bytes(deep.as_ptr(), deep.len() as u32);
+            assert!(
+                unsafe { js_json_parse_result(text) }.is_err(),
+                "input past the limit must be refused rather than descended into"
+            );
+        }
+    }
+
     #[test]
     fn parse_result_streaming_validation_rejects_malformed_and_trailing_input() {
         for input in [

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -69,8 +69,38 @@ fn syntax_error_value(message: &str) -> f64 {
     f64::from_bits(JSValue::pointer(err as *const u8).bits())
 }
 
+/// A catchable `RangeError`, for the one JSON failure that is about size
+/// rather than shape: input nested deeper than the parser can descend.
+fn range_error_value(message: &str) -> f64 {
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg_ptr);
+    f64::from_bits(JSValue::pointer(err as *const u8).bits())
+}
+
 fn throw_syntax_error(message: &str) -> ! {
     crate::exception::js_throw(syntax_error_value(message))
+}
+
+fn throw_range_error(message: &str) -> ! {
+    crate::exception::js_throw(range_error_value(message))
+}
+
+/// The one depth check, called by every entry that is about to descend.
+///
+/// `js_json_parse` and `js_json_parse_result` are separate implementations of
+/// the same flow, and the typed-array path is a third. Sharing the decision is
+/// what keeps them from drifting — the first version of this fix guarded only
+/// one of the three and appeared to do nothing at all, because the entry point
+/// codegen actually calls was one of the other two.
+fn nesting_is_too_deep(bytes: &[u8]) -> bool {
+    crate::json::parser::nesting_depth_exceeds(bytes, crate::json::parser::MAX_NESTING_DEPTH)
+}
+
+fn too_deep_message() -> String {
+    format!(
+        "JSON.parse: input nested deeper than {} levels",
+        crate::json::parser::MAX_NESTING_DEPTH
+    )
 }
 
 fn is_json_null_literal(bytes: &[u8]) -> bool {
@@ -104,6 +134,14 @@ pub unsafe fn js_json_parse_result(text_ptr: *const StringHeader) -> Result<JSVa
 
     if len == 0 {
         return Err(syntax_error_value("Unexpected end of JSON input"));
+    }
+
+    // #7792: depth first, BEFORE the validation pass below. That pass recurses
+    // once per nesting level itself, so a check placed after it would run after
+    // the crash it exists to prevent. The scan is one linear pass over bytes we
+    // are about to read anyway.
+    if nesting_is_too_deep(bytes) {
+        return Err(range_error_value(&too_deep_message()));
     }
 
     // Validate without constructing a second full JSON tree. The Perry parser
@@ -197,6 +235,12 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
 
     if len == 0 {
         throw_syntax_error("Unexpected end of JSON input");
+    }
+    // #7792: depth first, ahead of the validation pass, for the same reason as
+    // the `_result` twin above. This is the entry codegen emits, so a guard
+    // that covered only the twin covered nothing a compiled program can reach.
+    if nesting_is_too_deep(bytes) {
+        throw_range_error(&too_deep_message());
     }
     // Keep serde_json's strict syntax validation, but discard tokens as they
     // are read instead of allocating an intermediate `serde_json::Value`
@@ -514,6 +558,13 @@ pub unsafe extern "C" fn js_json_parse_typed_array(
     }
     let data_ptr = (text_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
     let bytes = std::slice::from_raw_parts(data_ptr, len);
+
+    // #7792: this path builds its own parser, so it needs its own guard. Hand
+    // deep input to the generic entry rather than repeating the error here, so
+    // both report it identically.
+    if nesting_is_too_deep(bytes) {
+        return js_json_parse(text_ptr);
+    }
 
     // Build the shape hint once. The keys_array + pre-interned key
     // pointers are owned by longlived arena + shape-cache structures,

--- a/crates/perry-runtime/src/json/parser.rs
+++ b/crates/perry-runtime/src/json/parser.rs
@@ -56,6 +56,71 @@ pub(crate) struct ObjectShapeHint {
     pub(crate) field_count: u32,
 }
 
+/// The deepest `[`/`{` nesting `JSON.parse` will accept.
+///
+/// Both parsers that see the input recurse once per level — the `serde_json`
+/// validation pass and Perry's own value parser — so a deep enough document
+/// exhausts the stack and takes the whole process out with SIGSEGV, no
+/// diagnostic and no output, on input that is very often attacker-supplied
+/// (#7792). Measured on a default 8 MB main-thread stack the crash lands
+/// between 20,000 and 40,000 levels — but that is the most generous stack in
+/// the process, and it is the wrong one to size against. Perry parses JSON on
+/// `perry/thread` workers and tokio workers too, and a 2 MiB thread stack
+/// overflows well before 10,000 levels: a first attempt at this limit picked
+/// 10,000 off the main-thread measurement, and the unit test below promptly
+/// crashed the test harness at 9,999.
+///
+/// So the limit is sized for the SMALLEST stack in the process, not the
+/// largest, and 1,000 is the same depth Python's parser has settled on. Real
+/// documents do not come close: JSON nested past a hundred levels is already
+/// unusual, and past a thousand is a machine talking to itself.
+///
+/// This is a deliberate parity gap. Node parses far deeper than this because
+/// V8's parser is iterative and does not consume stack per level; matching it
+/// means making this parser iterative too, which is the follow-up. Until then
+/// a catchable error beats a SIGSEGV on untrusted input.
+pub(crate) const MAX_NESTING_DEPTH: usize = 1_000;
+
+/// Does `bytes` nest deeper than `limit`?
+///
+/// Iterative on purpose. A recursive depth check would be the very thing it
+/// exists to prevent, and it would crash on exactly the documents it is
+/// supposed to reject.
+///
+/// Bracket bytes inside strings do not count, so a document that is one long
+/// `"[[[[[[…"` string is not mistaken for deep nesting. This runs before any
+/// syntax validation, so it must not assume the input is well-formed — an
+/// unbalanced `]` clamps at zero rather than underflowing.
+pub(crate) fn nesting_depth_exceeds(bytes: &[u8], limit: usize) -> bool {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for &byte in bytes {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'[' | b'{' => {
+                depth += 1;
+                if depth > limit {
+                    return true;
+                }
+            }
+            b']' | b'}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
+}
+
 pub(crate) struct DirectParser<'a> {
     input: &'a [u8],
     pos: usize,


### PR DESCRIPTION
Refs [#7792](https://github.com/PerryTS/perry/issues/7792).

`JSON.parse` on a deeply nested document did not throw — it killed the process with SIGSEGV and printed nothing at all, so a program had no way to see what happened, let alone recover.

| | node 26.5.1 | scriptc | perry before | perry after |
|---|---|---|---|---|
| 300,000 levels | parses it | catchable `RangeError` | **SIGSEGV, exit 139, no output** | catchable `RangeError`, exit 0 |

Deeply nested JSON is a well-known shape for untrusted input, which is what makes a crash the wrong answer even though such a document is unusual.

<details>
<summary><b>Why it crashed, and why the check had to go where it did</b></summary>

Two parsers read the text and both descend one function call per nesting level: the `serde_json` syntax-validation pass, and Perry's own value parser. Deep enough input exhausts the stack in whichever gets there first.

`JSON.parse` now measures nesting depth before either one descends. Three details in that sentence are load-bearing:

**The measurement is iterative.** A recursive depth check would crash on exactly the documents it exists to reject, which would be a guard that cannot fire.

**It runs before syntax validation, not after.** The validation pass recurses per level itself, so a check placed after it would run after the crash. That ordering has a consequence: the scan sees input nobody has validated yet, so it cannot assume well-formed text. Brackets inside strings do not count toward depth, and an unbalanced closing bracket clamps at zero rather than underflowing.

**All three entry points share one guard.** `js_json_parse` and `js_json_parse_result` turned out to be separate implementations of the same flow, and the typed-array path is a third. My first attempt guarded only `js_json_parse_result` and appeared to change nothing at all — the entry that compiled code actually reaches is one of the other two. The decision now lives in one function that all three call.

</details>

<details>
<summary><b>Why the limit is 1,000</b></summary>

Because it has to be safe on the **smallest** stack in the process, not the largest.

I first picked 10,000, measured against the main thread's 8 MB stack where the crash lands between 20,000 and 40,000 levels. The unit test then crashed the test harness at 9,999 levels — a Rust test thread gets about 2 MiB. Perry parses JSON on `perry/thread` workers and tokio workers as well as the main thread, so the main-thread measurement was the wrong one to size against.

1,000 is the same depth Python's parser settled on, and real documents are nowhere near it: JSON nested past a hundred levels is already unusual, and past a thousand is a machine talking to itself.

**This is a deliberate parity gap and I want to be plain about it.** Node parses far deeper because V8's parser is iterative and consumes no stack per level. Closing the gap properly means making Perry's parser iterative too, which is a much larger change — so this PR says `Refs #7792` rather than `Closes`, and I will open a follow-up for the iterative parser. A catchable error is strictly better than a crash in the meantime, but it is not parity.

</details>

<details>
<summary><b>Tests</b></summary>

Two unit tests in `crates/perry-runtime/src/json/mod.rs`:

| Test | Asserts |
|---|---|
| `the_scan_counts_only_structural_brackets` | Depth counting itself — nesting inside strings does not count, an escaped quote does not lose the string's end, an unbalanced closer clamps instead of underflowing, and empty input is fine |
| `parse_refuses_input_past_the_limit_and_accepts_input_under_it` | The boundary: one level under the limit still parses, one level over is refused |

Removing the guard turns the second one red with `input past the limit must be refused rather than descended into`, so it fails for the reason it claims. And the boundary test is what caught the unsafe 10,000 limit in the first place — it crashed the harness rather than passing, which is the outcome I wanted from it.

`cargo test -p perry-runtime --lib -- --test-threads=1`: **2053 passing, 0 failing**.

Checked end to end against a rebuilt runtime archive (mtime confirmed moved, per the CLAUDE.md warning about stale `.a` files making both arms of an A/B look identical):

```
depth 100     exit=0  ok 100
depth 999     exit=0  ok 999
depth 1001    exit=0  threw: RangeError: JSON.parse: input nested deeper than 1000 levels
depth 40000   exit=0  threw: RangeError: ...
depth 300000  exit=0  threw: RangeError: ...
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON parsing now safely handles deeply nested input without risking a stack overflow.
  * Inputs exceeding 1,000 nesting levels return a catchable `RangeError`.
  * Nesting checks correctly ignore brackets inside strings and handle malformed JSON safely.
  * Consistent depth-limit behavior is now applied across standard, non-throwing, and typed-array parsing paths.

* **Documentation**
  * Added documentation describing the nesting limit and updated error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->