### PR TITLE
fix(indexing): classify string receivers behind array claims (#7891)

### DIFF
--- a/changelog.d/7904-declared-array-string-index.md
+++ b/changelog.d/7904-declared-array-string-index.md
@@ -1,0 +1,1 @@
+Fixes numeric string-key reads through erased array declarations when the runtime receiver is a string.

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -275,6 +275,57 @@ fn lower_array_index_get_via_runtime_key(
     }
 }
 
+/// Read a string-valued key from a receiver admitted by an erased Array type.
+///
+/// The ordinary array ABI takes an already-unboxed `ArrayHeader*`, which loses
+/// an SSO String's tag/payload before the runtime can validate the claim. Keep
+/// the receiver boxed until that immediate representation is separated; heap
+/// Strings remain real pointers and are classified inside the array-key helper,
+/// while every other value retains the established fallback.
+fn lower_claimable_array_string_key_get(
+    ctx: &mut FnCtx<'_>,
+    arr_box: &str,
+    idx_double: &str,
+) -> String {
+    let string_idx = ctx.new_block("aidxkey.sso");
+    let array_idx = ctx.new_block("aidxkey.raw");
+    let merge_idx = ctx.new_block("aidxkey.merge");
+    let string_label = ctx.block_label(string_idx);
+    let array_label = ctx.block_label(array_idx);
+    let merge_label = ctx.block_label(merge_idx);
+
+    let bits = ctx.block().bitcast_double_to_i64(arr_box);
+    let top16 = ctx.block().lshr(I64, &bits, "48");
+    let is_sso_string = ctx.block().icmp_eq(I64, &top16, "32761"); // SHORT_STRING_TAG
+    ctx.block()
+        .cond_br(&is_sso_string, &string_label, &array_label);
+
+    ctx.current_block = string_idx;
+    let string_value = ctx.block().call(
+        DOUBLE,
+        "js_string_index_get_boxed",
+        &[(DOUBLE, arr_box), (DOUBLE, idx_double)],
+    );
+    let string_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = array_idx;
+    let arr_handle = unbox_to_i64(ctx.block(), arr_box);
+    let array_value = ctx.block().call(
+        DOUBLE,
+        "js_array_get_index_or_string",
+        &[(I64, &arr_handle), (DOUBLE, idx_double)],
+    );
+    let array_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    ctx.block().phi(
+        DOUBLE,
+        &[(&string_value, &string_end), (&array_value, &array_end)],
+    )
+}
+
 fn is_async_dispose_symbol_index(index: &Expr) -> bool {
     let Expr::SymbolFor(symbol_name) = index else {
         return false;
@@ -1153,20 +1204,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // records that the same guard is what makes a typed-array-valued
             // member receiver safe on this path.)
             //
-            // Restricted to a NON-string, NON-symbol key, and that restriction is
-            // load-bearing rather than tidy. The string-key arm of the array
-            // branch is `js_array_get_index_or_string`, whose string half calls
-            // `js_object_get_field_by_name` on the receiver — and that answers
-            // `undefined` for `s["0"]` on a heap STRING receiver, where JS
-            // answers the character. That is a pre-existing wrong answer on
-            // `main` — reachable today through a plain non-union declared
-            // receiver, filed as #7891 with a minimal repro — and a claim must
-            // not widen the set of shapes that reach it. With
-            // the restriction, a string or symbol key takes exactly the generic
-            // path it takes today; only the numeric read moves.
-            let claimed_array = recv_unknown
-                && !index_is_static_string_or_symbol
-                && crate::type_analysis::declared_array_property_claim(ctx, object);
+            // Restricted to a NON-string, NON-symbol key because only the
+            // numeric array tier has its own receiver guard. String-valued
+            // keys on an array claim are handled below by an SSO-tag guard;
+            // heap strings remain pointers and are classified inside the
+            // established array-key fallback before object lookup.
+            let declared_array_claim =
+                crate::type_analysis::declared_array_property_claim(ctx, object);
+            let claimed_array =
+                recv_unknown && !index_is_static_string_or_symbol && declared_array_claim;
             let recv_unknown = recv_unknown && !claimed_array;
             if recv_unknown && !index_is_static_string_or_symbol {
                 // #7640 section B: receiver live across an unconstrained index.
@@ -1188,7 +1234,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             //      generic object field access via js_object_get_field_by_name_f64
             //   3. Anything else → fall back to dynamic object field
             //      access by stringifying the index at runtime
-            if is_array_expr(ctx, object) || claimed_array {
+            if is_array_expr(ctx, object) || declared_array_claim {
                 // #321: a symbol-keyed array read (`arr[Symbol.iterator]`) must
                 // NOT take the numeric fast path below — `fptosi` on the symbol
                 // value yields a garbage index (returned a number). Route symbol
@@ -1209,18 +1255,27 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     });
                 }
                 if !is_numeric_expr(ctx, index) {
-                    // #7640 section B: `!is_numeric_expr` does not restrict the
-                    // index to a safe shape — `arr[f()]` is exactly this arm.
+                    // #7891: this route must retain the receiver's NaN-box tag.
+                    // `is_array_expr` trusts an erased declaration, so the
+                    // runtime value can be a String. The ordinary array helper
+                    // takes an already unboxed ArrayHeader pointer; its
+                    // string-key arm therefore answered `undefined` for a
+                    // string-valued receiver's canonical key (`xs["0"]`) and
+                    // could not represent SSO strings at all. The local tag
+                    // guard routes the immediate SSO encoding to the boxed
+                    // string index helper. Heap strings remain pointers and the
+                    // array helper classifies them before object lookup; every
+                    // other shape keeps the existing fallback. Numeric keys
+                    // retain the guarded array tier below.
+                    //
+                    // #7640 section B: `!is_numeric_expr` also does not restrict
+                    // the index to a safe shape — `arr[f()]` is exactly this arm.
                     return rooting::with_operands_rooted(ctx, &[object, index], |ctx, vals| {
                         let (arr_box, idx_double) = (vals[0].clone(), vals[1].clone());
-                        let arr_handle = {
-                            let blk = ctx.block();
-                            unbox_to_i64(blk, &arr_box)
-                        };
-                        Ok(ctx.block().call(
-                            DOUBLE,
-                            "js_array_get_index_or_string",
-                            &[(I64, &arr_handle), (DOUBLE, &idx_double)],
+                        Ok(lower_claimable_array_string_key_get(
+                            ctx,
+                            &arr_box,
+                            &idx_double,
                         ))
                     });
                 }

--- a/crates/perry-codegen/src/expr/index_get_claim_tests.rs
+++ b/crates/perry-codegen/src/expr/index_get_claim_tests.rs
@@ -1,0 +1,66 @@
+//! #7891: an array annotation is a claim, not a receiver-tag proof.
+//!
+//! These IR assertions discriminate the fix from a parity-only test: a string
+//! key must retain the SSO receiver representation, while the numeric sibling
+//! must keep the guarded array tier whose receiver checks make that claim safe.
+
+use crate::temp_root_coverage::main_ir_for as ir_for;
+use perry_hir::types::Type;
+use perry_hir::{Expr, Stmt};
+
+const ITEMS: u32 = 1;
+const RESULT: u32 = 2;
+
+fn declared_array_read_ir(name: &str, index: Expr) -> String {
+    ir_for(
+        name,
+        vec![
+            Stmt::Let {
+                id: ITEMS,
+                name: "items".to_string(),
+                ty: Type::Array(Box::new(Type::String)),
+                mutable: false,
+                // Deliberately violate the annotation in HIR. The source-level
+                // repro does the same through an `any` value stored in a typed
+                // field; this smaller shape reaches the identical IndexGet arm.
+                init: Some(Expr::String("ss".to_string())),
+            },
+            Stmt::Let {
+                id: RESULT,
+                name: "result".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(ITEMS)),
+                    index: Box::new(index),
+                }),
+            },
+        ],
+    )
+}
+
+#[test]
+fn string_key_on_a_declared_array_keeps_the_receiver_boxed() {
+    let ir = declared_array_read_ir("declared_array_string_key", Expr::String("0".to_string()));
+    assert!(
+        ir.contains("aidxkey.sso") && ir.contains("call double @js_string_index_get_boxed("),
+        "the claim-safe SSO tag arm was not emitted:\n{ir}"
+    );
+    assert!(
+        ir.contains("aidxkey.raw") && ir.contains("call double @js_array_get_index_or_string("),
+        "the pointer/primitive receiver fallback disappeared:\n{ir}"
+    );
+}
+
+#[test]
+fn numeric_key_on_a_declared_array_keeps_the_guarded_array_tier() {
+    let ir = declared_array_read_ir("declared_array_numeric_key", Expr::Integer(0));
+    assert!(
+        ir.contains("arr.guard.deref"),
+        "the numeric receiver-validation tier was not emitted:\n{ir}"
+    );
+    assert!(
+        !ir.contains("aidxkey.sso") && !ir.contains("call double @js_string_index_get_boxed("),
+        "the SSO receiver guard widened onto the numeric array path:\n{ir}"
+    );
+}

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1944,6 +1944,8 @@ mod dyn_extern_i18n;
 mod env_clones;
 mod fs_await;
 mod index_get;
+#[cfg(test)]
+mod index_get_claim_tests;
 mod masked_window;
 mod ptr_numarray_access;
 mod ta_param_f64_read;

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -523,6 +523,27 @@ pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
 }
 
 fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringHeader) -> f64 {
+    // #7891: an erased Array declaration can feed this ABI a heap StringHeader.
+    // The receiver arrived unboxed and no longer carries STRING_TAG, so recover
+    // its runtime kind from the GC header before ordinary by-name lookup. A
+    // canonical index reads the UTF-16 code unit; `length`, `constructor`, OOB
+    // and non-index keys fall through to the established String property path.
+    // (SSO strings have no pointer/header and are separated by codegen.)
+    if !arr.is_null() && !key.is_null() {
+        if let Some(header) = unsafe { crate::value::addr_class::try_read_gc_header(arr as usize) }
+        {
+            if header.obj_type == crate::gc::GC_TYPE_STRING {
+                let key_value = crate::value::JSValue::string_ptr(key as *mut crate::StringHeader);
+                let indexed = crate::string::js_string_index_get(
+                    arr as *const crate::StringHeader,
+                    f64::from_bits(key_value.bits()),
+                );
+                if indexed.to_bits() != crate::value::TAG_UNDEFINED {
+                    return indexed;
+                }
+            }
+        }
+    }
     let value =
         crate::object::js_object_get_field_by_name(arr as *const crate::object::ObjectHeader, key);
     f64::from_bits(value.bits())
@@ -1903,5 +1924,24 @@ mod keys_len_cap_tests {
             capacity,
             "cap must bound a bogus oversized length to the array's capacity"
         );
+    }
+}
+
+#[cfg(test)]
+mod claimed_array_string_receiver_tests {
+    use super::array_get_property_by_key;
+
+    #[test]
+    fn numeric_string_key_reads_a_heap_string_before_by_name_fallback() {
+        let receiver = crate::string::js_string_from_bytes(b"ss".as_ptr(), 2);
+        let zero = crate::string::js_string_from_bytes(b"0".as_ptr(), 1);
+        let indexed = array_get_property_by_key(receiver.cast(), zero);
+        assert_eq!(
+            crate::builtins::jsvalue_string_content(indexed).as_deref(),
+            Some("s")
+        );
+
+        let length = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+        assert_eq!(array_get_property_by_key(receiver.cast(), length), 2.0);
     }
 }

--- a/test-files/test_gap_7890_declared_array_receiver_element_read.ts
+++ b/test-files/test_gap_7890_declared_array_receiver_element_read.ts
@@ -164,8 +164,9 @@ console.log(scan(mkAlias([1, 2, 3] as any), "a"));
 console.log(scan(mkAlias({ length: 3 }), "a"));
 
 // A STRING-literal key on the same receiver shape is deliberately NOT admitted
-// to the array arm by #7890 — see `index_get.rs`. It stays on the generic path,
-// which is what these rows pin.
+// to the numeric array tier by #7890 — see `index_get.rs`. #7891 routes it
+// through an SSO-tag guard plus heap-header classification so a violated
+// declaration keeps enough receiver identity for string indexing.
 function stringKey(b: Bag): string {
   return (
     "" + b.items["length"] + "/" + b.items["nope"] + "/" + typeof b.items["constructor"]

--- a/test-files/test_gap_7891_string_receiver_numeric_string_key.ts
+++ b/test-files/test_gap_7891_string_receiver_numeric_string_key.ts
@@ -1,0 +1,44 @@
+// #7891: an erased array annotation must not make a numeric string key
+// interpret a runtime string receiver as an ArrayHeader.
+
+type Bag = { items: string[] };
+
+function mk(value: any): Bag {
+  return { items: value };
+}
+
+function viaDeclared(bag: Bag): string {
+  return "" + bag.items["0"] + "/" + bag.items[0];
+}
+
+function viaDynamicKey(bag: Bag, key: string): string {
+  return "" + bag.items[key];
+}
+
+function viaNullable(bag: Bag | null): string {
+  if (bag === null) return "null";
+  return "" + bag.items["0"];
+}
+
+const stringValue: any = "ss";
+console.log(viaDeclared(mk(stringValue)));
+console.log(viaDynamicKey(mk(stringValue), "1"));
+console.log("" + stringValue["length"] + "/" + typeof stringValue["constructor"]);
+console.log(viaNullable(mk(stringValue)));
+
+// JSON.parse produces an inline short string on Perry, exercising the second
+// receiver representation that cannot survive an ArrayHeader unbox at all.
+const shortStringValue: any = JSON.parse('{"value":"ss"}').value;
+console.log(viaDeclared(mk(shortStringValue)));
+console.log(viaDynamicKey(mk(shortStringValue), "1"));
+
+// Keep the ordinary array arm and the direct, runtime-classified string arm
+// beside the violated declaration so the expected behavior is unambiguous.
+console.log(viaDeclared(mk(["a", "b"])));
+console.log(viaDynamicKey(mk(["a", "b"]), "1"));
+const direct: any = "ss";
+console.log("" + direct["0"] + "/" + direct[0]);
+
+// The same false claim may hold an ordinary object; its established property
+// lookup must remain unchanged by the String-specific receiver guard.
+console.log(viaDeclared(mk({ 0: "object" })));


### PR DESCRIPTION
Closes #7891.

## What changed

- keep an SSO receiver boxed when a string-valued key is read through an erased Array declaration
- classify heap String receivers by their GC header before the array by-name fallback
- leave the numeric guarded-array tier unchanged
- add IR gates for the string-key and numeric-key siblings plus a runtime heap-string unit test
- add source parity coverage for literal/dynamic keys, heap/SSO strings, arrays, objects, and the existing direct-string behavior

## Reproduction

On current main, the new fixture printed `undefined/s` for the declared receiver while Node printed `s/s`. The direct `any` control already printed `s/s` in both.

## Validation

- focused codegen tests: 2 passed
- focused runtime test: 1 passed
- `cargo test -p perry-codegen`: passed, including integration and doc tests
- exact wrapper build: `-p perry -p perry-runtime-static -p perry-stdlib-static`
- fixture: Perry exit 0, Node exit 0, byte-exact output
- test-registration check: 197 files across 4 registries
- file-size gate: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric string-key access when values declared as arrays contain runtime strings.
  * Preserved expected string indexing and `length` property behavior across declared, nullable, parsed, and dynamic values.
  * Maintained correct behavior for ordinary arrays and object property lookups.

* **Tests**
  * Added regression coverage for string receivers, numeric and non-numeric keys, short parsed strings, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->