### PR TITLE
fix(runtime): give the primitive receiver to an accessor `toString` in toLocaleString

### DIFF
--- a/changelog.d/7823-tolocalestring-primitive-receiver.md
+++ b/changelog.d/7823-tolocalestring-primitive-receiver.md
@@ -1,0 +1,21 @@
+**`Object.prototype.toLocaleString` now gives an accessor `toString` the primitive receiver.**
+The spec routes it through `Invoke(O, "toString")` → `GetV(O, "toString")` →
+`ToObject(O).[[Get]]("toString", O)`, and that third argument is the *receiver*:
+the original primitive, not the wrapper object the lookup walked through. Perry
+resolved the method with a plain get **on the prototype**, which is
+unobservable for a data property but runs an **accessor**'s getter with the
+prototype as `this` — so
+`Object.defineProperty(Boolean.prototype, "toString", { get() { … } })` saw
+`typeof this === "object"` where the spec requires `"boolean"`
+(test262 `built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js`).
+An accessor is now resolved explicitly and its getter invoked through
+`call_primitive_closure_value`, the helper the callers already use for the
+resolved method: it hands a raw primitive `this` to a strict callee and a boxed
+wrapper to a sloppy one. Both resolvers on the path — the resolve-and-call
+`call_primitive_builtin_prototype_method` and the resolve-only
+`builtin_proto_user_method` — share the new helper so they cannot drift.
+Covered by `test-files/test_gap_object_tolocalestring_primitive_receiver.ts`.
+Still divergent, and independent of this rule: a `toString` resolving to a
+**non-callable** should throw, while Perry falls through to the native method —
+that reproduces identically through a plain data property, because the resolver
+collapses "absent" and "present but not callable" into one answer. (#5901)

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -346,9 +346,48 @@ unsafe fn call_primitive_builtin_prototype_method(
     if proto_ptr.is_null() {
         return None;
     }
+    if let Some(value) = builtin_proto_accessor_method(proto_ptr, method_name, receiver) {
+        return call_primitive_closure_value(receiver, value, args_ptr, args_len);
+    }
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let value = js_object_get_field_by_name(proto_ptr, key);
     call_primitive_closure_value(receiver, value, args_ptr, args_len)
+}
+
+/// #5901: resolve `method_name` on a builtin's prototype the way the spec's
+/// `GetV(O, P)` does when the property is an ACCESSOR.
+///
+/// `Invoke(O, "toString")` is `GetV(O, "toString")` -> `ToObject(O).[[Get]]("toString", O)`,
+/// and that third argument is the RECEIVER: the ORIGINAL primitive, not the
+/// wrapper the lookup walked to find the property. A plain
+/// `js_object_get_field_by_name(proto_ptr, key)` runs the getter with the
+/// PROTOTYPE as `this`, so
+/// `Object.defineProperty(Boolean.prototype, "toString", { get() { … } })`
+/// observed `typeof this === "object"` where the spec requires `"boolean"`
+/// (test262 `built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js`).
+///
+/// Returns `None` when the key is not an accessor — the caller then performs
+/// the ordinary data-property get, which needs no receiver fixup.
+unsafe fn builtin_proto_accessor_method(
+    proto_ptr: *const ObjectHeader,
+    method_name: &str,
+    receiver: f64,
+) -> Option<JSValue> {
+    let accessor =
+        crate::object::descriptor_state::get_accessor_descriptor(proto_ptr as usize, method_name)?;
+    if accessor.get == 0 {
+        return None;
+    }
+    // `call_primitive_closure_value` already delivers a raw primitive `this` to
+    // a strict callee and a boxed wrapper to a sloppy one, which is exactly the
+    // distinction the spec draws for the getter's own `this`.
+    let resolved = call_primitive_closure_value(
+        receiver,
+        JSValue::from_bits(accessor.get),
+        std::ptr::null(),
+        0,
+    )?;
+    Some(JSValue::from_bits(resolved.to_bits()))
 }
 
 /// A *user-installed* method on a builtin's prototype object (e.g.
@@ -356,7 +395,11 @@ unsafe fn call_primitive_builtin_prototype_method(
 /// closure value, or `None` when the property is absent / not a real closure /
 /// the no-op-backed builtin placeholder — i.e. `None` means "the native
 /// builtin behavior is still in effect".
-unsafe fn builtin_proto_user_method(builtin_name: &[u8], method_name: &str) -> Option<JSValue> {
+unsafe fn builtin_proto_user_method(
+    builtin_name: &[u8],
+    method_name: &str,
+    receiver: f64,
+) -> Option<JSValue> {
     let ctor =
         crate::object::js_get_global_this_builtin_value(builtin_name.as_ptr(), builtin_name.len());
     let ctor_value = JSValue::from_bits(ctor.to_bits());
@@ -373,8 +416,14 @@ unsafe fn builtin_proto_user_method(builtin_name: &[u8], method_name: &str) -> O
     if proto_ptr.is_null() {
         return None;
     }
-    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
-    let value = js_object_get_field_by_name(proto_ptr, key);
+    let value = match builtin_proto_accessor_method(proto_ptr, method_name, receiver) {
+        Some(value) => value,
+        None => {
+            let key =
+                crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+            js_object_get_field_by_name(proto_ptr, key)
+        }
+    };
     if (value.bits() & crate::value::TAG_MASK) != crate::value::POINTER_TAG {
         return None;
     }

--- a/crates/perry-runtime/src/object/native_call_method/object_proto.rs
+++ b/crates/perry-runtime/src/object/native_call_method/object_proto.rs
@@ -116,7 +116,7 @@ pub(crate) unsafe fn js_object_default_to_locale_string(receiver: f64) -> f64 {
         };
         if !builtin_name.is_empty() {
             if let Some(patched) =
-                unsafe { super::builtin_proto_user_method(builtin_name, "toString") }
+                unsafe { super::builtin_proto_user_method(builtin_name, "toString", receiver) }
             {
                 if let Some(result) =
                     unsafe { call_primitive_closure_value(receiver, patched, std::ptr::null(), 0) }

--- a/crates/perry-runtime/src/object/native_call_method/typed_array.rs
+++ b/crates/perry-runtime/src/object/native_call_method/typed_array.rs
@@ -232,7 +232,13 @@ pub(crate) unsafe fn dispatch_typed_array_method(
                 Some(crate::typedarray::KIND_BIGINT64) | Some(crate::typedarray::KIND_BIGUINT64)
             );
             let builtin: &[u8] = if is_bigint { b"BigInt" } else { b"Number" };
-            match builtin_proto_user_method(builtin, "toLocaleString") {
+            // #5901: no primitive receiver here — the element values are
+            // formatted individually below, so pass `undefined`.
+            match builtin_proto_user_method(
+                builtin,
+                "toLocaleString",
+                f64::from_bits(crate::value::TAG_UNDEFINED),
+            ) {
                 None => {
                     let s = crate::typedarray::js_typed_array_join_value(
                         ta,

--- a/test-files/test_gap_object_tolocalestring_primitive_receiver.ts
+++ b/test-files/test_gap_object_tolocalestring_primitive_receiver.ts
@@ -1,0 +1,87 @@
+// `Object.prototype.toLocaleString` is specified as `Invoke(O, "toString")`,
+// which is `GetV(O, "toString")` -> `ToObject(O).[[Get]]("toString", O)`. That
+// third argument is the RECEIVER, and it is the ORIGINAL primitive — not the
+// wrapper object the property lookup walked through to find the property.
+//
+// The distinction is only observable when the prototype's `toString` is an
+// ACCESSOR: a plain get resolves the getter against the prototype, so the
+// getter's `this` was `Boolean.prototype` (an object) instead of the boolean.
+// test262 pins this as
+// `built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js`.
+//
+// Module code is strict, so a strict getter keeps the raw primitive `this`
+// rather than a boxed wrapper — which is exactly the value being asserted.
+
+Object.defineProperty(Boolean.prototype, "toString", {
+  configurable: true,
+  get: function (this: any) {
+    const seen = typeof this;
+    const value = this;
+    return function () {
+      return seen + ":" + String(value);
+    };
+  },
+});
+
+console.log("true:", (true as any).toLocaleString());
+console.log("false:", (false as any).toLocaleString());
+
+Object.defineProperty(String.prototype, "toString", {
+  configurable: true,
+  get: function (this: any) {
+    const seen = typeof this;
+    return function () {
+      return seen;
+    };
+  },
+});
+
+console.log("string:", ("abc" as any).toLocaleString());
+
+// A getter installed on `Symbol.prototype` sees the symbol itself.
+Object.defineProperty(Symbol.prototype, "toString", {
+  configurable: true,
+  get: function (this: any) {
+    const seen = typeof this;
+    return function () {
+      return seen;
+    };
+  },
+});
+
+console.log("symbol:", (Symbol("s") as any).toLocaleString());
+
+// An object receiver is unaffected: the getter's `this` is the object itself,
+// which is also what the receiver rule prescribes.
+const proto = {
+  get toString(this: any) {
+    const seen = typeof this;
+    const tag = this.tag;
+    return function () {
+      return seen + ":" + tag;
+    };
+  },
+};
+const obj: any = Object.create(proto);
+obj.tag = "own";
+console.log("object:", obj.toLocaleString());
+
+// The ordinary DATA-property path must keep working — the accessor lookup is
+// an addition to it, not a replacement.
+Object.defineProperty(Boolean.prototype, "toString", {
+  configurable: true,
+  value: function (this: any) {
+    return "data:" + typeof this;
+  },
+  writable: true,
+});
+
+console.log("data:", (true as any).toLocaleString());
+
+// NOT covered here: a `toString` that resolves to a NON-CALLABLE. The spec
+// throws (`Invoke` -> `Call` on a non-callable), while Perry falls through to
+// the native `toString`. That divergence is independent of the receiver rule —
+// it predates this file and reproduces identically through a plain DATA
+// property (`defineProperty(String.prototype, "toString", { value: 42 })`),
+// because the resolver collapses "absent" and "present but not callable" into
+// one "native behavior still applies" answer.


### PR DESCRIPTION
Refs #5901.

`Object.prototype.toLocaleString` is specified as `Invoke(O, "toString")`, which
expands to `GetV(O, "toString")` -> `ToObject(O).[[Get]]("toString", O)`. That
third argument is the **receiver**, and it is the *original primitive* — not the
wrapper object the property lookup walked through on its way to the property.

Perry resolved the method with `js_object_get_field_by_name(proto_ptr, key)`, a
plain get **on the prototype**. For a data property the receiver is
unobservable, so this was invisible. For an **accessor** it runs the getter with
the prototype as `this`:

```ts
Object.defineProperty(Boolean.prototype, "toString", {
  get: function () { const v = typeof this; return function () { return v; }; },
});
console.log((true as any).toLocaleString());
```

| | before | after | node |
|---|---|---|---|
| `Boolean.prototype` accessor | `object` | `boolean` | `boolean` |
| `String.prototype` accessor | `object` | `string` | `string` |

test262 pins this as
`built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js`,
whose sidecar reason was `Expected SameValue(«"object"», «"boolean"») to be
true`.

## Fix

Resolve an accessor explicitly and invoke its getter through
`call_primitive_closure_value` — the same helper the callers already use for the
resolved method. It hands a raw primitive `this` to a strict callee and a boxed
wrapper to a sloppy one, which is exactly the distinction the spec draws for the
getter's own `this` (module code is strict, so the test's getter keeps the raw
primitive).

Both resolvers on this path share the new `builtin_proto_accessor_method`
helper — the resolve-and-call `call_primitive_builtin_prototype_method` and the
resolve-only `builtin_proto_user_method` — so the two cannot drift apart.

## Not addressed here (pre-existing, and not this rule)

A `toString` that resolves to a **non-callable** should throw (`Invoke` ->
`Call` on a non-callable); Perry falls through to the native method and returns
its result. That is independent of the receiver rule and reproduces identically
through a plain **data** property:

```ts
Object.defineProperty(String.prototype, "toString", { value: 42 });
("abc" as any).toLocaleString();   // node: TypeError   perry: "abc"
```

The resolver collapses "absent" and "present but not callable" into one
"native behavior still applies" answer, and `%TypedArray%.prototype.toLocaleString`
depends on that same contract — so it is called out in the new test file rather
than changed under this fix.

## Validation

- New gap test `test-files/test_gap_object_tolocalestring_primitive_receiver.ts`
  is **byte-identical** to `node --experimental-strip-types` (accessor on
  `Boolean`/`String`/`Symbol` prototypes, an object receiver, and the ordinary
  data-property path). Its first two lines print `object` on the pre-fix
  runtime, so it fails without the change.
- `cargo test -p perry-runtime`: 2051 passed, 0 failed.
- `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.
- test262 `built-ins/Object` subset — see the comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Object.prototype.toLocaleString` behavior for Boolean, String, Symbol, and object values.
  * Accessor-based and customized `toString` implementations now receive the correct original receiver.
  * Preserved expected formatting behavior for typed-array elements and built-in prototype methods.

* **Tests**
  * Added coverage for primitive and object receivers, including accessor and data-property implementations.

* **Documentation**
  * Documented the updated receiver behavior and the remaining handling distinction for non-callable `toString` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->