### PR TITLE
fix(link): preserve native members in Windows UI dedup

### DIFF
--- a/changelog.d/7920-windows-ui-archive-dedup.md
+++ b/changelog.d/7920-windows-ui-archive-dedup.md
@@ -1,0 +1,9 @@
+**Windows UI archive dedup no longer drops path-qualified native members.**
+Rebuilding the deduplicated Windows UI archive flattened member names, so
+equal basenames overwrote one another and WebView2LoaderStatic's
+`obj/.../*.obj` members (plus part of `winspool.drv`) were silently omitted —
+leaving `CreateCoreWebView2EnvironmentWithOptions` and friends undefined at
+link. Members are now normalized to unique flat names, `.drv` members are
+treated as import-library members alongside `.dll`, and `uxtheme.lib` /
+`winspool.lib` / `rpcrt4.lib` come from the canonical system link line.
+(Fragment added at merge; see the PR body for the full analysis.)

--- a/crates/perry/src/commands/compile/link/windows_link.rs
+++ b/crates/perry/src/commands/compile/link/windows_link.rs
@@ -44,6 +44,14 @@ pub(super) fn add_system_libs(cmd: &mut Command) {
         .arg("shlwapi.lib")
         .arg("ole32.lib")
         .arg("comctl32.lib")
+        // Perry strips bundled `.dll` import-library members from the UI
+        // staticlib during runtime deduplication. Keep every UI import explicit
+        // here so the trimmed archive remains self-contained at final link:
+        // uxtheme provides SetWindowTheme, winspool supplies the print-dialog
+        // imports, and rpcrt4 provides UuidCreate (windows-core GUID::new).
+        .arg("uxtheme.lib")
+        .arg("winspool.lib")
+        .arg("rpcrt4.lib")
         .arg("advapi32.lib")
         .arg("comdlg32.lib")
         .arg("ws2_32.lib")
@@ -80,7 +88,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn image_widget_system_imports_survive_the_staticlib_boundary() {
+    fn windows_ui_system_imports_survive_the_staticlib_boundary() {
         let mut command = Command::new("link.exe");
         add_system_libs(&mut command);
         let args: Vec<_> = command
@@ -89,6 +97,9 @@ mod tests {
             .collect();
         assert!(args.iter().any(|arg| arg == "shlwapi.lib"));
         assert!(args.iter().any(|arg| arg == "winhttp.lib"));
+        assert!(args.iter().any(|arg| arg == "uxtheme.lib"));
+        assert!(args.iter().any(|arg| arg == "winspool.lib"));
+        assert!(args.iter().any(|arg| arg == "rpcrt4.lib"));
     }
 }
 

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -412,6 +412,38 @@ fn collect_archive_undefined_by_member(
     )))
 }
 
+/// Locate a member after `llvm-ar x` extracted it into `extract_dir`.
+///
+/// COFF archives can preserve path-qualified member names (WebView2's loader
+/// uses names such as `obj/.../loader_impl.obj`), but `llvm-ar x` writes those
+/// members as their basename. Looking only at `extract_dir.join(member)` made
+/// the extraction appear successful while silently omitting the object from
+/// the rebuilt UI archive.
+fn extracted_archive_member(extract_dir: &Path, member: &str) -> Option<PathBuf> {
+    let exact = extract_dir.join(member);
+    if exact.exists() {
+        return Some(exact);
+    }
+    Path::new(member)
+        .file_name()
+        .map(|name| extract_dir.join(name))
+        .filter(|path| path.exists())
+}
+
+/// Rust staticlibs can bundle Windows SDK import-library members named after
+/// either a `.dll` or a `.drv` (notably the five same-named `winspool.drv`
+/// members). These must come from Perry's canonical system-library link line:
+/// extracting same-named import members one by one flattens/overwrites them and
+/// leaves an incomplete descriptor/thunk set in the rebuilt archive.
+fn is_windows_import_archive_member(member: &str) -> bool {
+    Path::new(member)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("dll") || extension.eq_ignore_ascii_case("drv")
+        })
+}
+
 /// On Windows, build a trimmed UI lib using the rlib (not staticlib).
 ///
 /// perry-ui-windows builds as both rlib and staticlib. The staticlib bundles
@@ -701,7 +733,7 @@ pub(super) fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<Pat
     let ui_only_deps: Vec<&String> = staticlib_members
         .iter()
         .filter(|m| {
-            if m.ends_with(".dll") {
+            if is_windows_import_archive_member(m) {
                 return false;
             }
             if m.contains("compiler_builtins") {
@@ -769,7 +801,7 @@ pub(super) fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<Pat
         let abs_rlib = std::fs::canonicalize(&rlib_path)?;
         let mut rlib_extracted = 0usize;
         let mut rlib_skipped = 0usize;
-        for member in &rlib_objects {
+        for (member_index, member) in rlib_objects.iter().enumerate() {
             let is_alloc_shim = !member.contains(".cgu.") && !member.contains("-cgu.");
             if is_alloc_shim {
                 rlib_skipped += 1;
@@ -782,9 +814,14 @@ pub(super) fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<Pat
                 .current_dir(&extract_dir)
                 .output()?;
             if out.status.success() {
-                let p = extract_dir.join(member);
-                if p.exists() {
-                    all_objects.push(p);
+                if let Some(extracted) = extracted_archive_member(&extract_dir, member) {
+                    // Move every extracted object to a unique flat name before
+                    // extracting the next member. Two path-qualified members
+                    // may share a basename, and llvm-ar would otherwise
+                    // overwrite the earlier one.
+                    let normalized = extract_dir.join(format!("rlib_{member_index}.obj"));
+                    std::fs::rename(extracted, &normalized)?;
+                    all_objects.push(normalized);
                     rlib_extracted += 1;
                 }
             }
@@ -798,7 +835,7 @@ pub(super) fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<Pat
     // is read (the warning below); the parallel `extract_ok` counter
     // was incremented but never reported. Dropped.
     let mut extract_fail = 0usize;
-    for member in &ui_only_deps {
+    for (member_index, member) in ui_only_deps.iter().enumerate() {
         let out = Command::new(&llvm_ar)
             .arg("x")
             .arg(&abs_staticlib)
@@ -806,9 +843,12 @@ pub(super) fn strip_duplicate_objects_from_lib(lib_path: &PathBuf) -> Result<Pat
             .current_dir(&extract_dir)
             .output()?;
         if out.status.success() {
-            let p = extract_dir.join(member.as_str());
-            if p.exists() {
-                all_objects.push(p);
+            if let Some(extracted) = extracted_archive_member(&extract_dir, member) {
+                let normalized = extract_dir.join(format!("static_{member_index}.obj"));
+                std::fs::rename(extracted, &normalized)?;
+                all_objects.push(normalized);
+            } else {
+                extract_fail += 1;
             }
         } else {
             extract_fail += 1;
@@ -1848,6 +1888,29 @@ empty_marker.o:
         let symbols = collect_archive_symbols_flat(&llvm_nm, &trimmed);
         assert!(symbols.contains("ui_only_symbol"));
         assert!(!symbols.contains("runtime_canonical"));
+    }
+
+    #[test]
+    fn extracted_path_qualified_archive_member_falls_back_to_basename() {
+        let temp = tempfile::tempdir().unwrap();
+        let extracted = temp.path().join("loader_impl.obj");
+        std::fs::write(&extracted, b"native object fixture").unwrap();
+
+        assert_eq!(
+            super::extracted_archive_member(
+                temp.path(),
+                "obj/edge_embedded_browser/client/win/WebView2LoaderLib/loader_impl.obj",
+            ),
+            Some(extracted)
+        );
+    }
+
+    #[test]
+    fn windows_import_members_include_dll_and_driver_archives() {
+        assert!(super::is_windows_import_archive_member("uxtheme.dll"));
+        assert!(super::is_windows_import_archive_member("winspool.drv"));
+        assert!(super::is_windows_import_archive_member("WINSPool.DRV"));
+        assert!(!super::is_windows_import_archive_member("loader_impl.obj"));
     }
 }
 


### PR DESCRIPTION
## Summary

- preserve path-qualified native COFF members when rebuilding the deduplicated Windows UI archive (notably WebView2LoaderStatic's `obj/.../*.obj` members)
- normalize extracted members to unique flat names so equal basenames cannot overwrite one another
- treat `.drv` members as Windows import-library members alongside `.dll`, and supply `uxtheme.lib`, `winspool.lib`, and `rpcrt4.lib` from the canonical system link line

## Why

#6051 fixed #6023's original `LNK1158: cannot run mt.exe`, but the TextField half was never verified. During a current-main Windows validation, `perry/ui` linking failed earlier because UI archive dedup silently omitted WebView2's path-qualified objects and retained an incomplete flattened subset of `winspool.drv` members. This left `CreateCoreWebView2EnvironmentWithOptions`, `SetWindowTheme`, `UuidCreate`, and winspool descriptor/thunk symbols unresolved.

With the archive fix applied, the current Windows UI fixture links and runs. Sending `EN_CHANGE` through the TextField's actual immediate `PerryVStack` parent reaches the callback and prints the updated value; Toggle callback dispatch also succeeds as a control. The historical mt.exe discovery/fallback tests remain green.

## Validation

- `cargo test -p perry --no-default-features --features dev-cli --bin perry windows_link -- --nocapture` — 22 passed
- `cargo test -p perry --no-default-features --features dev-cli --bin perry commands::compile::strip_dedup::strip_dedup_tests -- --nocapture` — 9 passed
- `cargo build --release -p perry-runtime-static -p perry-ui-windows`
- patched compiler: `test-files/test_ui_controls.ts` linked successfully on Windows with the coherent current-main runtime/UI archives
- Win32 event probe: TextField `EN_CHANGE` through `PerryVStack` emitted `Name: parent-route`; direct app-route control emitted `Name: top-route`; Toggle emitted `Notifications: 1`
- `cargo fmt --check -p perry`
- no version bump

Closes #6023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows builds by preserving required UI and runtime system library imports.
  * Fixed handling of path-qualified archive members and Windows DLL/driver import entries.
  * Prevented filename collisions when extracting bundled object files, improving build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->