### PR TITLE
diag(gc): attribute a copying minor's root scan per scanner (#7915)

### DIFF
--- a/changelog.d/7915-root-scan-attribution.md
+++ b/changelog.d/7915-root-scan-attribution.md
@@ -1,0 +1,46 @@
+### Added
+
+- **gc: per-scanner root attribution for the copied-minor root scan (#7915).**
+  Under the existing `PERRY_GC_DIAG` (no new knob — CLAUDE.md's GC knob
+  kill-policy), each copying minor prints `[gc-scanner-profile]`: per registered
+  scanner, the wall time and the slots / pointer-roots / rewrites it accounted
+  for, sorted by time. Registration sites carry their own path as the name
+  (`stringify!` in `gc_init`'s `reg_scanner!` / `reg_budgeted_scanner!` macros),
+  so a name cannot drift from the list it describes.
+
+  The aggregate `root_sources.runtime_mutable_scanners` counter sums all 82
+  scanners and every pass into one number, which is enough to see that a cost is
+  per-root and not enough to say which registry holds the roots. That gap is why
+  #7915 read as a property of "82 registered scanners over 218 455 pointer
+  roots" when the attribution says it is **one** scanner:
+  `crate::box::scan_box_roots_mut` is 92 % of the pointer roots and 89.5 % of all
+  root-scan time, while the suspected promise registry visits **12 slots** and
+  costs 4–43 µs.
+
+  The instrument then refutes the framing it was built to confirm. A cheap slot
+  visit costs ~4 ns (`intern_table_mutable_root_scanner`: 16 384 slots, 1 144
+  pointer roots, 68 µs); the box scanner costs 98.8 ns/slot because essentially
+  every box slot *is* a from-space pointer, so visiting it in `CopyingMark` mode
+  evacuates the object it names — 93 380 of one minor's 156 236 evacuations come
+  straight out of box roots. The fixed per-root overhead the issue targets is
+  ~4 ns × 265 000 ≈ **1 ms of a 65–101 ms pause**. Full write-up, including the
+  measurement that shows `asyncpipe`'s young generation is 96 % retained by the
+  never-freed box registry rather than by the program:
+  `gc-handoff/ROOTS-NOTES.md`.
+
+- **gc: counters for the three unobserved `gc_safepoint_moving_minor` entry
+  guards (#7915).** Only the `budgeted` arm was counted, so a precise safepoint
+  that returned without collecting had one observable explanation and three
+  invisible ones. `[gc-incremental]` now also reports
+  `safepoints_blocked(in_alloc=… unsafe_zone=… root_lock=…)`, which is what turns
+  "an active `setjmp`/`try` region suppresses the copying minor" (#7910) into a
+  claim a single run can settle.
+
+### Fixed
+
+- **lint: `gc_runtime_root_holders.py` did not know `gc_init`'s registration
+  macros (#7915).** `reg_scanner!` / `reg_budgeted_scanner!` expand to
+  `gc_register_*` calls, but the gate matches the call *name*, so introducing
+  them dropped its registered-scanner count from 122 to 24 and every holder
+  reached only from `gc_init` would have read as uncovered. Its `MIN_REGISTERED`
+  floor caught it, which is exactly what that floor is for.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1261,7 +1261,10 @@ impl CopiedMinorEligibility {
         {
             let mut visitor = RuntimeRootVisitor::for_copying_check(&mut checker);
             for entry in scanners {
-                (entry.scanner)(&mut visitor);
+                let (_, nanos) = super::scanner_profile::record_scanner(|| {
+                    (entry.scanner)(&mut visitor);
+                });
+                super::scanner_profile::note_scanner(entry.name, nanos, 0, 0, 0);
             }
             visit_ffi_mutable_registered_roots(&mut visitor);
         }
@@ -1496,9 +1499,13 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
                 },
                 None => None,
             };
+            let before = super::scanner_profile::snapshot_stats(stats);
             let previous = visitor.set_root_source_stats(stats);
-            (entry.scanner)(&mut visitor);
+            let (_, nanos) = super::scanner_profile::record_scanner(|| {
+                (entry.scanner)(&mut visitor);
+            });
             visitor.set_root_source_stats(previous);
+            super::scanner_profile::note_stats_delta(entry.name, nanos, before, stats);
         }
         visit_ffi_mutable_registered_roots_with_sources(&mut visitor, root_sources);
     }
@@ -1568,9 +1575,13 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
                 },
                 None => None,
             };
+            let before = super::scanner_profile::snapshot_stats(stats);
             let previous = visitor.set_root_source_stats(stats);
-            (entry.scanner)(&mut visitor);
+            let (_, nanos) = super::scanner_profile::record_scanner(|| {
+                (entry.scanner)(&mut visitor);
+            });
             visitor.set_root_source_stats(previous);
+            super::scanner_profile::note_stats_delta(entry.name, nanos, before, stats);
         }
         visit_ffi_mutable_registered_roots_with_sources(&mut visitor, root_sources);
     }
@@ -1840,6 +1851,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
             super::policy::GC_AT_DECLARED_SAFEPOINT.with(std::cell::Cell::get)
         );
     }
+    super::scanner_profile::report_and_reset("copying_minor");
     Some(CopiedMinorFastPathOutcome {
         freed_bytes,
         malloc_swept: malloc_sweep_due,

--- a/crates/perry-runtime/src/gc/instruments.rs
+++ b/crates/perry-runtime/src/gc/instruments.rs
@@ -173,6 +173,41 @@ pub fn moving_safepoints_blocked_by_budgeted() -> u64 {
     MOVING_SAFEPOINT_BLOCKED_BY_BUDGETED.load(Ordering::Relaxed)
 }
 
+static MOVING_SAFEPOINT_BLOCKED_BY_ALLOC: AtomicU64 = AtomicU64::new(0);
+static MOVING_SAFEPOINT_BLOCKED_BY_UNSAFE_ZONE: AtomicU64 = AtomicU64::new(0);
+static MOVING_SAFEPOINT_BLOCKED_BY_ROOT_LOCK: AtomicU64 = AtomicU64::new(0);
+
+/// The other three entry guards of `gc_safepoint_moving_minor`.
+///
+/// Before this existed only the budgeted arm was counted, so "the precise
+/// collector did not run here" had exactly one observable explanation and
+/// three invisible ones — and a hypothesis about a *different* suppressor
+/// (an active `setjmp`/`try` region, #7910) could be neither confirmed nor
+/// refuted from a run. Each arm is counted separately because they mean
+/// different things: `in_alloc` and `root_lock` are transient and retried,
+/// `unsafe_zone` is held across native work, and `budgeted` can be permanent.
+#[inline]
+pub(crate) fn note_moving_safepoint_blocked(in_alloc: bool, unsafe_zone: bool, root_lock: bool) {
+    if in_alloc {
+        MOVING_SAFEPOINT_BLOCKED_BY_ALLOC.fetch_add(1, Ordering::Relaxed);
+    }
+    if unsafe_zone {
+        MOVING_SAFEPOINT_BLOCKED_BY_UNSAFE_ZONE.fetch_add(1, Ordering::Relaxed);
+    }
+    if root_lock {
+        MOVING_SAFEPOINT_BLOCKED_BY_ROOT_LOCK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// `(in_alloc_or_suppressed, unsafe_ffi_zone, root_lock_depth)` rejection counts.
+pub fn moving_safepoints_blocked_by_other_guards() -> (u64, u64, u64) {
+    (
+        MOVING_SAFEPOINT_BLOCKED_BY_ALLOC.load(Ordering::Relaxed),
+        MOVING_SAFEPOINT_BLOCKED_BY_UNSAFE_ZONE.load(Ordering::Relaxed),
+        MOVING_SAFEPOINT_BLOCKED_BY_ROOT_LOCK.load(Ordering::Relaxed),
+    )
+}
+
 /// Why a budgeted step did no work. Every arm is a distinct reason a cycle can
 /// stall, and a stalled-but-active cycle keeps the mark barrier armed.
 #[derive(Clone, Copy)]

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -128,6 +128,8 @@ use pin::{note_preflight_skipped, note_preflight_walked, young_pin_latch_armed};
 mod prefetch;
 
 mod copying;
+/// Per-scanner root attribution for the copied-minor root scan (#7915).
+mod scanner_profile;
 use copying::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry
 // pass in `crate::weakref` (#6182), which lives outside the gc module.
@@ -689,6 +691,29 @@ pub(crate) fn ensure_gc_initialized() {
     }
 }
 
+/// Register a mutable root scanner, tagging it with its own path as the
+/// attribution name (`gc/scanner_profile.rs`, #7915). Root-scan cost on
+/// promise-heavy workloads is per registered root, so "which registry" is the
+/// first question any investigation asks; deriving the name from the
+/// registration site keeps the answer from drifting away from the list.
+macro_rules! reg_scanner {
+    ($scanner:expr $(,)?) => {
+        gc_register_named_mutable_root_scanner(stringify!($scanner), $scanner)
+    };
+}
+
+macro_rules! reg_budgeted_scanner {
+    ($scanner:expr, $step:expr, $state:expr, $source:expr $(,)?) => {
+        gc_register_budgeted_named_mutable_root_scanner_with_source(
+            stringify!($scanner),
+            $scanner,
+            $step,
+            $state,
+            $source,
+        )
+    };
+}
+
 pub fn gc_init() {
     // Idempotent per thread: production calls this at startup, and
     // `ensure_gc_initialized` calls it lazily on threads that don't. Latch the
@@ -698,7 +723,7 @@ pub fn gc_init() {
         return;
     }
     crate::perf_hooks::init_time_origin();
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         scan_runtime_handle_roots_mut,
         scan_runtime_handle_roots_mut_step,
         new_runtime_handle_root_scan_state,
@@ -708,20 +733,20 @@ pub fn gc_init() {
     // across a collection point. Same standing as the shadow stack — a precise
     // mutable root that is marked AND rewritten — and, like the shadow stack,
     // load-bearing the moment the conservative native-stack scan is off.
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         scan_temp_roots_mut,
         scan_temp_roots_mut_step,
         new_temp_root_scan_state,
         MutableRootScannerSource::RuntimeMutableScanner,
     );
-    gc_register_mutable_root_scanner(crate::promise::scan_native_async_completion_roots_mut);
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_scanner!(crate::promise::scan_native_async_completion_roots_mut);
+    reg_budgeted_scanner!(
         promise_mutable_root_scanner,
         crate::promise::scan_promise_roots_mut_step,
         crate::promise::new_promise_root_scan_state,
         MutableRootScannerSource::RuntimeMutableScanner,
     );
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         timer_mutable_root_scanner,
         crate::timer::scan_timer_roots_mut_step,
         crate::timer::new_timer_root_scan_state,
@@ -731,24 +756,22 @@ pub fn gc_init() {
     // tables (defineProperty accessors/attrs) and the proxy registry +
     // reflect-metadata store were invisible to GC — values swept/moved under
     // live references, owner keys stale after evacuation.
-    gc_register_mutable_root_scanner(crate::object::descriptor_state::scan_descriptor_roots_mut);
+    reg_scanner!(crate::object::descriptor_state::scan_descriptor_roots_mut);
     // #6759 Phase C3a: shape records follow their keys array across
     // evacuation (metadata-rewrite rekey only; the records hold no heap
     // references and mark nothing).
-    gc_register_mutable_root_scanner(crate::object::shapes::scan_shape_table_rekey_mut);
-    gc_register_mutable_root_scanner(crate::proxy::scan_proxy_roots_mut);
+    reg_scanner!(crate::object::shapes::scan_shape_table_rekey_mut);
+    reg_scanner!(crate::proxy::scan_proxy_roots_mut);
     // Object/string-valued `err.<prop> = v` user props live as raw bits in
     // ERROR_USER_PROPS — invisible to GC without this scanner (collectable
     // while reachable; stale addresses after a move). The address KEYS are
     // maintained by the ErrorSideTables move/finalize hooks.
-    gc_register_mutable_root_scanner(
-        crate::node_submodules::diagnostics_gc::scan_error_user_props_roots_mut,
-    );
-    gc_register_mutable_root_scanner(exception_mutable_root_scanner);
-    gc_register_mutable_root_scanner(async_context_mutable_root_scanner);
-    gc_register_mutable_root_scanner(async_hooks_mutable_root_scanner);
-    gc_register_mutable_root_scanner(shape_cache_mutable_root_scanner);
-    gc_register_mutable_root_scanner(crate::regex::scan_last_exec_groups_root_mut);
+    reg_scanner!(crate::node_submodules::diagnostics_gc::scan_error_user_props_roots_mut,);
+    reg_scanner!(exception_mutable_root_scanner);
+    reg_scanner!(async_context_mutable_root_scanner);
+    reg_scanner!(async_hooks_mutable_root_scanner);
+    reg_scanner!(shape_cache_mutable_root_scanner);
+    reg_scanner!(crate::regex::scan_last_exec_groups_root_mut);
     // #7211: the eight interned `typeof` result strings, and JSON.rawJSON's
     // interned `"rawJSON"` key. Both are thread-local caches of a RAW
     // `StringHeader*` allocated in the nursery and referenced by nothing else,
@@ -759,44 +782,42 @@ pub fn gc_init() {
     // `PERRY_GC_MOVING_LOOP_POLLS=1` build failed 10/10 rather than
     // intermittently, and why the from-space reporter blamed
     // `retired_by_minor=#0`.
-    gc_register_mutable_root_scanner(crate::builtins::arithmetic::scan_typeof_string_roots_mut);
-    gc_register_mutable_root_scanner(crate::json::raw_json::scan_raw_json_key_root_mut);
-    gc_register_mutable_root_scanner(crate::object::scan_exotic_expando_roots_mut);
-    gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
+    reg_scanner!(crate::builtins::arithmetic::scan_typeof_string_roots_mut);
+    reg_scanner!(crate::json::raw_json::scan_raw_json_key_root_mut);
+    reg_scanner!(crate::object::scan_exotic_expando_roots_mut);
+    reg_scanner!(crate::array::scan_template_raw_roots_mut);
     // #6981: the memoized `Array.prototype` / `Object.prototype` addresses in
     // `array::indexing`. Raw addresses of movable objects — a relocating cycle
     // that does not rewrite them leaves the hole/OOB read fallback comparing a
     // stale address against a forwarding-resolved receiver, which defeats its
     // own self-recursion guard and drives the mutator into unbounded recursion.
-    gc_register_mutable_root_scanner(crate::array::scan_prototype_addr_cache_roots_mut);
+    reg_scanner!(crate::array::scan_prototype_addr_cache_roots_mut);
     // #6763: inherited-property resolution retains an owner while an accessor
     // or Proxy trap can re-enter after moving GC. Rewrite that temporary
     // identity so malformed prototype cycles remain bounded.
-    gc_register_mutable_root_scanner(
-        crate::object::prototype_chain::scan_prototype_resolution_stack_roots_mut,
-    );
-    gc_register_mutable_root_scanner(crate::map::scan_map_iterator_array_roots_mut);
-    gc_register_mutable_root_scanner(crate::set::scan_set_iterator_array_roots_mut);
-    gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
-    gc_register_mutable_root_scanner(crate::v8::scan_v8_promise_hook_roots_mut);
-    gc_register_mutable_root_scanner(crate::typed_feedback::scan_typed_feedback_roots_mut);
-    gc_register_mutable_root_scanner(crate::typedarray_props::scan_typed_array_own_props_roots_mut);
+    reg_scanner!(crate::object::prototype_chain::scan_prototype_resolution_stack_roots_mut,);
+    reg_scanner!(crate::map::scan_map_iterator_array_roots_mut);
+    reg_scanner!(crate::set::scan_set_iterator_array_roots_mut);
+    reg_scanner!(crate::perf_hooks::scan_perf_entries_roots_mut);
+    reg_scanner!(crate::v8::scan_v8_promise_hook_roots_mut);
+    reg_scanner!(crate::typed_feedback::scan_typed_feedback_roots_mut);
+    reg_scanner!(crate::typedarray_props::scan_typed_array_own_props_roots_mut);
     // A typed array's materialized backing ArrayBuffer lives only as a raw
     // address in TYPED_ARRAY_VIEW_META — collectable/stale under a live typed
     // array, which made `subarray` hand back a garbage-length view.
-    gc_register_mutable_root_scanner(crate::typedarray_view::scan_typed_array_view_meta_roots_mut);
-    gc_register_mutable_root_scanner(transition_cache_mutable_root_scanner);
-    gc_register_mutable_root_scanner(crate::object::scan_object_cache_roots_mut);
-    gc_register_mutable_root_scanner(crate::object::scan_arguments_object_roots_mut);
+    reg_scanner!(crate::typedarray_view::scan_typed_array_view_meta_roots_mut);
+    reg_scanner!(transition_cache_mutable_root_scanner);
+    reg_scanner!(crate::object::scan_object_cache_roots_mut);
+    reg_scanner!(crate::object::scan_arguments_object_roots_mut);
     // bun:ffi (#6562): the cached FFIType enum object.
-    gc_register_mutable_root_scanner(crate::bun_ffi::scan_bun_ffi_roots_mut);
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_scanner!(crate::bun_ffi::scan_bun_ffi_roots_mut);
+    reg_budgeted_scanner!(
         crate::object::scan_class_side_table_roots_mut,
         crate::object::scan_class_side_table_roots_mut_step,
         crate::object::new_class_side_table_root_scan_state,
         MutableRootScannerSource::RuntimeMutableScanner,
     );
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         crate::symbol::scan_symbol_side_table_roots_mut,
         crate::symbol::scan_symbol_side_table_roots_mut_step,
         crate::symbol::new_symbol_side_table_root_scan_state,
@@ -807,10 +828,10 @@ pub fn gc_init() {
     // that body (e.g. @perryts/mysql Pool.acquire → handshake → nativeScramble
     // under concurrent load) must rewrite the cell, or the body's next
     // `this`-derived dispatch derefs a relocated receiver → SIGSEGV.
-    gc_register_mutable_root_scanner(crate::object::scan_implicit_this_roots_mut);
+    reg_scanner!(crate::object::scan_implicit_this_roots_mut);
     // Connected inspector sessions are retained only by the inspector's
     // thread-local registry while they receive protocol notifications.
-    gc_register_mutable_root_scanner(crate::node_inspector::scan_inspector_roots_mut);
+    reg_scanner!(crate::node_inspector::scan_inspector_roots_mut);
     // Issue #1790 (epic #1785 class-object dispatch / design #1772): the class
     // static-inheritance side-tables CLASS_PROTOTYPE_OBJECTS and
     // CLASS_PARENT_CLOSURES hold the heap parent (`class Sub extends make(...)`
@@ -818,23 +839,23 @@ pub fn gc_init() {
     // them so a parent reachable only through the table survives collection and
     // its address is fixed up after a copying-nursery / evacuation move,
     // keeping `Sub.ast` and inherited static methods resolvable.
-    gc_register_mutable_root_scanner(crate::object::scan_class_inheritance_roots_mut);
+    reg_scanner!(crate::object::scan_class_inheritance_roots_mut);
     // #1934: live `child_process.spawn` ChildProcess objects are reachable only
     // from the reactor's registry (the event loop holds no JSValue root for a
     // fire-and-forget spawn). Scan + rewrite them so a GC between ticks doesn't
     // reclaim the object whose `data`/`exit` handlers are still pending.
-    gc_register_mutable_root_scanner(crate::child_process::reactor::cp_reactor_scan_roots_mut);
+    reg_scanner!(crate::child_process::reactor::cp_reactor_scan_roots_mut);
     // #6563: live node-pty IPty objects are likewise reachable only from the
     // pty reactor's registry while their onData/onExit handlers are pending.
     #[cfg(unix)]
-    gc_register_mutable_root_scanner(crate::pty::reactor::pty_reactor_scan_roots_mut);
+    reg_scanner!(crate::pty::reactor::pty_reactor_scan_roots_mut);
     // #4911: a bound node:dgram socket is reachable only from the dgram
     // reactor's registry while its recv thread runs; scan + rewrite it so a GC
     // between ticks doesn't reclaim the object whose `message` handlers fire.
     #[cfg(feature = "mod-dgram")]
-    gc_register_mutable_root_scanner(crate::dgram_reactor::scan_roots_mut);
-    gc_register_mutable_root_scanner(json_parse_mutable_root_scanner);
-    gc_register_mutable_root_scanner(intern_table_mutable_root_scanner);
+    reg_scanner!(crate::dgram_reactor::scan_roots_mut);
+    reg_scanner!(json_parse_mutable_root_scanner);
+    reg_scanner!(intern_table_mutable_root_scanner);
     // #7564: the per-thread `{ value, done }` / `{ done, value }` keys arrays
     // shared by every iterator result the runtime builds. Nothing else in the
     // heap references them — the result objects that use them are short-lived
@@ -842,61 +863,59 @@ pub fn gc_init() {
     // swept and the next `.next()` would install a freed keys array. It also
     // REWRITES: an evacuating collection moves them like any other array, and
     // the thread-local slot is the only place the new address can be recorded.
-    gc_register_mutable_root_scanner(crate::iter_result::scan_iter_result_keys_roots_mut);
-    gc_register_mutable_root_scanner(small_int_cache_mutable_root_scanner);
-    gc_register_mutable_root_scanner(crate::builtins::scan_console_log_singleton_roots_mut);
-    gc_register_mutable_root_scanner(crate::builtins::scan_boxed_primitive_payload_roots_mut);
-    gc_register_mutable_root_scanner(crate::weakref::scan_pending_finalization_jobs_roots_mut);
+    reg_scanner!(crate::iter_result::scan_iter_result_keys_roots_mut);
+    reg_scanner!(small_int_cache_mutable_root_scanner);
+    reg_scanner!(crate::builtins::scan_console_log_singleton_roots_mut);
+    reg_scanner!(crate::builtins::scan_boxed_primitive_payload_roots_mut);
+    reg_scanner!(crate::weakref::scan_pending_finalization_jobs_roots_mut);
     // #6182: keep the weak-holder registry's stored holder ADDRESSES current
     // across evacuation. Metadata-only (non-rooting) — it rewrites forwarded
     // addresses in rewrite phases and emits nothing during mark, so it never
     // keeps a dead holder alive. Copied-minor liveness/prune is driven by
     // `process_weak_targets_from_registry`; this covers full-cycle currency.
-    gc_register_mutable_root_scanner(crate::weakref::scan_weak_holders_roots_mut);
+    reg_scanner!(crate::weakref::scan_weak_holders_roots_mut);
     // Issue #841: GC roots for the per-(submodule, export) function
     // singletons + per-submodule namespace stub objects allocated by
     // `node_submodules.rs`. Without this scanner the next GC cycle
     // after first import-binding use would reclaim the singletons
     // (nothing else holds them — they live for the program's lifetime
     // via codegen `getter` calls, not via a user-visible JSValue root).
-    gc_register_mutable_root_scanner(
-        crate::node_submodules::scan_node_submodule_singleton_roots_mut,
-    );
+    reg_scanner!(crate::node_submodules::scan_node_submodule_singleton_roots_mut,);
     // Box-capture root scanner (mutable closure captures, esp. the
     // generator state-machine's `__iter` and `__step` boxes that hold
     // the iter object + step closure across awaits).
-    gc_register_mutable_root_scanner(crate::r#box::scan_box_roots_mut);
+    reg_scanner!(crate::r#box::scan_box_roots_mut);
     // Iter-result scratch slot — the async-step fast path stows the
     // generator's most recent yield value here; it stays live until
     // the step driver reads it back.
-    gc_register_mutable_root_scanner(crate::promise::scan_iter_result_root_mut);
+    reg_scanner!(crate::promise::scan_iter_result_root_mut);
     // Async-step thunk single-slot cache (build_async_step_thunks).
-    gc_register_mutable_root_scanner(crate::promise::scan_async_step_thunk_cache_mut);
+    reg_scanner!(crate::promise::scan_async_step_thunk_cache_mut);
     // Closure singleton caches. Captured-closure cache keys mirror closure
     // capture heap words, so copied-minor must rewrite them after moving
     // captured young values or future cache hits miss on stale addresses.
-    gc_register_mutable_root_scanner(crate::closure::scan_singleton_closure_roots_mut);
-    gc_register_mutable_root_scanner(crate::closure::scan_closure_dynamic_props_roots_mut);
-    gc_register_mutable_root_scanner(crate::buffer::scan_buffer_own_props_roots_mut);
+    reg_scanner!(crate::closure::scan_singleton_closure_roots_mut);
+    reg_scanner!(crate::closure::scan_closure_dynamic_props_roots_mut);
+    reg_scanner!(crate::buffer::scan_buffer_own_props_roots_mut);
     // Generic per-handle expando properties (`blob.colors = [...]` and other
     // arbitrary own props on native HANDLE values). Keys are stable small handle
     // ids; only the stored VALUES are JS references that must be traced.
-    gc_register_mutable_root_scanner(crate::object::handle_expando::scan_handle_expando_roots_mut);
+    reg_scanner!(crate::object::handle_expando::scan_handle_expando_roots_mut);
     // Native-module callable export singletons and process stdio stream
     // singletons store heap pointers in TLS caches; keep them live and rewrite
     // them if a copying collection moves their backing allocations.
-    gc_register_mutable_root_scanner(crate::object::scan_native_callable_export_roots_mut);
-    gc_register_mutable_root_scanner(crate::object::scan_class_capture_value_roots_mut);
-    gc_register_mutable_root_scanner(crate::node_vm::scan_vm_roots_mut);
+    reg_scanner!(crate::object::scan_native_callable_export_roots_mut);
+    reg_scanner!(crate::object::scan_class_capture_value_roots_mut);
+    reg_scanner!(crate::node_vm::scan_vm_roots_mut);
     // #6559: the dyn-eval interpreter's rooted value stack (environments,
     // temporaries, arguments of in-flight interpreted frames). Mark +
     // REWRITE — interpreter state must survive moving collections triggered
     // from inside interpreted code.
     #[cfg(feature = "dyn-eval")]
-    gc_register_mutable_root_scanner(crate::dyn_eval::scan_dyn_eval_roots_mut);
-    gc_register_mutable_root_scanner(crate::tls::scan_tls_roots_mut);
-    gc_register_mutable_root_scanner(crate::process::scan_process_finalization_roots_mut);
-    gc_register_mutable_root_scanner(crate::process::scan_process_module_loader_roots_mut);
+    reg_scanner!(crate::dyn_eval::scan_dyn_eval_roots_mut);
+    reg_scanner!(crate::tls::scan_tls_roots_mut);
+    reg_scanner!(crate::process::scan_process_finalization_roots_mut);
+    reg_scanner!(crate::process::scan_process_module_loader_roots_mut);
     // #7231: the materialize-once `process.*` caches. Each is a thread-local
     // cell holding a NURSERY-allocated object that nothing else refers to —
     // `process.env` / `.permission` / `.report` are getter CALLS, not fields
@@ -906,22 +925,22 @@ pub fn gc_init() {
     // `CACHED_ENV` is the load-bearing one: `process.env` is touched by nearly
     // every real Node program, and every `process.env.X = v` after the first
     // collection wrote through a dangling pointer.
-    gc_register_mutable_root_scanner(crate::process::scan_process_env_cache_roots_mut);
-    gc_register_mutable_root_scanner(crate::process::scan_permission_cache_roots_mut);
-    gc_register_mutable_root_scanner(crate::process::scan_report_cache_roots_mut);
+    reg_scanner!(crate::process::scan_process_env_cache_roots_mut);
+    reg_scanner!(crate::process::scan_permission_cache_roots_mut);
+    reg_scanner!(crate::process::scan_report_cache_roots_mut);
     // #7231: the raw `Error` constructor address behind
     // `Error.prepareStackTrace`. The closure is reachable through `globalThis`
     // so it is not swept, but this duplicate lives outside the object graph
     // and goes stale on a move.
-    gc_register_mutable_root_scanner(crate::object::scan_error_constructor_root_mut);
+    reg_scanner!(crate::object::scan_error_constructor_root_mut);
     // #7231: native callback slots that bypass their rooted sibling
     // structures. `RESIZE_CALLBACK` bypasses the EventEmitter listener array;
     // `FRAME_CALLBACKS` is rooted only transiently by a `RuntimeHandleScope`
     // during registration; `INPUT_HANDLER` holds the `useInput` arrow, which
     // in idiomatic inline form has no other reference at all.
-    gc_register_mutable_root_scanner(crate::tty::scan_tty_resize_callback_root_mut);
-    gc_register_mutable_root_scanner(crate::frame::scan_frame_callback_roots_mut);
-    gc_register_mutable_root_scanner(crate::tui::input::scan_tui_input_handler_root_mut);
+    reg_scanner!(crate::tty::scan_tty_resize_callback_root_mut);
+    reg_scanner!(crate::frame::scan_frame_callback_roots_mut);
+    reg_scanner!(crate::tui::input::scan_tui_input_handler_root_mut);
     // #7231: three in-flight cells that hold a NaN-boxed heap value across a
     // window in which user code can run. Each is a second copy of a value
     // whose original is rooted elsewhere, or the only copy for the length of
@@ -929,21 +948,21 @@ pub fn gc_init() {
     // CELL is the half a scanner can close — the displaced value each
     // save/restore idiom parks in a bare Rust local is noted at each
     // declaration and needs `RuntimeHandleScope` plumbing, not a scanner.
-    gc_register_mutable_root_scanner(crate::object::scan_current_new_target_root_mut);
-    gc_register_mutable_root_scanner(crate::object::scan_accessor_receiver_override_root_mut);
-    gc_register_mutable_root_scanner(crate::object::scan_pending_fetch_signal_root_mut);
-    gc_register_mutable_root_scanner(crate::os::scan_process_event_listener_roots_mut);
+    reg_scanner!(crate::object::scan_current_new_target_root_mut);
+    reg_scanner!(crate::object::scan_accessor_receiver_override_root_mut);
+    reg_scanner!(crate::object::scan_pending_fetch_signal_root_mut);
+    reg_scanner!(crate::os::scan_process_event_listener_roots_mut);
     // #6077: keep promises tracked for an unhandled rejection alive + address-
     // stable until reported, so the program-end report is not a stale/UAF read.
-    gc_register_mutable_root_scanner(crate::promise::scan_unhandled_rejection_roots_mut);
-    gc_register_mutable_root_scanner(crate::os::scan_process_stream_singleton_roots_mut);
-    gc_register_mutable_root_scanner(crate::fs::scan_fs_handle_roots_mut);
-    gc_register_mutable_root_scanner(crate::fs::scan_fs_stream_roots_mut);
-    gc_register_mutable_root_scanner(crate::fs::scan_fs_watcher_roots_mut);
+    reg_scanner!(crate::promise::scan_unhandled_rejection_roots_mut);
+    reg_scanner!(crate::os::scan_process_stream_singleton_roots_mut);
+    reg_scanner!(crate::fs::scan_fs_handle_roots_mut);
+    reg_scanner!(crate::fs::scan_fs_stream_roots_mut);
+    reg_scanner!(crate::fs::scan_fs_watcher_roots_mut);
     #[cfg(feature = "full")]
-    gc_register_mutable_root_scanner(crate::plugin::scan_plugin_roots_mut);
-    gc_register_mutable_root_scanner(crate::geisterhand_registry::scan_geisterhand_roots_mut);
-    gc_register_mutable_root_scanner(crate::ui_text_registry::scan_ui_text_registry_roots_mut);
+    reg_scanner!(crate::plugin::scan_plugin_roots_mut);
+    reg_scanner!(crate::geisterhand_registry::scan_geisterhand_roots_mut);
+    reg_scanner!(crate::ui_text_registry::scan_ui_text_registry_roots_mut);
     // perry/tui hook + state slot pools — they store raw NaN-boxed
     // value bits but the GC has no other way to know which slots hold
     // heap pointers (arrays/objects/strings stashed via setState /
@@ -952,20 +971,20 @@ pub fn gc_init() {
     // the next allocation triggered minor GC, and the array was
     // reclaimed because nothing else held it — `messages.map(…)` on
     // the stale pointer produced an empty render.
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         crate::tui::hooks::scan_hook_slot_roots_mut,
         crate::tui::hooks::scan_hook_slot_roots_mut_step,
         crate::tui::hooks::new_hook_slot_root_scan_state,
         MutableRootScannerSource::RuntimeMutableScanner,
     );
-    gc_register_budgeted_mutable_root_scanner_with_source(
+    reg_budgeted_scanner!(
         crate::tui::state::scan_state_slot_roots_mut,
         crate::tui::state::scan_state_slot_roots_mut_step,
         crate::tui::state::new_state_slot_root_scan_state,
         MutableRootScannerSource::RuntimeMutableScanner,
     );
     #[cfg(feature = "ohos-napi")]
-    gc_register_mutable_root_scanner(crate::arkts_callbacks::arkts_callbacks_root_scanner_mut);
+    reg_scanner!(crate::arkts_callbacks::arkts_callbacks_root_scanner_mut);
 }
 
 #[no_mangle]
@@ -1060,11 +1079,15 @@ fn emit_incremental_liveness_diag() {
         return;
     }
     let (reentrant, no_trigger, start_blocked, resume_blocked) = instruments::budgeted_step_skips();
+    let (blocked_alloc, blocked_unsafe_zone, blocked_root_lock) =
+        instruments::moving_safepoints_blocked_by_other_guards();
     eprintln!(
         "[gc-incremental] cycle_starts={} steps={} completions={} active_at_exit={} \
          mark_barrier_arms={} mark_barrier_armed_us={} \
          skips(reentrant={reentrant} no_trigger={no_trigger} start_blocked={start_blocked} \
          resume_blocked={resume_blocked}) safepoints_blocked_by_budgeted={} \
+         safepoints_blocked(in_alloc={blocked_alloc} unsafe_zone={blocked_unsafe_zone} \
+         root_lock={blocked_root_lock}) \
          copying_minors={} loop_polls={} poll_arm_events={} \
          poll_armed_at_exit={}",
         instruments::incremental_cycle_starts(),

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -2581,6 +2581,7 @@ pub(crate) fn gc_safepoint_moving_minor() -> bool {
         if budgeted {
             super::instruments::note_moving_safepoint_blocked_by_budgeted();
         }
+        super::instruments::note_moving_safepoint_blocked(in_alloc, unsafe_zone, root_lock);
         return false;
     }
     // We are handling this safepoint (collect or find nothing due): clear the

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -82,6 +82,10 @@ pub(super) struct MutableRootScannerEntry {
     pub(super) source: MutableRootScannerSource,
     pub(super) budgeted_scanner: Option<BudgetedMutableRootScanner>,
     pub(super) budgeted_state_factory: Option<BudgetedMutableRootScannerStateFactory>,
+    /// Registration-site name, for per-scanner root attribution
+    /// (`gc/scanner_profile.rs`, #7915). Diagnostics only — nothing in the
+    /// collector's control flow reads it.
+    pub(super) name: &'static str,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -222,14 +226,35 @@ pub fn gc_register_mutable_root_scanner(scanner: MutableRootScanner) {
     );
 }
 
+/// `gc_register_mutable_root_scanner` plus a registration-site name for
+/// per-scanner root attribution (`gc/scanner_profile.rs`).
+pub(crate) fn gc_register_named_mutable_root_scanner(
+    name: &'static str,
+    scanner: MutableRootScanner,
+) {
+    gc_register_mutable_root_scanner_named_with_source(
+        name,
+        scanner,
+        MutableRootScannerSource::RuntimeMutableScanner,
+    );
+}
+
 /// Compatibility wrapper for callers that provide a human-readable scanner
 /// name. Current root-source telemetry groups these under runtime mutable
 /// scanners.
-pub fn gc_register_mutable_root_scanner_named(_source: &'static str, scanner: MutableRootScanner) {
-    gc_register_mutable_root_scanner(scanner);
+pub fn gc_register_mutable_root_scanner_named(source: &'static str, scanner: MutableRootScanner) {
+    gc_register_named_mutable_root_scanner(source, scanner);
 }
 
 pub(super) fn gc_register_mutable_root_scanner_with_source(
+    scanner: MutableRootScanner,
+    source: MutableRootScannerSource,
+) {
+    gc_register_mutable_root_scanner_named_with_source("unnamed", scanner, source);
+}
+
+pub(super) fn gc_register_mutable_root_scanner_named_with_source(
+    name: &'static str,
     scanner: MutableRootScanner,
     source: MutableRootScannerSource,
 ) {
@@ -239,11 +264,28 @@ pub(super) fn gc_register_mutable_root_scanner_with_source(
             source,
             budgeted_scanner: None,
             budgeted_state_factory: None,
+            name,
         });
     });
 }
 
 pub(super) fn gc_register_budgeted_mutable_root_scanner_with_source(
+    scanner: MutableRootScanner,
+    budgeted_scanner: BudgetedMutableRootScanner,
+    budgeted_state_factory: BudgetedMutableRootScannerStateFactory,
+    source: MutableRootScannerSource,
+) {
+    gc_register_budgeted_named_mutable_root_scanner_with_source(
+        "unnamed",
+        scanner,
+        budgeted_scanner,
+        budgeted_state_factory,
+        source,
+    );
+}
+
+pub(super) fn gc_register_budgeted_named_mutable_root_scanner_with_source(
+    name: &'static str,
     scanner: MutableRootScanner,
     budgeted_scanner: BudgetedMutableRootScanner,
     budgeted_state_factory: BudgetedMutableRootScannerStateFactory,
@@ -255,6 +297,7 @@ pub(super) fn gc_register_budgeted_mutable_root_scanner_with_source(
             source,
             budgeted_scanner: Some(budgeted_scanner),
             budgeted_state_factory: Some(budgeted_state_factory),
+            name,
         });
     });
 }

--- a/crates/perry-runtime/src/gc/scanner_profile.rs
+++ b/crates/perry-runtime/src/gc/scanner_profile.rs
@@ -1,0 +1,161 @@
+//! Per-scanner attribution for the copied-minor root scan (#7915).
+//!
+//! A copying minor runs the whole registered mutable-root scanner list THREE
+//! times — preflight, mark, rewrite — and the aggregate telemetry
+//! (`root_sources.runtime_mutable_scanners`) sums all of them into one number.
+//! That is enough to see that the cost is per-root rather than per-copied
+//! object, and not enough to say WHICH registry holds the roots.
+//!
+//! This module records, per registered scanner and per pass, the wall time it
+//! spent and the slots/pointer-roots/rewrites it accounted for. It is gated on
+//! the existing `PERRY_GC_DIAG` knob (no new knob — see CLAUDE.md's GC knob
+//! kill-policy) and is inert otherwise: the enable check is a cached bool and
+//! every recording site is behind it.
+
+use std::cell::RefCell;
+use std::time::Instant;
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct ScannerProfileRow {
+    pub(super) nanos: u64,
+    pub(super) calls: u32,
+    pub(super) slots: u64,
+    pub(super) pointer_roots: u64,
+    pub(super) rewrites: u64,
+}
+
+crate::perry_thread_local! {
+    static SCANNER_PROFILE: RefCell<Vec<(&'static str, ScannerProfileRow)>> =
+        const { RefCell::new(Vec::new()) };
+    static PROFILE_ENABLED: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+}
+
+#[inline]
+pub(super) fn scanner_profile_enabled() -> bool {
+    PROFILE_ENABLED.with(|cell| {
+        let cached = cell.get();
+        if cached != 0 {
+            return cached == 2;
+        }
+        let on = std::env::var_os("PERRY_GC_DIAG").is_some();
+        cell.set(if on { 2 } else { 1 });
+        on
+    })
+}
+
+/// Time `body`, attributing its wall time and its slot deltas to `name`.
+///
+/// `deltas` is `(slots, pointer_roots, rewrites)` measured by the caller around
+/// the same call — the trace stats live behind a raw pointer the caller already
+/// owns, so reading them here would need a second borrow.
+pub(super) fn record_scanner<R>(body: impl FnOnce() -> R) -> (R, u64) {
+    if !scanner_profile_enabled() {
+        return (body(), 0);
+    }
+    let start = Instant::now();
+    let out = body();
+    let nanos = start.elapsed().as_nanos() as u64;
+    (out, nanos)
+}
+
+/// Read the three counters this module attributes, before a scanner runs.
+pub(super) fn snapshot_stats(
+    stats: Option<*mut super::telemetry::RootSourceSlotTraceStats>,
+) -> (u64, u64, u64) {
+    match stats {
+        Some(stats) if scanner_profile_enabled() => unsafe {
+            (
+                (*stats).slots_scanned as u64,
+                (*stats).pointer_roots as u64,
+                (*stats).rewritten_slots as u64,
+            )
+        },
+        _ => (0, 0, 0),
+    }
+}
+
+pub(super) fn note_stats_delta(
+    name: &'static str,
+    nanos: u64,
+    before: (u64, u64, u64),
+    stats: Option<*mut super::telemetry::RootSourceSlotTraceStats>,
+) {
+    if !scanner_profile_enabled() {
+        return;
+    }
+    let after = snapshot_stats(stats);
+    note_scanner(
+        name,
+        nanos,
+        after.0.saturating_sub(before.0),
+        after.1.saturating_sub(before.1),
+        after.2.saturating_sub(before.2),
+    );
+}
+
+pub(super) fn note_scanner(
+    name: &'static str,
+    nanos: u64,
+    slots: u64,
+    pointer_roots: u64,
+    rewrites: u64,
+) {
+    if !scanner_profile_enabled() {
+        return;
+    }
+    SCANNER_PROFILE.with(|rows| {
+        let mut rows = rows.borrow_mut();
+        if let Some((_, row)) = rows.iter_mut().find(|(row_name, _)| *row_name == name) {
+            row.nanos = row.nanos.saturating_add(nanos);
+            row.calls = row.calls.saturating_add(1);
+            row.slots = row.slots.saturating_add(slots);
+            row.pointer_roots = row.pointer_roots.saturating_add(pointer_roots);
+            row.rewrites = row.rewrites.saturating_add(rewrites);
+            return;
+        }
+        rows.push((
+            name,
+            ScannerProfileRow {
+                nanos,
+                calls: 1,
+                slots,
+                pointer_roots,
+                rewrites,
+            },
+        ));
+    });
+}
+
+/// Print the per-scanner breakdown accumulated since the last report, then
+/// clear it. Called once per copied minor from the `[gc-copy-minor]` diag site.
+pub(super) fn report_and_reset(cycle_label: &str) {
+    if !scanner_profile_enabled() {
+        return;
+    }
+    let mut rows = SCANNER_PROFILE.with(|rows| std::mem::take(&mut *rows.borrow_mut()));
+    if rows.is_empty() {
+        return;
+    }
+    rows.sort_by(|a, b| b.1.nanos.cmp(&a.1.nanos));
+    let total_ns: u64 = rows.iter().map(|(_, row)| row.nanos).sum();
+    let total_slots: u64 = rows.iter().map(|(_, row)| row.slots).sum();
+    eprintln!(
+        "[gc-scanner-profile] {cycle_label} scanners={} total_us={} total_slots={}",
+        rows.len(),
+        total_ns / 1000,
+        total_slots
+    );
+    for (name, row) in rows.iter().take(14) {
+        if row.nanos == 0 && row.slots == 0 {
+            continue;
+        }
+        eprintln!(
+            "[gc-scanner-profile]   {name} us={} calls={} slots={} ptr_roots={} rewrites={}",
+            row.nanos / 1000,
+            row.calls,
+            row.slots,
+            row.pointer_roots,
+            row.rewrites
+        );
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/copying.rs
+++ b/crates/perry-runtime/src/gc/tests/copying.rs
@@ -145,6 +145,7 @@ impl TemporaryRustMutableRootScanner {
                 source: MutableRootScannerSource::RuntimeMutableScanner,
                 budgeted_scanner: None,
                 budgeted_state_factory: None,
+                name: "test_rust_mutable_root_scanner",
             });
             previous_len
         });

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -154,7 +154,18 @@ ALLOCATOR_TOKENS = (
 # "stdlib:worker_threads:workers", scan_worker_roots_mut)` puts the scanner
 # SECOND, and a first-argument-only regex silently reported every holder that
 # scanner covers as uncovered — six of them, in one file.
-REGISTER_CALL = re.compile(r"gc_register_\w*root_scanner\w*\s*\((?P<args>[^;()]*)\)", re.S)
+#
+# `reg_scanner!` / `reg_budgeted_scanner!` are `gc_init`'s wrappers (#7915):
+# they exist only to attach `stringify!`'d registration-site names, and they
+# expand to the same `gc_register_*` calls. They must be matched here or every
+# holder reached only from `gc_init` reads as uncovered — which is exactly what
+# happened when they were introduced, and the MIN_REGISTERED floor below is
+# what caught it.
+REGISTER_CALL = re.compile(
+    r"(?:gc_register_\w*root_scanner\w*|reg_scanner!|reg_budgeted_scanner!)"
+    r"\s*\((?P<args>[^;()]*)\)",
+    re.S,
+)
 FN_DEF = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|extern\s+\"C\"\s+)*fn\s+(\w+)")
 IDENT = re.compile(r"\b[A-Za-z_]\w*\b")
 


### PR DESCRIPTION
Closes #7915 (as far as it can be closed — see "What this does not do").

## What #7915 asked, and what the measurement says

> `asyncpipe` runs a 134 ms minor collection that copied zero objects and zero
> bytes … the work is per registered root, not per copied object: 82 registered
> runtime mutable root scanners over 218 455 pointer roots.

Both halves turn out to be artefacts of which counter was read. Reproduced on
`origin/main`, `asyncpipe` at 240 batches, `PERRY_GC_TRACE=1 PERRY_GC_DIAG=1`:

**1. The "zero objects" minor handled 200 201 of them.**

```
[gc-copy-minor] ran … survival_permille=895
  copied_objects=0 copied_bytes=0
  promoted_objects=200201 promoted_bytes=15860160 …
```

`copied_objects` counts survivor-space copies only. On a promoting cycle it is
structurally zero, which is the same shape as CLAUDE.md's "a gate must assert
its subject was live" — a counter that cannot be non-zero on the path being
measured. 101 ms / 200 201 objects is 505 ns/object, not a fixed per-cycle cost.

**2. The root population is one registry, not 82 scanners.**

This PR adds the per-scanner attribution that shows it. `crate::box::scan_box_roots_mut`
is **92 % of the pointer roots and 89.5 % of all root-scan time**; the other 81
scanners are 8.8 % between them. The suspected culprit, the promise registry,
visits **12 slots** and costs 4–43 µs.

**3. …and that 89.5 % is not root-scan overhead, it is the object trace.**

A cheap slot visit costs ~4 ns (`intern_table_mutable_root_scanner`: 16 384
slots, 1 144 pointer roots, 68 µs). The box scanner costs 98.8 ns/slot because
essentially every box slot *is* a from-space pointer, so visiting it in
`CopyingMark` mode evacuates the object it names — 93 380 of minor #1's 156 236
evacuations are driven straight out of box roots. 98.8 ns/pointer-root is the
same price as a measured full evacuation (123 ns/object).

So the fixed per-root overhead the issue is aimed at is about
**4 ns × 265 000 ≈ 1 ms of a 65–101 ms pause**. Generational filtering, dirty
tracking of the registries and cheaper registry representations all attack that
1 ms. I built the third one (slab-allocated box cells, so the scan streams
instead of chasing ~121 500 scattered 8-byte mallocs in hash order, twice per cycle) and it
measured **+0.03 % instructions / −1.8 % cycles / no RSS change / pause
indistinguishable over 7 runs**, so it is **not** in this PR.

## What is in this PR

Instruments and one lint fix — no behaviour change.

- **`[gc-scanner-profile]`**, per registered scanner: wall time and
  slots/pointer-roots/rewrites, sorted by time, once per copying minor, under
  the **existing** `PERRY_GC_DIAG` (no new knob — CLAUDE.md's GC knob
  kill-policy). Registration sites carry their own path as the name via
  `stringify!` in `gc_init`'s `reg_scanner!`/`reg_budgeted_scanner!` macros, so
  a name cannot drift from the list it describes. The aggregate
  `root_sources.runtime_mutable_scanners` counter sums all 82 scanners and all
  passes into one number — enough to see that a cost is per-root, not enough to
  say which registry holds the roots, which is exactly how #7915 came to read as
  a property of "the registries".

- **Counters for the three unobserved `gc_safepoint_moving_minor` entry
  guards.** Only `budgeted` was counted, so a precise safepoint that returned
  without collecting had one observable explanation and three invisible ones.
  `[gc-incremental]` now also prints
  `safepoints_blocked(in_alloc=… unsafe_zone=… root_lock=…)`. This is what makes
  "an active `setjmp`/`try` region suppresses the copying minor" (#7910) a
  testable claim rather than an argument about the guard list.

- **`scripts/gc_runtime_root_holders.py` learns the two registration macros.**
  They expand to `gc_register_*` calls but the gate matches the call *name*, so
  introducing them dropped its registered-scanner count from 122 to 24 and every
  holder reached only from `gc_init` would have read as uncovered. Its
  `MIN_REGISTERED` floor caught it, which is what that floor is for.

## Where the cost actually is (and it is not the collector)

`asyncpipe`'s `young_survival_permille` is **695** and **895**, against **0–4**
for every other churn-shaped program in the corpus — and it is a churn program
by construction: each batch builds 200 `Req`s / 200 `Ok`s / 200 strings, folds
them into six numbers, and drops the batch.

A one-env-var probe (temporary, not in this PR) makes `scan_box_roots_mut` skip
*marking* while still rewriting:

| | control | box roots do not mark |
|---|--:|--:|
| minor #1 `young_survival_permille` | **695** | **24** |
| minor #1 `copied_objects` | **156 236** | **6 634** (−95.8 %) |
| minor #1 `freed_bytes` | 5 456 696 | **17 451 568** (3.2×) |
| minor #2 | 200 201 objects promoted | **never happens** |
| exit | 0, correct output | 134 (SIGABRT) |

**`asyncpipe`'s real live young set is ~6 600 objects. The other 96 % is alive
only because a completed async activation's boxed locals are still GC roots** —
the transform boxes every body local of every `async` function and nothing ever
frees or clears one, so every local of all 48 000 completed activations is a
permanent root. At 6 634 live objects a minor costs ~0.8 ms instead of 62 ms.

The SIGABRT is the control, not a failure: not marking is unsound, which is
precisely why the fix is *clearing* an activation's boxes at its terminal state
rather than not marking them. That is a codegen change in the async transform
and wants its own issue; this PR contributes the evidence that it is the lever.
Full write-up: `gc-handoff/ROOTS-NOTES.md` §7–8.

## Validation

- `cargo test --release -p perry-runtime --lib` (`RUST_TEST_THREADS=1`),
  GC/copying + box suites: 127 passed, 0 failed.
- All 19 corpus programs byte-identical to node, exit 0.
- `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/gc_runtime_root_holders.py` (+ `--self-test`),
  `scripts/addr_class_inventory.py` (+ `--self-test`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional garbage-collection diagnostics through `PERRY_GC_DIAG`.
  * Reports per-scanner timing, root statistics, rewrite activity, and aggregate analysis.
  * Added visibility into moving safepoints blocked by allocation, unsafe zones, and root locks.

* **Documentation**
  * Documented GC root-scan attribution findings, including box-root and promise-registry costs.
  * Improved scanner registration coverage checks for diagnostics tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->