### PR TITLE
fix(compile): stop post-link ancestor resource copies

### DIFF
--- a/changelog.d/7945-post-link-resource-copies.md
+++ b/changelog.d/7945-post-link-resource-copies.md
@@ -1,0 +1,9 @@
+**Standalone resource staging stops copying an unrelated ancestor's asset
+tree after linking (#6899).** The post-link staging walk looked upward for
+`package.json` only, so a perry.toml-anchored app nested under another
+package selected the wrong project root and recursively copied its
+`logo`/`assets`/`resources`/`images` — presenting as a silent post-link
+hang. Staging now routes through the shared project-root/copy helpers,
+`perry.toml` anchors the walk like `package.json`, and an unanchored search
+falls back to the starting directory as its contract always said.
+(Fragment added at merge; full analysis in the PR body.)

--- a/crates/perry/src/commands/compile/resources.rs
+++ b/crates/perry/src/commands/compile/resources.rs
@@ -24,13 +24,14 @@ const BACKEND_PACKAGE_METADATA_FILE: &str = "perry-backend-package.json";
 /// the deepest directory that holds an anchor; if none found within
 /// the bound, returns the starting input unchanged.
 pub(super) fn find_project_root_for_resources(start: &Path, watch_for_perry_toml: bool) -> PathBuf {
+    let fallback = start.to_path_buf();
     let mut project_root = start.to_path_buf();
     for _ in 0..5 {
         if project_root.join("package.json").exists() {
-            break;
+            return project_root;
         }
         if watch_for_perry_toml && project_root.join("perry.toml").exists() {
-            break;
+            return project_root;
         }
         if let Some(parent) = project_root.parent() {
             project_root = parent.to_path_buf();
@@ -38,7 +39,43 @@ pub(super) fn find_project_root_for_resources(start: &Path, watch_for_perry_toml
             break;
         }
     }
-    project_root
+    fallback
+}
+
+/// Copy conventional resource directories next to a standalone executable.
+///
+/// Standalone builds use `perry.toml` as a project anchor just like the rest of
+/// the compile pipeline.  The old inline implementation only looked for
+/// `package.json`, so an app with only `perry.toml` could select an unrelated
+/// ancestor package and recursively copy its assets after the linker had
+/// already finished (#6899).
+pub(super) fn copy_standalone_resource_dirs(input: &Path, dest_dir: &Path) {
+    let Some(source_dir) = input
+        .canonicalize()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+    else {
+        return;
+    };
+    let project_root = find_project_root_for_resources(&source_dir, true);
+    let output_resolved = if dest_dir.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        dest_dir.to_path_buf()
+    };
+    let output_canon = output_resolved
+        .canonicalize()
+        .unwrap_or_else(|_| output_resolved.clone());
+    let project_canon = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.clone());
+
+    // Copying a resource directory onto itself truncates files before reading
+    // them. It is also unnecessary when the executable already lives at the
+    // project root.
+    if output_canon != project_canon {
+        copy_bundle_resource_dirs(&project_root, dest_dir);
+    }
 }
 
 /// Recursive copy used by the per-target bundle writers. Mirrors the
@@ -603,5 +640,47 @@ mod native_resource_tests {
             fs::read(package_resource_dir.join("d3d12/compute.hlsl.dxil")).unwrap(),
             b"dxil"
         );
+    }
+}
+
+#[cfg(test)]
+mod project_resource_tests {
+    use std::fs;
+
+    use super::{copy_standalone_resource_dirs, find_project_root_for_resources};
+
+    #[test]
+    fn project_root_falls_back_to_start_when_no_anchor_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let start = dir.path().join("one/two/three");
+        fs::create_dir_all(&start).unwrap();
+
+        assert_eq!(find_project_root_for_resources(&start, true), start);
+    }
+
+    #[test]
+    fn standalone_resources_prefer_nearest_perry_toml_over_ancestor_package() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("packages/demo");
+        let src = app.join("src");
+        let output = app.join("dist");
+        fs::create_dir_all(app.join("assets")).unwrap();
+        fs::create_dir_all(dir.path().join("resources")).unwrap();
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(&output).unwrap();
+        fs::write(dir.path().join("package.json"), "{}\n").unwrap();
+        fs::write(app.join("perry.toml"), "[perry]\n").unwrap();
+        fs::write(app.join("assets/app.txt"), "app\n").unwrap();
+        fs::write(dir.path().join("resources/ancestor.txt"), "ancestor\n").unwrap();
+        let input = src.join("main.ts");
+        fs::write(&input, "console.log('hello');\n").unwrap();
+
+        copy_standalone_resource_dirs(&input, &output);
+
+        assert_eq!(
+            fs::read_to_string(output.join("assets/app.txt")).unwrap(),
+            "app\n"
+        );
+        assert!(!output.join("resources/ancestor.txt").exists());
     }
 }

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -6176,64 +6176,7 @@ pub fn run_with_parse_cache(
         // For Windows/Linux (non-bundle targets), copy asset directories next to the exe
         // so that resolve_asset_path can find them relative to the executable.
         if let Some(output_dir) = exe_path.parent() {
-            let source_dir = args
-                .input
-                .canonicalize()
-                .ok()
-                .and_then(|p| p.parent().map(|d| d.to_path_buf()));
-            if let Some(src_dir) = source_dir {
-                let mut project_root = src_dir.clone();
-                for _ in 0..5 {
-                    if project_root.join("package.json").exists() {
-                        break;
-                    }
-                    if let Some(parent) = project_root.parent() {
-                        project_root = parent.to_path_buf();
-                    } else {
-                        break;
-                    }
-                }
-                fn copy_dir_recursive_standalone(
-                    src: &std::path::Path,
-                    dst: &std::path::Path,
-                ) -> std::io::Result<()> {
-                    fs::create_dir_all(dst)?;
-                    for entry in fs::read_dir(src)? {
-                        let entry = entry?;
-                        let ty = entry.file_type()?;
-                        let dest_path = dst.join(entry.file_name());
-                        if ty.is_dir() {
-                            copy_dir_recursive_standalone(&entry.path(), &dest_path)?;
-                        } else {
-                            fs::copy(entry.path(), &dest_path)?;
-                        }
-                    }
-                    Ok(())
-                }
-                // Resolve output_dir: exe_path.parent() returns "" for bare filenames like "Mango"
-                let output_resolved = if output_dir.as_os_str().is_empty() {
-                    std::path::PathBuf::from(".")
-                } else {
-                    output_dir.to_path_buf()
-                };
-                let output_canon = output_resolved
-                    .canonicalize()
-                    .unwrap_or_else(|_| output_resolved.clone());
-                let project_canon = project_root
-                    .canonicalize()
-                    .unwrap_or_else(|_| project_root.to_path_buf());
-                // Skip asset copying if output dir IS the project root
-                // (fs::copy to self truncates files to 0 bytes)
-                if output_canon != project_canon {
-                    for dir_name in &["logo", "assets", "resources", "images"] {
-                        let resource_dir = project_root.join(dir_name);
-                        if resource_dir.is_dir() {
-                            let dest = output_dir.join(dir_name);
-                            let _ = copy_dir_recursive_standalone(&resource_dir, &dest);
-                        }
-                    }
-                }
-            }
+            resources::copy_standalone_resource_dirs(&args.input, output_dir);
             if !is_harmonyos {
                 resources::stage_native_library_artifacts(&ctx, output_dir, format)?;
             }


### PR DESCRIPTION
Fixes #6899

## Root cause

The reporter established that `link.exe` had exited, the output executable already existed, and `perry.exe` was still doing sustained disk I/O. The only ordinary Windows/Linux work in that silent interval before `Wrote executable:` is standalone resource staging.

That path independently walked upward looking only for `package.json`. It ignored the `perry.toml` that `perry doctor` had found, so a perry.toml-only app nested beneath another package could select an unrelated ancestor project and recursively copy its `logo`, `assets`, `resources`, or `images` tree after linking. A sufficiently large ancestor resource tree presents exactly as the reported post-link hang.

The shared resource-root helper also contradicted its contract: when no anchor was found within the bounded walk, it returned the last ancestor visited instead of the starting directory.

## Fix

- route standalone resource staging through the shared project-root and copy helpers;
- treat the nearest `perry.toml` as an anchor as well as `package.json`;
- make an unanchored search actually fall back to its starting directory;
- retain the existing self-copy guard when the executable is written at the project root;
- add regressions for a perry.toml app beneath an unrelated ancestor package and for the no-anchor fallback.

No version bump.

## Validation

- `cargo test -p perry project_resource_tests` using Perry's documented `perry-codegen --no-default-features` local bisection mode: 2 passed
- `cargo check -p perry --tests`
- `rustfmt --edition 2021 --check crates/perry/src/commands/compile/resources.rs crates/perry/src/commands/compile/run_pipeline.rs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed standalone resource staging to identify project roots using `perry.toml`.
  - Prevented unrelated assets from ancestor directories from being copied.
  - Added a fallback to the starting directory when no project root is found.
  - Avoided copying a resource directory into itself.

- **Tests**
  - Added coverage for project-root selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->