### PR TITLE
perf(codegen): inline bounded indirect closure allocations

### DIFF
--- a/changelog.d/7925-indirect-closure-inline-new.md
+++ b/changelog.d/7925-indirect-closure-inline-new.md
@@ -1,0 +1,17 @@
+### Indirect pipeline closures inline their bounded hot allocations
+
+The allocation-hot pre-pass previously recognized only direct `FuncRef` calls.
+A closure reached through an array or local value therefore kept calling the
+outlined object allocator even when the call itself sat in a hot loop. The
+pipeline workload paid that call for each of its three stages on every record.
+
+Modules with an indirect loop call now admit allocation-bearing closure bodies
+when the module contains at most eight closure `new` sites in total. The cap is
+all-or-none and counts nested expression containers and parameter defaults, so
+speculative code growth is bounded and independent of traversal order. Closure
+compilation now propagates the admission bit to the allocator gate.
+
+On the 19-program corpus, 18 binaries remain byte-identical and only `pipeline`
+changes. Its text grows by 276 bytes (+0.0030%; no executable-size change) while
+retired instructions fall by 13.89% on the quiet M1 benchmark host. All corpus
+outputs remain exact.

--- a/crates/perry-codegen/src/codegen/closure.rs
+++ b/crates/perry-codegen/src/codegen/closure.rs
@@ -572,6 +572,12 @@ pub(super) fn compile_closure(
     let ic_base = llmod.ic_counter;
     let buffer_alias_base = llmod.buffer_alias_counter;
     let lf = llmod.define_function(&llvm_name, DOUBLE, llvm_params);
+    // #7908: closures live outside `hir.functions`, so they do not pass
+    // through `codegen/function.rs`, which applies this same collector result
+    // to ordinary functions. Without propagating the bit here, bounded
+    // indirect-call admission is computed correctly but never reaches
+    // `new_site_is_in_loop` while the closure body is emitted.
+    lf.alloc_hot = cross_module.alloc_hot_functions.contains(&func_id);
     if typed_public_trampoline.is_some() {
         lf.linkage = "internal".to_string();
     }

--- a/crates/perry-codegen/src/collectors/hot_callees.rs
+++ b/crates/perry-codegen/src/collectors/hot_callees.rs
@@ -36,7 +36,15 @@ struct HotCalleeScan {
     in_loop: HashSet<u32>,
     /// Total direct call-site count per FuncId (loop and non-loop).
     call_counts: HashMap<u32, u32>,
+    /// Whether any loop calls through a value whose FuncId is unknown here.
+    indirect_call_in_loop: bool,
 }
+
+/// #7908: indirect calls do not provide a cheap points-to proof, so admission
+/// is all-or-none and capped on the cost-bearing unit: allocation sites in
+/// closure bodies. At the measured ~268 bytes per inline bump this bounds a
+/// module's speculative growth to ~2.1 KiB.
+const INDIRECT_CLOSURE_ALLOC_SITE_BUDGET: u32 = 8;
 
 /// Collect the set of `FuncId`s eligible for `inlinehint`: those with ≥1 direct
 /// call site inside a loop AND at most `max_call_sites` total direct call sites
@@ -124,7 +132,7 @@ pub fn collect_hot_loop_callees(hir: &Module, max_call_sites: u32) -> HashSet<u3
 /// other 16 within a ±1.6% noise floor established by the 15 binaries that
 /// come out byte-identical.
 ///
-/// ## The two admission rules
+/// ## The three admission rules
 ///
 /// 1. **≥1 direct call site inside a loop** — the existing proxy for "runs many
 ///    times", now uncapped.
@@ -133,6 +141,13 @@ pub fn collect_hot_loop_callees(hir: &Module, max_call_sites: u32) -> HashSet<u3
 ///    a recursive descent whose entry call happens to sit in straight-line code
 ///    would otherwise pay the outlined allocator at every level of the
 ///    recursion.
+/// 3. **Bounded closure module with an indirect loop call** — an indirect call
+///    through a local/array value does not expose the target FuncId, as in
+///    `pipeline`'s `stage = stages[s]; stage(rec)`. If the module contains such
+///    a call, admit its allocation-bearing closures only when they contain at
+///    most [`INDIRECT_CLOSURE_ALLOC_SITE_BUDGET`] `new` sites in total. The
+///    all-or-none cap avoids traversal-order-dependent code size and prices the
+///    actual emitted cost rather than closure count.
 ///
 /// Direction of error is unchanged from the sibling: under-inclusion forgoes
 /// speed, never correctness — the outlined call performs the identical bump
@@ -180,6 +195,24 @@ pub fn collect_alloc_hot_functions(hir: &Module) -> HashSet<u32> {
             hot.insert(f.id);
         }
     }
+    // Rule 3: the call site proves hotness but not identity. Speculate only
+    // when every allocation-bearing closure in the module fits the fixed byte
+    // budget; otherwise admit none of them.
+    let closure_alloc_sites = collect_closure_alloc_sites(hir);
+    let closure_alloc_site_count = closure_alloc_sites
+        .values()
+        .copied()
+        .fold(0_u32, u32::saturating_add);
+    if scan.indirect_call_in_loop
+        && closure_alloc_site_count > 0
+        && closure_alloc_site_count <= INDIRECT_CLOSURE_ALLOC_SITE_BUDGET
+    {
+        hot.extend(
+            closure_alloc_sites
+                .iter()
+                .filter_map(|(&func_id, &sites)| (sites > 0).then_some(func_id)),
+        );
+    }
     hot
 }
 
@@ -189,6 +222,10 @@ fn record_callee(callee: &Expr, in_loop: bool, scan: &mut HotCalleeScan) {
         if in_loop {
             scan.in_loop.insert(*id);
         }
+    } else if in_loop && !matches!(callee, Expr::ExternFuncRef { .. }) {
+        // ExternFuncRef is statically identified even though it has no local
+        // FuncId. Every other generic Call callee is a runtime value here.
+        scan.indirect_call_in_loop = true;
     }
 }
 
@@ -416,4 +453,161 @@ fn walk_expr(e: &Expr, in_loop: bool, scan: &mut HotCalleeScan) {
         // heuristic targets; not descending is a safe under-approximation.
         _ => {}
     }
+}
+
+/// Count every `new` emitted in every closure body, keyed by the closure's
+/// FuncId. This is deliberately separate from [`walk_expr`]: that hot-callee
+/// walker is an under-approximation, while the byte cap must be exhaustive.
+/// `walk_expr_children` is the HIR's checked source of truth for expression
+/// children, including parameter defaults; closure statement bodies are the
+/// only boundary it intentionally leaves to consumers.
+fn collect_closure_alloc_sites(hir: &Module) -> HashMap<u32, u32> {
+    let mut sites = HashMap::new();
+    count_alloc_sites_in_stmts(&hir.init, None, &mut sites);
+    for f in &hir.functions {
+        count_alloc_sites_in_stmts(&f.body, None, &mut sites);
+    }
+    for c in &hir.classes {
+        if let Some(ctor) = &c.constructor {
+            count_alloc_sites_in_stmts(&ctor.body, None, &mut sites);
+        }
+        for m in c.methods.iter().chain(c.static_methods.iter()) {
+            count_alloc_sites_in_stmts(&m.body, None, &mut sites);
+        }
+        for (_, g) in &c.getters {
+            count_alloc_sites_in_stmts(&g.body, None, &mut sites);
+        }
+        for (_, s) in &c.setters {
+            count_alloc_sites_in_stmts(&s.body, None, &mut sites);
+        }
+        for cm in &c.computed_members {
+            count_alloc_sites_in_expr(&cm.key_expr, None, &mut sites);
+            count_alloc_sites_in_stmts(&cm.function.body, None, &mut sites);
+        }
+        for field in c.fields.iter().chain(c.static_fields.iter()) {
+            if let Some(key) = &field.key_expr {
+                count_alloc_sites_in_expr(key, None, &mut sites);
+            }
+            if let Some(init) = &field.init {
+                count_alloc_sites_in_expr(init, None, &mut sites);
+            }
+        }
+    }
+    sites
+}
+
+fn count_alloc_sites_in_stmts(
+    stmts: &[Stmt],
+    closure_id: Option<u32>,
+    sites: &mut HashMap<u32, u32>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::Let {
+                init: Some(expr), ..
+            }
+            | Stmt::Expr(expr)
+            | Stmt::Throw(expr)
+            | Stmt::Return(Some(expr)) => count_alloc_sites_in_expr(expr, closure_id, sites),
+            Stmt::Let { init: None, .. } | Stmt::Return(None) => {}
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                count_alloc_sites_in_expr(condition, closure_id, sites);
+                count_alloc_sites_in_stmts(then_branch, closure_id, sites);
+                if let Some(else_branch) = else_branch {
+                    count_alloc_sites_in_stmts(else_branch, closure_id, sites);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                count_alloc_sites_in_expr(condition, closure_id, sites);
+                count_alloc_sites_in_stmts(body, closure_id, sites);
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    count_alloc_sites_in_stmts(
+                        std::slice::from_ref(init.as_ref()),
+                        closure_id,
+                        sites,
+                    );
+                }
+                if let Some(condition) = condition {
+                    count_alloc_sites_in_expr(condition, closure_id, sites);
+                }
+                if let Some(update) = update {
+                    count_alloc_sites_in_expr(update, closure_id, sites);
+                }
+                count_alloc_sites_in_stmts(body, closure_id, sites);
+            }
+            Stmt::Labeled { body, .. } => {
+                count_alloc_sites_in_stmts(std::slice::from_ref(body.as_ref()), closure_id, sites)
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                count_alloc_sites_in_stmts(body, closure_id, sites);
+                if let Some(catch) = catch {
+                    count_alloc_sites_in_stmts(&catch.body, closure_id, sites);
+                }
+                if let Some(finally) = finally {
+                    count_alloc_sites_in_stmts(finally, closure_id, sites);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                count_alloc_sites_in_expr(discriminant, closure_id, sites);
+                for case in cases {
+                    if let Some(test) = &case.test {
+                        count_alloc_sites_in_expr(test, closure_id, sites);
+                    }
+                    count_alloc_sites_in_stmts(&case.body, closure_id, sites);
+                }
+            }
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_) => {}
+        }
+    }
+}
+
+fn count_alloc_sites_in_expr(expr: &Expr, closure_id: Option<u32>, sites: &mut HashMap<u32, u32>) {
+    if let Expr::Closure {
+        func_id,
+        body,
+        params: _,
+        ..
+    } = expr
+    {
+        sites.entry(*func_id).or_insert(0);
+        // The canonical child walker visits this closure's param defaults.
+        perry_hir::walker::walk_expr_children(expr, &mut |child| {
+            count_alloc_sites_in_expr(child, Some(*func_id), sites)
+        });
+        count_alloc_sites_in_stmts(body, Some(*func_id), sites);
+        return;
+    }
+
+    if matches!(expr, Expr::New { .. }) {
+        if let Some(func_id) = closure_id {
+            let count = sites.entry(func_id).or_insert(0);
+            *count = count.saturating_add(1);
+        }
+    }
+    perry_hir::walker::walk_expr_children(expr, &mut |child| {
+        count_alloc_sites_in_expr(child, closure_id, sites)
+    });
 }

--- a/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
+++ b/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
@@ -1,4 +1,4 @@
-//! #7871: a self-recursive function's `new` sites take the INLINE bump
+//! #7871 / #7908: allocation-hot functions and closures take the INLINE bump
 //! allocator.
 //!
 //! The subject is [`super::new_alloc::new_site_is_in_loop`]'s second arm and the
@@ -14,8 +14,9 @@
 //!
 //! The negative half is the anti-bloat property: a `new` in a function that is
 //! neither in a loop, nor called from one, nor recursive keeps the outlined
-//! call. Without it this file would pass just as happily if the gate had been
-//! widened to "always", which is the ~268-bytes-per-site default the
+//! call. Likewise, indirect closure admission has a per-module allocation-site
+//! cap. Without those checks this file would pass just as happily if the gate
+//! had been widened to "always", which is the ~268-bytes-per-site default the
 //! `[#bloat]` comment in `new_alloc.rs` exists to refuse.
 
 use crate::{compile_module, AppMetadata, CompileOptions};
@@ -37,6 +38,8 @@ const OUTLINED_CALL: &str = "call i64 @js_object_alloc_class_inline_keys";
 
 const N_ID: u32 = 11;
 const WALK_ID: u32 = 700;
+const STAGE_LOCAL_BASE: u32 = 800;
+const STAGE_FUNC_BASE: u32 = 900;
 
 fn ir_opts() -> CompileOptions {
     CompileOptions {
@@ -200,6 +203,69 @@ fn walk_module(recurse: bool) -> Module {
     m
 }
 
+/// A minimized version of #7908's pipeline shape:
+///
+/// ```text
+/// const stage = () => new Cell(1)
+/// while (...) stage()
+/// ```
+///
+/// `stage()` is deliberately a `LocalGet`, not a `FuncRef`: the closure may
+/// have arrived through an array lookup, so the loop gives codegen no cheap
+/// points-to proof. `site_count` creates independent closure allocation sites
+/// so the admission budget is observable in emitted IR.
+fn indirect_closure_module(site_count: u32, call_in_loop: bool) -> Module {
+    let mut m = Module::new("alloc_hot_indirect_closure.ts");
+    m.classes = vec![cell_class()];
+
+    for i in 0..site_count {
+        m.init.push(Stmt::Let {
+            id: STAGE_LOCAL_BASE + i,
+            name: format!("stage_{i}"),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Closure {
+                func_id: STAGE_FUNC_BASE + i,
+                params: Vec::new(),
+                return_type: Type::Named("Cell".to_string()),
+                body: vec![Stmt::Return(Some(Expr::New {
+                    class_name: "Cell".to_string(),
+                    args: vec![Expr::Number(i as f64)],
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                    cap_args_appended: 0,
+                }))],
+                captures: Vec::new(),
+                mutable_captures: Vec::new(),
+                captures_this: false,
+                captures_new_target: false,
+                enclosing_class: None,
+                is_arrow: true,
+                is_async: false,
+                is_generator: false,
+                is_strict: true,
+            }),
+        });
+    }
+
+    let indirect_call = Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::LocalGet(STAGE_LOCAL_BASE)),
+        args: Vec::new(),
+        type_args: Vec::new(),
+        byte_offset: 0,
+    });
+    if call_in_loop {
+        m.init.push(Stmt::While {
+            condition: Expr::Bool(false),
+            body: vec![indirect_call],
+        });
+    } else {
+        m.init.push(indirect_call);
+    }
+    m.init_kind = ModuleInitKind::Eager;
+    m
+}
+
 fn ir_for(m: Module) -> String {
     String::from_utf8(compile_module(&m, ir_opts()).expect("module compiles"))
         .expect("LLVM IR should be UTF-8")
@@ -248,5 +314,66 @@ fn a_cold_straight_line_function_keeps_the_outlined_allocator() {
     assert!(
         !ir.contains(INLINE_SLOW_CALL),
         "the inline bump allocator reached a cold site:\n{ir}"
+    );
+}
+
+#[test]
+fn allocation_closures_are_admitted_by_an_indirect_loop_call() {
+    assert_inline_new_not_forced();
+    let ir = ir_for(indirect_closure_module(3, true));
+    assert!(
+        ir.contains(INLINE_SLOW_CALL) && ir.contains(INLINE_FAST_BLOCK),
+        "an indirect call in a loop should admit the module's three bounded \
+         allocation closures, matching the pipeline stage shape:\n{ir}"
+    );
+    assert!(
+        !ir.contains(OUTLINED_CALL),
+        "the admitted closure bodies still use the outlined allocator:\n{ir}"
+    );
+}
+
+#[test]
+fn a_straight_line_indirect_call_does_not_admit_its_closure() {
+    assert_inline_new_not_forced();
+    let ir = ir_for(indirect_closure_module(1, false));
+    assert!(
+        ir.contains(OUTLINED_CALL),
+        "an indirect call outside a loop supplied no hotness evidence, but its \
+         closure allocation was inlined:\n{ir}"
+    );
+    assert!(
+        !ir.contains(INLINE_SLOW_CALL),
+        "the inline bump allocator reached a closure with no hot call shape:\n{ir}"
+    );
+}
+
+#[test]
+fn indirect_closure_admission_refuses_modules_over_eight_sites() {
+    assert_inline_new_not_forced();
+    let ir = ir_for(indirect_closure_module(9, true));
+    assert!(
+        ir.contains(OUTLINED_CALL),
+        "nine closure allocation sites exceed the 8-site / ~2.1 KiB module \
+         budget, but the outlined allocator disappeared:\n{ir}"
+    );
+    assert!(
+        !ir.contains(INLINE_SLOW_CALL),
+        "an over-budget module admitted some closure sites; admission must be \
+         all-or-none so traversal order cannot affect code size:\n{ir}"
+    );
+}
+
+#[test]
+fn indirect_closure_admission_accepts_the_eight_site_budget() {
+    assert_inline_new_not_forced();
+    let ir = ir_for(indirect_closure_module(8, true));
+    assert!(
+        ir.contains(INLINE_SLOW_CALL) && ir.contains(INLINE_FAST_BLOCK),
+        "eight closure allocation sites are exactly within the module budget, \
+         but they did not take the inline allocator:\n{ir}"
+    );
+    assert!(
+        !ir.contains(OUTLINED_CALL),
+        "the eight-site boundary was only partially admitted:\n{ir}"
     );
 }


### PR DESCRIPTION
Closes #7908.

## Problem

`collect_alloc_hot_functions` could identify only direct `FuncRef` callees. A closure reached through an array/local, such as `stage = stages[s]; stage(rec)` in the pipeline workload, therefore kept every allocation on the outlined `js_object_alloc_class_inline_keys` path even inside a hot loop. Closure compilation also did not propagate collector admission into `LlFunction::alloc_hot`.

## Change

- Record whether a loop contains a generic indirect call.
- Exhaustively count `new` sites in closure bodies, including nested expression containers and parameter defaults.
- Admit allocation-bearing closures only when the module total is 1–8 sites. Admission is all-or-none, so traversal order cannot change emitted size. At the previously measured ~268 bytes/site, speculative growth is bounded to about 2.1 KiB before LLVM optimization.
- Propagate the resulting admission bit into ordinary closure compilation.

This is intentionally a bounded module-level heuristic rather than a points-to pass. It can include an unrelated closure when a module also has an indirect loop call, but it cannot include more than eight cost-bearing sites; modules above the cap retain the outlined default everywhere.

## Validation

- Focused emitted-IR gate: 6/6 pass. It covers the three-stage positive shape, no-loop negative, exactly-eight boundary, nine-site refusal, and the existing recursive/cold-function arms.
- `cargo test -p perry-codegen`: full unit, integration, and doc-test run passed before the final runtime-only/test-only main rebases (908 unit tests; no failures). The focused gate was rerun after the codegen rebase and passed 6/6.
- 19-program codegen-only corpus A/B: all 19 outputs matched expected; 18/19 binaries were byte-identical. Only `pipeline` changed.
- Current-main exact pipeline IR: 5 outlined + 2 inline allocation sites became 2 outlined + 5 inline; closure IDs 8, 10, and 11 are the three changed sites.
- Current-main static runtime/stdlib wrappers were built and pinned as the single runtime for both compiler arms.
- Emitted size: `__text` 9,780,976 → 9,781,252 bytes (+276, +0.0030%); executable size unchanged at 13,428,552 bytes.
- Quiet M1 mini, lock held, 15 interleaved pairs using instructions retired:
  - best: 3,073,755,239 → 2,646,944,831 (-13.886%)
  - median: 3,073,901,177 → 2,647,030,998 (-13.887%)
  - run spread: 0.0152% base / 0.0084% fix
  - all 30 runs exited 0 and printed identical `55626000 3 3`
- `bash scripts/check_file_size.sh` passes.