### PR TITLE
ci: make public baseline inputs declarative

### DIFF
--- a/benchmarks/app-patterns/run.sh
+++ b/benchmarks/app-patterns/run.sh
@@ -24,6 +24,16 @@ KERNELS_DIR="$SCRIPT_DIR/kernels"
 RESULTS_DIR="$SCRIPT_DIR/results"
 mkdir -p "$RESULTS_DIR"
 PUBLIC_JSON_OUT="${PUBLIC_BENCH_JSON_OUT:-}"
+WARMUP="${PUBLIC_BENCH_WARMUP:-3}"
+RUNS="${PUBLIC_BENCH_RUNS:-15}"
+if [[ ! "$WARMUP" =~ ^[0-9]+$ ]]; then
+  echo "Error: PUBLIC_BENCH_WARMUP must be a non-negative integer" >&2
+  exit 2
+fi
+if [[ ! "$RUNS" =~ ^[0-9]+$ ]] || (( RUNS < 2 )); then
+  echo "Error: PUBLIC_BENCH_RUNS must be an integer of at least 2" >&2
+  exit 2
+fi
 RAW_JSONL=$(mktemp "${TMPDIR:-/tmp}/perry-app-patterns.XXXXXX")
 trap 'rm -f "$RAW_JSONL"' EXIT
 
@@ -128,7 +138,7 @@ for KERNEL in "${KERNELS[@]}"; do
   # interleave (less affected by transient system load on any one
   # runtime).
   JSON="/tmp/bench-app-pattern-$NAME.json"
-  hyperfine --warmup 3 --runs 15 --time-unit millisecond \
+  hyperfine --warmup "$WARMUP" --runs "$RUNS" --time-unit millisecond \
     --export-json "$JSON" \
     --command-name "perry"  "$PERRY_OUT" \
     --command-name "bun"    "bun run $KERNEL" \
@@ -210,13 +220,16 @@ cat "$OUTPUT"
 
 if [ -n "$PUBLIC_JSON_OUT" ]; then
   mkdir -p "$(dirname "$PUBLIC_JSON_OUT")"
-  PYTHONPATH="$REPO_ROOT" python3 - "$RAW_JSONL" "$PUBLIC_JSON_OUT" "$REPO_ROOT" <<'PY'
+  PYTHONPATH="$REPO_ROOT" python3 - \
+    "$RAW_JSONL" "$PUBLIC_JSON_OUT" "$REPO_ROOT" "$WARMUP" "$RUNS" <<'PY'
 import json, shutil, subprocess, sys
 from datetime import datetime, timezone
 from pathlib import Path
 from benchmarks.public_baseline import distribution
 
-records_path, output_path, root = sys.argv[1:]
+records_path, output_path, root, warmup_raw, requested_raw = sys.argv[1:]
+warmup = int(warmup_raw)
+requested = int(requested_raw)
 records = [json.loads(line) for line in open(records_path) if line.strip()]
 expected = sorted(path.rsplit("/", 1)[-1].removesuffix(".ts")
                   for path in __import__("glob").glob(root + "/benchmarks/app-patterns/kernels/*.ts"))
@@ -237,12 +250,18 @@ component = {
     "suite": "app_patterns",
     "commit": subprocess.check_output(["git", "-C", root, "rev-parse", "HEAD"], text=True).strip(),
     "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "run_config": {"warmup": 3, "requested_samples": 15, "interleaved": True},
+    "run_config": {
+        "warmup": warmup,
+        "requested_samples": requested,
+        "interleaved": True,
+    },
     "commands": {
         "perry": [root + "/target/release/perry", "<kernel.ts>", "-o", "<compiled-kernel>"],
         "node": [shutil.which("node"), "--experimental-strip-types", "<kernel.ts>"],
         "bun": [shutil.which("bun"), "run", "<kernel.ts>"],
-        "measurement": ["hyperfine", "--warmup", "3", "--runs", "15"],
+        "measurement": [
+            "hyperfine", "--warmup", str(warmup), "--runs", str(requested)
+        ],
     },
     "runtime_metadata": {
         "perry": {

--- a/benchmarks/ci_public_baseline_check.py
+++ b/benchmarks/ci_public_baseline_check.py
@@ -12,12 +12,11 @@ different, hand-curated performance section and intentionally dropped the
 auto-generated public-node-bun block. ``public_baseline.py check`` still *requires*
 that block, so it fails on every PR ("README generated markers are missing").
 
-This policy lives in a SEPARATE module on purpose: ``public_baseline.py`` is a
-fingerprinted harness file (``HARNESS_PATHS``), so relaxing the check there would
-change ``harness_fingerprint`` and trip ``validate_public``'s "harness changed;
-regenerate" guard — which can't be satisfied without re-running the full
-Node/Bun/Perry benchmark suite. Reusing its functions from here leaves the file,
-and therefore the fingerprint, untouched.
+This policy lives in a SEPARATE module on purpose: the checker and assembler are
+plumbing rather than measurement inputs. ``HARNESS_PATHS`` fingerprints the
+declarative measurement config and correctness oracle instead, while this thin
+wrapper reuses the same validation functions and cannot drift into a second
+implementation of the freshness policy.
 """
 
 from __future__ import annotations

--- a/benchmarks/public-baseline-config.json
+++ b/benchmarks/public-baseline-config.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "toolchains": {
+    "node": "v22.23.1",
+    "bun": "1.3.14"
+  },
+  "quiet_host": {
+    "maximum_cpu_active_percent": 25.0,
+    "consecutive_seconds": 60
+  },
+  "components": {
+    "suite": {
+      "measured_runs": 5
+    },
+    "polyglot": {
+      "measured_runs": 11
+    },
+    "json_polyglot": {
+      "measured_runs": 11
+    },
+    "app_patterns": {
+      "warmup_runs": 3,
+      "measured_runs": 15
+    },
+    "honest_bench": {
+      "workloads": [1, 3],
+      "warmup_runs": 5,
+      "measured_runs": 20
+    }
+  }
+}

--- a/benchmarks/public_baseline.py
+++ b/benchmarks/public_baseline.py
@@ -26,6 +26,7 @@ from benchmarks.benchmark_gate import ArtifactError, load_artifact, validate_art
 
 
 DEFAULT_ARTIFACT = ROOT / "benchmarks/results/public-node-bun-v1.json"
+MEASUREMENT_CONFIG = ROOT / "benchmarks/public-baseline-config.json"
 README = ROOT / "README.md"
 SUITE_RESULTS = ROOT / "benchmarks/suite/results/RESULTS.md"
 README_START = "<!-- public-node-bun:start -->"
@@ -35,24 +36,37 @@ SOURCE_PATHS = (
     "benchmarks/suite/*.ts",
     "benchmarks/json_polyglot/*.ts",
     "benchmarks/app-patterns/kernels/*.ts",
+    "benchmarks/honest_bench/scripts/gen_image.py",
+    "benchmarks/honest_bench/scripts/gen_json.py",
+    "benchmarks/honest_bench/workloads/1_json_pipeline/node/*.ts",
+    "benchmarks/honest_bench/workloads/1_json_pipeline/perry/*.ts",
+    "benchmarks/honest_bench/workloads/3_image_convolution/node/*.ts",
+    "benchmarks/honest_bench/workloads/3_image_convolution/perry/*.ts",
 )
 HARNESS_PATHS = (
-    "benchmarks/public_baseline.py",
-    "benchmarks/run_public_baseline.sh",
-    "benchmarks/compare.sh",
-    "benchmarks/verify_benchmark_output.py",
-    "benchmarks/benchmark_gate.py",
-    "benchmarks/polyglot/run_all.sh",
-    "benchmarks/json_polyglot/run.sh",
-    "benchmarks/app-patterns/run.sh",
-    "benchmarks/honest_bench/run.sh",
-    "benchmarks/honest_bench/harness",
-    "benchmarks/honest_bench/scripts",
-    "benchmarks/honest_bench/workloads",
+    # #7282: these are the declarative inputs that can change what is
+    # measured. The large shell/Python drivers are plumbing: error messages,
+    # output formatting, and cleanup fixes must not demand a two-hour rerun.
+    # Assembly cross-checks every component's recorded sample/warmup metadata
+    # against this config, so a driver cannot silently ignore it.
+    "benchmarks/public-baseline-config.json",
     "benchmarks/honest_bench/results/expected.json",
 )
+# The currently published artifact was proven fresh under the broader path set
+# before #7282 narrowed it. Accept exactly that old->new digest transition so
+# this bookkeeping change does not itself demand a two-hour regeneration. Any
+# subsequent edit to either new input set misses the exact destination digest
+# and hard-fails normally; the next real refresh records the new hashes and no
+# longer takes this migration path.
+_SOURCE_FINGERPRINT_MIGRATION = (
+    "65a1218e02c95b4aa8ed22065ca33e4653addcd81a77a4fb1a810e5153e07887",
+    "b689e1e57d9a7c216497d4d033f8d96f6c35de9edcfc32fb046b8ddad51fc66b",
+)
+_HARNESS_FINGERPRINT_MIGRATION = (
+    "28117b86b2bcca9cc4e6f418f156bfcce0b4bf0851698c3e88525737221df49b",
+    "513dba8ff9eaf931edc8a5fc01a0093a1156c31b0b6c9cc1218f710405e315e0",
+)
 RUNTIMES = ("perry", "node", "bun")
-PINNED_VERSIONS = {"node": "v22.23.1", "bun": "1.3.14"}
 REFRESH_COMMAND = "./benchmarks/run_public_baseline.sh"
 EXPECTED_COMPONENT_BENCHMARKS = {
     "polyglot": {
@@ -219,6 +233,81 @@ def _load(path: Path) -> dict[str, Any]:
         raise ArtifactError(f"could not load {path}: {exc}") from exc
 
 
+def load_measurement_config(path: Path = MEASUREMENT_CONFIG) -> dict[str, Any]:
+    """Load and validate the declarative inputs for public measurements."""
+    config = _load(path)
+    if config.get("schema_version") != 1:
+        raise ArtifactError("public measurement config: unsupported schema")
+
+    toolchains = config.get("toolchains")
+    if not isinstance(toolchains, dict):
+        raise ArtifactError("public measurement config: missing toolchains")
+    for runtime in ("node", "bun"):
+        if not isinstance(toolchains.get(runtime), str) or not toolchains[runtime]:
+            raise ArtifactError(
+                f"public measurement config: invalid {runtime} toolchain pin"
+            )
+
+    quiet = config.get("quiet_host")
+    if not isinstance(quiet, dict):
+        raise ArtifactError("public measurement config: missing quiet_host")
+    maximum = quiet.get("maximum_cpu_active_percent")
+    seconds = quiet.get("consecutive_seconds")
+    if not isinstance(maximum, (int, float)) or not 0 < maximum <= 100:
+        raise ArtifactError("public measurement config: invalid CPU-active maximum")
+    if not isinstance(seconds, int) or seconds < 1:
+        raise ArtifactError("public measurement config: invalid quiet-host duration")
+
+    components = config.get("components")
+    if not isinstance(components, dict):
+        raise ArtifactError("public measurement config: missing components")
+    for name in ("suite", "polyglot", "json_polyglot", "app_patterns", "honest_bench"):
+        component = components.get(name)
+        if not isinstance(component, dict):
+            raise ArtifactError(f"public measurement config: missing {name}")
+        measured = component.get("measured_runs")
+        if not isinstance(measured, int) or measured < 2:
+            raise ArtifactError(
+                f"public measurement config: {name}.measured_runs must be at least 2"
+            )
+    for name in ("app_patterns", "honest_bench"):
+        warmup = components[name].get("warmup_runs")
+        if not isinstance(warmup, int) or warmup < 0:
+            raise ArtifactError(
+                f"public measurement config: {name}.warmup_runs must be non-negative"
+            )
+    if components["honest_bench"].get("workloads") != [1, 3]:
+        raise ArtifactError(
+            "public measurement config: honest_bench workloads must match the published 1,3 set"
+        )
+    return config
+
+
+def _validate_component_measurement_config(
+    components: Mapping[str, Any], config: Mapping[str, Any]
+) -> None:
+    """Reject an artifact produced with parameters other than the config."""
+    expected = config["components"]
+    for name in ("suite", "polyglot", "json_polyglot", "app_patterns", "honest_bench"):
+        actual_runs = components.get(name, {}).get("run_config", {}).get(
+            "requested_samples"
+        )
+        expected_runs = expected[name]["measured_runs"]
+        if actual_runs != expected_runs:
+            raise ArtifactError(
+                f"{name}: requested_samples {actual_runs!r} does not match public "
+                f"measurement config {expected_runs}"
+            )
+    for name in ("app_patterns", "honest_bench"):
+        actual_warmup = components[name].get("run_config", {}).get("warmup")
+        expected_warmup = expected[name]["warmup_runs"]
+        if actual_warmup != expected_warmup:
+            raise ArtifactError(
+                f"{name}: warmup {actual_warmup!r} does not match public "
+                f"measurement config {expected_warmup}"
+            )
+
+
 def _validate_component(component: Mapping[str, Any], suite: str) -> None:
     if component.get("schema_version") != 1 or component.get("suite") != suite:
         raise ArtifactError(f"{suite}: unsupported component schema")
@@ -338,6 +427,7 @@ def assemble(
     honest_results_path: Path,
     honest_metadata_path: Path,
 ) -> dict[str, Any]:
+    measurement_config = load_measurement_config()
     suite = load_artifact(suite_path)
     _validate_suite(suite)
     suite.setdefault("run_config", {})["warmup"] = (
@@ -354,6 +444,7 @@ def assemble(
     }
     for name in ("polyglot", "json_polyglot", "app_patterns"):
         _validate_component(components[name], name)
+    _validate_component_measurement_config(components, measurement_config)
 
     full_commit = _git("rev-parse", "HEAD")
     commits = {str(component.get("commit") or "") for component in components.values()}
@@ -368,9 +459,10 @@ def assemble(
         metadata = runtimes.get(runtime, {})
         if not metadata.get("available") or not metadata.get("version") or not metadata.get("command"):
             raise ArtifactError(f"suite: {runtime} metadata is incomplete")
-        if runtime in PINNED_VERSIONS and metadata["version"] != PINNED_VERSIONS[runtime]:
+        pinned_versions = measurement_config["toolchains"]
+        if runtime in pinned_versions and metadata["version"] != pinned_versions[runtime]:
             raise ArtifactError(
-                f"suite: expected {runtime} {PINNED_VERSIONS[runtime]}, found {metadata['version']}"
+                f"suite: expected {runtime} {pinned_versions[runtime]}, found {metadata['version']}"
             )
         executable = metadata["command"][0]
         if runtime == "perry":
@@ -422,8 +514,12 @@ def assemble(
             "publishable": True,
             "quiet_host": {
                 "metric": "aggregate CPU active percentage",
-                "maximum_percent": 25.0,
-                "consecutive_seconds": 60,
+                "maximum_percent": measurement_config["quiet_host"][
+                    "maximum_cpu_active_percent"
+                ],
+                "consecutive_seconds": measurement_config["quiet_host"][
+                    "consecutive_seconds"
+                ],
                 "checked_before_each_component": True,
             },
             "requirements": [
@@ -549,6 +645,7 @@ def render(artifact: Mapping[str, Any]) -> None:
 
 
 def validate_public(artifact: Mapping[str, Any], max_age_days: int) -> None:
+    measurement_config = load_measurement_config()
     if artifact.get("schema_version") != 1 or not artifact.get("policy", {}).get("publishable"):
         raise ArtifactError("public artifact is not publishable schema version 1")
     generated = datetime.fromisoformat(str(artifact["generated_at"]).replace("Z", "+00:00"))
@@ -560,17 +657,42 @@ def validate_public(artifact: Mapping[str, Any], max_age_days: int) -> None:
             f"public artifact is stale ({age.days} days old); regenerate it with {REFRESH_COMMAND}"
         )
     freshness = artifact.get("freshness", {})
-    if freshness.get("source_fingerprint") != tracked_fingerprint(SOURCE_PATHS):
+    recorded_source = freshness.get("source_fingerprint")
+    current_source = tracked_fingerprint(SOURCE_PATHS)
+    source_migrated = (recorded_source, current_source) == _SOURCE_FINGERPRINT_MIGRATION
+    if recorded_source != current_source and not source_migrated:
         raise ArtifactError(
             f"public artifact benchmark inputs changed; regenerate it with {REFRESH_COMMAND}"
         )
-    if freshness.get("harness_fingerprint") != tracked_fingerprint(HARNESS_PATHS):
+    recorded_harness = freshness.get("harness_fingerprint")
+    current_harness = tracked_fingerprint(HARNESS_PATHS)
+    harness_migrated = (
+        recorded_harness,
+        current_harness,
+    ) == _HARNESS_FINGERPRINT_MIGRATION
+    if recorded_harness != current_harness and not harness_migrated:
         raise ArtifactError(
             f"public artifact benchmark harness changed; regenerate it with {REFRESH_COMMAND}"
         )
     for name in ("polyglot", "json_polyglot", "app_patterns", "honest_bench"):
         _validate_component(artifact["components"][name], name)
     _validate_suite(artifact["components"]["suite"])
+    _validate_component_measurement_config(artifact["components"], measurement_config)
+    for runtime, expected_version in measurement_config["toolchains"].items():
+        actual_version = artifact.get("runtimes", {}).get(runtime, {}).get("version")
+        if actual_version != expected_version:
+            raise ArtifactError(
+                f"public artifact {runtime} version {actual_version!r} does not match "
+                f"measurement config {expected_version!r}"
+            )
+    quiet = artifact.get("policy", {}).get("quiet_host", {})
+    expected_quiet = measurement_config["quiet_host"]
+    if (
+        quiet.get("maximum_percent")
+        != expected_quiet["maximum_cpu_active_percent"]
+        or quiet.get("consecutive_seconds") != expected_quiet["consecutive_seconds"]
+    ):
+        raise ArtifactError("public artifact quiet-host policy does not match measurement config")
 
 
 def check(artifact: Mapping[str, Any], max_age_days: int) -> None:

--- a/benchmarks/run_public_baseline.sh
+++ b/benchmarks/run_public_baseline.sh
@@ -6,10 +6,38 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-EXPECTED_NODE="${PUBLIC_NODE_VERSION:-v22.23.1}"
-EXPECTED_BUN="${PUBLIC_BUN_VERSION:-1.3.14}"
-MAX_CPU_ACTIVE="25.0"
-QUIET_SECONDS="60"
+MEASUREMENT_CONFIG="$ROOT/benchmarks/public-baseline-config.json"
+IFS=$'\t' read -r \
+  CONFIG_NODE CONFIG_BUN MAX_CPU_ACTIVE QUIET_SECONDS \
+  SUITE_RUNS POLYGLOT_RUNS JSON_POLYGLOT_RUNS \
+  APP_WARMUP APP_RUNS HONEST_WORKLOADS HONEST_WARMUP HONEST_RUNS < <(
+    python3 - "$MEASUREMENT_CONFIG" <<'PY'
+import sys
+from pathlib import Path
+
+from benchmarks.public_baseline import load_measurement_config
+
+config = load_measurement_config(Path(sys.argv[1]))
+components = config["components"]
+print(
+    config["toolchains"]["node"],
+    config["toolchains"]["bun"],
+    config["quiet_host"]["maximum_cpu_active_percent"],
+    config["quiet_host"]["consecutive_seconds"],
+    components["suite"]["measured_runs"],
+    components["polyglot"]["measured_runs"],
+    components["json_polyglot"]["measured_runs"],
+    components["app_patterns"]["warmup_runs"],
+    components["app_patterns"]["measured_runs"],
+    ",".join(str(value) for value in components["honest_bench"]["workloads"]),
+    components["honest_bench"]["warmup_runs"],
+    components["honest_bench"]["measured_runs"],
+    sep="\t",
+)
+PY
+  )
+EXPECTED_NODE="$CONFIG_NODE"
+EXPECTED_BUN="$CONFIG_BUN"
 OUT="$ROOT/.bench-results/public"
 FINAL="$ROOT/benchmarks/results/public-node-bun-v1.json"
 mkdir -p "$OUT"
@@ -103,25 +131,29 @@ done
 wait_for_quiet
 
 echo "=== suite ==="
-./benchmarks/compare.sh --full --runs 5 --json-out "$OUT/suite.json" --warn-only
+./benchmarks/compare.sh --full --runs "$SUITE_RUNS" --json-out "$OUT/suite.json" --warn-only
 wait_for_quiet
 
 echo "=== polyglot ==="
-PUBLIC_BENCH_JSON_OUT="$OUT/polyglot.json" ./benchmarks/polyglot/run_all.sh 11
+PUBLIC_BENCH_JSON_OUT="$OUT/polyglot.json" ./benchmarks/polyglot/run_all.sh "$POLYGLOT_RUNS"
 wait_for_quiet
 
 echo "=== JSON polyglot ==="
-PUBLIC_BENCH_JSON_OUT="$OUT/json-polyglot.json" RUNS=11 ./benchmarks/json_polyglot/run.sh
+PUBLIC_BENCH_JSON_OUT="$OUT/json-polyglot.json" RUNS="$JSON_POLYGLOT_RUNS" \
+  ./benchmarks/json_polyglot/run.sh
 wait_for_quiet
 
 echo "=== app patterns ==="
-PUBLIC_BENCH_JSON_OUT="$OUT/app-patterns.json" ./benchmarks/app-patterns/run.sh
+PUBLIC_BENCH_JSON_OUT="$OUT/app-patterns.json" \
+PUBLIC_BENCH_WARMUP="$APP_WARMUP" \
+PUBLIC_BENCH_RUNS="$APP_RUNS" \
+  ./benchmarks/app-patterns/run.sh
 wait_for_quiet
 
 echo "=== honest bench ==="
-HONEST_BENCH_ONLY=1,3 \
-HONEST_BENCH_WARMUP=5 \
-HONEST_BENCH_MEASURED=20 \
+HONEST_BENCH_ONLY="$HONEST_WORKLOADS" \
+HONEST_BENCH_WARMUP="$HONEST_WARMUP" \
+HONEST_BENCH_MEASURED="$HONEST_RUNS" \
   ./benchmarks/honest_bench/run.sh --strict-output
 python3 benchmarks/honest_bench/scripts/report.py
 

--- a/changelog.d/7958-public-baseline-inputs.md
+++ b/changelog.d/7958-public-baseline-inputs.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **The public performance baseline now fingerprints a small declarative
+  measurement protocol instead of benchmark-runner plumbing (#7282).** Pinned
+  toolchains, quiet-host thresholds, samples, warmups, selected workloads,
+  kernels, fixture generators, and the correctness oracle remain hard-gated;
+  logging, cleanup, and output-format changes no longer demand a two-hour
+  baseline regeneration.

--- a/tests/test_public_baseline.py
+++ b/tests/test_public_baseline.py
@@ -1,14 +1,23 @@
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
 from benchmarks.benchmark_gate import ArtifactError, build_artifact
 from benchmarks.public_baseline import (
     EXPECTED_SUITE_BENCHMARKS,
+    HARNESS_PATHS,
     README_END,
     README_START,
+    ROOT,
+    SOURCE_PATHS,
     _CARGO_VERSION_RE,
+    _cargo_profile_tables,
     _replace_block,
+    _validate_component_measurement_config,
     _validate_suite,
     distribution,
+    load_measurement_config,
     normalize_honest,
     readme_block,
     utc_z_timestamp,
@@ -128,16 +137,94 @@ class PublicBaselineTests(unittest.TestCase):
         # guard — before this, the freshness gate reddened on every PR that
         # followed a version bump (Cargo.toml is a fingerprinted source path).
         def normalize(data):
-            return _CARGO_VERSION_RE.sub(b'version = "0.0.0"', data)
+            normalized = _CARGO_VERSION_RE.sub(b'version = "0.0.0"', data)
+            return _cargo_profile_tables(normalized)
 
-        base = b'[workspace.package]\nversion = "0.5.1258"\nedition = "2021"\n'
-        bumped = b'[workspace.package]\nversion = "0.5.1300"\nedition = "2021"\n'
+        base = (
+            b'[workspace.package]\nversion = "0.5.1258"\nedition = "2021"\n'
+            b'[profile.release]\nopt-level = 3\n'
+        )
+        bumped = (
+            b'[workspace.package]\nversion = "0.5.1300"\nedition = "2021"\n'
+            b'[profile.release]\nopt-level = 3\n'
+        )
         self.assertEqual(normalize(base), normalize(bumped))
 
-        # A benchmark-relevant change (e.g. edition/profile/deps) must still
-        # move the fingerprint input.
-        edition_change = b'[workspace.package]\nversion = "0.5.1258"\nedition = "2024"\n'
-        self.assertNotEqual(normalize(base), normalize(edition_change))
+        # Workspace/dependency plumbing is outside the extract, while a build
+        # profile change must still move it.
+        dependency_change = base.replace(
+            b"[profile.release]", b'foo = "1"\n[profile.release]'
+        )
+        profile_change = base.replace(b"opt-level = 3", b"opt-level = 2")
+        self.assertEqual(normalize(base), normalize(dependency_change))
+        self.assertNotEqual(normalize(base), normalize(profile_change))
+
+    def test_measurement_config_is_the_fingerprinted_protocol(self):
+        config = load_measurement_config()
+        self.assertEqual(config["components"]["suite"]["measured_runs"], 5)
+        self.assertEqual(config["components"]["honest_bench"]["workloads"], [1, 3])
+        self.assertEqual(
+            HARNESS_PATHS,
+            (
+                "benchmarks/public-baseline-config.json",
+                "benchmarks/honest_bench/results/expected.json",
+            ),
+        )
+        for plumbing in (
+            "benchmarks/public_baseline.py",
+            "benchmarks/run_public_baseline.sh",
+            "benchmarks/json_polyglot/run.sh",
+        ):
+            self.assertNotIn(plumbing, HARNESS_PATHS)
+        self.assertIn(
+            "benchmarks/honest_bench/workloads/1_json_pipeline/perry/*.ts",
+            SOURCE_PATHS,
+        )
+
+    def test_measurement_config_rejects_an_invalid_run_count(self):
+        config = load_measurement_config()
+        config["components"]["polyglot"]["measured_runs"] = 1
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(json.dumps(config), encoding="utf-8")
+            with self.assertRaisesRegex(ArtifactError, "must be at least 2"):
+                load_measurement_config(path)
+
+    def test_component_metadata_must_match_measurement_config(self):
+        config = load_measurement_config()
+        components = {
+            name: {
+                "run_config": {"requested_samples": values["measured_runs"]}
+            }
+            for name, values in config["components"].items()
+        }
+        for name in ("app_patterns", "honest_bench"):
+            components[name]["run_config"]["warmup"] = config["components"][name][
+                "warmup_runs"
+            ]
+        _validate_component_measurement_config(components, config)
+
+        components["app_patterns"]["run_config"]["requested_samples"] -= 1
+        with self.assertRaisesRegex(ArtifactError, "does not match"):
+            _validate_component_measurement_config(components, config)
+
+    def test_measurement_drivers_consume_the_configured_parameters(self):
+        orchestrator = (ROOT / "benchmarks/run_public_baseline.sh").read_text()
+        for variable in (
+            "SUITE_RUNS",
+            "POLYGLOT_RUNS",
+            "JSON_POLYGLOT_RUNS",
+            "APP_WARMUP",
+            "APP_RUNS",
+            "HONEST_WORKLOADS",
+            "HONEST_WARMUP",
+            "HONEST_RUNS",
+        ):
+            self.assertIn(f'"${variable}"', orchestrator)
+
+        app_runner = (ROOT / "benchmarks/app-patterns/run.sh").read_text()
+        self.assertIn('hyperfine --warmup "$WARMUP" --runs "$RUNS"', app_runner)
+        self.assertIn('"requested_samples": requested', app_runner)
 
     def test_generated_marker_replacement_is_deterministic(self):
         original = f"before\n{README_START}\nold\n{README_END}\nafter\n"


### PR DESCRIPTION
Closes #7282

## What changed

The public benchmark protocol now lives in `benchmarks/public-baseline-config.json`. It owns:

- pinned Node/Bun versions
- quiet-host threshold and duration
- measured run counts and warmups for all five components
- the selected honest-bench workloads

`run_public_baseline.sh` consumes those values, and artifact assembly/freshness validation rejects component metadata, runtime versions, or quiet-host policy that disagrees with the config. The app-pattern runner now records the configured warmup/sample counts it actually passes to hyperfine.

The fingerprint now covers the declarative config plus the honest-bench correctness oracle. Honest-bench kernels and fixture generators remain protected as source inputs. Large runner/checker files are plumbing, so logging, cleanup, error handling, and output-format changes no longer require a two-hour regeneration.

## Reproduction and sabotage

Before this change, adding one comment to `benchmarks/json_polyglot/run.sh` changed the harness digest from `28117b86…` to `d9eec9be…` and made the required checker exit 2.

After the change:

- The same plumbing-only edit leaves digest `513dba8f…` unchanged and the checker exits 0.
- Changing `polyglot.measured_runs` from 11 to 12 makes the checker exit 2.
- Changing an app-pattern kernel makes the checker exit 2.
- The harness set shrinks from 47 files / 318,493 bytes to 2 files / 1,544 bytes; the source set explicitly retains the honest-bench kernels and generators.

The existing artifact was green under the broader fingerprint before this change. An exact old-digest → new-digest migration accepts only this narrowing; any later input edit misses the pinned destination and hard-fails. No measurements or artifact values were changed.

## Validation

- `python3 -m unittest tests.test_public_baseline` — 11 passed
- `python3 benchmarks/ci_public_baseline_check.py`
- Config/plumbing/kernel sabotage in both directions
- `bash -n benchmarks/run_public_baseline.sh benchmarks/app-patterns/run.sh`
- `shellcheck -e SC2162 benchmarks/run_public_baseline.sh benchmarks/app-patterns/run.sh`
- Orchestrator smoke: config parsed and stopped before build on the host's Node-version mismatch
- `python3 -m py_compile ...`
- `python3 -m json.tool benchmarks/public-baseline-config.json`
- `bash scripts/check_file_size.sh`
- `git diff HEAD~1 --check`

No performance run is needed: this changes freshness bookkeeping and parameter ownership, while preserving every currently published parameter and measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable benchmark warmup counts, run counts, workloads, toolchain versions, and host quietness thresholds.
  * Added a public benchmark configuration file for consistent measurement settings.
  * Public benchmark artifacts now record and validate the measurement configuration.

* **Bug Fixes**
  * Added validation to reject invalid run counts, warmups, component metadata, runtime versions, and host conditions.

* **Documentation**
  * Documented the expanded public performance-baseline measurement protocol and fingerprinting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->