### PR TITLE
fix(gc): report live arena bytes after collection (#7879)

### DIFF
--- a/changelog.d/7886-live-heap-accounting.md
+++ b/changelog.d/7886-live-heap-accounting.md
@@ -1,0 +1,24 @@
+### Fixed: `heapUsed` and major-GC pacing counted arena high-water as live memory
+
+`process.memoryUsage().heapUsed`, V8-compatible heap telemetry, and major-GC
+pacing used the sum of arena block bump offsets as if it were live allocation.
+A tiny survivor therefore charged every dead object below the same block's bump
+pointer, while reusable old-generation holes were corrected in public telemetry
+but not in pacing.
+
+Completed collections now publish a header-inclusive live-object census.
+Between collections, bump growth and general/old free-list consumption advance
+that census without adding work to the generated inline allocator. Copying
+minors derive the next census from the previous live count minus from-space plus
+copied/promoted survivors; full and non-moving collections use their sweep walk.
+Reserved capacity and allocation high-water remain available as separate
+fragmentation diagnostics.
+
+On the quiet M1 mini, seven-repeat A/B measurements across all 14 GC-ratchet
+probes produced byte-identical program output and reduced reported `heapUsed` by
+59.2% to 99.99%, while `heapTotal` was unchanged in every probe. For example,
+the promoted-then-released large-live-set probe reports 51,457,736 → 4,462,040
+bytes (−91.3%). Collector counters and timing were unchanged on 13 probes. The
+64 MiB large-Eden probe performed one additional GC step, trading +7.5% wall
+time for −5.9% RSS; this is the explicit pacing tradeoff of using live bytes
+rather than fragmentation as the major-collection signal.

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -112,10 +112,11 @@ pub(crate) use quarantine::{
 pub use quarantine::{quarantine_stats, QuarantineStats};
 
 // stats.rs
+pub(crate) use stats::record_arena_live_census;
 pub(crate) use stats::{active_survivor_space, inactive_survivor_space};
 pub use stats::{
-    js_arena_stats, longlived_in_use_bytes, old_gen_in_use_bytes, pointer_in_nursery,
-    pointer_in_old_gen,
+    arena_live_allocated_bytes, js_arena_stats, longlived_in_use_bytes, old_gen_in_use_bytes,
+    pointer_in_nursery, pointer_in_old_gen,
 };
 #[cfg(test)]
 pub(crate) use stats::{old_gen_in_use_bytes_recomputed, old_gen_in_use_bytes_resync};

--- a/crates/perry-runtime/src/arena/stats.rs
+++ b/crates/perry-runtime/src/arena/stats.rs
@@ -1,62 +1,131 @@
 use super::*;
 
-/// Get arena memory statistics: (heap_used, heap_total)
-/// heap_used = total bytes allocated across all blocks
-/// heap_total = total bytes reserved across all blocks
+/// Exact live-object census at the end of the most recent collection, plus
+/// the allocation state needed to advance it without taxing the inline bump
+/// allocator. Between collections arena offsets can only grow, while a
+/// free-list allocation consumes a hole without moving an offset; those two
+/// deltas therefore account for every new arena allocation.
+#[derive(Clone, Copy, Default)]
+struct ArenaLiveCensus {
+    live_bytes: usize,
+    high_water_bytes: usize,
+    arena_free_bytes: usize,
+    old_free_bytes: usize,
+    valid: bool,
+}
+
+crate::perry_thread_local! {
+    static ARENA_LIVE_CENSUS: Cell<ArenaLiveCensus> =
+        const { Cell::new(ArenaLiveCensus {
+            live_bytes: 0,
+            high_water_bytes: 0,
+            arena_free_bytes: 0,
+            old_free_bytes: 0,
+            valid: false,
+        }) };
+}
+
+fn arena_free_bytes() -> usize {
+    crate::gc::ARENA_FREE_LIST
+        .with(|free| free.borrow().iter().map(|&(_, slot_size)| slot_size).sum())
+}
+
+/// Record the exact header-inclusive live bytes found by a completed GC walk.
+/// This is called after block reset/reclaim, so its high-water and hole
+/// snapshots describe the same instant as `live_bytes`.
+pub(crate) fn record_arena_live_census(live_bytes: usize) {
+    let high_water_bytes = arena_in_use_bytes();
+    ARENA_LIVE_CENSUS.with(|census| {
+        census.set(ArenaLiveCensus {
+            live_bytes,
+            high_water_bytes,
+            arena_free_bytes: arena_free_bytes(),
+            old_free_bytes: crate::gc::old_free_bytes(),
+            valid: true,
+        });
+    });
+}
+
+/// Header-inclusive bytes occupied by live arena objects.
+///
+/// A GC publishes an exact object census. Until the next collection, new bump
+/// allocations are the increase in block high-water and old/general hole reuse
+/// is the decrease in free-list bytes. This keeps `heapUsed` and major-GC
+/// pacing exact after a collection without adding a counter update to the
+/// generated inline allocation fast path.
+pub fn arena_live_allocated_bytes() -> usize {
+    let high_water_bytes = arena_in_use_bytes();
+    let arena_free_bytes = arena_free_bytes();
+    let old_free_bytes = crate::gc::old_free_bytes();
+    ARENA_LIVE_CENSUS.with(|census_cell| {
+        let census = census_cell.get();
+        if !census.valid {
+            return high_water_bytes
+                .saturating_sub(arena_free_bytes)
+                .saturating_sub(old_free_bytes);
+        }
+        if high_water_bytes < census.high_water_bytes {
+            // Before the first census all bytes below the bump pointers are
+            // allocated except known holes. A decreasing high-water means a
+            // direct reset happened outside the normal collect/publish path;
+            // invalidate the stale census so later growth cannot accidentally
+            // cross its old high-water and revive it.
+            census_cell.set(ArenaLiveCensus {
+                valid: false,
+                ..ArenaLiveCensus::default()
+            });
+            return high_water_bytes
+                .saturating_sub(arena_free_bytes)
+                .saturating_sub(old_free_bytes);
+        }
+        census
+            .live_bytes
+            .saturating_add(high_water_bytes - census.high_water_bytes)
+            .saturating_add(census.arena_free_bytes.saturating_sub(arena_free_bytes))
+            .saturating_add(census.old_free_bytes.saturating_sub(old_free_bytes))
+    })
+}
+
+/// Get arena memory statistics: (heap_used, heap_total).
+/// `heap_used` is live allocated object bytes; `heap_total` is total reserved
+/// block capacity. Allocation high-water remains separately available through
+/// [`arena_in_use_bytes`].
 #[no_mangle]
 pub extern "C" fn js_arena_stats(out_used: *mut u64, out_total: *mut u64) {
-    // Sync inline state so the "used" count reflects the inline-burst
-    // high-water mark, not just the last sync point.
-    sync_inline_arena_state();
-    let mut used: u64 = 0;
+    let used = arena_live_allocated_bytes() as u64;
     let mut total: u64 = 0;
     ARENA.with(|arena| {
         let arena = unsafe { &*arena.get() };
         for block in &arena.blocks {
-            used += block.offset as u64;
             total += block.size as u64;
         }
     });
     LONGLIVED_ARENA.with(|arena| {
         let arena = unsafe { &*arena.get() };
         for block in &arena.blocks {
-            used += block.offset as u64;
             total += block.size as u64;
         }
     });
     SURVIVOR_ARENA_0.with(|arena| {
         let arena = unsafe { &*arena.get() };
         for block in &arena.blocks {
-            used += block.offset as u64;
             total += block.size as u64;
         }
     });
     SURVIVOR_ARENA_1.with(|arena| {
         let arena = unsafe { &*arena.get() };
         for block in &arena.blocks {
-            used += block.offset as u64;
             total += block.size as u64;
         }
     });
     // Old-generation arena. Large objects (>16 KB — typed arrays, big arrays /
-    // strings) are born here, and minor-GC survivors are promoted here. Without
-    // this region `heapUsed` / `heapTotal` collapse toward 0 while RSS climbs,
-    // since the live/large heap lives entirely in old-gen. Mirrors the old-gen
-    // phase of `arena_in_use_bytes` (walk.rs) so the two accounts agree.
+    // strings) are born here, and minor-GC survivors are promoted here.
     OLD_ARENA.with(|arena| {
         let arena = unsafe { &*arena.get() };
         for block in &arena.blocks {
-            used += block.offset as u64;
             total += block.size as u64;
         }
     });
-    // #7437: swept old-gen holes are reusable capacity, not used heap.
-    // Block offsets cannot express a hole (the bump pointer never moves
-    // back), so without this subtraction `heapUsed` reports the scattered-
-    // survivor high-water forever — 105.6 MB for a ~1 MB live set on the
-    // 12_large_live_set ratchet probe — and looks like a leak that no
-    // amount of collecting can fix.
-    used = used.saturating_sub(crate::gc::old_free_bytes() as u64);
     unsafe {
         *out_used = used;
         *out_total = total;

--- a/crates/perry-runtime/src/arena/walk.rs
+++ b/crates/perry-runtime/src/arena/walk.rs
@@ -321,11 +321,12 @@ pub fn arena_total_bytes() -> usize {
     ARENA_TOTAL_BYTES.with(|t| t.get())
 }
 
-/// Get bytes currently in use (sum of `block.offset` across blocks).
-/// Used by adaptive GC to measure how much actual data the program is
-/// holding live, separately from how much arena space we've reserved.
-/// After a GC sweep that resets empty blocks, in-use bytes drop
-/// dramatically while reserved bytes stay constant.
+/// Get allocation high-water bytes (sum of `block.offset` across blocks).
+///
+/// This includes swept holes in partially-live blocks and is deliberately a
+/// placement/fragmentation quantity, not live heap usage. Consumers that need
+/// object occupancy (`heapUsed`, major-GC pacing) use
+/// [`arena_live_allocated_bytes`](super::arena_live_allocated_bytes).
 pub fn arena_in_use_bytes() -> usize {
     sync_inline_arena_state();
     let mut used: usize = 0;
@@ -379,6 +380,7 @@ pub(crate) struct ArenaTelemetrySnapshot {
     pub(crate) longlived: ArenaRegionTelemetry,
     pub(crate) old: ArenaRegionTelemetry,
     pub(crate) total_in_use_bytes: usize,
+    pub(crate) total_live_allocated_bytes: usize,
     pub(crate) total_reserved_bytes: usize,
     pub(crate) total_block_count: usize,
 }
@@ -432,6 +434,7 @@ pub(crate) fn arena_telemetry_snapshot() -> ArenaTelemetrySnapshot {
             + survivor1.in_use_bytes
             + longlived.in_use_bytes
             + old.in_use_bytes,
+        total_live_allocated_bytes: arena_live_allocated_bytes(),
         total_reserved_bytes: arena.reserved_bytes
             + survivor0.reserved_bytes
             + survivor1.reserved_bytes

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1333,6 +1333,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
 
     let phase_start = trace_phase_start(trace);
     let from_space_bytes = crate::arena::copying_from_space_in_use_bytes();
+    let pre_collection_live_bytes = crate::arena::arena_live_allocated_bytes();
     // #7742: decide BEFORE anything classifies, then retag the young blocks so
     // every classification for the rest of this cycle already reads the
     // generation those objects will have when it ends. The eligibility
@@ -1636,6 +1637,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
             // the collections that run NO copying minor.
             eden_live_bytes: 0,
             eden_dead_bytes: 0,
+            arena_live_bytes: 0,
         };
         trace.pause_us = start.elapsed().as_micros() as u64;
         trace.capture_layout_scans();
@@ -1655,10 +1657,25 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     // the stale baseline and schedules a full that is guaranteed to free
     // nothing (see `credit_promoted_bytes_to_old_baseline`).
     credit_promoted_bytes_to_old_baseline(collector.stats.promoted_bytes);
+    // Everything outside from-space retains its pre-minor accounting. Remove
+    // the entire Eden/active-survivor high-water, then add back exactly the
+    // objects that survived by copy or promotion. This also preserves objects
+    // promoted by an EARLIER minor: old-page cycle summaries do not retain a
+    // complete allocated-byte census across later cycles (#7879 A/B caught
+    // `12_large_live_set` dropping ~38 MiB of prior promotions from heapUsed).
+    // Whole-block promotion is covered too: subtracting the full from-space
+    // high-water excludes its dead bytes, while `promoted_bytes` adds back only
+    // marked objects. No second object walk is needed.
+    let arena_live_bytes = pre_collection_live_bytes
+        .saturating_sub(from_space_bytes)
+        .saturating_add(collector.stats.copied_bytes)
+        .saturating_add(collector.stats.promoted_bytes);
+    crate::arena::record_arena_live_census(arena_live_bytes);
+    note_collection_finished_arena_occupancy();
     // The same argument one trigger over: a young generation that did not die
     // is a heap growing by LIVE data, so arena-growth pacing must not read that
-    // growth as garbage accumulating. Fed here, after the reset, so the
-    // re-baseline sees post-collection occupancy.
+    // growth as garbage accumulating. Fed after publishing the census so the
+    // re-baseline sees post-collection live allocation rather than high-water.
     note_copying_minor_young_survival(collector.stats.young_survival_permille);
     maybe_schedule_old_reclaim_after_copied_minor();
     retune_after_scavenge(

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1895,13 +1895,18 @@ impl GcCycleState {
             trace.pause_us = elapsed_us;
             trace.capture_layout_scans();
         }
-        if self.minor.is_none() {
-            finish_full_old_reclaim_baseline();
-        }
+        let arena_live_bytes = self
+            .sweep
+            .map(|sweep| sweep.arena_live_bytes as usize)
+            .unwrap_or_else(crate::arena::arena_live_allocated_bytes);
+        crate::arena::record_arena_live_census(arena_live_bytes);
         // #7865: arena-growth pacing tests a POST-collection occupancy, which
         // is the same kind of quantity as its post-full baseline. Recorded here
         // rather than per-kind because this is the one site both kinds reach.
         super::policy::note_collection_finished_arena_occupancy();
+        if self.minor.is_none() {
+            finish_full_old_reclaim_baseline();
+        }
 
         let malloc_swept = self
             .minor

--- a/crates/perry-runtime/src/gc/old_free.rs
+++ b/crates/perry-runtime/src/gc/old_free.rs
@@ -31,11 +31,13 @@
 //! `OLD_ARENA_FREE_BYTES` tracks the total. It is deliberately NOT
 //! subtracted from `OLD_GEN_IN_USE_BYTES` — that cache is defined (and
 //! debug-asserted) as the sum of old block offsets, which hole reuse does
-//! not change. Consumers that want *live* old pressure (the old-reclaim
-//! pacing arms, `process.memoryUsage().heapUsed`) subtract
-//! [`old_free_bytes`] instead; before this, dead-but-unreclaimable bytes
-//! counted as pressure, so old-reclaim kept re-firing full collections
-//! that could not actually lower the number they were watching.
+//! not change. Consumers that want old-generation pressure subtract
+//! [`old_free_bytes`]. The live-allocation census used by
+//! `process.memoryUsage().heapUsed` and major pacing excludes these holes at
+//! collection time and observes later reuse through the decrease in this
+//! counter; before this, dead-but-reusable bytes counted as pressure, so
+//! reclaim kept re-firing full collections that could not lower the number it
+//! was watching.
 //!
 //! Entries are only pushed for dead objects in blocks that still hold a
 //! live object (fully-dead blocks go through block reclaim, which is

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -124,6 +124,9 @@ pub(super) struct SweepTraceStats {
     /// documents the policy and why the signal is not self-referential.
     pub(super) eden_live_bytes: u64,
     pub(super) eden_dead_bytes: u64,
+    /// Header-inclusive bytes this arena walk classified live. Unlike block
+    /// offsets, this excludes dead objects stranded beside a tiny survivor.
+    pub(super) arena_live_bytes: u64,
 }
 
 pub(super) fn evacuation_policy_initial_decision(
@@ -749,6 +752,7 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
     };
     let mut retained_forwarded_stub_objects: usize = 0;
     let mut retained_forwarded_stub_bytes: usize = 0;
+    let mut arena_live_bytes: u64 = 0;
 
     // Sweep arena objects. Two-phase strategy:
     //
@@ -853,6 +857,7 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
                 return;
             }
             if flags & GC_FLAG_PINNED != 0 {
+                arena_live_bytes = arena_live_bytes.saturating_add((*header).size as u64);
                 if block_idx >= old_block_start {
                     crate::arena::old_page_account_swept_object(
                         header as usize,
@@ -890,6 +895,13 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
                     || (block_idx < resettable_general_n
                         && crate::arena::general_block_in_recent_window(block_idx));
                 if retain_stub {
+                    // A full collection can leave an unmarked stub in the
+                    // recent-block safety window without mistaking it for a
+                    // live object. Keep the block/header, but do not charge
+                    // that proven-dead stub to the live census.
+                    if do_age_bump || flags & GC_FLAG_MARKED != 0 {
+                        arena_live_bytes = arena_live_bytes.saturating_add((*header).size as u64);
+                    }
                     if block_idx >= old_block_start {
                         crate::arena::old_page_account_swept_object(
                             header as usize,
@@ -964,6 +976,7 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
                     invalidate_dead_old_arena_header(header, total_size);
                 }
             } else {
+                arena_live_bytes = arena_live_bytes.saturating_add((*header).size as u64);
                 if block_idx >= old_block_start {
                     crate::arena::old_page_account_swept_object(
                         header as usize,
@@ -1065,6 +1078,7 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
         // the #7598 seed.
         eden_live_bytes: 0,
         eden_dead_bytes: 0,
+        arena_live_bytes,
     }
 }
 
@@ -1236,6 +1250,7 @@ impl IncrementalSweepState {
                         retained_forwarded_stub_bytes: self.arena.retained_forwarded_stub_bytes,
                         eden_live_bytes: self.arena.eden_live_bytes,
                         eden_dead_bytes: self.arena.eden_dead_bytes,
+                        arena_live_bytes: self.arena.arena_live_bytes,
                     };
                     self.subphase = SweepCycleSubphase::Done;
                     return true;
@@ -1300,6 +1315,7 @@ struct ArenaSweepObjectsState {
     /// #7598 Eden census: see `SweepTraceStats`.
     eden_live_bytes: u64,
     eden_dead_bytes: u64,
+    arena_live_bytes: u64,
 }
 
 impl ArenaSweepObjectsState {
@@ -1331,6 +1347,7 @@ impl ArenaSweepObjectsState {
             retained_forwarded_stub_bytes: 0,
             eden_live_bytes: 0,
             eden_dead_bytes: 0,
+            arena_live_bytes: 0,
         }
     }
 
@@ -1401,7 +1418,7 @@ impl ArenaSweepObjectsState {
                 return;
             }
             if flags & GC_FLAG_PINNED != 0 {
-                self.keep_live_object(header, block_idx, flags, age_bump_this, true);
+                self.keep_live_object(header, block_idx, flags, age_bump_this, true, true);
                 return;
             }
             if flags & GC_FLAG_FORWARDED != 0 {
@@ -1411,7 +1428,7 @@ impl ArenaSweepObjectsState {
             if flags & GC_FLAG_MARKED == 0 && self.unmarked_is_provably_dead(block_idx) {
                 self.reclaim_dead_object(header, block_idx);
             } else {
-                self.keep_live_object(header, block_idx, flags, age_bump_this, false);
+                self.keep_live_object(header, block_idx, flags, age_bump_this, false, true);
             }
         }
     }
@@ -1448,6 +1465,7 @@ impl ArenaSweepObjectsState {
         flags: u8,
         age_bump_this: bool,
         pinned: bool,
+        count_in_live_census: bool,
     ) {
         if block_idx >= self.old_block_start {
             crate::arena::old_page_account_swept_object(
@@ -1462,6 +1480,9 @@ impl ArenaSweepObjectsState {
         }
         if block_idx < self.resettable_general_n {
             self.eden_live_bytes = self.eden_live_bytes.saturating_add((*header).size as u64);
+        }
+        if count_in_live_census {
+            self.arena_live_bytes = self.arena_live_bytes.saturating_add((*header).size as u64);
         }
         if age_bump_this && flags & GC_FLAG_TENURED == 0 {
             if flags & GC_FLAG_HAS_SURVIVED != 0 {
@@ -1489,7 +1510,11 @@ impl ArenaSweepObjectsState {
             || (block_idx < self.resettable_general_n
                 && crate::arena::general_block_in_recent_window(block_idx));
         if retain_stub {
-            self.keep_live_object(header, block_idx, flags, false, false);
+            // A full collection can leave an unmarked stub in the recent-block
+            // safety window. It still pins the block, but it is proven dead and
+            // therefore excluded from live-allocation accounting.
+            let count_in_live_census = self.minor_sweep || flags & GC_FLAG_MARKED != 0;
+            self.keep_live_object(header, block_idx, flags, false, false, count_in_live_census);
             if block_idx < self.resettable_general_n {
                 self.retained_forwarded_stub_objects =
                     self.retained_forwarded_stub_objects.saturating_add(1);

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -883,20 +883,22 @@ thread_local! {
         const { Cell::new(DeferredGcRequest::None) };
     pub(super) static GC_OLD_RECLAIM_PENDING: Cell<bool> = const { Cell::new(false) };
     pub(super) static GC_LAST_OLD_RECLAIM_IN_USE_BYTES: Cell<usize> = const { Cell::new(0) };
-    /// Total arena in-use bytes measured right after the last FULL mark-sweep —
-    /// the baseline for major-GC pacing (`arena_growth_full_escalation_due`).
+    /// Live allocated arena bytes measured right after the last FULL
+    /// mark-sweep — the baseline for major-GC pacing
+    /// (`arena_growth_full_escalation_due`).
     pub(super) static GC_LAST_FULL_ARENA_IN_USE_BYTES: Cell<usize> = const { Cell::new(0) };
-    /// Total arena in-use bytes measured when the last FULL mark-sweep STARTED.
+    /// Live allocated arena bytes measured when the last FULL mark-sweep STARTED.
     /// Paired with `GC_LAST_FULL_ARENA_IN_USE_BYTES` to price what that full
     /// actually reclaimed — see `GC_MAJOR_PACING_BACKOFF_SHIFT`.
     pub(super) static GC_FULL_CYCLE_PRE_IN_USE_BYTES: Cell<usize> = const { Cell::new(0) };
-    /// Total arena in-use bytes measured at the END of the most recent
+    /// Live allocated arena bytes measured at the END of the most recent
     /// collection of ANY kind — the reading arena-growth pacing tests against
     /// its boundary (#7865).
     ///
     /// The pacing baseline (`GC_LAST_FULL_ARENA_IN_USE_BYTES`) is a *post*-full
-    /// reading, i.e. LIVE bytes. Testing it against `arena_in_use_bytes()` at
-    /// the moment a trigger fires compared it against *allocated* bytes — the
+    /// reading, i.e. LIVE bytes. Before #7879, testing it against
+    /// `arena_in_use_bytes()` at the moment a trigger fired compared it against
+    /// allocation high-water — the
     /// entire un-collected nursery, most of which is garbage a minor is about
     /// to reclaim for free. On `gc-handoff/bench/tree.ts` that reading is
     /// 37.7 MB against a 32 MB floor on **every** cycle, so all 40 collections
@@ -1614,7 +1616,7 @@ pub(super) fn finish_full_old_reclaim_baseline() {
     // Record the TOTAL post-full live set for major-GC pacing (young+old): the
     // full sweep is the only collection that frees forwarding stubs, so this is
     // the "clean" size the arena returns to and the base for the K× growth gate.
-    let post_in_use = crate::arena::arena_in_use_bytes();
+    let post_in_use = crate::arena::arena_live_allocated_bytes();
     GC_LAST_FULL_ARENA_IN_USE_BYTES.with(|bytes| bytes.set(post_in_use));
     update_major_pacing_backoff(post_in_use);
     GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(false));
@@ -1721,8 +1723,9 @@ fn note_full_cycle_started() {
 ///
 /// `update_major_pacing_backoff`'s doc already says these are "deliberately
 /// measured on the SAME metric ... so the two cannot disagree about whether a
-/// full helped". Reading `arena_in_use_bytes()` twice made that a convention;
-/// one accessor makes it structural (#7737).
+/// full helped". The accessor now deliberately reads live allocated object
+/// bytes, not block high-water: fragmentation must not schedule a full or make
+/// one look unproductive (#7879).
 ///
 /// It is also the injection point the positive-direction test needs. Forcing a
 /// `true` verdict from the REAL predicate otherwise requires an arena above
@@ -1734,18 +1737,18 @@ fn note_full_cycle_started() {
 /// compiles out of every shipping build and is not a mode anything can be
 /// configured into (CLAUDE.md's GC knob kill-policy is about runtime knobs;
 /// this is not one).
-fn pacing_arena_in_use_bytes() -> usize {
+pub(super) fn pacing_arena_in_use_bytes() -> usize {
     #[cfg(test)]
     if let Some(bytes) = TEST_PACING_ARENA_IN_USE.with(|cell| cell.get()) {
         return bytes;
     }
-    crate::arena::arena_in_use_bytes()
+    crate::arena::arena_live_allocated_bytes()
 }
 
-/// Record the post-collection arena occupancy arena-growth pacing tests
-/// against. Called once at the end of every cycle, minor and full alike, from
-/// `GcCycle::publish_reclaim_outcome` — the single site both kinds pass
-/// through, so a future collection kind cannot forget it.
+/// Record the post-collection live arena bytes arena-growth pacing tests
+/// against. Called once at the end of every cycle, minor and full alike. The
+/// copying fast path publishes directly; non-copying cycles publish from
+/// `GcCycle::publish_reclaim_outcome` after their sweep census.
 pub(super) fn note_collection_finished_arena_occupancy() {
     let bytes = pacing_arena_in_use_bytes();
     GC_LAST_COLLECTION_POST_IN_USE_BYTES.with(|cell| cell.set(bytes));
@@ -1784,7 +1787,7 @@ pub(super) fn major_pacing_backoff_shift() -> u32 {
     GC_MAJOR_PACING_BACKOFF_SHIFT.with(|shift| shift.get())
 }
 
-/// `(post-full baseline bytes, backoff shift, arena in-use bytes at or above
+/// `(post-full baseline bytes, backoff shift, live allocated bytes at or above
 /// which the next minor escalates to a full)` — emitted in the GC trace so a
 /// gate can prove the backoff actually engaged rather than merely that nothing
 /// threw.
@@ -1842,7 +1845,7 @@ pub(super) fn test_set_major_pacing_baseline(bytes: usize) -> usize {
 }
 
 /// Override the arena reading arena-growth pacing sees, for the duration of a
-/// test. `None` restores the real `arena_in_use_bytes()`. Returns the previous
+/// test. `None` restores the real live-allocation reading. Returns the previous
 /// value so a test can restore it rather than assume it was unset.
 #[cfg(test)]
 pub(super) fn test_set_pacing_arena_in_use(bytes: Option<usize>) -> Option<usize> {
@@ -2956,7 +2959,7 @@ fn arena_growth_full_escalation_due_inner() -> bool {
     }
 }
 
-/// The smallest `arena_in_use_bytes()` reading that escalates the next minor to
+/// The smallest live-allocation reading that escalates the next minor to
 /// a full, or `None` when arena-growth pacing is disabled outright and no
 /// reading escalates.
 ///

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -1525,6 +1525,7 @@ pub(super) fn arena_snapshot_json(
         "longlived": arena_region_json(snapshot.longlived),
         "old": arena_region_json(snapshot.old),
         "total_in_use_bytes": snapshot.total_in_use_bytes,
+        "total_live_allocated_bytes": snapshot.total_live_allocated_bytes,
         "total_reserved_bytes": snapshot.total_reserved_bytes,
         "total_block_count": snapshot.total_block_count,
     })

--- a/crates/perry-runtime/src/gc/tests/heap_accounting.rs
+++ b/crates/perry-runtime/src/gc/tests/heap_accounting.rs
@@ -1,0 +1,158 @@
+//! Live-allocation accounting for public heap telemetry and GC pacing (#7879).
+
+use super::super::*;
+use super::support::*;
+
+#[test]
+fn one_tiny_survivor_does_not_charge_a_partially_dead_block_to_heap_used() {
+    std::thread::spawn(|| {
+        let _copying = CopyingNurseryTestGuard::new(0);
+        let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+        reset_global_roots();
+        let _root_reset = ShadowAndGlobalRootResetGuard;
+
+        // More than one block of short-lived objects, followed by one rooted
+        // survivor in the allocator's recent-block safety window. A full sweep
+        // can prove the preceding objects dead but deliberately cannot reset
+        // that partially-live block, so block.offset retains their high-water.
+        for _ in 0..40_000 {
+            std::hint::black_box(young_leaf());
+        }
+        let survivor_bytes = b"heap_accounting_survivor";
+        let survivor = crate::string::js_string_from_bytes(
+            survivor_bytes.as_ptr(),
+            survivor_bytes.len() as u32,
+        ) as usize;
+        let mut root_slot = string_bits(survivor);
+        js_gc_register_global_root(&mut root_slot as *mut u64 as i64);
+
+        gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Manual));
+
+        let high_water = crate::arena::arena_in_use_bytes() as u64;
+        let mut heap_used = 0_u64;
+        let mut heap_total = 0_u64;
+        crate::arena::js_arena_stats(&mut heap_used, &mut heap_total);
+
+        assert!(heap_total >= high_water);
+        assert_eq!(
+            super::super::policy::pacing_arena_in_use_bytes(),
+            heap_used as usize,
+            "major-GC pacing and public heapUsed must consume the same live metric"
+        );
+        assert!(
+            high_water >= heap_used.saturating_add((crate::arena::BLOCK_SIZE / 2) as u64),
+            "one tiny survivor must not make heapUsed report its block's high-water: \
+             heapUsed={heap_used} high_water={high_water} heapTotal={heap_total}"
+        );
+        unsafe {
+            assert_string_bytes(
+                (root_slot & POINTER_MASK) as *const crate::StringHeader,
+                survivor_bytes,
+            );
+        }
+    })
+    .join()
+    .expect("heap-accounting test thread must not panic");
+}
+
+#[test]
+fn allocations_after_a_census_count_bump_growth_and_old_hole_reuse() {
+    std::thread::spawn(|| {
+        let _copying = CopyingNurseryTestGuard::new(0);
+        let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+        reset_global_roots();
+        let _root_reset = ShadowAndGlobalRootResetGuard;
+
+        let dead = unsafe { alloc_old_test_promise() };
+        let rooted = unsafe { alloc_old_test_promise() };
+        let dead_total = unsafe { (*header_from_user_ptr(dead as *const u8)).size as usize };
+        let mut root_slot = ptr_bits(rooted as usize);
+        js_gc_register_global_root(&mut root_slot as *mut u64 as i64);
+
+        gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Manual));
+
+        let live_before_reuse = crate::arena::arena_live_allocated_bytes();
+        let high_water_before_reuse = crate::arena::arena_in_use_bytes();
+        let old_free_before_reuse = old_free_bytes();
+        assert!(old_free_before_reuse >= dead_total);
+
+        let replacement = unsafe { alloc_old_test_promise() };
+        std::hint::black_box(replacement);
+        let old_free_after_reuse = old_free_bytes();
+        let reused = old_free_before_reuse - old_free_after_reuse;
+        assert_eq!(reused, dead_total);
+        assert_eq!(
+            crate::arena::arena_in_use_bytes(),
+            high_water_before_reuse,
+            "exact-fit old-hole reuse must not move a block bump pointer"
+        );
+        assert_eq!(
+            crate::arena::arena_live_allocated_bytes(),
+            live_before_reuse + reused,
+            "consuming a hole must still increase live allocated bytes"
+        );
+
+        let live_before_bump = crate::arena::arena_live_allocated_bytes();
+        let young = young_leaf();
+        let young_total = unsafe { (*header_from_user_ptr(young as *const u8)).size as usize };
+        assert_eq!(
+            crate::arena::arena_live_allocated_bytes(),
+            live_before_bump + young_total,
+            "a post-census bump allocation must advance live allocated bytes"
+        );
+    })
+    .join()
+    .expect("heap-accounting delta test thread must not panic");
+}
+
+#[test]
+fn copying_minors_preserve_prior_promotions_in_the_live_census() {
+    std::thread::spawn(|| {
+        let _copying = CopyingNurseryTestGuard::new(1);
+        let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+        reset_global_roots();
+        let _root_reset = ShadowAndGlobalRootResetGuard;
+
+        for _ in 0..10_000 {
+            std::hint::black_box(young_leaf());
+        }
+        let survivor_bytes = b"copying_census_survivor";
+        let survivor = crate::string::js_string_from_bytes(
+            survivor_bytes.as_ptr(),
+            survivor_bytes.len() as u32,
+        ) as usize;
+        js_shadow_slot_set(0, string_bits(survivor));
+
+        let mut saw_promotion = false;
+        for cycle in 0..=GC_COPY_PROMOTION_SURVIVALS {
+            let pre_live = crate::arena::arena_live_allocated_bytes();
+            let from_space = crate::arena::copying_from_space_in_use_bytes();
+            let trace = collect_minor_trace(GcTriggerKind::Direct);
+            assert!(trace.copying_nursery.eligible);
+
+            let expected_live = pre_live
+                .saturating_sub(from_space)
+                .saturating_add(trace.copying_nursery.copied_bytes)
+                .saturating_add(trace.copying_nursery.promoted_bytes);
+            assert_eq!(
+                crate::arena::arena_live_allocated_bytes(),
+                expected_live,
+                "copying-minor cycle {cycle} must preserve non-from-space live bytes and add survivors"
+            );
+            assert_eq!(
+                super::super::policy::pacing_arena_in_use_bytes(),
+                expected_live
+            );
+            saw_promotion |= trace.copying_nursery.promoted_bytes != 0;
+        }
+
+        assert!(saw_promotion, "test must drive its survivor into old-gen");
+        let survivor_after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+        assert_ne!(survivor_after, survivor);
+        unsafe {
+            assert_string_bytes(survivor_after as *const crate::StringHeader, survivor_bytes);
+        }
+    })
+    .join()
+    .expect("copying-minor census test thread must not panic");
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -19,6 +19,7 @@ mod fromspace_protect;
 mod fromspace_scan;
 mod global_bootstrap;
 mod global_sink_isolation;
+mod heap_accounting;
 mod helper_stores;
 mod host_safepoints;
 mod incremental_sweep_reclaim;


### PR DESCRIPTION
Closes #7879

## What changed

- Publish a header-inclusive arena live-allocation census from the existing full/non-moving sweep walk.
- Derive the copying-minor census from the previous live count minus from-space plus copied and promoted survivors, preserving promotions from earlier cycles without another object walk.
- Advance the census between collections from bump high-water growth and general/old free-list consumption, without adding work to the generated inline allocator.
- Route `process.memoryUsage().heapUsed`, compatible V8 telemetry, and both sides of major-GC pacing through the live metric.
- Keep reserved capacity and allocation high-water as separate fragmentation diagnostics; diagnostic snapshots now expose `total_live_allocated_bytes` alongside `total_in_use_bytes`.

## Reproduction and tests

The regression test applied unchanged to clean `main` reports:

```
heapUsed=1919928 high_water=1919928 heapTotal=2097152
```

A tiny rooted survivor therefore charges the whole partially dead block. With this branch, the focused accounting suite proves:

- one tiny survivor leaves at least half a block between high-water and `heapUsed`;
- bump allocation and exact old-hole reuse advance the census byte-for-byte;
- copying minors preserve the census through survivor copies, promotion, and a later cycle after promotion.

Validation:

- `cargo test -p perry-runtime --lib gc::tests::heap_accounting`: 3 passed
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime --lib`: 2,128 passed, 4 ignored
- `cargo check -p perry-runtime --features diagnostics`: passed
- TLS policy, address classification, test registration, rustfmt, diff, and file-size gates: passed

## Quiet-host A/B

Seven repeats per probe on the locked M1 mini, with fresh 60-second quiet qualification for each arm (5.8% active for base, 4.8% for fix). Both arms used the same compiler and stdlib; only `libperry_runtime.a` differed. All 14 probes passed their Node oracle and produced byte-identical stdout.

- `heapUsed` fell by 59.2% to 99.99% across all 14 probes; `heapTotal` was unchanged in every probe.
- `12_large_live_set`, which promotes a large cohort and then releases most of it: 51,457,736 -> 4,462,040 bytes (-91.3%), with identical GC counters, -0.05% wall, and -0.09% RSS.
- Collector counters and timing were unchanged on 13 probes.
- `13_large_eden_survivors` performed one additional GC step: wall +7.5% (920.6 -> 989.9 ms), RSS -5.9% (205.6 -> 193.4 MB). This is the explicit pacing tradeoff of using live allocation rather than fragmentation as the major-collection signal.

The repository ratchet pin is already stale on the clean base. Its `--check` fails current-main cells including the known `14_grow_then_churn` counter shift; the fix arm leaves those same #14 cells and turns every heap-used comparison into an improvement. No ratchet artifact is changed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heap usage reporting to count live objects more accurately.
  * `heapUsed` now excludes reclaimed and reusable memory, while `heapTotal` remains unchanged.
  * Improved garbage-collection pacing and V8-compatible telemetry.
  * Updated accounting across minor collections, full collections, promotions, and reused free space.

* **Diagnostics**
  * Arena telemetry now includes total live allocated bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->