### PR TITLE
fix(runtime): bound deep recursive value consumers

### DIFF
--- a/changelog.d/7847-deep-recursive-consumers.md
+++ b/changelog.d/7847-deep-recursive-consumers.md
@@ -1,0 +1,4 @@
+**Deeply nested values now raise a catchable error during serialization and
+cloning instead of exhausting the native stack.** `JSON.stringify` and
+`structuredClone` cap recursive traversal at 1,000 nested containers and remain
+usable after the error is caught.

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -413,6 +413,11 @@ fn structured_clone_unmark(ptr: usize) {
     });
 }
 
+fn reset_structured_clone_state() {
+    STRUCTURED_CLONE_IN_PROGRESS.with(|set| set.borrow_mut().clear());
+    STRUCTURED_CLONE_TRANSFER_STATE.with(|state| *state.borrow_mut() = None);
+}
+
 /// RAII guard that unmarks a pointer from the in-progress set when dropped,
 /// even on early returns from `js_structured_clone`'s POINTER_TAG branches.
 struct CloneCycleGuard(usize);
@@ -440,6 +445,15 @@ fn throw_structured_clone_type_error(message: &str) -> ! {
 fn throw_data_clone_error(message: &str) -> ! {
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_error_new_with_name_message(b"DataCloneError", msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+const MAX_STRUCTURED_CLONE_NESTING_DEPTH: usize = 1_000;
+
+fn throw_structured_clone_depth_error() -> ! {
+    let message = "structuredClone: value nested deeper than 1000 levels";
+    let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
@@ -622,12 +636,16 @@ fn collect_transfer_list(options: f64) -> std::collections::HashSet<usize> {
 /// Handles numbers (pass-through), strings (copy), arrays/objects (shallow for now)
 #[no_mangle]
 pub extern "C" fn js_structured_clone(value: f64) -> f64 {
-    js_structured_clone_inner(value)
+    // Runtime throws use longjmp and therefore skip Rust destructors. Clear
+    // traversal state left by a previously caught error before a new clone.
+    reset_structured_clone_state();
+    js_structured_clone_inner(value, 0)
 }
 
 /// structuredClone(value, options) -> deep-cloned value with supported transfers.
 #[no_mangle]
 pub extern "C" fn js_structured_clone_with_options(value: f64, options: f64) -> f64 {
+    reset_structured_clone_state();
     let transferables = collect_transfer_list(options);
     let previous = STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
         state.borrow_mut().replace(StructuredCloneTransferState {
@@ -636,12 +654,12 @@ pub extern "C" fn js_structured_clone_with_options(value: f64, options: f64) -> 
         })
     });
     let _guard = CloneTransferStateGuard(previous);
-    let cloned = js_structured_clone_inner(value);
+    let cloned = js_structured_clone_inner(value, 0);
     detach_transferables_after_success();
     cloned
 }
 
-fn js_structured_clone_inner(value: f64) -> f64 {
+fn js_structured_clone_inner(value: f64, depth: usize) -> f64 {
     if crate::value::is_js_handle(value) && crate::value::js_handle_is_function(value) {
         throw_data_clone_error("Function could not be cloned");
     }
@@ -681,6 +699,9 @@ fn js_structured_clone_inner(value: f64) -> f64 {
             value
         }
         0x7FFD => {
+            if depth > MAX_STRUCTURED_CLONE_NESTING_DEPTH {
+                throw_structured_clone_depth_error();
+            }
             // POINTER_TAG — could be array/object/Map/Set/RegExp. Deep clone recursively.
             let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const u8;
             let addr = ptr as usize;
@@ -728,7 +749,7 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                 for i in 0..size {
                     let src_now = src_handle.get_raw_const_ptr::<crate::set::SetHeader>();
                     let elem = crate::set::js_set_value_at(src_now, i);
-                    let v = js_structured_clone(elem);
+                    let v = js_structured_clone_inner(elem, depth + 1);
                     let new_set_now = new_set_handle.get_raw_mut_ptr::<crate::set::SetHeader>();
                     crate::set::js_set_add(new_set_now, v);
                 }
@@ -753,7 +774,7 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                         as *mut f64;
                     for i in 0..len as usize {
                         let elem = *elements.add(i);
-                        let cloned = js_structured_clone(elem);
+                        let cloned = js_structured_clone_inner(elem, depth + 1);
                         // GC_STORE_AUDIT(BARRIERED): note_array_slot below re-stores this slot with the barrier.
                         *elements.add(i) = cloned;
                         crate::array::note_array_slot(new_arr, i, cloned.to_bits());
@@ -816,7 +837,8 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                                     None => continue,
                                 };
                             let field = crate::object::js_object_get_field(src_now, i as u32);
-                            let cloned = js_structured_clone(f64::from_bits(field.bits()));
+                            let cloned =
+                                js_structured_clone_inner(f64::from_bits(field.bits()), depth + 1);
                             let key_ptr = crate::string::js_string_from_bytes(
                                 key_bytes.as_ptr(),
                                 key_bytes.len() as u32,
@@ -840,7 +862,7 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                             as *mut f64;
                         for i in 0..field_count as usize {
                             let field = *fields.add(i);
-                            let cloned = js_structured_clone(field);
+                            let cloned = js_structured_clone_inner(field, depth + 1);
                             // GC_STORE_AUDIT(BARRIERED): cloned field uses the shared object slot-store helper.
                             // The recursive clone above can run minor GCs that tenure `cloned_obj`
                             // mid-loop, so this store must be barriered like the array branch.
@@ -886,13 +908,15 @@ fn js_structured_clone_inner(value: f64) -> f64 {
                         let pair_now = pair_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
                         let key_handle = entry_scope
                             .root_nanbox_f64(crate::array::js_array_get_f64(pair_now, 0));
-                        let cloned_key = js_structured_clone(key_handle.get_nanbox_f64());
+                        let cloned_key =
+                            js_structured_clone_inner(key_handle.get_nanbox_f64(), depth + 1);
                         key_handle.set_nanbox_f64(cloned_key);
 
                         let pair_now = pair_handle.get_raw_const_ptr::<crate::array::ArrayHeader>();
                         let value_handle = entry_scope
                             .root_nanbox_f64(crate::array::js_array_get_f64(pair_now, 1));
-                        let cloned_value = js_structured_clone(value_handle.get_nanbox_f64());
+                        let cloned_value =
+                            js_structured_clone_inner(value_handle.get_nanbox_f64(), depth + 1);
                         value_handle.set_nanbox_f64(cloned_value);
 
                         let new_map = new_map_handle.get_raw_mut_ptr::<crate::map::MapHeader>();

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -72,8 +72,9 @@ pub(crate) use raw_json::{ptr_is_raw_json_wrapper, raw_json_text_bytes};
 pub(crate) use reviver::test_apply_reviver_for_value;
 pub(crate) use simd::find_string_terminator;
 pub(crate) use stringify::{
-    arm_to_json_result_guard, estimate_json_size, is_closure_value, is_object_pointer,
-    is_symbol_value, object_get_to_json, stringify_value, write_escaped_string, write_number,
+    arm_to_json_result_guard, check_stringify_nesting_depth, estimate_json_size, is_closure_value,
+    is_object_pointer, is_symbol_value, object_get_to_json, stringify_value, write_escaped_string,
+    write_number,
 };
 pub(crate) use stringify_api::{redirect_lazy_to_materialized, try_stringify_lazy_array};
 pub(crate) use stringify_buffer::{

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -358,6 +358,7 @@ pub(crate) unsafe fn stringify_object_with_replacer_pretty(
     indent: &str,
     depth: usize,
 ) {
+    check_stringify_nesting_depth(depth);
     // Circular-reference detection (mirrors the pretty/array-replacer paths).
     if STRINGIFY_STACK.with(|s| s.borrow().contains(&(ptr as usize))) {
         let msg = "Converting circular structure to JSON";
@@ -519,6 +520,7 @@ pub(crate) unsafe fn stringify_array_with_replacer_pretty(
     indent: &str,
     depth: usize,
 ) {
+    check_stringify_nesting_depth(depth);
     // #7269: follow GC_FLAG_FORWARDED array-growth stubs (`js_array_grow`,
     // issue #233) before any header read — mirrors the resolution in
     // `dispatch_pointer_with_replacer`'s array arm and
@@ -923,6 +925,7 @@ pub(crate) unsafe fn stringify_object_pretty(
     indent: &str,
     depth: usize,
 ) {
+    check_stringify_nesting_depth(depth);
     // Same deref-safety gate the plain path applies in `is_object_pointer`: the
     // `field_count` / `keys_array` reads below load straight through `ptr`, so an
     // in-range-but-unmapped garbage address (a denormal double that survived the
@@ -1056,6 +1059,7 @@ pub(crate) unsafe fn stringify_array_pretty(
     indent: &str,
     depth: usize,
 ) {
+    check_stringify_nesting_depth(depth);
     // #7269: resolve GC_FLAG_FORWARDED array-growth stubs before any header
     // read. `ptr_is_tracked_heap_object` below only confirms the address is a
     // live tracked allocation — a forwarded stub still passes that check
@@ -1129,6 +1133,7 @@ pub(crate) unsafe fn stringify_object_with_array_replacer(
     depth: usize,
     use_pretty: bool,
 ) {
+    check_stringify_nesting_depth(depth);
     // Circular reference check
     if STRINGIFY_STACK.with(|s| s.borrow().contains(&(ptr as usize))) {
         let msg = "Converting circular structure to JSON";
@@ -1315,6 +1320,7 @@ pub(crate) unsafe fn stringify_array_with_array_replacer(
     depth: usize,
     use_pretty: bool,
 ) {
+    check_stringify_nesting_depth(depth);
     // #5989: follow GC_FLAG_FORWARDED array-growth stubs (`js_array_grow`, issue
     // #233) so a stale pre-grow pointer serializes the current grown array —
     // mirrors the resolution in `dispatch_pointer_with_replacer`'s array arm.

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -21,6 +21,18 @@ use super::stringify_shape_template::{
 
 // ─── JSON.stringify ───────────────────────────────────────────────────────────
 
+pub(crate) const MAX_STRINGIFY_NESTING_DEPTH: usize = 1_000;
+
+#[inline]
+pub(crate) fn check_stringify_nesting_depth(depth: usize) {
+    if depth > MAX_STRINGIFY_NESTING_DEPTH {
+        let message = "JSON.stringify: value nested deeper than 1000 levels";
+        let message_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+        let error = crate::error::js_rangeerror_new(message_ptr);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(error as i64));
+    }
+}
+
 #[inline]
 /// True only when `ptr` is an address the GC actually tracks — an arena
 /// allocation (nursery/old/longlived per the page-map) or a registered malloc
@@ -896,6 +908,7 @@ unsafe fn member_to_json(value: f64) -> Option<f64> {
 }
 
 pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, depth: u32) {
+    check_stringify_nesting_depth(depth as usize);
     // #6519: a WHATWG `URL` instance is a plain `GC_TYPE_OBJECT` (class_id 0)
     // whose `searchParams` field points back at the URL — walking its fields
     // trips the circular-structure detector. Node serializes a URL via
@@ -1346,6 +1359,7 @@ pub(crate) unsafe fn stringify_array(ptr: *const u8, buf: &mut String) {
 
 /// Depth-aware variant of stringify_array for recursive calls.
 pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, depth: u32) {
+    check_stringify_nesting_depth(depth as usize);
     // Issue #2021: an array that has grown past its initial inline capacity
     // (16) was reallocated to a new block, leaving a GC_FLAG_FORWARDED stub
     // at the old address. Callers (and element decoders) hand us whatever
@@ -1370,7 +1384,7 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
     // needs that still-open entry to trip the check.
     if let Some(to_json_val) = array_get_to_json(arr) {
         arm_to_json_result_guard(to_json_val);
-        stringify_value(to_json_val, TYPE_UNKNOWN, buf);
+        stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth + 1);
         SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
         return;
     }
@@ -1459,9 +1473,9 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             // have run user code / allocated (and moved this array).
             let elem = elem_at(i as usize);
             let elem_bits = elem.to_bits();
-            if !try_emit_shape_element(elem_bits, tmpl, buf, depth) {
-                // Match the slow path: array descent does not bump depth.
-                stringify_value_depth(elem, TYPE_UNKNOWN, buf, depth);
+            if !try_emit_shape_element(elem_bits, tmpl, buf, depth + 1) {
+                // The element is one container below its enclosing array.
+                stringify_value_depth(elem, TYPE_UNKNOWN, buf, depth + 1);
             }
         }
         buf.push(']');
@@ -1544,11 +1558,11 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
                 // `stringify_value` (test262 JSON/stringify/value-tojson-result).
                 if let Some(to_json_val) = object_get_to_json(elem_ptr) {
                     arm_to_json_result_guard(to_json_val);
-                    stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth);
+                    stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth + 1);
                     SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
                     continue;
                 }
-                stringify_value_depth(prim, TYPE_UNKNOWN, buf, depth);
+                stringify_value_depth(prim, TYPE_UNKNOWN, buf, depth + 1);
                 continue;
             }
             // #2089: a Date element → its toJSON() ISO string (or null),
@@ -1579,8 +1593,8 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
                 continue;
             }
             match gc_obj_type(elem_ptr) {
-                crate::gc::GC_TYPE_OBJECT => stringify_object_inner(elem_ptr, buf, depth),
-                crate::gc::GC_TYPE_ARRAY => stringify_array_depth(elem_ptr, buf, depth),
+                crate::gc::GC_TYPE_OBJECT => stringify_object_inner(elem_ptr, buf, depth + 1),
+                crate::gc::GC_TYPE_ARRAY => stringify_array_depth(elem_ptr, buf, depth + 1),
                 crate::gc::GC_TYPE_STRING => {
                     let str_ptr = elem_ptr as *const StringHeader;
                     if let Some(s) = str_from_header(str_ptr) {
@@ -1603,13 +1617,13 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
                 }
                 _ => {
                     if is_object_pointer(elem_ptr) {
-                        stringify_object_inner(elem_ptr, buf, depth);
+                        stringify_object_inner(elem_ptr, buf, depth + 1);
                     } else {
                         let arr_elem = elem_ptr as *const crate::ArrayHeader;
                         let arr_len = (*arr_elem).length;
                         let arr_cap = (*arr_elem).capacity;
                         if arr_len <= arr_cap && arr_cap > 0 && arr_cap < 10000 {
-                            stringify_array_depth(elem_ptr, buf, depth);
+                            stringify_array_depth(elem_ptr, buf, depth + 1);
                         } else {
                             let str_ptr = elem_ptr as *const StringHeader;
                             if let Some(s) = str_from_header(str_ptr) {

--- a/crates/perry/tests/issue_7845_deep_recursive_consumers.rs
+++ b/crates/perry/tests/issue_7845_deep_recursive_consumers.rs
@@ -1,0 +1,78 @@
+//! Regression test for #7845: deeply nested values must raise a catchable
+//! exception instead of exhausting the native stack in JSON.stringify or
+//! structuredClone.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run_ts(src: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write");
+    let out = dir.path().join("bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&out).output().expect("run");
+    assert!(
+        run.status.success(),
+        "binary exited with {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn deep_stringify_and_clone_errors_are_catchable() {
+    let stdout = run_ts(
+        r#"
+let value: any = 0
+for (let i = 0; i < 1002; i++) value = [value]
+
+try {
+  JSON.stringify(value)
+  console.log("stringify: missed")
+} catch (error) {
+  console.log("stringify:", error instanceof RangeError)
+}
+console.log("stringify-after:", JSON.stringify([1, 2]))
+
+try {
+  structuredClone(value)
+  console.log("clone: missed")
+} catch (error) {
+  console.log("clone:", error instanceof RangeError)
+}
+const after: any = structuredClone({ ok: [3, 4] })
+console.log("clone-after:", after.ok.join(","))
+"#,
+    );
+
+    for expected in [
+        "stringify: true",
+        "stringify-after: [1,2]",
+        "clone: true",
+        "clone-after: 3,4",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing `{expected}` in:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7845

## Summary
- cap JSON.stringify recursion at 1,000 nested containers and throw a catchable RangeError
- apply the same bound to structuredClone and reset traversal state after caught errors
- cover the default, pretty, and replacer stringify walkers

## Validation
- reproduced exit 139 at 35,000 JSON.stringify levels and 50,000 structuredClone levels on main
- fixed binaries catch RangeError and continue at both reported depths
- cargo test -p perry --test issue_7845_deep_recursive_consumers
- cargo test -p perry-runtime (2,109 passed, 4 ignored)
- bash scripts/check_file_size.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deeply nested values now produce catchable `RangeError`s during `JSON.stringify` and `structuredClone`, instead of exhausting the native stack.
  - Nesting is safely limited to 1,000 levels.
  - Both operations remain usable after handling the error.

- **Tests**
  - Added coverage verifying safe behavior for deeply recursive values and continued operation afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->