### PR TITLE
fix(gc): make per-object layout gate authoritative

### DIFF
--- a/changelog.d/7894-layout-latch.md
+++ b/changelog.d/7894-layout-latch.md
@@ -1,0 +1,3 @@
+Fixed the process-wide per-object GC layout gate so concurrent thread arm/disarm
+transitions cannot publish a false zero, and workers that exit with live layout
+records no longer leave the allocation fast path permanently armed.

--- a/crates/perry-codegen/src/block.rs
+++ b/crates/perry-codegen/src/block.rs
@@ -592,6 +592,19 @@ impl LlBlock {
         r
     }
 
+    /// Monotonic atomic load for an authoritative global whose value is a
+    /// fast-path gate, but which does not publish any accompanying memory.
+    pub fn load_atomic_monotonic(&mut self, ty: LlvmType, ptr: &str, alignment: u32) -> String {
+        let r = self.reg();
+        self.push_inst(crate::inst::LlInst::Load {
+            dst: r.clone(),
+            ty,
+            ptr: ptr.to_string(),
+            flavor: crate::inst::LoadFlavor::AtomicMonotonic(alignment),
+        });
+        r
+    }
+
     /// Sequentially-consistent atomic load for globals shared with runtime
     /// atomics. The explicit alignment is required by LLVM atomic loads.
     pub fn load_atomic_seq_cst(&mut self, ty: LlvmType, ptr: &str, alignment: u32) -> String {

--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -1243,6 +1243,17 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
                     LF::Volatile => {
                         let _ = v.as_instruction_value().map(|i| i.set_volatile(true));
                     }
+                    LF::AtomicMonotonic(n) => {
+                        if let Some(i) = v.as_instruction_value() {
+                            unsafe {
+                                llvm_sys::core::LLVMSetOrdering(
+                                    i.as_value_ref(),
+                                    llvm_sys::LLVMAtomicOrdering::LLVMAtomicOrderingMonotonic,
+                                )
+                            };
+                            let _ = i.set_alignment(*n);
+                        }
+                    }
                     LF::AtomicSeqCst(n) => {
                         if let Some(i) = v.as_instruction_value() {
                             unsafe {

--- a/crates/perry-codegen/src/inst.rs
+++ b/crates/perry-codegen/src/inst.rs
@@ -20,6 +20,7 @@ pub enum LoadFlavor {
     Plain,
     Aligned(u32),
     Volatile,
+    AtomicMonotonic(u32),
     AtomicSeqCst(u32),
     /// `!invariant.load !0` tagged (issue #52).
     Invariant,
@@ -192,6 +193,12 @@ impl LlInst {
                 }
                 LoadFlavor::Volatile => {
                     let _ = write!(out, "  {dst} = load volatile {ty}, ptr {ptr}");
+                }
+                LoadFlavor::AtomicMonotonic(n) => {
+                    let _ = write!(
+                        out,
+                        "  {dst} = load atomic {ty}, ptr {ptr} monotonic, align {n}"
+                    );
                 }
                 LoadFlavor::AtomicSeqCst(n) => {
                     let _ = write!(

--- a/crates/perry-codegen/src/lower_call/typed_shape_bake_tests.rs
+++ b/crates/perry-codegen/src/lower_call/typed_shape_bake_tests.rs
@@ -48,6 +48,8 @@ const DECLARE_CALL: &str = "call void @js_gc_declare_typed_shape_layout(";
 const FORGET_CALL: &str = "call void @js_gc_forget_object_layout(";
 /// The process-global emptiness proof the remainder is gated on.
 const ANY_GLOBAL: &str = "@PERRY_PER_OBJECT_LAYOUTS_ANY";
+const ANY_ATOMIC_LOAD: &str =
+    "load atomic i32, ptr @PERRY_PER_OBJECT_LAYOUTS_ANY monotonic, align 4";
 
 /// The packed `GcHeader` word the inline bump writes for a two-`number`-field
 /// class, WITH the baked layout:
@@ -328,7 +330,7 @@ fn a_pointer_free_shape_bakes_its_layout_into_the_header_constant() {
          ticket removes:\n{ir}"
     );
     assert!(
-        ir.contains(FORGET_CALL) && ir.contains(ANY_GLOBAL),
+        ir.contains(FORGET_CALL) && ir.contains(ANY_GLOBAL) && ir.contains(ANY_ATOMIC_LOAD),
         "the address-dependent half must survive, gated on the global \
          emptiness proof: a recycled address can carry a previous tenant's \
          per-object mask, and `layout_note_slot` would then OR the new \

--- a/crates/perry-codegen/src/lower_call/typed_shape_init.rs
+++ b/crates/perry-codegen/src/lower_call/typed_shape_init.rs
@@ -127,11 +127,10 @@ pub(super) fn emit_typed_shape_layout_declare(
 
 /// `if (PERRY_PER_OBJECT_LAYOUTS_ANY) js_gc_forget_object_layout(obj);`
 ///
-/// The load is **volatile** for the same reason
-/// `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED`'s is: the runtime flips this byte
-/// mid-execution (both ways), and LLVM must not hoist a stale `0` out of the
-/// loop this construction sits in. A never-taken branch per allocation is the
-/// entire steady-state cost.
+/// The count is the runtime's authoritative atomic state (#7873), not a mirror:
+/// a zero load proves no thread is armed, while a non-zero count conservatively
+/// takes the call. A never-taken branch per allocation is the entire
+/// steady-state cost.
 fn emit_gated_forget_object_layout(ctx: &mut FnCtx<'_>, obj_handle: &str) {
     let call_idx = ctx.new_block("layout_forget.armed");
     let done_idx = ctx.new_block("layout_forget.done");
@@ -139,8 +138,8 @@ fn emit_gated_forget_object_layout(ctx: &mut FnCtx<'_>, obj_handle: &str) {
     let done_label = ctx.block_label(done_idx);
     {
         let blk = ctx.block();
-        let any = blk.load_volatile(crate::types::I8, "@PERRY_PER_OBJECT_LAYOUTS_ANY");
-        let armed = blk.icmp_ne(crate::types::I8, &any, "0");
+        let any = blk.load_atomic_monotonic(crate::types::I32, "@PERRY_PER_OBJECT_LAYOUTS_ANY", 4);
+        let armed = blk.icmp_ne(crate::types::I32, &any, "0");
         blk.cond_br(&armed, &call_label, &done_label);
     }
     ctx.current_block = call_idx;

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -29,11 +29,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     // when it is non-zero (descriptors / typed-feedback in use). Defined in
     // perry-runtime as `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED`.
     module.add_external_global("PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED", I8);
-    // #7834: process-global "some thread holds a per-object layout record".
+    // #7834/#7873: process-global count of threads with per-object records.
     // `0` proves both per-object side tables are empty everywhere, so a
     // construction site can skip `js_gc_forget_object_layout` outright.
     // perry-runtime: `gc::layout_tables::PERRY_PER_OBJECT_LAYOUTS_ANY`.
-    module.add_external_global("PERRY_PER_OBJECT_LAYOUTS_ANY", I8);
+    module.add_external_global("PERRY_PER_OBJECT_LAYOUTS_ANY", I32);
     // Sticky summary of indexed Array/Object prototype pollution and custom
     // Array [[Prototype]] installation. Normal compiled programs read this
     // byte directly in the inline plain-array index guard.

--- a/crates/perry-runtime/src/gc/layout_tables.rs
+++ b/crates/perry-runtime/src/gc/layout_tables.rs
@@ -82,6 +82,18 @@ impl PerObjectLayoutHint {
     }
 }
 
+impl Drop for PerObjectLayoutHint {
+    fn drop(&mut self) {
+        // The ownership bit and its teardown live in this ONE TLS value. The
+        // side-table keys may already have been destroyed (TLS destructor
+        // order is deliberately irrelevant); `nonempty` is the authority for
+        // whether this thread contributed to the process-global count.
+        if self.nonempty.get() {
+            per_object_layouts_global_disarm();
+        }
+    }
+}
+
 /// Bits in the per-object address filter (see [`layout_addr_filter_may_hold`]).
 /// 4096 bits is 512 B of thread-local storage, held INLINE in
 /// [`PerObjectLayoutHint`] so the flag and the filter share one hot slot. One
@@ -386,53 +398,72 @@ pub(in crate::gc) fn mark_per_object_layouts_nonempty() {
     }
 }
 
-/// Process-global mirror of [`PER_OBJECT_LAYOUTS_NONEMPTY`], ORed over every
-/// thread, exported so **generated code** can test it with one load (#7834).
+/// Process-global count of threads whose [`PER_OBJECT_LAYOUTS_NONEMPTY`] is
+/// armed, exported so **generated code** can test it with one load (#7834).
 ///
 /// `layout_forget_object` is a runtime call on every inline-bump construction,
 /// and on a monomorphic workload every one of those calls returns immediately
 /// having proved emptiness. The proof itself is thread-local, so codegen could
 /// not read it: a `_tlv_get_addr` from generated code costs more than the call
-/// it would replace. This byte is the same proof in a plain `static`, so the
-/// construction site becomes `load i8` + a never-taken branch.
+/// it would replace. This count is the same proof in a plain `static`, so the
+/// construction site becomes `load atomic i32` + a never-taken branch.
 ///
 /// `0` is a proof that **no thread** holds a per-object layout record, and so
-/// that no recycled address can carry a stale one. `1` is only a hint — the
-/// call it gates re-tests the thread-local flag and the address filter, exactly
-/// as it always did.
+/// that no recycled address can carry a stale one. A non-zero count is only a
+/// hint — the call it gates re-tests the thread-local flag and the address
+/// filter, exactly as it always did.
 ///
-/// Maintained by a count of *armed threads* rather than a sticky set, so a
-/// workload that arms the regime transiently (a `tree`-shaped phase that later
-/// drops every per-object record) returns to the cheap path. A thread that
-/// exits while armed leaks its count, which can only leave this stuck at `1` —
-/// the conservative direction, costing the pre-#7834 call and nothing else.
+/// This exported count is the ONE authoritative state. Keeping a separate
+/// count and byte permits a disarm/re-arm interleaving to publish a false zero
+/// after the re-arm (#7873), regardless of memory ordering. The owning TLS
+/// value's destructor also removes its contribution when a worker exits with
+/// records still live.
 #[no_mangle]
-pub static PERRY_PER_OBJECT_LAYOUTS_ANY: std::sync::atomic::AtomicU8 =
-    std::sync::atomic::AtomicU8::new(0);
-
-/// How many threads currently have a non-empty per-object layout table.
-static PER_OBJECT_LAYOUT_ARMED_THREADS: std::sync::atomic::AtomicIsize =
-    std::sync::atomic::AtomicIsize::new(0);
+pub static PERRY_PER_OBJECT_LAYOUTS_ANY: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
 
 #[inline(never)]
 fn per_object_layouts_global_arm() {
     use std::sync::atomic::Ordering;
-    PER_OBJECT_LAYOUT_ARMED_THREADS.fetch_add(1, Ordering::Relaxed);
-    PERRY_PER_OBJECT_LAYOUTS_ANY.store(1, Ordering::Release);
+    PERRY_PER_OBJECT_LAYOUTS_ANY
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+            count.checked_add(1)
+        })
+        .expect("per-object layout thread count overflow");
 }
 
 #[inline(never)]
 fn per_object_layouts_global_disarm() {
+    per_object_layouts_global_disarm_with_hook(&PERRY_PER_OBJECT_LAYOUTS_ANY, || {});
+}
+
+fn per_object_layouts_global_disarm_with_hook(
+    armed_threads: &std::sync::atomic::AtomicU32,
+    after_decrement: impl FnOnce(),
+) {
     use std::sync::atomic::Ordering;
-    if PER_OBJECT_LAYOUT_ARMED_THREADS.fetch_sub(1, Ordering::Relaxed) <= 1 {
-        // Re-read rather than trusting the returned value: another thread may
-        // have armed between the decrement and here, and the store must not
-        // clear a live arm. A lost race leaves the byte at `1` with the count
-        // at `0`, which is the conservative direction (see the doc above).
-        if PER_OBJECT_LAYOUT_ARMED_THREADS.load(Ordering::Relaxed) <= 0 {
-            PERRY_PER_OBJECT_LAYOUTS_ANY.store(0, Ordering::Release);
-        }
-    }
+    armed_threads
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+            count.checked_sub(1)
+        })
+        .expect("per-object layout thread count underflow");
+    // Test hook for #7873's former vulnerable window. There is no second
+    // publication after this point: a concurrent re-arm updates this same
+    // atomic, so it cannot be overwritten by a delayed zero store.
+    after_decrement();
+}
+
+#[cfg(test)]
+pub(in crate::gc) fn test_per_object_layouts_global_disarm_with_hook(
+    armed_threads: &std::sync::atomic::AtomicU32,
+    after_decrement: impl FnOnce(),
+) {
+    per_object_layouts_global_disarm_with_hook(armed_threads, after_decrement);
+}
+
+#[cfg(test)]
+pub(in crate::gc) fn test_per_object_layout_armed_threads() -> u32 {
+    PERRY_PER_OBJECT_LAYOUTS_ANY.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 /// The generated-code entry point for [`layout_forget_object`] (#7834).
@@ -605,14 +636,14 @@ pub(in crate::gc) fn transfer_per_object_slot_mask(old_user: usize, new_user: us
 /// pre-#7510 path unchanged, and re-arms the flag on the way out.
 #[inline]
 pub(in crate::gc) fn layout_forget_object(user_ptr: usize) {
-    // #7834: the process-global mirror first, because reading it is a plain
-    // static load while `hot_per_object_layout_hint()` is a thread-local — and
-    // on Darwin a thread-local access is an out-of-line `_tlv_get_addr` call.
+    // #7834/#7873: the process-global atomic first, because reading it avoids
+    // resolving `hot_per_object_layout_hint()` — on Darwin a thread-local
+    // access is an out-of-line `_tlv_get_addr` call.
     // `0` proves every thread's tables are empty, which is the steady state of
     // every monomorphic workload, so the disarmed path now costs one load and
     // one branch instead of a call. (Measured as 6% of `cycles`, whose
     // pointer-bearing shape keeps the full runtime declare.)
-    if PERRY_PER_OBJECT_LAYOUTS_ANY.load(std::sync::atomic::Ordering::Acquire) == 0 {
+    if PERRY_PER_OBJECT_LAYOUTS_ANY.load(std::sync::atomic::Ordering::SeqCst) == 0 {
         return;
     }
     // ONE hot-slot resolution for both halves of the guard: the flag (cheap,

--- a/crates/perry-runtime/src/gc/tests/layout_trace/per_object_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/per_object_tables.rs
@@ -13,6 +13,85 @@ use super::*;
 use crate::gc::layout_tables::{test_per_object_tables_are_empty, PER_OBJECT_LAYOUTS_NONEMPTY};
 use crate::gc::ImmortalLayoutScope;
 
+/// Force the exact #7873 interleaving: A has decremented the last arm and
+/// decided to publish zero, B re-arms, then A performs its delayed zero store.
+/// The exported gate must never claim emptiness after B owns a live arm.
+#[test]
+fn test_global_layout_gate_cannot_publish_false_zero_during_rearm() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    let armed_threads = Arc::new(AtomicU32::new(1));
+    let decremented = Arc::new(Barrier::new(2));
+    let rearmed = Arc::new(Barrier::new(2));
+
+    let a_count = Arc::clone(&armed_threads);
+    let a_decremented = Arc::clone(&decremented);
+    let a_rearmed = Arc::clone(&rearmed);
+    let disarm = std::thread::spawn(move || {
+        crate::gc::layout_tables::test_per_object_layouts_global_disarm_with_hook(&a_count, || {
+            a_decremented.wait();
+            a_rearmed.wait();
+        });
+    });
+
+    decremented.wait();
+    armed_threads.fetch_add(1, Ordering::SeqCst);
+    rearmed.wait();
+    disarm.join().expect("disarm thread panicked");
+
+    assert_eq!(
+        armed_threads.load(Ordering::SeqCst),
+        1,
+        "the authoritative gate published false zero after a concurrent re-arm"
+    );
+}
+
+/// Run the exit assertion in a child test process so unrelated parallel tests
+/// cannot contribute arms to this process-global count.
+#[test]
+fn test_armed_per_object_layout_thread_exit_disarms_global_count() {
+    const CHILD_ENV: &str = "PERRY_TEST_LAYOUT_ARM_EXIT_CHILD";
+    if std::env::var_os(CHILD_ENV).is_some() {
+        assert_eq!(
+            crate::gc::layout_tables::test_per_object_layout_armed_threads(),
+            0,
+            "isolated child must start with no armed layout threads"
+        );
+        std::thread::spawn(|| {
+            crate::gc::layout_tables::slot_masks_insert(
+                0x1234_0000,
+                crate::gc::layout::LayoutSlotMask::from_words(&[1]),
+            );
+            assert_eq!(
+                crate::gc::layout_tables::test_per_object_layout_armed_threads(),
+                1,
+                "installing a side-table record must arm this worker"
+            );
+        })
+        .join()
+        .expect("armed worker panicked");
+        assert_eq!(
+            crate::gc::layout_tables::test_per_object_layout_armed_threads(),
+            0,
+            "the owning TLS value must disarm the global count on thread exit"
+        );
+        return;
+    }
+
+    let status = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .arg(
+            "gc::tests::layout_trace::per_object_tables::\
+             test_armed_per_object_layout_thread_exit_disarms_global_count",
+        )
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(CHILD_ENV, "1")
+        .status()
+        .expect("launch isolated thread-exit test");
+    assert!(status.success(), "isolated thread-exit witness failed");
+}
+
 fn flag() -> bool {
     PER_OBJECT_LAYOUTS_NONEMPTY.with(|h| h.nonempty.get())
 }
@@ -68,6 +147,47 @@ fn test_per_object_tables_flag_arms_on_install_and_clears_on_death() {
         !flag(),
         "draining the last per-object record must re-arm the empty fast path"
     );
+
+    clear_marks();
+    clear_mark_seeds();
+}
+
+/// The codegen gate protects this exact address-reuse boundary: a freshly
+/// allocated object must not inherit the previous tenant's per-object mask.
+/// The IR census pins the atomic load and call; this runtime half proves the
+/// non-zero authority lets that call find and remove the stale address key.
+#[test]
+fn test_global_gate_exposes_a_recycled_address_record_to_forget() {
+    clear_marks();
+    clear_mark_seeds();
+
+    let previous_tenant = crate::object::js_object_alloc(0, 2);
+    let child = crate::object::js_object_alloc(0, 0);
+    crate::gc::layout_note_slot(
+        previous_tenant as usize,
+        1,
+        POINTER_TAG | (child as u64 & POINTER_MASK),
+    );
+    assert_eq!(
+        test_layout_pointer_slot_count(previous_tenant as usize, 2),
+        Some(1),
+        "test premise: the previous tenant must leave an address-keyed mask"
+    );
+    assert_ne!(
+        crate::gc::layout_tables::test_per_object_layout_armed_threads(),
+        0,
+        "the generated gate must be armed while the stale record exists"
+    );
+
+    // This is the runtime call emitted immediately after an inline-bump
+    // allocation reuses `previous_tenant`'s address.
+    crate::gc::layout_tables::js_gc_forget_object_layout(previous_tenant as u64);
+
+    assert!(
+        test_per_object_tables_are_empty(),
+        "the recycled address retained its previous tenant's layout record"
+    );
+    assert!(!flag(), "draining the stale record must disarm this thread");
 
     clear_marks();
     clear_mark_seeds();


### PR DESCRIPTION
## Summary

- replace the racy count-plus-byte mirror with one exported `AtomicU32` armed-thread count
- disarm that count from the owning `PerObjectLayoutHint` TLS destructor when a worker exits armed
- make generated allocation gates read the authoritative count with an LLVM monotonic atomic load
- retain the recycled-address cleanup path and add deterministic race, worker-exit, and address-reuse witnesses

## Reproduction

The synchronization-hook regression forces the reported ordering: A decrements the last arm, B re-arms in the former publication window, then A resumes. Before the fix it ended with `count=1, gate=0` and failed. The isolated worker test also failed before the fix with a leaked count of `1` after `join()`.

## Performance

Quiet M1 mini, same base commit and runtime/compiler pairs, 5 warmups plus 25 alternating measured pairs of the 50,000,000-allocation pointer-free typed-shape probe:

- base median: 289.646 ms
- fix median: 289.754 ms
- delta: +0.037% (noise-level)
- paired median difference: +0.252 ms

A seq-cst generated load was measured and rejected before this final version: 286.584 ms to 299.293 ms (+4.43%). The final monotonic load remains atomic and authoritative but avoids that ARM acquire-load tax; the counter transitions remain seq-cst.

## Validation

- `cargo test -p perry-runtime`: 2,145 passed, 0 failed, 4 ignored; doc tests clean
- concurrent per-object layout suite after rebase: 15 passed
- `cargo test -p perry-codegen --lib`: 897 passed
- production `cargo check -p perry-runtime -p perry-codegen`
- file-size, test-registration, TLS-budget, address-class, formatting, and whitespace gates

Fixes #7873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage collection layout tracking during concurrent operations.
  - Fixed stale layout records that could remain after memory addresses were reused.
  - Ensured thread cleanup correctly updates layout state when workers exit.
  - Strengthened allocation and object-layout cleanup reliability under concurrent workloads.

- **Tests**
  - Added coverage for concurrent layout transitions, thread-exit cleanup, and recycled-address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->