### PR TITLE
fix(release): unify extension archive feature builds

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -428,6 +428,12 @@ jobs:
         # needs the prebuilt `libperry_ext_*.a` sitting next to
         # libperry_runtime.a so `perry compile` can link them without a
         # workspace checkout (see optimized_libs.rs::resolve_prebuilt_ext_libs).
+        # #7358: keep the compiler and both shipped wrapper archives in each
+        # Cargo invocation. Building an ext staticlib alone gives its bundled
+        # runtime/shared dependencies a different feature union from stdlib;
+        # the link deduper then cannot remove the whole second copy, and the
+        # HTTP accept loop reads a different async reactor from the one the JS
+        # event loop drives.
         # Best-effort per crate: a wrapper that can't build on this host must
         # not fail the whole release — the packaging glob below ships
         # whatever was produced.
@@ -437,7 +443,8 @@ jobs:
             [ -d "$d" ] || continue
             name=$(basename "$d")
             echo "::group::build $name"
-            cargo build --profile dist --target ${{ matrix.target }} -p "$name" \
+            cargo build --profile dist --target ${{ matrix.target }} \
+              -p perry -p perry-runtime-static -p perry-stdlib-static -p "$name" \
               || echo "  (skipped $name — failed to build on this host)"
             echo "::endgroup::"
           done

--- a/changelog.d/7952-ext-feature-union.md
+++ b/changelog.d/7952-ext-feature-union.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Native extension archives in release packages now share the shipped
+  runtime and stdlib feature set (#7358).** Building each `perry-ext-*` crate
+  alone could leave a partial second runtime in standalone binaries, attaching
+  HTTP work to an async reactor the JavaScript event loop did not drive. Release
+  packaging now selects the compiler, both static wrapper crates, and each
+  extension in one Cargo invocation.

--- a/crates/perry/src/commands/compile/well_known.rs
+++ b/crates/perry/src/commands/compile/well_known.rs
@@ -669,6 +669,50 @@ mod tests {
         );
     }
 
+    /// #7358 — the manifest features above are necessary but not sufficient:
+    /// Cargo resolves features over the package set selected by one command.
+    /// A release build of an ext staticlib alone can therefore bundle a
+    /// runtime/shared-dependency set that differs from the separately-built
+    /// stdlib archive. The link deduper cannot drop that whole second copy,
+    /// leaving HTTP attached to an async reactor the JS event loop never
+    /// drives. Keep the shipping workflow's package set paired with the
+    /// compiler and both static wrapper crates.
+    #[test]
+    fn release_ext_builds_share_the_shipped_runtime_feature_set() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root reachable from CARGO_MANIFEST_DIR");
+        let workflow =
+            std::fs::read_to_string(workspace_root.join(".github/workflows/release-packages.yml"))
+                .expect("read release-packages workflow");
+        let step = workflow
+            .split("- name: Build native ext libraries (Unix)")
+            .nth(1)
+            .and_then(|tail| tail.split("- name: Build UI library (macOS)").next())
+            .expect("native ext release step remains present");
+        let command: String = step
+            .lines()
+            .skip_while(|line| !line.trim_start().starts_with("cargo build "))
+            .take_while(|line| !line.contains("|| echo"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+
+        for package in ["perry", "perry-runtime-static", "perry-stdlib-static"] {
+            assert!(
+                tokens.windows(2).any(|pair| pair == ["-p", package]),
+                "#7358: release ext build must select `{package}` in the same Cargo \
+                 invocation so its bundled runtime matches the shipped archives; got:\n{command}"
+            );
+        }
+        assert!(
+            tokens.windows(2).any(|pair| pair == ["-p", "\"$name\""]),
+            "native ext release command stopped selecting the loop's crate: {command}"
+        );
+    }
+
     #[test]
     fn upstream_pin_parses() {
         let raw = r#"


### PR DESCRIPTION
Closes #7358

## What changed

Release packaging now builds every native extension archive in the same Cargo invocation as `perry`, `perry-runtime-static`, and `perry-stdlib-static`. This gives the extension and the separately shipped runtime/stdlib archives the same resolved feature union.

A regression test checks that the release workflow keeps those packages paired.

## Root cause

The release workflow built each `perry-ext-*` crate alone. Cargo therefore resolved a different runtime/shared-dependency feature set for that archive than for the separately built stdlib/runtime archives. The compiler's archive deduper could not discard the entire duplicate copy, leaving the HTTP accept loop attached to a reactor different from the one driven by the JS event loop.

The old no-op dispatch warning was removed by #6574, but that did not fix this feature-resolution mismatch.

## Reproduction and verification

Using one compiler/runtime build and changing only how `perry-ext-http` was built:

- Extension-only package set: the linker dropped 993 shared archive members, then the server panicked before responding because no reactor was running.
- Unified package set: the linker dropped 1,676 shared archive members; `curl` received HTTP 200 with `pong`, and the TypeScript handler logged `request received: /`.

Additional checks:

- `cargo test -p perry --bin perry commands::compile::well_known::tests::` (21 passed)
- Regression-test sabotage: removing `perry-stdlib-static` from the workflow made the new test fail
- `cargo fmt --all -- --check`
- `actionlint -shellcheck= .github/workflows/release-packages.yml`
- `bash scripts/check_file_size.sh`
- `git diff HEAD~1 --check`

No performance benchmark is needed: this changes release build package selection, not generated code or runtime hot paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native extension release packaging so extensions share the shipped runtime and standard-library features.
  * Prevented incomplete or duplicated runtime components that could affect asynchronous HTTP functionality.

* **Tests**
  * Added validation to ensure release builds include all required runtime, standard-library, compiler, and extension components together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->