### PR TITLE
perf(gc): pace the full mark-sweep on what a collection failed to reclaim, not on allocation volume (tree 1.167 -> 0.595, tree_wide 1.647 -> 1.075)

### DIFF
--- a/changelog.d/7869-gc-pacing-escalation-reading.md
+++ b/changelog.d/7869-gc-pacing-escalation-reading.md
@@ -1,0 +1,51 @@
+### Fixed: arena-growth pacing escalated on allocation volume, not on unreclaimed bytes
+
+`gc-handoff/bench/tree.ts` and `tree_wide.ts` — the two slowest programs in the GC
+benchmark corpus — spent **more than half their runtime in full mark-sweeps**, and the
+copying minor that would have reclaimed the same bytes was never attempted. All 40 of
+each program's collections were fulls (`PERRY_GC_TRACE=1`:
+`{'full': 40}`, `copying_nursery.eligible: false`, `fallback_reason: "not_attempted"`).
+
+**Root cause.** `arena_growth_full_escalation_due` escalates a minor to a full once the
+arena reading passes `max(PERRY_GC_MAJOR_PACING_FLOOR_MB, K × baseline)`. The baseline
+(`GC_LAST_FULL_ARENA_IN_USE_BYTES`) is measured *after* a full, so it is LIVE bytes; the
+reading was `arena_in_use_bytes()` sampled when the trigger fires, which is ALLOCATED
+bytes — the entire un-collected nursery, nearly all of it garbage a minor is about to
+reclaim for free. The two sides of the comparison were different kinds of quantity.
+`tree`'s nursery high-water is 37.7 MB against the 32 MB floor, so every cycle escalated,
+and the escalation perpetuated itself: `note_copying_minor_young_survival` is the only
+thing that can widen the band, and it runs only when a copying minor runs.
+
+**Fix.** The escalation now tests the arena occupancy recorded at the **end of the last
+collection** — the same kind of quantity as its baseline, and precisely what the
+escalation exists to detect: bytes a collection could not reclaim. Array-growth
+forwarding stubs, the hazard the escalation was written for, pin their blocks through a
+non-moving minor and so remain in that reading and still escalate; nursery garbage does
+not. Recorded once per cycle in `GcCycle::publish_reclaim_outcome`, the one site both
+collection kinds pass through.
+
+**Measured** (absolute seconds, quiet M1 mini, best-of-5, exit-checked, window verified
+quiet at both ends; 22 programs byte-identical to `node --experimental-strip-types` and
+exit 0 on both arms before timing):
+
+| bench | main | after | delta | node |
+|---|--:|--:|--:|--:|
+| `tree` | 1.1671 | **0.5947** | **−49.0%** | 0.450 |
+| `tree_wide` | 1.6468 | **1.0747** | **−34.7%** | 0.896 |
+| every other of the 22 | | | within ±0.7% | |
+
+`ns` per GC-managed allocation on `tree`: **55.65 → 28.36**. `churn_alloc` (12.03 → 12.02)
+and `retain` (89.17 → 89.37) are unchanged *by construction* — identical cycle counts,
+identical collection kinds, and identical `promoted_objects + copied_objects`
+(47,707 and 2,358,760) on both arms.
+
+**Peak RSS falls**: `tree` 57.0 → 45.0 MB (−21.0%), `tree_wide` 82.1 → 70.3 MB (−14.4%),
+every other program within ±0.2%. A full mark-sweep's non-moving reclaim leaves the arena
+fragmented; the copying minor returns whole blocks.
+
+The GC trace now emits `major_pacing.escalation_reading_bytes` — the left-hand side of the
+comparison, previously invisible, which is how a post-full live baseline could be tested
+against a pre-collection allocated reading with nothing in the trace saying so. The new
+unit test asserts **both** directions: an arena the last collection emptied must not
+escalate, and an arena still at the floor after a collection must still escalate — only
+the pair distinguishes this from switching the escalation off.

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1898,6 +1898,10 @@ impl GcCycleState {
         if self.minor.is_none() {
             finish_full_old_reclaim_baseline();
         }
+        // #7865: arena-growth pacing tests a POST-collection occupancy, which
+        // is the same kind of quantity as its post-full baseline. Recorded here
+        // rather than per-kind because this is the one site both kinds reach.
+        super::policy::note_collection_finished_arena_occupancy();
 
         let malloc_swept = self
             .minor

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -890,6 +890,30 @@ thread_local! {
     /// Paired with `GC_LAST_FULL_ARENA_IN_USE_BYTES` to price what that full
     /// actually reclaimed — see `GC_MAJOR_PACING_BACKOFF_SHIFT`.
     pub(super) static GC_FULL_CYCLE_PRE_IN_USE_BYTES: Cell<usize> = const { Cell::new(0) };
+    /// Total arena in-use bytes measured at the END of the most recent
+    /// collection of ANY kind — the reading arena-growth pacing tests against
+    /// its boundary (#7865).
+    ///
+    /// The pacing baseline (`GC_LAST_FULL_ARENA_IN_USE_BYTES`) is a *post*-full
+    /// reading, i.e. LIVE bytes. Testing it against `arena_in_use_bytes()` at
+    /// the moment a trigger fires compared it against *allocated* bytes — the
+    /// entire un-collected nursery, most of which is garbage a minor is about
+    /// to reclaim for free. On `gc-handoff/bench/tree.ts` that reading is
+    /// 37.7 MB against a 32 MB floor on **every** cycle, so all 40 collections
+    /// escalated to a whole-heap mark-sweep and the copying minor was never
+    /// even attempted (`copying_nursery.eligible: false`,
+    /// `fallback_reason: "not_attempted"`). The escalation then perpetuates
+    /// itself: `note_copying_minor_young_survival` is the only thing that can
+    /// widen the band, and it only runs when a copying minor runs.
+    ///
+    /// A post-collection reading is the same *kind* of quantity as the
+    /// baseline, and it says exactly what the escalation exists to detect:
+    /// **bytes the last minor could not reclaim.** Array-growth forwarding
+    /// stubs — the hazard `arena_growth_full_escalation_due` was written for —
+    /// pin their blocks through a non-moving minor, so they are still in this
+    /// reading and still escalate. Nursery garbage is not.
+    pub(super) static GC_LAST_COLLECTION_POST_IN_USE_BYTES: Cell<usize> =
+        const { Cell::new(0) };
     /// Yield-adaptive backoff for major-GC pacing (#7726).
     ///
     /// `arena_growth_full_escalation_due` escalates a minor to a full once the
@@ -1718,6 +1742,34 @@ fn pacing_arena_in_use_bytes() -> usize {
     crate::arena::arena_in_use_bytes()
 }
 
+/// Record the post-collection arena occupancy arena-growth pacing tests
+/// against. Called once at the end of every cycle, minor and full alike, from
+/// `GcCycle::publish_reclaim_outcome` — the single site both kinds pass
+/// through, so a future collection kind cannot forget it.
+pub(super) fn note_collection_finished_arena_occupancy() {
+    let bytes = pacing_arena_in_use_bytes();
+    GC_LAST_COLLECTION_POST_IN_USE_BYTES.with(|cell| cell.set(bytes));
+}
+
+/// The arena reading [`arena_growth_full_escalation_due`] tests — see
+/// [`GC_LAST_COLLECTION_POST_IN_USE_BYTES`].
+///
+/// Zero before any collection has finished, so the very first collection of a
+/// process is never escalated: there is no evidence yet that a minor would
+/// fail to reclaim, and the whole point of the pacing is to fire on that
+/// evidence rather than on allocation volume.
+///
+/// Keeps the `#[cfg(test)]` seam in front, so the existing positive-direction
+/// tests that force a `true` verdict out of the real predicate keep working
+/// without a 32 MB live heap.
+pub(super) fn pacing_escalation_reading_bytes() -> usize {
+    #[cfg(test)]
+    if let Some(bytes) = TEST_PACING_ARENA_IN_USE.with(|cell| cell.get()) {
+        return bytes;
+    }
+    GC_LAST_COLLECTION_POST_IN_USE_BYTES.with(|cell| cell.get())
+}
+
 #[cfg(test)]
 thread_local! {
     /// Test-only override for [`pacing_arena_in_use_bytes`]. Thread-local, so
@@ -1767,6 +1819,17 @@ pub(super) fn test_reset_major_pacing_backoff() {
 #[cfg(test)]
 pub(super) fn test_major_pacing_pre_in_use_bytes() -> usize {
     GC_FULL_CYCLE_PRE_IN_USE_BYTES.with(|bytes| bytes.get())
+}
+
+/// Override the post-collection occupancy the escalation predicate reads.
+/// Returns the previous value so a test can restore it.
+#[cfg(test)]
+pub(super) fn test_set_collection_post_in_use_bytes(bytes: usize) -> usize {
+    GC_LAST_COLLECTION_POST_IN_USE_BYTES.with(|cell| {
+        let previous = cell.get();
+        cell.set(bytes);
+        previous
+    })
 }
 
 #[cfg(test)]
@@ -2889,7 +2952,7 @@ fn arena_growth_full_escalation_due_inner() -> bool {
         // `PERRY_GC_MAJOR_PACING_FLOOR_MB=0` disables the pacing: no reading
         // escalates, so there is no boundary to compare against.
         None => false,
-        Some(threshold) => pacing_arena_in_use_bytes() >= threshold,
+        Some(threshold) => pacing_escalation_reading_bytes() >= threshold,
     }
 }
 

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -1186,6 +1186,13 @@ impl GcCycleTrace {
             // survival-adaptive band is indistinguishable from one that did and
             // simply had nothing to skip.
             "retaining": super::policy::major_pacing_retaining(),
+            // #7865: the reading actually compared against
+            // `escalate_at_or_above_bytes`. Emitted because the two used to be
+            // different KINDS of quantity — a post-full live baseline against a
+            // pre-collection allocated reading — and nothing in the trace said
+            // so. A gate that cannot see the left-hand side cannot prove which
+            // way the comparison went.
+            "escalation_reading_bytes": super::policy::pacing_escalation_reading_bytes(),
         });
         serde_json::json!({
             "event": "gc_cycle",

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -1363,3 +1363,67 @@ fn retaining_rebaseline_never_lowers_the_pacing_baseline() {
         "a larger post-minor occupancy must raise it"
     );
 }
+
+/// #7865 — arena-growth pacing must escalate on **bytes a collection could not
+/// reclaim**, not on allocation volume.
+///
+/// The baseline (`GC_LAST_FULL_ARENA_IN_USE_BYTES`) is a post-full reading, so
+/// it is LIVE bytes. Testing it against `arena_in_use_bytes()` at the moment a
+/// trigger fires compared it against ALLOCATED bytes — the whole un-collected
+/// nursery. `gc-handoff/bench/tree.ts` reads 37.7 MB against the 32 MB floor on
+/// every cycle, so all 40 of its collections escalated to a whole-heap
+/// mark-sweep (1.76 s of pause on the dev host) and the copying minor that
+/// would have reclaimed the same bytes was never attempted. Worse, the
+/// escalation perpetuates itself: `note_copying_minor_young_survival` is the
+/// only thing that can widen the band, and it runs only when a copying minor
+/// runs.
+///
+/// Both directions are asserted, because only the pair distinguishes the fix
+/// from "escalation switched off": a heap the last collection LEFT full still
+/// escalates — that is the array-growth-forwarding-stub case the escalation was
+/// written for, and stubs survive a non-moving minor precisely by staying in
+/// this reading.
+#[test]
+fn escalation_reads_what_the_last_collection_failed_to_reclaim() {
+    use super::super::policy::{
+        arena_growth_full_escalation_due, major_pacing_config, test_reset_major_pacing_backoff,
+        test_set_collection_post_in_use_bytes, test_set_major_pacing_baseline,
+        test_set_pacing_arena_in_use,
+    };
+
+    let (floor_bytes, _growth_num) = major_pacing_config();
+    if floor_bytes == 0 {
+        return; // pacing disabled outright: no boundary to test
+    }
+
+    // The `#[cfg(test)]` injection seam short-circuits the real reading, so it
+    // has to be OFF for this test to exercise the path it is about.
+    let previous_seam = test_set_pacing_arena_in_use(None);
+    test_reset_major_pacing_backoff();
+    let previous_baseline = test_set_major_pacing_baseline(0); // boundary == floor
+
+    // A nursery-churn workload: the last collection emptied the arena. The
+    // program may have allocated gigabytes since; none of it is evidence that a
+    // full is needed.
+    let previous_post = test_set_collection_post_in_use_bytes(0);
+    let emptied_due = arena_growth_full_escalation_due();
+
+    // A stub-pinned workload: the last collection ran and the arena is STILL at
+    // the floor. That is the escalation's subject and it must still fire.
+    test_set_collection_post_in_use_bytes(floor_bytes);
+    let retained_due = arena_growth_full_escalation_due();
+
+    test_set_collection_post_in_use_bytes(previous_post);
+    test_set_major_pacing_baseline(previous_baseline);
+    test_set_pacing_arena_in_use(previous_seam);
+    test_reset_major_pacing_backoff();
+
+    assert!(
+        !emptied_due,
+        "a collection that emptied the arena must not escalate the next one"
+    );
+    assert!(
+        retained_due,
+        "an arena still at the floor after a collection must still escalate"
+    );
+}


### PR DESCRIPTION
## The finding

`gc-handoff/bench/tree.ts` and `tree_wide.ts` — the two slowest programs in the GC
benchmark corpus — spend **more than half their runtime in full mark-sweeps that a
copying minor would have done ~100× faster**, and the copying minor is never even
attempted. `PERRY_GC_TRACE=1` on `main`:

```
tree       {'full': 40}   copying_nursery.eligible: false, fallback_reason: "not_attempted"
tree_wide  {'full': 40}   same
```

40 collections, 40 whole-heap mark-sweeps, zero minors.

## Why

Arena-growth pacing (`arena_growth_full_escalation_due`) escalates a minor to a full when
the arena reading passes `max(floor, K × baseline)`. The **baseline**
(`GC_LAST_FULL_ARENA_IN_USE_BYTES`) is measured *after* a full — it is LIVE bytes. The
**reading** was `arena_in_use_bytes()` sampled when the trigger fires — that is
ALLOCATED bytes, i.e. the whole un-collected nursery, most of which is garbage the minor
is about to reclaim for free.

The two sides were different *kinds* of quantity. `tree`'s nursery high-water is 37.7 MB
against the 32 MB `PERRY_GC_MAJOR_PACING_FLOOR_MB` floor, so **every** cycle escalated.
And the escalation perpetuates itself: `note_copying_minor_young_survival` is the only
thing that can widen the band, and it only runs when a copying minor runs.

## The fix

Test the escalation against the arena occupancy measured **at the end of the last
collection** — the same kind of quantity as the baseline, and exactly what the escalation
exists to detect: *bytes a collection could not reclaim*.

Array-growth forwarding stubs — the hazard the escalation was written for — pin their
blocks through a non-moving minor, so they are still in that reading and still escalate.
Nursery garbage is not.

Recorded once per cycle in `GcCycle::publish_reclaim_outcome`, the one site both
collection kinds pass through.

## Numbers — absolute seconds, quiet M1 mini, best-of-5, exit-checked

Window verified quiet at both ends (load 2.05 → 2.02, zero foreign processes),
token-guarded lock. Outputs byte-identical to `node --experimental-strip-types` and exit 0
for all 22 programs on both arms, **verified before timing**.

| bench | main | this PR | delta | node |
|---|--:|--:|--:|--:|
| **tree** | 1.1671 | **0.5947** | **−49.0%** | 0.450 |
| **tree_wide** | 1.6468 | **1.0747** | **−34.7%** | 0.896 |
| every other of the 22 | | | within ±0.7% | |

`P/node` on `tree` goes 2.59 → 1.32 and on `tree_wide` 1.84 → 1.20.

**ns per GC-managed allocation** (mini seconds ÷ allocation count, from
`PERRY_GC_TRACE=1`): `tree` **55.65 → 28.36 ns**. `churn_alloc` 12.03 → 12.02 and
`retain` 89.17 → 89.37 — unchanged, and unchanged *by construction*: both keep identical
cycle counts, identical collection kinds, and identical `promoted_objects + copied_objects`
(2,358,760 for `retain`, 47,707 for `churn_alloc`) on both arms.

**Peak RSS is LOWER, not higher** — `tree` 57.0 → 45.0 MB (−21.0%), `tree_wide` 82.1 →
70.3 MB (−14.4%), every other program within ±0.2%. The full mark-sweep's non-moving
reclaim leaves a fragmented arena; the copying minor returns whole blocks.

## The subject is asserted live, not assumed

- The trace now emits `major_pacing.escalation_reading_bytes` — the left-hand side of the
  comparison. It was previously invisible, which is why a post-full baseline could be
  tested against a pre-collection allocated reading with nothing in the trace saying so.
- The `collection_kind` histogram is deterministic and load-independent:
  `{'full': 40} → {'minor': 40}` on `tree`/`tree_wide`, and **identical on all 20 other
  programs**.
- The new unit test asserts **both directions** — an arena the last collection emptied
  must not escalate, and an arena still at the floor after a collection must still
  escalate. Only the pair distinguishes this from "escalation switched off".

## Validation

- Corpus: 22 programs, exit 0 + byte-identical output vs `node` (`m0810/expected/`).
- `cargo test --release -p perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2119 passed, 0 failed**.
- Canary `gc-handoff/apps/iso_miss.ts` → `checksum 437840 misses 0`, plain and under
  `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`
  `PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_SCHEDULE_RATE=1` — **with the instrument proven
  live** (`PERRY_GC_DIAG=1` reports 50 non-empty retired sets; a zero retired set protects
  nothing).
- GC stress sweep: 11 corpus programs × 3 knob configurations
  (`PROTECT_FROMSPACE`+`VERIFY_EVACUATION`, `FORCE_EVACUATE`,
  `SCHEDULE_RATE=1 SCHEDULE_ALLOC_KB=0`) — all byte-identical, exit 0.
- `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/addr_class_inventory.py`, `scripts/gc_runtime_root_holders.py`: all clean.

Runtime-only change; no codegen edit, so the corpus binaries differ only by the linked
runtime archive.

## Measured and NOT shipped (recorded so it is not re-walked)

Lowering `INLINE_SLOT_FLOOR` 4 → 2 — every Perry object reserves a minimum of 4 inline
field slots, so a two-field record is `8 + 32 + 32 = 72` bytes to carry 16 bytes of data —
was built and measured on the same host in the same window. It is *correct* (22/22
byte-identical, 2120 runtime tests green) and it does cut memory (`retain` RSS −14.3%,
exactly the predicted 3M × 16 bytes; `tree` −35.7%), but it **regresses `deeplist` +17.1%
and `retain1` +13.4%**: smaller objects mean more objects per nursery, so more of them are
copied twice before tenuring (`promoted + copied` goes 989,836 → 1,272,654 on `retain1` for
the same 1M records). Branch `perf/inline-slot-floor-measured`; notes in
`gc-handoff/LAYOUT-NOTES.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection pacing to avoid unnecessary full collections caused by temporary nursery allocations.
  - Preserved escalation when memory remains occupied after collection, including pinned blocks.
  - Added regression coverage for both escalation and non-escalation scenarios.

- **Diagnostics**
  - GC telemetry now reports the memory reading used for pacing escalation decisions.

- **Documentation**
  - Added benchmark, allocation, RSS, and GC-trace results describing the pacing improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->