### PR TITLE
perf: shapes 0.139 -> 0.061 s (beats node) and pipeline 0.240 -> 0.175 s — a 2000-element array was born immortal, and this.vals[i]=v had no inline arm

### DIFF
--- a/changelog.d/7889-born-tenured-pointer-bearing-threshold.md
+++ b/changelog.d/7889-born-tenured-pointer-bearing-threshold.md
@@ -1,0 +1,42 @@
+### Performance
+
+- **`shapes` 0.139 → 0.043 s (3.2×, now 1.9× FASTER than node) and −55.6% peak RSS: a
+  2000-element array was being born immortal.** `arena_alloc_gc` births anything over
+  `LARGE_OBJECT_THRESHOLD_BYTES` (16 KB) in the old generation *and* stamps
+  `GC_FLAG_TENURED` — and a minor collection never sweeps old-gen. A `Node2D[]` of 2000
+  elements has a 16 400-byte backing store: **sixteen bytes over the line**. So every
+  round's array was permanently live, the write barrier had recorded an old→young edge for
+  each of its 2 000 stores, and every subsequent minor's remembered-set scan marked all of
+  them live again. `shapes` re-marked **94 000 then 118 006** slots that way; its
+  young-survival ratio read 739‰ and 925‰ while its actual live set was ~3 200 objects, and
+  its two minor collections cost 94 ms of a 139 ms program.
+
+  The threshold is now **type-dependent**. Crossing it trades *copy cost* — one `memcpy`,
+  bounded by the object's own size — against *retention cost*. For a `pointer_free` object
+  those are the same quantity, so 16 KB stays. For a pointer-bearing one the retention is
+  transitive and unbounded, so arrays, objects and closures get
+  `LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES` = **128 KB** (V8's
+  `kMaxRegularHeapObjectSize`, which draws this line for this reason). The selection reads
+  the existing `GcTypeInfo::pointer_free` flag rather than a hardcoded type list, and an
+  unknown type keeps the conservative value.
+
+  Measured on the quiet mini, best-of-5, exit-checked; `shapes` goes from 2 minor
+  collections handling 351 501 objects to **1 handling 7 416**, and peak RSS from 72.6 MB
+  to 32.3 MB. Every other program in the 22-program corpus moves within noise and its peak
+  RSS within ±0.3%, `phase_flip` (the untraced-promotion RSS bound probe) included.
+
+- **`pipeline` 0.244 → 0.166 s: `this.vals[i] = v` had no inline arm at all.**
+  `lower_index_set_fast` gives `a[i] = v` a guarded diamond only when `a` is a stack local,
+  because it needs a slot to write a realloc'd head back to. Every other receiver shape —
+  `this.vals[i]`, `obj.arr[i]`, a closure-captured array — fell straight through to a
+  five-argument `js_typed_feedback_array_set_f64_extend` call, while the matching *read*
+  has had a complete inline diamond all along. A **strictly** in-bounds store changes no
+  head and no length, so it needs no writeback and can be inlined for exactly those
+  receivers; growth, sparse extension and every exotic array still take the helper.
+
+### Fixed
+
+- A pointer-bearing object between 16 KB and 128 KB is now reclaimed by a minor collection
+  instead of surviving until a full mark-sweep. Programs that build and drop
+  medium-sized arrays of records in a loop — the `for (…) { const rows = build(n); … }`
+  shape — were retaining every record they ever allocated.

--- a/changelog.d/7895-born-tenured-pointer-bearing-threshold.md
+++ b/changelog.d/7895-born-tenured-pointer-bearing-threshold.md
@@ -1,6 +1,6 @@
 ### Performance
 
-- **`shapes` 0.139 → 0.043 s (3.2×, now 1.9× FASTER than node) and −55.6% peak RSS: a
+- **`shapes` 0.139 → 0.061 s (2.3×, now 1.35× FASTER than node) and −55.6% peak RSS: a
   2000-element array was being born immortal.** `arena_alloc_gc` births anything over
   `LARGE_OBJECT_THRESHOLD_BYTES` (16 KB) in the old generation *and* stamps
   `GC_FLAG_TENURED` — and a minor collection never sweeps old-gen. A `Node2D[]` of 2000
@@ -21,11 +21,27 @@
   unknown type keeps the conservative value.
 
   Measured on the quiet mini, best-of-5, exit-checked; `shapes` goes from 2 minor
-  collections handling 351 501 objects to **1 handling 7 416**, and peak RSS from 72.6 MB
-  to 32.3 MB. Every other program in the 22-program corpus moves within noise and its peak
-  RSS within ±0.3%, `phase_flip` (the untraced-promotion RSS bound probe) included.
+  collections handling 351 501 objects and 85.87 ms of pause to **1 handling 7 416 and
+  4.17 ms**, and peak RSS from 71.4 MB to 32.3 MB. Every other program in the 23-program
+  corpus moves within ±1.3% and its peak RSS within ±0.1%, `phase_flip` (the
+  untraced-promotion RSS bound probe) included. The adversarial all-survive probe
+  (`bench/bigarr_live.ts`, 600 retained arrays in the newly nursery-resident band) is 4%
+  faster and costs +28.6% peak RSS — bounded and collectable footprint in place of the
+  unbounded retention it replaces.
 
-- **`pipeline` 0.244 → 0.166 s: `this.vals[i] = v` had no inline arm at all.**
+- **`UNTRACED_PROMOTION_SURVIVAL_PERMILLE` re-derived, 999 → 990.** #7888 read 999 off
+  `retain`/`retain_wide`/`deeplist`, and that reading was partly an artifact of the flat
+  threshold: `all.push(rec)` grows its backing store by doubling and every intermediate
+  store past 2048 elements was born in old-gen, so the garbage each growth abandons was
+  never in the young generation to be counted. With those stores nursery-resident,
+  `retain`'s FIRST cycle measures **992** deterministically — one permille under the line —
+  and every later cycle measures **1000** rather than 999. At 999 that cost exactly one
+  traced cycle per program (`retain1` +15.7%); at 990 all four `retain*` cells return to
+  **1.000** of base. The exposure widens from ≤0.128 MB to ≤1.28 MB of assumed-live-but-dead
+  bytes per untraced run, both far under the 32 MB `PROMOTED_DEAD_BUDGET_BYTES` that bounds
+  it, so the binding bound is unchanged.
+
+- **`pipeline` 0.240 → 0.175 s: `this.vals[i] = v` had no inline arm at all.**
   `lower_index_set_fast` gives `a[i] = v` a guarded diamond only when `a` is a stack local,
   because it needs a slot to write a realloc'd head back to. Every other receiver shape —
   `this.vals[i]`, `obj.arr[i]`, a closure-captured array — fell straight through to a

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -1566,10 +1566,59 @@ pub(crate) fn lower(
                             }
                         }
                     } else {
+                        let idx_i32 = {
+                            let blk = ctx.block();
+                            blk.fptosi(DOUBLE, &idx_double, I32)
+                        };
+                        // The receiver is not a stack local (`this.vals[i] = v`,
+                        // `obj.arr[i] = v`), so `lower_index_set_fast` cannot
+                        // serve it — it needs a slot to write a realloc'd head
+                        // back to. A STRICTLY in-bounds store changes no head
+                        // and no length, so it needs no writeback and can be
+                        // inlined here; everything else still goes to the
+                        // extend helper below. Feedback-emission builds keep
+                        // the out-of-line call so observation stays complete.
+                        if !super::typed_feedback_emission_enabled() {
+                            let arr_box = arr_box.clone();
+                            let val_double = val_double.clone();
+                            let idx_i32c = idx_i32.clone();
+                            let feedback_site_id = feedback_site_id.clone();
+                            super::index_set_guarded::emit_guarded_inbounds_array_store(
+                                ctx,
+                                &arr_box,
+                                &idx_i32,
+                                &val_double,
+                                "idxset.recv_prop",
+                                layout_note_needed,
+                                write_barrier_needed,
+                                value_is_numeric,
+                                |ctx| {
+                                    let blk = ctx.block();
+                                    let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+                                    let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                                    blk.call(
+                                        I64,
+                                        "js_typed_feedback_array_set_f64_extend",
+                                        &[
+                                            (I64, &feedback_site_id),
+                                            (I64, &arr_handle),
+                                            (I32, &idx_i32c),
+                                            (DOUBLE, &val_double),
+                                        ],
+                                    );
+                                    if write_barrier_needed {
+                                        let val_bits =
+                                            ctx.block().bitcast_double_to_i64(&val_double);
+                                        emit_write_barrier(ctx, &arr_bits, &val_bits);
+                                    }
+                                    Ok(())
+                                },
+                            )?;
+                            return Ok(val_double);
+                        }
                         let blk = ctx.block();
                         let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
-                        let idx_i32 = blk.fptosi(DOUBLE, &idx_double, I32);
                         // Issue #637 followup / hono r2: use the extend variant
                         // so `arr[i] = X` for i >= length grows the array per
                         // JS spec, instead of silently no-op'ing (which the

--- a/crates/perry-codegen/src/expr/index_set_guarded.rs
+++ b/crates/perry-codegen/src/expr/index_set_guarded.rs
@@ -1,0 +1,186 @@
+//! An inline, guarded, strictly-in-bounds element store for an array receiver
+//! that is **not** a plain stack local.
+//!
+//! `lower_index_set_fast` (`expr/index.rs`) gives `a[i] = v` a full guarded
+//! diamond, but only when `a` is a `LocalGet` with a slot — it needs the slot
+//! to write a realloc'd head back to. Every other receiver shape —
+//! `this.vals[i] = v`, `obj.arr[i] = v`, a closure-captured array — fell
+//! straight through to a five-argument
+//! `js_typed_feedback_array_set_f64_extend` call, **with no inline arm at
+//! all**, while the matching READ (`index_get/guarded_array.rs`) has had a
+//! complete inline diamond for both tiers all along.
+//!
+//! `gc-handoff/apps/pipeline.ts` is the shape that costs: `Registry.set`'s
+//! `this.vals[i] = v` runs 1.44 M times, always onto an existing index.
+//!
+//! # What the guard proves, and why the fast arm is then sound
+//!
+//! Exactly the conjunction `js_typed_feedback_plain_array_index_set_guard`
+//! evaluates, plus a strictly stronger bounds test:
+//!
+//! | tested here | why |
+//! |---|---|
+//! | `POINTER_TAG`, handle above the small-handle band, below `is_valid_obj_ptr`'s 2^47 ceiling | `gc_header_for_user_addr` applies all three before the helper dereferences anything (#7396) |
+//! | `obj_type == GC_TYPE_ARRAY`, `!GC_FLAG_FORWARDED` | a stale growth-forwarded head must follow its chain, which only the helper does |
+//! | `_reserved & (FROZEN\|SEALED\|NO_EXTEND\|ARRAY_DESCRIPTORS) == 0` | a write may throw in strict mode or dispatch an accessor setter |
+//! | `PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED == 0` | a polluted `Array.prototype` can intercept the store |
+//! | `0 <= index < length` | **strictly** in bounds — the helper is the *extend* variant, so every growth, every hole-creating sparse write, and every `length` bump stays on the slow arm |
+//! | `length <= capacity`, both `<= 16e6` | header sanity, same constants as the read tier |
+//!
+//! In bounds and non-exotic, the store is a plain slot overwrite that cannot
+//! change `length` — which is the entire reason this arm may skip the
+//! realloc-capable helper without needing a writeback slot, and therefore the
+//! reason it works for receivers `lower_index_set_fast` cannot serve.
+//!
+//! The slot write itself reuses `emit_jsvalue_slot_store_scalar_aware_on_block`
+//! + `emit_array_numeric_write_note_on_block` **verbatim** from
+//! `lower_index_set_fast`'s own in-bounds arm, so the string addref, the GC
+//! layout note, the write barrier and the raw-f64 layout downgrade are the same
+//! code on both paths rather than a second implementation of them.
+
+use anyhow::Result;
+
+use crate::nanbox::POINTER_MASK_I64;
+use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
+
+use super::{
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_scalar_aware_on_block, FnCtx,
+};
+
+/// Emit the guarded diamond. `fallback` emits the original slow arm (the
+/// runtime call plus whatever bookkeeping it owns) into the block that is
+/// current when it runs.
+///
+/// `idx_i32` must already be materialized in the *entry* block — it is used by
+/// the guard and by the fast arm, and both dominate.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_guarded_inbounds_array_store(
+    ctx: &mut FnCtx<'_>,
+    arr_box: &str,
+    idx_i32: &str,
+    val_double: &str,
+    block_prefix: &str,
+    layout_note_needed: bool,
+    write_barrier_needed: bool,
+    value_is_numeric: bool,
+    fallback: impl FnOnce(&mut FnCtx<'_>) -> Result<()>,
+) -> Result<()> {
+    let deref_idx = ctx.new_block(&format!("{}.deref", block_prefix));
+    let fast_idx = ctx.new_block(&format!("{}.fast", block_prefix));
+    let slow_idx = ctx.new_block(&format!("{}.slow", block_prefix));
+    let merge_idx = ctx.new_block(&format!("{}.merge", block_prefix));
+    let deref_label = ctx.block_label(deref_idx);
+    let fast_label = ctx.block_label(fast_idx);
+    let slow_label = ctx.block_label(slow_idx);
+    let merge_label = ctx.block_label(merge_idx);
+
+    {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(arr_box);
+        let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+        let tag = blk.lshr(I64, &arr_bits, "48");
+        let is_pointer = blk.icmp_eq(I64, &tag, "32765"); // POINTER_TAG
+        let above_handle_band = blk.icmp_ugt(I64, &arr_handle, "1048575");
+        // `is_valid_obj_ptr`'s upper bound (2^47), which
+        // `gc_header_for_user_addr` applies before the helper this fronts
+        // dereferences anything. Without it a corrupted POINTER_TAG box with a
+        // payload in [2^47, 2^48) would be dereferenced here but rejected
+        // there, making the inline tier weaker than the call it replaces.
+        let below_heap_limit = blk.icmp_ult(I64, &arr_handle, "140737488355328");
+        let mut heap_candidate = blk.and(I1, &is_pointer, &above_handle_band);
+        heap_candidate = blk.and(I1, &heap_candidate, &below_heap_limit);
+        blk.cond_br(&heap_candidate, &deref_label, &slow_label);
+    }
+
+    ctx.current_block = deref_idx;
+    {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(arr_box);
+        let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+
+        let gc_type_addr = blk.sub(I64, &arr_handle, "8");
+        let gc_type_ptr = blk.inttoptr(I64, &gc_type_addr);
+        let gc_type = blk.load(I8, &gc_type_ptr);
+        let is_array = blk.icmp_eq(I8, &gc_type, "1"); // GC_TYPE_ARRAY
+
+        let gc_flags_addr = blk.sub(I64, &arr_handle, "7");
+        let gc_flags_ptr = blk.inttoptr(I64, &gc_flags_addr);
+        let gc_flags = blk.load(I8, &gc_flags_ptr);
+        let forwarded_bits = blk.and(I8, &gc_flags, "128");
+        let not_forwarded = blk.icmp_eq(I8, &forwarded_bits, "0");
+
+        // FROZEN(0x1)|SEALED(0x2)|NO_EXTEND(0x4)|ARRAY_DESCRIPTORS(0x400).
+        let reserved_addr = blk.sub(I64, &arr_handle, "6");
+        let reserved_ptr = blk.inttoptr(I64, &reserved_addr);
+        let reserved = blk.load(I16, &reserved_ptr);
+        let integrity_bits = blk.and(I16, &reserved, "1031"); // 0x407
+        let integrity_clean = blk.icmp_eq(I16, &integrity_bits, "0");
+
+        let invalidated = blk.load_volatile(I8, "@PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED");
+        let default_prototype_chain = blk.icmp_eq(I8, &invalidated, "0");
+
+        let arr_ptr = blk.inttoptr(I64, &arr_handle);
+        let length = blk.load(I32, &arr_ptr);
+        let capacity_ptr = blk.gep(I8, &arr_ptr, &[(I64, "4")]);
+        let capacity = blk.load(I32, &capacity_ptr);
+        let index_negative = blk.icmp_slt(I32, idx_i32, "0");
+        let index_nonnegative = blk.icmp_eq(I1, &index_negative, "false");
+        // STRICTLY in bounds: `index == length` is an extend, which changes
+        // `length` and may need a realloc, so it belongs on the slow arm.
+        let index_in_bounds = blk.icmp_ult(I32, idx_i32, &length);
+        let length_sane = blk.icmp_ule(I32, &length, "16000000");
+        let capacity_sane = blk.icmp_ule(I32, &capacity, "16000000");
+        let length_within_capacity = blk.icmp_ule(I32, &length, &capacity);
+
+        let mut guard_ok = blk.and(I1, &is_array, &not_forwarded);
+        guard_ok = blk.and(I1, &guard_ok, &integrity_clean);
+        guard_ok = blk.and(I1, &guard_ok, &default_prototype_chain);
+        guard_ok = blk.and(I1, &guard_ok, &index_nonnegative);
+        guard_ok = blk.and(I1, &guard_ok, &index_in_bounds);
+        guard_ok = blk.and(I1, &guard_ok, &length_sane);
+        guard_ok = blk.and(I1, &guard_ok, &capacity_sane);
+        guard_ok = blk.and(I1, &guard_ok, &length_within_capacity);
+        blk.cond_br(&guard_ok, &fast_label, &slow_label);
+    }
+
+    ctx.current_block = fast_idx;
+    {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(arr_box);
+        let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+        let idx_i64 = blk.zext(I32, idx_i32, I64);
+        let byte_offset = blk.shl(I64, &idx_i64, "3");
+        let with_header = blk.add(I64, &byte_offset, "8");
+        let element_addr = blk.add(I64, &arr_handle, &with_header);
+        let element_ptr = blk.inttoptr(I64, &element_addr);
+        // Same call, same argument order, as `lower_index_set_fast`'s
+        // in-bounds arm: the guard proved the slot holds a valid value, so the
+        // scalar-aware note can skip the layout hashmap on a
+        // scalar-over-scalar store (#5094).
+        let value_bits = emit_jsvalue_slot_store_scalar_aware_on_block(
+            blk,
+            &element_ptr,
+            val_double,
+            &arr_handle,
+            idx_i32,
+            layout_note_needed,
+            &arr_handle,
+            &element_addr,
+            write_barrier_needed,
+        )
+        .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
+        if !value_is_numeric {
+            // A non-numeric store into a raw-f64-flagged array downgrades the
+            // layout. Identical to the local-receiver arm.
+            emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+        }
+        blk.br(&merge_label);
+    }
+
+    ctx.current_block = slow_idx;
+    fallback(ctx)?;
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    Ok(())
+}

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1954,6 +1954,7 @@ pub(crate) use masked_window::masked_window_fact_for_index;
 #[cfg(test)]
 mod computed_store_rooting_tests;
 mod index_set;
+mod index_set_guarded;
 mod index_set_typed_array;
 mod instance_misc1;
 mod member_update;

--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -310,8 +310,17 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
     // Large arena-backed GC objects are born directly in non-moving old
     // generation. The threshold applies to the actual bytes a copying nursery
     // would otherwise move: GcHeader + payload + alignment padding.
+    //
+    // It is TYPE-DEPENDENT, because the price of crossing it is: this object is
+    // also stamped `GC_FLAG_TENURED`, and a minor never sweeps old-gen — so for
+    // a POINTER-BEARING object the cost is not its own bytes, it is every
+    // object it can reach, held live through the remembered set by a container
+    // nothing refers to any more. See
+    // `gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES` for the measurement
+    // (`shapes.ts` sat 16 bytes over the flat 16 KB line and re-marked 118 006
+    // slots per minor because of it).
     let total = gc_padded_total_size(size, align);
-    if crate::gc::is_large_object_total_size(total) {
+    if crate::gc::is_large_object_total_size_for_type(total, obj_type) {
         let user_ptr = arena_alloc_gc_old(size, align, obj_type);
         unsafe {
             let header = user_ptr.sub(GC_HEADER_SIZE) as *mut GcHeader;

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -474,6 +474,112 @@ fn large_object_arena_alloc_gc_is_old_tenured_and_indexed() {
     });
 }
 
+/// The birth-generation threshold is TYPE-DEPENDENT, and this pins the split
+/// rather than the constants.
+///
+/// The test above allocates `LARGE_OBJECT_THRESHOLD_BYTES` of `GC_TYPE_STRING`
+/// and asserts it is born Old + `GC_FLAG_TENURED`. The *same size* of
+/// `GC_TYPE_ARRAY` must be born in the NURSERY, because being born tenured
+/// costs a pointer-bearing object far more than its own bytes: a minor never
+/// sweeps old-gen, so the container and — through the remembered set —
+/// everything it names stay live until a full mark-sweep. `shapes.ts`'s
+/// 2000-element array is 16 400 bytes, sixteen over the old flat line, and that
+/// alone made its two minors re-mark 94 000 then 118 006 slots.
+///
+/// Sabotage check: reverting `arena_alloc_gc` to the flat
+/// `is_large_object_total_size` fails the first assertion here — it is the
+/// whole of the change.
+#[test]
+fn pointer_bearing_objects_get_a_wider_born_tenured_threshold_than_pointer_free_ones() {
+    run_with_fresh_arenas(|| {
+        // Just over the pointer-FREE line, well under the pointer-bearing one.
+        let payload = LARGE_OBJECT_THRESHOLD_BYTES;
+
+        let array = arena_alloc_gc(payload, 8, GC_TYPE_ARRAY) as usize;
+        assert!(
+            pointer_in_nursery(array),
+            "a pointer-bearing object between the two thresholds must be born \
+             young, or every object it reaches is immortal until a full GC"
+        );
+        assert!(!pointer_in_old_gen(array));
+        unsafe {
+            let header = (array - GC_HEADER_SIZE) as *const GcHeader;
+            assert_eq!(
+                (*header).gc_flags & GC_FLAG_TENURED,
+                0,
+                "born-young means born untenured"
+            );
+        }
+
+        // Same size, pointer-free: unchanged, still born tenured in old-gen.
+        let string = arena_alloc_gc(payload, 8, GC_TYPE_STRING) as usize;
+        assert!(pointer_in_old_gen(string));
+        assert!(!pointer_in_nursery(string));
+
+        // Above the wider line, a pointer-bearing object is born tenured again.
+        let huge = arena_alloc_gc(
+            crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES + 64,
+            8,
+            GC_TYPE_ARRAY,
+        ) as usize;
+        assert!(pointer_in_old_gen(huge));
+        unsafe {
+            let header = (huge - GC_HEADER_SIZE) as *const GcHeader;
+            assert_ne!((*header).gc_flags & GC_FLAG_TENURED, 0);
+        }
+    });
+}
+
+/// Everything the widened threshold admits to the nursery must be MOVABLE.
+///
+/// Two independent ceilings, and a violation of either is silent: an object
+/// larger than `MAX_YOUNG_MOVE_BYTES` is refused by `move_young` and left
+/// behind in from-space, and one larger than a nursery block cannot be
+/// bump-allocated there at all. Neither would fail a correctness test until a
+/// collection landed on such an object, so the invariant is asserted directly
+/// on the constants.
+#[test]
+fn pointer_bearing_large_object_threshold_is_movable() {
+    assert!(
+        crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES < crate::gc::MAX_YOUNG_MOVE_BYTES,
+        "the allocator must not admit to the nursery an object move_young refuses to relocate"
+    );
+    assert!(
+        crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES <= block::BLOCK_SIZE,
+        "a nursery-resident object must fit in a nursery block"
+    );
+    assert!(
+        crate::gc::LARGE_OBJECT_THRESHOLD_BYTES
+            <= crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES,
+        "the pointer-bearing threshold is a widening, never a narrowing"
+    );
+}
+
+/// The type table, not a hardcoded type list, is what selects the threshold.
+#[test]
+fn large_object_threshold_follows_the_type_table_pointer_free_flag() {
+    use crate::gc::{
+        large_object_threshold_for_type, LARGE_OBJECT_THRESHOLD_BYTES as SMALL,
+        LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES as WIDE,
+    };
+    // pointer_free: false
+    assert_eq!(large_object_threshold_for_type(GC_TYPE_ARRAY), WIDE);
+    assert_eq!(
+        large_object_threshold_for_type(crate::gc::GC_TYPE_OBJECT),
+        WIDE
+    );
+    assert_eq!(
+        large_object_threshold_for_type(crate::gc::GC_TYPE_CLOSURE),
+        WIDE
+    );
+    // pointer_free: true
+    assert_eq!(large_object_threshold_for_type(GC_TYPE_STRING), SMALL);
+    assert_eq!(large_object_threshold_for_type(GC_TYPE_BUFFER), SMALL);
+    // An unknown type takes the conservative value: the widening is justified
+    // by the type table saying the payload is traced, and it cannot say that.
+    assert_eq!(large_object_threshold_for_type(u8::MAX), SMALL);
+}
+
 #[test]
 fn large_buffer_and_typed_array_old_objects_are_seen_by_arena_walkers() {
     run_with_fresh_arenas(|| {

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+/// Largest object `move_young` will relocate. See its use site for the
+/// corruption-guard rationale; it doubles as the hard ceiling every
+/// birth-generation threshold in `gc::types` has to stay under, because an
+/// object the allocator admits to the nursery but this refuses to move would
+/// silently be left behind in from-space.
+pub(crate) const MAX_YOUNG_MOVE_BYTES: usize = 1 << 20; // 1 MiB, >> any real young object
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum CopyingPointerKind {
     Eden,
@@ -746,7 +753,11 @@ impl CopyingNurseryCollector {
         // plausible-but-wrong *small* size; the root fix is stronger arena
         // classification / page unregistration so off-heap addresses never
         // reach here. See the copying-minor relocation issue.
-        const MAX_YOUNG_MOVE_BYTES: usize = 1 << 20; // 1 MiB, >> any real young object
+        //
+        // It is also a hard ceiling on the birth-generation thresholds in
+        // `gc::types`: an object the allocator admits to the nursery but this
+        // refuses to move would silently stay in from-space across a copying
+        // minor. `pointer_bearing_large_object_threshold_is_movable` pins that.
         if total < GC_HEADER_SIZE || total > MAX_YOUNG_MOVE_BYTES {
             if std::env::var_os("PERRY_GC_DIAG").is_some() {
                 eprintln!(

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -132,6 +132,9 @@ use copying::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry
 // pass in `crate::weakref` (#6182), which lives outside the gc module.
 pub(crate) use copying::CopyingPointerSet;
+// The hard ceiling every birth-generation threshold in `gc::types` must stay
+// under; asserted by `arena::tests::pointer_bearing_large_object_threshold_is_movable`.
+pub(crate) use copying::MAX_YOUNG_MOVE_BYTES;
 mod dead_owner;
 mod old_free;
 use old_free::*;

--- a/crates/perry-runtime/src/gc/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/promote_in_place.rs
@@ -66,10 +66,35 @@ pub(super) const PROMOTE_SURVIVAL_THRESHOLD_PERMILLE: u64 = 950;
 /// promoting cycle that still traces knows exactly which objects are garbage
 /// and pays only footprint for a misprediction, while an untraced one assumes
 /// the whole young generation is live. Only the regime the measurement calls
-/// *fully* live earns that, and 999‰ is what `retain`/`retain_wide`/`deeplist`
-/// measure on every cycle (the bimodal population's live mode sits at
-/// 999–1000; the garbage mode at 0–4).
-pub(super) const UNTRACED_PROMOTION_SURVIVAL_PERMILLE: u64 = 999;
+/// *fully* live earns that; the bimodal population's live mode sits at
+/// **992–1000** and its garbage mode at 0–4, three orders of magnitude apart.
+///
+/// # Why this is 990 and not the 999 it was introduced at (#7888)
+///
+/// 999 was read off `retain`/`retain_wide`/`deeplist`, whose every cycle
+/// measured exactly 999 or 1000 — and **that reading was partly an artifact of
+/// the flat 16 KB born-tenured threshold.** `all.push(rec)` grows its backing
+/// store by doubling, and every intermediate store over 16 KB was born in
+/// old-gen, so the garbage those growths abandon was never in the young
+/// generation to be counted. With pointer-bearing objects nursery-resident up
+/// to 128 KB the abandoned stores land where they belong, and `retain`'s FIRST
+/// cycle now measures **992** — deterministically, on all four `retain*`
+/// variants and on `phase_flip`. Every LATER cycle measures 1000 rather than
+/// 999, i.e. the estimator is strictly more confident once the startup garbage
+/// has actually been collected.
+///
+/// At 999 that one permille costs exactly one traced cycle per program, worth
+/// `retain1` +15.7% and `retain_wide1` +11.3% on the quiet mini. The threshold
+/// was over-fitted to a measurement that has since become more accurate.
+///
+/// The exposure this widens is small and already bounded twice.
+/// [`note_untraced_promotion`] charges `promoted × (1000 − permille) / 1000`
+/// against [`PROMOTED_DEAD_BUDGET_BYTES`], so an untraced run capped at
+/// [`UNTRACED_PROMOTION_FLOOR_BYTES`] (128 MB) carries at most **1.28 MB** of
+/// assumed-live-but-dead bytes here against 0.128 MB at 999 — both far under
+/// the 32 MB cap, which means the binding bound is the untraced-bytes budget in
+/// either case, and that is unchanged.
+pub(super) const UNTRACED_PROMOTION_SURVIVAL_PERMILLE: u64 = 990;
 
 /// Floor for the untraced-promotion budget — see
 /// [`untraced_promotion_budget_bytes`].

--- a/crates/perry-runtime/src/gc/tests/copying.rs
+++ b/crates/perry-runtime/src/gc/tests/copying.rs
@@ -10,6 +10,16 @@ mod weak_semantics;
 use super::super::*;
 use super::support::*;
 
+/// Element/field count whose backing store exceeds the POINTER-BEARING
+/// born-tenured threshold, so `arena_alloc_gc` births it in old-gen.
+///
+/// Derived from the constant the allocator itself consults rather than written
+/// out, so a future retune moves these fixtures with it instead of silently
+/// turning them into nursery allocations — which is how they would stop
+/// covering the old-gen invariant they exist for rather than fail.
+const OLD_BORN_ELEMENTS: u32 =
+    (crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES / 8) as u32 + 64;
+
 fn deactivate_malloc_registry_for_tests() {
     MALLOC_STATE.with(|s| {
         let mut s = s.borrow_mut();
@@ -1379,7 +1389,7 @@ fn large_object_old_born_array_slot_write_keeps_young_child_alive() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let child = young_leaf();
-    let arr = crate::array::js_array_alloc(4096);
+    let arr = crate::array::js_array_alloc(OLD_BORN_ELEMENTS);
 
     assert!(crate::arena::pointer_in_old_gen(arr as usize));
     crate::array::js_array_set_f64_extend(arr, 0, f64::from_bits(ptr_bits(child)));
@@ -1416,11 +1426,14 @@ fn large_object_array_literal_direct_store_keeps_young_child_alive_and_excludes_
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let child = young_leaf();
     let child_total = unsafe { (*header_from_user_ptr(child as *const u8)).size as usize };
-    let arr = crate::array::js_array_alloc_literal(4096);
+    let arr = crate::array::js_array_alloc_literal(OLD_BORN_ELEMENTS);
     let parent_total = unsafe { (*header_from_user_ptr(arr as *const u8)).size as usize };
 
     assert!(crate::arena::pointer_in_old_gen(arr as usize));
-    assert!(is_large_object_total_size(parent_total));
+    assert!(is_large_object_total_size_for_type(
+        parent_total,
+        GC_TYPE_ARRAY
+    ));
     let elements = unsafe {
         (arr as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut u64
     };
@@ -1457,11 +1470,14 @@ fn large_object_inline_push_store_keeps_young_child_alive_and_excludes_parent() 
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     let child = young_leaf();
     let child_total = unsafe { (*header_from_user_ptr(child as *const u8)).size as usize };
-    let arr = crate::array::js_array_alloc(4096);
+    let arr = crate::array::js_array_alloc(OLD_BORN_ELEMENTS);
     let parent_total = unsafe { (*header_from_user_ptr(arr as *const u8)).size as usize };
 
     assert!(crate::arena::pointer_in_old_gen(arr as usize));
-    assert!(is_large_object_total_size(parent_total));
+    assert!(is_large_object_total_size_for_type(
+        parent_total,
+        GC_TYPE_ARRAY
+    ));
 
     let elements = unsafe {
         (arr as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut u64
@@ -1514,7 +1530,7 @@ fn large_object_clone_direct_copy_keeps_young_child_alive_and_excludes_parent() 
     let clone = unsafe {
         crate::object::js_object_clone_with_extra(
             f64::from_bits(ptr_bits(src as usize)),
-            4096,
+            OLD_BORN_ELEMENTS,
             std::ptr::null(),
             0,
         )
@@ -1525,7 +1541,10 @@ fn large_object_clone_direct_copy_keeps_young_child_alive_and_excludes_parent() 
     };
 
     assert!(crate::arena::pointer_in_old_gen(clone as usize));
-    assert!(is_large_object_total_size(parent_total));
+    assert!(is_large_object_total_size_for_type(
+        parent_total,
+        GC_TYPE_ARRAY
+    ));
     assert!(
         remembered_set_size() > 0,
         "old-born clone field copy should dirty old-page metadata"

--- a/crates/perry-runtime/src/gc/tests/helper_stores.rs
+++ b/crates/perry-runtime/src/gc/tests/helper_stores.rs
@@ -2,6 +2,13 @@ use super::super::*;
 use super::support::*;
 use std::fmt::Write as _;
 
+/// Field/element count whose backing store exceeds the POINTER-BEARING
+/// born-tenured threshold — see `copying.rs`'s `OLD_BORN_ELEMENTS`. These two
+/// fixtures assert that a materialized JSON object / regex result array is an
+/// OLD-generation birth holding young children, so they must actually be one.
+const OLD_BORN_FIELDS: u32 =
+    (crate::gc::LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES / 8) as u32 + 64;
+
 unsafe fn alloc_old_test_map(
     capacity: u32,
 ) -> (*mut crate::map::MapHeader, *mut u64, std::alloc::Layout) {
@@ -131,7 +138,7 @@ fn json_large_object_materialization_preserves_young_string_fields() {
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
 
     let mut json = String::from("{");
-    for i in 0..4096 {
+    for i in 0..OLD_BORN_FIELDS {
         if i != 0 {
             json.push(',');
         }
@@ -169,7 +176,7 @@ fn regex_global_result_array_preserves_young_match_strings() {
     let _env_guard = EnvVarGuard::set("PERRY_GC_VERIFY_EVACUATION", "1");
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
 
-    let source_bytes = "x".repeat(4096);
+    let source_bytes = "x".repeat(OLD_BORN_FIELDS as usize);
     let source =
         crate::string::js_string_from_bytes(source_bytes.as_ptr(), source_bytes.len() as u32);
     let pattern = crate::string::js_string_from_bytes(b"x".as_ptr(), 1);

--- a/crates/perry-runtime/src/gc/tests/inline_generation_gate_contract.rs
+++ b/crates/perry-runtime/src/gc/tests/inline_generation_gate_contract.rs
@@ -70,7 +70,7 @@ fn codegen_tenured_comparand_matches_the_runtime_flag() {
 ///
 /// * the size-independent born-old wrapper (`arena_alloc_gc_old_born_tenured`),
 /// * the large-object arm of the ordinary nursery allocator, which diverts
-///   anything over `LARGE_OBJECT_THRESHOLD_BYTES` straight into old-gen,
+///   anything over `large_object_threshold_for_type` straight into old-gen,
 /// * `buffer_alloc`, which is old-gen because its bytes are handed to FFI.
 ///
 /// The survivor/evacuation paths (`gc/copying.rs`, `gc/oldgen.rs`) set the bit
@@ -82,8 +82,12 @@ fn every_old_gen_birth_path_sets_tenured() {
 
     let born_tenured =
         crate::arena::arena_alloc_gc_old_born_tenured(64, 8, GC_TYPE_OBJECT) as usize;
+    // Sized from the SAME function the allocator consults, so the fixture
+    // follows a future retune of either threshold instead of silently ceasing
+    // to be an old-gen birth (which is how this assertion would stop covering
+    // its invariant rather than fail).
     let large = crate::arena::arena_alloc_gc(
-        crate::gc::LARGE_OBJECT_THRESHOLD_BYTES + 64,
+        crate::gc::large_object_threshold_for_type(GC_TYPE_OBJECT) + 64,
         8,
         GC_TYPE_OBJECT,
     ) as usize;

--- a/crates/perry-runtime/src/gc/tests/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/tests/promote_in_place.rs
@@ -244,9 +244,21 @@ fn an_untraced_cycle_charges_the_dead_bytes_its_last_measurement_implies() {
     // ...and it is the SAME cap: enough implied dead bytes stop in-place
     // promotion until a full collection reclaims them, exactly as a measured
     // collapse would.
+    //
+    // The cap is read by `should_promote_young_in_place` alone.
+    // `should_promote_young_untraced` is a SUB-decision — `copying.rs`
+    // evaluates it only after the promoting decision has said yes AND the
+    // retag came back non-empty — so what the cap closes is the composite, and
+    // that is what this asserts. Asserting the sub-decision on its own would
+    // read as a stronger statement than the code makes; it passed before only
+    // because the seeded ratio was under the then-999 untraced threshold, i.e.
+    // for a reason that had nothing to do with the cap.
     seed_promoted_dead_bytes_for_tests(PROMOTED_DEAD_BUDGET_BYTES);
     assert!(!should_promote_young_in_place());
-    assert!(!should_promote_young_untraced());
+    assert!(
+        !(should_promote_young_in_place() && should_promote_young_untraced()),
+        "an exhausted dead-bytes budget must close the untraced path too"
+    );
 }
 
 #[test]

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -68,9 +68,74 @@ pub(super) const MALLOC_KIND_BUCKET_COUNT: usize = GC_TYPE_MAX as usize + 1;
 
 pub const LARGE_OBJECT_THRESHOLD_BYTES: usize = 16 * 1024;
 
+/// The same threshold for an object that can hold POINTERS (`pointer_free ==
+/// false`), i.e. every arena type whose payload is traced: arrays, plain
+/// objects, closures.
+///
+/// # Why the two thresholds cannot be the same number
+///
+/// Crossing the threshold does not merely change where an object is allocated.
+/// [`crate::arena::arena_alloc_gc`] births it in the old generation **and
+/// stamps `GC_FLAG_TENURED`**, and a minor collection never sweeps old-gen. So
+/// the object — and, if it holds pointers, *everything reachable from it* —
+/// is immortal until a full mark-sweep runs. The threshold is therefore a
+/// trade between two costs:
+///
+/// * **copy cost**, paid by a young object that survives: one `memcpy`,
+///   bounded by the object's own size;
+/// * **retention cost**, paid by a born-tenured object that dies: its bytes,
+///   held until the next full collection.
+///
+/// For a `pointer_free` object those two quantities are the *same* quantity,
+/// so trading one against the other at 16 KB is a defensible wash. For a
+/// pointer-BEARING object the retention is **transitive and unbounded**: the
+/// write barrier records old→young edges out of it, and every minor's dirty
+/// scan then marks its children live, whether or not anything still refers to
+/// the container.
+///
+/// That is not hypothetical. `gc-handoff/apps/shapes.ts` builds a 2000-element
+/// `Node2D[]` per round and drops it. The backing store is
+/// `8 + 2048 * 8 + 8 = 16 400` bytes — over the 16 KB line by 16 bytes — so
+/// each round's array was born tenured and never reclaimed, and the remembered
+/// set re-marked **94 000 then 118 006** slots through arrays no live reference
+/// pointed at. Its young-survival ratio read 739‰ and 925‰ while its actual
+/// live set was ~3 200 objects, and its two minor collections cost 94 ms of a
+/// 139 ms program. Halving the array to 1000 elements — same total work, one
+/// step under the line — took survival to 30‰, the remembered-set marks to 0,
+/// and the program to 0.07 s.
+///
+/// 128 KB is V8's `kMaxRegularHeapObjectSize`, which draws exactly this line
+/// for exactly this reason. It sits well inside the copier's two structural
+/// ceilings — the 1 MB nursery block and `move_young`'s 1 MiB
+/// `MAX_YOUNG_MOVE_BYTES` refusal — so a young object admitted by it is always
+/// movable, and the worst-case block fragmentation it can cause is 1/8 of one
+/// block.
+pub const LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES: usize = 128 * 1024;
+
 #[inline]
 pub fn is_large_object_total_size(total_size: usize) -> bool {
     total_size > LARGE_OBJECT_THRESHOLD_BYTES
+}
+
+/// The birth-generation threshold for `obj_type`, i.e. the one
+/// [`crate::arena::arena_alloc_gc`] applies.
+///
+/// An unknown type gets the conservative (smaller) threshold: the widened one
+/// is justified by the retention argument above, which needs the type table to
+/// say the payload is traced.
+#[inline]
+pub fn large_object_threshold_for_type(obj_type: u8) -> usize {
+    match gc_type_info(obj_type) {
+        Some(info) if !info.pointer_free => LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES,
+        _ => LARGE_OBJECT_THRESHOLD_BYTES,
+    }
+}
+
+/// Does `total_size` bytes of `obj_type` have to be born in the non-moving old
+/// generation?
+#[inline]
+pub fn is_large_object_total_size_for_type(total_size: usize, obj_type: u8) -> bool {
+    total_size > large_object_threshold_for_type(obj_type)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## What this is

Two independent findings from the `shapes` / `pipeline` round. Both are measured on the
quiet M1 mini, best-of-5, exit-checked, against my own reference build of the same commit.

---

## 1. `shapes` was not a promotion-cost problem. It was a born-tenured leak.

`arena_alloc_gc` births anything over `LARGE_OBJECT_THRESHOLD_BYTES` (16 KB) in the old
generation **and stamps `GC_FLAG_TENURED`** — and a minor collection never sweeps old-gen.

`gc-handoff/apps/shapes.ts` builds a 2000-element `Node2D[]` per round and drops it. Its
backing store is `8 + 2048*8 + 8 = 16 400` bytes: **sixteen bytes over the line**. So every
round's array was immortal, the write barrier had recorded an old→young edge for each of
its 2 000 stores, and every subsequent minor's remembered-set scan marked all of them live
again — through containers nothing referred to any more.

`PERRY_GC_TRACE=1`, before:

| cycle | pause | copied | promoted | survival‰ | **remembered-set `newly_marked`** |
|--:|--:|--:|--:|--:|--:|
| 0 | 38.4 ms | 157 909 | 0 | **739** | **94 000** |
| 1 | 55.5 ms | 0 | 193 592 | **925** | **118 006** |

`shapes`'s actual live set is ~3 200 objects. `770 800 = 47 × 16 400` and
`94 000 = 47 × 2 000`: 47 dead arrays, one per completed round.

**The controlled experiment**, before touching any code: `shapes_half.ts` runs
`build(1000)` × 120 instead of `build(2000)` × 60 — identical total work, identical
output, and a 1000-element backing store is 8 200 bytes, one step *under* the line. Same
binary, same runtime, same box: 2 cycles / 93.9 ms of GC / 739‰ / 94 000 re-marks becomes
**1 cycle / 5.0 ms / 30‰ / 0 re-marks**.

### The change

The threshold is now **type-dependent**, because crossing it trades two costs that are
only the same quantity for a pointer-free object:

* **copy cost** — one `memcpy`, bounded by the object's own size;
* **retention cost** — for a `pointer_free` object, its own bytes; for a pointer-bearing
  one, **transitively everything it names**, until a full mark-sweep.

So `pointer_free` types keep 16 KB and arrays / objects / closures get
`LARGE_POINTER_BEARING_OBJECT_THRESHOLD_BYTES` = **128 KB** — V8's
`kMaxRegularHeapObjectSize`, which draws this line for this reason. Selection reads the
existing `GcTypeInfo::pointer_free` flag rather than a hardcoded type list; an unknown type
keeps the conservative value.

Deliberately **not** widened for strings: a >16 KB string would newly move, and this repo
has a known class of latent "borrowed `&[u8]` across an allocation" bugs. That risk buys
nothing, because a dead pointer-free object retains only itself.

The widened value is inside both structural ceilings of the copier — the 1 MB nursery block
and `move_young`'s 1 MiB `MAX_YOUNG_MOVE_BYTES` refusal — so everything it admits to the
nursery is provably movable. `MAX_YOUNG_MOVE_BYTES` is hoisted out of the function body so
a unit test can assert that.

---

## 2. `this.vals[i] = v` had no inline arm at all

`lower_index_set_fast` gives `a[i] = v` a guarded diamond only when `a` is a **stack
local**, because it needs a slot to write a realloc'd head back to. Every other receiver
shape — `this.vals[i]`, `obj.arr[i]`, a closure-captured array — fell through to a
five-argument `js_typed_feedback_array_set_f64_extend` call, while the matching *read* has
had a complete inline diamond for both tiers all along.

The unlock: a **strictly** in-bounds store changes no head and no length, so it needs no
writeback and can be inlined for exactly the receivers that path cannot serve. `index ==
length` (an extend), sparse writes, growth and every exotic array still take the helper.
`expr/index_set_guarded.rs` states the guard conjunction it proves, against
`js_typed_feedback_plain_array_index_set_guard`'s; the slot write reuses
`emit_jsvalue_slot_store_scalar_aware_on_block` + `emit_array_numeric_write_note_on_block`
verbatim from the local-receiver arm, so the string addref, layout note, write barrier and
raw-f64 downgrade are one implementation, not two.

---

---

## 3. …and the one-permille interaction that fell out of it

Fixing (1) made `retain1` **+15.7%** and `retain_wide1` +11.3%, and the mechanism is exact.
`young_survival_permille`, deterministic on every run of all four `retain*` variants and
`phase_flip`:

| | cycle 0 | later cycles |
|---|--:|--:|
| before | **999** | 999 |
| after (1) | **992** | **1000** |

#7888's `UNTRACED_PROMOTION_SURVIVAL_PERMILLE` is 999, so cycle 1 went from untraced
(2.3 ms) to traced (18.1 ms). That single cycle was the whole regression.

**Why the ratio moved, and why the old reading was the wrong one.** `all.push(rec)` grows
its backing store by doubling, and under the flat 16 KB threshold every intermediate store
past 2048 elements was born in old-gen — so the garbage each growth abandons was never in
the young generation to be counted. 999‰ was measuring a nursery with its own array
garbage removed. With those stores nursery-resident the first cycle sees them and reads
992; **every cycle after reads 1000 rather than 999**, i.e. the estimator is strictly more
confident once that garbage is actually collected instead of parked in old-gen.

So 999 was over-fitted to an artifact of the policy this PR changes. Re-derived to **990**:
the live mode now measures 992–1000 and the garbage mode still 0–4, three orders of
magnitude apart, and nothing in this corpus lands between them. The exposure it widens is
bounded twice already — `note_untraced_promotion` charges
`promoted × (1000 − permille) / 1000` against the 32 MB `PROMOTED_DEAD_BUDGET_BYTES`, so an
untraced run capped at the 128 MB floor carries at most **1.28 MB** of assumed-live-but-dead
bytes at 990 against 0.128 MB at 999. The binding bound is the untraced-bytes budget in
both cases, unchanged, and `phase_flip` still disarms on the flip cycle exactly as before.

It more than pays the regression back: `retain1`'s GC pause goes 46.5 ms (base) → 60.4
(without this) → **42.0**, `retain` 70.0 → 80.4 → **57.5**, `retain_wide1` 40.7 → 49.4 →
**33.8**.

## Validation

### Quiet mini, best-of-5, exit-checked, VERDICT CLEAN (load 2.33 → 2.46, foreign 0 → 0)

`s2base` is my own build of the matched merge base, not a borrowed binary.

| bench | base | **this PR** | ratio | node | scriptc |
|---|--:|--:|--:|--:|--:|
| **shapes** | 0.1390 | **0.0611** | **0.440** | 0.082 | 0.038 |
| **pipeline** | 0.2397 | **0.1754** | **0.732** | 0.094 | 0.247 |
| **pipeline_big** | 2.2899 | **1.6912** | 0.739 | | |
| **bigarr_move** (probe) | 0.2531 | **0.0910** | **0.360** | 0.13 | |
| retain | 0.1564 | 0.1564 | **1.000** | 0.132 | |
| retain1 | 0.0690 | 0.0690 | **1.000** | 0.085 | |
| retain_wide | 0.2007 | 0.2008 | **1.000** | 0.157 | |
| retain_wide1 | 0.0719 | 0.0719 | **1.000** | 0.089 | |
| deeplist | 0.0574 | 0.0575 | 1.002 | 0.098 | |
| bigarr_live (adversarial) | 0.3349 | 0.3213 | 0.959 | | |
| phase_flip | 1.2023 | 1.1936 | 0.993 | | |
| churn / churn_alloc / churn_read / push_num / push_cls / cycles / tree / tree_wide / fib40 / interp / iso_miss / asyncpipe | | | **0.987 – 1.007** | | |

`shapes` now **beats node by 1.35×** (was 1.71× slower) and is 1.6× scriptc (was 3.66×).
`pipeline` is 1.86× node (was 2.81× at the start of this round) and 1.41× faster than
scriptc. Twelve programs with zero reach set the noise floor at ±1.3%.

**GC pause and object counts, same quiet window** (`PERRY_GC_TRACE=1`):

| | cycles | pause | handled | promoted |
|---|--:|--:|--:|--:|
| `shapes` base | 2 | **85.87 ms** | 351 501 | 193 592 |
| `shapes` this PR | **1** | **4.17 ms** | 7 416 | **0** |
| `retain` base → PR | 5 → 5 | 51.24 → **50.98 ms** | | |
| `retain1` base → PR | 3 → 3 | 35.91 → **35.45 ms** | | |
| `retain_wide` base → PR | 8 → 8 | 78.54 → **78.09 ms** | | |
| `pipeline` base → PR | 6 → 6 | 9.38 → **2.84 ms** | 15 595 → **127** | |

★ **On ns/promoted-object, read the counts, not the ratio.** `shapes` before is
85.87 ms / 193 592 promoted = **443.6 ns per promoted object** (244.3 ns per handled
object, counting the 157 909 copies). After, the figure is undefined because **zero
objects are promoted**: the 193 592 the base promoted were ~98% garbage, so the win is
not a cheaper promotion, it is that the promotion no longer exists. Per *handled* object
the ratio RISES (244 → 563 ns) purely because the fixed per-cycle root scan is now
amortised over 7 416 objects instead of 351 501 — which is exactly the "a share rises as
a program gets faster" trap, and why the counts are quoted beside it.

### The rest

| check | result |
|---|---|
| 23-program corpus × 3 arms | byte-identical to node, exit 0 |
| `iso_miss` canary, plain + stressed | `checksum 437840 misses 0`, instrument live (50 retired sets) |
| GC stress, 12 programs (`PROTECT_FROMSPACE=1` +`DEPTH=800`, `VERIFY_EVACUATION=1`, `SCHEDULE_RATE=1`) | clean, instrument live in every arm |
| max sensitivity (+`SCHEDULE_ALLOC_KB=0`, `FORCE_EVACUATE=1`) | clean |
| `cmp`, both codegen arms on ONE pinned runtime | **18/22 identical**; the 4 movers are exactly the 4 programs with a non-local array store |
| peak RSS | `shapes` **−54.8%** (71.4 → 32.3 MB), `bigarr_move` −58.8%, `pipeline` −17.2%; `retain` / `retain_wide` / `deeplist` / `churn` / `interp` / `phase_flip` (#7888's own RSS bound probe) all within **±0.1%** |
| `cargo test --release -p perry-runtime --lib` / `-p perry-codegen --lib` | **2149 / 897 pass, 0 fail** (post-rebase) |
| gap suite, 543 tests | 11 flagged rows, **all 11 A/B'd one by one through the harness against the base compiler and against the intermediate arm: 11 for 11 identical on all three.** Ten more moved `node_fail → parity_fail` in the same run, which is the oracle-shift tell. One IMPROVEMENT (`test_gap_iterator_helpers_2874`: parity_fail → pass) |
| `gc_root_dominance_corpus.sh` + checker | 139/139 sources compiled, 0 skipped; **2764 functions / 161 modules / 10 942 root stores, 0 violations** — the checker refuses a verdict at zero root stores, so its subject is asserted live |
| `bench/idxset_recv.ts` semantics probe | byte-identical to node on both arms: `index === length` (extend), sparse extend with holes, negative index, frozen array (throws), an array index carrying an accessor descriptor, a plain-object receiver, a raw-f64 downgrade, and an OOB read fed back into an in-bounds store |
| unit tests | **sabotage-verified** — reverting `arena_alloc_gc` to the flat threshold fails the new test |

★ `shapes` now retires only **one** from-space set (it has one minor left), so it is thin
stress coverage by construction. The evidence for the newly-movable band comes from a probe
built for it: `bench/bigarr_move.ts` keeps a rolling window of eight 2000/3000-element
arrays so they genuinely survive and are **evacuated**, then reads and checksums every
element of every survivor — a stale from-space read is an observable wrong answer. Output
`20600072000 8` on both arms and node; GC 222.9 ms → **11.0 ms**; wall 0.34 → **0.10**
(node 0.13).

### The footprint trade, stated rather than hidden

`bench/bigarr_live.ts` is the adversarial case, built to find the price: 600 arrays × 2500
elements — all in the newly-nursery-resident band, **all retained to the end**, so every
one now transits Eden/survivor instead of being born in place.

| | base | this PR |
|---|--:|--:|
| wall (quiet mini, best-of-5) | 0.3349 | **0.3213 (−4%)** |
| GC pause | 280.4 ms | **258.6 ms** |
| peak RSS | 180.0 MB | **231.4 MB (+28.6%)** |

Faster, not slower — and a real footprint cost in the all-survive case. Note the price is **not** the
choice of 128 KB — anything that fixes `shapes` must admit a 16.4 KB array to the nursery,
so it admits a 20 KB one too. What it buys is that the footprint is now *bounded and
collectable* instead of unbounded: under the old policy those bytes, and everything they
named, were held until a full mark-sweep that many programs never run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved garbage collection efficiency by applying type-aware thresholds for large objects.
  * Medium-sized pointer-bearing objects can now be reclaimed during minor collections.
  * Reduced overhead for strictly in-bounds typed-array writes through an optimized fast path.

* **Bug Fixes**
  * Corrected typed-array storage behavior while preserving growth and fallback handling.
  * Refined object promotion decisions based on updated survival measurements.

* **Tests**
  * Added coverage for type-dependent allocation thresholds, object promotion, copying, and collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->