### PR TITLE
perf(transform): eliminate redundant property reads across diverging guard chains

### DIFF
--- a/changelog.d/7833-prop-cse-diverging-guard-chains.md
+++ b/changelog.d/7833-prop-cse-diverging-guard-chains.md
@@ -1,0 +1,139 @@
+### `perf(transform)`: eliminate redundant property reads across diverging guard chains
+
+The discriminated-union dispatch idiom — the most common shape in idiomatic
+TypeScript — reads its discriminant once per arm:
+
+```ts
+function evalNode(n: Node, env: Env): Value {
+  if (n.kind === "num") return { kind: "num", num: n.num };
+  if (n.kind === "str") return { kind: "str", str: n.str };
+  if (n.kind === "var") return lookup(env, n.name);
+  …
+}
+```
+
+Every one of those reads compiled to a **full generic property-get diamond**:
+the receiver-tag routing (`pget.recv_sso` / `pget.check_class_ref` /
+`pget.recv_ok`), the monomorphic-IC guard ladder (five loads out of the object
+header, two global loads, ~20 ALU ops), `pic.hit` / `pic.miss` / `pic.merge`,
+and a four-way `phi` — about fifty instructions and six branches per site
+(`expr/property_get/generic_dispatch.rs`).
+
+LLVM `-O3` cannot remove them, and the reason is structural rather than a
+missing attribute: GVN dedupes *instructions*, not congruent control-flow
+regions, and every arm of the diamond that is not the inline fast load ends in
+an opaque call (`js_object_get_field_ic_miss`,
+`js_object_get_field_by_name_f64`) whose memory effects license nothing. So
+the redundancy has to be removed before it becomes a diamond.
+
+`perry_transform::prop_cse` does that. Inside a run of consecutive
+`if (COND) { … }` statements with no `else` whose bodies **always diverge**
+(`return` / `throw` / `break` / `continue`), the fall-through path from one
+guard to the next runs no user code at all — only the guard expressions
+themselves. A `local.property` read appearing in two or more guards of such a
+run is therefore redundant, and one hoisted `const` replaces all of them.
+Divergence is what makes the run analyzable: a body that falls through could
+call anything, and then the next guard's read is a genuinely fresh
+observation.
+
+The pass runs after the inliner and the loop unroller, so inlined callee
+bodies get the same treatment.
+
+**Where the hoist may go.** Not "the top of the run" — the hoisted read is
+evaluated where the `Let` lands, so it must land somewhere the original
+program already evaluated it *unconditionally*. Otherwise
+`if (a.x === 1) return; if (b.y === 2) return;` would start dereferencing `b`
+on the path where the first guard returns, and a null `b` would throw where it
+previously did not. A key is a candidate only at the guard where it is that
+guard's **first unconditionally-evaluated read** — first, so hoisting it in
+front of the guard cannot reorder it past a sibling read that could throw
+first; unconditional, so it is not under the right-hand side of `&&`/`||`/`??`,
+which the original may skip. Both halves have a test.
+
+**What gates it.** Everything a guard may contain is on a closed allowlist:
+literals, `LocalGet`, `local.prop`, **strict** `===`/`!==`, `&&`/`||`/`??`,
+`!`, `typeof`. Loose compares and relational operators are excluded because
+they coerce, and coercion calls `valueOf`/`toString`; `Binary` is excluded
+wholesale for the same reason; calls, `new`, assignments, `await` and index
+reads are excluded outright.
+
+That leaves exactly one way for user code to run between two reads of
+`n.kind`: **`kind` could be an accessor**, and a stateful getter returning a
+different value on its second invocation would observe the difference. So the
+pass carries a whole-module veto — a class getter or setter, an object-literal
+accessor (`js_object_define_accessor`), a call naming
+`defineProperty`/`defineProperties`/`__defineGetter__`/`__defineSetter__`, or
+a `Proxy` construction anywhere in the module turns it off entirely. This
+mirrors `perry-codegen`'s `Ptr<Shape>` promotion, which is vetoed module-wide
+by the same family of constructs (`collectors/ptr_shape.rs`) before it emits
+an *unguarded* field load — a strictly stronger assumption than this one. Two
+residual holes are deliberate and named in the module docs:
+`Object.create(proto, descriptors)`, and an object built by a getter-defining
+module and passed in (the veto is per-module because the transform pipeline
+is).
+
+Async and generator bodies are skipped: those transforms run afterwards and
+box every body local into a shared mutable `Any` cell, so a hoisted `const`
+would become one more boxed cell rather than a register.
+
+**Deliberately not covered yet**, each a straightforward follow-up rather than
+a soundness question:
+
+* `else if` chains. `if (a) … else if (b) …` nests as
+  `If { else_branch: Some([If { … }]) }`, so each `else` list holds a run of
+  one and nothing repeats within it. The same argument applies across the
+  `else` edge — the else branch is reached exactly when an analyzable
+  condition evaluated false, which ran no user code — so the run can be
+  threaded through the nesting; it just needs a different traversal than the
+  flat slice this version walks.
+* Closure bodies. `Expr::Closure`'s body is a `Vec<Stmt>` the expression
+  walker deliberately does not descend into, and this pass follows statements
+  only.
+
+`PERRY_PROP_CSE=0` disables the pass for bisection.
+
+**Measured** (quiet M1 mini, best-of-5, `origin/main` @ `1ee158d27`, outputs
+byte-identical to `node --experimental-strip-types` and exit-code checked;
+both arms are the SAME binary with only the knob flipped, so nothing but the
+pass differs):
+
+| bench | pass off | pass on | |
+|---|--:|--:|--:|
+| `gc-handoff/apps/interp` | 1.4964 | **1.2424** | −17.0% |
+| `gc-handoff/apps/iso_miss` | 1.9244 | **1.6819** | −12.6% |
+
+The control arm is not a separate build: `pass off` is the same binary with
+`PERRY_PROP_CSE=0`, and it reproduces the independently-built `main`
+reference (`1ee158d27`) to within 0.2 ms — 1.4964 vs 1.4962 on `interp`,
+1.9244 vs 1.9238 on `iso_miss` — so the delta is the pass and nothing else.
+
+**The no-regression claim is a byte-comparison, not a timing run.** Compiling
+the whole 25-program corpus twice from the same binary — once with the pass
+on, once with `PERRY_PROP_CSE=0` — leaves **23 of 25 executables byte-identical**
+(`churn`, `churn_alloc`, `churn_read`, `push_num`, `push_cls`, `cycles`,
+`deeplist`, `tree`, `tree_wide`, `retain`, `retain1`, `retain_wide`,
+`retain_wide1`, `fib40`, `asyncpipe`, `shapes`, `pipeline` and the six
+bootstrap variants). The pass is a provable no-op for them, so their timing
+cannot move — no host quiet enough to measure that is required. The two that
+differ are the two that improved.
+
+A full interleaved corpus run confirms it from the other direction. That run
+was **not** taken under the shared-host lock, so its absolute seconds sit ~3%
+high across every arm and are not quoted here — but the arms are interleaved
+and 23 of the programs are byte-identical, so their `on/off` ratio *is* the
+run's noise floor: it lands between **0.94 and 1.01** for every one of them.
+`interp` (0.831), `interp_fo` (0.830) and `iso_miss` (0.875) sit far outside
+that band, and reproduce the locked run's ratios (0.830 / 0.874) to ±0.001.
+
+`interp_fo` — `interp.ts` with a `for (const _x of [1]) {}` prologue, which
+forces the `globalThis` builtin bootstrap — gains exactly as much as `interp`,
+and costs 0.14% over it.
+Module-wide the generic-get site count in `iso_FIB.ts` falls from 238 to 208,
+and `evalNode`'s emitted IR from 19102 to 17022 lines.
+
+15 unit tests in `crates/perry-transform/src/prop_cse.rs` cover the rewrite,
+each refusal (fall-through body, an intervening call, loose equality,
+relational compare, a single occurrence, a short-circuited read, a key first
+read by a later guard), the module veto in both directions — including an
+accessor installed in a `for` **init**, which is a `Stmt` the flat expression
+walk cannot reach — and the async-body skip.

--- a/crates/perry-transform/src/lib.rs
+++ b/crates/perry-transform/src/lib.rs
@@ -13,6 +13,7 @@ pub mod finally_inline;
 pub mod generator;
 pub mod i18n;
 pub mod inline;
+pub mod prop_cse;
 pub mod state_desugar;
 pub mod unroll;
 
@@ -27,3 +28,23 @@ pub use inline::{
     gather_cross_module_methods_with_extern_imports, inline_functions, MethodCandidate,
 };
 pub use unroll::unroll_static_loops;
+
+/// Post-inline HIR cleanups, in the one order that works for both.
+///
+/// [`unroll_static_loops`] and [`prop_cse::run`] share their ordering
+/// constraint, so the driver runs them through a single entry point rather
+/// than repeating the constraint at each call site:
+///
+/// * **After the inliner** — both want the inlined callee bodies. The unroller
+///   gets their loops; `prop_cse` gets the guard chains an inlined body
+///   contributes, and the copies the unroller then makes.
+/// * **Before the async/generator transforms** — those rewrite control flow
+///   into state-machine shapes the unroll match no longer recognizes, and they
+///   box every body local into a shared mutable `Any` cell, which would turn a
+///   hoisted `const` into one more boxed cell instead of a register.
+///   (`prop_cse` skips async/generator bodies for exactly that reason; keeping
+///   the order here stops the two facts from drifting apart.)
+pub fn post_inline_cleanups(module: &mut perry_hir::Module) {
+    unroll_static_loops(module);
+    prop_cse::run(module);
+}

--- a/crates/perry-transform/src/prop_cse.rs
+++ b/crates/perry-transform/src/prop_cse.rs
@@ -1,0 +1,948 @@
+//! Redundant property-read elimination over **diverging guard chains**.
+//!
+//! # The shape
+//!
+//! The discriminated-union dispatch idiom is the single most common shape in
+//! idiomatic TypeScript, and it reads the discriminant once per arm:
+//!
+//! ```ignore
+//! function evalNode(n: Node, env: Env): Value {
+//!   if (n.kind === "num") return { kind: "num", num: n.num };
+//!   if (n.kind === "str") return { kind: "str", str: n.str };
+//!   if (n.kind === "var") return lookup(env, n.name);
+//!   …
+//! }
+//! ```
+//!
+//! Every one of those `n.kind` reads compiles to a **full generic
+//! property-get diamond** — `pget.recv_sso` / `pget.check_class_ref` /
+//! `pget.recv_ok` / the monomorphic-IC guard ladder / `pic.hit` / `pic.miss` /
+//! `pget.recv_merge` — about fifty instructions and six branches per site
+//! (`expr/property_get/generic_dispatch.rs`). `gc-handoff/apps/interp.ts`'s
+//! `evalNode` has **53 such sites**, of which `n.kind` accounts for seven and
+//! `n.op` for seven more.
+//!
+//! LLVM `-O3` cannot remove them. GVN dedupes *instructions*, not congruent
+//! control-flow regions, and every arm of the diamond that is not the inline
+//! fast load ends in an opaque call (`js_object_get_field_ic_miss`,
+//! `js_object_get_field_by_name_f64`) whose memory effects license nothing. So
+//! the redundancy has to be removed before it becomes a diamond — here.
+//!
+//! # The rewrite
+//!
+//! Inside a run of consecutive `if (COND) { … }` statements that have no
+//! `else` and whose bodies **always diverge** (`return` / `throw` / `break` /
+//! `continue`), the fall-through path from one guard to the next runs *no user
+//! code at all* — only the guard expressions themselves. So a
+//! `local.property` read appearing in two or more guards of the run is
+//! redundant, and one hoisted `const` in front of the run replaces all of
+//! them.
+//!
+//! Divergence is what makes the run analyzable: a body that falls through
+//! could call anything, and then the next guard's read is a genuinely fresh
+//! observation.
+//!
+//! # Why this is sound, and the one thing that gates it
+//!
+//! Everything the guards may contain is on a closed allowlist
+//! ([`guard_expr_is_analyzable`]): literals, `LocalGet`, `local.prop` reads,
+//! **strict** `===`/`!==` compares, `&&`/`||`/`??`, `!`, and `typeof`. Loose
+//! compares and relational operators are excluded because they can invoke
+//! `valueOf`/`toString`; `Binary` is excluded wholesale for the same reason;
+//! calls, `new`, assignments, `await` and index reads are excluded outright.
+//! A run containing an assignment to any local is skipped, so the receiver
+//! cannot change between guards.
+//!
+//! That leaves exactly one way for user code to run between two reads of
+//! `n.kind`: **`kind` could be an accessor**, and a stateful getter that
+//! returns a different value on its second invocation would observe the
+//! difference. The guard is therefore a whole-module veto
+//! ([`module_defines_accessors`]) — if the module defines a class getter or
+//! setter, defines an object-literal accessor, calls
+//! `Object.defineProperty`/`defineProperties`/`__defineGetter__`/
+//! `__defineSetter__`, or constructs a `Proxy`, the pass does nothing at all.
+//! This mirrors `perry-codegen`'s `Ptr<Shape>` promotion, which is vetoed
+//! module-wide by the same family of constructs (`collectors/ptr_shape.rs`)
+//! before it emits an *unguarded* field load — a strictly stronger assumption
+//! than this one.
+//!
+//! `PERRY_PROP_CSE=0` disables the pass for bisection.
+
+use std::collections::HashMap;
+
+use perry_hir::types::{LocalId, Type};
+use perry_hir::{CompareOp, Expr, Function, Module, Stmt, UnaryOp};
+
+/// A hoistable read: `LocalGet(id).property`.
+type ReadKey = (LocalId, String);
+
+/// `PERRY_PROP_CSE=0` / `off` / `false` disables the pass.
+fn enabled() -> bool {
+    match std::env::var("PERRY_PROP_CSE") {
+        Ok(v) => !matches!(v.as_str(), "0" | "off" | "false"),
+        Err(_) => true,
+    }
+}
+
+/// Entry point. Runs after the inliner and the loop unroller, so inlined
+/// callee bodies get the same treatment.
+pub fn run(module: &mut Module) {
+    if !enabled() || module_defines_accessors(module) {
+        return;
+    }
+    let mut next_local_id = crate::generator::compute_max_local_id(module).saturating_add(1);
+
+    // `module.init` is deliberately skipped: a module-level `Stmt::Let` is not
+    // an ordinary local (module variables live in `@perry_global_<mod>__<id>`
+    // and are registered as GC roots before init), so minting one here would
+    // need registration this pass does not do. It is also cold code.
+    for f in &mut module.functions {
+        run_function(f, &mut next_local_id);
+    }
+    for c in &mut module.classes {
+        if let Some(ctor) = &mut c.constructor {
+            run_function(ctor, &mut next_local_id);
+        }
+        for m in &mut c.methods {
+            run_function(m, &mut next_local_id);
+        }
+        // Accessor bodies cannot exist here — `module_defines_accessors`
+        // already returned early if the module had any.
+    }
+}
+
+fn run_function(f: &mut Function, next_local_id: &mut LocalId) {
+    // The async/generator transforms run AFTER this pass and box every body
+    // local into a shared mutable `Any` cell. A hoisted `const` would become
+    // one more boxed cell rather than a register, which is a pessimization,
+    // and the boxing path is a known-weak area (per-iteration bindings
+    // collapse there). Leave those bodies alone.
+    if f.is_async || f.is_generator {
+        return;
+    }
+    cse_stmts(&mut f.body, next_local_id);
+}
+
+/// Walk a statement list, rewriting maximal runs of diverging guards.
+/// Recurses into every nested statement list first so inner runs are handled
+/// in their own right.
+fn cse_stmts(stmts: &mut Vec<Stmt>, next_local_id: &mut LocalId) {
+    for s in stmts.iter_mut() {
+        for inner in nested_stmt_lists(s) {
+            cse_stmts(inner, next_local_id);
+        }
+    }
+
+    let mut i = 0usize;
+    while i < stmts.len() {
+        let mut j = i;
+        while j < stmts.len() && diverging_guard(&stmts[j]).is_some() {
+            j += 1;
+        }
+        if j - i >= 2 {
+            // `rewrite_run` reports each hoist as (offset-within-run, Let).
+            // Inserting from the back keeps the earlier offsets valid.
+            let mut hoists = rewrite_run(&mut stmts[i..j], next_local_id);
+            let n = hoists.len();
+            hoists.sort_by_key(|(at, _)| std::cmp::Reverse(*at));
+            for (at, stmt) in hoists {
+                stmts.insert(i + at, stmt);
+            }
+            i = j + n;
+        } else {
+            i = if j > i { j } else { i + 1 };
+        }
+    }
+}
+
+/// The guard condition of an `if (COND) { … }` whose body always diverges and
+/// which has no `else`, provided the condition is on the analyzable allowlist.
+fn diverging_guard(stmt: &Stmt) -> Option<&Expr> {
+    match stmt {
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch: None,
+        } if always_diverges(then_branch) && guard_expr_is_analyzable(condition) => Some(condition),
+        _ => None,
+    }
+}
+
+/// Every path through `stmts` leaves the enclosing statement list.
+fn always_diverges(stmts: &[Stmt]) -> bool {
+    match stmts.last() {
+        Some(Stmt::Return(_))
+        | Some(Stmt::Throw(_))
+        | Some(Stmt::Break)
+        | Some(Stmt::Continue)
+        | Some(Stmt::LabeledBreak(_))
+        | Some(Stmt::LabeledContinue(_)) => true,
+        Some(Stmt::If {
+            then_branch,
+            else_branch: Some(else_branch),
+            ..
+        }) => always_diverges(then_branch) && always_diverges(else_branch),
+        _ => false,
+    }
+}
+
+/// Closed allowlist of guard expressions: nothing here can run user code
+/// except a property read, which is precisely what the module-wide accessor
+/// veto rules out.
+fn guard_expr_is_analyzable(e: &Expr) -> bool {
+    match e {
+        Expr::Undefined
+        | Expr::Null
+        | Expr::Bool(_)
+        | Expr::Number(_)
+        | Expr::Integer(_)
+        | Expr::BigInt(_)
+        | Expr::String(_)
+        | Expr::WtfString(_)
+        | Expr::This
+        | Expr::LocalGet(_)
+        | Expr::FuncRef(_)
+        | Expr::ClassRef(_) => true,
+        // Only a direct local receiver. A nested `a.b.c` would need the inner
+        // read hoisted too, and the outer key would then be keyed on a
+        // temporary — not worth the extra bookkeeping for the idiom this
+        // targets.
+        Expr::PropertyGet { object, .. } => matches!(object.as_ref(), Expr::LocalGet(_)),
+        // STRICT compares only. `==`/`!=`/`<`/`<=`/`>`/`>=` all coerce, and
+        // coercion calls `valueOf`/`toString`.
+        Expr::Compare { op, left, right } => {
+            matches!(op, CompareOp::Eq | CompareOp::Ne)
+                && guard_expr_is_analyzable(left)
+                && guard_expr_is_analyzable(right)
+        }
+        Expr::Logical { left, right, .. } => {
+            guard_expr_is_analyzable(left) && guard_expr_is_analyzable(right)
+        }
+        Expr::Unary { op, operand } => {
+            matches!(op, UnaryOp::Not) && guard_expr_is_analyzable(operand)
+        }
+        Expr::TypeOf(operand) => guard_expr_is_analyzable(operand),
+        _ => false,
+    }
+}
+
+/// Hoist repeated reads. Returns `(offset within the run, the `Stmt::Let`)`
+/// pairs; the caller inserts them.
+///
+/// # Where a hoist may go, and why it is not simply "the top of the run"
+///
+/// The hoisted read is evaluated where the `Let` lands, so it must land
+/// somewhere the original program already evaluated it **unconditionally** —
+/// otherwise `if (a.x === 1) return; if (b.y === 2) return;` would start
+/// dereferencing `b` on the path where `a.x === 1` returns, and a null `b`
+/// would throw where it previously did not.
+///
+/// So a key is a candidate only at the guard where it is that guard's **first
+/// unconditionally-evaluated read** — first, so hoisting it in front of the
+/// guard cannot reorder it past a sibling read that could throw first; and
+/// unconditional, so it is not under the right-hand side of `&&`/`||`/`??`,
+/// which the original may skip. The `Let` goes immediately before that guard,
+/// and every occurrence from there to the end of the run is replaced.
+fn rewrite_run(run: &mut [Stmt], next_local_id: &mut LocalId) -> Vec<(usize, Stmt)> {
+    // Candidate key per guard: its first unconditional read, if any.
+    let candidates: Vec<Option<ReadKey>> = run
+        .iter()
+        .map(|s| diverging_guard(s).and_then(first_unconditional_read))
+        .collect();
+
+    let mut hoists: Vec<(usize, Stmt)> = Vec::new();
+    let mut claimed: Vec<ReadKey> = Vec::new();
+    for (at, cand) in candidates.iter().enumerate() {
+        let Some(key) = cand else { continue };
+        if claimed.contains(key) {
+            continue;
+        }
+        // Occurrences from this guard to the end of the run — the region the
+        // hoisted value dominates.
+        let mut uses = 0usize;
+        for stmt in run[at..].iter() {
+            if let Some(cond) = diverging_guard(stmt) {
+                uses += count_reads_of(cond, key);
+            }
+        }
+        if uses < 2 {
+            continue;
+        }
+        let id = *next_local_id;
+        *next_local_id += 1;
+        hoists.push((
+            at,
+            Stmt::Let {
+                id,
+                name: format!("__perry_cse_{}_{}", key.1, id),
+                // `Any` — the hoist must not claim knowledge the read did not
+                // have. Codegen's string-literal `===` inlining (#7767) keys
+                // on the literal side, so it still fires through an `Any`.
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(key.0)),
+                    property: key.1.clone(),
+                    byte_offset: 0,
+                }),
+            },
+        ));
+        let subst: HashMap<ReadKey, LocalId> = std::iter::once((key.clone(), id)).collect();
+        for stmt in run[at..].iter_mut() {
+            if let Stmt::If { condition, .. } = stmt {
+                substitute_reads(condition, &subst);
+            }
+        }
+        claimed.push(key.clone());
+    }
+    hoists
+}
+
+/// The first `local.prop` read this expression evaluates on every path,
+/// walking left to right and never entering the right-hand side of a
+/// short-circuiting operator.
+fn first_unconditional_read(e: &Expr) -> Option<ReadKey> {
+    match e {
+        Expr::PropertyGet {
+            object, property, ..
+        } => match object.as_ref() {
+            Expr::LocalGet(id) => Some((*id, property.clone())),
+            _ => None,
+        },
+        Expr::Compare { left, right, .. } => {
+            first_unconditional_read(left).or_else(|| first_unconditional_read(right))
+        }
+        // Only the LEFT operand of `&&`/`||`/`??` is unconditional.
+        Expr::Logical { left, .. } => first_unconditional_read(left),
+        Expr::Unary { operand, .. } | Expr::TypeOf(operand) => first_unconditional_read(operand),
+        _ => None,
+    }
+}
+
+fn count_reads_of(e: &Expr, key: &ReadKey) -> usize {
+    match e {
+        Expr::PropertyGet {
+            object, property, ..
+        } => match object.as_ref() {
+            Expr::LocalGet(id) if *id == key.0 && *property == key.1 => 1,
+            _ => 0,
+        },
+        Expr::Compare { left, right, .. } | Expr::Logical { left, right, .. } => {
+            count_reads_of(left, key) + count_reads_of(right, key)
+        }
+        Expr::Unary { operand, .. } | Expr::TypeOf(operand) => count_reads_of(operand, key),
+        _ => 0,
+    }
+}
+
+fn substitute_reads(e: &mut Expr, subst: &HashMap<ReadKey, LocalId>) {
+    match e {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
+            if let Expr::LocalGet(id) = object.as_ref() {
+                if let Some(tmp) = subst.get(&(*id, property.clone())) {
+                    *e = Expr::LocalGet(*tmp);
+                }
+            }
+        }
+        Expr::Compare { left, right, .. } | Expr::Logical { left, right, .. } => {
+            substitute_reads(left, subst);
+            substitute_reads(right, subst);
+        }
+        Expr::Unary { operand, .. } | Expr::TypeOf(operand) => substitute_reads(operand, subst),
+        _ => {}
+    }
+}
+
+/// Statement lists nested directly inside `s`.
+fn nested_stmt_lists(s: &mut Stmt) -> Vec<&mut Vec<Stmt>> {
+    match s {
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => match else_branch {
+            Some(e) => vec![then_branch, e],
+            None => vec![then_branch],
+        },
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => vec![body],
+        Stmt::For { body, .. } => vec![body],
+        Stmt::Labeled { body, .. } => nested_stmt_lists(body),
+        Stmt::Switch { cases, .. } => cases.iter_mut().map(|c| &mut c.body).collect(),
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            let mut v = vec![body];
+            if let Some(c) = catch {
+                v.push(&mut c.body);
+            }
+            if let Some(f) = finally {
+                v.push(f);
+            }
+            v
+        }
+        _ => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module-wide accessor veto
+// ---------------------------------------------------------------------------
+
+/// Property names that install an accessor. None of them is a plausible
+/// user-defined method name, so matching on the name alone (rather than on
+/// `Object.` as the receiver) costs no realistic optimization opportunity and
+/// keeps the scan a flat expression walk.
+const ACCESSOR_INSTALLERS: &[&str] = &[
+    "defineProperty",
+    "defineProperties",
+    "__defineGetter__",
+    "__defineSetter__",
+];
+
+/// Extern helpers the object-literal lowering emits for `{ get x() {} }`
+/// (`SpreadOp::DefineAccessor`, `lower/expr_object.rs`).
+const ACCESSOR_EXTERNS: &[&str] = &[
+    "js_object_define_accessor",
+    "js_object_define_property",
+    "js_class_define_accessor",
+];
+
+/// Two residual holes, both deliberate and both closed by `PERRY_PROP_CSE=0`:
+///
+/// * `Object.create(proto, descriptors)` can install a getter through a
+///   descriptor object without naming `defineProperty`. Vetoing every
+///   `.create(` would disable the pass for most real modules to close a
+///   pattern that essentially does not occur.
+/// * An object built in **another** module by a getter-defining module and
+///   passed in. The veto is per-module because the transform pipeline is.
+fn module_defines_accessors(module: &Module) -> bool {
+    for c in &module.classes {
+        if !c.getters.is_empty() || !c.setters.is_empty() {
+            return true;
+        }
+    }
+    let mut found = false;
+    let scan = |stmts: &Vec<Stmt>, found: &mut bool| {
+        for s in stmts {
+            scan_stmt(s, found);
+        }
+    };
+    scan(&module.init, &mut found);
+    for f in &module.functions {
+        scan(&f.body, &mut found);
+    }
+    for c in &module.classes {
+        if let Some(ctor) = &c.constructor {
+            scan(&ctor.body, &mut found);
+        }
+        for m in &c.methods {
+            scan(&m.body, &mut found);
+        }
+    }
+    found
+}
+
+fn scan_stmt(s: &Stmt, found: &mut bool) {
+    if *found {
+        return;
+    }
+    for e in stmt_exprs(s) {
+        scan_expr(e, found);
+    }
+    // `nested_stmt_lists` needs `&mut`; this immutable scan mirrors it.
+    match s {
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            for st in then_branch {
+                scan_stmt(st, found);
+            }
+            if let Some(e) = else_branch {
+                for st in e {
+                    scan_stmt(st, found);
+                }
+            }
+        }
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+            for st in body {
+                scan_stmt(st, found);
+            }
+        }
+        // `For`'s init is a `Stmt`, not an expression — `stmt_exprs` cannot
+        // reach it, so the veto would miss an accessor installed there.
+        Stmt::For { init, body, .. } => {
+            if let Some(init) = init {
+                scan_stmt(init, found);
+            }
+            for st in body {
+                scan_stmt(st, found);
+            }
+        }
+        Stmt::Labeled { body, .. } => scan_stmt(body, found),
+        Stmt::Switch { cases, .. } => {
+            for c in cases {
+                for st in &c.body {
+                    scan_stmt(st, found);
+                }
+            }
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            for st in body {
+                scan_stmt(st, found);
+            }
+            if let Some(c) = catch {
+                for st in &c.body {
+                    scan_stmt(st, found);
+                }
+            }
+            if let Some(f) = finally {
+                for st in f {
+                    scan_stmt(st, found);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn stmt_exprs(s: &Stmt) -> Vec<&Expr> {
+    match s {
+        Stmt::Let { init, .. } => init.iter().collect(),
+        Stmt::Expr(e) | Stmt::Throw(e) => vec![e],
+        Stmt::Return(e) => e.iter().collect(),
+        Stmt::If { condition, .. }
+        | Stmt::While { condition, .. }
+        | Stmt::DoWhile { condition, .. } => vec![condition],
+        Stmt::For {
+            condition, update, ..
+        } => condition.iter().chain(update.iter()).collect(),
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => std::iter::once(discriminant)
+            .chain(cases.iter().filter_map(|c| c.test.as_ref()))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn scan_expr(e: &Expr, found: &mut bool) {
+    if *found {
+        return;
+    }
+    if expr_installs_accessor(e) {
+        *found = true;
+        return;
+    }
+    // A closure body is a `Vec<Stmt>` the expression walker does not descend
+    // into; a getter installed from inside one still counts.
+    if let Expr::Closure { body, .. } = e {
+        for st in body {
+            scan_stmt(st, found);
+        }
+    }
+    perry_hir::walker::walk_expr_children(e, &mut |child: &Expr| scan_expr(child, found));
+}
+
+fn expr_installs_accessor(e: &Expr) -> bool {
+    match e {
+        Expr::ExternFuncRef { name, .. } => ACCESSOR_EXTERNS.contains(&name.as_str()),
+        Expr::PropertyGet { property, .. } => ACCESSOR_INSTALLERS.contains(&property.as_str()),
+        Expr::New { class_name, .. } => class_name == "Proxy",
+        Expr::ClassRef(name) => name == "Proxy",
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const N: LocalId = 1;
+
+    fn read(id: LocalId, prop: &str) -> Expr {
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(id)),
+            property: prop.to_string(),
+            byte_offset: 0,
+        }
+    }
+
+    fn guard(prop: &str, lit: &str, body: Vec<Stmt>) -> Stmt {
+        Stmt::If {
+            condition: Expr::Compare {
+                op: CompareOp::Eq,
+                left: Box::new(read(N, prop)),
+                right: Box::new(Expr::String(lit.to_string())),
+            },
+            then_branch: body,
+            else_branch: None,
+        }
+    }
+
+    fn diverging(prop: &str, lit: &str) -> Stmt {
+        guard(prop, lit, vec![Stmt::Return(Some(Expr::Integer(0)))])
+    }
+
+    /// Every `local.prop` read still present anywhere in `stmts`.
+    fn count_reads(stmts: &[Stmt], prop: &str) -> usize {
+        fn in_expr(e: &Expr, prop: &str, n: &mut usize) {
+            if let Expr::PropertyGet { property, .. } = e {
+                if property == prop {
+                    *n += 1;
+                }
+            }
+            perry_hir::walker::walk_expr_children(e, &mut |c: &Expr| in_expr(c, prop, n));
+        }
+        let mut n = 0;
+        for s in stmts {
+            for e in stmt_exprs(s) {
+                in_expr(e, prop, &mut n);
+            }
+            if let Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } = s
+            {
+                n += count_reads(then_branch, prop);
+                if let Some(e) = else_branch {
+                    n += count_reads(e, prop);
+                }
+            }
+        }
+        n
+    }
+
+    #[test]
+    fn hoists_a_diverging_guard_chain_to_one_read() {
+        let mut body = vec![
+            diverging("kind", "num"),
+            diverging("kind", "str"),
+            diverging("kind", "var"),
+            diverging("kind", "fun"),
+        ];
+        assert_eq!(count_reads(&body, "kind"), 4);
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(
+            count_reads(&body, "kind"),
+            1,
+            "four guards must collapse to the single hoisted read"
+        );
+        assert_eq!(body.len(), 5, "one Let inserted in front of the run");
+        match &body[0] {
+            Stmt::Let { id, init, .. } => {
+                assert_eq!(*id, 100);
+                assert!(matches!(init, Some(Expr::PropertyGet { .. })));
+            }
+            other => panic!("expected the hoisted Let, got {:?}", other),
+        }
+        // The guards now compare the temporary.
+        for s in &body[1..] {
+            match s {
+                Stmt::If {
+                    condition: Expr::Compare { left, .. },
+                    ..
+                } => assert!(matches!(left.as_ref(), Expr::LocalGet(100))),
+                other => panic!("guard was rewritten wrong: {:?}", other),
+            }
+        }
+    }
+
+    /// The divergence requirement is the whole safety argument: a body that
+    /// falls through can call anything, and the next guard's read is then a
+    /// fresh observation.
+    #[test]
+    fn a_falling_through_body_blocks_the_hoist() {
+        let mut body = vec![
+            guard("kind", "num", vec![Stmt::Expr(Expr::Integer(0))]),
+            guard("kind", "str", vec![Stmt::Expr(Expr::Integer(0))]),
+            guard("kind", "var", vec![Stmt::Expr(Expr::Integer(0))]),
+        ];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "kind"), 3);
+        assert_eq!(next, 100, "no temporary was minted");
+    }
+
+    /// One call in the middle splits the run in two, and neither half repeats.
+    #[test]
+    fn a_call_between_guards_splits_the_run() {
+        let mut body = vec![
+            diverging("kind", "num"),
+            Stmt::Expr(Expr::Call {
+                callee: Box::new(Expr::FuncRef(7)),
+                args: vec![],
+                type_args: vec![],
+                byte_offset: 0,
+            }),
+            diverging("kind", "str"),
+        ];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "kind"), 2);
+        assert_eq!(next, 100);
+    }
+
+    /// `==` coerces, and coercion calls `valueOf`/`toString`.
+    #[test]
+    fn loose_equality_is_not_analyzable() {
+        let mk = |lit: &str| Stmt::If {
+            condition: Expr::Compare {
+                op: CompareOp::LooseEq,
+                left: Box::new(read(N, "kind")),
+                right: Box::new(Expr::String(lit.to_string())),
+            },
+            then_branch: vec![Stmt::Return(None)],
+            else_branch: None,
+        };
+        let mut body = vec![mk("num"), mk("str"), mk("var")];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "kind"), 3);
+        assert_eq!(next, 100);
+    }
+
+    /// Relational compares coerce too.
+    #[test]
+    fn relational_compare_is_not_analyzable() {
+        assert!(!guard_expr_is_analyzable(&Expr::Compare {
+            op: CompareOp::Lt,
+            left: Box::new(read(N, "kind")),
+            right: Box::new(Expr::Integer(1)),
+        }));
+    }
+
+    #[test]
+    fn a_single_occurrence_is_not_hoisted() {
+        let mut body = vec![diverging("kind", "num"), diverging("op", "+")];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "kind"), 1);
+        assert_eq!(count_reads(&body, "op"), 1);
+        assert_eq!(next, 100);
+    }
+
+    /// Two distinct repeated keys interleaved in one run: each `Let` lands
+    /// immediately before the guard that first read it unconditionally, never
+    /// at the top of the run.
+    #[test]
+    fn two_repeated_keys_hoist_at_their_own_first_guard() {
+        let mut body = vec![
+            diverging("op", "+"),
+            diverging("kind", "num"),
+            diverging("op", "-"),
+            diverging("kind", "str"),
+        ];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "op"), 1);
+        assert_eq!(count_reads(&body, "kind"), 1);
+        let props: Vec<Option<&str>> = body
+            .iter()
+            .map(|s| match s {
+                Stmt::Let {
+                    init: Some(Expr::PropertyGet { property, .. }),
+                    ..
+                } => Some(property.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            props,
+            vec![Some("op"), None, Some("kind"), None, None, None],
+            "each Let sits in front of its own first guard"
+        );
+    }
+
+    /// The evaluation-order rule: a key first read by a LATER guard must not
+    /// be hoisted to the top of the run, or a receiver that is only safe to
+    /// dereference once the earlier guards have failed would throw early.
+    #[test]
+    fn a_key_first_read_later_is_not_hoisted_above_the_earlier_guards() {
+        let other: LocalId = 2;
+        let later = |lit: &str| Stmt::If {
+            condition: Expr::Compare {
+                op: CompareOp::Eq,
+                left: Box::new(read(other, "y")),
+                right: Box::new(Expr::String(lit.to_string())),
+            },
+            then_branch: vec![Stmt::Return(None)],
+            else_branch: None,
+        };
+        let mut body = vec![diverging("kind", "num"), later("a"), later("b")];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        // `y` is hoisted, but only in front of the guard at index 1.
+        assert_eq!(count_reads(&body, "y"), 1);
+        assert!(
+            matches!(&body[0], Stmt::If { .. }),
+            "the run still starts with the original first guard, not a Let"
+        );
+        assert!(matches!(&body[1], Stmt::Let { .. }));
+    }
+
+    /// A read under the right-hand side of `&&` is conditional: the original
+    /// may never evaluate it, so it is not a hoist candidate at that guard.
+    #[test]
+    fn a_short_circuited_read_is_not_a_candidate() {
+        let other: LocalId = 2;
+        let g = |lit: &str| Stmt::If {
+            condition: Expr::Logical {
+                op: perry_hir::LogicalOp::And,
+                left: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(read(N, "kind")),
+                    right: Box::new(Expr::String("bin".to_string())),
+                }),
+                right: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(read(other, "y")),
+                    right: Box::new(Expr::String(lit.to_string())),
+                }),
+            },
+            then_branch: vec![Stmt::Return(None)],
+            else_branch: None,
+        };
+        let mut body = vec![g("a"), g("b")];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(
+            count_reads(&body, "y"),
+            2,
+            "the short-circuited read must survive"
+        );
+        assert_eq!(count_reads(&body, "kind"), 1, "the left read still hoists");
+    }
+
+    /// Nested runs inside a diverging body are handled in their own right —
+    /// this is the `if (n.kind === "bin") { … if (n.op === "+") … }` shape.
+    #[test]
+    fn a_nested_run_inside_a_diverging_body_is_rewritten() {
+        let inner = vec![
+            diverging("op", "+"),
+            diverging("op", "-"),
+            diverging("op", "*"),
+            Stmt::Return(None),
+        ];
+        let mut body = vec![guard("kind", "bin", inner)];
+        let mut next = 100;
+        cse_stmts(&mut body, &mut next);
+        assert_eq!(count_reads(&body, "op"), 1);
+        assert_eq!(count_reads(&body, "kind"), 1);
+    }
+
+    fn accessor_module(f: Function) -> Module {
+        let mut m = Module::new("t");
+        m.functions.push(f);
+        m
+    }
+
+    fn fn_with(body: Vec<Stmt>) -> Function {
+        Function {
+            id: 1,
+            name: "f".to_string(),
+            type_params: vec![],
+            params: vec![],
+            return_type: Type::Any,
+            body,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+            is_exported: false,
+            captures: vec![],
+            decorators: vec![],
+            was_plain_async: false,
+            was_unrolled: false,
+        }
+    }
+
+    /// The whole-module veto: a `defineProperty` anywhere turns the pass off,
+    /// because a property read is then no longer provably free of user code.
+    #[test]
+    fn define_property_anywhere_vetoes_the_module() {
+        let body = vec![
+            Stmt::Expr(Expr::Call {
+                callee: Box::new(read(9, "defineProperty")),
+                args: vec![],
+                type_args: vec![],
+                byte_offset: 0,
+            }),
+            diverging("kind", "num"),
+            diverging("kind", "str"),
+        ];
+        let mut m = accessor_module(fn_with(body));
+        assert!(module_defines_accessors(&m));
+        run(&mut m);
+        assert_eq!(count_reads(&m.functions[0].body, "kind"), 2);
+    }
+
+    #[test]
+    fn an_object_literal_accessor_vetoes_the_module() {
+        let body = vec![Stmt::Expr(Expr::Call {
+            callee: Box::new(Expr::ExternFuncRef {
+                name: "js_object_define_accessor".to_string(),
+                param_types: vec![],
+                return_type: Type::Void,
+            }),
+            args: vec![],
+            type_args: vec![],
+            byte_offset: 0,
+        })];
+        let m = accessor_module(fn_with(body));
+        assert!(module_defines_accessors(&m));
+    }
+
+    /// `For`'s init is a `Stmt`, not an expression, so the flat expression
+    /// walk cannot reach it — the veto has to recurse into it explicitly.
+    #[test]
+    fn an_accessor_installed_in_a_for_init_vetoes_the_module() {
+        let body = vec![Stmt::For {
+            init: Some(Box::new(Stmt::Expr(Expr::Call {
+                callee: Box::new(read(9, "defineProperty")),
+                args: vec![],
+                type_args: vec![],
+                byte_offset: 0,
+            }))),
+            condition: None,
+            update: None,
+            body: vec![],
+        }];
+        let m = accessor_module(fn_with(body));
+        assert!(module_defines_accessors(&m));
+    }
+
+    #[test]
+    fn a_clean_module_is_not_vetoed_and_is_rewritten() {
+        let mut m = accessor_module(fn_with(vec![
+            diverging("kind", "num"),
+            diverging("kind", "str"),
+        ]));
+        assert!(!module_defines_accessors(&m));
+        run(&mut m);
+        assert_eq!(count_reads(&m.functions[0].body, "kind"), 1);
+    }
+
+    /// Async and generator bodies are skipped: the async→generator transform
+    /// runs after this pass and boxes every body local.
+    #[test]
+    fn async_bodies_are_skipped() {
+        let mut f = fn_with(vec![diverging("kind", "num"), diverging("kind", "str")]);
+        f.is_async = true;
+        let mut next = 100;
+        run_function(&mut f, &mut next);
+        assert_eq!(count_reads(&f.body, "kind"), 2);
+        assert_eq!(next, 100);
+    }
+}

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -1927,15 +1927,15 @@ fn collect_module_finish(
             &extra_class_fields,
             &extra_anon_classes,
         );
-        // Static-trip-count for-loop unroll. Runs AFTER the inliner so any
-        // inlined function bodies' loops also get unrolled. Runs BEFORE the
-        // async/generator transforms — those transforms pre-emptively rewrite
-        // control flow into state-machine shapes that the unroll match would
-        // no longer recognize. Doing it pre-async keeps the analysis simple.
-        // image_convolution's 5x5 blur kernel: outer ky and inner kx both
-        // become 25 fully-unrolled stmts with `KERNEL[ky+2][kx+2]` collapsed
-        // to compile-time integer literals — see crates/perry-transform/
-        // src/unroll.rs.
+        // Post-inline HIR cleanups, in ONE call because they share their
+        // ordering constraint — `perry_transform::post_inline_cleanups`:
+        // static-trip-count for-loop unroll, then redundant property-read
+        // elimination over diverging guard chains. Both want the INLINED
+        // (and unrolled) bodies, and both must run BEFORE the async/generator
+        // transforms: those rewrite control flow into state-machine shapes the
+        // unroll match no longer recognizes, and box every body local into a
+        // shared mutable cell, which would turn a hoisted `const` into one
+        // more boxed cell. See crates/perry-transform/src/{unroll,prop_cse}.
         progress.record(ProgressSnapshot {
             stage: "transform-unroll-static-loops",
             module_path: Some(&canonical),
@@ -1944,7 +1944,7 @@ fn collect_module_finish(
             collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
             ..Default::default()
         });
-        perry_transform::unroll_static_loops(&mut hir_module);
+        perry_transform::post_inline_cleanups(&mut hir_module);
         // Inline `finally` bodies before each abrupt completion
         // (`return` / `break` / `continue` / labeled-break / labeled-
         // continue) reachable inside a `try { ... } finally { Y }`

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -4344,7 +4344,7 @@ pub fn run_with_parse_cache(
             // The HIR fingerprint is computed inside this rayon job
             // (paralelizes the cost across modules and avoids an extra
             // serial O(modules) pass). Crucially, every HIR-mutating
-            // pass (inline_functions, unroll_static_loops,
+            // pass (inline_functions, unroll_static_loops, prop_cse,
             // inline_finally_into_returns, transform_async_to_generator,
             // transform_generators per-module; transform_js_imports,
             // fix_local_native_instances, fix_cross_module_native_instances,


### PR DESCRIPTION
## What

A new HIR pass, `perry_transform::prop_cse`, that removes redundant property
reads across **diverging guard chains** — the discriminated-union dispatch
idiom.

```ts
function evalNode(n: Node, env: Env): Value {
  if (n.kind === "num") return { kind: "num", num: n.num };
  if (n.kind === "str") return { kind: "str", str: n.str };
  if (n.kind === "var") return lookup(env, n.name);
  …
}
```

Each `n.kind` compiled to a full generic property-get diamond: receiver-tag
routing (`pget.recv_sso` / `pget.check_class_ref` / `pget.recv_ok`), the
monomorphic-IC guard ladder — **five loads out of the object header, two
global loads and ~20 ALU ops** — `pic.hit` / `pic.miss` / `pic.merge` and a
four-way `phi`. About fifty instructions and six branches, per site.

## Why LLVM does not already do this

Not a missing attribute. GVN dedupes *instructions*, not congruent
control-flow regions, and every arm of the diamond that is not the inline fast
load ends in an opaque call (`js_object_get_field_ic_miss`,
`js_object_get_field_by_name_f64`) whose memory effects license nothing. The
redundancy has to be removed before it becomes a diamond.

## The rule

Inside a run of consecutive `if (COND) { … }` statements with no `else` whose
bodies **always diverge** (`return`/`throw`/`break`/`continue`), the
fall-through path from one guard to the next runs no user code at all — only
the guard expressions. A `local.prop` read appearing in two or more guards of
such a run is redundant. Divergence is exactly what makes the run analyzable:
a body that falls through could call anything.

**The hoist does not go to the top of the run.** It goes immediately before
the guard where the key is *that guard's first unconditionally-evaluated
read* — first, so it cannot be reordered past a sibling read that could throw
first; unconditional, so it is not under the RHS of a short-circuiting
operator the original may skip. Without that,
`if (a.x === 1) return; if (b.y === 2) return;` would start dereferencing `b`
on the path where the first guard returns. Both halves have a test.

## What gates it

Guards are a closed allowlist: literals, `LocalGet`, `local.prop`, **strict**
`===`/`!==`, `&&`/`||`/`??`, `!`, `typeof`. Loose and relational compares are
excluded because they coerce and coercion calls `valueOf`/`toString`;
`Binary` is excluded wholesale; calls, `new`, assignments, `await` and index
reads are excluded outright.

That leaves exactly one way for user code to run between two reads of
`n.kind`: **`kind` could be an accessor.** So the pass carries a whole-module
veto — a class getter/setter, an object-literal accessor
(`js_object_define_accessor`), a `defineProperty`-family call, or a `Proxy`
construction anywhere in the module turns it off entirely. This mirrors
`perry-codegen`'s `Ptr<Shape>` promotion, vetoed module-wide by the same
family of constructs before it emits an **unguarded** field load — a strictly
stronger assumption than this one. Two residual holes are named in the module
docs: `Object.create(proto, descriptors)`, and an object built by a
getter-defining module and passed in.

`PERRY_PROP_CSE=0` disables the pass. The object cache cannot serve a stale
hit across the knob: the cache key is the **post-transform HIR hash**, which
the rewrite changes.

## Measurement

Quiet M1 mini, best-of-5, interleaved arm-by-arm, exit code recorded per cell.
`pass off` is the **same binary** with `PERRY_PROP_CSE=0`, so nothing but the
pass differs between the two columns.

| bench | main @`1ee158d27` | pass off | **pass on** | |
|---|--:|--:|--:|--:|
| `interp` | 1.4962 | 1.4964 | **1.2424** | −17.0% |
| `iso_miss` | 1.9238 | 1.9244 | **1.6819** | −12.6% |

The independently-built `main` reference and the knob-off arm agree to 0.2 ms
on both, and `med` sits within 0.6 ms of `best` in every cell — the run was
not perturbed.

### No regression, proved by byte-comparison rather than by timing

Compiling the 25-program corpus twice from the same binary, once per knob
setting, leaves **23 of 25 executables byte-identical**: `churn`,
`churn_alloc`, `churn_read`, `push_num`, `push_cls`, `cycles`, `deeplist`,
`tree`, `tree_wide`, `retain`, `retain1`, `retain_wide`, `retain_wide1`,
`fib40`, `asyncpipe`, `shapes`, `pipeline`, and the six bootstrap variants.
The pass is a provable no-op for all of them, so their timing cannot move and
no quiet host is needed to establish it. The two that differ are the two that
improved.

A full interleaved corpus run confirms it from the other side. That run was
**not** taken under the shared-host lock, so its absolute seconds sit ~3% high
across every arm and are not quoted — but with interleaved arms and 23
byte-identical programs, their `on/off` ratio *is* the run's noise floor:

| byte-identical programs | on/off ratio |
|---|--:|
| all 20 measured (`churn`, `tree`, `retain*`, `fib40`, `pipeline`, `shapes`, …) | **0.94 – 1.01** |
| `interp` | **0.831** |
| `interp_fo` | **0.830** |
| `iso_miss` | **0.875** |

reproducing the locked run's ratios (0.830 / 0.874) to +/-0.001. `interp_fo`
(`interp.ts` plus a `for (const _x of [1]) {}` prologue, which forces the
`globalThis` builtin bootstrap) gains exactly as much as `interp` and costs
0.14% over it.

### Static effect

In `iso_FIB.ts` the module's generic property-get sites fall **238 -> 208**,
and `evalNode`'s emitted IR from **19102 to 17022 lines**.

## Validation

* **Outputs**: all 25 corpus programs byte-identical to
  `node --experimental-strip-types` with exit 0, in **both** knob arms.
* **Canary**: `iso_miss` prints `checksum 437840 misses 0`. Also clean under
  `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`,
  `PERRY_GC_VERIFY_EVACUATION=1`, and
  `PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_FORCE_EVACUATE=1` together — and the
  instrument was **shown to have run**, not merely to have not complained:
  `PERRY_GC_DIAG=1` reports 50 `[gc-fromspace-protect]` retired sets and
  `[gc-copy-minor] ... copied_objects=6124`.
* `cargo test -p perry-transform`: 15 new tests, all pass.
* `cargo test -p perry-codegen --no-fail-fast` (26 targets): one failure,
  `large_object_barriers::large_local_array_push_inbounds_store_emits_precise_slot_barrier`,
  which **fails identically with `PERRY_PROP_CSE=0`** — pre-existing on the
  base commit.
* `cargo test -p perry-hir --no-fail-fast`: clean.
* `cargo fmt --all -- --check`, `scripts/check_file_size.sh`: clean (the call
  site is in a file that sits exactly at the 2000-line cap, which is why the
  two passes are invoked through one `post_inline_cleanups` entry point).
* **Gap suite**: could not be completed on a quiet host — the dev machine ran
  at load 40-60 with four other agents building throughout. A partial run
  (340/535) flagged 22 tests; **every one of the 22 was then compiled and run
  directly in both knob arms and behaves identically** (the only textual
  differences are thread IDs in panic messages from HTTP tests that abort in
  both arms). So none of them is caused by this change. A full run is in
  flight but is not what this PR rests on.


## Where the rest of the gap is

This pass removed the *redundant* property reads. Every surviving read still
pays the full ~50-instruction diamond, and `evalNode` is still **27.2%** of a
quiet-mini profile of the post-CSE binary. The next lever is shape narrowing,
and the information it needs is already present:

`perry --trace hir --focus evalNode` shows the parameter carries the
**complete** discriminated union — eight `Object` members, each with a
`StringLiteral` discriminant and a `property_order`. Each object literal
already lowers to `New { class_name: "__AnonShape_<hash>" }`, i.e. a named
class with a `class_id` and a direct-GEP layout. And codegen already maps
`HirType::Named(n)` through `receiver_class_name`
(`type_analysis/predicates.rs:297`) to `class_field_global_index` and a
guarded inline field load. So inside `if (n.kind === "bin")`, binding a fresh
local typed as that one member's anon-shape class and substituting it through
the branch turns `n.op` / `n.left` / `n.right` into direct slot loads.

Full profile, the two open questions that have to be settled first (where the
anon-shape class name is reachable from, and what happens when the synthesized
claim is wrong), and the round's refutations are written up in
**`gc-handoff/PROFILE-interp-round3.md`**.

Profile caveat recorded there and repeated here because it is easy to misread:
it was taken on a `--debug-symbols` build, so `js_set_call_location` (3.9%) is
an artifact of that build and every other share is diluted ~4%.
