### PR TITLE
perf(runtime): guarded per-element fast arm for Promise.all (#7911)

### DIFF
--- a/changelog.d/7924-promise-all-fast-arm.md
+++ b/changelog.d/7924-promise-all-fast-arm.md
@@ -1,0 +1,95 @@
+### `Promise.all`: a guarded per-element fast arm, and a measured "no" to routing it natively (#7911)
+
+`Promise.all([...])` lowers to `js_promise_all_iterable` → the spec combinator
+(`spec_combinators.rs::run_combinator`). #7911 asked whether it could instead be
+routed to the simplified native `js_promise_all`, whose fan-out is ~29 % of the
+`asyncpipe` benchmark — and deliberately framed that as an open question rather
+than a given.
+
+**The answer is no, and it is measured rather than argued.** Seven probe files
+(~90 assertions) were written against `node 26.5.1 --experimental-strip-types`
+first, then run against the current path and against a throwaway build that
+routes `Promise.all` into `js_promise_all`:
+
+* the current spec path matches node on **7/7** `Promise.resolve` observables
+  (read once off `C`, invoked per element with `this === Promise`, a patched
+  `resolve` transforming the values, non-callable → `TypeError`, a throwing
+  `resolve` propagating, `Promise.resolve(p) === p`). Routed natively: **0/7** —
+  `Promise.resolve` is never read at all.
+* an own `then` on an element is invoked today and ignored when routed.
+* **the routed build dies**: `js_promise_all` never invokes `then`, so it never
+  runs `mark_rejection_handled`; a rejection the combinator swallows stays
+  flagged unhandled and terminates the process. Two of the seven probes exit 1
+  with `Uncaught (in promise)`. `Promise.all([Promise.reject(a),
+  Promise.reject(b)])` inside a `try/catch` is an ordinary shape.
+
+The cost, however, is not intrinsic to the spec algorithm — it is in HOW the two
+observable per-element steps run. `Call(promiseResolve, C, «next»)` reaches
+`js_promise_resolved(next)` through a setjmp frame, two `js_implicit_this_set`
+TLS writes, a closure dispatch, a `RuntimeHandleScope`, and an
+`is_default_promise_constructor` that allocates a fresh `"Promise"` key string
+per element. `Invoke(nextPromise, "then", …)` reaches `js_promise_then` through
+a second setjmp frame, the whole `native_call_method` tower and three
+own-property probes, and then allocates a chained promise per element that
+`Promise.all` immediately discards.
+
+So this adds a per-element fast arm that calls the primitives those towers
+select, entered only when: `C` is the intrinsic `%Promise%`; the
+`promiseResolve` value — already read once, observably, by `get_promise_resolve`
+— is the reified `promise_resolve_static` thunk (matched by closure FUNCTION
+POINTER, because `Get(Promise, "resolve")` may reify a fresh closure object per
+read); neither `v8.promiseHooks` nor `async_hooks` is active; and the value the
+resolve step produced is a genuine `GC_TYPE_PROMISE` with no own `then` and no
+own `constructor`. The last two are exactly the tests
+`native_call_method/primitive_methods.rs` makes before jumping to
+`js_promise_then`, and they are re-tested on the RESOLVED value rather than the
+raw element because `js_promise_resolved` returns the element itself for promise
+identity. The hooks clause is what makes dropping the discarded chained promise
+unobservable — `js_promise_attach_handlers` is `js_promise_then` minus that
+allocation, and the allocation's only external effect is the lifecycle
+callbacks.
+
+Nothing the spec makes observable moves: the iterator drain,
+`NewPromiseCapability`, the single `Get(C, "resolve")`, the resolve-element
+closures with their `[[AlreadyCalled]]` guards and `remainingElementsCount`, and
+the final `Call(cap.resolve, …)` are all unchanged. Only a boolean is hoisted
+out of the loop — the capability's reject function is a GC object, and caching
+its raw address across a loop that allocates a guard array and a closure every
+iteration is the #7184/#7497 defect shape verbatim, so that address is re-read
+from its handle at each use.
+
+**Measured** (instructions retired, `/usr/bin/time -l`, both arms from one
+binary; no wall clock quoted — the dev box ran at load 17–90):
+
+| program | before | after | Δ |
+|---|--:|--:|--:|
+| 1200×200 fan-out, settled elements | 548 345 659 | 397 709 920 | −27.5 % |
+| 1200×200 fan-out, pending elements | 803 142 312 | 651 573 199 | −18.9 % |
+| `asyncpipe` @240 / @360 / @480 batches | — | — | −33.9 % / −34.3 % / −30.7 % |
+| `asyncpipe` @120, nursery cap inactive | 1 686 481 864 | 1 534 500 019 | −9.0 % |
+| `asyncpipe` @120, default config | 1 927 275 215 | 2 017 785 565 | **+4.7 %** |
+
+`PERRY_MT_PROFILE=1` on `asyncpipe`: `then=23800 → 0`, `new=95641 → 71841`; every
+other counter unchanged.
+
+★ **The one regression is a GC trigger boundary and is reported, not hidden.**
+`asyncpipe` at its shipped 120 batches runs 0 copying minors before and 1 after
+(`copied_objects=156236`, `trigger=ArenaBytes`); arena in-use at the decision
+point is 17 452 448 B vs 17 896 616 B, a 444 KB window on 17.5 MB. At 240/360/480
+batches, where both arms run the same number of copying minors, the change is
+−31 %…−34 %. This is the knife edge `gc-handoff/ASYNC2-NOTES.md` already
+documents, and the consequence for future work is that **`asyncpipe`@120 is not
+a usable A/B target for `Promise.all` changes** — the scaled variants are.
+
+Validation: 19/19 corpus programs byte-exact and identical between arms; 98
+async/promise/stream/timer/thread `test-files` with zero arm-vs-arm differences;
+the seven probe files byte-identical to the pre-change build, including all
+eight pre-existing node divergences the probes surfaced (patched
+`Array.prototype[@@iterator]`, patched `Promise.prototype.then`, spec iteration
+interleaving, `class Q extends Promise` with an explicit constructor, an
+element's own `constructor` — all documented in
+`gc-handoff/PROMISEALL-NOTES.md` for separate issues). Two new gap files pin the
+observables on both sides of the guard, and six `perry-runtime` unit tests cover
+the guard predicates — one of them asserting via a `cfg(test)` tally that the
+fast arm was actually TAKEN, so a fast path that silently stopped firing fails
+rather than passes. No env knob ships.

--- a/crates/perry-runtime/src/promise/spec_combinators.rs
+++ b/crates/perry-runtime/src/promise/spec_combinators.rs
@@ -557,6 +557,111 @@ fn build_settled_rejected(reason: f64) -> f64 {
 // PerformPromise{All,AllSettled,Race,Any}
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// #7911: `Promise.all` per-element fast arm.
+//
+// The two per-element steps the spec makes observable — `Call(promiseResolve,
+// C, «next»)` and `Invoke(nextPromise, "then", …)` — are BOTH inert when the
+// combinator is running on the intrinsic `Promise` with the intrinsic
+// `Promise.resolve`, and the element resolves to a native promise carrying no
+// own `then` / `constructor` expando. `fast_element_ok` states that condition;
+// see `docs`/`changelog.d` for the enumerated observables. The fast arm calls
+// the SAME two runtime primitives the slow arm reaches through the dispatch
+// towers, so the resulting microtask job graph is identical:
+//
+//   Call(%Promise.resolve%, %Promise%, «next») == js_promise_resolved(next)
+//        (`js_promise_resolve_spec`'s own `is_default_promise_constructor` arm)
+//   Invoke(p, "then", «onFul, onRej»)          == js_promise_then(p, …)
+//        (`native_call_method/primitive_methods.rs`'s intrinsic then arm)
+//
+// with one deliberate difference: `js_promise_attach_handlers` replaces
+// `js_promise_then`, i.e. the chained promise `Promise.prototype.then` would
+// return is not allocated. `Promise.all` discards it, it is unreachable from
+// user code, and its only externally visible effects are the
+// `v8.promiseHooks` / `async_hooks` lifecycle callbacks — which the guard
+// excludes by requiring both hook sets to be inactive.
+
+// A test-only tally of how many elements actually took the fast arm. A test
+// that only asserts "nothing broke" cannot tell a working fast path from a
+// dead one — CLAUDE.md's "a gate must assert its subject was live".
+#[cfg(test)]
+crate::perry_thread_local! {
+    pub(super) static FAST_ARM_ELEMENTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[inline]
+#[allow(unused_variables)]
+fn note_fast_arm_element(taken: bool) {
+    #[cfg(test)]
+    if taken {
+        FAST_ARM_ELEMENTS.with(|c| c.set(c.get() + 1));
+    }
+}
+
+/// True iff `resolve_fn` is the intrinsic `Promise.resolve` — i.e. the reified
+/// `promise_resolve_static` thunk, not a user replacement. Compares the
+/// CLOSURE'S FUNCTION POINTER, not the closure object: `Get(Promise,
+/// "resolve")` may hand back a freshly reified closure each read, so object
+/// identity is not stable, but the underlying thunk is.
+fn is_intrinsic_promise_resolve(resolve_fn: f64) -> bool {
+    let Some((intrinsic, _, _, _)) = crate::object::promise_static_function_spec("resolve") else {
+        return false;
+    };
+    let bits = resolve_fn.to_bits();
+    if (bits & crate::value::TAG_MASK) != crate::value::POINTER_TAG {
+        return false;
+    }
+    let raw = (bits & crate::value::POINTER_MASK) as usize;
+    if crate::value::addr_class::is_handle_band(raw) || !crate::closure::is_closure_ptr(raw) {
+        return false;
+    }
+    unsafe { (*(raw as *const crate::closure::ClosureHeader)).func_ptr == intrinsic }
+}
+
+/// True while any promise-lifecycle observer is installed. Re-checked per
+/// element because the loop runs user JS (a thenable's `then` getter) between
+/// elements and `v8.promiseHooks` can be armed from it.
+#[inline]
+fn promise_lifecycle_observed() -> bool {
+    crate::v8::promise_hooks_active() || crate::async_hooks::hooks_active()
+}
+
+/// The element's resolved promise, when it is a plain native `Promise` whose
+/// `then` would dispatch to the intrinsic `Promise.prototype.then`. Mirrors the
+/// own-property tests in `native_call_method/primitive_methods.rs`: an own
+/// `then` is a user override that must be invoked, and an own `constructor`
+/// sends `then` through `SpeciesConstructor` (a user-observable read).
+fn attachable_native_promise(value: f64) -> Option<*mut Promise> {
+    if crate::promise::js_value_is_promise(value) == 0 {
+        return None;
+    }
+    let p: *mut Promise = unboxed_ptr(value);
+    if p.is_null() {
+        return None;
+    }
+    let addr = p as usize;
+    if crate::promise::promise_has_own_property(addr, "then")
+        || crate::promise::promise_has_own_constructor(addr)
+    {
+        return None;
+    }
+    Some(p)
+}
+
+/// A capability resolving function as a raw `ClosurePtr`, or `None` if it is
+/// not a plain closure (a user constructor's capability can hold anything).
+fn as_closure_ptr(value: f64) -> Option<crate::promise::ClosurePtr> {
+    let bits = value.to_bits();
+    if (bits & crate::value::TAG_MASK) != crate::value::POINTER_TAG {
+        return None;
+    }
+    let raw = (bits & crate::value::POINTER_MASK) as usize;
+    if crate::value::addr_class::is_handle_band(raw) || !crate::closure::is_closure_ptr(raw) {
+        return None;
+    }
+    Some(raw as crate::promise::ClosurePtr)
+}
+
 /// Run the per-element loop. `cap` is the result capability, `promise_resolve`
 /// the `C.resolve` function, `elements` the snapshot of iterated values.
 /// Returns `Ok(())` on success or `Err(thrown)` for `IfAbruptRejectPromise`.
@@ -611,15 +716,46 @@ fn perform(
     let values_ptr =
         || -> *mut crate::array::ArrayHeader { unboxed_ptr(values_h.get_nanbox_f64()) };
 
+    // #7911: hoisted half of the fast-arm guard. Both operands are read ONCE by
+    // the spec (`C` is the captured `this`, `promiseResolve` the single
+    // `Get(C, "resolve")` in `run_combinator`), so hoisting is not just an
+    // optimisation — re-reading `globalThis.Promise` per element would be the
+    // less faithful thing to do.
+    let fast_arm = kind == CombinatorKind::All
+        && is_default_promise_constructor(ctor_h.get_nanbox_f64())
+        && is_intrinsic_promise_resolve(resolve_fn_h.get_nanbox_f64());
+    // Only a BOOLEAN is hoisted. The capability's reject function is a GC
+    // object; caching its raw address across the per-element loop (which
+    // allocates a guard array and a closure every iteration, and runs user JS)
+    // is the #7184/#7497 defect shape verbatim. The address is re-read from
+    // `cap_reject_h` at each point of use.
+    let cap_reject_is_closure = fast_arm && as_closure_ptr(cap_reject_h.get_nanbox_f64()).is_some();
+
     for i in 0..count {
         let iter = crate::gc::RuntimeHandleScope::new();
         let next = js_array_get_f64(unboxed_ptr(elements_h.get_nanbox_f64()), i);
         // nextPromise = ? Call(promiseResolve, C, «next»)
-        let next_promise = call_with_this(
-            resolve_fn_h.get_nanbox_f64(),
-            ctor_h.get_nanbox_f64(),
-            &[next],
-        )?;
+        //
+        // #7911 fast arm: with C = %Promise% and the intrinsic `Promise.resolve`
+        // this call is `js_promise_resolved(next)` verbatim — see
+        // `js_promise_resolve_spec`'s `is_default_promise_constructor` branch.
+        // The `combinator_catch_js` frame is kept because thenable assimilation
+        // reads `Get(next, "then")`, whose getter may throw and must funnel
+        // through IfAbruptRejectPromise exactly as the generic call does.
+        let element_fast = cap_reject_is_closure && !promise_lifecycle_observed();
+        let next_promise = if element_fast {
+            let next_h = iter.root_nanbox_f64(next);
+            combinator_catch_js(|| {
+                let p = crate::promise::js_promise_resolved(next_h.get_nanbox_f64());
+                boxed_ptr(p)
+            })?
+        } else {
+            call_with_this(
+                resolve_fn_h.get_nanbox_f64(),
+                ctor_h.get_nanbox_f64(),
+                &[next],
+            )?
+        };
         let next_promise_h = iter.root_nanbox_f64(next_promise);
 
         match kind {
@@ -636,10 +772,39 @@ fn perform(
                 )));
                 let state = state_ptr();
                 js_array_set_f64(state, 0, js_array_get_f64(state, 0) + 1.0);
-                invoke_then(
-                    next_promise_h.get_nanbox_f64(),
-                    &[elem_h.get_nanbox_f64(), cap_reject_h.get_nanbox_f64()],
-                )?;
+                // `attachable_native_promise` is re-tested here rather than
+                // above because `js_promise_resolved` may have RETURNED the
+                // element itself (promise identity), so the own-`then` /
+                // own-`constructor` expandos that would make `Invoke` observable
+                // belong to the resolved value, not to the raw element.
+                let attached = if element_fast
+                    && !promise_lifecycle_observed()
+                    && attachable_native_promise(next_promise_h.get_nanbox_f64()).is_some()
+                {
+                    // Every address below is re-read from its handle here, AFTER
+                    // the last thing that can allocate (`attachable_native_promise`
+                    // interns the "then"/"constructor" keys), and nothing between
+                    // these four lines allocates.
+                    let p: *mut Promise = unboxed_ptr(next_promise_h.get_nanbox_f64());
+                    let on_fulfilled = as_closure_ptr(elem_h.get_nanbox_f64());
+                    let on_rejected = as_closure_ptr(cap_reject_h.get_nanbox_f64());
+                    match (on_fulfilled, on_rejected) {
+                        (Some(f), Some(r)) => {
+                            crate::promise::js_promise_attach_handlers(p, f, r);
+                            true
+                        }
+                        _ => false,
+                    }
+                } else {
+                    false
+                };
+                note_fast_arm_element(attached);
+                if !attached {
+                    invoke_then(
+                        next_promise_h.get_nanbox_f64(),
+                        &[elem_h.get_nanbox_f64(), cap_reject_h.get_nanbox_f64()],
+                    )?;
+                }
             }
             CombinatorKind::AllSettled => {
                 let guard_h = iter.root_nanbox_f64(boxed_ptr(new_guard()));
@@ -1022,4 +1187,178 @@ pub extern "C" fn js_promise_try_spec(this_ctor: f64, callback: f64, rest: f64) 
         }
     }
     cap_promise_h.get_nanbox_f64()
+}
+
+// ---------------------------------------------------------------------------
+// #7911 fast-arm tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod fast_arm_tests {
+    use super::*;
+    use crate::array::{js_array_alloc, js_array_get_f64, js_array_set_f64};
+    use crate::closure::{js_closure_alloc, js_closure_set_capture_f64};
+    use crate::promise::{js_promise_run_microtasks, PromiseState};
+
+    fn reset() {
+        FAST_ARM_ELEMENTS.with(|c| c.set(0));
+    }
+
+    fn taken() -> u64 {
+        FAST_ARM_ELEMENTS.with(|c| c.get())
+    }
+
+    fn array_of(values: &[f64]) -> f64 {
+        let arr = js_array_alloc(values.len() as u32);
+        unsafe {
+            (*arr).length = values.len() as u32;
+        }
+        for (i, v) in values.iter().enumerate() {
+            js_array_set_f64(arr, i as u32, *v);
+        }
+        js_nanbox_pointer(arr as i64)
+    }
+
+    fn settled_promise(value: f64) -> f64 {
+        boxed_ptr(crate::promise::js_promise_resolved(value))
+    }
+
+    fn run_all(iterable: f64) -> *mut Promise {
+        let c = default_promise_ctor();
+        unboxed_ptr(js_promise_all_spec(c, iterable))
+    }
+
+    /// The guard's identity test must accept the reified intrinsic and reject
+    /// anything else — including another `Promise` static, which is the shape a
+    /// `Promise.resolve = Promise.reject` assignment produces.
+    #[test]
+    fn intrinsic_promise_resolve_is_identified_by_thunk_not_by_object() {
+        let (resolve_thunk, _, _, _) =
+            crate::object::promise_static_function_spec("resolve").expect("resolve spec");
+        let (reject_thunk, _, _, _) =
+            crate::object::promise_static_function_spec("reject").expect("reject spec");
+        assert_ne!(resolve_thunk, reject_thunk);
+
+        let good = boxed_ptr(js_closure_alloc(resolve_thunk, 0));
+        assert!(is_intrinsic_promise_resolve(good));
+
+        let wrong_static = boxed_ptr(js_closure_alloc(reject_thunk, 0));
+        assert!(!is_intrinsic_promise_resolve(wrong_static));
+
+        // Non-closure values must not be probed as closures.
+        assert!(!is_intrinsic_promise_resolve(undef()));
+        assert!(!is_intrinsic_promise_resolve(1.0));
+        assert!(!is_intrinsic_promise_resolve(js_nanbox_pointer(0x40001)));
+    }
+
+    /// The subject is live: `Promise.all` over plain native promises takes the
+    /// fast arm for every element, and still resolves with the right values.
+    #[test]
+    fn fast_arm_is_taken_for_plain_native_promises() {
+        reset();
+        let elements = array_of(&[
+            settled_promise(1.0),
+            settled_promise(2.0),
+            settled_promise(3.0),
+        ]);
+        let all = run_all(elements);
+        assert!(!all.is_null());
+        js_promise_run_microtasks();
+        unsafe {
+            assert_eq!((*all).state, PromiseState::Fulfilled);
+            let results = crate::value::js_nanbox_get_pointer((*all).value)
+                as *const crate::array::ArrayHeader;
+            assert_eq!(js_array_get_f64(results, 0), 1.0);
+            assert_eq!(js_array_get_f64(results, 1), 2.0);
+            assert_eq!(js_array_get_f64(results, 2), 3.0);
+        }
+        assert_eq!(taken(), 3, "every element should have taken the fast arm");
+    }
+
+    /// Non-promise elements resolve through the same `js_promise_resolved`, so
+    /// they are still eligible once wrapped.
+    #[test]
+    fn fast_arm_handles_plain_values() {
+        reset();
+        let all = run_all(array_of(&[10.0, 20.0]));
+        js_promise_run_microtasks();
+        unsafe {
+            assert_eq!((*all).state, PromiseState::Fulfilled);
+        }
+        assert_eq!(taken(), 2);
+    }
+
+    extern "C" fn own_then_fn(
+        closure: *const crate::closure::ClosureHeader,
+        on_fulfilled: f64,
+        _on_rejected: f64,
+    ) -> f64 {
+        let v = crate::closure::js_closure_get_capture_f64(closure, 0);
+        unsafe {
+            crate::closure::js_native_call_value(on_fulfilled, [v].as_ptr(), 1);
+        }
+        undef()
+    }
+
+    /// An own `then` on the resolved element is a user override the spec must
+    /// invoke — the fast arm must refuse it, and the override must run.
+    #[test]
+    fn own_then_expando_forces_the_slow_arm_and_is_invoked() {
+        reset();
+        let p = settled_promise(1.0);
+        let then = js_closure_alloc(own_then_fn as *const u8, 1);
+        js_closure_set_capture_f64(then, 0, 99.0);
+        unsafe {
+            crate::object::exotic_expando::exotic_set_property(
+                unboxed_ptr::<u8>(p) as usize,
+                crate::object::exotic_expando::ExoticKind::Promise,
+                "then",
+                boxed_ptr(then),
+                p,
+            );
+        }
+        assert!(attachable_native_promise(p).is_none());
+
+        let all = run_all(array_of(&[p]));
+        js_promise_run_microtasks();
+        unsafe {
+            assert_eq!((*all).state, PromiseState::Fulfilled);
+            let results = crate::value::js_nanbox_get_pointer((*all).value)
+                as *const crate::array::ArrayHeader;
+            assert_eq!(
+                js_array_get_f64(results, 0),
+                99.0,
+                "the own `then` override must supply the value"
+            );
+        }
+        assert_eq!(taken(), 0, "an own `then` must not take the fast arm");
+    }
+
+    /// An own `constructor` sends `then` through SpeciesConstructor, a
+    /// user-observable read, so it is likewise excluded.
+    #[test]
+    fn own_constructor_expando_forces_the_slow_arm() {
+        let p = settled_promise(5.0);
+        assert!(attachable_native_promise(p).is_some());
+        unsafe {
+            crate::object::exotic_expando::exotic_set_property(
+                unboxed_ptr::<u8>(p) as usize,
+                crate::object::exotic_expando::ExoticKind::Promise,
+                "constructor",
+                1.0,
+                p,
+            );
+        }
+        assert!(attachable_native_promise(p).is_none());
+    }
+
+    /// Values that are not native promises are never attachable, and the probe
+    /// must not dereference them as promise headers.
+    #[test]
+    fn non_promise_values_are_never_attachable() {
+        assert!(attachable_native_promise(undef()).is_none());
+        assert!(attachable_native_promise(3.5).is_none());
+        assert!(attachable_native_promise(js_nanbox_pointer(0x40001)).is_none());
+        assert!(attachable_native_promise(array_of(&[1.0])).is_none());
+    }
 }

--- a/test-files/test_gap_7911_promise_all_fast_arm.ts
+++ b/test-files/test_gap_7911_promise_all_fast_arm.ts
@@ -1,0 +1,209 @@
+// #7911: `Promise.all` runs a guarded per-element fast arm when the
+// combinator is on the intrinsic `Promise` with an unpatched
+// `Promise.resolve` and the element resolves to a plain native promise.
+//
+// This file pins the observables of the cases that DO take that arm: the
+// microtask job graph (tick counts and interleaving), rejection ordering and
+// unhandled-rejection accounting, and the shape/identity of the resolved
+// values. Every line here must stay byte-identical to
+// `node --experimental-strip-types`.
+//
+// The complementary file, `test_gap_7911_promise_all_slow_arm_guards.ts`,
+// pins the cases that must FALL BACK to the generic spec path.
+
+function say(s: string) {
+  console.log(s);
+}
+
+// Race the subject against a chain of plain microtask ticks: the number of
+// ticks that elapse before it settles is the combinator's job count, and is
+// the single most sensitive thing a `then`-bypassing fast path can break.
+function tickRace(label: string, make: () => Promise<unknown>): Promise<void> {
+  return new Promise<void>((done) => {
+    let ticks = 0;
+    let settled = false;
+    const bump = () => {
+      if (settled) return;
+      ticks++;
+      if (ticks > 40) {
+        say(label + " ticks=OVERFLOW");
+        done();
+        return;
+      }
+      Promise.resolve().then(bump);
+    };
+    make().then(() => {
+      settled = true;
+      say(label + " ticks=" + ticks);
+      done();
+    });
+    Promise.resolve().then(bump);
+  });
+}
+
+async function main() {
+  // ---- microtask job counts -------------------------------------------
+  await tickRace("a empty", () => Promise.all([]));
+  await tickRace("b one-plain", () => Promise.all([1]));
+  await tickRace("c three-plain", () => Promise.all([1, 2, 3]));
+  await tickRace("d one-promise", () => Promise.all([Promise.resolve(1)]));
+  await tickRace("e two-promises", () =>
+    Promise.all([Promise.resolve(1), Promise.resolve(2)]),
+  );
+  await tickRace("f thenable", () => Promise.all([{ then: (r: any) => r(1) } as any]));
+  await tickRace("g nested-resolve", () =>
+    Promise.all([Promise.resolve(Promise.resolve(1))]),
+  );
+
+  // ---- interleaving against an independent chain ------------------------
+  const seq: string[] = [];
+  await new Promise<void>((done) => {
+    Promise.resolve()
+      .then(() => seq.push("a1"))
+      .then(() => seq.push("a2"))
+      .then(() => seq.push("a3"))
+      .then(() => seq.push("a4"))
+      .then(() => seq.push("a5"))
+      .then(() => {
+        say("h " + seq.join(","));
+        done();
+      });
+    Promise.all([1, 2]).then(() => seq.push("ALL"));
+  });
+
+  // ---- rejection ordering and unhandled accounting ----------------------
+  let unhandled = 0;
+  const onUnhandled = () => {
+    unhandled++;
+  };
+  (process as any).on("unhandledRejection", onUnhandled);
+
+  // The first rejection wins; the later one must be swallowed AND must not
+  // surface as an unhandled rejection. A fast path that skips `then` never
+  // marks the loser handled and kills the process here.
+  let which = "none";
+  try {
+    await Promise.all([Promise.reject(new Error("A")), Promise.reject(new Error("B"))]);
+  } catch (e: any) {
+    which = e.message;
+  }
+  await new Promise((r) => setTimeout(r, 20));
+  say("i first-rejection=" + which + " unhandled=" + unhandled);
+
+  unhandled = 0;
+  try {
+    await Promise.all([Promise.reject(new Error("x")), Promise.resolve(1)]);
+  } catch {
+    /* handled */
+  }
+  await new Promise((r) => setTimeout(r, 20));
+  say("j unhandled=" + unhandled);
+  (process as any).off("unhandledRejection", onUnhandled);
+
+  // Timer-ordered rejections: the earlier one wins.
+  const p1 = new Promise((_, rej) => setTimeout(() => rej(new Error("r1")), 0));
+  const p2 = new Promise((_, rej) => setTimeout(() => rej(new Error("r2")), 5));
+  let caught = "none";
+  try {
+    await Promise.all([p1, p2]);
+  } catch (e: any) {
+    caught = e.message;
+  }
+  await new Promise((r) => setTimeout(r, 20));
+  say("k " + caught);
+
+  // ---- values and shape -------------------------------------------------
+  const obj = { a: 1 };
+  const mixed = await Promise.all([1, "two", true, null, undefined, obj, NaN, -0, 10n] as any);
+  say(
+    "l " +
+      mixed
+        .map((v: any) =>
+          typeof v === "bigint" ? v.toString() + "n" : Object.is(v, -0) ? "-0" : String(v),
+        )
+        .join("|"),
+  );
+  say("m sameObj=" + (mixed[5] === obj));
+
+  const shape = await Promise.all([1, 2, 3]);
+  say(
+    "n isArray=" +
+      Array.isArray(shape) +
+      " len=" +
+      shape.length +
+      " proto=" +
+      (Object.getPrototypeOf(shape) === Array.prototype) +
+      " keys=" +
+      Object.keys(shape).join(","),
+  );
+
+  // Index order, not settlement order.
+  const slow = new Promise((res) => setTimeout(() => res("slow"), 10));
+  say("o " + JSON.stringify(await Promise.all([slow, Promise.resolve("fast"), "plain"])));
+
+  // Pending elements resolved out of order.
+  const pend: Promise<number>[] = [];
+  const resolvers: any[] = [];
+  for (let i = 0; i < 4; i++) pend.push(new Promise<number>((res) => resolvers.push(res)));
+  resolvers[2](2);
+  resolvers[0](0);
+  resolvers[3](3);
+  resolvers[1](1);
+  say("p " + JSON.stringify(await Promise.all(pend)));
+
+  // The SAME pending promise three times: three independent reactions on one
+  // promise, so the reaction-slot overflow path is exercised.
+  let rres: any;
+  const one = new Promise((res) => (rres = res));
+  const three = Promise.all([one, one, one]);
+  rres("same");
+  say("q " + JSON.stringify(await three));
+
+  // A user reaction already attached to the element: both must fire, in
+  // registration order.
+  const seq2: string[] = [];
+  const shared = Promise.resolve("v");
+  shared.then(() => seq2.push("user"));
+  await Promise.all([shared]).then(() => seq2.push("all"));
+  say("r " + seq2.join(","));
+
+  // Duplicates, nesting, other iterables, async-function elements.
+  const dup = Promise.resolve("d");
+  say("s " + JSON.stringify(await Promise.all([dup, dup, dup])));
+  say("t " + JSON.stringify(await Promise.all([Promise.resolve(Promise.resolve("inner"))])));
+  say("u " + JSON.stringify(await Promise.all([Promise.all([1, 2]), Promise.all([3, 4])])));
+  say("v " + JSON.stringify(await Promise.all(new Set([1, 2, 2, 3]))));
+  say("w " + JSON.stringify(await Promise.all("abc" as any)));
+
+  async function unit(n: number): Promise<number> {
+    return n * 3;
+  }
+  const jobs: Promise<number>[] = [];
+  for (let i = 0; i < 8; i++) jobs.push(unit(i));
+  say("x " + JSON.stringify(await Promise.all(jobs)));
+
+  // Scale: 1000 native promises through one call.
+  const big: Promise<number>[] = [];
+  for (let i = 0; i < 1000; i++) big.push(Promise.resolve(i));
+  const rb = await Promise.all(big);
+  let sum = 0;
+  for (const v of rb) sum += v;
+  say("y len=" + rb.length + " sum=" + sum);
+
+  // A promise resolved with itself rejects with a TypeError, and that
+  // rejection must be handled by the combinator's reject reaction.
+  let selfErr = "none";
+  {
+    let selfRes: any;
+    const self = new Promise((res) => (selfRes = res));
+    selfRes(self);
+    try {
+      await Promise.all([self]);
+    } catch (e: any) {
+      selfErr = e.constructor.name;
+    }
+  }
+  say("z " + selfErr);
+}
+
+main();

--- a/test-files/test_gap_7911_promise_all_slow_arm_guards.ts
+++ b/test-files/test_gap_7911_promise_all_slow_arm_guards.ts
@@ -1,0 +1,321 @@
+// #7911: the cases `Promise.all`'s per-element fast arm must REFUSE.
+//
+// The fast arm replaces two observable spec steps —
+// `Call(promiseResolve, C, «next»)` and `Invoke(nextPromise, "then", …)` —
+// with the runtime primitives they select. That is only sound when the
+// combinator is on the intrinsic `Promise`, `Promise.resolve` is the
+// intrinsic, and the resolved element is a plain native promise with no own
+// `then` and no own `constructor`. Each case below breaks exactly one of
+// those and must still behave like `node --experimental-strip-types`.
+
+function say(s: string) {
+  console.log(s);
+}
+async function step(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (e: any) {
+    say(name + " THREW " + (e && e.constructor ? e.constructor.name : "?") + ": " + (e && e.message));
+  }
+}
+
+const origResolve = Promise.resolve;
+
+async function main() {
+  // --- `Promise.resolve` is read ONCE off the constructor ----------------
+  await step("a", async () => {
+    let getCount = 0;
+    Object.defineProperty(Promise, "resolve", {
+      configurable: true,
+      get() {
+        getCount++;
+        return origResolve;
+      },
+    });
+    await Promise.all([1, 2, 3]);
+    Object.defineProperty(Promise, "resolve", {
+      configurable: true,
+      writable: true,
+      value: origResolve,
+    });
+    say("a getCount=" + getCount);
+  });
+
+  // --- and CALLED per element, with `this` = the constructor -------------
+  await step("b", async () => {
+    const calls: string[] = [];
+    (Promise as any).resolve = function (v: any) {
+      calls.push(String(v) + ":" + (this === Promise));
+      return origResolve.call(this, v);
+    };
+    const r = await Promise.all([1, 2]);
+    (Promise as any).resolve = origResolve;
+    say("b " + calls.join(",") + " r=" + JSON.stringify(r));
+  });
+
+  // --- a patched `Promise.resolve` TRANSFORMS the element values ---------
+  await step("c", async () => {
+    (Promise as any).resolve = function (v: any) {
+      return origResolve.call(this, (v as number) * 10);
+    };
+    const r = await Promise.all([1, 2, 3]);
+    (Promise as any).resolve = origResolve;
+    say("c " + JSON.stringify(r));
+  });
+
+  // --- a non-callable `Promise.resolve` rejects with a TypeError ---------
+  await step("d", async () => {
+    (Promise as any).resolve = 42;
+    let e = "none";
+    try {
+      await Promise.all([1]);
+    } catch (err: any) {
+      e = err.constructor.name;
+    }
+    (Promise as any).resolve = origResolve;
+    say("d " + e);
+  });
+
+  // --- a throwing `Promise.resolve` propagates through IfAbruptReject ----
+  await step("e", async () => {
+    (Promise as any).resolve = function () {
+      throw new Error("resolve-boom");
+    };
+    let e = "none";
+    try {
+      await Promise.all([1, 2]);
+    } catch (err: any) {
+      e = err.message;
+    }
+    (Promise as any).resolve = origResolve;
+    say("e " + e);
+  });
+
+  // --- `Promise.resolve` observes promise identity (`Promise.resolve(p) === p`)
+  await step("f", async () => {
+    const p = origResolve.call(Promise, 7);
+    let sawSame = false;
+    (Promise as any).resolve = function (v: any) {
+      if (v === p) sawSame = true;
+      return origResolve.call(this, v);
+    };
+    await Promise.all([p]);
+    (Promise as any).resolve = origResolve;
+    say("f sawSame=" + sawSame);
+  });
+
+  // --- a non-constructor `this` still throws from NewPromiseCapability ---
+  await step("g", async () => {
+    let e = "none";
+    try {
+      await (Promise.all as any).call({}, []);
+    } catch (err: any) {
+      e = err.constructor.name;
+    }
+    say("g " + e);
+  });
+
+  // --- an OWN `then` on an element shadows the intrinsic ----------------
+  await step("h", async () => {
+    const p = origResolve.call(Promise, 1);
+    let called = 0;
+    (p as any).then = function (res: any) {
+      called++;
+      res("own");
+    };
+    const r = await Promise.all([p]);
+    say("h called=" + called + " r=" + JSON.stringify(r));
+  });
+
+  // --- a non-callable own `then` is a TypeError -------------------------
+  await step("i", async () => {
+    const p = origResolve.call(Promise, 5);
+    (p as any).then = 42;
+    let e = "none";
+    try {
+      await Promise.all([p]);
+    } catch (err: any) {
+      e = err.constructor.name;
+    }
+    say("i " + e);
+  });
+
+  // --- plain thenables go through assimilation, not the native reaction --
+  await step("j", async () => {
+    say("j " + JSON.stringify(await Promise.all([{ then: (res: any) => res("T") } as any])));
+  });
+
+  // --- resolve-function-called-once, in all three shapes ----------------
+  await step("k", async () => {
+    const twice = {
+      then(res: any) {
+        res("first");
+        res("second");
+      },
+    };
+    const resThenRej = {
+      then(res: any, rej: any) {
+        res("ok");
+        rej(new Error("late"));
+      },
+    };
+    const throwAfter = {
+      then(res: any) {
+        res("done");
+        throw new Error("after");
+      },
+    };
+    say(
+      "k " +
+        JSON.stringify(await Promise.all([twice as any])) +
+        JSON.stringify(await Promise.all([resThenRej as any])) +
+        JSON.stringify(await Promise.all([throwAfter as any])),
+    );
+  });
+
+  // --- a `then` that throws BEFORE resolving rejects the combinator -----
+  await step("l", async () => {
+    let e = "none";
+    try {
+      await Promise.all([
+        {
+          then() {
+            throw new Error("before");
+          },
+        } as any,
+      ]);
+    } catch (err: any) {
+      e = err.message;
+    }
+    say("l " + e);
+  });
+
+  // --- a thenable that stashes its resolve and calls it later ----------
+  await step("m", async () => {
+    let stash: any = null;
+    const t = {
+      then(res: any) {
+        stash = res;
+        res("first");
+      },
+    };
+    const r = await Promise.all([t as any, "x"]);
+    stash("late");
+    await new Promise((rr) => setTimeout(rr, 5));
+    say("m " + JSON.stringify(r));
+  });
+
+  // --- a custom constructor: capability construction is observable ------
+  await step("n", async () => {
+    let e = "none";
+    class Bad {
+      constructor(exec: any) {
+        exec(
+          () => {},
+          () => {},
+        );
+        exec(
+          () => {},
+          () => {},
+        );
+      }
+    }
+    try {
+      (Promise.all as any).call(Bad, []);
+    } catch (err: any) {
+      e = err.constructor.name;
+    }
+    let e2 = "none";
+    class Never {
+      constructor(_exec: any) {}
+    }
+    try {
+      (Promise.all as any).call(Never, []);
+    } catch (err: any) {
+      e2 = err.constructor.name;
+    }
+    say("n " + e + " " + e2);
+  });
+
+  // --- a Promise subclass as the constructor ---------------------------
+  await step("o", async () => {
+    class P extends Promise<any> {}
+    const r = await P.all([1, 2, 3]);
+    const inst = P.all([1]);
+    say("o " + JSON.stringify(r) + " instP=" + (inst instanceof P) + " instPromise=" + (inst instanceof Promise));
+    await inst;
+    say("o call " + JSON.stringify(await (Promise.all as any).call(P, [4, 5])));
+  });
+
+  // --- iterator protocol: the drain is not part of the fast arm ---------
+  await step("p", async () => {
+    const trace: string[] = [];
+    const custom = {
+      [Symbol.iterator]() {
+        let i = 0;
+        trace.push("iter");
+        return {
+          next() {
+            trace.push("n" + i);
+            if (i < 3) return { value: Promise.resolve(i++), done: false };
+            return { value: undefined, done: true };
+          },
+        };
+      },
+    };
+    const r = await Promise.all(custom as any);
+    say("p " + trace.join(",") + " r=" + JSON.stringify(r));
+  });
+
+  await step("q", async () => {
+    function* gen() {
+      yield 10;
+      yield Promise.resolve(20);
+    }
+    say("q " + JSON.stringify(await Promise.all(gen())));
+  });
+
+  await step("r", async () => {
+    let e = "none";
+    const bad = {
+      [Symbol.iterator]() {
+        let n = 0;
+        return {
+          next() {
+            n++;
+            if (n === 2) throw new Error("iter-boom");
+            return { value: n, done: false };
+          },
+        };
+      },
+    };
+    try {
+      await Promise.all(bad as any);
+    } catch (err: any) {
+      e = err.message;
+    }
+    let e2 = "none";
+    try {
+      await Promise.all(5 as any);
+    } catch (err: any) {
+      e2 = err.constructor.name;
+    }
+    let e3 = "none";
+    try {
+      await (Promise.all as any)();
+    } catch (err: any) {
+      e3 = err.constructor.name;
+    }
+    say("r " + e + " " + e2 + " " + e3);
+  });
+
+  await step("s", async () => {
+    const sparse = [1, , 3];
+    const r = await Promise.all(sparse as any);
+    say("s " + JSON.stringify(r) + " len=" + r.length);
+    const empty = await Promise.all([]);
+    say("s empty=" + JSON.stringify(empty) + " isArr=" + Array.isArray(empty));
+  });
+}
+
+main();


### PR DESCRIPTION
Closes #7911.

## The question the issue asked

> Are the spec combinator and `js_promise_all` spec-equivalent enough to route
> `Promise.all` to the native path?

**Answered by measurement: no.** Full write-up and every per-behaviour result:
`gc-handoff/PROMISEALL-NOTES.md`.

Seven probe files (~90 assertions) were written against `node 26.5.1
--experimental-strip-types` first, then run against the `origin/main` build,
then against a throwaway build that routes `js_promise_all_iterable` straight
into `js_promise_all`:

| | spec combinator (today) | routed to `js_promise_all` |
|---|---|---|
| `Promise.resolve` read once off `C`, called per element with `this === Promise`, a patched `resolve` transforming values, non-callable → `TypeError`, throwing `resolve` propagating, `Promise.resolve(p) === p` | **7/7 match node** | **0/7** — `getCount=0`, no calls, no transform, no `TypeError` |
| own `then` on an element; non-callable own `then` | match node | ignored; no `TypeError` |
| unhandled-rejection accounting | 0, like node | **1 and 2 — and the process DIES** |
| microtask tick counts + interleaving | 11/11 match node | tick counts survive, then `Uncaught (in promise) Error: A`, exit 1 |

The two process deaths are the decisive part. `js_promise_all` never invokes
`then`, so it never runs `mark_rejection_handled`; a rejection the combinator
swallows stays flagged unhandled and terminates the program.
`Promise.all([Promise.reject(a), Promise.reject(b)])` inside a `try/catch` is
an ordinary shape.

## What is admissible instead

The cost is not intrinsic to the spec algorithm — it is in HOW the two
observable per-element steps are executed. Both are inert under a guard that
can be stated precisely, and the fast arm calls the very primitives the generic
dispatch towers select. The entry condition and the reasoning for each clause
are in the commit message and in the code comments; the short form is
`C === %Promise%`, an unpatched intrinsic `Promise.resolve` (matched by closure
FUNCTION POINTER, not object identity), no promise-lifecycle hooks, and a
resolved element that is a genuine native promise with no own `then` and no own
`constructor`.

Nothing the spec makes observable changes: the iterator drain,
`NewPromiseCapability`, the single `Get(C,"resolve")`, the resolve-element
closures with their `[[AlreadyCalled]]` guards and `remainingElementsCount`,
and the final `Call(cap.resolve, …)`.

## Measurements

Instructions retired (`/usr/bin/time -l`), both arms from ONE binary via a
throwaway knob, best of 3–7, run-to-run spread 0.02–1.7 %. The dev box was at
load 17–90 all session, so **no wall clock is quoted**.

| program | before | after | Δ | GC cycles |
|---|--:|--:|--:|---|
| 1200×200 fan-out, settled elements | 548 345 659 | 397 709 920 | **−27.5 %** | 0 / 0 |
| 1200×200 fan-out, pending elements | 803 142 312 | 651 573 199 | **−18.9 %** | 0 / 0 |
| `asyncpipe` @240 batches | 6 702 369 624 | 4 432 278 684 | **−33.9 %** | 2 / 2 |
| `asyncpipe` @360 batches | 11 872 893 316 | 7 801 222 330 | **−34.3 %** | 3 / 3 |
| `asyncpipe` @480 batches | 13 604 723 374 | 9 429 231 942 | **−30.7 %** | 3 / 3 |
| `asyncpipe` @120, nursery cap inactive | 1 686 481 864 | 1 534 500 019 | **−9.0 %** | 0 / 0 |
| `asyncpipe` @120, default config | 1 927 275 215 | 2 017 785 565 | **+4.7 %** | **0 / 1** |

`PERRY_MT_PROFILE=1` on `asyncpipe`: `then=23800 → 0` and `new=95641 → 71841`
(one fewer promise per element). `runs`, `resolved`, `closure alloc`,
`thenable_probe`, `step_chain_reuse` are all unchanged.

### ★ The one regression is a GC trigger boundary, and it is reported, not hidden

`asyncpipe` at its shipped 120 batches is the single arm that goes backwards,
and it is entirely GC scheduling: the before arm runs **0** copying minors, the
after arm runs **1** (`copied_objects=156236`, `copied_bytes=12439144`,
`trigger=ArenaBytes`). Arena in-use at the decision point is **17 452 448 B vs
17 896 616 B** — a **444 KB window on 17.5 MB** decides whether the program
collects at all. With `PERRY_GC_MOVING_LOOP_POLLS=0` (which is what
`nursery_cap_active()` gates on) neither arm collects and the same program is
−9.0 %; at 240/360/480 batches, where both arms run the same number of copying
minors, it is −31 %…−34 %.

This is the hazard `gc-handoff/ASYNC2-NOTES.md` already flags: *"the zero-GC
status of `asyncpipe` is a knife-edge property of its exact batch count, not a
structural one."* Left open and written up in the notes: the fast arm allocates
strictly less (23 800 fewer promises) yet reaches a higher arena in-use before
the trigger, which points at *when* the microtask pump reaches the outermost
precise-root safepoint rather than at extra allocation. Consequence for future
work: **`asyncpipe`@120 is not a usable A/B target for `Promise.all` changes**.

## Validation

* 7 probe files (~90 assertions): **byte-identical to the `origin/main` build in
  every file**, including all 8 pre-existing node divergences (documented in the
  notes: patched `Array.prototype[@@iterator]`, patched
  `Promise.prototype.then`, spec iteration interleaving, `class Q extends
  Promise` with an explicit constructor, an element's own `constructor`).
* 19-program corpus (`gc-handoff/m0810/`): **19/19 byte-exact vs expected**,
  identical between arms, exit 0.
* 98 async/promise/stream/timer/thread `test-files`: **0 arm-vs-arm diffs**.
  Two apparent diffs were nondeterministic thread ids in a pre-existing
  `perry-ext-http` panic — they differ between two runs of the *same* arm. 13
  node diffs are present in both arms (pre-existing), 82 match node, 1 does not
  compile on either arm.
* Two new gap files byte-identical to node 26.5.1.
* Six `perry-runtime` unit tests (visible to the per-PR `cargo-test`), one of
  which asserts via a `cfg(test)` tally that the fast arm was actually TAKEN —
  a fast path that silently stopped firing would fail rather than pass.
* `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.

No env knob ships: the A/B and experiment knobs were removed before this commit,
so there is no unexercised mode left behind.
