### PR TITLE
fix(tooling): make GC structural audits portable (#7878)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1065,6 +1065,17 @@ jobs:
           # (zizmor "artipacked", flagged by review on #6610).
           persist-credentials: false
 
+      - name: GC structural audits (Windows)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/gc_runtime_root_holders.py --self-test
+          python scripts/gc_runtime_root_holders.py
+          python scripts/check_thread_locals.py --self-test
+          python scripts/check_thread_locals.py
+          python -m unittest discover -s tests -p 'test_gc_ratchet.py' -v
+          python benchmarks/gc_ratchet/gc_ratchet.py validate --scope structural
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/setup-llvm22

--- a/benchmarks/gc_ratchet/gc_ratchet.py
+++ b/benchmarks/gc_ratchet/gc_ratchet.py
@@ -78,7 +78,6 @@ import math
 import os
 import platform
 import re
-import resource
 import shutil
 import statistics
 import subprocess
@@ -406,6 +405,11 @@ def run_once(
     otherwise usable sandboxed macOS environments, masking a successful exit.
     Darwin reports ``ru_maxrss`` in bytes, Linux in KiB.
     """
+    if not callable(getattr(os, "wait4", None)):
+        raise RatchetError(
+            "GC ratchet measurement requires os.wait4 (Unix); "
+            "artifact validation remains supported on this host"
+        )
     import time
 
     env = dict(os.environ)

--- a/changelog.d/7882-windows-gc-audits.md
+++ b/changelog.d/7882-windows-gc-audits.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The lightweight GC root-holder, thread-local, and ratchet audits now run on
+  Windows** (#7878). Repository-relative scanner keys use stable forward-slash
+  paths, the ratchet's structural validator no longer imports a Unix-only
+  module, and the Windows CI job exercises both scanners plus structural
+  ratchet validation before starting its compiler build. The measurement path
+  still requires Unix `os.wait4` so its per-process peak-RSS readings cannot
+  silently degrade.

--- a/scripts/check_thread_locals.py
+++ b/scripts/check_thread_locals.py
@@ -74,7 +74,7 @@ import os
 import re
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePath, PureWindowsPath
 
 REPO = Path(__file__).resolve().parent.parent
 ALLOWLIST = REPO / "scripts" / "thread_local_cold_allowlist.json"
@@ -94,6 +94,11 @@ DECL_RE = re.compile(
 # itself and the macro's expansion target, so they cannot be written with the
 # macro without infinite regress.
 EXCLUDED = {"crates/perry-runtime/src/tls_hot.rs"}
+
+
+def repo_relative(path: PurePath, root: PurePath) -> str:
+    """Return a stable repository-relative key on every host platform."""
+    return path.relative_to(root).as_posix()
 
 # `#[cfg(test)] mod <stem>;` — the whole file is a test module.
 CFG_TEST_MOD_RE = re.compile(
@@ -159,7 +164,7 @@ def cfg_test_module_files(root: Path, crates: list[str]) -> set[str]:
                 if not name.endswith(".rs"):
                     continue
                 path = Path(dirpath) / name
-                rel = str(path.relative_to(root))
+                rel = repo_relative(path, root)
                 src = path.read_text()
                 parent = path.parent if name in ("lib.rs", "mod.rs") else path.with_suffix("")
                 gated = set(CFG_TEST_MOD_RE.findall(src))
@@ -167,7 +172,7 @@ def cfg_test_module_files(root: Path, crates: list[str]) -> set[str]:
                 for stem in set(ANY_MOD_RE.findall(src)):
                     for candidate in (parent / f"{stem}.rs", parent / stem / "mod.rs"):
                         if candidate.exists():
-                            edges.append((str(candidate.relative_to(root)), stem in gated))
+                            edges.append((repo_relative(candidate, root), stem in gated))
                 declares[rel] = edges
 
     test_only = {child for edges in declares.values() for child, gated in edges if gated}
@@ -213,7 +218,7 @@ def scan(root: Path, crates: list[str]) -> tuple[dict[str, int], int]:
                 if not name.endswith(".rs"):
                     continue
                 path = Path(dirpath) / name
-                rel = str(path.relative_to(root))
+                rel = repo_relative(path, root)
                 src = path.read_text()
                 hot_declarations += sum(
                     len(DECL_RE.findall(body)) for body in block_bodies(src, HOT_RE)
@@ -301,6 +306,9 @@ def write_allowlist(root: Path, crates: list[str], allowlist_path: Path) -> None
 def self_test() -> int:
     """Prove the checker can say no, in both directions."""
     failures = []
+    windows_root = PureWindowsPath(r"C:\perry")
+    if repo_relative(windows_root / "crates" / "runtime.rs", windows_root) != "crates/runtime.rs":
+        failures.append("repository-relative keys are not normalized on Windows")
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         src_dir = root / "crates/perry-runtime/src"
@@ -411,7 +419,7 @@ def main() -> int:
         return self_test()
     if args.update:
         write_allowlist(REPO, CRATES, ALLOWLIST)
-        print(f"wrote {ALLOWLIST.relative_to(REPO)}")
+        print(f"wrote {ALLOWLIST.relative_to(REPO).as_posix()}")
         return 0
 
     problems = verify(REPO, CRATES, ALLOWLIST)

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -98,12 +98,17 @@ import json
 import re
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePath, PureWindowsPath
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INVENTORY_PATH = REPO_ROOT / "scripts" / "gc_runtime_root_holders.json"
 
 CRATES = ("crates/perry-runtime/src", "crates/perry-stdlib/src")
+
+
+def repo_relative(path: PurePath, root: PurePath) -> str:
+    """Return a stable repository-relative key on every host platform."""
+    return path.relative_to(root).as_posix()
 
 # Types whose NAME says "this is a pointer into the GC heap".
 HEAP_TYPE_TOKENS = (
@@ -379,7 +384,7 @@ def scan(root: Path) -> tuple[list[dict], int]:
     # 3. classify declarations
     holders: list[dict] = []
     for path, text in texts.items():
-        rel = str(path.relative_to(root))
+        rel = repo_relative(path, root)
         allocating_context = "\n".join(
             body
             for _name, body in function_bodies(text).items()
@@ -692,6 +697,9 @@ def _scan_tree(extra: dict[str, str] | None = None) -> list[dict]:
 
 def self_test() -> int:
     failures: list[str] = []
+    windows_root = PureWindowsPath(r"C:\perry")
+    if repo_relative(windows_root / "crates" / "runtime.rs", windows_root) != "crates/runtime.rs":
+        failures.append("repository-relative keys are not normalized on Windows")
     holders = _scan_tree()
     by_key = {(h["file"], h["name"]): h for h in holders}
 

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import stat
 import sys
 import tempfile
 import subprocess
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from benchmarks.gc_ratchet.gc_ratchet import (
@@ -44,6 +46,7 @@ from benchmarks.gc_ratchet.gc_ratchet import (
     probe_run_env,
     render,
     render_classification,
+    run_once,
     tolerances_from_json,
     validate_artifact,
 )
@@ -168,6 +171,11 @@ def _hard(failures):
 
 
 class ParsingTests(unittest.TestCase):
+    def test_measurement_refuses_a_host_without_wait4_before_launching(self):
+        with mock.patch.object(os, "wait4", None, create=True):
+            with self.assertRaisesRegex(RatchetError, "requires os.wait4"):
+                run_once(["this-command-must-not-run"])
+
     def test_parses_gcmetric_lines_and_ignores_noise(self):
         stderr = (
             "some unrelated warning\n"
@@ -774,6 +782,7 @@ class ScanFallbackParsingTests(unittest.TestCase):
         self.assertEqual(parse_scan_fallbacks("[gc-step] pre_in_use=1 post_in_use=1"), {})
 
 
+@unittest.skipUnless(callable(getattr(os, "wait4", None)), "measurement requires os.wait4")
 class ClassifyTests(unittest.TestCase):
     """`classify` splits a retention reading into real retention and residue.
 
@@ -1202,6 +1211,7 @@ class ProbeRunEnvParsingTests(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(callable(getattr(os, "wait4", None)), "measurement requires os.wait4")
 class ProbeRunEnvDeliveryTests(unittest.TestCase):
     """The declared arm must reach the child process, not merely the artifact.
 
@@ -1391,4 +1401,3 @@ class RebaseStableProvenanceTests(unittest.TestCase):
             cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True, check=False,
         ).stdout.strip()
         self.assertEqual(value, expected)
-


### PR DESCRIPTION
## Summary

- normalize GC root-holder and thread-local audit identity keys to forward-slash repository paths on every host
- remove the ratchet harness's unused Unix-only import and clearly refuse only measurement when `os.wait4` is unavailable
- run the lightweight scanner checks, ratchet unit tests, and structural validation in Windows CI before the compiler build

## Tests

- `python3 scripts/gc_runtime_root_holders.py --self-test`
- `python3 scripts/gc_runtime_root_holders.py`
- `python3 scripts/check_thread_locals.py --self-test`
- `python3 scripts/check_thread_locals.py`
- `python3 -m unittest discover -s tests -p 'test_gc_ratchet.py' -v` (93 passed)
- `python3 benchmarks/gc_ratchet/gc_ratchet.py validate --scope structural`
- `python3 -m compileall -q scripts/gc_runtime_root_holders.py scripts/check_thread_locals.py benchmarks/gc_ratchet/gc_ratchet.py tests/test_gc_ratchet.py`
- `bash scripts/check_file_size.sh`
- YAML parse of `.github/workflows/test.yml`

Closes #7878


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for lightweight garbage-collection audits and ratchet validation.
  * Added consistent cross-platform path reporting with forward-slash formatting.
  * Added validation for environments without Unix-specific resource measurement support.

* **Bug Fixes**
  * Improved platform-specific test handling and expanded Windows build verification.
  * Clarified when peak memory measurement is unavailable while artifact validation remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->