### PR TITLE
fix(runtime): classify typed arrays before object headers

### DIFF
--- a/changelog.d/7940-typed-array-header-dispatch.md
+++ b/changelog.d/7940-typed-array-header-dispatch.md
@@ -1,0 +1,16 @@
+### fix(runtime): classify typed arrays before object headers
+
+Fix #7930: generic property reads on two-element typed arrays no longer return
+`undefined` for `.length` and `.byteLength`. `TypedArrayHeader::length` occupies
+the payload offset used by `ObjectHeader` for its object-type word, so length 2
+previously collided with `OBJECT_TYPE_ERROR == 2` and entered Error-object
+dispatch even though the typed-array constructor had produced the correct
+length.
+
+The dynamic getter now consults the authoritative typed-array registry before
+interpreting any header-shaped payload, roots the receiver across property-key
+allocation, and delegates to the canonical typed-array property path. This
+preserves own-property/accessor precedence, prototype mutations, indexed reads,
+and the remaining typed-array builtins. A regression constructs
+`Int32Array(2.5)`, verifies ToIndex produced length 2, and covers generic
+`.length` and `.byteLength` reads.

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -407,6 +407,31 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
         Err(_) => return f64::from_bits(TAG_UNDEFINED),
     };
 
+    // #7930: TypedArrayHeader starts with `length: u32`, at the same payload
+    // offset where ObjectHeader stores its object-type word. Classify the
+    // receiver through the authoritative side table before any header-shaped
+    // dispatch below: a two-element typed array otherwise reads as
+    // `OBJECT_TYPE_ERROR == 2`, so `.length` / `.byteLength` enter the Error
+    // branch and return `undefined` even though construction was correct.
+    //
+    // Delegate to the normal by-name typed-array path rather than duplicating
+    // its property semantics here. It gives an own expando/accessor precedence
+    // over the inherited `length` accessor and handles prototype mutations,
+    // indexed keys, `buffer`, and the remaining typed-array builtins. Creating
+    // the StringHeader may collect, so keep the old-generation typed-array
+    // receiver live and re-read its address after that allocation.
+    if crate::typedarray::lookup_typed_array_kind(ptr as usize).is_some() {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let receiver = scope.root_raw_const_ptr(ptr as *const crate::typedarray::TypedArrayHeader);
+        let (key, typed) = receiver.across_const(|| {
+            crate::string::js_string_from_bytes(name_slice.as_ptr(), name_slice.len() as u32)
+        });
+        return crate::object::js_object_get_field_by_name_f64(
+            typed as *const crate::object::ObjectHeader,
+            key,
+        );
+    }
+
     // Check if this is a ClosureHeader (CLOSURE_MAGIC at offset 12).
     // ClosureHeader layout: func_ptr (8B), capture_count u32 (4B), type_tag u32 (4B), captures at 16+
     // ObjectHeader layout: object_type u32 (4B), class_id u32 (4B), parent_class_id u32 (4B), field_count u32 (4B), keys_array (8B), ...
@@ -824,6 +849,30 @@ mod length_handle_band_tests {
             js_value_length_property_f64(boxed_obj).to_bits(),
             seven_value.to_bits(),
             "a source-level property read must not coerce its value"
+        );
+    }
+
+    /// #7930: `TypedArrayHeader::length` shares payload offset zero with an
+    /// `ObjectHeader`'s type word. A two-element typed array must be classified
+    /// by its registry entry before that word can masquerade as
+    /// `OBJECT_TYPE_ERROR == 2` in the generic property getter.
+    #[test]
+    fn length_two_typed_array_never_enters_error_object_dispatch() {
+        let typed =
+            crate::typedarray::js_typed_array_new(crate::typedarray::KIND_INT32 as i32, 2.5);
+        assert_eq!(
+            crate::typedarray::js_typed_array_length(typed),
+            2,
+            "test premise: ToIndex truncates the fractional constructor length"
+        );
+
+        let boxed = crate::value::js_nanbox_pointer(typed as i64);
+        assert_eq!(js_value_length_property_f64(boxed), 2.0);
+        assert_eq!(
+            unsafe {
+                js_dynamic_object_get_property(boxed, b"byteLength".as_ptr() as *const i8, 10)
+            },
+            8.0
         );
     }
 }


### PR DESCRIPTION
Closes #7930.

## Root cause

`TypedArrayHeader` begins with `length: u32` at the payload offset where `ObjectHeader` stores its object-type word. The generic dynamic getter classified the raw payload as an object header before consulting the authoritative typed-array registry. A two-element typed array therefore masqueraded as `OBJECT_TYPE_ERROR == 2`, sending `.length` and `.byteLength` through Error-object handling and returning `undefined`; construction itself was correct.

## Fix

- Classify typed arrays through their side table before closure, GC-header, and object-header-shaped dispatch.
- Root the receiver across property-key allocation, which may collect.
- Delegate to the canonical by-name typed-array getter so own accessors/expandos, prototype mutations, indices, `buffer`, and other builtins retain their existing precedence.
- Add a focused regression that constructs `Int32Array(2.5)`, proves its runtime length is 2, and exercises generic `.length` and `.byteLength` reads.

## Validation

- Red regression before the fix: expected `2.0`, received the NaN-boxed `undefined` tag.
- Exact release build of `perry`, `perry-runtime-static`, and `perry-stdlib-static`: passed.
- `test_gap_3146_spec_throws` and `test_gap_4103_typedarray_view_validation`: compile/run exit 0 and byte-identical to Node, including all formerly failing length-2 reads.
- `cargo test --release -p perry-runtime --lib`: 2,198 passed, 4 ignored, 0 failed.
- Formatting, diff check, 2,000-line gate, raw-handle debt, and GC root-holder checks: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect `length` and `byteLength` values for two-element typed arrays.
  * Preserved standard property and prototype behavior when accessing typed-array properties.
  * Improved reliability when typed arrays are accessed during dynamic property operations.
* **Tests**
  * Added regression coverage for typed arrays created with fractional lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->