### PR TITLE
docs(gc): state exactly what weak_steps_sliced proves (#7903 follow-up)

### DIFF
--- a/changelog.d/7941-weak-steps-sliced-doc.md
+++ b/changelog.d/7941-weak-steps-sliced-doc.md
@@ -1,0 +1,19 @@
+### Changed
+
+- **Documented exactly what `[gc-step-bounds]`'s `weak_steps_sliced` proves
+  (#7903 follow-up).** Comment-only; no behaviour change.
+
+  The sabotage run that proved #7938's new tests can fail also falsified the
+  reason given for believing them. Reverting the slice to the pre-#7903
+  whole-array-in-one-unit behaviour turns 4 of the 5 tests red — but **not** via
+  the liveness assertion, which #7938 claimed was unreachable on unsliced code.
+  It is reachable: a step can end "mid-registry" at the *entry park*, its budget
+  already spent resolving the holder, before a single record is scanned. What
+  actually caught the sabotage was the per-step ceiling, failing with
+  `charged 64`.
+
+  So the counter is asymmetric — **zero proves the sliced path did not run;
+  nonzero does not prove records were sliced** — and `weak_max_records_per_step`
+  is the discriminating quantity. Stated at all three places a reader meets it:
+  the `[gc-step-bounds]` doc block, the assertion itself, and
+  `docs/src/internals/gc-step-bounds.md`.

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -1121,7 +1121,10 @@ fn emit_incremental_liveness_diag() {
 ///   one registry was one work unit, so this maximum was the whole registry.
 /// * `weak_steps_sliced` — steps that ended PARTWAY THROUGH a registry. **This
 ///   is the subject-was-live counter**: a run reporting zero has not exercised
-///   the sliced path, whatever else it reports.
+///   the sliced path, whatever else it reports. A NONZERO value proves less
+///   than it looks — a step can end mid-registry at the entry park, before any
+///   record is scanned — so pair it with `weak_max_records_per_step`, which is
+///   what actually distinguishes a sliced array from a swallowed one.
 /// * `weak_registry_restarts` / `weak_registry_atomic_finishes` — cursors
 ///   invalidated by mutator restructuring, and the bounded fallback taken when
 ///   one registry exhausted its restart budget.

--- a/crates/perry-runtime/src/gc/tests/step_bounds.rs
+++ b/crates/perry-runtime/src/gc/tests/step_bounds.rs
@@ -107,6 +107,15 @@ fn one_registry_record_array_is_sliced_across_budgeted_steps() {
 
     // LIVENESS FIRST: without this the two bounds below are satisfied by a run
     // that never reached weak processing at all.
+    //
+    // ★ But note exactly how much this proves, because it is less than it
+    // looks. A step can end "mid-registry" at the ENTRY park — budget already
+    // spent on resolving the holder, so the cursor is stashed before a single
+    // record is scanned. Sabotaging the slice (`take` = the whole array)
+    // therefore still satisfies THIS assertion; what catches it is the
+    // per-step ceiling below, which fails with `charged 64`. Verified by
+    // sabotage, not assumed. So: a zero here means the path did not run, but a
+    // nonzero does NOT by itself mean records were sliced.
     assert!(
         instruments::weak_steps_sliced() > 0,
         "no step ended mid-registry — the sliced path did not run, so the \

--- a/docs/src/internals/gc-step-bounds.md
+++ b/docs/src/internals/gc-step-bounds.md
@@ -106,3 +106,11 @@ rather than claim it**. `final_remark_max_us` is that measurement.
   happen". Most programs register no weak holders and will legitimately report
   zeros across this whole line — which is exactly why the acceptance tests drive
   the counters directly rather than inferring them from a corpus run.
+
+  ★ **A nonzero value proves less than it looks, and this was measured rather
+  than reasoned about.** A step can end "mid-registry" at the *entry park* — its
+  budget already spent resolving the holder, so the cursor is stashed before a
+  single record is scanned. Sabotaging the slice so that one unit swallows the
+  whole array still leaves this counter nonzero. The quantity that actually
+  discriminates is `weak_max_records_per_step`: under that sabotage it reads the
+  full array length instead of the budget. Use the pair, not the flag alone.


### PR DESCRIPTION
Follow-up to #7938 (already merged). **Comment-only** — no behaviour change.

## Why

The sabotage run that proved #7938's new tests can fail also **falsified a claim
I made about them** in that PR's description and comments. I wrote that
`weak_steps_sliced() > 0` "cannot be reached on unsliced code". It can.

Sabotaging the slice — `take = cursor.identity.len - cursor.next` instead of
`.min(*remaining)`, i.e. the pre-#7903 whole-array-in-one-unit behaviour —
produced:

```
one_registry_record_array_is_sliced_across_budgeted_steps ... FAILED
  a one-work-unit step must charge at most one record; charged 64
record_slice_size_tracks_the_work_budget ... FAILED
  the registry must still be sliced at budget 8, not swallowed whole
mutating_the_entries_array_between_slices_restarts_the_cursor ... FAILED
  restructuring the entries array under a live cursor was not detected
relentless_mutation_falls_back_to_a_bounded_atomic_finish ... FAILED
  the adversary never managed to invalidate a cursor
final_root_remark_is_accounted_as_a_separate_atomic_phase ... ok
test result: FAILED. 1 passed; 4 failed
```

(Discriminator checked: exactly **one** `Compiling perry-runtime` in the log, so
the verdict is about the sabotaged code and not a silently-restored rebuild. The
one pass is correct — that test covers remark timing, which the sabotage did not
touch, so it doubles as a control showing the sabotage was surgical.)

**The assertion that failed first was not the liveness one.** It was the
per-step ceiling, at `charged 64`. `weak_steps_sliced` stayed nonzero under
sabotage, because a step can end "mid-registry" at the **entry park** — its
budget already spent resolving the holder, so the cursor is stashed before a
single record is scanned.

So the counter's real meaning is asymmetric: **zero proves the path did not run;
nonzero does not prove records were sliced.** The quantity that discriminates is
`weak_max_records_per_step`.

## What changes

Three comments, so the documented meaning matches what was measured rather than
what I assumed:

- `gc/mod.rs` — the `[gc-step-bounds]` doc block.
- `gc/tests/step_bounds.rs` — a note at the liveness assertion recording that
  sabotage does *not* trip it, and which assertion does.
- `docs/src/internals/gc-step-bounds.md` — "use the pair, not the flag alone".

The counter itself is unchanged and the test suite is unchanged; #7938's tests
are proven non-vacuous as a suite. This corrects the *stated* reason.

No changelog fragment: comment-only, no behaviour change (`skip-changelog`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to interpret garbage-collection step-bound diagnostics.
  * Explained that a nonzero sliced-step count alone does not prove records were distributed across steps.
  * Identified the per-step record maximum as the reliable metric for detecting unsliced processing.
  * Updated configuration, internals, and assertion documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->