### PR TITLE
fix(gc): classify boxed string concat as poll-capable

### DIFF
--- a/changelog.d/7896-boxed-concat-poll-reach.md
+++ b/changelog.d/7896-boxed-concat-poll-reach.md
@@ -1,0 +1,3 @@
+Fixed the GC root-dominance moving-only audits so boxed string concatenation is
+classified as poll-capable when it delegates non-string operands through
+coercion and user code.

--- a/changelog.d/7896-boxed-concat-poll-reach.md
+++ b/changelog.d/7896-boxed-concat-poll-reach.md
@@ -1,3 +1,15 @@
 Fixed the GC root-dominance moving-only audits so boxed string concatenation is
 classified as poll-capable when it delegates non-string operands through
 coercion and user code.
+
+Issue #7872 exposed the missing edge: `js_string_concat_box` can call
+`js_dynamic_string_or_number_add`, which can reach `js_number_coerce` and run
+user code. The runtime call-graph classifier omitted the boxed-concat wrapper,
+so moving-only dominance audits could incorrectly treat its callers as unable
+to poll. An exact two-hop self-test now keeps that reachability visible.
+
+Validation ran all four static GC audits, their self-tests and gate wiring,
+plus the shadow and native root-dominance corpora. The shadow corpus passed
+139/139 programs; the native corpus emitted 35,246 statepoints and 21,290 live
+root bundles with zero dominance or unrooted-allocation hazards. Curated
+before/after classification found no newly exposed stale window.

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -1283,6 +1283,7 @@ POLL_CAPABLE_RUNTIME = {
     "js_object_get_own_property_names", "js_object_keys",
     "js_object_keys_value",
     "js_reflect_construct", "js_regexp_construct_call",
+    "js_string_concat_box",
     "js_string_from_char_code_array",
     "js_string_index_get_boxed", "js_string_substr",
     "js_super_construct_apply",
@@ -5330,6 +5331,11 @@ _POLL_REACH_FIXTURE = {
     # one-hop audit misses entirely.
     "js_gadget_create": ["{ js_helper_that_coerces(v) }"],
     "js_helper_that_coerces": ["{ js_string_coerce(v) }"],
+    # #7872's exact edge: the allocating concat wrapper reaches coercion via
+    # a non-ALLOC_RE arithmetic helper. Keeping the production names here
+    # proves the audit can still expose this two-hop disagreement.
+    "js_string_concat_box": ["{ js_dynamic_string_or_number_add(l, r) }"],
+    "js_dynamic_string_or_number_add": ["{ js_number_coerce(v) }"],
     # a name that appears ONLY in a comment and a string literal. Reported
     # would mean `_strip_noncode` has stopped working and the audit is
     # extracting premises from prose.
@@ -5346,13 +5352,15 @@ _POLL_REACH_FIXTURE = {
 
 def poll_reach_self_test():
     ok = True
-    poll = {"js_object_get_field_by_name", "js_string_coerce"}
+    poll = {"js_object_get_field_by_name", "js_string_coerce",
+            "js_number_coerce"}
     # Through the SAME stripper `runtime_symbol_bodies` applies, so the decoy
     # arm below tests the real pipeline rather than a hand-cleaned copy of it.
     fixture = {sym: [_strip_noncode(b) for b in bodies]
                for sym, bodies in _POLL_REACH_FIXTURE.items()}
     gaps = dict(poll_reach_gaps(fixture, poll))
-    want = {"js_widget_new", "js_widget_new_from_value", "js_gadget_create"}
+    want = {"js_widget_new", "js_widget_new_from_value", "js_gadget_create",
+            "js_string_concat_box"}
     if set(gaps) != want:
         print("self-test FAIL: --audit-poll-reach over the planted fixture -> "
               f"{sorted(gaps)}, expected {sorted(want)}", file=sys.stderr)


### PR DESCRIPTION
Closes #7872.

## Summary

- add `js_string_concat_box` to `POLL_CAPABLE_RUNTIME`, so every `--moving-only` checker arm sees the helper's path through `js_dynamic_string_or_number_add` to coercion/user code
- extend the planted poll-reach self-test with that exact two-hop production edge

## Reproduction

On the pre-fix `main` checkout:

```text
$ python3 scripts/gc_root_dominance_check.py --audit-poll-reach
error: ALLOC_RE symbols that CALL a POLL_CAPABLE_RUNTIME symbol but are not in POLL_CAPABLE_RUNTIME:
  js_string_concat_box                             -> js_dynamic_string_or_number_add
AUDIT_EXIT=2
```

After this change, the same audit reports 3,791 exported symbols, 1,616 intra-runtime call edges, 384 `ALLOC_RE` matches, and no unlisted poll-reaching allocation wrapper.

## Validation

- `python3 scripts/gc_root_dominance_check.py --self-test`
- all four static audits (`--audit-alloc-re`, `--audit-poll-capable`, `--audit-poll-reach`, `--audit-immovable-sources`)
- `python3 scripts/gc_gate_wiring_check.py`
- `python3 scripts/check_test_registration.py`
- shadow corpus: 139/139 sources, 161 IR modules, 0 skips
  - root-store dominance: 0 violations; 40/40 planted violations caught
  - unrooted allocas: 0
  - stale registers: 18, within the pinned 39 budget
- native corpus: 139/139 sources, 161 IR modules, 0 skips, 35,246 emitted statepoints / 21,290 non-empty live bundles
  - checked 35,085 safepoints and 50,900 relocations
  - 0 unrooted, 0 stale; 40/40 planted statepoint violations caught
- exact before/after classification over the curated corpus found 27 newly poll-reaching compiled functions but **0 newly exposed stale windows**
- `bash scripts/check_file_size.sh`
- `git diff --check`

Additional observation, not changed here: the dependency-scale Zod corpus emitted all 81 expected IR modules but its final link failed on unresolved intra-Zod symbols, identically with Perry's cache disabled. Running the checker directly over those emitted modules still met the normal floors (12,903 functions), reported 0 dominance violations, 0 unrooted allocas, and 89 stale uses within the 118 budget; the exact classification delta for this list entry was 0 newly exposed stale windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection safety checks for boxed string concatenation when coercion may execute user code.
  * Corrected poll-reachability analysis across indirect numeric coercion paths.
  * Added coverage for exact two-step coercion scenarios to improve audit accuracy and validation.

* **Documentation**
  * Added a changelog entry describing the corrected moving-only audit behavior and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->