### PR TITLE
fix(codegen): tag-guard String methods on Any receivers

### DIFF
--- a/changelog.d/7866-any-string-method-dispatch.md
+++ b/changelog.d/7866-any-string-method-dispatch.md
@@ -1,0 +1,1 @@
+Fixed String-named method calls on `any` values so user objects dispatch their own methods, while runtime-proven strings retain the direct String fast path.

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -730,6 +730,61 @@ pub fn try_lower_promise_static_call(
     Ok(None)
 }
 
+/// Emit the universal by-id method dispatcher for an already-evaluated and
+/// rooted receiver plus already-evaluated arguments.
+///
+/// Kept separate from the eligibility tower below so a tag-guarded String
+/// fast path can use the identical non-string arm without re-evaluating its
+/// receiver (#7673).
+pub(super) fn emit_native_method_str_dispatch(
+    ctx: &mut FnCtx<'_>,
+    property: &str,
+    call_byte_offset: u32,
+    recv_box: &str,
+    lowered_args: &[String],
+) -> String {
+    // Pass a tagged pointer to the immutable StringPool dispatch descriptor.
+    // A GC-backed string handle belongs to the main thread's arena and cannot
+    // be resolved safely by a `perry/thread` worker executing this closure.
+    let key_idx = ctx.strings.intern(property);
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
+    let method_id = crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
+    // The alloca MUST live in the entry block. An alloca in a loop body lowers
+    // to a runtime stack adjustment which is never restored (#167).
+    let (args_ptr, args_len_str) = if lowered_args.is_empty() {
+        ("null".to_string(), "0".to_string())
+    } else {
+        let n = lowered_args.len();
+        let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
+        let blk = ctx.block();
+        for (i, value) in lowered_args.iter().enumerate() {
+            let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &i.to_string())]);
+            blk.store(DOUBLE, value, &slot);
+        }
+        (buf_reg, n.to_string())
+    };
+    let site_id = emit_typed_feedback_register_site(
+        ctx,
+        TypedFeedbackKind::MethodCall,
+        property,
+        TypedFeedbackContract::method_call(),
+    );
+    // Arguments are already lowered, so a nested call can no longer shadow
+    // this call's source location.
+    crate::expr::calls::emit_call_location_at(ctx, call_byte_offset);
+    ctx.block().call(
+        DOUBLE,
+        "js_typed_feedback_native_call_method_by_id",
+        &[
+            (I64, &site_id),
+            (DOUBLE, recv_box),
+            (I64, &method_id),
+            (PTR, &args_ptr),
+            (I64, &args_len_str),
+        ],
+    )
+}
+
 pub fn try_lower_native_method_str_dispatch(
     ctx: &mut FnCtx<'_>,
     callee: &Expr,
@@ -970,53 +1025,12 @@ pub fn try_lower_native_method_str_dispatch(
             return with_operands_rooted(ctx, &operand_exprs, |ctx, rereads| {
                 let recv_box = rereads[0].clone();
                 let lowered_args: Vec<String> = rereads[1..].to_vec();
-                // Pass a tagged pointer to the immutable StringPool dispatch
-                // descriptor. A GC-backed string handle belongs to the main
-                // thread's arena and cannot be resolved safely by a
-                // `perry/thread` worker executing this compiled closure.
-                let key_idx = ctx.strings.intern(property);
-                let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
-                let method_id =
-                    crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
-                // Stack-allocate the args array if any. The alloca MUST live in
-                // the function entry block — emitting it into the current block
-                // (which may be a loop body) makes LLVM lower it as a runtime
-                // `sub %rsp, N` that never gets restored, eating the stack at
-                // ~16 bytes/iteration. See issue #167.
-                let (args_ptr, args_len_str) = if lowered_args.is_empty() {
-                    ("null".to_string(), "0".to_string())
-                } else {
-                    let n = lowered_args.len();
-                    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, n);
-                    let blk = ctx.block();
-                    for (i, v) in lowered_args.iter().enumerate() {
-                        let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
-                        blk.store(DOUBLE, v, &slot);
-                    }
-                    (buf_reg, n.to_string())
-                };
-                let site_id = emit_typed_feedback_register_site(
+                let result = emit_native_method_str_dispatch(
                     ctx,
-                    TypedFeedbackKind::MethodCall,
                     property,
-                    TypedFeedbackContract::method_call(),
-                );
-                // #5247: record the source location right before the dynamic
-                // dispatch so a thrown "X is not a function" TypeError carries
-                // `at <file>:<line>`. Args are already lowered above, so a nested
-                // call's location no longer shadows this one.
-                crate::expr::calls::emit_call_location_at(ctx, call_byte_offset);
-                let blk = ctx.block();
-                let result = blk.call(
-                    DOUBLE,
-                    "js_typed_feedback_native_call_method_by_id",
-                    &[
-                        (I64, &site_id),
-                        (DOUBLE, &recv_box),
-                        (I64, &method_id),
-                        (PTR, &args_ptr),
-                        (I64, &args_len_str),
-                    ],
+                    call_byte_offset,
+                    &recv_box,
+                    &lowered_args,
                 );
                 // The group is released AFTER the dispatch, not before: the
                 // dispatcher allocates while it reads these values. That is the

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -10,10 +10,14 @@
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::FnCtx;
+use crate::expr::{lower_expr, FnCtx};
 use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
-use crate::type_analysis::{is_array_expr, is_native_module_dynamic_index, is_string_expr};
+use crate::lower_string_method::{
+    is_known_string_method_name, lower_string_method, lower_string_method_from_proven_box,
+};
+use crate::rooting::{any_operand_may_collect, open_rooted_group, Repr};
+use crate::type_analysis::{is_array_expr, is_string_expr, receiver_class_name};
+use crate::types::{DOUBLE, I1, I64};
 
 mod dynamic_dispatch;
 mod fetch_chain;
@@ -28,9 +32,87 @@ mod static_dispatch;
 // original unqualified names.
 pub(crate) use helpers::{
     class_chain_has_field_named, is_array_only_method_name, is_date_receiver,
-    is_inherited_object_prototype_method, receiver_class_defines_method,
-    resolve_static_dispatch_cls, string_only_method_arity_ok,
+    is_inherited_object_prototype_method, resolve_static_dispatch_cls, string_only_method_arity_ok,
 };
+
+/// Preserve the old String-method fast path for an unproven receiver without
+/// using a method name as its type proof (#7673).
+///
+/// The receiver is evaluated once, then a pure NaN-box tag check selects the
+/// direct String lowering or the universal runtime method dispatcher. Known
+/// classes skip this guard and retain the class-dispatch tower below.
+fn try_lower_tag_guarded_string_method(
+    ctx: &mut FnCtx<'_>,
+    object: &Expr,
+    property: &str,
+    args: &[Expr],
+    call_byte_offset: u32,
+) -> Result<Option<String>> {
+    if !is_known_string_method_name(property)
+        || !string_only_method_arity_ok(property, args.len())
+        || is_string_expr(ctx, object)
+        || receiver_class_name(ctx, object).is_some()
+        || matches!(object, Expr::GlobalGet(_) | Expr::NativeModuleRef(_))
+    {
+        return Ok(None);
+    }
+
+    let recv_box = lower_expr(ctx, object)?;
+    let bits = ctx.block().bitcast_double_to_i64(&recv_box);
+    let tag = ctx.block().lshr(I64, &bits, "48");
+    let is_heap_string = ctx
+        .block()
+        .icmp_eq(I64, &tag, crate::nanbox::STRING_TAG_TOP16_I64);
+    let is_short_string = ctx
+        .block()
+        .icmp_eq(I64, &tag, crate::nanbox::SHORT_STRING_TAG_TOP16_I64);
+    let is_string = ctx.block().or(I1, &is_heap_string, &is_short_string);
+
+    let string_idx = ctx.new_block("anystr.string");
+    let generic_idx = ctx.new_block("anystr.generic");
+    let merge_idx = ctx.new_block("anystr.merge");
+    let string_label = ctx.block_label(string_idx);
+    let generic_label = ctx.block_label(generic_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    ctx.block()
+        .cond_br(&is_string, &string_label, &generic_label);
+
+    ctx.current_block = string_idx;
+    let string_value =
+        lower_string_method_from_proven_box(ctx, object, property, args, recv_box.clone())?;
+    let string_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = generic_idx;
+    let mut group = open_rooted_group(args.len() + 1);
+    let recv_collects = any_operand_may_collect(ctx, args.iter());
+    let rooted_recv = group.adopt_emitted(ctx, Repr::Boxed, &recv_box, recv_collects);
+    for (i, arg) in args.iter().enumerate() {
+        let collects = any_operand_may_collect(ctx, args[i + 1..].iter());
+        group.lower(ctx, arg, collects)?;
+    }
+    let generic_recv = group.reread_emitted(ctx, rooted_recv);
+    let generic_args = group.reread_all(ctx)?;
+    let generic_value = super::console_promise::emit_native_method_str_dispatch(
+        ctx,
+        property,
+        call_byte_offset,
+        &generic_recv,
+        &generic_args,
+    );
+    group.release(ctx);
+    let generic_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    Ok(Some(ctx.block().phi(
+        DOUBLE,
+        &[
+            (string_value.as_str(), string_end.as_str()),
+            (generic_value.as_str(), generic_end.as_str()),
+        ],
+    )))
+}
 
 /// Try to lower a `Call { callee: PropertyGet { .. } }` via the
 /// string/array/class/Map/Set/Promise/fetch/static/instance dispatch tower.
@@ -74,144 +156,11 @@ pub fn try_lower_property_get_method_call(
     {
         return Ok(Some(lower_string_method(ctx, object, property, args)?));
     }
-    // String method fallback for Any-typed receivers: when the method
-    // name is a well-known string method that has no array/object
-    // equivalent, route through the string dispatcher. This handles
-    // the common pattern where a cross-module function returns a string
-    // but the local is typed as Any (e.g., `readFileSync(path).split('\n')`).
-    // Without this, .split/.charCodeAt/.charAt/etc. on Any-typed strings
-    // fall through to js_native_call_method which returns [object Object].
-    {
-        // Only include methods that are EXCLUSIVELY string methods
-        // (no array/map/set equivalent). Exclude: slice, indexOf,
-        // lastIndexOf, includes, at, concat — these also exist on
-        // arrays and would break when the receiver is an Any-typed
-        // array. startsWith/endsWith are string-only in JS so the
-        // 2-arg form (searchString, position) is also unambiguous.
-        let is_string_only_method = match property.as_str() {
-            "split" | "charCodeAt" | "charAt" | "trim" | "trimStart" | "trimEnd" | "substring"
-            | "substr" | "toLowerCase" | "toUpperCase" | "toLocaleLowerCase"
-            | "toLocaleUpperCase" | "replaceAll" | "padStart" | "padEnd" | "repeat"
-            | "codePointAt" | "localeCompare" => true,
-            // Annex B §B.2.2 HTML wrappers (`bold`, `link`, `anchor`, …) are
-            // string-only in the spec but collide with common user method
-            // names — chalk's `chalk.bold(s)` is a styled-string builder
-            // (#5039). Forcing the string path here coerced the chalk closure
-            // to its source text and wrapped it in `<b>…</b>`. An Any-typed
-            // receiver that really is a string still gets them via the
-            // `jsval.is_string()` arm of `js_native_call_method`.
-            // (`normalize` is intentionally NOT in this unconditional list — the
-            // arg-gated `"normalize" if args.len() <= 1` arm below handles it so
-            // user 2-arg `normalize(pathname, matched)` methods fall through.)
-            // Issue #638: `replace` is also string-exclusive, but routing
-            // it here unconditionally caused regressions in async dispatch
-            // pathways. Only fire when args[1] is statically detectable as
-            // a closure literal — that's the failing case (replace
-            // callback got coerced to "[object Object]" via the runtime
-            // fallback path because the string-method dispatch never
-            // saw it). When args[1] is a string, the existing
-            // js_native_call_method fallback handles it correctly via
-            // js_string_replace_string.
-            "replace" if args.len() == 2 && matches!(&args[1], Expr::Closure { .. }) => true,
-            // `slice` exists on strings, arrays, buffers, and Blob-like
-            // objects. Let the runtime dispatcher choose by receiver shape;
-            // forcing the string path here turns Blob slices into string
-            // slices for Any-typed native-module results.
-            "slice" => false,
-            // `indexOf` / `includes` are NOT string-forced here: an
-            // Any-typed receiver may be a runtime array (e.g. a native
-            // module property like `PerformanceObserver.supportedEntryTypes`),
-            // and forcing the string path made `arr.includes(x)` always
-            // return false (string-includes on a non-string). Falling
-            // through routes both to `js_native_call_method`, which
-            // dispatches on the runtime type and handles string + array
-            // (with content-aware element comparison). Refs #1341.
-            // startsWith / endsWith are NOT string-forced here: an Any-typed
-            // receiver may be a user/library object with its OWN same-named
-            // method that returns something other than the String builtin's
-            // boolean — e.g. Zod's `z.string().startsWith("./")` returns a
-            // refined ZodString schema, not a boolean. Forcing the static
-            // string path made `.startsWith()`/`.endsWith()` return a boolean,
-            // so a chained `.describe()`/`.optional()` threw
-            // `(boolean).describe is not a function` (broke the bundled-CLI TUI
-            // schema init). Falling through routes to `js_native_call_method`,
-            // which dispatches on the runtime type and still services a genuine
-            // Any-typed string receiver via its `jsval.is_string()` arm (the
-            // runtime grew full string-method arms in #421/#514). Refs #1341
-            // (the same fix already applied to indexOf/includes above).
-            // `normalize` is NOT force-routed to the string path for Any-typed
-            // receivers at any arity. User classes commonly define a 1-arg
-            // `normalize(pathname)` method (Next.js route normalizers:
-            // `this.normalize(matchedPath)`, `normalizer.normalize(initPathname)`)
-            // — forcing the string path made the pathname argument the Unicode
-            // `form`, throwing `RangeError: The normalization form should be one
-            // of NFC, NFD, NFKC, NFKD` (Next.js wall 50). A receiver that really
-            // is a string still gets `String.prototype.normalize` two ways: the
-            // statically-typed-string fast path above (`is_string_expr`), and the
-            // `jsval.is_string()` arm of `js_native_call_method` for Any-typed
-            // strings. So nothing is lost by falling through here.
-            // `lastIndexOf` (number-returning) shares the startsWith/endsWith
-            // hazard above — an Any-typed object's own `lastIndexOf` would be
-            // clobbered by the String builtin. Fall through to the runtime,
-            // which services a genuine string receiver via `jsval.is_string()`.
-            _ => false,
-        };
-        // Don't route buffer/Uint8Array methods through the string path —
-        // buffers have a different header layout and their indexOf/includes
-        // go through dispatch_buffer_method via js_native_call_method.
-        let is_buffer = matches!(
-            crate::type_analysis::static_type_of(ctx, object),
-            Some(perry_hir::types::Type::Named(ref n)) if n == "Uint8Array" || n == "Buffer"
-        );
-        // #1760: a dynamic native-module sub-namespace receiver
-        // (`(path as any)[k]` → `path.win32`) is NOT a string, even though a
-        // method like `normalize` collides with a String.prototype name.
-        // Falling through here routes it to the generic `js_native_call_method`
-        // dispatch (→ `dispatch_native_module_method`); forcing the string path
-        // hands the namespace pointer to a string FFI and SIGSEGVs.
-        // #5271: a builtin-named method on a receiver that is NOT provably a
-        // string (object literal, `any`, unknown) may be a USER method that
-        // merely shares the name — joi's `internals.trim(value, schema)`, or
-        // any `{ trim() {…} }.trim()`. Forcing the static String path there
-        // hands the object pointer to a string FFI: it either aborts codegen
-        // on the String arity guard (`String.trim takes no args, got 2`) or
-        // bit-casts the object as a string and returns "[object Object]".
-        //
-        // Take the static String fast path only when:
-        //   * the receiver is NOT a known object-literal local — `o.trim()`
-        //     on `const o = { trim() {…} }` is the object's OWN method, never
-        //     `String.prototype.trim`, even when the arity matches; AND
-        //   * the arg count is plausible for the String builtin — when it is
-        //     NOT (joi's `internals.trim(value, schema)`: 2 args to a 0-arg
-        //     builtin), the call is a user method sharing the name.
-        // Otherwise fall through to `js_native_call_method`, which resolves
-        // the receiver's own member at runtime and still services a genuine
-        // (Any-typed) string receiver via its `jsval.is_string()` arm — so
-        // the earlier "[object Object]" hazard the comment above warns about
-        // no longer applies (the runtime grew full string-method arms in
-        // #421/#514). See #5271.
-        let receiver_is_object_literal = matches!(
-            &**object,
-            Expr::LocalGet(id) if ctx.object_literal_locals.contains(id)
-        ) || matches!(&**object, Expr::Object(_));
-        if is_string_only_method
-            && string_only_method_arity_ok(property, args.len())
-            && !receiver_is_object_literal
-            // A receiver whose statically-known class defines its OWN method of
-            // this name is calling THAT method, never the String builtin — even
-            // when the arity matches. Critical for the char-access methods
-            // (`charAt`/`charCodeAt`/`codePointAt`), whose arity gate above is a
-            // no-op (any arg count is spec-valid), so a user `charAt(n)` helper
-            // (e.g. the `yaml` package's `Lexer`) would otherwise be coerced to
-            // `String.prototype.charAt` on a `"[object Object]"` receiver.
-            && !receiver_class_defines_method(ctx, object, property)
-            && !is_array_expr(ctx, object)
-            && !is_buffer
-            && !is_native_module_dynamic_index(object)
-        {
-            return Ok(Some(lower_string_method(ctx, object, property, args)?));
-        }
-    }
+    // #7673: a String-builtin method NAME is not proof that its receiver is a
+    // string. An Any-typed call result may be a library object with an own
+    // `trim`/`split`/`charAt` method (Zod schemas are the reported case).
+    // Keep the static fast path positive-proof-only; the runtime dispatcher
+    // below handles both genuine Any-typed strings and user methods.
     if is_array_expr(ctx, object) && !is_inherited_object_prototype_method(property) {
         return Ok(Some(lower_array_method(ctx, object, property, args)?));
     }
@@ -240,6 +189,12 @@ pub fn try_lower_property_get_method_call(
     // Issue #687 — ClassRef receiver static-method dispatch.
     if let Some(value) =
         static_dispatch::try_lower_static_dispatch(ctx, callee, object, property, args)?
+    {
+        return Ok(Some(value));
+    }
+
+    if let Some(value) =
+        try_lower_tag_guarded_string_method(ctx, object, property, args, call_byte_offset)?
     {
         return Ok(Some(value));
     }

--- a/crates/perry-codegen/src/lower_call/property_get/helpers.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/helpers.rs
@@ -28,93 +28,22 @@ pub(crate) fn is_array_only_method_name(name: &str) -> bool {
     )
 }
 
-/// For the Any-typed-receiver string-method fallback only: is `argc` a
-/// plausible argument count for the String.prototype builtin named
-/// `name`? When a builtin-named method is invoked on a receiver that is
-/// NOT provably a string (object literal, `any`, unknown) AND the arg
-/// count can't match the String builtin's signature, the call is almost
-/// certainly a user method that merely shares a name with a String
-/// builtin — e.g. joi's `internals.trim(value, schema)` (#5271). Forcing
-/// the String path there used to abort codegen with
-/// "String.trim takes no args, got 2"; gating on arity here lets such
-/// calls fall through to the runtime method dispatcher instead.
-///
-/// The accepted ranges mirror `lower_string_method`'s per-arm arity
-/// guards. Char-access methods (`charAt`/`charCodeAt`/`codePointAt`)
-/// ignore surplus args per spec, so any count is fine for them.
+/// Whether an unproven receiver's argument count can use the selected static
+/// String lowering. Invalid counts must bypass the tag diamond because its
+/// String arm is emitted eagerly and may reject them before runtime dispatch.
 pub(crate) fn string_only_method_arity_ok(name: &str, argc: usize) -> bool {
     match name {
-        // No-arg string transforms.
         "trim" | "trimStart" | "trimEnd" | "toLowerCase" | "toUpperCase" => argc == 0,
-        // Locale-aware case folding: optional `locales`.
         "toLocaleLowerCase" | "toLocaleUpperCase" => argc <= 1,
-        // split(separator?, limit?).
-        "split" => argc <= 2,
-        // substring(start?, end?).
-        "substring" => argc <= 2,
-        // substr(start, length?) — start is required.
-        "substr" => argc == 1 || argc == 2,
-        // replaceAll(search, replace).
+        "split" | "substring" => argc <= 2,
+        "substr" | "padStart" | "padEnd" => argc == 1 || argc == 2,
         "replaceAll" => argc == 2,
-        // padStart/padEnd(targetLength, padString?).
-        "padStart" | "padEnd" => argc == 1 || argc == 2,
-        // repeat(count).
         "repeat" => argc == 1,
-        // localeCompare(that, locales?, options?).
         "localeCompare" => argc <= 3,
-        // Char-access ignores extra args (still evaluated for side effects).
+        // These lowerers intentionally evaluate and ignore surplus args.
         "charAt" | "charCodeAt" | "codePointAt" => true,
-        // Conservative default: methods reaching this gate but not listed
-        // here keep their prior (already arity-checked) routing.
         _ => true,
     }
-}
-
-/// True when `object`'s statically-known class (or an ancestor) defines its
-/// OWN instance method, getter, or field named `name`. Keeps the static
-/// String-method fast path from hijacking a user class member that merely
-/// shares a `String.prototype` name. This matters most for the char-access methods
-/// (`charAt`/`charCodeAt`/`codePointAt`): their arity gate can never
-/// disambiguate a user method from the builtin (any arg count is spec-valid,
-/// so `string_only_method_arity_ok` always returns `true`), so without this a
-/// `this.charAt(0)` on a class instance is lowered to `String.prototype.charAt`
-/// with the receiver coerced to `"[object Object]"` (yielding `"["`, `"o"`, …).
-/// The `yaml` package's `Lexer.charAt(n)` is exactly this shape — the tokenizer
-/// then reads garbage, and its `*lex` state machine never advances `pos`,
-/// spinning forever. A genuine string receiver is unaffected: it has no known
-/// class, so this returns `false` and the string path (or the runtime
-/// `jsval.is_string()` arm of `js_native_call_method`) still applies.
-pub(crate) fn receiver_class_defines_method(ctx: &FnCtx<'_>, object: &Expr, name: &str) -> bool {
-    let Some(mut class_name) = receiver_class_name(ctx, object) else {
-        return false;
-    };
-    // Bounded walk up the inheritance chain (defensive against a cyclic
-    // `extends_name` in malformed input).
-    for _ in 0..64 {
-        let Some(class) = ctx.classes.get(&class_name) else {
-            return false;
-        };
-        if class.methods.iter().any(|m| m.name == name)
-            || class.getters.iter().any(|(g, _)| g == name)
-            // An instance FIELD of that name shadows the builtin too: its
-            // init can be a function value (`charAt = (n) => …`), and even a
-            // non-function field makes `obj.charAt(0)` a runtime "not a
-            // function" TypeError — never the String builtin. A computed key
-            // (`key_expr`) could evaluate to `name`, so treat it as defining
-            // the member (same conservatism as `class_chain_has_field_named`).
-            || class
-                .fields
-                .iter()
-                .any(|f| f.key_expr.is_some() || (!f.is_private && f.name == name))
-        {
-            return true;
-        }
-        match &class.extends_name {
-            Some(parent) => class_name = parent.clone(),
-            None => return false,
-        }
-    }
-    false
 }
 
 pub(crate) fn is_date_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -126,40 +126,32 @@ pub(crate) fn lower_string_method(
     }
 
     let recv_box = lower_expr(ctx, object)?;
-    // Optimistic any-typed path: `property_get` routes `(x: any).charAt(i)` /
-    // `.split(…)` here even when `x` is not statically a string, because most
-    // such receivers ARE strings (e.g. `readFileSync(p).split('\n')`). But a
-    // boxed/object receiver — `new Boolean().charAt = String.prototype.charAt;
-    // …charAt(i)`, a `{ toString }` object — must have `ToString(this)` applied
-    // (ECMA-262 §22.1.3) before the inline string helpers run, or they would
-    // bit-cast the object pointer as a string and read garbage. A statically
-    // string-typed receiver skips this (fast path, no coercion).
-    let recv_box = if is_string_expr(ctx, object) {
-        recv_box
-    } else {
-        // A nullish receiver must throw the V8 member-access TypeError —
-        // `undefined.charAt(0)` reads `charAt` off `undefined` FIRST (ECMA-262
-        // §13.3), so it throws `Cannot read properties of undefined (reading
-        // 'charAt')` — NOT coerce `undefined`→`"undefined"` like the general
-        // `js_string_coerce`. The guarded helper does RequireObjectCoercible +
-        // ToString; pass the method name for the diagnostic.
-        let prop_idx = ctx.strings.intern(property);
-        let (prop_global, prop_len) = {
-            let entry = ctx.strings.entry(prop_idx);
-            (
-                format!("@{}", entry.bytes_global),
-                entry.byte_len.to_string(),
-            )
-        };
-        let blk = ctx.block();
-        let coerced = blk.call(
-            I64,
-            "js_string_coerce_method_this",
-            &[(DOUBLE, &recv_box), (PTR, &prop_global), (I64, &prop_len)],
-        );
-        nanbox_string_inline(blk, &coerced)
-    };
+    lower_string_method_from_box(ctx, object, property, args, recv_box)
+}
 
+/// Lower a string method after a runtime tag guard has proved that the
+/// already-evaluated receiver is a heap or short string.
+///
+/// Keeping the receiver as an SSA value is load-bearing: the non-string arm of
+/// the guard must dispatch the exact same value, rather than evaluate a
+/// side-effecting receiver expression a second time.
+pub(crate) fn lower_string_method_from_proven_box(
+    ctx: &mut FnCtx<'_>,
+    object: &Expr,
+    property: &str,
+    args: &[Expr],
+    recv_box: String,
+) -> Result<String> {
+    lower_string_method_from_box(ctx, object, property, args, recv_box)
+}
+
+fn lower_string_method_from_box(
+    ctx: &mut FnCtx<'_>,
+    object: &Expr,
+    property: &str,
+    args: &[Expr],
+    recv_box: String,
+) -> Result<String> {
     // #6971: the receiver is lowered BEFORE the arguments, and an argument's
     // lowering can collect — `fresh(k).concat("|" + churn(N))` dropped the
     // receiver, whose unboxed form is a BARE string address that only the

--- a/crates/perry-codegen/tests/argless_builtin_extra_args.rs
+++ b/crates/perry-codegen/tests/argless_builtin_extra_args.rs
@@ -5,6 +5,7 @@
 //! returns the trimmed string), so codegen must lower these without erroring.
 
 use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::types::Type;
 use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
 
 fn empty_opts() -> CompileOptions {
@@ -118,6 +119,110 @@ fn string_trim_with_extra_arg_compiles() {
     assert!(
         ir.contains("js_string_trim"),
         "expected trim lowering to emit js_string_trim"
+    );
+}
+
+/// #7673: `make(): any` may return a Zod schema (or any user object) whose own
+/// `trim` method returns that object. A builtin-shaped NAME needs a runtime
+/// string-tag proof before it can select the static String lowering.
+#[test]
+fn any_call_result_trim_emits_string_tag_dispatch() {
+    let receiver = Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: "make".to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }),
+        args: Vec::new(),
+        type_args: Vec::new(),
+        byte_offset: 0,
+    };
+    let stmt = Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
+            object: Box::new(receiver),
+            property: "trim".to_string(),
+        }),
+        args: Vec::new(),
+        type_args: Vec::new(),
+        byte_offset: 0,
+    });
+    let mut opts = empty_opts();
+    opts.import_function_prefixes
+        .insert("make".to_string(), "schema_ts".to_string());
+    let ir = String::from_utf8(
+        compile_module(&module_with_init(vec![stmt]), opts)
+            .expect("an Any-receiver trim call must compile through runtime dispatch"),
+    )
+    .unwrap();
+
+    assert!(
+        ir.contains("call double @js_typed_feedback_native_call_method_by_id"),
+        "the non-string arm must use runtime method dispatch:\n{ir}"
+    );
+    assert!(
+        ir.contains("lshr i64")
+            && ir.contains("32767")
+            && ir.contains("32761")
+            && ir.contains("call i64 @js_string_trim"),
+        "the string arm must be guarded by heap and short-string tags:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call i64 @js_string_coerce_method_this"),
+        "a tag-proven string must not be coerced again:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("= call double @perry_fn_schema_ts__make(")
+            .count(),
+        2,
+        "the receiver must be evaluated once in the init body (plus the generated extern wrapper):\n{ir}"
+    );
+}
+
+/// An invalid static String arity must not make an Any receiver fail codegen:
+/// the value may be a user object whose colliding method accepts that arity.
+#[test]
+fn any_call_result_invalid_string_arity_uses_generic_dispatch() {
+    let receiver = Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: "make".to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }),
+        args: Vec::new(),
+        type_args: Vec::new(),
+        byte_offset: 0,
+    };
+    let stmt = Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
+            object: Box::new(receiver),
+            property: "split".to_string(),
+        }),
+        args: vec![
+            Expr::String(",".to_string()),
+            Expr::Number(2.0),
+            Expr::Number(3.0),
+        ],
+        type_args: Vec::new(),
+        byte_offset: 0,
+    });
+    let mut opts = empty_opts();
+    opts.import_function_prefixes
+        .insert("make".to_string(), "factory_ts".to_string());
+    let ir = String::from_utf8(
+        compile_module(&module_with_init(vec![stmt]), opts)
+            .expect("an invalid String arity on an Any receiver must use generic dispatch"),
+    )
+    .unwrap();
+
+    assert!(
+        ir.contains("call double @js_typed_feedback_native_call_method_by_id"),
+        "the call must use generic runtime method dispatch:\n{ir}"
+    );
+    assert!(
+        !ir.contains("anystr.string") && !ir.contains("call i64 @js_string_split"),
+        "an unsupported static String arity must bypass the tag diamond:\n{ir}"
     );
 }
 

--- a/test-files/test_gap_7673_any_string_method_collision.ts
+++ b/test-files/test_gap_7673_any_string_method_collision.ts
@@ -1,0 +1,53 @@
+class Schema {
+  trim(): Schema {
+    return this;
+  }
+
+  split(_separator: string): Schema {
+    return this;
+  }
+
+  min(_n: number): Schema {
+    return this;
+  }
+}
+
+function makeSchema(): any {
+  return new Schema();
+}
+
+console.log("schema trim type:", typeof makeSchema().trim());
+console.log("schema trim member:", typeof makeSchema().trim().min);
+console.log("schema trim call:", makeSchema().trim().min(1) instanceof Schema);
+console.log("schema split type:", typeof makeSchema().split(","));
+
+function makeString(): any {
+  // Keep the runtime value a string while preventing local literal inference
+  // from turning this `any` fallback witness back into a proven string.
+  return JSON.parse(JSON.stringify("  Ab|Cd  "));
+}
+
+const value: any = makeString();
+console.log("trim:", value.trim());
+console.log("trimStart:", JSON.stringify(value.trimStart()));
+console.log("trimEnd:", JSON.stringify(value.trimEnd()));
+console.log("split:", value.split("|").join(","));
+console.log("charAt:", value.charAt(2));
+console.log("charCodeAt:", value.charCodeAt(2));
+console.log("codePointAt:", value.codePointAt(2));
+console.log("substring:", value.substring(2, 4));
+console.log("substr:", value.substr(2, 2));
+console.log("lower:", value.toLowerCase());
+console.log("upper:", value.toUpperCase());
+console.log("locale lower:", value.toLocaleLowerCase("en-US"));
+console.log("locale upper:", value.toLocaleUpperCase("en-US"));
+console.log("replaceAll:", value.replaceAll(" ", "_"));
+console.log("padStart:", value.trim().padStart(7, "."));
+console.log("padEnd:", value.trim().padEnd(7, "."));
+console.log("repeat:", value.trim().repeat(2));
+console.log("localeCompare:", Math.sign(value.trim().localeCompare("Ab|Ce")));
+console.log(
+  "replace callback:",
+  value.replace("Ab", (match: string) => match.toLowerCase()),
+);
+console.log("inline Any string:", makeString().trim());


### PR DESCRIPTION
## Summary

- evaluate an unproven method receiver once and test its heap-string/SSO NaN-box tag
- keep tag-proven strings on direct String lowering while routing objects with colliding names through universal method dispatch
- remove the method-name/arity and class-blocklist heuristics that mis-lowered `z.string().trim()`
- preserve the existing statically proven String, Array, built-in, and known-class dispatch paths

## Reproduction

The regression program covers a schema-like object whose `trim`, `split`, and `min` methods return the object, plus 18 String methods on an opaque `any` string. The fixed binary matches Node byte-for-byte across all 22 output rows.

## Performance

Measured on the locked M1 mini with both compilers linked against the same unchanged baseline runtime. The benchmark runs 30,000,000 `charCodeAt` calls on a string hidden behind `JSON.parse(process.argv[2])`; 30 alternating runs after two warmups per binary:

| case | baseline wall | fixed wall | delta |
| --- | ---: | ---: | ---: |
| Any receiver | 0.210294s | 0.149391s | -29.0% |
| typed control | 0.031693s | 0.031518s | -0.6% |

User-time deltas were -29.2% and -0.1%, respectively. The improvement comes from proving the runtime tag once and skipping the old per-call coercion.

## Tests

- `cargo test -p perry-codegen --lib` (889 passed)
- `cargo test -p perry-codegen --test argless_builtin_extra_args` (3 passed)
- `python3 scripts/check_test_registration.py`
- `bash scripts/check_file_size.sh`
- functional output comparison against Node

Closes #7673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected method dispatch for String-named calls on `any` values.
  * User-defined methods now take precedence on objects, while actual strings retain optimized String behavior.
  * Improved handling of runtime strings, callbacks, chained methods, and extra arguments.

* **Tests**
  * Added regression coverage for method-name collisions and runtime type-based dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->