### PR TITLE
perf(runtime): classify arena method receivers before side registries (#7850)

### DIFF
--- a/changelog.d/7864-arena-method-receiver-classification.md
+++ b/changelog.d/7864-arena-method-receiver-classification.md
@@ -1,0 +1,4 @@
+**Dynamic method calls no longer probe every native-kind side registry for arena values.**
+Ordinary objects and other GC-managed receivers are classified from their arena metadata and
+resident header, avoiding the armed Symbol registry's global lock and address hash. Persistent
+boxed symbols and process-global shared buffers retain the existing safe registry fallback.

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -19,6 +19,8 @@ mod string_methods;
 
 #[cfg(test)]
 mod dispatch_arg_coercion_tests;
+#[cfg(test)]
+mod gc_pointer_probe_tests;
 mod typed_array;
 
 use disposal::{
@@ -903,6 +905,60 @@ unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> 
         return None;
     }
     let addr = ptr as usize;
+
+    // #7850: current runtime-owned values are arena allocations with a real
+    // `GcHeader`: ordinary objects/arrays/strings, Maps, Sets, RegExps,
+    // Buffers, typed arrays, and fresh Symbols. The arena range lookup proves
+    // that `addr - GC_HEADER_SIZE` stays inside a registered allocation range,
+    // so classify those values from the header before touching any address-
+    // keyed kind registry. This matters once a program has created a Symbol:
+    // the old tail asked `is_registered_symbol` about every ordinary object,
+    // taking a process-global mutex and hashing the address on every dynamic
+    // method call.
+    //
+    // Header-less values still exist: persistent boxed Symbols and
+    // process-global SharedArrayBuffer backings. They are outside this
+    // runtime's arena ranges and deliberately fall through to the unchanged
+    // side-table tower below. The range-base check is load-bearing for a
+    // garbage candidate at the first byte of a registered range (#7742).
+    if let Some((_space, range_base)) = crate::arena::classify_heap_space_in_range(addr) {
+        if addr < range_base.saturating_add(crate::gc::GC_HEADER_SIZE) {
+            return None;
+        }
+        let gc_header =
+            (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        let gc_type = (*gc_header).obj_type;
+
+        // Map and Set have unambiguous dedicated GC types. Preserve the old
+        // helper contract (these native collection headers are not returned as
+        // generic GC pointers) without consulting their registries.
+        if matches!(gc_type, crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET) {
+            return None;
+        }
+        // RegExp shares GC_TYPE_OBJECT with ordinary objects, but every
+        // current RegExp carries a bounds-checked payload magic. Use that
+        // self-identifying header rather than falling through to REGEX_POINTERS.
+        if gc_type == crate::gc::GC_TYPE_OBJECT && crate::regex::regex_header_has_magic(ptr.cast())
+        {
+            return None;
+        }
+        // Fresh Symbols share GC_TYPE_STRING with strings. Arena membership
+        // makes the payload readable; the fixed-size symbol allocation plus
+        // its magic distinguishes it without the global SYMBOL_POINTERS lock.
+        if gc_type == crate::gc::GC_TYPE_STRING
+            && (*gc_header).size as usize
+                >= crate::gc::GC_HEADER_SIZE + std::mem::size_of::<crate::symbol::SymbolHeader>()
+        {
+            let symbol = ptr as *const crate::symbol::SymbolHeader;
+            if (*symbol).magic == crate::symbol::SYMBOL_MAGIC && (*symbol).registered <= 1 {
+                return None;
+            }
+        }
+        return Some((ptr, gc_type));
+    }
+
+    #[cfg(test)]
+    TEST_SIDE_REGISTRY_TOWER_ENTRIES.with(|count| count.set(count.get().wrapping_add(1)));
     if crate::buffer::is_any_array_buffer(addr) {
         return Some((ptr, crate::gc::GC_TYPE_BUFFER));
     }
@@ -924,6 +980,16 @@ unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> 
     }
     let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
     Some((ptr, (*gc_header).obj_type))
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_SIDE_REGISTRY_TOWER_ENTRIES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn test_side_registry_tower_entries() -> u64 {
+    TEST_SIDE_REGISTRY_TOWER_ENTRIES.with(std::cell::Cell::get)
 }
 
 #[inline]

--- a/crates/perry-runtime/src/object/native_call_method/gc_pointer_probe_tests.rs
+++ b/crates/perry-runtime/src/object/native_call_method/gc_pointer_probe_tests.rs
@@ -1,0 +1,105 @@
+use super::{gc_pointer_and_type_from_value, test_side_registry_tower_entries};
+
+#[test]
+fn arena_receiver_skips_side_registry_probe_tower() {
+    // Arm the expensive late probes. The ordinary object below is still fully
+    // described by its arena range and GcHeader, so none of these registries
+    // should be consulted to classify it.
+    let _map = crate::map::js_map_alloc(4);
+    let _set = crate::set::js_set_alloc(4);
+    let _symbol = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) };
+    let object = crate::object::js_object_alloc(0, 0);
+    let value = crate::value::js_nanbox_pointer(object as i64);
+
+    let before = test_side_registry_tower_entries();
+    let (actual, gc_type) = unsafe {
+        gc_pointer_and_type_from_value(value)
+            .expect("an ordinary arena object must resolve to its GC allocation")
+    };
+
+    assert_eq!(actual, object.cast());
+    assert_eq!(gc_type, crate::gc::GC_TYPE_OBJECT);
+    assert_eq!(
+        test_side_registry_tower_entries(),
+        before,
+        "arena metadata should bypass every address-keyed side-registry probe"
+    );
+}
+
+#[test]
+fn arena_native_kinds_keep_their_existing_classification() {
+    let buffer = crate::buffer::buffer_alloc(8);
+    let typed_array =
+        crate::typedarray::js_typed_array_new(crate::typedarray::KIND_UINT8 as i32, 8.0);
+    let map = crate::map::js_map_alloc(4);
+    let set = crate::set::js_set_alloc(4);
+    let symbol = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) };
+
+    let classify = |ptr: usize| unsafe {
+        gc_pointer_and_type_from_value(crate::value::js_nanbox_pointer(ptr as i64))
+    };
+    assert_eq!(
+        classify(buffer as usize).map(|(_, kind)| kind),
+        Some(crate::gc::GC_TYPE_BUFFER)
+    );
+    assert_eq!(
+        classify(typed_array as usize).map(|(_, kind)| kind),
+        Some(crate::gc::GC_TYPE_TYPED_ARRAY)
+    );
+    assert!(classify(map as usize).is_none());
+    assert!(classify(set as usize).is_none());
+    assert!(classify(symbol as usize).is_none());
+
+    // RegExp shares GC_TYPE_OBJECT with ordinary objects. Its resident magic,
+    // not the address registry, is the discriminator on the arena fast path.
+    let regexp = crate::arena::arena_alloc_gc(
+        std::mem::size_of::<crate::regex::RegExpHeader>(),
+        8,
+        crate::gc::GC_TYPE_OBJECT,
+    ) as *mut crate::regex::RegExpHeader;
+    unsafe {
+        std::ptr::write_bytes(
+            regexp.cast::<u8>(),
+            0,
+            std::mem::size_of::<crate::regex::RegExpHeader>(),
+        );
+        (*regexp).magic = crate::regex::REGEXP_MAGIC;
+    }
+    assert!(classify(regexp as usize).is_none());
+}
+
+#[test]
+fn headerless_values_still_use_the_side_registry_fallback() {
+    // Persistent Symbols (`Symbol.for` / well-known symbols) are Box-leaked,
+    // unlike fresh GC-managed Symbols. Build a fresh representative instead
+    // of using the process cache: the test harness resets SYMBOL_POINTERS
+    // between tests but deliberately does not reset that process-wide cache.
+    let symbol = Box::into_raw(Box::new(crate::symbol::SymbolHeader {
+        magic: crate::symbol::SYMBOL_MAGIC,
+        registered: 0,
+        description: std::ptr::null_mut(),
+        id: u64::MAX,
+    }));
+    crate::symbol::register_symbol_pointer(symbol as usize);
+    assert!(!crate::arena::pointer_in_nursery(symbol as usize));
+    assert!(!crate::arena::pointer_in_old_gen(symbol as usize));
+
+    let before = test_side_registry_tower_entries();
+    let actual =
+        unsafe { gc_pointer_and_type_from_value(crate::value::js_nanbox_pointer(symbol as i64)) };
+    assert!(actual.is_none());
+    assert_eq!(test_side_registry_tower_entries(), before + 1);
+
+    let shared = crate::shared_sab::alloc_shared_sab(8);
+    assert!(!crate::arena::pointer_in_nursery(shared as usize));
+    assert!(!crate::arena::pointer_in_old_gen(shared as usize));
+
+    let before = test_side_registry_tower_entries();
+    let actual =
+        unsafe { gc_pointer_and_type_from_value(crate::value::js_nanbox_pointer(shared as i64)) };
+    assert_eq!(
+        actual.map(|(_, kind)| kind),
+        Some(crate::gc::GC_TYPE_BUFFER)
+    );
+    assert_eq!(test_side_registry_tower_entries(), before + 1);
+}


### PR DESCRIPTION
Closes #7850.

## Problem

`gc_pointer_and_type_from_value` entered seven address-keyed kind probes before reading the `GcHeader` it ultimately needed. Once a program had created a Symbol, every ordinary dynamic method receiver therefore paid the process-global Symbol registry mutex and address hash.

## Fix

Use the arena range metadata to prove that current runtime-owned receivers carry a readable `GcHeader`, then classify them by GC type. Dedicated Map/Set types are rejected directly; the two shared types use their resident payload magic (RegExp/Object and fresh Symbol/String). The existing registry tower remains unchanged for outside-arena values, including boxed persistent Symbols and process-global SharedArrayBuffers.

## Tests

- Main-only regression reproduced first: an ordinary arena receiver entered the side-registry tower (`1 != 0`).
- Focused representation matrix: 3 passed (ordinary object, Buffer, typed array, Map, Set, RegExp, fresh Symbol, boxed Symbol, SharedArrayBuffer).
- `cargo test -p perry-runtime --lib`, single-threaded: all 2,120 functional tests passed; the unrelated wall-clock promise complexity guard is load-sensitive and reproduced on clean main during alternating fresh-process controls.
- `scripts/check_file_size.sh`: pass after rebasing onto v0.5.1471.

## Performance

Quiet-mini A/B is in progress; this PR remains draft until those results are posted.