### PR TITLE
fix(codegen): invalidate Array.isArray folds on reassignment

### DIFF
--- a/changelog.d/7855-array-isarray-reassignment.md
+++ b/changelog.d/7855-array-isarray-reassignment.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Array.isArray` now checks the current runtime value of reassigned locals instead of folding from the binding's initializer. This fixes both false negatives after assigning an array and false positives after assigning a non-array (#7844).

--- a/crates/perry-codegen/src/expr/array_methods.rs
+++ b/crates/perry-codegen/src/expr/array_methods.rs
@@ -84,7 +84,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `Tuple(_)` types short-circuit; anything Union-shaped
             // falls through to the runtime.
             let v = lower_expr(ctx, o)?;
-            if let Some(ty) = crate::type_analysis::static_type_of(ctx, o) {
+            // #7844: a local's type may have been refined from its initializer,
+            // but reassignment invalidates that proof in both directions. A
+            // number-initialized local can now hold an array, and an
+            // array-initialized local can now hold a number. Mirror
+            // `is_array_expr`/`receiver_class_name`: only fold a local whose
+            // binding has not been written after initialization.
+            let static_type_is_still_valid = !matches!(
+                o.as_ref(),
+                Expr::LocalGet(id) if ctx.reassigned_locals.contains(id)
+            );
+            if let Some(ty) = static_type_is_still_valid
+                .then_some(crate::type_analysis::static_type_of(ctx, o))
+                .flatten()
+            {
                 if matches!(
                     ty,
                     perry_hir::types::Type::Array(_) | perry_hir::types::Type::Tuple(_)

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -691,6 +691,54 @@ fn for_loop(counter_id: u32, bound: Expr, body: Vec<Stmt>) -> Stmt {
 use native_proof_support::assert_buffer_store_uses_dynamic_fallback;
 
 #[test]
+fn array_isarray_reassigned_local_uses_runtime_predicate() {
+    let body = vec![
+        Stmt::Let {
+            id: 1,
+            name: "number_to_array".to_string(),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(int(0)),
+        },
+        Stmt::Expr(Expr::LocalSet(1, Box::new(Expr::Array(vec![int(1)])))),
+        Stmt::Expr(Expr::ArrayIsArray(Box::new(local(1)))),
+        Stmt::Let {
+            id: 2,
+            name: "array_to_number".to_string(),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(Expr::Array(vec![int(1)])),
+        },
+        Stmt::Expr(Expr::LocalSet(2, Box::new(int(0)))),
+        Stmt::Expr(Expr::ArrayIsArray(Box::new(local(2)))),
+        Stmt::Let {
+            id: 3,
+            name: "unchanged_array".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Array(vec![int(1)])),
+        },
+        Stmt::Expr(Expr::ArrayIsArray(Box::new(local(3)))),
+        Stmt::Return(Some(int(0))),
+    ];
+    let ir = String::from_utf8(
+        compile_module(
+            &module("array_isarray_reassignment_7844.ts", body),
+            empty_opts(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        ir.matches("call double @js_array_is_array(").count(),
+        2,
+        "both reassigned locals must use the runtime predicate, while the unchanged array may \
+         retain its compile-time true fold:\n{ir}"
+    );
+}
+
+#[test]
 fn artifact_schema_v6_records_consumed_native_facts_for_buffer_region() {
     let body = vec![
         buffer_let(1, "src", int(8)),

--- a/test-files/test_gap_7844_array_isarray_reassigned_local.ts
+++ b/test-files/test_gap_7844_array_isarray_reassigned_local.ts
@@ -1,0 +1,52 @@
+let numberToArray: any = 0;
+numberToArray = [numberToArray];
+console.log(
+  "number-to-array",
+  Array.isArray(numberToArray),
+  numberToArray instanceof Array,
+  typeof numberToArray,
+);
+
+let stringToArray: any = "s";
+stringToArray = [stringToArray];
+console.log(
+  "string-to-array",
+  Array.isArray(stringToArray),
+  stringToArray instanceof Array,
+  typeof stringToArray,
+);
+
+let nullToArray: any = null;
+nullToArray = [nullToArray];
+console.log(
+  "null-to-array",
+  Array.isArray(nullToArray),
+  nullToArray instanceof Array,
+  typeof nullToArray,
+);
+
+let arrayToNumber: any = [9];
+arrayToNumber = 42;
+console.log(
+  "array-to-number",
+  Array.isArray(arrayToNumber),
+  arrayToNumber instanceof Array,
+  typeof arrayToNumber,
+);
+
+let arrayToString: any = [9];
+arrayToString = "s";
+console.log(
+  "array-to-string",
+  Array.isArray(arrayToString),
+  arrayToString instanceof Array,
+  typeof arrayToString,
+);
+
+const unchanged: any = [1];
+console.log(
+  "unchanged-array",
+  Array.isArray(unchanged),
+  unchanged instanceof Array,
+  typeof unchanged,
+);


### PR DESCRIPTION
## Summary

- stop `Array.isArray` from folding a reassigned local from its initializer-refined type
- route those locals through `js_array_is_array`, so the predicate checks the current runtime value
- retain the existing compile-time fold for literals and locals that were never reassigned

Closes #7844

## Reproduction

On `origin/main` (`079e646dd`), the same six-case program produced stale answers in both directions:

```text
number-to-array false true object
string-to-array false true object
null-to-array false true object
array-to-number true false number
array-to-string true false string
unchanged-array true true object
```

The second boolean is `instanceof Array`, showing that the runtime value itself was correct. Node and the fixed compiler both produce:

```text
number-to-array true true object
string-to-array true true object
null-to-array true true object
array-to-number false false number
array-to-string false false string
unchanged-array true true object
```

The A/B used two compilers against the same prebuilt runtime.

## Validation

- `cargo test -p perry-codegen --lib`: 877 passed
- focused IR regression: passed; exactly two `js_array_is_array` calls for the two reassigned locals, while the unchanged-array control remains folded
- `native_proof_regressions`: 262 passed with only `typed_f64_receiver_method_clone_raw_loads_after_composed_guards` skipped (the current-main #7506 failure, fixed separately in #7851)
- Node/baseline/fixed semantic A/B: fixed output matches Node in all six cases
- `python3 scripts/check_test_registration.py`: passed
- `cargo fmt --all -- --check`, `git diff --check`, and `bash scripts/check_file_size.sh`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Array.isArray` to correctly evaluate local values at runtime after reassignment.
  - Prevented incorrect array classifications when values change between arrays and non-arrays.
  - Preserved optimized handling for unchanged array values.
- **Tests**
  - Added coverage for reassigned values, `instanceof Array`, `null`, primitives, and unchanged arrays.
- **Documentation**
  - Added a changelog entry describing the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->