### PR TITLE
fix(codegen): verify cached typed-array pointer lifetime

### DIFF
--- a/changelog.d/7849-buffer-view-pointer-lifetime.md
+++ b/changelog.d/7849-buffer-view-pointer-lifetime.md
@@ -2,10 +2,12 @@
 
 - Native-region verification now tracks cached buffer-view pointer lifetime
   independently of bounds and alias facts. Accessing a typed array's `.buffer`
-  directly or through a computed key invalidates every copied view alias,
-  runtime fallbacks retain that evidence, and checked or unchecked native
-  access through the invalidated pointer is rejected. Scalar accesses through
-  cached views must carry the same pointer-lifetime evidence (#7220).
+  directly or through a computed or named accessor invalidates every copied
+  view alias, runtime fallbacks retain that evidence, and checked or unchecked
+  native access through the invalidated pointer is rejected. Statically proven
+  canonical numeric string keys remain on the non-invalidating element path.
+  Scalar accesses through cached views must carry the same pointer-lifetime
+  evidence (#7220).
 
   Targeted verifier and native-proof regressions cover direct, computed,
   copied-alias, scalar, and bulk-memory access after pointer invalidation.

--- a/changelog.d/7849-buffer-view-pointer-lifetime.md
+++ b/changelog.d/7849-buffer-view-pointer-lifetime.md
@@ -5,4 +5,7 @@
   directly or through a computed key invalidates every copied view alias,
   runtime fallbacks retain that evidence, and checked or unchecked native
   access through the invalidated pointer is rejected. Scalar accesses through
-  cached views must carry the same pointer-lifetime evidence.
+  cached views must carry the same pointer-lifetime evidence (#7220).
+
+  Targeted verifier and native-proof regressions cover direct, computed,
+  copied-alias, scalar, and bulk-memory access after pointer invalidation.

--- a/changelog.d/7849-buffer-view-pointer-lifetime.md
+++ b/changelog.d/7849-buffer-view-pointer-lifetime.md
@@ -1,0 +1,7 @@
+## Fixed
+
+- Native-region verification now tracks cached buffer-view pointer lifetime
+  independently of bounds and alias facts. Accessing a typed array's `.buffer`
+  records that its inline-storage pointer was invalidated, runtime fallbacks
+  retain that evidence, and checked or unchecked native access through the
+  invalidated pointer is rejected.

--- a/changelog.d/7849-buffer-view-pointer-lifetime.md
+++ b/changelog.d/7849-buffer-view-pointer-lifetime.md
@@ -2,6 +2,7 @@
 
 - Native-region verification now tracks cached buffer-view pointer lifetime
   independently of bounds and alias facts. Accessing a typed array's `.buffer`
-  records that its inline-storage pointer was invalidated, runtime fallbacks
-  retain that evidence, and checked or unchecked native access through the
-  invalidated pointer is rejected.
+  directly or through a computed key invalidates every copied view alias,
+  runtime fallbacks retain that evidence, and checked or unchecked native
+  access through the invalidated pointer is rejected. Scalar accesses through
+  cached views must carry the same pointer-lifetime evidence.

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -9,7 +9,9 @@ use perry_hir::Function;
 
 use crate::expr::FnCtx;
 use crate::module::LlModule;
-use crate::native_value::{AliasState, BufferElem, BufferIndexUnit, BufferViewSlot, LengthSource};
+use crate::native_value::{
+    AliasState, BufferElem, BufferIndexUnit, BufferViewPointerState, BufferViewSlot, LengthSource,
+};
 use crate::stmt;
 use crate::strings::StringPool;
 use crate::types::{LlvmType, DOUBLE, I1, I32, I64, I8, PTR};
@@ -957,6 +959,7 @@ pub(super) fn compile_function(
                 alias: AliasState::Unknown,
                 length_source: Some(LengthSource::Unknown),
                 native_owned: None,
+                pointer_state: BufferViewPointerState::Stable,
                 // Declared-type hoist only — the construction form is unknown,
                 // so no inline-storage proof.
                 storage_inline_proven: false,
@@ -1026,6 +1029,7 @@ pub(super) fn compile_function(
                         None => LengthSource::Unknown,
                     }),
                     native_owned: None,
+                    pointer_state: BufferViewPointerState::Stable,
                     storage_inline_proven: true,
                 },
             );

--- a/crates/perry-codegen/src/expr/buffer_access.rs
+++ b/crates/perry-codegen/src/expr/buffer_access.rs
@@ -248,6 +248,9 @@ pub(crate) fn lower_buffer_access_proof(
         },
         _ => return Ok(None),
     };
+    if !view.pointer_state.is_stable() {
+        return Ok(None);
+    }
 
     // A closure-captured buffer local is hazardous even before any escape
     // walk stamped `buffer_hazard_reasons` — the closure may mutate/realloc

--- a/crates/perry-codegen/src/expr/buffer_access.rs
+++ b/crates/perry-codegen/src/expr/buffer_access.rs
@@ -8,7 +8,7 @@ use crate::native_value::{
 use crate::types::{DOUBLE, F32, I16, I32, I8, PTR};
 
 use super::{
-    attach_native_owned_view_fact, bounds_for_buffer_access_width, buffer_alias_metadata_suffix,
+    attach_buffer_view_facts, bounds_for_buffer_access_width, buffer_alias_metadata_suffix,
     buffer_view_lowered_value, can_lower_expr_as_i32, effective_alias_state_for_access,
     int_range_expr, is_numeric_expr, lower_expr_native, FnCtx,
 };
@@ -386,7 +386,7 @@ fn record_buffer_view(
         proof.may_emit_noalias,
         vec![format!("elem={:?}", proof.view.elem)],
     );
-    attach_native_owned_view_fact(ctx, &proof.view);
+    attach_buffer_view_facts(ctx, &proof.view);
 }
 
 pub(crate) fn lower_buffer_load(
@@ -423,7 +423,7 @@ pub(crate) fn lower_buffer_load(
         proof.may_emit_noalias,
         vec![format!("zext_to={}", result_i32)],
     );
-    attach_native_owned_view_fact(ctx, &proof.view);
+    attach_buffer_view_facts(ctx, &proof.view);
     let result = LoweredValue::i32(result_i32);
     if let Some(consumer) = spec.result_consumer {
         let facts = access_facts_for_spec(spec, &proof.view, Some(&emission.len_i32));
@@ -442,7 +442,7 @@ pub(crate) fn lower_buffer_load(
             false,
             Vec::new(),
         );
-        attach_native_owned_view_fact(ctx, &proof.view);
+        attach_buffer_view_facts(ctx, &proof.view);
     }
     Ok(Some(result))
 }
@@ -482,7 +482,7 @@ pub(crate) fn lower_buffer_store(
         proof.may_emit_noalias,
         vec![format!("source_i32={}", val_i32)],
     );
-    attach_native_owned_view_fact(ctx, &proof.view);
+    attach_buffer_view_facts(ctx, &proof.view);
     let result = LoweredValue::i32(val_i32.clone());
     Ok(Some(StoreResult { result }))
 }
@@ -612,7 +612,7 @@ pub(crate) fn lower_typed_array_load(
         proof.may_emit_noalias,
         vec![format!("elem={:?}", proof.view.elem)],
     );
-    attach_native_owned_view_fact(ctx, &proof.view);
+    attach_buffer_view_facts(ctx, &proof.view);
     Ok(Some(result))
 }
 
@@ -765,6 +765,6 @@ pub(crate) fn lower_typed_array_store(
         proof.may_emit_noalias,
         vec![format!("elem={:?}", proof.view.elem)],
     );
-    attach_native_owned_view_fact(ctx, &proof.view);
+    attach_buffer_view_facts(ctx, &proof.view);
     Ok(Some(StoreResult { result }))
 }

--- a/crates/perry-codegen/src/expr/buffer_views.rs
+++ b/crates/perry-codegen/src/expr/buffer_views.rs
@@ -119,12 +119,26 @@ pub(crate) fn invalidate_buffer_view_pointer(
     id: u32,
     reason: MaterializationReason,
 ) {
-    if let Some(view) = ctx.buffer_view_slots.get_mut(&id) {
-        view.pointer_state = BufferViewPointerState::Invalidated {
-            reason: reason.clone(),
-        };
+    let affected_ids = if let Some(data_slot) = ctx
+        .buffer_view_slots
+        .get(&id)
+        .map(|view| view.data_slot.clone())
+    {
+        ctx.buffer_view_slots
+            .iter()
+            .filter_map(|(view_id, view)| (view.data_slot == data_slot).then_some(*view_id))
+            .collect::<Vec<_>>()
+    } else {
+        vec![id]
+    };
+    for affected_id in affected_ids {
+        if let Some(view) = ctx.buffer_view_slots.get_mut(&affected_id) {
+            view.pointer_state = BufferViewPointerState::Invalidated {
+                reason: reason.clone(),
+            };
+        }
+        downgrade_buffer_alias(ctx, affected_id, reason.clone());
     }
-    downgrade_buffer_alias(ctx, id, reason);
 }
 
 fn owner_alias_invalidation_reason(reason: &MaterializationReason) -> MaterializationReason {

--- a/crates/perry-codegen/src/expr/buffer_views.rs
+++ b/crates/perry-codegen/src/expr/buffer_views.rs
@@ -1,8 +1,8 @@
 use perry_hir::{walker::walk_expr_children, Expr};
 
 use crate::native_value::{
-    AliasState, BoundsState, BufferElem, BufferIndexUnit, BufferViewSlot, LengthSource,
-    LoweredValue, MaterializationReason, NativeOwnedViewFact,
+    AliasState, BoundsState, BufferElem, BufferIndexUnit, BufferViewPointerState, BufferViewSlot,
+    LengthSource, LoweredValue, MaterializationReason, NativeOwnedViewFact,
 };
 use crate::types::{I32, I64, I8, PTR};
 
@@ -109,6 +109,22 @@ pub(crate) fn downgrade_buffer_alias(ctx: &mut FnCtx<'_>, id: u32, reason: Mater
         id,
         owner_alias_invalidation_reason(&reason),
     );
+}
+
+/// Mark a cached data pointer as unusable after an operation changes which
+/// storage the receiver aliases. Alias state alone cannot express this: the
+/// pointer is stale, not merely shared.
+pub(crate) fn invalidate_buffer_view_pointer(
+    ctx: &mut FnCtx<'_>,
+    id: u32,
+    reason: MaterializationReason,
+) {
+    if let Some(view) = ctx.buffer_view_slots.get_mut(&id) {
+        view.pointer_state = BufferViewPointerState::Invalidated {
+            reason: reason.clone(),
+        };
+    }
+    downgrade_buffer_alias(ctx, id, reason);
 }
 
 fn owner_alias_invalidation_reason(reason: &MaterializationReason) -> MaterializationReason {
@@ -233,12 +249,27 @@ pub(crate) fn native_owned_fact_for_view(view: &BufferViewSlot) -> Option<Native
         .map(|native| native.fact(view.element_width_bytes, alias_group))
 }
 
-pub(crate) fn attach_native_owned_view_fact(ctx: &mut FnCtx<'_>, view: &BufferViewSlot) {
-    let Some(fact) = native_owned_fact_for_view(view) else {
+pub(crate) fn attach_buffer_view_facts(ctx: &mut FnCtx<'_>, view: &BufferViewSlot) {
+    if let Some(record) = ctx.native_rep_records.last_mut() {
+        record.buffer_view_pointer_state = Some(view.pointer_state.clone());
+        record.native_owned_view = native_owned_fact_for_view(view);
+    }
+}
+
+pub(crate) fn attach_buffer_view_pointer_state_for_expr(ctx: &mut FnCtx<'_>, expr: &Expr) {
+    let Expr::LocalGet(id) = expr else {
+        return;
+    };
+    let Some(state) = ctx
+        .buffer_view_slots
+        .get(id)
+        .map(|view| view.pointer_state.clone())
+    else {
         return;
     };
     if let Some(record) = ctx.native_rep_records.last_mut() {
-        record.native_owned_view = Some(fact);
+        record.local_id = Some(*id);
+        record.buffer_view_pointer_state = Some(state);
     }
 }
 
@@ -285,6 +316,7 @@ pub(crate) fn update_buffer_view_for_assignment(
                 alias: AliasState::MayAlias,
                 length_source: Some(LengthSource::Unknown),
                 native_owned: None,
+                pointer_state: BufferViewPointerState::Stable,
                 // Reassignment refresh: `Uint8ArrayNew` with a non-literal arg
                 // can be the view form (`new Uint8Array(buffer)`), so the
                 // inline-storage proof is not re-established here.

--- a/crates/perry-codegen/src/expr/i32_fast_path.rs
+++ b/crates/perry-codegen/src/expr/i32_fast_path.rs
@@ -583,7 +583,8 @@ fn ta_int_elem_load_is_i32_provable(ctx: &FnCtx<'_>, object: &Expr, index: &Expr
     let Some(view) = ctx.buffer_view_slots.get(id) else {
         return false;
     };
-    if view.index_unit != BufferIndexUnit::Element
+    if !view.pointer_state.is_stable()
+        || view.index_unit != BufferIndexUnit::Element
         || !view.alias.allows_noalias()
         || view.scope_idx.is_none()
     {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -33,11 +33,11 @@ use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 use super::{
     array_kind_fact, attach_buffer_view_pointer_state_for_expr,
     buffer_access_materialization_reason, emit_typed_feedback_register_site,
-    expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_load, lower_expr,
-    lower_expr_as_i32, lower_typed_array_load, materialize_js_value, raw_f64_layout_fact,
-    try_lower_flat_const_index_get, typed_feedback_emission_enabled, unbox_str_handle,
-    unbox_to_i64, BufferAccessSpec, FnCtx, PackedF64LoopFact, TypedFeedbackContract,
-    TypedFeedbackKind,
+    expr_has_numeric_pointer_free_array_layout, int_range_expr, invalidate_buffer_view_pointer,
+    lower_buffer_load, lower_expr, lower_expr_as_i32, lower_typed_array_load, materialize_js_value,
+    raw_f64_layout_fact, try_lower_flat_const_index_get, typed_feedback_emission_enabled,
+    unbox_str_handle, unbox_to_i64, BufferAccessSpec, FnCtx, PackedF64LoopFact,
+    TypedFeedbackContract, TypedFeedbackKind,
 };
 
 mod guarded_array;
@@ -216,6 +216,15 @@ fn numeric_index_needs_runtime_key(ctx: &FnCtx<'_>, object: &Expr, index: &Expr)
 fn typed_array_index_needs_runtime_key(ctx: &FnCtx<'_>, object: &Expr, index: &Expr) -> bool {
     !numeric_index_has_integer_array_index_proof(ctx, index)
         && !numeric_index_has_loop_array_index_proof(ctx, object, index)
+}
+
+fn runtime_key_may_expose_typed_array_backing_buffer(index: &Expr) -> bool {
+    match index {
+        Expr::String(key) => key == "buffer",
+        Expr::WtfString(key) => key == b"buffer",
+        Expr::Integer(_) | Expr::Number(_) => false,
+        _ => true,
+    }
 }
 
 fn lower_array_index_get_via_runtime_key(
@@ -826,6 +835,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     return Ok(v);
                 }
                 if typed_array_index_needs_runtime_key(ctx, object.as_ref(), index.as_ref()) {
+                    if runtime_key_may_expose_typed_array_backing_buffer(index) {
+                        if let Expr::LocalGet(id) = object.as_ref() {
+                            if ctx.buffer_view_slots.contains_key(id) {
+                                invalidate_buffer_view_pointer(
+                                    ctx,
+                                    *id,
+                                    MaterializationReason::MutableAlias,
+                                );
+                            }
+                        }
+                    }
                     let arr_box = lower_expr(ctx, object)?;
                     let key_box = lower_expr(ctx, index)?;
                     let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -31,7 +31,8 @@ use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, recei
 use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
 use super::{
-    array_kind_fact, buffer_access_materialization_reason, emit_typed_feedback_register_site,
+    array_kind_fact, attach_buffer_view_pointer_state_for_expr,
+    buffer_access_materialization_reason, emit_typed_feedback_register_site,
     expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_load, lower_expr,
     lower_expr_as_i32, lower_typed_array_load, materialize_js_value, raw_f64_layout_fact,
     try_lower_flat_const_index_get, typed_feedback_emission_enabled, unbox_str_handle,
@@ -849,6 +850,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         false,
                         vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                     );
+                    attach_buffer_view_pointer_state_for_expr(ctx, object);
                     return Ok(result);
                 }
 
@@ -893,6 +895,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     false,
                     vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                 );
+                attach_buffer_view_pointer_state_for_expr(ctx, object);
                 return Ok(result);
             }
             if is_uint8array_receiver(ctx, object) && is_numeric_expr(ctx, index) {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -218,10 +218,35 @@ fn typed_array_index_needs_runtime_key(ctx: &FnCtx<'_>, object: &Expr, index: &E
         && !numeric_index_has_loop_array_index_proof(ctx, object, index)
 }
 
+fn is_proven_canonical_numeric_string_literal(key: &[u8]) -> bool {
+    if matches!(key, b"-0" | b"NaN" | b"Infinity" | b"-Infinity") {
+        return true;
+    }
+
+    let digits = key.strip_prefix(b"-").unwrap_or(key);
+    if digits.is_empty()
+        || (digits.len() > 1 && digits[0] == b'0')
+        || !digits.iter().all(u8::is_ascii_digit)
+    {
+        return false;
+    }
+
+    // Decimal integers through Number.MAX_SAFE_INTEGER are exact, and this
+    // range is below the threshold where JS Number#toString switches to
+    // exponent notation. Their source spelling therefore proves
+    // CanonicalNumericIndexString without invoking runtime conversion.
+    digits
+        .iter()
+        .try_fold(0_u64, |value, digit| {
+            value.checked_mul(10)?.checked_add(u64::from(digit - b'0'))
+        })
+        .is_some_and(|value| value <= 9_007_199_254_740_991)
+}
+
 fn runtime_key_may_expose_typed_array_backing_buffer(index: &Expr) -> bool {
     match index {
-        Expr::String(key) => key == "buffer",
-        Expr::WtfString(key) => key == b"buffer",
+        Expr::String(key) => !is_proven_canonical_numeric_string_literal(key.as_bytes()),
+        Expr::WtfString(key) => !is_proven_canonical_numeric_string_literal(key),
         Expr::Integer(_) | Expr::Number(_) => false,
         _ => true,
     }

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -42,9 +42,9 @@ use crate::types::{DOUBLE, I32, I64};
 use super::index_set_typed_array::lower_inline_dyn_typed_array_set;
 use super::{
     array_kind_fact, array_store_needs_layout_note, array_store_needs_write_barrier,
-    buffer_access_materialization_reason, emit_array_numeric_write_note_on_block,
-    emit_jsvalue_slot_store_on_block, emit_root_nanbox_store_on_block,
-    emit_typed_feedback_register_site, emit_write_barrier,
+    attach_buffer_view_pointer_state_for_expr, buffer_access_materialization_reason,
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
+    emit_root_nanbox_store_on_block, emit_typed_feedback_register_site, emit_write_barrier,
     expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_store, lower_expr,
     lower_expr_as_i32, lower_expr_native, lower_index_set_fast, lower_typed_array_store,
     materialize_js_value, nanbox_pointer_inline, raw_f64_layout_fact, unbox_str_handle,
@@ -881,6 +881,7 @@ pub(crate) fn lower(
                         false,
                         vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                     );
+                    attach_buffer_view_pointer_state_for_expr(ctx, object);
                     return Ok(result);
                 }
 
@@ -911,6 +912,7 @@ pub(crate) fn lower(
                     false,
                     vec!["typed_array_fallback=untracked_or_unproven".to_string()],
                 );
+                attach_buffer_view_pointer_state_for_expr(ctx, object);
                 return Ok(val_double);
             }
             if is_uint8array_receiver(ctx, object) && is_numeric_expr(ctx, index) {

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -63,8 +63,9 @@ pub(crate) use buffer_access::{
     lower_typed_array_store, BufferAccessSpec,
 };
 pub(crate) use buffer_views::{
-    alias_buffer_view_slot, attach_native_owned_view_fact, buffer_access_materialization_reason,
-    buffer_view_lowered_value, downgrade_buffer_alias, downgrade_buffer_aliases_in_expr,
+    alias_buffer_view_slot, attach_buffer_view_facts, attach_buffer_view_pointer_state_for_expr,
+    buffer_access_materialization_reason, buffer_view_lowered_value, downgrade_buffer_alias,
+    downgrade_buffer_aliases_in_expr, invalidate_buffer_view_pointer,
     invalidate_native_owned_views_for_dispose, native_arena_canonical_owner_id,
     record_native_arena_owner_assignment, update_buffer_view_for_assignment,
 };

--- a/crates/perry-codegen/src/expr/native_memory.rs
+++ b/crates/perry-codegen/src/expr/native_memory.rs
@@ -9,7 +9,7 @@ use crate::native_value::{
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 use super::{
-    attach_native_owned_view_fact, buffer_access_materialization_reason, buffer_view_lowered_value,
+    attach_buffer_view_facts, buffer_access_materialization_reason, buffer_view_lowered_value,
     effective_alias_state_for_access, lower_expr, lower_expr_native, unbox_to_i64, FnCtx,
 };
 
@@ -290,7 +290,7 @@ fn record_bulk_view(
         false,
         Vec::new(),
     );
-    attach_native_owned_view_fact(ctx, view);
+    attach_buffer_view_facts(ctx, view);
 }
 
 fn record_runtime_fallback(

--- a/crates/perry-codegen/src/expr/native_memory.rs
+++ b/crates/perry-codegen/src/expr/native_memory.rs
@@ -180,6 +180,9 @@ fn proven_view(
         return None;
     }
     let slot = ctx.buffer_view_slots.get(local_id)?.clone();
+    if !slot.pointer_state.is_stable() {
+        return None;
+    }
     if slot.index_unit != BufferIndexUnit::Element {
         return None;
     }

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -95,7 +95,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         if property == "buffer" {
             if let Expr::LocalGet(id) = object.as_ref() {
                 if ctx.buffer_view_slots.contains_key(id) {
-                    super::downgrade_buffer_alias(
+                    super::invalidate_buffer_view_pointer(
                         ctx,
                         *id,
                         crate::native_value::MaterializationReason::MutableAlias,

--- a/crates/perry-codegen/src/expr/proven_view_access.rs
+++ b/crates/perry-codegen/src/expr/proven_view_access.rs
@@ -118,7 +118,8 @@ pub(crate) fn local_is_proven_int_store_view(ctx: &FnCtx<'_>, id: u32) -> bool {
         return false;
     }
     ctx.buffer_view_slots.get(&id).is_some_and(|view| {
-        view.storage_inline_proven
+        view.pointer_state.is_stable()
+            && view.storage_inline_proven
             && view.native_owned.is_none()
             && view.index_unit == BufferIndexUnit::Element
             && view.alias.allows_noalias()
@@ -148,7 +149,8 @@ fn proven_view_for(
         return None;
     };
     let view = ctx.buffer_view_slots.get(id)?.clone();
-    if !view.storage_inline_proven
+    if !view.pointer_state.is_stable()
+        || !view.storage_inline_proven
         || view.native_owned.is_some()
         || view.index_unit != BufferIndexUnit::Element
     {

--- a/crates/perry-codegen/src/expr/proven_view_access.rs
+++ b/crates/perry-codegen/src/expr/proven_view_access.rs
@@ -36,7 +36,9 @@
 use anyhow::Result;
 use perry_hir::{BinaryOp, Expr};
 
-use super::{can_lower_expr_as_i32, lower_expr_as_i32, lower_expr_native, FnCtx};
+use super::{
+    attach_buffer_view_facts, can_lower_expr_as_i32, lower_expr_as_i32, lower_expr_native, FnCtx,
+};
 use crate::nanbox::{double_literal, TAG_UNDEFINED};
 use crate::native_value::{
     BoundsState, BufferAccessMode, BufferElem, BufferIndexUnit, ExpectedNativeRep, LoweredValue,
@@ -302,6 +304,7 @@ pub(crate) fn try_lower_proven_view_checked_f64_load(
         false,
         vec!["proven_view=checked_inline; guards=none".to_string()],
     );
+    attach_buffer_view_facts(ctx, &view);
     Ok(Some(result))
 }
 
@@ -438,5 +441,6 @@ pub(crate) fn try_lower_proven_view_checked_store(
         false,
         vec!["proven_view=checked_inline; guards=none".to_string()],
     );
+    attach_buffer_view_facts(ctx, &view);
     Ok(Some(value_native))
 }

--- a/crates/perry-codegen/src/expr/record_value.rs
+++ b/crates/perry-codegen/src/expr/record_value.rs
@@ -319,6 +319,7 @@ impl<'a> FnCtx<'a> {
             access_mode,
             buffer_access,
             native_owned_view: None,
+            buffer_view_pointer_state: None,
             materialization_reason,
             fallback_reason,
             native_value_state,

--- a/crates/perry-codegen/src/native_value/artifact.rs
+++ b/crates/perry-codegen/src/native_value/artifact.rs
@@ -270,6 +270,7 @@ pub(crate) struct NativeRepRecord {
     pub access_mode: Option<BufferAccessMode>,
     pub buffer_access: Option<BufferAccessFacts>,
     pub native_owned_view: Option<NativeOwnedViewFact>,
+    pub buffer_view_pointer_state: Option<super::buffer::BufferViewPointerState>,
     pub materialization_reason: Option<MaterializationReason>,
     pub fallback_reason: Option<MaterializationReason>,
     pub native_value_state: NativeValueState,
@@ -315,6 +316,7 @@ pub(crate) fn typed_clone_rejection_record(
         access_mode: None,
         buffer_access: None,
         native_owned_view: None,
+        buffer_view_pointer_state: None,
         materialization_reason: None,
         fallback_reason: None,
         native_value_state: NativeValueState::RegionLocal,
@@ -609,7 +611,7 @@ pub(crate) fn write_native_rep_artifact_if_enabled(
         pid, wall_nonce, counter
     ));
     let artifact = NativeRepArtifact {
-        schema_version: 15,
+        schema_version: 16,
         module,
         records,
         pod_layouts: collect_pod_layouts(records),

--- a/crates/perry-codegen/src/native_value/buffer.rs
+++ b/crates/perry-codegen/src/native_value/buffer.rs
@@ -122,6 +122,12 @@ pub(crate) enum BufferViewPointerState {
     Invalidated { reason: MaterializationReason },
 }
 
+impl BufferViewPointerState {
+    pub(crate) fn is_stable(&self) -> bool {
+        matches!(self, Self::Stable)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct BufferViewRep {

--- a/crates/perry-codegen/src/native_value/buffer.rs
+++ b/crates/perry-codegen/src/native_value/buffer.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::rep::LoweredValue;
+use super::{materialize::MaterializationReason, rep::LoweredValue};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -110,6 +110,18 @@ pub(crate) enum BufferAccessMode {
     DynamicFallback,
 }
 
+/// Whether the data pointer cached for a tracked buffer view still names the
+/// receiver's current storage. This is distinct from aliasing: a pointer may
+/// safely alias another view, while exposing an inline typed array's `.buffer`
+/// can make the cached pointer stale by rebinding the receiver to materialized
+/// backing storage.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum BufferViewPointerState {
+    Stable,
+    Invalidated { reason: MaterializationReason },
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct BufferViewRep {
@@ -183,6 +195,7 @@ pub(crate) struct BufferViewSlot {
     pub alias: AliasState,
     pub length_source: Option<LengthSource>,
     pub native_owned: Option<NativeOwnedViewSlot>,
+    pub pointer_state: BufferViewPointerState,
     /// Representation-selection Phase 2: `true` when the receiver is PROVEN to
     /// be a freshly-constructed inline-storage (non-view) typed array /
     /// buffer — the construction form was a length or plain-array source,

--- a/crates/perry-codegen/src/native_value/mod.rs
+++ b/crates/perry-codegen/src/native_value/mod.rs
@@ -12,8 +12,8 @@ pub(crate) use artifact::{
 };
 pub(crate) use buffer::{
     AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessFacts, BufferAccessMode,
-    BufferAccessProof, BufferElem, BufferEndian, BufferIndexUnit, BufferViewSlot,
-    GuardedBufferIndex, LengthSource, NativeOwnedViewFact, NativeOwnedViewSlot,
+    BufferAccessProof, BufferElem, BufferEndian, BufferIndexUnit, BufferViewPointerState,
+    BufferViewSlot, GuardedBufferIndex, LengthSource, NativeOwnedViewFact, NativeOwnedViewSlot,
 };
 pub(crate) use materialize::{
     materialize_js_value, materialize_js_value_bits, materialize_js_value_without_record,

--- a/crates/perry-codegen/src/native_value/verify.rs
+++ b/crates/perry-codegen/src/native_value/verify.rs
@@ -246,8 +246,14 @@ pub(crate) fn verify_native_rep_records(records: &[NativeRepRecord]) -> Result<(
                 record.function, record.block_label, record.consumer
             ));
         }
+        let uses_cached_buffer_view_pointer = matches!(record.native_rep, NativeRep::BufferView(_))
+            || record.buffer_access.is_some()
+            || record
+                .notes
+                .iter()
+                .any(|note| note.starts_with("proven_view=checked_inline"));
         if uses_native_buffer_pointer
-            && matches!(record.native_rep, NativeRep::BufferView(_))
+            && uses_cached_buffer_view_pointer
             && record.buffer_view_pointer_state.is_none()
         {
             errors.push(format!(

--- a/crates/perry-codegen/src/native_value/verify.rs
+++ b/crates/perry-codegen/src/native_value/verify.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Result};
 #[cfg(test)]
 use super::artifact::{NativeAbiTransitionOp, NativeAbiTransitionRecord};
 use super::artifact::{NativeRepRecord, NativeValueState};
-use super::buffer::{AliasState, BoundsState, BufferAccessMode};
+use super::buffer::{AliasState, BoundsState, BufferAccessMode, BufferViewPointerState};
 #[cfg(test)]
 use super::pod::recompute_layout_from_fields;
 use super::rep::NativeRep;
@@ -228,6 +228,30 @@ pub(crate) fn verify_native_rep_records(records: &[NativeRepRecord]) -> Result<(
         ) {
             errors.push(format!(
                 "{}:{} {} used unchecked native buffer access without proven/guarded bounds",
+                record.function, record.block_label, record.consumer
+            ));
+        }
+        let uses_native_buffer_pointer = matches!(
+            record.access_mode.as_ref(),
+            Some(BufferAccessMode::UncheckedNative | BufferAccessMode::CheckedNative)
+        );
+        if uses_native_buffer_pointer
+            && matches!(
+                record.buffer_view_pointer_state,
+                Some(BufferViewPointerState::Invalidated { .. })
+            )
+        {
+            errors.push(format!(
+                "{}:{} {} used an invalidated buffer-view data pointer",
+                record.function, record.block_label, record.consumer
+            ));
+        }
+        if uses_native_buffer_pointer
+            && matches!(record.native_rep, NativeRep::BufferView(_))
+            && record.buffer_view_pointer_state.is_none()
+        {
+            errors.push(format!(
+                "{}:{} {} native buffer-view access omitted pointer-lifetime evidence",
                 record.function, record.block_label, record.consumer
             ));
         }

--- a/crates/perry-codegen/src/native_value/verify/tests.rs
+++ b/crates/perry-codegen/src/native_value/verify/tests.rs
@@ -485,6 +485,22 @@ fn rejects_native_access_through_invalidated_buffer_view_pointer() {
 }
 
 #[test]
+fn rejects_scalar_cached_view_access_without_pointer_lifetime_evidence() {
+    let mut r = record();
+    r.access_mode = Some(BufferAccessMode::CheckedNative);
+    r.bounds_state = Some(BoundsState::Proven {
+        proof: BoundsProof::ExplicitGuard,
+    });
+    r.notes = vec!["proven_view=checked_inline; guards=none".to_string()];
+
+    let err = verify_native_rep_records(&[r])
+        .expect_err("scalar access through a cached view must carry pointer-lifetime evidence");
+    assert!(err
+        .to_string()
+        .contains("native buffer-view access omitted pointer-lifetime evidence"));
+}
+
+#[test]
 fn accepts_runtime_fallback_after_buffer_view_pointer_invalidation() {
     let mut r = record();
     r.access_mode = Some(BufferAccessMode::DynamicFallback);

--- a/crates/perry-codegen/src/native_value/verify/tests.rs
+++ b/crates/perry-codegen/src/native_value/verify/tests.rs
@@ -1,8 +1,8 @@
 use super::{NativeAbiTransitionOp, NativeAbiTransitionRecord};
 use crate::native_value::{
     verify_native_rep_records, AliasState, BoundsProof, BoundsState, BufferAccessMode,
-    BufferViewRep, LoweredValue, MaterializationReason, NativeAbiDirection, NativeAbiTypeRecord,
-    NativeFactUse, NativeRep, NativeRepRecord, NativeValueState, SemanticKind,
+    BufferViewPointerState, BufferViewRep, LoweredValue, MaterializationReason, NativeAbiDirection,
+    NativeAbiTypeRecord, NativeFactUse, NativeRep, NativeRepRecord, NativeValueState, SemanticKind,
 };
 use crate::types::{DOUBLE, F32, I32, I64, PTR};
 
@@ -33,6 +33,7 @@ fn record() -> NativeRepRecord {
         access_mode: None,
         buffer_access: None,
         native_owned_view: None,
+        buffer_view_pointer_state: None,
         materialization_reason: None,
         fallback_reason: None,
         native_value_state: NativeValueState::RegionLocal,
@@ -463,6 +464,39 @@ fn accepts_unchecked_native_proven_and_guarded_bounds() {
         guard_id: "loop_guard".to_string(),
     });
     assert!(verify_native_rep_records(&[proven, guarded]).is_ok());
+}
+
+#[test]
+fn rejects_native_access_through_invalidated_buffer_view_pointer() {
+    let mut r = record();
+    r.access_mode = Some(BufferAccessMode::UncheckedNative);
+    r.bounds_state = Some(BoundsState::Proven {
+        proof: BoundsProof::ExplicitGuard,
+    });
+    r.alias_state = Some(AliasState::NoAliasProven);
+    r.buffer_view_pointer_state = Some(BufferViewPointerState::Invalidated {
+        reason: MaterializationReason::MutableAlias,
+    });
+
+    let err = verify_native_rep_records(&[r]).expect_err("stale pointer must be rejected");
+    assert!(err
+        .to_string()
+        .contains("invalidated buffer-view data pointer"));
+}
+
+#[test]
+fn accepts_runtime_fallback_after_buffer_view_pointer_invalidation() {
+    let mut r = record();
+    r.access_mode = Some(BufferAccessMode::DynamicFallback);
+    r.bounds_state = Some(BoundsState::Unknown);
+    r.materialization_reason = Some(MaterializationReason::MutableAlias);
+    r.fallback_reason = Some(MaterializationReason::MutableAlias);
+    r.native_value_state = NativeValueState::DynamicFallback;
+    r.buffer_view_pointer_state = Some(BufferViewPointerState::Invalidated {
+        reason: MaterializationReason::MutableAlias,
+    });
+
+    assert!(verify_native_rep_records(&[r]).is_ok());
 }
 
 #[test]

--- a/crates/perry-codegen/src/stmt/let_buffer_views.rs
+++ b/crates/perry-codegen/src/stmt/let_buffer_views.rs
@@ -4,7 +4,8 @@
 
 use crate::expr::FnCtx;
 use crate::native_value::{
-    AliasState, BufferElem, BufferIndexUnit, BufferViewSlot, LengthSource, NativeOwnedViewSlot,
+    AliasState, BufferElem, BufferIndexUnit, BufferViewPointerState, BufferViewSlot, LengthSource,
+    NativeOwnedViewSlot,
 };
 use crate::types::{I32, I64, I8, PTR};
 
@@ -93,6 +94,7 @@ pub(super) fn register_noalias_buffer_view(
             alias: AliasState::NoAliasProven,
             length_source: Some(init.length_source),
             native_owned,
+            pointer_state: BufferViewPointerState::Stable,
             storage_inline_proven: init.storage_inline_proven,
         },
     );

--- a/crates/perry-codegen/src/stmt/masked_window_region.rs
+++ b/crates/perry-codegen/src/stmt/masked_window_region.rs
@@ -524,7 +524,8 @@ pub(super) fn try_match_masked_window_region(
             .buffer_view_slots
             .get(&access.array_id)
             .is_some_and(|view| {
-                view.storage_inline_proven
+                view.pointer_state.is_stable()
+                    && view.storage_inline_proven
                     && view.native_owned.is_none()
                     && view.alias.allows_noalias()
                     && view.scope_idx.is_some()

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -27,6 +27,9 @@ use native_proof_support::{
     NativeRepsEnv,
 };
 
+#[path = "native_proof_buffer_views/pointer_lifetime.rs"]
+mod pointer_lifetime;
+
 fn empty_opts() -> CompileOptions {
     CompileOptions {
         target: None,

--- a/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn backing_buffer_exposure_records_pointer_invalidation_before_fallback() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(1),
+        ),
+        array_set(1, int(0), int(7)),
+        typed_array_let(
+            2,
+            "bytes",
+            "Uint8Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT8,
+            Expr::PropertyGet {
+                byte_offset: 0,
+                object: Box::new(local(1)),
+                property: "buffer".to_string(),
+            },
+        ),
+        array_set(1, int(0), int(0x01020304)),
+        Stmt::Return(Some(index_get(2, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArraySet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "unchecked_native"
+                && record["buffer_view_pointer_state"]["state"] == "stable"
+        }),
+        "expected the pre-exposure access to carry stable-pointer evidence:\n{artifact:#}"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArraySet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "dynamic_fallback"
+                && record["materialization_reason"] == "mutable_alias"
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+                && record["buffer_view_pointer_state"]["reason"] == "mutable_alias"
+        }),
+        "expected `.buffer` exposure to invalidate the cached pointer before fallback:\n{artifact:#}"
+    );
+    assert!(
+        !records.iter().any(|record| {
+            record["local_id"] == 1
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+                && matches!(
+                    record["access_mode"].as_str(),
+                    Some("unchecked_native" | "checked_native")
+                )
+        }),
+        "the invalidated words pointer must not reach a native access:\n{artifact:#}"
+    );
+}

--- a/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
@@ -65,3 +65,93 @@ fn backing_buffer_exposure_records_pointer_invalidation_before_fallback() {
         "the invalidated words pointer must not reach a native access:\n{artifact:#}"
     );
 }
+
+#[test]
+fn computed_backing_buffer_exposure_invalidates_cached_pointer() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(1),
+        ),
+        Stmt::Expr(index_get(1, Expr::String("buffer".to_string()))),
+        array_set(1, int(0), int(0x01020304)),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("computed_buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayGet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "dynamic_fallback"
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+        }),
+        "computed `words[\"buffer\"]` must invalidate the cached pointer before fallback:\n\
+         {artifact:#}"
+    );
+    assert!(
+        !records.iter().any(|record| {
+            record["local_id"] == 1
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+                && matches!(
+                    record["access_mode"].as_str(),
+                    Some("unchecked_native" | "checked_native")
+                )
+        }),
+        "the invalidated computed-property receiver must not reach native access:\n{artifact:#}"
+    );
+}
+
+#[test]
+fn backing_buffer_exposure_invalidates_copied_view_alias_group() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(1),
+        ),
+        Stmt::Let {
+            id: 2,
+            name: "alias".to_string(),
+            ty: Type::Named("Uint32Array".to_string()),
+            mutable: false,
+            init: Some(local(1)),
+        },
+        Stmt::Expr(Expr::PropertyGet {
+            byte_offset: 0,
+            object: Box::new(local(2)),
+            property: "buffer".to_string(),
+        }),
+        array_set(1, int(0), int(0x01020304)),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("aliased_buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArraySet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "dynamic_fallback"
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+        }),
+        "exposing an alias's backing buffer must invalidate every cached pointer sharing its \
+         data slot:\n{artifact:#}"
+    );
+}

--- a/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
@@ -155,3 +155,54 @@ fn backing_buffer_exposure_invalidates_copied_view_alias_group() {
          data slot:\n{artifact:#}"
     );
 }
+
+#[test]
+fn native_memory_bulk_access_rejects_invalidated_cached_pointer() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(4),
+        ),
+        Stmt::Expr(Expr::PropertyGet {
+            byte_offset: 0,
+            object: Box::new(local(1)),
+            property: "buffer".to_string(),
+        }),
+        Stmt::Expr(Expr::NativeMemoryFillU32 {
+            view: Box::new(local(1)),
+            value: Box::new(int(0)),
+        }),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("native_memory_buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "NativeMemoryFillU32"
+                && record["consumer"] == "NativeMemoryFillU32.runtime_fallback"
+                && record["access_mode"] == "dynamic_fallback"
+        }),
+        "bulk access through an invalidated cached pointer must use the runtime fallback:\n\
+         {artifact:#}"
+    );
+    assert!(
+        !records.iter().any(|record| {
+            record["expr_kind"] == "NativeMemoryFillU32"
+                && matches!(
+                    record["consumer"].as_str(),
+                    Some("NativeMemoryFillU32.memset_zero" | "NativeMemoryFillU32.store_loop")
+                )
+        }),
+        "bulk access through an invalidated cached pointer must not emit native writes:\n\
+         {artifact:#}"
+    );
+}

--- a/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views/pointer_lifetime.rs
@@ -112,6 +112,98 @@ fn computed_backing_buffer_exposure_invalidates_cached_pointer() {
 }
 
 #[test]
+fn named_typed_array_getter_invalidates_cached_pointer() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(1),
+        ),
+        // A non-canonical named key uses ordinary [[Get]]. It can therefore
+        // invoke an accessor that reads `this.buffer` and rebinds storage.
+        Stmt::Expr(index_get(1, Expr::String("probe".to_string()))),
+        array_set(1, int(0), int(0x01020304)),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("named_getter_buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayGet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "dynamic_fallback"
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+        }),
+        "a named typed-array getter must invalidate the cached pointer before [[Get]]:\n\
+         {artifact:#}"
+    );
+    assert!(
+        !records.iter().any(|record| {
+            record["local_id"] == 1
+                && record["buffer_view_pointer_state"]["state"] == "invalidated"
+                && matches!(
+                    record["access_mode"].as_str(),
+                    Some("unchecked_native" | "checked_native")
+                )
+        }),
+        "the pointer invalidated by a named getter must not reach native access:\n{artifact:#}"
+    );
+}
+
+#[test]
+fn canonical_numeric_string_get_preserves_cached_pointer() {
+    let body = vec![
+        typed_array_let(
+            1,
+            "words",
+            "Uint32Array",
+            perry_hir::TYPED_ARRAY_KIND_UINT32,
+            int(1),
+        ),
+        Stmt::Expr(index_get(1, Expr::String("0".to_string()))),
+        array_set(1, int(0), int(7)),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let mut opts = empty_opts();
+    opts.verify_native_regions = true;
+    let artifact = compile_artifact_json_for_module_with_opts(
+        module("numeric_string_buffer_pointer_lifetime_7220.ts", body),
+        opts,
+    );
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayGet"
+                && record["local_id"] == 1
+                && record["access_mode"] == "dynamic_fallback"
+                && record["buffer_view_pointer_state"]["state"] == "stable"
+        }),
+        "canonical numeric strings cannot invoke a named accessor:\n{artifact:#}"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArraySet"
+                && record["local_id"] == 1
+                && matches!(
+                    record["access_mode"].as_str(),
+                    Some("unchecked_native" | "checked_native")
+                )
+                && record["buffer_view_pointer_state"]["state"] == "stable"
+        }),
+        "a canonical numeric-string get should preserve later native access:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn backing_buffer_exposure_invalidates_copied_view_alias_group() {
     let body = vec![
         typed_array_let(

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -700,7 +700,7 @@ fn artifact_schema_v6_records_consumed_native_facts_for_buffer_region() {
     ];
 
     let artifact = compile_artifact_json("artifact_positive_buffer_region.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     let records = artifact["records"].as_array().unwrap();
     assert!(
         records.iter().any(|record| {
@@ -733,7 +733,7 @@ fn artifact_schema_v6_records_rejected_facts_for_buffer_fallback() {
     ];
 
     let artifact = compile_artifact_json("artifact_rejected_buffer_region.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     let records = artifact["records"].as_array().unwrap();
     assert!(
         records.iter().any(|record| {
@@ -780,7 +780,7 @@ fn artifact_schema_v6_records_c_layout_pod_manifest() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_record.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     assert_eq!(artifact["summary"]["pod_layout_count"], 1);
     assert_eq!(artifact["summary"]["pod_record_count"], 1);
     let layouts = artifact["pod_layouts"].as_array().unwrap();
@@ -1278,7 +1278,7 @@ fn artifact_schema_v6_records_pod_dynamic_write_fallback() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_dynamic_write.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     assert!(
         artifact["records"]
             .as_array()
@@ -1515,7 +1515,7 @@ fn artifact_schema_v8_rejects_inexact_pod_initializer_values() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_init_reject.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     assert_eq!(artifact["summary"]["pod_layout_count"], 0);
     assert_eq!(artifact["summary"]["pod_record_count"], 0);
     assert!(artifact["pod_layouts"].as_array().unwrap().is_empty());
@@ -1567,7 +1567,7 @@ fn artifact_schema_v6_records_pod_pointerful_field_rejection() {
     ];
 
     let artifact = compile_artifact_json("artifact_c_layout_pod_reject.ts", body);
-    assert_eq!(artifact["schema_version"], 15);
+    assert_eq!(artifact["schema_version"], 16);
     assert_eq!(artifact["summary"]["pod_layout_count"], 0);
     assert!(artifact["pod_layouts"].as_array().unwrap().is_empty());
     assert!(

--- a/test-files/test_gap_7220_typed_array_named_getter_pointer.ts
+++ b/test-files/test_gap_7220_typed_array_named_getter_pointer.ts
@@ -1,0 +1,19 @@
+// A named typed-array property uses ordinary [[Get]]. Its getter may expose
+// `.buffer`, which materializes backing storage and can rebind the view away
+// from the codegen-cached element pointer.
+let exposed: any = null;
+
+Object.defineProperty(Uint32Array.prototype, "probe", {
+  configurable: true,
+  get() {
+    exposed = this.buffer;
+    return "getter-ran";
+  },
+});
+
+const words = new Uint32Array(1);
+console.log("named getter:", words["probe" as any]);
+words[0] = 0x01020304;
+
+const bytes = new Uint8Array(exposed);
+console.log("shared bytes:", bytes[0], bytes[1], bytes[2], bytes[3]);


### PR DESCRIPTION
## Summary

- Track whether each cached buffer-view data pointer is stable or invalidated, separately from alias state.
- Mark a typed array's cached pointer invalid before `.buffer` materializes and rebinds its storage.
- Carry pointer-lifetime evidence on native and runtime-fallback records, and bump the native-representation artifact schema to v16.
- Make `--verify-native-regions` reject checked or unchecked native access through an invalidated pointer, and reject native BufferView records that omit lifetime evidence.

Fixes #7220.

## Why this is separate from #7827

#7827 stopped the stale state from reaching native lowering, but the verifier still could not describe or reject that state. Bounds and alias facts are not enough: a pointer can safely alias another view, while `.buffer` exposure can make the cached pointer point at storage the receiver no longer uses.

The new regression proves both sides with verification enabled: a write before exposure carries stable-pointer evidence and uses native lowering; a write after exposure carries invalidated-pointer evidence and uses the runtime fallback. A verifier unit test constructs the formerly accepted combination directly and confirms that proven bounds plus no-alias evidence cannot override an invalid pointer lifetime.

## Validation

- `cargo test -p perry-codegen --lib native_value::verify::tests::`: 52 passed.
- `cargo test -p perry-codegen --test native_proof_buffer_views`: 37 passed.
- `cargo test -p perry-codegen --test native_proof_regressions`: 261 passed; one unrelated failure (`typed_f64_receiver_method_clone_raw_loads_after_composed_guards`) reproduces unchanged on detached clean `origin/main` at 079e646dd.
- `cargo test -p perry-codegen`: 879 library tests and the preceding integration suites passed, then the documented pre-existing `large_local_array_push_inbounds_store_emits_precise_slot_barrier` failure returned 101.
- Fresh optimized build with `-p perry -p perry-runtime-static -p perry-stdlib-static`: exit 0.
- Exact issue repro compiled with the fresh archives and `--no-cache --verify-native-regions`: compiler exit 0; binary exit 0; output `{\"expected\":10,\"actual\":10,\"passed\":true}`.
- `cargo fmt --all -- --check` and `bash scripts/check_file_size.sh`: pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for typed-array and buffer access after underlying data is exposed or invalidated.
  * Prevented native reads and writes when pointer validity cannot be verified.
  * Preserved safe runtime fallback behavior for dynamic access after invalidation.
  * Continued to support optimized access for safe, canonical numeric indexing.

* **Tests**
  * Added coverage for direct, computed, aliased, named-property, scalar, and bulk-memory access.
  * Updated native artifact regression checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->