### PR TITLE
fix(runtime): convert #7811/#7815's new bare raw-handle reads to across_* (#7838)

### DIFF
--- a/changelog.d/7840-raw-handle-debt-across.md
+++ b/changelog.d/7840-raw-handle-debt-across.md
@@ -1,0 +1,47 @@
+### Fixed
+
+- **The raw-handle debt ratchet is green again on `main` (#7838).** It went red at
+  1,013 bare `get_raw_{mut,const}_ptr` reads against a baseline of 998, with four
+  per-module violations. The +15 all arrived with the two #6949 rooting fixes in the
+  2026-08-11 batch (#7811, #7815); #7825 — same batch — closed the hole that had been
+  letting a PR's own checkout carry the comparison baseline, so the ratchet only
+  started seeing them once it landed. While a required gate is red on `main`, no agent
+  can tell its own breakage from inherited breakage, which is the condition a real
+  regression merges unnoticed in.
+
+  **All fifteen convert to `RuntimeHandle::across_{mut,const}`. No ceiling was raised
+  and `raw_handle_debt_baseline.txt` is untouched** — the total lands back on 998
+  exactly, and `regex/replace_fn.rs` returns to its recorded ceiling of 3.
+  `disposable.rs`, `messaging.rs` and `builtins/formatting/boxed_primitives.rs` reach
+  zero and stay unlisted.
+
+  **`replace_fn.rs` did not need the 3 → 13 raise #7838 proposed.** The proposal rested
+  on all thirteen being the one shape `raw_handle_debt_files.txt` sanctions joining the
+  list for — a loop whose collection window is a user-visible callback, where a
+  `cur_str` helper re-derives at every access and `across_*` (one call ↔ one re-read)
+  cannot express it. That describes **three** of them, and those three are
+  *pre-existing*: `git show 6af7e5840^:…/replace_fn.rs | grep -c get_raw_` is 3, which
+  is what the ceiling of 3 was recorded for. #7811 added **ten**, all of them plain
+  root → one allocating `js_string_coerce` → read-for-the-call. Four are two-receiver
+  sites; two receivers compose by **nesting** `across_const`, the same way
+  `path::value_args::with_two_headers` already does it, and two small private
+  combinators carry them.
+
+- **`SuppressedError` filed its property attributes under a possibly-stale address.**
+  `set_nonenum` called `object::set_property_attrs(obj as usize, …)` *after*
+  `js_object_set_field_by_name`, which allocates when the object grows. That side table
+  is keyed on the address, so a pre-call copy does not fault — it files the attributes
+  where nothing will look them up, and `error` / `suppressed` / `message` silently
+  become **enumerable** on a `SuppressedError` that grew during the set.
+
+- **`js_suppressed_error_new` returned a NaN-box built before its last allocating
+  call.** `js_nanbox_pointer(obj)` was computed, then the `SuppressedError.prototype`
+  lookup ran, then the box was returned. A NaN-box is a frozen address the collector
+  cannot rewrite, so the returned value named from-space if that lookup collected. The
+  box is now built last.
+
+  Both are the #7192 shape — the store is in-frame but *after* a call that allocates —
+  and neither is reachable without evacuation actually moving the receiver, so this is
+  ordering hygiene rather than an observed crash. They are recorded because writing the
+  `across_*` ordering out is what made them visible, which is the argument for the
+  discipline the ratchet enforces.

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -308,17 +308,20 @@ pub extern "C" fn js_boxed_string_new(value: f64, has_arg: i32) -> f64 {
     // dereferences or keys on it.
     let scope = crate::gc::RuntimeHandleScope::new();
     let obj_handle = scope.root_raw_mut_ptr(obj);
-    // `new String()` (no args) is spec'd to box "", not "undefined".
-    let ptr = if has_arg == 0 {
-        crate::string::js_string_from_bytes(std::ptr::null(), 0)
-    } else {
-        // ECMA-262 §22.1.1 step 2b: ToString(value) — throws TypeError for Symbol.
-        if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
-            crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
+    let (ptr, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        // `new String()` (no args) is spec'd to box "", not "undefined".
+        if has_arg == 0 {
+            crate::string::js_string_from_bytes(std::ptr::null(), 0)
+        } else {
+            // ECMA-262 §22.1.1 step 2b: ToString(value) — throws TypeError for Symbol.
+            if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+                crate::collection_iter::throw_type_error(
+                    "Cannot convert a Symbol value to a string",
+                );
+            }
+            js_string_coerce(value)
         }
-        js_string_coerce(value)
-    };
-    let obj = obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
+    });
     let boxed = f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits());
     register_boxed_primitive_payload(obj, boxed);
     install_string_wrapper_indices(obj, ptr);

--- a/crates/perry-runtime/src/disposable.rs
+++ b/crates/perry-runtime/src/disposable.rs
@@ -474,13 +474,23 @@ pub extern "C" fn js_suppressed_error_new(error: f64, suppressed: f64, message: 
     // prototype under an address nothing will look up, and `instanceof
     // SuppressedError` quietly stops resolving.
     //
-    // So root once and re-read at every use, which is what the handle gives.
+    // So root once and re-read at every use, which is what the handle gives —
+    // through `across_mut`, so the pre-call address is never *nameable* (#7341).
+    // Note the second `across_mut` below is not cosmetic: `set_property_attrs`
+    // keys the attribute side table on `obj as usize`, and it runs AFTER
+    // `js_object_set_field_by_name`, which allocates when the object grows. A
+    // pre-call address there does not fault — it files the attributes under an
+    // address nothing will look up, and the property silently becomes
+    // enumerable.
     let scope = crate::gc::RuntimeHandleScope::new();
     let obj_handle = scope.root_raw_mut_ptr(obj);
     let set_nonenum = |key: &str, value: f64| {
-        let key_ptr = js_string_from_bytes(key.as_ptr(), key.len() as u32);
-        let obj = obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        js_object_set_field_by_name(obj, key_ptr, value);
+        let (key_ptr, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+            js_string_from_bytes(key.as_ptr(), key.len() as u32)
+        });
+        let ((), obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+            js_object_set_field_by_name(obj, key_ptr, value)
+        });
         crate::object::set_property_attrs(
             obj as usize,
             key.to_string(),
@@ -501,16 +511,26 @@ pub extern "C" fn js_suppressed_error_new(error: f64, suppressed: f64, message: 
         };
         set_nonenum("message", message_val);
     }
-    let obj = obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-    let result = js_nanbox_pointer(obj as i64);
     // Link the instance to `SuppressedError.prototype` so `name`/`message`
     // defaults and `instanceof SuppressedError` resolve through the chain.
-    let proto = crate::object::builtin_prototype_value("SuppressedError");
-    if proto.to_bits() != TAG_UNDEFINED && js_nanbox_get_pointer(proto) != 0 {
-        let obj = obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        crate::object::prototype_chain::object_set_static_prototype(obj as usize, proto.to_bits());
-    }
-    result
+    //
+    // The NaN-box of the result is built LAST, after every allocating call. The
+    // pre-#7341 shape built it before the prototype lookup and returned that
+    // copy, which is a stale address by the same argument as everything above —
+    // `js_nanbox_pointer` freezes an address into a return value the collector
+    // cannot rewrite.
+    let (proto, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        crate::object::builtin_prototype_value("SuppressedError")
+    });
+    let ((), obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        if proto.to_bits() != TAG_UNDEFINED && js_nanbox_get_pointer(proto) != 0 {
+            crate::object::prototype_chain::object_set_static_prototype(
+                obj as usize,
+                proto.to_bits(),
+            );
+        }
+    });
+    js_nanbox_pointer(obj as i64)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/messaging.rs
+++ b/crates/perry-runtime/src/messaging.rs
@@ -613,8 +613,8 @@ pub extern "C" fn js_broadcast_channel_new(name: f64) -> f64 {
     // through it. Root it across the coercion and re-read.
     let scope = crate::gc::RuntimeHandleScope::new();
     let obj_handle = scope.root_raw_mut_ptr(obj);
-    let name_ptr = crate::builtins::js_string_coerce(name);
-    let obj = obj_handle.get_raw_mut_ptr::<object::ObjectHeader>();
+    let (name_ptr, obj) = obj_handle
+        .across_mut::<object::ObjectHeader, _>(|| crate::builtins::js_string_coerce(name));
     let name_value = f64::from_bits(JSValue::string_ptr(name_ptr).bits());
     set_field(obj, "name", name_value);
     install_method(obj, "close", noop0 as *const u8, 0);

--- a/crates/perry-runtime/src/regex/replace_fn.rs
+++ b/crates/perry-runtime/src/regex/replace_fn.rs
@@ -353,6 +353,44 @@ fn replacement_is_callable(value: f64) -> bool {
     crate::closure::is_closure_ptr((bits & crate::value::POINTER_MASK) as usize)
 }
 
+/// Root TWO raw receivers across one allocating coercion and hand the callee
+/// the POST-collection addresses.
+///
+/// `RuntimeHandle::across_const` pairs exactly one allocating call with one
+/// re-read, so two receivers compose by NESTING: the inner call runs `coerce`
+/// and re-reads `b`, the outer then re-reads `a`. Neither pre-call address is
+/// ever bound, which is the property `across_*` exists to provide (#7341) and
+/// the one `scripts/raw_handle_debt.py` counts. `path::value_args`'
+/// `with_two_headers` uses the same nesting for the same reason.
+///
+/// Both receivers are rooted BEFORE `coerce` runs, so a collection inside it
+/// marks and rewrites both slots; `f` then sees two addresses that are current
+/// as of the same collection.
+fn with_two_receivers_across<A, B, C, R>(
+    a: *const A,
+    b: *const B,
+    coerce: impl FnOnce() -> C,
+    f: impl FnOnce(*const A, *const B, C) -> R,
+) -> R {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let a_handle = scope.root_raw_const_ptr(a);
+    let b_handle = scope.root_raw_const_ptr(b);
+    let ((coerced, b), a) = a_handle.across_const::<A, _>(|| b_handle.across_const::<B, _>(coerce));
+    f(a, b, coerced)
+}
+
+/// One-receiver twin of [`with_two_receivers_across`].
+fn with_receiver_across<A, C, R>(
+    a: *const A,
+    coerce: impl FnOnce() -> C,
+    f: impl FnOnce(*const A, C) -> R,
+) -> R {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let a_handle = scope.root_raw_const_ptr(a);
+    let (coerced, a) = a_handle.across_const::<A, _>(coerce);
+    f(a, coerced)
+}
+
 #[no_mangle]
 pub extern "C" fn js_string_replace_string_dyn(
     s: *const StringHeader,
@@ -370,14 +408,11 @@ pub extern "C" fn js_string_replace_string_dyn(
     if replacement_is_callable(replacement) {
         return js_string_replace_string_fn(s, pattern, replacement);
     }
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let pattern_handle = scope.root_raw_const_ptr(pattern);
-    let coerced = crate::builtins::js_string_coerce(replacement);
-    js_string_replace_string(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        pattern_handle.get_raw_const_ptr::<StringHeader>(),
-        coerced,
+    with_two_receivers_across(
+        s,
+        pattern,
+        || crate::builtins::js_string_coerce(replacement),
+        |s, pattern, coerced| js_string_replace_string(s, pattern, coerced),
     )
 }
 
@@ -390,14 +425,11 @@ pub extern "C" fn js_string_replace_all_string_dyn(
     if replacement_is_callable(replacement) {
         return js_string_replace_all_string_fn(s, pattern, replacement);
     }
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let pattern_handle = scope.root_raw_const_ptr(pattern);
-    let coerced = crate::builtins::js_string_coerce(replacement);
-    js_string_replace_all_string(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        pattern_handle.get_raw_const_ptr::<StringHeader>(),
-        coerced,
+    with_two_receivers_across(
+        s,
+        pattern,
+        || crate::builtins::js_string_coerce(replacement),
+        |s, pattern, coerced| js_string_replace_all_string(s, pattern, coerced),
     )
 }
 
@@ -440,13 +472,10 @@ pub extern "C" fn js_string_replace_search_dyn(
     if let Some(re) = needle_regex_ptr(needle) {
         return js_string_replace_regex_dyn(s, re, replacement);
     }
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let needle = crate::builtins::js_string_coerce(needle);
-    js_string_replace_string_dyn(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        needle,
-        replacement,
+    with_receiver_across(
+        s,
+        || crate::builtins::js_string_coerce(needle),
+        |s, needle| js_string_replace_string_dyn(s, needle, replacement),
     )
 }
 
@@ -461,13 +490,10 @@ pub extern "C" fn js_string_replace_all_search_dyn(
     if let Some(re) = needle_regex_ptr(needle) {
         return js_string_replace_all_regex_dyn(s, re, replacement);
     }
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let needle = crate::builtins::js_string_coerce(needle);
-    js_string_replace_all_string_dyn(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        needle,
-        replacement,
+    with_receiver_across(
+        s,
+        || crate::builtins::js_string_coerce(needle),
+        |s, needle| js_string_replace_all_string_dyn(s, needle, replacement),
     )
 }
 
@@ -485,14 +511,11 @@ pub extern "C" fn js_string_replace_regex_dyn(
     // #6949(a): both raw params span the coercion — and `re` is a
     // `RegExpHeader`, not a string, so a stale one is read for its compiled
     // pattern rather than merely for bytes.
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let re_handle = scope.root_raw_const_ptr(re);
-    let coerced = crate::builtins::js_string_coerce(replacement);
-    crate::regex::js_string_replace_regex_named(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        re_handle.get_raw_const_ptr::<crate::regex::RegExpHeader>(),
-        coerced,
+    with_two_receivers_across(
+        s,
+        re,
+        || crate::builtins::js_string_coerce(replacement),
+        |s, re, coerced| crate::regex::js_string_replace_regex_named(s, re, coerced),
     )
 }
 
@@ -509,14 +532,11 @@ pub extern "C" fn js_string_replace_all_regex_dyn(
     // #6949(a): both raw params span the coercion — and `re` is a
     // `RegExpHeader`, not a string, so a stale one is read for its compiled
     // pattern rather than merely for bytes.
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let s_handle = scope.root_raw_const_ptr(s);
-    let re_handle = scope.root_raw_const_ptr(re);
-    let coerced = crate::builtins::js_string_coerce(replacement);
-    crate::regex::js_string_replace_all_regex_named(
-        s_handle.get_raw_const_ptr::<StringHeader>(),
-        re_handle.get_raw_const_ptr::<crate::regex::RegExpHeader>(),
-        coerced,
+    with_two_receivers_across(
+        s,
+        re,
+        || crate::builtins::js_string_coerce(replacement),
+        |s, re, coerced| crate::regex::js_string_replace_all_regex_named(s, re, coerced),
     )
 }
 


### PR DESCRIPTION
Closes #7838.

The raw-handle debt ratchet is red on `main`: **1,013 bare reads against a baseline of 998**, four per-module violations. The +15 arrived with the two #6949 rooting fixes in the 2026-08-11 batch (#7811, #7815), and #7825 — same batch — closed the hole that had been letting a PR's own checkout carry the comparison baseline, so the ratchet only started seeing them once it landed.

**All fifteen convert to `RuntimeHandle::across_{mut,const}`. No ceiling was raised and `raw_handle_debt_baseline.txt` is untouched** — the total lands back on 998 exactly, and `regex/replace_fn.rs` returns to its recorded ceiling of 3.

| module | before | after | disposition |
|---|--:|--:|---|
| `disposable.rs` | 3 | **0** | converted; module stays unlisted |
| `builtins/formatting/boxed_primitives.rs` | 1 | **0** | converted; module stays unlisted |
| `messaging.rs` | 1 | **0** | converted; module stays unlisted |
| `regex/replace_fn.rs` | 13 | **3** | 10 converted; back at its existing ceiling |

## Why `replace_fn.rs` did not need a ceiling raise

#7838 proposed raising it 3 → 13 on the grounds that the thirteen are the one shape `raw_handle_debt_files.txt` sanctions joining the list for — a loop whose collection window is a user-visible callback, where `cur_str = || string_as_str(handle.get_raw_const_ptr(..))` re-derives at every access and `across_*` (one call ↔ one re-read) cannot express it.

That is true of **three** of them, not thirteen — and those three are *pre-existing*, which is exactly what the ceiling of 3 was recorded for. `git show 6af7e5840^:crates/perry-runtime/src/regex/replace_fn.rs | grep -c get_raw_` is **3**; at `6af7e5840` it is **13**. So #7811 added **10**, and all ten are the plain `across_*` shape: root → one allocating `js_string_coerce` → read-for-the-call. They convert mechanically.

Four of the ten are two-receiver call sites (`s` + `pattern`, `s` + `re`). Two receivers compose by **nesting** `across_const` — the inner call runs the coercion and re-reads `b`, the outer then re-reads `a` — which is how `path::value_args::with_two_headers` already does it. Two small private combinators (`with_two_receivers_across`, `with_receiver_across`) carry them so the nesting is written once.

## Two conversions are not purely mechanical

Writing the ordering out made a latent stale-address use visible in `disposable.rs` (`js_suppressed_error_new`). Both are the #7192 shape — the store is in-frame but *after* a call that allocates — and neither is reachable without evacuation actually moving the receiver, so this is ordering hygiene rather than an observed crash:

- **`set_nonenum` filed attributes under a possibly-stale address.** It called `crate::object::set_property_attrs(obj as usize, ..)` *after* `js_object_set_field_by_name`, which allocates when the object grows. That side table is keyed on the address, so a pre-call copy does not fault — it files the attributes where nothing will look them up, and `error` / `suppressed` / `message` silently become **enumerable** on a `SuppressedError` that grew during the set. Now re-read across the field-set.
- **The returned NaN-box was built before the prototype lookup.** `js_nanbox_pointer(obj)` was computed, then `builtin_prototype_value("SuppressedError")` ran, then the box was returned. A NaN-box is a frozen address the collector cannot rewrite, so the returned value named from-space if that lookup collected. The box is now built **last**, after every allocating call.

## Validation

```
$ python3 scripts/raw_handle_debt.py ; echo $?
bare raw-handle reads: 998 (baseline 998)
per-module: 110 module(s) within ceilings; every other runtime module is locked at zero
0
```

(the script's own exit code, not a pipeline's). `--no-raise-vs origin/main`, the mode CI runs, also exits 0: `baseline 998 -> 998, 110 -> 110 module ceiling(s), none raised`. Release build of `-p perry -p perry-runtime-static -p perry-stdlib-static` is clean; the `perry-runtime` test suite is still running and I will post the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stability when creating boxed strings, suppressed errors, and broadcast channels.
  * Fixed potential failures during regular-expression replacement when values require conversion or memory cleanup occurs.
  * Improved error handling and object safety during operations that may trigger memory management.
  * Preserved existing behavior for empty strings, symbol conversion errors, callable replacements, and regular-expression processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
