### PR TITLE
perf(codegen): gate the guarded element store's write barrier on the stored value (#7715)

### DIFF
--- a/changelog.d/7715-element-store-barrier-value-gate.md
+++ b/changelog.d/7715-element-store-barrier-value-gate.md
@@ -1,0 +1,37 @@
+### Gate the guarded array-element store's write barrier on the stored value
+
+`this.vals[i] = v` — the in-bounds arm of the guarded element store — called
+`js_write_barrier_slot` unconditionally. On `gc-handoff/apps/pipeline.ts`, whose
+`Registry.set` runs that statement 1.44 M times, `PERRY_GC_TRACE=1` counts
+**1,265,933 barrier calls of which 1,265,925 (99.999%) return at
+`non_pointer_child_skips`**: the stored value is a number, so the call decodes
+it, finds no heap pointer, and returns having done nothing.
+
+The call now sits behind the same live test of the stored bits that the
+class-field store has carried since #7511, and then behind the parent's
+generation test from #7871. The two are **nested, value first**, not fused into
+one `and`: `emit_may_carry_heap_pointer_check` is pure register arithmetic on
+the value, while the parent test performs a `monotonic` load of
+`@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT` that LLVM may not hoist out of
+the loop — fusing would charge that non-hoistable load to exactly the numeric
+stores this exists to make free.
+
+Skipping on the value test alone is sound because `write_barrier_slot_inner`'s
+first action is `barrier_child_prologue(child)`, which returns before the SATB
+shading, the armed check, the parent decode and the remembered set when
+`decode_heap_addr(child) == 0`; the emitted predicate is a documented superset
+of that decode (`gc::tests::inline_pointer_bearing_contract` enumerates the
+whole 16-bit tag space against it). A value carrying no heap pointer has nothing
+to shade, which is why the incremental clause belongs to the parent half and not
+this one. The parent half's obligations are unchanged and stay pinned by
+`gc::tests::inline_generation_gate_contract`.
+
+`expr/index_set_barrier_tests.rs` walks the emitted def chain rather than
+looking for instructions nearby: a hard-wired `br i1 true`/`false` that leaves
+the dead predicate in the block fails it, as does dropping any of the three heap
+tag comparands, putting the barrier on the false edge, or eliding the call
+instead of guarding it.
+
+Measured on the 19-program GC corpus: only `pipeline`, `interp` and `iso_miss`
+contain the site at all, and `parent_not_old_skips` is 0 on all three — the
+value test is the lever there, not the generation test.

--- a/crates/perry-codegen/src/expr/class_field_barrier_tests.rs
+++ b/crates/perry-codegen/src/expr/class_field_barrier_tests.rs
@@ -48,7 +48,7 @@ const BARRIER_CALL: &str = "call void @js_write_barrier_slot";
 /// These tests describe DEFAULT barrier emission. `PERRY_WRITE_BARRIERS=0`
 /// removes every barrier and would make all of them vacuously "pass" the
 /// negative half while the positive half fails for the wrong reason.
-fn assert_default_barrier_env_not_disabled() {
+pub(super) fn assert_default_barrier_env_not_disabled() {
     assert!(
         !matches!(
             std::env::var("PERRY_WRITE_BARRIERS").as_deref(),
@@ -58,7 +58,7 @@ fn assert_default_barrier_env_not_disabled() {
     );
 }
 
-fn ir_opts() -> CompileOptions {
+pub(super) fn ir_opts() -> CompileOptions {
     CompileOptions {
         target: None,
         is_entry_module: true,
@@ -239,6 +239,12 @@ fn ir() -> String {
 /// slicing text around the first mention of the barrier name — the first
 /// mention IS the branch, and a slice starting there is empty.
 fn branch_into_barrier(ir: &str) -> Option<(String, String)> {
+    branch_into_block(ir, BARRIER_BLOCK)
+}
+
+/// [`branch_into_barrier`] for any block name — #7715 reuses it for the
+/// element-store gate (`expr/index_set_barrier_tests.rs`).
+pub(super) fn branch_into_block(ir: &str, block: &str) -> Option<(String, String)> {
     let mut current_body: Vec<&str> = Vec::new();
     for line in ir.lines() {
         let trimmed = line.trim_end();
@@ -247,7 +253,7 @@ fn branch_into_barrier(ir: &str) -> Option<(String, String)> {
             continue;
         }
         let t = trimmed.trim_start();
-        if t.starts_with("br i1 ") && t.contains(&format!("label %{BARRIER_BLOCK}")) {
+        if t.starts_with("br i1 ") && t.contains(&format!("label %{block}")) {
             return Some((trimmed.to_string(), current_body.join("\n")));
         }
         current_body.push(line);
@@ -256,7 +262,7 @@ fn branch_into_barrier(ir: &str) -> Option<(String, String)> {
 }
 
 /// Body of the named block (label definition to its terminator, inclusive).
-fn block_body(ir: &str, label_prefix: &str) -> Option<String> {
+pub(super) fn block_body(ir: &str, label_prefix: &str) -> Option<String> {
     let mut inside = false;
     let mut out: Vec<&str> = Vec::new();
     for line in ir.lines() {
@@ -280,7 +286,7 @@ fn block_body(ir: &str, label_prefix: &str) -> Option<String> {
 
 /// The instruction that defines `%reg` inside `body`, without its `%reg = `
 /// prefix. `None` for a constant operand or a value defined elsewhere.
-fn def_of<'a>(body: &'a str, reg: &str) -> Option<&'a str> {
+pub(super) fn def_of<'a>(body: &'a str, reg: &str) -> Option<&'a str> {
     let needle = format!("{reg} = ");
     body.lines()
         .map(str::trim)
@@ -289,7 +295,7 @@ fn def_of<'a>(body: &'a str, reg: &str) -> Option<&'a str> {
 }
 
 /// The `i`th SSA operand (`%…`) of an instruction.
-fn operand(instr: &str, i: usize) -> Option<String> {
+pub(super) fn operand(instr: &str, i: usize) -> Option<String> {
     instr.match_indices('%').nth(i).map(|(pos, _)| {
         instr[pos..]
             .split(|c: char| c == ',' || c.is_whitespace() || c == ')')

--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -6,7 +6,8 @@ use anyhow::{anyhow, Result};
 use super::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_jsvalue_slot_store_scalar_aware_on_block, emit_write_barrier_slot_on_block,
-    nanbox_pointer_inline, raw_f64_layout_fact, FnCtx,
+    emit_write_barrier_slot_value_and_generation_tested, nanbox_pointer_inline,
+    raw_f64_layout_fact, FnCtx,
 };
 use crate::block::LlBlock;
 use crate::nanbox::POINTER_MASK_I64;
@@ -377,7 +378,12 @@ pub(crate) fn lower_index_set_fast(
 
     // FASTEST: in-bounds path. Store directly, jump to merge.
     ctx.current_block = inbounds_idx;
-    {
+    // #7715 B3: on the JSValue arm the barrier is emitted separately, behind an
+    // inline live test of the stored VALUE and then of the parent array's
+    // generation — see `emit_write_barrier_slot_value_and_generation_tested`.
+    // Nothing else about the store moves, and the barrier still lands between
+    // the layout note and the numeric-write note exactly where it did.
+    let gated_barrier = {
         let blk = ctx.block();
         let (element_addr, element_ptr) = element_slot(blk, &arr_handle, &idx_i32);
         if require_numeric_layout {
@@ -394,6 +400,7 @@ pub(crate) fn lower_index_set_fast(
                 let numeric_value = canonicalize_raw_f64_numeric_store_value(blk, val_double);
                 blk.store(DOUBLE, &numeric_value, &element_ptr);
             }
+            None
         } else {
             // In-place overwrite of a non-raw-layout (e.g. downgraded `any[]`)
             // array element: the slot holds a valid value, so the scalar-aware
@@ -408,15 +415,40 @@ pub(crate) fn lower_index_set_fast(
                 layout_note_needed,
                 &arr_handle,
                 &element_addr,
-                write_barrier_needed,
+                false,
             )
             .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
-            if !value_is_numeric {
-                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+            if write_barrier_needed {
+                Some((element_addr, value_bits))
+            } else {
+                if !value_is_numeric {
+                    emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                }
+                None
             }
         }
-        blk.br(&merge_label);
+    };
+    if let Some((element_addr, child_bits)) = gated_barrier {
+        // `arr_handle` reached this block through the guard — the inline tier's
+        // own `obj_type`/`!FORWARDED` header reads, or the out-of-line
+        // `js_typed_feedback_plain_array_index_set_guard` — and the arm above
+        // has already stored raw into `arr_handle + 8 + i*8`, so reading the
+        // header byte at `arr_handle - 7` is strictly weaker than what this
+        // block already does.
+        emit_write_barrier_slot_value_and_generation_tested(
+            ctx,
+            &arr_handle,
+            &arr_handle,
+            &element_addr,
+            &child_bits,
+            "idxset.inbounds",
+        );
+        if !value_is_numeric {
+            let blk = ctx.block();
+            emit_array_numeric_write_note_on_block(blk, &arr_handle, &child_bits);
+        }
     }
+    ctx.block().br(&merge_label);
     if require_numeric_layout {
         let stored = LoweredValue {
             semantic: SemanticKind::JsNumber,

--- a/crates/perry-codegen/src/expr/index_set_barrier_tests.rs
+++ b/crates/perry-codegen/src/expr/index_set_barrier_tests.rs
@@ -1,0 +1,379 @@
+//! #7715 (B3): the guarded array-ELEMENT store's remembered-set write barrier
+//! sits behind a live test of the stored VALUE, and then of the parent's
+//! generation.
+//!
+//! The subject is the tail of
+//! [`super::index_set_guarded::emit_guarded_inbounds_array_store`] — the inline
+//! in-bounds arm `this.vals[i] = v` lowers to — and its emitter
+//! [`super::write_barrier::emit_write_barrier_slot_value_and_generation_tested`].
+//!
+//! ## Why the value test is the outer one here
+//!
+//! `gc-handoff/apps/pipeline.ts`'s `Registry.set` runs `this.vals[i] = v`
+//! 1.44 M times. Measured with `PERRY_GC_TRACE=1`, the program makes
+//! **1 265 933 write-barrier calls of which 1 265 925 (99.999%) exit at
+//! `non_pointer_child_skips`** — the stored value is a number and the call does
+//! nothing at all — while `parent_not_old_skips` is **0**, because the
+//! container's backing array is long-lived. So on this shape the parent gate
+//! (#7511/#7871) would skip nothing and the value test skips everything, which
+//! is the opposite of the array PUSH the parent gate was written for.
+//!
+//! Nesting, rather than one fused `and`, is load-bearing:
+//! `emit_may_carry_heap_pointer_check` is pure register arithmetic on the
+//! stored bits, while `emit_parent_may_need_remembering_check` performs a
+//! `monotonic` load of `@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT`, which
+//! LLVM may not hoist out of the loop. Fusing would charge that non-hoistable
+//! load to every numeric store — the exact traffic this exists to make free.
+//!
+//! ## What these tests pin
+//!
+//! Same three obligations as `class_field_barrier_tests`, on the new site:
+//!
+//! 1. the value gate is **REACHED** — a `cond_br` INTO `…barrier.maybe`, not
+//!    merely a block with that name;
+//! 2. its condition **is** the pointer-bearing predicate, and the inner block's
+//!    condition **is** the live header + incremental-count disjunction, proved
+//!    by walking the def chain rather than by finding the instructions nearby;
+//! 3. the barrier is on the TAKEN edge of both and `js_write_barrier_slot` is
+//!    still emitted inside — this is a guard, never an elision.
+
+use super::class_field_barrier_tests::{
+    assert_default_barrier_env_not_disabled, block_body, branch_into_block, def_of, ir_opts,
+    operand,
+};
+use crate::compile_module;
+use perry_hir::types::Type;
+use perry_hir::{
+    Class, ClassField, CompareOp, Expr, Function, Module, ModuleInitKind, Param, Stmt, UpdateOp,
+};
+
+/// The blocks that exist only when the #7715 gate was emitted. `idxset.recv_prop`
+/// is the `block_prefix` `expr/index_set.rs` passes for a property receiver.
+const VALUE_GATE_BLOCK: &str = "idxset.recv_prop.barrier.maybe";
+const BARRIER_BLOCK: &str = "idxset.recv_prop.barrier.";
+const BARRIER_CALL: &str = "call void @js_write_barrier_slot";
+const INCREMENTAL_GLOBAL: &str = "@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT";
+
+const RECV_ID: u32 = 11;
+const IDX_ID: u32 = 12;
+const VAL_ID: u32 = 13;
+
+fn any_field(name: &str) -> ClassField {
+    ClassField {
+        name: name.to_string(),
+        key_expr: None,
+        ty: Type::Array(Box::new(Type::Any)),
+        init: None,
+        is_private: false,
+        is_readonly: false,
+        decorators: Vec::new(),
+    }
+}
+
+/// `set(v) { for (let i = 0; i < 8; i++) this.vals[i] = v }` — `Registry.set`'s
+/// hot statement, minus the key compare.
+///
+/// Three properties of the fixture are load-bearing and each was arrived at by
+/// watching the emitted IR take a different path without it:
+///
+/// * the receiver is a **property**, not a stack local, which is what routes
+///   the store through `emit_guarded_inbounds_array_store` instead of
+///   `lower_index_set_fast` (the latter needs a slot to write a realloc'd head
+///   back to);
+/// * the index is a **`for`-loop counter seeded from an integer literal**, not
+///   a `number` parameter. `numeric_index_needs_runtime_key` sends any numeric
+///   index WITHOUT an integer-array-index proof to
+///   `js_typed_feedback_array_set_index_or_string` — a `let k = 1.5` must write
+///   the property `"1.5"` rather than truncate — and a `Type::Number` param has
+///   no such proof;
+/// * `v: Any` is what leaves the stored value's pointer-ness undecidable
+///   statically and puts the store on the live-test tier at all.
+fn setter() -> Function {
+    Function {
+        id: 91,
+        name: "set".to_string(),
+        type_params: Vec::new(),
+        params: vec![Param {
+            id: VAL_ID,
+            name: "v".to_string(),
+            ty: Type::Any,
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }],
+        return_type: Type::Void,
+        body: vec![Stmt::For {
+            init: Some(Box::new(Stmt::Let {
+                id: IDX_ID,
+                name: "i".to_string(),
+                ty: Type::Number,
+                mutable: true,
+                init: Some(Expr::Integer(0)),
+            })),
+            condition: Some(Expr::Compare {
+                op: CompareOp::Lt,
+                left: Box::new(Expr::LocalGet(IDX_ID)),
+                right: Box::new(Expr::Integer(8)),
+            }),
+            update: Some(Expr::Update {
+                id: IDX_ID,
+                op: UpdateOp::Increment,
+                prefix: false,
+            }),
+            body: vec![Stmt::Expr(Expr::IndexSet {
+                object: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::This),
+                    property: "vals".to_string(),
+                    byte_offset: 0,
+                }),
+                index: Box::new(Expr::LocalGet(IDX_ID)),
+                value: Box::new(Expr::LocalGet(VAL_ID)),
+            })],
+        }],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    }
+}
+
+fn bag_class() -> Class {
+    Class {
+        id: 3,
+        name: "Bag".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: vec![any_field("vals")],
+        constructor: None,
+        methods: vec![setter()],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        computed_members: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        aliases: Vec::new(),
+        is_nested: false,
+        alloc_width_hint: 0,
+        specialized_from: None,
+    }
+}
+
+fn probe_module() -> Module {
+    let mut m = Module::new("index_set_barrier.ts");
+    m.classes = vec![bag_class()];
+    // The class method is what carries the subject; the init only has to make
+    // the class reachable, so it allocates one instance and nothing else.
+    m.init = vec![Stmt::Let {
+        id: RECV_ID,
+        name: "b".to_string(),
+        ty: Type::Named("Bag".to_string()),
+        mutable: false,
+        init: Some(Expr::New {
+            class_name: "Bag".to_string(),
+            args: Vec::new(),
+            type_args: Vec::new(),
+            byte_offset: 0,
+            cap_args_appended: 0,
+        }),
+    }];
+    m.init_kind = ModuleInitKind::Eager;
+    m
+}
+
+fn ir() -> String {
+    String::from_utf8(compile_module(&probe_module(), ir_opts()).expect("module compiles"))
+        .expect("LLVM IR should be UTF-8")
+}
+
+/// (1) + (2), outer half: the VALUE gate exists, is branched into, and its
+/// condition is the pointer-bearing predicate rather than a constant.
+///
+/// The def-chain walk is what separates this from a label-presence check: a
+/// sabotage that hard-wires `br i1 true` while leaving the (now dead) predicate
+/// instructions in the block passes a "does the block contain an lshr" test and
+/// fails this one.
+#[test]
+fn the_element_store_barrier_sits_behind_a_live_value_test() {
+    assert_default_barrier_env_not_disabled();
+    let ir = ir();
+    let (branch, body) = branch_into_block(&ir, VALUE_GATE_BLOCK).unwrap_or_else(|| {
+        panic!(
+            "no `br i1 ..., label %{VALUE_GATE_BLOCK}` — the #7715 value gate was \
+             never REACHED, so every numeric element store still pays the \
+             remembered-set call (1.27 M of them on pipeline.ts):\n{ir}"
+        )
+    });
+
+    let cond = branch
+        .trim_start()
+        .strip_prefix("br i1 ")
+        .and_then(|rest| rest.split(',').next())
+        .map(str::trim)
+        .unwrap_or("");
+    assert!(
+        cond.starts_with('%'),
+        "the value gate's condition is the constant `{cond}` — the branch \
+         cannot fail, so the barrier is either always taken (no win) or NEVER \
+         taken (a stranded child on the next minor GC): {branch}"
+    );
+    // cond = or(or(or(is_pointer, is_string), is_bigint), is_raw_addr)
+    let or_instr = def_of(&body, cond).unwrap_or_else(|| {
+        panic!("the value gate's condition {cond} is not defined in the branching block:\n{body}")
+    });
+    assert!(
+        or_instr.starts_with("or i1 "),
+        "the value gate's condition is `{or_instr}`, not the disjunction over \
+         the heap-bearing NaN-box tags:\n{body}"
+    );
+    // Every heap tag the runtime's `decode_heap_addr` accepts must be compared
+    // against. Dropping one is the direction that STRANDS a child, so the whole
+    // comparand set is pinned, not just its shape.
+    for tag in ["32765", "32767", "32762"] {
+        assert!(
+            body.contains(&format!(", {tag}\n")) || body.contains(&format!(", {tag}")),
+            "the value gate never compares against tag {tag}; a value carrying \
+             it would skip the barrier while the runtime would have decoded a \
+             heap address from it:\n{body}"
+        );
+    }
+    assert!(
+        body.contains("lshr i64") && body.contains(", 48"),
+        "the value gate does not derive the top 16 bits of the stored value, \
+         so it is testing something other than the NaN-box tag:\n{body}"
+    );
+
+    let successors: Vec<&str> = branch
+        .split("label %")
+        .skip(1)
+        .map(|part| part.split([',', ' ']).next().unwrap())
+        .collect();
+    assert_eq!(successors.len(), 2, "expected a two-way branch: {branch}");
+    assert!(
+        successors[0].starts_with(VALUE_GATE_BLOCK),
+        "the barrier is on the FALSE edge of the value test — a pointer store \
+         would skip the barrier and a numeric one would take it, which is \
+         exactly backwards: {branch}"
+    );
+}
+
+/// (2), inner half: the block the value gate branches into is the #7511 parent
+/// generation test, unchanged — `GC_FLAG_TENURED` off a live header load, OR
+/// the incremental-cycle count.
+///
+/// The incremental clause is not decoration. Skipping the call also skips
+/// `barrier_child_prologue`'s SATB shading, which is not a generational
+/// question; `gc::tests::inline_generation_gate_contract` is the runtime-side
+/// half of the same obligation.
+#[test]
+fn the_value_gate_branches_into_the_parent_generation_test() {
+    assert_default_barrier_env_not_disabled();
+    let ir = ir();
+    let body = block_body(&ir, VALUE_GATE_BLOCK)
+        .unwrap_or_else(|| panic!("no `{VALUE_GATE_BLOCK}` block body:\n{ir}"));
+    let branch = body
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("br i1 "))
+        .unwrap_or_else(|| {
+            panic!("`{VALUE_GATE_BLOCK}` does not end in a two-way branch:\n{body}")
+        });
+
+    let cond = branch
+        .strip_prefix("br i1 ")
+        .and_then(|rest| rest.split(',').next())
+        .map(str::trim)
+        .unwrap_or("");
+    assert!(
+        cond.starts_with('%'),
+        "the parent gate's condition is the constant `{cond}`: {branch}"
+    );
+    let or_instr = def_of(&body, cond).unwrap_or_else(|| {
+        panic!("the parent gate's condition {cond} is not defined here:\n{body}")
+    });
+    assert!(
+        or_instr.starts_with("or i1 "),
+        "the parent gate's condition is `{or_instr}`, not the disjunction of \
+         the generational and incremental clauses:\n{body}"
+    );
+    let tenured_cmp_reg = operand(or_instr, 0).expect("or lhs");
+    let incremental_cmp_reg = operand(or_instr, 1).expect("or rhs");
+
+    let tenured_cmp = def_of(&body, &tenured_cmp_reg).unwrap_or_default();
+    assert!(
+        tenured_cmp.starts_with("icmp ne i8 ") && tenured_cmp.ends_with(", 0"),
+        "the generational clause is `{tenured_cmp}`, not `gc_flags & TENURED != 0`:\n{body}"
+    );
+    let mask_reg = operand(tenured_cmp, 0).expect("icmp lhs");
+    let mask = def_of(&body, &mask_reg).unwrap_or_default();
+    assert!(
+        mask.starts_with("and i8") && mask.ends_with(", 32"),
+        "the generational clause masks `{mask}` rather than GC_FLAG_TENURED (0x20):\n{body}"
+    );
+
+    let incremental_cmp = def_of(&body, &incremental_cmp_reg).unwrap_or_default();
+    assert!(
+        incremental_cmp.starts_with("icmp ne i32 ") && incremental_cmp.ends_with(", 0"),
+        "the incremental clause is `{incremental_cmp}`:\n{body}"
+    );
+    let count_reg = operand(incremental_cmp, 0).expect("icmp lhs");
+    let count_load = def_of(&body, &count_reg).unwrap_or_default();
+    assert!(
+        count_load.contains(INCREMENTAL_GLOBAL) && count_load.starts_with("load atomic i32"),
+        "the incremental clause does not read {INCREMENTAL_GLOBAL} atomically; \
+         skipping the barrier also skips SATB shading:\n{body}"
+    );
+}
+
+/// Body of the `idxset.recv_prop.barrier.<N>` block — the innermost one, whose
+/// label is the prefix followed by DIGITS.
+///
+/// A plain prefix match cannot be used: `idxset.recv_prop.barrier.maybe.<N>`
+/// and `idxset.recv_prop.barrier.done.<N>` share the prefix, and `block_body`
+/// returns the first match, so the assertion below would read the gate block
+/// and report the call missing from it. (That is exactly how this test first
+/// failed.)
+fn numbered_barrier_block_body(ir: &str) -> Option<String> {
+    ir.lines()
+        .filter(|line| !line.starts_with(char::is_whitespace))
+        .filter_map(|line| line.trim_end().strip_suffix(':'))
+        .find(|label| {
+            label
+                .strip_prefix(BARRIER_BLOCK)
+                .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+        })
+        .and_then(|label| block_body(ir, label))
+}
+
+/// (3) The boundary: a guard, not an elision. A tenured array holding a pointer
+/// store still reaches `js_write_barrier_slot`, in the block both gates branch
+/// into. A test that asserted the call ABSENT would be pinning a stranded child.
+#[test]
+fn the_gated_element_store_still_reaches_the_barrier_call() {
+    assert_default_barrier_env_not_disabled();
+    let ir = ir();
+    let barrier_body = numbered_barrier_block_body(&ir)
+        .unwrap_or_else(|| panic!("no `{BARRIER_BLOCK}<N>` block body:\n{ir}"));
+    assert!(
+        barrier_body.contains(BARRIER_CALL),
+        "js_write_barrier_slot was ELIDED rather than gated — a tenured array \
+         would publish an old->young edge nobody records:\n{barrier_body}"
+    );
+    assert!(
+        ir.contains("call void @js_gc_write_barriers_emitted(i32 1)"),
+        "the module must still declare to the runtime that generated barriers \
+         exist — the remembered set's arming protocol reads this:\n{ir}"
+    );
+}

--- a/crates/perry-codegen/src/expr/index_set_guarded.rs
+++ b/crates/perry-codegen/src/expr/index_set_guarded.rs
@@ -44,7 +44,8 @@ use crate::nanbox::POINTER_MASK_I64;
 use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
 use super::{
-    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_scalar_aware_on_block, FnCtx,
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_scalar_aware_on_block,
+    emit_write_barrier_slot_value_and_generation_tested, FnCtx,
 };
 
 /// Emit the guarded diamond. `fallback` emits the original slow arm (the
@@ -144,7 +145,20 @@ pub(super) fn emit_guarded_inbounds_array_store(
     }
 
     ctx.current_block = fast_idx;
-    {
+    // #7715 B3: the barrier is emitted separately, behind an inline live test
+    // of the stored VALUE and then of the parent array's generation, so the
+    // store emitter is told not to emit it. Everything else — the slot write,
+    // the string addref, the layout note, and their ordering — is unchanged,
+    // and the barrier still lands between the layout note and the
+    // numeric-write note, exactly where it did.
+    //
+    // The layout note deliberately stays OUTSIDE the value test even though
+    // the class-field emitter puts its own note inside one: `layout_note_slot`
+    // funnels `crate::array::note_element_store` (#7480), and a non-pointer
+    // stored over a pointer is exactly the store that must clear
+    // `GC_ARRAY_ELEMENT_SHAPE`. Class fields have no such per-slot array
+    // invariant, which is why that half of #7511's argument does not transfer.
+    let (arr_handle, element_addr, value_bits) = {
         let blk = ctx.block();
         let arr_bits = blk.bitcast_double_to_i64(arr_box);
         let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
@@ -166,9 +180,28 @@ pub(super) fn emit_guarded_inbounds_array_store(
             layout_note_needed,
             &arr_handle,
             &element_addr,
-            write_barrier_needed,
+            false,
         )
         .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
+        (arr_handle, element_addr, value_bits)
+    };
+    if write_barrier_needed {
+        // `arr_handle` reached this block through the guard's own
+        // `obj_type == GC_TYPE_ARRAY` / `!GC_FLAG_FORWARDED` header reads, so
+        // it is a live, non-forwarded GC array user pointer — the precondition
+        // for reading its header byte. (LLVM CSEs that byte load with the
+        // guard's, so the gate costs the test and the branch, not a reload.)
+        emit_write_barrier_slot_value_and_generation_tested(
+            ctx,
+            &arr_handle,
+            &arr_handle,
+            &element_addr,
+            &value_bits,
+            block_prefix,
+        );
+    }
+    {
+        let blk = ctx.block();
         if !value_is_numeric {
             // A non-numeric store into a raw-f64-flagged array downgrades the
             // layout. Identical to the local-receiver arm.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -127,8 +127,8 @@ pub(crate) use write_barrier::{
     emit_layout_note_slot_on_block, emit_may_carry_heap_pointer_check,
     emit_root_heap_word_store_on_block, emit_root_nanbox_store_on_block, emit_write_barrier,
     emit_write_barrier_slot_generation_tested, emit_write_barrier_slot_on_block,
-    lower_array_super_init, lower_event_emitter_subclass_init, lower_node_stream_super_init,
-    lower_stream_super_init,
+    emit_write_barrier_slot_value_and_generation_tested, lower_array_super_init,
+    lower_event_emitter_subclass_init, lower_node_stream_super_init, lower_stream_super_init,
 };
 
 // Issue #1098 phase 3: the `FnCtx` definition stays in this trunk, but its
@@ -140,6 +140,8 @@ mod array_push_guard_tests;
 #[cfg(test)]
 mod class_field_barrier_tests;
 mod dispatch;
+#[cfg(test)]
+mod index_set_barrier_tests;
 mod record_value;
 mod repsel_gates;
 mod scalar_slot_root;

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -217,6 +217,90 @@ pub(crate) fn emit_write_barrier_slot_generation_tested(
     ctx.current_block = done_idx;
 }
 
+/// #7715 (B3) — an array ELEMENT store's `js_write_barrier_slot` behind BOTH
+/// halves of the question the barrier itself asks, nested value-test-first.
+///
+/// [`emit_write_barrier_slot_generation_tested`] asks only the parent's half.
+/// That is the right shape for the array PUSH (#7511), where the pushed value
+/// is a heap pointer 100% of the time and the parent is the only variable. It
+/// is the wrong shape for an element OVERWRITE: measured on
+/// `gc-handoff/apps/pipeline.ts`, whose `Registry.set` runs `this.vals[i] = v`
+/// 1.44 M times, `PERRY_GC_TRACE` counts **1,265,933 barrier calls of which
+/// 1,265,925 (99.999%) exit at `non_pointer_child_skips`** — the value is a
+/// number, and the call is made anyway because the emitter has no value test
+/// at all. `parent_not_old_skips` is **zero** there: the container's backing
+/// array is long-lived, so the parent gate alone would skip nothing.
+///
+/// So the tests are NESTED rather than fused, value first:
+///
+/// * [`emit_may_carry_heap_pointer_check`] is pure register arithmetic on the
+///   stored bits — no memory operand at all. A numeric store pays that and a
+///   perfectly-predicted branch.
+/// * [`emit_parent_may_need_remembering_check`] loads the parent's header byte
+///   AND does a `monotonic` load of the incremental-cycle count. `monotonic`
+///   is not hoistable out of a loop, so putting it on the numeric path would
+///   charge a non-hoistable load per iteration to the very stores this exists
+///   to make free.
+///
+/// A single fused `and` of the two would do exactly that, which is why this is
+/// two branches and not one.
+///
+/// ## Why skipping on the value test alone is sound
+///
+/// `write_barrier_slot_inner`'s first action is `barrier_child_prologue(child)`,
+/// which returns `None` — before the incremental-mark shading, before the armed
+/// check, before the parent decode and before the remembered set — when
+/// `decode_heap_addr(child) == 0`. `emit_may_carry_heap_pointer_check` is a
+/// documented **superset** of that decode (its doc records why the direction is
+/// load-bearing, and `gc::tests::inline_pointer_bearing_contract` enumerates
+/// the whole 16-bit tag space against it), so a store this predicate rejects is
+/// one the call would have returned from immediately. In particular the SATB /
+/// insertion shading is NOT skipped by this half: a value that carries no heap
+/// pointer has nothing to shade, which is why the incremental clause lives in
+/// the parent test and not here.
+///
+/// The parent half's obligations are unchanged and are pinned by
+/// `gc::tests::inline_generation_gate_contract`.
+///
+/// `parent_handle` must be a validated, non-forwarded GC user pointer — see
+/// [`emit_parent_may_need_remembering_check`].
+pub(crate) fn emit_write_barrier_slot_value_and_generation_tested(
+    ctx: &mut FnCtx<'_>,
+    parent_handle: &str,
+    parent_bits: &str,
+    slot_addr: &str,
+    child_bits: &str,
+    stem: &str,
+) {
+    if !crate::codegen::write_barriers_enabled() {
+        return;
+    }
+    let generation_idx = ctx.new_block(&format!("{}.barrier.maybe", stem));
+    let barrier_idx = ctx.new_block(&format!("{}.barrier", stem));
+    let done_idx = ctx.new_block(&format!("{}.barrier.done", stem));
+    let generation_label = ctx.block_label(generation_idx);
+    let barrier_label = ctx.block_label(barrier_idx);
+    let done_label = ctx.block_label(done_idx);
+    {
+        let blk = ctx.block();
+        let may_carry = emit_may_carry_heap_pointer_check(blk, child_bits);
+        blk.cond_br(&may_carry, &generation_label, &done_label);
+    }
+    ctx.current_block = generation_idx;
+    {
+        let blk = ctx.block();
+        let needed = emit_parent_may_need_remembering_check(blk, parent_handle);
+        blk.cond_br(&needed, &barrier_label, &done_label);
+    }
+    ctx.current_block = barrier_idx;
+    {
+        let blk = ctx.block();
+        emit_write_barrier_slot_on_block(blk, parent_bits, slot_addr, child_bits);
+        blk.br(&done_label);
+    }
+    ctx.current_block = done_idx;
+}
+
 pub(crate) fn emit_root_nanbox_store_on_block(blk: &mut LlBlock, value: &str, root_slot: &str) {
     blk.store(DOUBLE, value, root_slot);
     let value_bits = blk.bitcast_double_to_i64(value);

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -815,9 +815,31 @@ fn pointer_store_into_numeric_array_keeps_layout_note_and_barrier() {
         inbounds_ir.contains("call void @js_gc_note_slot_layout"),
         "pointer stores into statically numeric arrays must update slot layout"
     );
+    // #7715: the barrier still exists and is still reached from this arm, but
+    // it now sits in its own block behind a live test of the stored value (and
+    // then of the parent's generation) rather than inline in `idxset.inbounds`.
+    // So the assertion follows the EDGE: the in-bounds arm must branch into the
+    // gate, and the block the gate leads to must still hold the call. Asserting
+    // only that the call exists somewhere in the module would pass even if this
+    // arm stopped reaching it.
     assert!(
-        inbounds_ir.contains("call void @js_write_barrier_slot"),
-        "pointer stores into statically numeric arrays must emit slot barriers"
+        inbounds_ir.contains("label %idxset.inbounds.barrier.maybe."),
+        "the in-bounds arm no longer branches into the #7715 value gate, so a \
+         pointer store here reaches no barrier at all:\n{inbounds_ir}"
+    );
+    let gate_ir = block_between(
+        &ir,
+        "\nidxset.inbounds.barrier.maybe.",
+        "\nidxset.inbounds.barrier.done.",
+    );
+    assert!(
+        gate_ir.contains("call void @js_write_barrier_slot"),
+        "pointer stores into statically numeric arrays must emit slot barriers:\n{gate_ir}"
+    );
+    assert!(
+        gate_ir.contains("@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT"),
+        "the gate between the store and the barrier is not the #7511 parent \
+         generation test:\n{gate_ir}"
     );
 }
 


### PR DESCRIPTION
Part of #7715 (write-barrier tower, B3 "slot elision").

## The measurement that chose this change

`#7715` scopes B3 as "skip the write-barrier slot computation where the store
provably cannot create an old→young edge", and B4 as "carry generation in the
header". I re-profiled first, as the issue instructs, and the data pointed
somewhere neither bullet did.

Static census of `js_write_barrier{,_slot}` call sites across all 19 GC-corpus
programs (`--trace llvm`, bucketed by the block they sit in):

| program | gated (`*.barrier`, #7511/#7871) | **ungated `idxset.recv_prop.fast`** | value-gated `wb.maybe` |
|---|--:|--:|--:|
| pipeline | 20 | **6** | 6 |
| interp | 48 | 1 | 1 |
| iso_miss | 48 | 1 | 1 |
| everything else | ≤48 | 0 | 0–53 |

Dynamic counters (`PERRY_GC_TRACE=1 PERRY_GC_DIAG=1`, per-cycle `write_barrier`
block summed):

| program | calls | non_pointer_child | parent_not_old | slow hits |
|---|--:|--:|--:|--:|
| **pipeline** | **1 265 933** | **1 265 925 (99.999%)** | **0** | 0 |
| churn | 119 716 | 0 | 118 235 | 0 |
| interp | 11 539 | 678 | 322 | 146 |
| iso_miss | 11 302 | 596 | 172 | 146 |

`pipeline`'s `Registry.set` runs `this.vals[i] = v` 1.44 M times. Every one of
those calls decodes the stored value, finds it is a number, and returns having
done nothing — **and `parent_not_old_skips` is 0**, so the parent-generation
gate #7511/#7871 shipped would have skipped nothing there. The lever at this
site is the VALUE test, not the generation test.

## The change

`js_write_barrier_slot` at the two array-element store sites
(`emit_guarded_inbounds_array_store`, and `lower_index_set_fast`'s JSValue
in-bounds arm) now sits behind `emit_may_carry_heap_pointer_check`, and then
behind `emit_parent_may_need_remembering_check` — the same two predicates the
class-field store has carried since #7511/#7871, **nested value-first**, not
fused into one `and`.

Nesting is load-bearing: the value test is pure register arithmetic on the
stored bits, while the parent test does a `monotonic` load of
`@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT` that LLVM may not hoist out of
the loop. A fused `and` would charge that non-hoistable load to exactly the
numeric stores this exists to make free.

## Soundness

Skipping on the value test alone is sound because `write_barrier_slot_inner`'s
first action is `barrier_child_prologue(child)`, which returns — before the SATB
shading, the armed check, the parent decode and the remembered set — when
`decode_heap_addr(child) == 0`. The emitted predicate is a documented
**superset** of that decode; `gc::tests::inline_pointer_bearing_contract`
enumerates the whole 16-bit tag space against it. A value carrying no heap
pointer has nothing to shade, which is why the incremental clause belongs to the
parent half and not this one; the parent half's obligations are unchanged and
stay pinned by `gc::tests::inline_generation_gate_contract`.

Reading the parent's header byte at `arr_handle - 7` is safe on both arms: each
reached its block through a guard that already read `obj_type` at `-8` and
`gc_flags` at `-7`, and has already performed a raw store into
`arr_handle + 8 + i*8`.

**What deliberately stays outside the value test**: the layout note. The
class-field emitter puts its note behind the same test, but that argument does
**not** transfer — `layout_note_slot` funnels
`crate::array::note_element_store` (#7480), and a non-pointer stored over a
pointer is exactly the store that must clear `GC_ARRAY_ELEMENT_SHAPE`.
`js_array_note_numeric_write` is likewise not skippable on a pointer test:
`undefined`/booleans are non-pointers that still have to downgrade the array's
raw-f64 layout.

## Tests

`expr/index_set_barrier_tests.rs` walks the emitted def chain rather than
looking for instructions nearby. It fails on: a hard-wired `br i1 true/false`
that leaves the dead predicate in the block; dropping any of the three heap-tag
comparands from the value predicate; dropping either disjunct of the parent
predicate; putting the barrier on the false edge; and eliding the call instead
of guarding it.

## B4 — reported as measured-negative, not attempted

Recorded in `gc-handoff/BARRIER-NOTES.md` §2.3/§2.5 so it is not re-derived:

* **There is no bit.** `gc_flags` is full — `gc/types.rs:975` says so in terms
  ("This is the last bit in the u8 gc_flags. Adding more flags requires
  extending GcHeader ... extending breaks ABI everywhere") — and `_reserved` is
  fully allocated and already `obj_type`-overloaded.
* **The prize is 118 k calls on one program.** `churn`'s
  `parent_not_old_skips` are the `Old ⊊ TENURED` gap: objects the non-moving
  minor promoted *logically* (`gc/oldgen.rs`) carry `TENURED` while still living
  in the nursery, so they pass the codegen gate and fail the runtime's
  `classify_heap_generation == Old`. `gc/trace.rs:799-810` is explicit that this
  state must still be traced, which is why the approximation is sound and why
  closing it needs a genuinely new bit. Outside `churn` the whole corpus totals
  494 such calls.
* **A runtime-side `!TENURED` short-circuit is worth nothing either**, for the
  same reason: every call that reaches `barrier_parent_needs_remembering` got
  there by passing the gate, so its parent is TENURED.

## Measured

Both arms built from this worktree at `ac52a5c38` (0.5.1490; the branch was
rebased onto `b392f7b5d` afterwards, and the diff is unchanged). The change is
codegen-only
(`git diff --name-only` touches nothing under `perry-runtime`/`perry-stdlib`),
so both link the **same** `libperry_{runtime,stdlib}.a` and the corpus was
compiled with the same output basenames in different directories.

**`cmp` over the 19-program GC corpus: 16 identical, 3 differ — and the 3 are
exactly `pipeline`, `interp`, `iso_miss`, i.e. precisely the programs the census
says contain the site.** The other 16 are provably unchanged and need no timing.

Instructions retired (`ab_instr.py`, best of 7, dev box, spread ≤ 0.86%):

| program | base instr (M) | fix instr (M) | Δ instr | Δ cycles |
|---|--:|--:|--:|--:|
| **pipeline** | 2657.8 | **2582.0** | **−2.85%** | **−3.91%** |
| interp | 11540.4 | 11540.7 | +0.00% | +0.73% |
| iso_miss | 14101.6 | 14101.1 | −0.00% | −0.11% |

(Direction only — final wall-clock belongs on the quiet mini. `interp`'s cycles
column moves with the box; its instruction count is flat to three digits and its
binary differs by one gated site.)

## Correctness

* 19/19 corpus programs byte-identical to `m0810/expected/`, exit 0 — including
  the `iso_miss` canary (`checksum 437840 misses 0`).
* 9 programs re-run byte-identical under `PERRY_GC_PROTECT_FROMSPACE=1
  PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, under `PERRY_GC_VERIFY_EVACUATION=1`,
  and (the 3 that differ) under `PERRY_GC_SCHEDULE_RATE=1
  PERRY_GC_SCHEDULE_ALLOC_KB=64`.
* `cargo test -p perry-codegen --lib`: 921 passed, 0 failed.
* The three new tests were **sabotage-run**, not merely written:
  hard-wiring the value gate's branch to `true` (leaving the dead predicate in
  the block) fails only `the_element_store_barrier_sits_behind_a_live_value_test`;
  dropping the incremental disjunct fails only the two parent-gate tests
  (including #7871's existing one); eliding the call inside the barrier block
  fails only `the_gated_element_store_still_reaches_the_barrier_call`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guarded array updates by skipping write-barrier work when stored values cannot contain heap references.
  * Preserved generation and incremental-marking checks for values that may reference managed memory.
  * Maintained existing behavior for numeric and raw array stores.

* **Tests**
  * Added comprehensive coverage validating barrier conditions and generated code paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->