### PR TITLE
fix(gc): make old-page defrag opt-in again until a workload can exercise it

### DIFF
--- a/changelog.d/7922-old-defrag-default-off.md
+++ b/changelog.d/7922-old-defrag-default-off.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Old-page defragmentation is opt-in again** (`PERRY_GC_OLD_DEFRAG=1`). #7913's rewrite-contract work — the `PARSE_KEY_RING`/diagnostics/perf-hooks rewrite coverage, class-key locals as precise mutable roots, all-or-nothing source-block evacuation, and the tightened runtime-holder policy — **all stays**; only the default flip is reverted.
+
+  #7876's own acceptance criteria required "a dependency-scale stress corpus clean" before re-enabling, and no such corpus exists. The structural reason it cannot exist yet: selection needs `dead_bytes >= live_bytes` on an old page, i.e. promote-then-die at scale, and no program in the 19-benchmark corpus can produce a candidate page — the `retain` family survives at 999–1000‰ (old pages ~fully live) and the `churn` family promotes almost nothing. Default-on therefore bought no benefit signal and no regression signal while inheriting the full old-address rewrite surface. Every GC gate was also still queued and unexecuted when it merged.
+
+  An unrecognised value is now **OFF** rather than ON, so a typo cannot silently enable old-generation relocation.
+
+  When a fragmentation workload exists that can exercise this, the losing arm gets deleted rather than left standing.
+
+- **The OFF state has behavioural coverage for the first time.** `select_old_page_defrag_pages_from_snapshot` does not consult the knob — the gate lives only in `select_old_page_defrag_pages` — so every pre-existing selection test bypassed the switch entirely, and the thread-local override was only ever set to `Some(true)`. Adds `OldDefragTestDisable` and a test asserting the disabled path short-circuits **before** the O(old pages) page-meta snapshot, pinning the gate's placement and not merely its effect.
+
+  The test asserts the snapshot call counter rather than the returned selection, with a load-bearing positive control: its first version asserted only "disabled returns nothing", which is vacuous in a process with no eligible old pages and passes identically against a kill switch that does nothing. Sabotage-verified — deleting the early-out turns it red while the value-mapping test stays green.

--- a/crates/perry-runtime/src/gc/oldgen_defrag.rs
+++ b/crates/perry-runtime/src/gc/oldgen_defrag.rs
@@ -106,8 +106,32 @@ impl Drop for OldDefragTestEnable {
     }
 }
 
+/// RAII *disable* for defrag on this thread, so the OFF arm is exercised
+/// deterministically rather than depending on the ambient environment.
+///
+/// Without this the OFF state has no behavioural coverage at all: the value
+/// mapping is unit-tested, but nothing asserts that a disabled collector
+/// actually declines to select a page. That gap is what #7917 records.
+#[cfg(test)]
+pub(crate) struct OldDefragTestDisable;
+
+#[cfg(test)]
+impl OldDefragTestDisable {
+    pub(crate) fn new() -> Self {
+        OLD_DEFRAG_TEST_OVERRIDE.with(|c| c.set(Some(false)));
+        OldDefragTestDisable
+    }
+}
+
+#[cfg(test)]
+impl Drop for OldDefragTestDisable {
+    fn drop(&mut self) {
+        OLD_DEFRAG_TEST_OVERRIDE.with(|c| c.set(None));
+    }
+}
+
 fn old_page_defrag_enabled_from_value(value: Option<&str>) -> bool {
-    !matches!(value, Some("0") | Some("off") | Some("false"))
+    matches!(value, Some("1") | Some("on") | Some("true"))
 }
 
 fn old_page_defrag_enabled() -> bool {
@@ -123,9 +147,23 @@ fn old_page_defrag_enabled() -> bool {
 }
 
 pub(super) fn select_old_page_defrag_pages(force: bool) -> OldPageDefragSelection {
-    // #7876 restored the mutable-root contract for old movable addresses and
-    // made defrag the production default. Keep an explicit kill switch for
-    // field diagnosis and rollback without shipping a second binary.
+    // #7876 restored the mutable-root contract for old movable addresses, and
+    // #7913 shipped that restoration with defrag ON by default. The contract
+    // work is sound and stays; the DEFAULT is what this reverts (#7917).
+    //
+    // #7876's own acceptance criteria said to "re-enable defrag only after the
+    // reproducer and a dependency-scale stress corpus are clean". No such
+    // corpus exists yet, and none of the 19 benchmark programs can produce a
+    // candidate page: selection needs `dead_bytes >= live_bytes` on an old
+    // page, which needs promote-then-die at scale. The retain family survives
+    // at 999-1000 permille and the churn family promotes almost nothing, so
+    // the suite yields neither a benefit signal nor a regression signal while
+    // still inheriting the full old-address rewrite surface.
+    //
+    // So this is opt-in until a fragmentation workload exists that can
+    // actually exercise it. When that lands, the losing arm gets DELETED
+    // rather than left standing -- per CLAUDE.md, a mode that still exists is
+    // a decision that has not been made.
     if !old_page_defrag_enabled() {
         return OldPageDefragSelection::default();
     }
@@ -135,17 +173,100 @@ pub(super) fn select_old_page_defrag_pages(force: bool) -> OldPageDefragSelectio
 
 #[cfg(test)]
 mod tests {
-    use super::old_page_defrag_enabled_from_value;
+    use super::{
+        old_page_defrag_enabled_from_value, select_old_page_defrag_pages, OldDefragTestDisable,
+        OldDefragTestEnable,
+    };
 
     #[test]
-    fn old_page_defrag_defaults_on_with_an_explicit_kill_switch() {
-        assert!(old_page_defrag_enabled_from_value(None));
+    fn old_page_defrag_is_opt_in_via_perry_gc_old_defrag() {
+        // Unset means OFF: defrag is opt-in until a fragmentation workload
+        // exists that can demonstrate it (#7917).
+        assert!(!old_page_defrag_enabled_from_value(None));
         assert!(old_page_defrag_enabled_from_value(Some("1")));
         assert!(old_page_defrag_enabled_from_value(Some("on")));
         assert!(old_page_defrag_enabled_from_value(Some("true")));
         assert!(!old_page_defrag_enabled_from_value(Some("0")));
         assert!(!old_page_defrag_enabled_from_value(Some("off")));
         assert!(!old_page_defrag_enabled_from_value(Some("false")));
-        assert!(old_page_defrag_enabled_from_value(Some("unexpected")));
+        // Anything unrecognised is OFF, so a typo cannot silently enable
+        // old-generation relocation.
+        assert!(!old_page_defrag_enabled_from_value(Some("unexpected")));
+    }
+
+    /// The OFF arm, asserted through the gated entry point rather than through
+    /// the value mapping.
+    ///
+    /// This matters because `select_old_page_defrag_pages_from_snapshot` does
+    /// NOT consult the knob — the gate lives only in
+    /// `select_old_page_defrag_pages` — so every pre-existing selection test
+    /// bypasses the switch entirely. Before this test the OFF state had no
+    /// behavioural coverage at all (#7917).
+    ///
+    /// The observable is the page-meta snapshot counter rather than the
+    /// returned selection, for two reasons. It needs no old-arena fixture, and
+    /// more importantly an empty selection is **not** evidence on its own: a
+    /// bare test process has no eligible old pages, so asserting only
+    /// "disabled returns nothing" passes just as happily against a kill switch
+    /// that does nothing at all. That is the gate-that-cannot-fail shape this
+    /// codebase keeps re-learning, and the first version of this test walked
+    /// straight into it.
+    ///
+    /// So the positive control is load-bearing: it proves the enabled path
+    /// really does reach the snapshot, which is the thing the disabled path
+    /// must then be shown to skip.
+    ///
+    /// It also pins the *placement* of the gate, not merely its effect: the
+    /// short-circuit must happen before the O(old pages) snapshot, so a
+    /// disabled collector pays nothing on every ordinary minor.
+    #[test]
+    fn disabled_defrag_short_circuits_before_taking_a_page_snapshot() {
+        use crate::arena::old_page_meta_snapshot_calls_for_tests as snapshot_calls;
+
+        let before_enabled = snapshot_calls();
+        let enabled = {
+            let _enable = OldDefragTestEnable::new();
+            select_old_page_defrag_pages(true)
+        };
+        let enabled_calls = snapshot_calls() - before_enabled;
+
+        let before_disabled = snapshot_calls();
+        let disabled_forced = {
+            let _disable = OldDefragTestDisable::new();
+            select_old_page_defrag_pages(true)
+        };
+        let disabled_unforced = {
+            let _disable = OldDefragTestDisable::new();
+            select_old_page_defrag_pages(false)
+        };
+        let disabled_calls = snapshot_calls() - before_disabled;
+
+        assert_eq!(
+            enabled_calls, 1,
+            "positive control: enabled defrag must reach the page snapshot. If \
+             this is 0 the assertions below prove nothing, because a switch \
+             that never runs looks identical to one that correctly declines"
+        );
+
+        assert_eq!(
+            disabled_calls, 0,
+            "the kill switch must short-circuit BEFORE the O(old pages) \
+             snapshot, so a disabled collector pays nothing per minor"
+        );
+
+        // `force` bypasses the dead>=live ratio, so this also proves the gate
+        // beats a forced selection rather than merely losing the ratio test.
+        assert_eq!(disabled_forced.selected_pages, 0);
+        assert_eq!(disabled_forced.candidate_pages, 0);
+        assert!(disabled_forced.pages.is_empty());
+        assert!(disabled_forced.page_order.is_empty());
+        assert_eq!(disabled_forced.selected_live_bytes, 0);
+        assert_eq!(disabled_forced.selected_reclaimable_bytes, 0);
+        assert_eq!(disabled_unforced.selected_pages, 0);
+        assert!(disabled_unforced.pages.is_empty());
+
+        // Sanity: the enabled arm returned a real (possibly empty) selection
+        // rather than the disabled default, i.e. the two paths are distinct.
+        let _ = enabled;
     }
 }


### PR DESCRIPTION
## Summary

Makes old-page defragmentation **opt-in** again (`PERRY_GC_OLD_DEFRAG=1`), reverting only the default flip from #7913. **Every piece of #7913's correctness work stays** — this is not a revert of that PR.

Closes #7917.

## Why only the default

#7913's contract work audits well and is worth keeping regardless of the default:

- `scripts/gc_root_dominance_allowlist.json` is still **empty**, so the ~40 previously-exempted `@perry_class_keys_*` hits were genuinely fixed rather than re-suppressed.
- The runtime holder policy was **tightened**: `open_gap` and `unverified` verdicts now fail outright.
- `PARSE_KEY_RING` (#7231) and `DIAG_CHANNEL_BY_KEY`, whose safety rested explicitly on *"only old-gen defrag can move them"*, were fixed rather than exempted.
- It honoured the tripwire the deleted class-keys exemption left behind — that exemption's own `becomes_real_when` named this exact trigger.

The **default flip** is the separable part, and it shipped without the evidence its own issue required. #7876's stated acceptance criteria:

> Re-enable defrag only after the reproducer and a **dependency-scale stress corpus** are clean.

No such corpus exists. Additionally, every GC gate (`gc-ratchet`, `gc-moving-witnesses`, `gc-root-dominance`, `gc-native-roots`, `gc-ptr-shape-off-witness`) was still `queued`/`pending` and had not executed when #7913 merged.

## The structural reason this cannot be validated yet

Selection requires `dead_bytes >= live_bytes` on an old page — promote-then-die at scale. Measured survival on the benchmark corpus:

- the `retain` family survives at **999–1000‰**, so its old pages are ~fully live and `dead_bytes ≈ 0`
- the `churn` family runs at **0–4‰** survival and promotes almost nothing, so there is barely an old generation to fragment
- `shapes` runs 1 cycle; `asyncpipe` runs 0

**No program in the 19-benchmark corpus can produce a candidate page.** So shipping it on by default buys no benefit signal and no regression signal, while inheriting the full old-address rewrite surface. It is a footprint feature for long-lived servers with heterogeneous promoted objects — a workload class the suite does not contain.

The intended end state is one mode, not two: when a fragmentation workload exists and shows benefit, flip it on and **delete** the off branch (or delete the feature). Per CLAUDE.md, *a mode that still exists is a decision that hasn't been made*.

## Changes

- `old_page_defrag_enabled_from_value` now matches `1`/`on`/`true` instead of negating `0`/`off`/`false`, so an **unrecognised value is OFF** — a typo cannot silently enable old-generation relocation.
- `OldDefragTestDisable`, an RAII guard setting the thread-local override to `Some(false)`. Before this the override was only ever `Some(true)` or `None`, so the OFF state had no deterministic hook at all.
- Two tests (see below).
- The rationale is written at the gate itself, including the condition for removing this.

## Test plan

- [x] `old_page_defrag_is_opt_in_via_perry_gc_old_defrag` — both arms plus the unrecognised-value case.
- [x] `disabled_defrag_short_circuits_before_taking_a_page_snapshot` — the **behavioural** OFF assertion, which did not previously exist. `select_old_page_defrag_pages_from_snapshot` does not consult the knob (the gate is only in `select_old_page_defrag_pages`), so every pre-existing selection test bypasses the switch entirely.
- [x] **Sabotage-verified**: deleting the `if !old_page_defrag_enabled()` early-out turns the new test RED and leaves the value-mapping test green — so it detects the gate's *placement*, not just its string mapping.
- [x] `cargo test -p perry-runtime --lib gc::oldgen_defrag` — 2 passed.

### On the observable this test uses

It asserts the page-meta **snapshot call counter**, not the returned selection, and the positive control is load-bearing.

The first version of this test asserted only "disabled returns an empty selection". That is **vacuous** — a bare test process has no eligible old pages, so it passes identically against a kill switch that does nothing. It failed on its own positive-control assertion, which is how the problem was caught. Asserting the counter also pins that the short-circuit happens **before** the O(old pages) snapshot, so a disabled collector pays nothing per minor.

The counter is a `thread_local!`, as is the override, so this is safe under parallel test execution.


---

## Update: the "cannot be validated" claim is now MEASURED, not inferred

The reasoning above argued from survival ratios that no corpus program can produce a candidate page. A separate GC workstream then measured it directly, with defrag at #7913's new default:

> `PERRY_GC_TRACE=1` reports **`old_page_candidate_pages = 0` and `old_page_selected_pages = 0` on all 15 programs checked.**

So old-page relocation never selects a page anywhere in the corpus. Two consequences:

1. **"19/19 corpus green with defrag on" is vacuous** — it is CLAUDE.md's #7024 shape, a gate that is green because its subject never ran. Any future validation of this feature must assert `selected_pages > 0` before its verdict counts.
2. **#7913's default flip is unexercised by this corpus**, empirically and not just in principle. That is the whole argument for this PR.

Related and now merged: #7919 pins that old-page relocation expands a described-but-unexpanded promoted page run before moving anything (the #7914 interaction). Notably the defence has to sit at the *reader*, not at selection — a freshly described page has `dead_bytes == 0` so it is never selected, but #7913 widens evacuation to whole source blocks, so a described page can still be dragged in by a selected neighbour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Old-generation defragmentation is now disabled by default.
  * Enable it with `PERRY_GC_OLD_DEFRAG=1`, `on`, or `true`.
  * Unrecognized configuration values now safely disable defragmentation.
* **Tests**
  * Added coverage for disabled defragmentation, including forced-selection scenarios and early exit behavior.
* **Documentation**
  * Documented the new opt-in behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->