### PR TITLE
fix(opt-report): report spec_no_call_sites instead of silence when every call was inlined away (#7111)

### DIFF
--- a/changelog.d/7818-opt-report-no-call-sites.md
+++ b/changelog.d/7818-opt-report-no-call-sites.md
@@ -1,0 +1,18 @@
+**`--opt-report` now says `spec_no_call_sites` where it used to say nothing** (#7111).
+
+A function whose call sites were all removed by an earlier pass — the inliner, then `unroll_static_loops` constant-folding what it produced — has no entry in `spec_facts.call_sites`, which is built by walking `hir.init` and every body for direct `Call` expressions. The spec-ABI decision loop `continue`d on that **before** constructing any `TypedCloneRejectionReason`, so nothing reached `record_typed_clone_rejection` and nothing reached `opt_report::deny_named`.
+
+The result was silence, and silence is the one answer this report cannot afford: it is indistinguishable from "not analysed" and from "analysed and denied". A reader now sees that the loop was reached and had nothing to decide.
+
+Measured on a four-line fixture whose only call to `tiny()` is inlined and folded away:
+
+| | entries | rules |
+|---|--:|---|
+| before | 1 | `not_index_used_or_bounded` |
+| after | 2 | `not_index_used_or_bounded`, **`spec_no_call_sites`** |
+
+The new `TypedCloneRejectionReason::SpecNoCallSites` is deliberately not framed as a denial — its doc says so — because there is nothing to specialise *for*; it is reported so the absence is legible rather than inferred.
+
+Worth recording for the next person: `--opt-report` writes to **stderr**, deliberately, so it cannot contaminate a `--format json` stdout payload or piped program output. Three of my attempts to observe it came back empty because they were running under `2>/dev/null`. That is also the likeliest reason a report looks like it "did not render".
+
+`cargo test -p perry-codegen --lib` 851 passed / 0 failed; fmt and file-size clean.

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -2183,9 +2183,6 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         let spec_budget = spec_abi::spec_abi_max();
         let mut spec_emitted = 0usize;
         for f in &hir.functions {
-            let Some(sites) = spec_facts.call_sites.get(&f.id) else {
-                continue;
-            };
             let reject =
                 |reason: typed_abi::TypedCloneRejectionReason,
                  records: &mut Vec<crate::native_value::NativeRepRecord>| {
@@ -2201,6 +2198,20 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                         ],
                     );
                 };
+            // #7111: a function whose call sites were all inlined away — and
+            // then constant-folded by `unroll_static_loops` — has no entry in
+            // `spec_facts.call_sites`, which is built by walking `hir.init` and
+            // every body for direct `Call` expressions. This used to `continue`
+            // BEFORE any rejection was constructed, so `--opt-report` said
+            // nothing at all about the function: indistinguishable from "not
+            // analysed" and from "analysed and denied". Say "moot" instead.
+            let Some(sites) = spec_facts.call_sites.get(&f.id) else {
+                reject(
+                    typed_abi::TypedCloneRejectionReason::SpecNoCallSites,
+                    &mut typed_clone_rejection_records,
+                );
+                continue;
+            };
             if f.is_async || f.is_generator || f.was_plain_async {
                 reject(
                     typed_abi::TypedCloneRejectionReason::AsyncOrGenerator,

--- a/crates/perry-codegen/src/codegen/typed_abi.rs
+++ b/crates/perry-codegen/src/codegen/typed_abi.rs
@@ -245,6 +245,17 @@ pub(crate) enum TypedCloneRejectionReason {
     ReceiverFieldNotOwn,
     ReceiverFieldNotF64,
     ThisEscape,
+    /// #7111 — Spec-ABI: the function has NO direct call sites left to analyse,
+    /// because an earlier pass removed them all (the inliner, then
+    /// `unroll_static_loops` constant-folding what it produced).
+    ///
+    /// This is not a denial in the usual sense: there is nothing to specialise
+    /// FOR. It is reported anyway because the alternative is silence, and
+    /// silence here is indistinguishable from "not analysed" and from "analysed
+    /// and denied" — which is the whole complaint the opt-report exists to
+    /// answer. A reader seeing `spec_no_call_sites` knows the decision loop was
+    /// reached and had nothing to decide.
+    SpecNoCallSites,
     /// Spec-ABI (Phase 2): no call site proved a viable representation tuple.
     SpecTupleUnproven,
     /// Spec-ABI: the function already carries a typed_abi clone family —
@@ -292,6 +303,7 @@ impl TypedCloneRejectionReason {
             Self::ReceiverFieldNotOwn => "receiver_field_not_own",
             Self::ReceiverFieldNotF64 => "receiver_field_not_f64",
             Self::ThisEscape => "this_escape",
+            Self::SpecNoCallSites => "spec_no_call_sites",
             Self::SpecTupleUnproven => "spec_tuple_unproven",
             Self::SpecTypedCloneOverlap => "spec_typed_clone_overlap",
             Self::SpecBudgetExceeded => "spec_budget_exceeded",


### PR DESCRIPTION
**`--opt-report` now says `spec_no_call_sites` where it used to say nothing** (#7111).

A function whose call sites were all removed by an earlier pass — the inliner, then `unroll_static_loops` constant-folding what it produced — has no entry in `spec_facts.call_sites`, which is built by walking `hir.init` and every body for direct `Call` expressions. The spec-ABI decision loop `continue`d on that **before** constructing any `TypedCloneRejectionReason`, so nothing reached `record_typed_clone_rejection` and nothing reached `opt_report::deny_named`.

The result was silence, and silence is the one answer this report cannot afford: it is indistinguishable from "not analysed" and from "analysed and denied". A reader now sees that the loop was reached and had nothing to decide.

Measured on a four-line fixture whose only call to `tiny()` is inlined and folded away:

| | entries | rules |
|---|--:|---|
| before | 1 | `not_index_used_or_bounded` |
| after | 2 | `not_index_used_or_bounded`, **`spec_no_call_sites`** |

The new `TypedCloneRejectionReason::SpecNoCallSites` is deliberately not framed as a denial — its doc says so — because there is nothing to specialise *for*; it is reported so the absence is legible rather than inferred.

Worth recording for the next person: `--opt-report` writes to **stderr**, deliberately, so it cannot contaminate a `--format json` stdout payload or piped program output. Three of my attempts to observe it came back empty because they were running under `2>/dev/null`. That is also the likeliest reason a report looks like it "did not render".

`cargo test -p perry-codegen --lib` 851 passed / 0 failed; fmt and file-size clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimization reports now identify functions with no remaining call sites before specialization analysis.
  * Added the `spec_no_call_sites` report reason for clearer diagnostics.

* **Documentation**
  * Clarified that this condition is informational—not a denial—and that reports are written to stderr.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->