### PR TITLE
perf(gc): let the first copying minor decide its promotion from its own trace (#7937)

### DIFF
--- a/changelog.d/7937-first-cycle-promotion.md
+++ b/changelog.d/7937-first-cycle-promotion.md
@@ -17,18 +17,23 @@ Measured on `gc-handoff/bench` + `gc-handoff/apps` (19/19 byte-exact against
 `node --experimental-strip-types`, exit 0), instructions retired and peak RSS —
 both load-independent, which the dev box at load 35–75 required:
 
-| program | instructions | peak RSS |
-|---|--:|--:|
-| `retain1` | **−31%** | −4% |
-| `retain_wide1` | **−25%** | 0 |
-| `retain` | **−23%** | 0 |
-| `deeplist` | **−18%** | 0 |
-| `retain_wide` | **−14%** | 0 |
-| `asyncpipe` | **−11%** | **−17%** |
-| everything else | ±0.4% | ±0 |
+| program | cycles | instructions | peak RSS |
+|---|---|--:|--:|
+| `retain1` | 3 → **2** | **−31%** | **−4%** |
+| `retain_wide1` | 4 → **3** | **−24%** | 0 |
+| `retain` | 5 → **4** | **−23%** | 0 |
+| `deeplist` | 3 → **2** | **−17%** | **−3%** |
+| `retain_wide` | 8 → **6** | **−14%** | 0 |
+| `asyncpipe` | 1 → 1 | **−11%** | **−17%** |
+| `shapes` | 1 → 1 | +1.3% | 0 |
+| everything else | unchanged | ±1% | 0 |
 
-Cycle-0 pause itself falls 20–40% on that cluster (best-of-5 minimum), and
-`retain` drops a whole cycle (5 → 4) while `retain1` and `deeplist` drop to 2.
+Cycle-0 pause itself falls 20–40% on that cluster (best-of-5 minimum). **No
+program gains a cycle or a full collection.** `shapes`' +1.3% is exactly the
+wasted mark of a rolled-back attempt over its 6 536 live objects — the price of
+the measurement, paid once, on the one program in the corpus whose cycle 0 has a
+non-trivial live set below the threshold. Wall clock is deliberately not quoted:
+the dev box ran at load 35–97, and absolute seconds belong to the quiet mini.
 
 #### The rollback, and why its obligation list is two items long
 
@@ -42,14 +47,24 @@ is a **precondition** of attempting at all, which is why the attempt is gated on
 `untraced_promotion_instrument_veto`, so the stress/verify instruments are never
 shown a discarded trace.
 
-★ The retag is not only a relabel: `retag_block_space` to `HeapGeneration::Old`
-also *registers old-gen page metadata* for every page of the block, and
-relabelling back does not remove it. Undoing that is the second half of the
-rollback; without it the whole young generation is left carrying old-gen page
-entries — worth +4–10% peak RSS, and a lie the dirty scan and the defrag page
-selector both read. Both halves are **sabotage-verified**: deleting either one
-turns `a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates`
-red (`copied_objects: 0` and `old_pages: 256 vs 0` respectively).
+★ A retag is not only a relabel: `retag_block_space` to `HeapGeneration::Old`
+also mints one zeroed `OldPageMeta` per **4 KB** of every block it touches, so a
+speculative attempt mints one for the whole young generation. Measured cost when
+it did: `tree_wide` 67.8 → 74.8 MB, `tree` 35.8 → 39.3, `churn` 25.0 → 26.6 —
++4–10% peak RSS on the 11 programs whose cycle 0 rolls back. **Removing the
+entries in the rollback does not give it back** — a `HashMap` never returns its
+capacity, and 61 MB of young generation is 15 616 pages in a table grown to
+32 768 slots. So the attempt does not mint them:
+`retag_block_space_deferring_old_page_registration`, sound exactly there because
+a speculative attempt requires `skip_remembering`, which is the proof that no
+remembered-set insertion — the only reader that wants a promoted page's metadata
+before it exists — can happen between the retag and the finish. On commit,
+`finish_in_place_promotion` mints them on the way past.
+
+Both halves of the rollback are **sabotage-verified**: deleting the retag undo,
+or minting the page metadata eagerly, each turns
+`a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates` red
+(`copied_objects: 0` and `old_pages: 256 vs 0` respectively).
 
 #### The `old_gen_bytes` absolute arm is granularity-sensitive, and that had to be fixed first
 

--- a/changelog.d/7937-first-cycle-promotion.md
+++ b/changelog.d/7937-first-cycle-promotion.md
@@ -13,27 +13,35 @@ runs *before* the trace, after which no address classifies as `Nursery`, so
 `FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE` (500) the attempt **rolls back** and the
 cycle re-runs as an ordinary copying minor.
 
-Measured on `gc-handoff/bench` + `gc-handoff/apps` (19/19 byte-exact against
-`node --experimental-strip-types`, exit 0), instructions retired and peak RSS —
-both load-independent, which the dev box at load 35–75 required:
+Measured on `gc-handoff/bench` + `gc-handoff/apps` against `main` @ `d78efca41`
+(19/19 byte-exact against `node --experimental-strip-types`, exit 0, both arms
+built here), instructions retired and peak RSS — both load-independent, which
+the dev box at load 35–97 required:
 
-| program | cycles | instructions | peak RSS |
-|---|---|--:|--:|
-| `retain1` | 3 → **2** | **−31%** | **−4%** |
-| `retain_wide1` | 4 → **3** | **−24%** | 0 |
-| `retain` | 5 → **4** | **−23%** | 0 |
-| `deeplist` | 3 → **2** | **−17%** | **−3%** |
-| `retain_wide` | 8 → **6** | **−14%** | 0 |
-| `asyncpipe` | 1 → 1 | **−11%** | **−17%** |
-| `shapes` | 1 → 1 | +1.3% | 0 |
-| everything else | unchanged | ±1% | 0 |
+| program | cycles | full | instructions | peak RSS |
+|---|---|--:|--:|--:|
+| `retain1` | 4 → **2** | 1 → **0** | **−77.0%** | **−28.3%** |
+| `deeplist` | 4 → **2** | 1 → **0** | **−76.9%** | **−29.0%** |
+| `retain_wide1` | 5 → **3** | 1 → **0** | **−66.0%** | **−5.1%** |
+| `retain_wide` | 9 → **7** | 2 → **1** | **−41.4%** | **−2.8%** |
+| `retain` | 8 → **5** | 2 → **1** | **−41.0%** | **−10.8%** |
+| `asyncpipe` | 1 → 1 | 0 | +2.1% | +0.3% |
+| `shapes` | 1 → 1 | 0 | +1.5% | +0.8% |
+| `churn` `churn_alloc` `push_cls` `push_num` `cycles` `tree` `tree_wide` `interp` `iso_miss` `pipeline` `churn_read` `fib40` | unchanged | 0 | ±0.1% | ±0.5% |
 
-Cycle-0 pause itself falls 20–40% on that cluster (best-of-5 minimum). **No
-program gains a cycle or a full collection.** `shapes`' +1.3% is exactly the
-wasted mark of a rolled-back attempt over its 6 536 live objects — the price of
-the measurement, paid once, on the one program in the corpus whose cycle 0 has a
-non-trivial live set below the threshold. Wall clock is deliberately not quoted:
-the dev box ran at load 35–97, and absolute seconds belong to the quiet mini.
+**No program gains a cycle or a full collection**, and five lose one or two of
+each. The two regressions are the wasted mark of a rolled-back attempt over
+6 536 and 6 686 live objects — the price of the measurement, paid once. Wall
+clock is deliberately not quoted: the dev box ran at load 35–97, and absolute
+seconds belong to the quiet mini.
+
+★ Part of that headline is `main` being in a bad state rather than this change
+being that good. Between `8260a9e50` and `d78efca41` the `retain` cluster
+regressed on `main` alone — `retain` 2 840 M → 12 421 M instructions with 0 → 2
+`old_gen_bytes` fulls, `retain1` 1 396 M → 3 724 M, `deeplist` 1 172 M →
+3 910 M — and the fulls are the same granularity-sensitive arm described below.
+Measured against the earlier base, this change is worth −14% to −31%. Both
+numbers are real; the second is the one to quote for the mechanism.
 
 #### The rollback, and why its obligation list is two items long
 
@@ -99,9 +107,11 @@ asserted by `the_absolute_old_reclaim_arm_stands_down_on_a_retaining_heap`.
 * `FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE` is 500 rather than the steady-state
   950 because it bounds a different thing: 950 bounds a *prediction* that can be
   wrong repeatedly, while cycle 0 is reading its own measurement and can only be
-  wrong once, for at most `(1 − ratio) ×` the scavenge nursery cap. The measured
-  cycle-0 population has an empty band between 25‰ (`shapes`) and 770‰
-  (`asyncpipe`); 500 is its midpoint, and `asyncpipe` is why the steady-state
-  number is the wrong one here — promoting its single cycle is −11%
-  instructions and −17% RSS, while rolling it back would buy a 172 415-object
-  mark pass for nothing.
+  wrong once, for at most `(1 − ratio) ×` the scavenge nursery cap. On today's
+  corpus the cycle-0 population is bimodal with an empty 25→992 band and 950
+  would classify it identically — but three days ago `asyncpipe`'s cycle 0
+  measured **770‰ over 172 415 objects**, squarely between the modes, and at 950
+  it would have paid that whole mark pass and then rolled back. #7959 changed
+  its shape and the outlier vanished. A threshold that only works while the
+  corpus happens to be bimodal is fitted to a coincidence; this one is justified
+  by its exposure.

--- a/changelog.d/7937-first-cycle-promotion.md
+++ b/changelog.d/7937-first-cycle-promotion.md
@@ -1,0 +1,92 @@
+### perf(gc): the first copying minor decides its promotion from its own trace (#7937)
+
+Whole-block in-place promotion (#7742/#7888) could never apply to the **first**
+copying minor of a thread: the policy reads the *previous* cycle's measured
+young-survival ratio and cycle 0 has no previous cycle. On the fully-live
+workloads that one cycle was 58–81% of all GC pause.
+
+Cycle 0 now **attempts** the promotion and decides afterwards, from the ratio it
+just measured. That is possible because a promoting cycle's trace is exactly a
+mark pass over the blocks it would keep — `retag_young_for_in_place_promotion`
+runs *before* the trace, after which no address classifies as `Nursery`, so
+`move_young` is unreachable and the Cheney pass degenerates into marking. Below
+`FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE` (500) the attempt **rolls back** and the
+cycle re-runs as an ordinary copying minor.
+
+Measured on `gc-handoff/bench` + `gc-handoff/apps` (19/19 byte-exact against
+`node --experimental-strip-types`, exit 0), instructions retired and peak RSS —
+both load-independent, which the dev box at load 35–75 required:
+
+| program | instructions | peak RSS |
+|---|--:|--:|
+| `retain1` | **−31%** | −4% |
+| `retain_wide1` | **−25%** | 0 |
+| `retain` | **−23%** | 0 |
+| `deeplist` | **−18%** | 0 |
+| `retain_wide` | **−14%** | 0 |
+| `asyncpipe` | **−11%** | **−17%** |
+| everything else | ±0.4% | ±0 |
+
+Cycle-0 pause itself falls 20–40% on that cluster (best-of-5 minimum), and
+`retain` drops a whole cycle (5 → 4) while `retain1` and `deeplist` drop to 2.
+
+#### The rollback, and why its obligation list is two items long
+
+`undo_in_place_promotion_retag` (the retag is the only physical commitment —
+nothing moved, no block changed arenas, no bump pointer moved, and
+`finish_in_place_promotion` has not run) and `clear_marks`. Everything else the
+attempt did is a *provable* no-op on a promoting cycle: every root and slot
+rewrite (nothing moved), and every remembered-set insertion — `skip_remembering`
+is a **precondition** of attempting at all, which is why the attempt is gated on
+`malloc_registry_empty_at_start`. It is also gated on
+`untraced_promotion_instrument_veto`, so the stress/verify instruments are never
+shown a discarded trace.
+
+★ The retag is not only a relabel: `retag_block_space` to `HeapGeneration::Old`
+also *registers old-gen page metadata* for every page of the block, and
+relabelling back does not remove it. Undoing that is the second half of the
+rollback; without it the whole young generation is left carrying old-gen page
+entries — worth +4–10% peak RSS, and a lie the dirty scan and the defrag page
+selector both read. Both halves are **sabotage-verified**: deleting either one
+turns `a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates`
+red (`copied_objects: 0` and `old_pages: 256 vs 0` respectively).
+
+#### The `old_gen_bytes` absolute arm is granularity-sensitive, and that had to be fixed first
+
+`old_reclaim_pressure_due`'s first arm is `old_in_use >= T && baseline < T`, and
+`baseline` is credited by every promotion
+(`credit_promoted_bytes_to_old_baseline`) — so it is a race between two
+quantities moving in the same direction at different step sizes. **Whether it
+fires depends on the size of the promotion steps, not on any property of the
+heap.** Instrumented on `retain`: same program, same live set, same total
+promotion, and changing the schedule from (18.7 MB, 34.6 MB) to
+(17.7 MB, 17.8 MB) makes it fire twice — `old_in_use=52.3 MB, baseline=35.5 MB,
+T=48 MB` — buying two full mark-sweeps that cost **588 ms against a 55 ms GC
+budget**, with the proportional arm correctly declining (`band=128 MB`) and
+`GC_MAJOR_PACING_RETAINING` armed.
+
+That is the futile-full shape #7592 removed one arm over: a heap whose young
+generation is not dying is retaining live data, and a full mark-sweep cannot
+lower the number being watched. #7592 exempted the *proportional* arm via
+`GC_MAJOR_PACING_RETAINING` and left the absolute one un-exempted; it is the
+absolute one that fires. It now stands down while that latch is armed. The
+proportional arm still bounds old-gen growth, so this defers reclamation rather
+than removing it — the same trade the existing multiplier makes. Both states are
+asserted by `the_absolute_old_reclaim_arm_stands_down_on_a_retaining_heap`.
+
+#### Also
+
+* New promotion telemetry `in_place_dead_blocks` / `in_place_dead_block_bytes`:
+  promoted blocks with **zero** live objects, i.e. the ones a promotion kept for
+  nothing. Distinct from `in_place_sparse_blocks` (under 50% live) and the
+  distinction is load-bearing — on a speculatively promoting cycle 0 `churn`
+  reads 17 sparse of 18 blocks but 15 fully dead, `tree_wide` 61 and 60.
+* `FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE` is 500 rather than the steady-state
+  950 because it bounds a different thing: 950 bounds a *prediction* that can be
+  wrong repeatedly, while cycle 0 is reading its own measurement and can only be
+  wrong once, for at most `(1 − ratio) ×` the scavenge nursery cap. The measured
+  cycle-0 population has an empty band between 25‰ (`shapes`) and 770‰
+  (`asyncpipe`); 500 is its midpoint, and `asyncpipe` is why the steady-state
+  number is the wrong one here — promoting its single cycle is −11%
+  instructions and −17% RSS, while rolling it back would buy a 172 415-object
+  mark pass for nothing.

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -105,8 +105,8 @@ pub use reset::{arena_reset_all_blocks_to_zero, arena_reset_empty_blocks};
 #[cfg(debug_assertions)]
 pub(crate) use promote::young_in_use_bytes_after_retag;
 pub(crate) use promote::{
-    finish_in_place_promotion, retag_young_for_in_place_promotion, InPlacePromotion,
-    InPlacePromotionStats, PromotionLiveness,
+    finish_in_place_promotion, retag_young_for_in_place_promotion, undo_in_place_promotion_retag,
+    InPlacePromotion, InPlacePromotionStats, PromotionLiveness,
 };
 
 // quarantine.rs (#7154 from-space protection; default-off)

--- a/crates/perry-runtime/src/arena/page_meta.rs
+++ b/crates/perry-runtime/src/arena/page_meta.rs
@@ -532,6 +532,44 @@ pub(crate) fn retag_block_space(
     generation: HeapGeneration,
     space: HeapSpace,
 ) {
+    retag_block_space_inner(base, size, generation, space, true);
+}
+
+/// Relabel a block WITHOUT minting the old-gen page-metadata entries an
+/// `Old` retag normally mints (#7937).
+///
+/// For a retag that may be UNDONE — the speculative first-cycle promotion,
+/// which decides from its own trace and rolls back if the trace disagrees —
+/// eager registration is both wasted and expensive: it mints one zeroed
+/// `OldPageMeta` per 4 KB of the whole young generation, and a `HashMap` never
+/// gives its capacity back, so removing the entries afterwards does not undo
+/// the footprint. Measured: `tree_wide` +6 MB, `tree` +3 MB, `churn` +1 MB of
+/// peak RSS for blocks that were handed straight back to the nursery.
+///
+/// Deferring it is sound for that caller specifically because a speculative
+/// attempt requires `skip_remembering` (see `gc::copying`), which is the proof
+/// that NO remembered-set insertion can happen between the retag and the
+/// finish — and the remembered set is the only reader that would want a
+/// promoted page's metadata before it exists. If the attempt commits,
+/// `finish_in_place_promotion` mints the entries on the way past: both
+/// `register_promoted_page_headers`/`_run` (per live page) and its closing
+/// `retag_block_space(.., Old, HeapSpace::Old)` (every page) create them.
+pub(crate) fn retag_block_space_deferring_old_page_registration(
+    base: usize,
+    size: usize,
+    generation: HeapGeneration,
+    space: HeapSpace,
+) {
+    retag_block_space_inner(base, size, generation, space, false);
+}
+
+fn retag_block_space_inner(
+    base: usize,
+    size: usize,
+    generation: HeapGeneration,
+    space: HeapSpace,
+    register_old_pages: bool,
+) {
     if base == 0 || size == 0 || matches!(generation, HeapGeneration::Unknown) {
         return;
     }
@@ -562,7 +600,7 @@ pub(crate) fn retag_block_space(
             }
         }
     });
-    if matches!(generation, HeapGeneration::Old) {
+    if register_old_pages && matches!(generation, HeapGeneration::Old) {
         register_old_block_pages(base, size);
     }
     invalidate_generation_cache();

--- a/crates/perry-runtime/src/arena/promote.rs
+++ b/crates/perry-runtime/src/arena/promote.rs
@@ -62,7 +62,7 @@
 
 use super::page_meta::{
     generation_page_base, register_promoted_page_headers, register_promoted_page_run,
-    retag_block_space, GENERATION_PAGE_SIZE,
+    retag_block_space, retag_block_space_deferring_old_page_registration, GENERATION_PAGE_SIZE,
 };
 use super::*;
 
@@ -173,7 +173,13 @@ pub(crate) struct InPlacePromotionStats {
 /// Returns the blocks captured. An empty result means there was nothing to
 /// promote and the caller must fall back to the ordinary copying path (in
 /// particular it must NOT skip the from-space reset).
-pub(crate) fn retag_young_for_in_place_promotion() -> InPlacePromotion {
+/// `defer_old_page_registration` is for the speculative first-cycle attempt,
+/// which may undo this retag — see
+/// [`retag_block_space_deferring_old_page_registration`] for why it is sound
+/// exactly there and for what it costs when it is not deferred.
+pub(crate) fn retag_young_for_in_place_promotion(
+    defer_old_page_registration: bool,
+) -> InPlacePromotion {
     sync_inline_arena_state();
     let mut promotion = InPlacePromotion::default();
 
@@ -198,12 +204,21 @@ pub(crate) fn retag_young_for_in_place_promotion() -> InPlacePromotion {
     }
 
     for block in &promotion.blocks {
-        retag_block_space(
-            block.base,
-            block.size,
-            HeapGeneration::Old,
-            HeapSpace::PromotedYoung,
-        );
+        if defer_old_page_registration {
+            retag_block_space_deferring_old_page_registration(
+                block.base,
+                block.size,
+                HeapGeneration::Old,
+                HeapSpace::PromotedYoung,
+            );
+        } else {
+            retag_block_space(
+                block.base,
+                block.size,
+                HeapGeneration::Old,
+                HeapSpace::PromotedYoung,
+            );
+        }
     }
     promotion
 }
@@ -219,16 +234,15 @@ pub(crate) fn retag_young_for_in_place_promotion() -> InPlacePromotion {
 /// (clear the marks the trace set, and do not consume the remembered set); see
 /// `gc::copying`'s rollback for why the list is exactly that long.
 ///
-/// ★ The retag is NOT only a relabel. `retag_block_space` to
-/// `HeapGeneration::Old` also **registers old-gen page metadata** for every
-/// page of the block (`register_old_block_pages`), and relabelling back to
-/// `Nursery` does not take it away — the entries are removed by
-/// `unregister_old_block_pages`, which is what every other "this block stops
-/// being old-gen" path calls. Omitting it leaves the whole young generation
-/// carrying zeroed `OLD_GEN_PAGE_META` entries: measured as +4–10% peak RSS
-/// across the rolled-back half of the corpus (`tree_wide` 67.8 → 74.8 MB), and
-/// worse than the footprint, a page registered as old-gen while its block is
-/// young again is a lie the dirty scan and the defrag page selector both read.
+/// ★ The retag is NOT only a relabel — an `Old` retag also mints an old-gen
+/// page-metadata entry per 4 KB of the block. This undo does not have to take
+/// them away, because the speculative attempt never mints them: it retags
+/// through [`retag_block_space_deferring_old_page_registration`], which is
+/// sound exactly there and saves 1–6 MB of peak RSS that removing the entries
+/// afterwards would NOT have saved (a `HashMap` never returns its capacity).
+/// `a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates`
+/// asserts the old-gen page count is unchanged across a rollback, so a future
+/// retag that starts minting them again turns that test red.
 pub(crate) fn undo_in_place_promotion_retag(promotion: &InPlacePromotion) {
     for block in &promotion.blocks {
         let space = match block.source {
@@ -237,10 +251,6 @@ pub(crate) fn undo_in_place_promotion_retag(promotion: &InPlacePromotion) {
             PromotionSource::Survivor(_) => HeapSpace::Survivor1,
         };
         retag_block_space(block.base, block.size, HeapGeneration::Nursery, space);
-        let first_page = generation_page_for_addr(block.base);
-        let last_page = generation_page_for_addr(block.base + block.size - 1);
-        let pages: Vec<usize> = (first_page..=last_page).collect();
-        super::page_meta::unregister_old_block_pages(&pages);
     }
 }
 

--- a/crates/perry-runtime/src/arena/promote.rs
+++ b/crates/perry-runtime/src/arena/promote.rs
@@ -161,6 +161,11 @@ pub(crate) struct InPlacePromotionStats {
     /// Blocks whose live fraction was below 50% — the shape that would have
     /// been better served by evacuation. Zero on every benchmark measured.
     pub(crate) sparse_blocks: usize,
+    /// Blocks with ZERO live objects, and their bytes. These are the blocks a
+    /// promotion keeps for nothing: no live object needs their addresses held
+    /// still, so the ordinary from-space reset would have recycled them.
+    pub(crate) dead_blocks: usize,
+    pub(crate) dead_block_bytes: usize,
 }
 
 /// Retag every in-use young block as old-gen `PromotedYoung`.
@@ -201,6 +206,27 @@ pub(crate) fn retag_young_for_in_place_promotion() -> InPlacePromotion {
         );
     }
     promotion
+}
+
+/// Put every block [`retag_young_for_in_place_promotion`] captured back in the
+/// young generation, in the space it came from (#7937).
+///
+/// This is the whole of the physical rollback for a speculative first-cycle
+/// promotion, and it is complete because the retag is the whole of the physical
+/// commitment: nothing moved, no block changed arenas, no bump pointer moved,
+/// and `finish_in_place_promotion` — the only step that hands a block to
+/// `OLD_ARENA` — has not run. The caller owns the two remaining obligations
+/// (clear the marks the trace set, and do not consume the remembered set); see
+/// `gc::copying`'s rollback for why the list is exactly that long.
+pub(crate) fn undo_in_place_promotion_retag(promotion: &InPlacePromotion) {
+    for block in &promotion.blocks {
+        let space = match block.source {
+            PromotionSource::Eden => HeapSpace::NurseryEden,
+            PromotionSource::Survivor(0) => HeapSpace::Survivor0,
+            PromotionSource::Survivor(_) => HeapSpace::Survivor1,
+        };
+        retag_block_space(block.base, block.size, HeapGeneration::Nursery, space);
+    }
 }
 
 /// Bytes still in use in blocks that classify as young generation. The premise
@@ -278,6 +304,10 @@ pub(crate) fn finish_in_place_promotion(
         stats.live_bytes += live_bytes;
         if taken.offset > 0 && live_bytes * 2 < taken.offset {
             stats.sparse_blocks += 1;
+        }
+        if taken.offset > 0 && live_objects == 0 {
+            stats.dead_blocks += 1;
+            stats.dead_block_bytes += taken.offset;
         }
         moved_blocks.push(taken);
     }

--- a/crates/perry-runtime/src/arena/promote.rs
+++ b/crates/perry-runtime/src/arena/promote.rs
@@ -218,6 +218,17 @@ pub(crate) fn retag_young_for_in_place_promotion() -> InPlacePromotion {
 /// `OLD_ARENA` — has not run. The caller owns the two remaining obligations
 /// (clear the marks the trace set, and do not consume the remembered set); see
 /// `gc::copying`'s rollback for why the list is exactly that long.
+///
+/// ★ The retag is NOT only a relabel. `retag_block_space` to
+/// `HeapGeneration::Old` also **registers old-gen page metadata** for every
+/// page of the block (`register_old_block_pages`), and relabelling back to
+/// `Nursery` does not take it away — the entries are removed by
+/// `unregister_old_block_pages`, which is what every other "this block stops
+/// being old-gen" path calls. Omitting it leaves the whole young generation
+/// carrying zeroed `OLD_GEN_PAGE_META` entries: measured as +4–10% peak RSS
+/// across the rolled-back half of the corpus (`tree_wide` 67.8 → 74.8 MB), and
+/// worse than the footprint, a page registered as old-gen while its block is
+/// young again is a lie the dirty scan and the defrag page selector both read.
 pub(crate) fn undo_in_place_promotion_retag(promotion: &InPlacePromotion) {
     for block in &promotion.blocks {
         let space = match block.source {
@@ -226,6 +237,10 @@ pub(crate) fn undo_in_place_promotion_retag(promotion: &InPlacePromotion) {
             PromotionSource::Survivor(_) => HeapSpace::Survivor1,
         };
         retag_block_space(block.base, block.size, HeapGeneration::Nursery, space);
+        let first_page = generation_page_for_addr(block.base);
+        let last_page = generation_page_for_addr(block.base + block.size - 1);
+        let pages: Vec<usize> = (first_page..=last_page).collect();
+        super::page_meta::unregister_old_block_pages(&pages);
     }
 }
 

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1360,12 +1360,49 @@ pub(super) fn gc_collect_minor_copying_fast_path(
     gc_collect_minor_copying_fast_path_with_eligibility(trace, start, eligibility, trigger_kind)
 }
 
+/// How a copied-minor attempt ended. `RolledBack` is only ever produced by the
+/// #7937 speculative first-cycle promotion, and it means the heap is in exactly
+/// the state it was in when the attempt began.
+enum CopiedMinorAttempt {
+    Done(Option<CopiedMinorFastPathOutcome>),
+    RolledBack,
+}
+
 pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     trace: &mut Option<GcCycleTrace>,
     start: Instant,
     eligibility: CopiedMinorEligibility,
-    _trigger_kind: GcTriggerKind,
+    trigger_kind: GcTriggerKind,
 ) -> Option<CopiedMinorFastPathOutcome> {
+    match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, true) {
+        CopiedMinorAttempt::Done(outcome) => outcome,
+        // #7937: the first-cycle promotion attempt read its own trace and the
+        // ratio said evacuate. The retag is undone and the marks are cleared,
+        // so re-deriving eligibility observes the same heap the first attempt
+        // did and the second attempt is an ordinary copying minor. It is
+        // re-derived rather than reused because `CopiedMinorEligibility` owns
+        // the pointer classifier the first attempt consumed; the only cost is
+        // one more preflight, on a cycle that by construction has almost
+        // nothing live to walk.
+        CopiedMinorAttempt::RolledBack => {
+            let eligibility = CopiedMinorEligibility::evaluate(trigger_kind);
+            match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, false) {
+                CopiedMinorAttempt::Done(outcome) => outcome,
+                CopiedMinorAttempt::RolledBack => {
+                    unreachable!("a non-speculative copied-minor attempt cannot roll back")
+                }
+            }
+        }
+    }
+}
+
+fn run_copied_minor_attempt(
+    trace: &mut Option<GcCycleTrace>,
+    start: Instant,
+    eligibility: CopiedMinorEligibility,
+    _trigger_kind: GcTriggerKind,
+    may_speculate: bool,
+) -> CopiedMinorAttempt {
     if let Some(trace) = trace.as_mut() {
         trace.copying_nursery = eligibility.trace_stats();
         trace.legacy_copy_only_scanner_pinned = eligibility.legacy_root_stats;
@@ -1396,7 +1433,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
         );
     }
     if !eligibility.eligible {
-        return None;
+        return CopiedMinorAttempt::Done(None);
     }
     let preflight_skipped = eligibility.preflight_skipped;
     let malloc_sweep_due = eligibility.malloc_sweep_due;
@@ -1416,7 +1453,32 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     // preflight above ran against the pre-retag labels, which is correct — it
     // answers "may this cycle move objects at all", a question the retag does
     // not change.
-    let promotion = if super::should_promote_young_in_place() {
+    // #7937: the FIRST copying minor has no previous cycle to read, so the
+    // steady-state policy above always declines — and on the fully-live
+    // workloads that one cycle is 58–81% of all GC pause. It may instead
+    // ATTEMPT the promotion and decide from its own trace, because on a
+    // promoting cycle the trace IS a mark pass over the blocks it would keep.
+    //
+    // Two preconditions, and both are about making the rollback's obligations
+    // provably empty rather than about liveness:
+    //
+    // * `malloc_registry_empty_at_start` is what makes `skip_remembering` true
+    //   below, and `skip_remembering` is what stops the attempt from touching
+    //   the remembered set at all — `visit_slot_with_parent`'s
+    //   `sticky.remember_slot` is gated on it, and so is
+    //   `rebuild_evacuated_old_to_young_remembered_set`. Without it a rollback
+    //   would have to un-remember, and a dropped old→young edge is a
+    //   swept-live-object crash a cycle later.
+    // * `untraced_promotion_instrument_veto` keeps the stress/verify
+    //   instruments off this path: each of them takes the trace as its subject,
+    //   and a rolled-back attempt would show them a trace that produced nothing
+    //   followed by a second one — the "instrument stopped exercising its
+    //   subject" shape, in a mode whose whole purpose is to exercise it.
+    let speculate_first_cycle = may_speculate
+        && ptrs.malloc_registry_empty_at_start
+        && !untraced_promotion_instrument_veto()
+        && super::should_attempt_first_cycle_promotion();
+    let promotion = if super::should_promote_young_in_place() || speculate_first_cycle {
         crate::arena::retag_young_for_in_place_promotion()
     } else {
         crate::arena::InPlacePromotion::default()
@@ -1649,6 +1711,40 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     }
     trace_phase_record(trace, "copying_nursery", phase_start);
 
+    // #7937: the attempt's own trace has finished, so the ratio it was missing
+    // now exists. This is the decision point the steady-state policy cannot
+    // have — it commits before the trace and corrects on the NEXT cycle; here
+    // the correction is available within the cycle, and nothing has been handed
+    // to old-gen yet.
+    //
+    // Rolling back restores the pre-cycle state exactly, and the list of things
+    // to restore is exactly two long:
+    //
+    // * the retag (`undo_in_place_promotion_retag`) — the only physical
+    //   commitment, since nothing moved and no block changed arenas;
+    // * the marks the trace set (`clear_marks` over `marked_headers` +
+    //   `moved_headers`, which is where `mark_promoted_young` puts every object
+    //   it touched).
+    //
+    // Everything else the attempt did is a PROVABLE no-op on a promoting cycle
+    // and needs no undoing: after the retag no address classifies as `Nursery`,
+    // so `move_young` is unreachable, every root rewrite and slot rewrite is a
+    // no-op, and `skip_remembering` (a precondition of speculating at all) means
+    // no remembered-set entry was created or consumed. `remembered_set_clear()`
+    // and the from-space reset are both below this point.
+    if speculate_first_cycle && promoting_in_place {
+        let holds_up =
+            super::first_cycle_promotion_holds_up(from_space_bytes, collector.live_from_bytes);
+        super::note_first_cycle_promotion(!holds_up);
+        if !holds_up {
+            unsafe {
+                collector.clear_marks();
+            }
+            crate::arena::undo_in_place_promotion_retag(&promotion);
+            return CopiedMinorAttempt::RolledBack;
+        }
+    }
+
     // Weak semantics for the copied-minor fast path. This path bypasses
     // cycle.rs's `WeakProcessing` subphase entirely, so before this block
     // existed NOTHING here tombstoned dead weak targets — and the scan
@@ -1761,6 +1857,8 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
         .bytes
         .saturating_sub(promotion_stats.live_bytes);
     collector.stats.in_place_sparse_blocks = promotion_stats.sparse_blocks;
+    collector.stats.in_place_dead_blocks = promotion_stats.dead_blocks;
+    collector.stats.in_place_dead_block_bytes = promotion_stats.dead_block_bytes;
     if let Some(trace) = trace.as_mut() {
         trace.old_pages = crate::arena::old_page_summary();
     }
@@ -1943,10 +2041,10 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
         );
     }
     super::scanner_profile::report_and_reset("copying_minor");
-    Some(CopiedMinorFastPathOutcome {
+    CopiedMinorAttempt::Done(Some(CopiedMinorFastPathOutcome {
         freed_bytes,
         malloc_swept: malloc_sweep_due,
-    })
+    }))
 }
 
 fn finalize_dead_copied_minor_from_space_side_allocations() {

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1492,6 +1492,11 @@ fn run_copied_minor_attempt(
     collector.stats.malloc_sweep_due = malloc_sweep_due;
     collector.stats.preflight_skipped = preflight_skipped;
     collector.stats.in_place_promotion = promoting_in_place;
+    // `may_speculate` is false on exactly one path: the retry the wrapper runs
+    // after a rollback. So this pair is exact without threading extra state
+    // through, and it survives the retry overwriting the trace.
+    collector.stats.first_cycle_promotion_attempted = speculate_first_cycle || !may_speculate;
+    collector.stats.first_cycle_promotion_rolled_back = !may_speculate;
     collector.stats.in_place_promoted_blocks = promotion.block_count();
     // See `CopyingNurseryCollector::skip_remembering` for the proof.
     collector.skip_remembering =

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1479,7 +1479,7 @@ fn run_copied_minor_attempt(
         && !untraced_promotion_instrument_veto()
         && super::should_attempt_first_cycle_promotion();
     let promotion = if super::should_promote_young_in_place() || speculate_first_cycle {
-        crate::arena::retag_young_for_in_place_promotion()
+        crate::arena::retag_young_for_in_place_promotion(speculate_first_cycle)
     } else {
         crate::arena::InPlacePromotion::default()
     };

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -373,55 +373,6 @@ impl CopyingNurseryPreflight {
     }
 }
 
-#[derive(Default)]
-pub(super) struct StickyRememberedSet {
-    pub(super) old_pages: crate::fast_hash::PtrHashSet<usize>,
-    pub(super) external_pages: Vec<(usize, usize)>,
-}
-
-impl StickyRememberedSet {
-    pub(super) fn remember_slot(
-        &mut self,
-        parent_header: *mut GcHeader,
-        slot: *mut u64,
-        external: bool,
-    ) {
-        if parent_header.is_null() || slot.is_null() {
-            return;
-        }
-        let page = crate::arena::generation_page_for_addr(slot as usize);
-        if external {
-            // #7538: an owner's external buffer can contribute thousands of
-            // slots (a lazy JSON array's sparse element cache is one 8-byte
-            // slot per element), and they are visited in address order — so
-            // one adjacent-duplicate check collapses a whole page's worth of
-            // pushes into a single entry. `restore` dedupes again inside
-            // `mark_dirty_external_slot_page`; this keeps the intermediate
-            // Vec from growing with the element count.
-            let entry = (parent_header as usize, page);
-            if self.external_pages.last() != Some(&entry) {
-                self.external_pages.push(entry);
-            }
-        } else {
-            self.old_pages.insert(page);
-        }
-    }
-
-    pub(super) fn restore(&self) {
-        for &page in &self.old_pages {
-            mark_dirty_old_page(page);
-        }
-        for &(header, page) in &self.external_pages {
-            mark_dirty_external_slot_page(header, page);
-        }
-    }
-
-    pub(super) fn extend(&mut self, other: StickyRememberedSet) {
-        self.old_pages.extend(other.old_pages);
-        self.external_pages.extend(other.external_pages);
-    }
-}
-
 pub(super) struct CopyingNurseryCollector {
     pub(super) ptrs: CopyingPointerSet,
     pub(super) worklist: Vec<*mut GcHeader>,
@@ -1360,43 +1311,7 @@ pub(super) fn gc_collect_minor_copying_fast_path(
     gc_collect_minor_copying_fast_path_with_eligibility(trace, start, eligibility, trigger_kind)
 }
 
-/// How a copied-minor attempt ended. `RolledBack` is only ever produced by the
-/// #7937 speculative first-cycle promotion, and it means the heap is in exactly
-/// the state it was in when the attempt began.
-enum CopiedMinorAttempt {
-    Done(Option<CopiedMinorFastPathOutcome>),
-    RolledBack,
-}
-
-pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
-    trace: &mut Option<GcCycleTrace>,
-    start: Instant,
-    eligibility: CopiedMinorEligibility,
-    trigger_kind: GcTriggerKind,
-) -> Option<CopiedMinorFastPathOutcome> {
-    match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, true) {
-        CopiedMinorAttempt::Done(outcome) => outcome,
-        // #7937: the first-cycle promotion attempt read its own trace and the
-        // ratio said evacuate. The retag is undone and the marks are cleared,
-        // so re-deriving eligibility observes the same heap the first attempt
-        // did and the second attempt is an ordinary copying minor. It is
-        // re-derived rather than reused because `CopiedMinorEligibility` owns
-        // the pointer classifier the first attempt consumed; the only cost is
-        // one more preflight, on a cycle that by construction has almost
-        // nothing live to walk.
-        CopiedMinorAttempt::RolledBack => {
-            let eligibility = CopiedMinorEligibility::evaluate(trigger_kind);
-            match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, false) {
-                CopiedMinorAttempt::Done(outcome) => outcome,
-                CopiedMinorAttempt::RolledBack => {
-                    unreachable!("a non-speculative copied-minor attempt cannot roll back")
-                }
-            }
-        }
-    }
-}
-
-fn run_copied_minor_attempt(
+pub(super) fn run_copied_minor_attempt(
     trace: &mut Option<GcCycleTrace>,
     start: Instant,
     eligibility: CopiedMinorEligibility,
@@ -1454,29 +1369,14 @@ fn run_copied_minor_attempt(
     // answers "may this cycle move objects at all", a question the retag does
     // not change.
     // #7937: the FIRST copying minor has no previous cycle to read, so the
-    // steady-state policy above always declines — and on the fully-live
-    // workloads that one cycle is 58–81% of all GC pause. It may instead
-    // ATTEMPT the promotion and decide from its own trace, because on a
-    // promoting cycle the trace IS a mark pass over the blocks it would keep.
-    //
-    // Two preconditions, and both are about making the rollback's obligations
-    // provably empty rather than about liveness:
-    //
-    // * `malloc_registry_empty_at_start` is what makes `skip_remembering` true
-    //   below, and `skip_remembering` is what stops the attempt from touching
-    //   the remembered set at all — `visit_slot_with_parent`'s
-    //   `sticky.remember_slot` is gated on it, and so is
-    //   `rebuild_evacuated_old_to_young_remembered_set`. Without it a rollback
-    //   would have to un-remember, and a dropped old→young edge is a
-    //   swept-live-object crash a cycle later.
-    // * `untraced_promotion_instrument_veto` keeps the stress/verify
-    //   instruments off this path: each of them takes the trace as its subject,
-    //   and a rolled-back attempt would show them a trace that produced nothing
-    //   followed by a second one — the "instrument stopped exercising its
-    //   subject" shape, in a mode whose whole purpose is to exercise it.
+    // steady-state policy above always declines. It may instead ATTEMPT the
+    // promotion and decide from its own trace — see
+    // `should_attempt_first_cycle_promotion` for why, and for why both extra
+    // preconditions here are about making the ROLLBACK's obligations provably
+    // empty rather than about liveness.
     let speculate_first_cycle = may_speculate
         && ptrs.malloc_registry_empty_at_start
-        && !untraced_promotion_instrument_veto()
+        && untraced_promotion_instrument_veto().is_none()
         && super::should_attempt_first_cycle_promotion();
     let promotion = if super::should_promote_young_in_place() || speculate_first_cycle {
         crate::arena::retag_young_for_in_place_promotion(speculate_first_cycle)
@@ -1717,26 +1617,14 @@ fn run_copied_minor_attempt(
     trace_phase_record(trace, "copying_nursery", phase_start);
 
     // #7937: the attempt's own trace has finished, so the ratio it was missing
-    // now exists. This is the decision point the steady-state policy cannot
-    // have — it commits before the trace and corrects on the NEXT cycle; here
-    // the correction is available within the cycle, and nothing has been handed
-    // to old-gen yet.
-    //
-    // Rolling back restores the pre-cycle state exactly, and the list of things
-    // to restore is exactly two long:
-    //
-    // * the retag (`undo_in_place_promotion_retag`) — the only physical
-    //   commitment, since nothing moved and no block changed arenas;
-    // * the marks the trace set (`clear_marks` over `marked_headers` +
-    //   `moved_headers`, which is where `mark_promoted_young` puts every object
-    //   it touched).
-    //
-    // Everything else the attempt did is a PROVABLE no-op on a promoting cycle
-    // and needs no undoing: after the retag no address classifies as `Nursery`,
-    // so `move_young` is unreachable, every root rewrite and slot rewrite is a
-    // no-op, and `skip_remembering` (a precondition of speculating at all) means
-    // no remembered-set entry was created or consumed. `remembered_set_clear()`
-    // and the from-space reset are both below this point.
+    // now exists. Nothing has been handed to old-gen yet, so rolling back
+    // restores the pre-cycle state, and the list is exactly two long: the retag
+    // (the only physical commitment) and the marks. Everything else the attempt
+    // did is a PROVABLE no-op on a promoting cycle — after the retag no address
+    // classifies as `Nursery`, so `move_young` is unreachable and every root
+    // and slot rewrite is a no-op, and `skip_remembering` (a precondition of
+    // attempting) means no remembered-set entry was created or consumed.
+    // `remembered_set_clear()` and the from-space reset are both below here.
     if speculate_first_cycle && promoting_in_place {
         let holds_up =
             super::first_cycle_promotion_holds_up(from_space_bytes, collector.live_from_bytes);

--- a/crates/perry-runtime/src/gc/copying_first_cycle.rs
+++ b/crates/perry-runtime/src/gc/copying_first_cycle.rs
@@ -1,0 +1,56 @@
+//! The first copying minor's promotion attempt, and its rollback (#7937).
+//!
+//! The steady-state in-place promotion policy (`gc::promote_in_place`) reads
+//! the PREVIOUS cycle's measured young-survival ratio, so it always declines on
+//! the first copying minor of a thread — and on the fully-live workloads that
+//! one cycle was 58–81% of all GC pause.
+//!
+//! Cycle 0 instead ATTEMPTS the promotion and decides afterwards, from the
+//! ratio its own trace just measured. That is possible because a promoting
+//! cycle's trace IS a mark pass over the blocks it would keep:
+//! `retag_young_for_in_place_promotion` runs before the trace, after which no
+//! address in the heap classifies as `Nursery`, so `move_young` is unreachable
+//! and the Cheney pass degenerates into marking.
+//!
+//! If the ratio disagrees, `gc::copying`'s decision point rolls the attempt
+//! back — restoring the retag and clearing the marks, which is the whole of the
+//! commitment — and this wrapper re-runs the cycle as an ordinary copying
+//! minor.
+
+use super::copying::{run_copied_minor_attempt, CopiedMinorEligibility};
+use super::*;
+
+/// How a copied-minor attempt ended. `RolledBack` is only ever produced by the
+/// speculative first-cycle promotion, and it means the heap is in exactly the
+/// state it was in when the attempt began.
+pub(super) enum CopiedMinorAttempt {
+    Done(Option<CopiedMinorFastPathOutcome>),
+    RolledBack,
+}
+
+pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
+    trace: &mut Option<GcCycleTrace>,
+    start: Instant,
+    eligibility: CopiedMinorEligibility,
+    trigger_kind: GcTriggerKind,
+) -> Option<CopiedMinorFastPathOutcome> {
+    match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, true) {
+        CopiedMinorAttempt::Done(outcome) => outcome,
+        // The first-cycle attempt read its own trace and the ratio said
+        // evacuate. The rollback restored the pre-cycle heap, so re-deriving
+        // eligibility observes what the first attempt did and this is an
+        // ordinary copying minor. Re-derived rather than reused because
+        // `CopiedMinorEligibility` owns the pointer classifier the first
+        // attempt consumed; the cost is one more preflight, on a cycle that by
+        // construction has almost nothing live to walk.
+        CopiedMinorAttempt::RolledBack => {
+            let eligibility = CopiedMinorEligibility::evaluate(trigger_kind);
+            match run_copied_minor_attempt(trace, start, eligibility, trigger_kind, false) {
+                CopiedMinorAttempt::Done(outcome) => outcome,
+                CopiedMinorAttempt::RolledBack => {
+                    unreachable!("a non-speculative copied-minor attempt cannot roll back")
+                }
+            }
+        }
+    }
+}

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -128,9 +128,13 @@ use pin::{note_preflight_skipped, note_preflight_walked, young_pin_latch_armed};
 mod prefetch;
 
 mod copying;
+mod copying_first_cycle;
 /// Per-scanner root attribution for the copied-minor root scan (#7915).
 mod scanner_profile;
+mod sticky_remembered;
 use copying::*;
+use copying_first_cycle::*;
+use sticky_remembered::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry
 // pass in `crate::weakref` (#6182), which lives outside the gc module.
 pub(crate) use copying::CopyingPointerSet;

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -160,8 +160,8 @@ mod fromspace_scan;
 mod promote_in_place;
 use promote_in_place::*;
 pub use promote_in_place::{
-    in_place_promoted_objects, in_place_promotion_cycles, untraced_promoted_objects,
-    untraced_promotion_cycles,
+    first_cycle_promotion_attempts, first_cycle_promotion_rollbacks, in_place_promoted_objects,
+    in_place_promotion_cycles, untraced_promoted_objects, untraced_promotion_cycles,
 };
 /// Instrument-liveness counters (#7604): copying minors completed, objects
 /// relocated, loop back-edge polls reached. Mode-independent — they count what

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1404,8 +1404,33 @@ pub(super) fn gc_old_reclaim_growth_band_bytes(baseline: usize) -> usize {
 
 #[inline]
 pub(super) fn old_reclaim_pressure_due(old_in_use: usize, baseline: usize) -> bool {
-    (old_in_use >= gc_old_gen_reclaim_threshold_dyn_bytes()
-        && baseline < gc_old_gen_reclaim_threshold_dyn_bytes())
+    let threshold = gc_old_gen_reclaim_threshold_dyn_bytes();
+    // #7937: the absolute first-crossing arm is exempted while the heap is
+    // measurably RETAINING, for the reason #7592 already exempted the
+    // proportional arm two functions down — and it is the arm that actually
+    // fires.
+    //
+    // `baseline` is credited by every promotion
+    // (`credit_promoted_bytes_to_old_baseline`), so `old_in_use >= T &&
+    // baseline < T` is a race between two quantities that move in the same
+    // direction at different granularities. Whether it fires therefore depends
+    // on the SIZE OF THE PROMOTION STEPS, not on any property of the heap.
+    // Measured on `retain.ts` (#7937, `gc-handoff/CYCLE0-NOTES.md`): same
+    // program, same live set, same total promotion — changing the schedule from
+    // (18.7 MB, 34.6 MB) to (17.7 MB, 17.8 MB) makes it fire twice and buys two
+    // full mark-sweeps costing 588 ms against a 55 ms GC budget, at
+    // `old_in_use=52.3 MB, baseline=35.5 MB, T=48 MB` with the proportional arm
+    // correctly declining (`band=128 MB`) and `retaining=true`.
+    //
+    // That is the futile-full shape #7592 removed one trigger over: a heap
+    // whose young generation is not dying is retaining live data, and a full
+    // mark-sweep cannot lower the number being watched. The proportional arm
+    // still bounds the exposure, so this defers reclamation, it does not remove
+    // it — the same trade the RETAINING multiplier already makes.
+    let crossed_absolute_threshold = old_in_use >= threshold
+        && baseline < threshold
+        && !GC_MAJOR_PACING_RETAINING.with(|c| c.get());
+    crossed_absolute_threshold
         || old_in_use.saturating_sub(baseline) >= gc_old_reclaim_growth_band_bytes(baseline)
 }
 

--- a/crates/perry-runtime/src/gc/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/promote_in_place.rs
@@ -171,6 +171,10 @@ thread_local! {
     /// Old-gen occupancy when the last real measurement landed — the base the
     /// untraced budget's relative half is taken against.
     static OLD_GEN_AT_LAST_MEASUREMENT: Cell<usize> = const { Cell::new(0) };
+    /// #7937 live-subject counters for the first-cycle attempt and its
+    /// rollback.
+    static FIRST_CYCLE_PROMOTION_ATTEMPTS: Cell<u64> = const { Cell::new(0) };
+    static FIRST_CYCLE_PROMOTION_ROLLBACKS: Cell<u64> = const { Cell::new(0) };
 }
 
 /// Record that `bytes` of young capacity became old-gen, so the next
@@ -213,8 +217,46 @@ pub(super) fn parse_promote_in_place(raw: Option<&str>) -> bool {
     }
 }
 
-/// Should this copying minor promote the young generation whole, in place?
-pub(super) fn should_promote_young_in_place() -> bool {
+/// Young-survival ratio, in permille, at or above which the FIRST copying
+/// minor of a thread keeps the promotion it attempted (#7937).
+///
+/// # Why this is not [`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`]
+///
+/// 950 bounds a PREDICTION: the steady-state policy commits to a promotion
+/// from the previous cycle's ratio, and a workload that flips costs one
+/// nursery of retained garbage before the re-measurement turns it off. It has
+/// to be conservative because it can be wrong repeatedly.
+///
+/// Cycle 0 is not predicting. It attempts the promotion, TRACES (its trace is
+/// a mark pass over the very blocks it would keep), and then reads the ratio it
+/// just measured — so the number here answers a different question: *given* the
+/// measured ratio, is keeping this nursery cheaper than evacuating it? Keeping
+/// costs `(1 − ratio) × young bytes` of old-gen garbage ONCE, bounded by the
+/// scavenge nursery cap, and charged to [`PROMOTED_DEAD_BUDGET_BYTES`] like
+/// every other promotion. At 500‰ over a 16 MB cap that is ≤ 8 MB — a quarter
+/// of that budget — against a copy of every surviving object.
+///
+/// # The measured population it separates
+///
+/// Cycle-0 young survival over `gc-handoff/bench` + `gc-handoff/apps`
+/// (`gc-handoff/c0/cycles.py`, 2026-08-12, `origin/main` @ `8260a9e50`):
+///
+/// | ‰ | programs |
+/// |--:|---|
+/// | 0–3 | `churn`, `churn_alloc`, `push_cls`, `push_num`, `cycles`, `pipeline`, `tree`, `tree_wide` |
+/// | 25 | `shapes` |
+/// | **770** | **`asyncpipe`** |
+/// | 992–1000 | `retain`, `retain1`, `retain_wide`, `retain_wide1`, `deeplist` |
+///
+/// The band between 25 and 770 is empty and 500 is its midpoint. `asyncpipe`
+/// is the reason the steady-state 950 is the wrong number here and was
+/// measured, not assumed: promoting its one cycle is −12% instructions retired
+/// and −17% peak RSS, while rolling it back would make it pay a 172 415-object
+/// mark pass for nothing.
+pub(super) const FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE: u64 = 500;
+
+/// The guards every in-place promotion shares, whatever supplies the ratio.
+fn in_place_promotion_admissible() -> bool {
     // In test builds the path is opt-in per thread. The unit suite drives
     // `gc_collect_minor` directly and asserts object IDENTITY across it
     // ("the survivor is at a new address"), so a policy keyed on the whole
@@ -236,9 +278,71 @@ pub(super) fn should_promote_young_in_place() -> bool {
     if gc_force_evacuate_enabled() {
         return false;
     }
-    if PROMOTED_DEAD_BYTES.with(Cell::get) >= PROMOTED_DEAD_BUDGET_BYTES {
+    PROMOTED_DEAD_BYTES.with(Cell::get) < PROMOTED_DEAD_BUDGET_BYTES
+}
+
+/// May the FIRST copying minor of this thread *attempt* a promotion? (#7937)
+///
+/// The steady-state policy declines here by construction — it reads the
+/// previous cycle's ratio and there is no previous cycle — and cycle 0 is the
+/// largest single GC pause on the fully-live workloads precisely because of
+/// that (58–81% of all GC pause on the `retain*` cluster).
+///
+/// This answers only "may it try". The decision itself is taken AFTER the
+/// trace, from this cycle's own measurement, by
+/// [`first_cycle_promotion_holds_up`] — see `gc::copying` for the rollback and
+/// the proof that it restores the pre-cycle state exactly.
+pub(super) fn should_attempt_first_cycle_promotion() -> bool {
+    if LAST_YOUNG_SURVIVAL_PERMILLE.with(Cell::get).is_some() {
         return false;
     }
+    in_place_promotion_admissible()
+}
+
+/// Did the attempt's own trace agree with it?
+///
+/// `young_bytes` is the from-space size the cycle started with, `live_bytes`
+/// what the trace marked. Below the threshold the caller rolls the promotion
+/// back and re-runs the cycle as an ordinary evacuation.
+pub(super) fn first_cycle_promotion_holds_up(young_bytes: usize, live_bytes: usize) -> bool {
+    if young_bytes == 0 {
+        return false;
+    }
+    let permille = (live_bytes as u64)
+        .saturating_mul(1000)
+        .checked_div(young_bytes as u64)
+        .unwrap_or(0);
+    permille >= FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE
+}
+
+/// Count a first-cycle attempt and how it resolved. These are the live-subject
+/// counters: a corpus that never attempted the path proves nothing about it,
+/// and one that attempted and never rolled back proves nothing about the
+/// rollback — which is the half that can corrupt the heap.
+pub(super) fn note_first_cycle_promotion(rolled_back: bool) {
+    FIRST_CYCLE_PROMOTION_ATTEMPTS.with(|c| c.set(c.get().saturating_add(1)));
+    if rolled_back {
+        FIRST_CYCLE_PROMOTION_ROLLBACKS.with(|c| c.set(c.get().saturating_add(1)));
+    }
+}
+
+pub fn first_cycle_promotion_attempts() -> u64 {
+    FIRST_CYCLE_PROMOTION_ATTEMPTS.with(Cell::get)
+}
+
+pub fn first_cycle_promotion_rollbacks() -> u64 {
+    FIRST_CYCLE_PROMOTION_ROLLBACKS.with(Cell::get)
+}
+
+/// Should this copying minor promote the young generation whole, in place?
+pub(super) fn should_promote_young_in_place() -> bool {
+    if !in_place_promotion_admissible() {
+        return false;
+    }
+    // `None` — no copying minor has run on this thread — deliberately does NOT
+    // promote here. That case is `should_attempt_first_cycle_promotion`, which
+    // decides from its own trace rather than from a measurement it does not
+    // have.
     LAST_YOUNG_SURVIVAL_PERMILLE
         .with(Cell::get)
         .is_some_and(|permille| permille >= PROMOTE_SURVIVAL_THRESHOLD_PERMILLE)

--- a/crates/perry-runtime/src/gc/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/promote_in_place.rs
@@ -239,20 +239,25 @@ pub(super) fn parse_promote_in_place(raw: Option<&str>) -> bool {
 /// # The measured population it separates
 ///
 /// Cycle-0 young survival over `gc-handoff/bench` + `gc-handoff/apps`
-/// (`gc-handoff/c0/cycles.py`, 2026-08-12, `origin/main` @ `8260a9e50`):
+/// (`gc-handoff/c0/cycles.py`, 2026-08-12, `origin/main` @ `d78efca41`):
 ///
 /// | ‰ | programs |
 /// |--:|---|
-/// | 0–3 | `churn`, `churn_alloc`, `push_cls`, `push_num`, `cycles`, `pipeline`, `tree`, `tree_wide` |
-/// | 25 | `shapes` |
-/// | **770** | **`asyncpipe`** |
+/// | 0–1 | `tree`, `tree_wide`, `cycles`, `push_num`, `pipeline`, `churn`, `churn_alloc`, `push_cls` |
+/// | 23–25 | `interp`, `iso_miss`, `shapes`, `asyncpipe` |
 /// | 992–1000 | `retain`, `retain1`, `retain_wide`, `retain_wide1`, `deeplist` |
 ///
-/// The band between 25 and 770 is empty and 500 is its midpoint. `asyncpipe`
-/// is the reason the steady-state 950 is the wrong number here and was
-/// measured, not assumed: promoting its one cycle is −12% instructions retired
-/// and −17% peak RSS, while rolling it back would make it pay a 172 415-object
-/// mark pass for nothing.
+/// 500 sits in the empty band, which on this reading runs 25 → 992 and would
+/// admit the steady-state 950 too.
+///
+/// ★ It is set below 950 anyway, and the reason is a MEASURED moving target
+/// rather than a preference: three days earlier `asyncpipe`'s cycle 0 measured
+/// **770‰** over 172 415 objects, i.e. squarely between the modes, and at 950
+/// it would have paid a 172 415-object mark pass and then rolled back. #7959
+/// changed its shape (25‰ over 6 686 objects) and the outlier vanished. A
+/// cycle-0 threshold that only works while the corpus happens to be bimodal is
+/// fitted to a coincidence; this one is justified by its exposure instead —
+/// see above.
 pub(super) const FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE: u64 = 500;
 
 /// The guards every in-place promotion shares, whatever supplies the ratio.

--- a/crates/perry-runtime/src/gc/sticky_remembered.rs
+++ b/crates/perry-runtime/src/gc/sticky_remembered.rs
@@ -1,0 +1,61 @@
+//! The copied minor's sticky remembered-set buffer.
+//!
+//! A copying minor clears the remembered set and rebuilds it from what the
+//! cycle observed. Entries discovered during the scan are buffered here rather
+//! than written straight through, because the write would be undone by the
+//! clear; `restore` replays them after it.
+//!
+//! Split out of `gc::copying` for the 2000-line file cap; it is a
+//! self-contained buffer with no cycle state.
+
+use super::barrier::{mark_dirty_external_slot_page, mark_dirty_old_page};
+use super::GcHeader;
+
+#[derive(Default)]
+pub(super) struct StickyRememberedSet {
+    pub(super) old_pages: crate::fast_hash::PtrHashSet<usize>,
+    pub(super) external_pages: Vec<(usize, usize)>,
+}
+
+impl StickyRememberedSet {
+    pub(super) fn remember_slot(
+        &mut self,
+        parent_header: *mut GcHeader,
+        slot: *mut u64,
+        external: bool,
+    ) {
+        if parent_header.is_null() || slot.is_null() {
+            return;
+        }
+        let page = crate::arena::generation_page_for_addr(slot as usize);
+        if external {
+            // #7538: an owner's external buffer can contribute thousands of
+            // slots (a lazy JSON array's sparse element cache is one 8-byte
+            // slot per element), and they are visited in address order — so
+            // one adjacent-duplicate check collapses a whole page's worth of
+            // pushes into a single entry. `restore` dedupes again inside
+            // `mark_dirty_external_slot_page`; this keeps the intermediate
+            // Vec from growing with the element count.
+            let entry = (parent_header as usize, page);
+            if self.external_pages.last() != Some(&entry) {
+                self.external_pages.push(entry);
+            }
+        } else {
+            self.old_pages.insert(page);
+        }
+    }
+
+    pub(super) fn restore(&self) {
+        for &page in &self.old_pages {
+            mark_dirty_old_page(page);
+        }
+        for &(header, page) in &self.external_pages {
+            mark_dirty_external_slot_page(header, page);
+        }
+    }
+
+    pub(super) fn extend(&mut self, other: StickyRememberedSet) {
+        self.old_pages.extend(other.old_pages);
+        self.external_pages.extend(other.external_pages);
+    }
+}

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -261,6 +261,13 @@ pub(super) struct CopyingNurseryTraceStats {
     /// dead, `tree_wide` 61 sparse and 60 fully dead.
     pub(super) in_place_dead_blocks: usize,
     pub(super) in_place_dead_block_bytes: usize,
+    /// #7937: this cycle ATTEMPTED the first-cycle promotion, and whether its
+    /// own trace refuted it. The live-subject pair for that path — a corpus row
+    /// with neither set never entered it, and the rollback half is otherwise
+    /// invisible because the cycle that gets reported is the one it rolled back
+    /// TO.
+    pub(super) first_cycle_promotion_attempted: bool,
+    pub(super) first_cycle_promotion_rolled_back: bool,
     /// Young-survival ratio (permille) this cycle measured — the input the
     /// NEXT cycle's promotion decision is taken from.
     pub(super) young_survival_permille: u64,
@@ -1081,6 +1088,8 @@ impl GcCycleTrace {
             "in_place_sparse_blocks": self.copying_nursery.in_place_sparse_blocks,
             "in_place_dead_blocks": self.copying_nursery.in_place_dead_blocks,
             "in_place_dead_block_bytes": self.copying_nursery.in_place_dead_block_bytes,
+            "first_cycle_promotion_attempted": self.copying_nursery.first_cycle_promotion_attempted,
+            "first_cycle_promotion_rolled_back": self.copying_nursery.first_cycle_promotion_rolled_back,
             "young_survival_permille": self.copying_nursery.young_survival_permille,
             "remembering_skipped": self.copying_nursery.remembering_skipped,
         });

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -252,6 +252,15 @@ pub(super) struct CopyingNurseryTraceStats {
     /// promotion is the wrong answer for. Non-zero here means the policy
     /// threshold is admitting cycles it should not.
     pub(super) in_place_sparse_blocks: usize,
+    /// #7937: promoted blocks with ZERO live objects, and their bytes. The
+    /// blocks a promotion kept for nothing — no live object needed their
+    /// addresses held still, so the ordinary from-space reset would have
+    /// recycled them. Distinct from `in_place_sparse_blocks` (under 50% live)
+    /// and the distinction is load-bearing: measured on a speculatively
+    /// promoting cycle 0, `churn` reads 17 sparse of 18 blocks but 15 FULLY
+    /// dead, `tree_wide` 61 sparse and 60 fully dead.
+    pub(super) in_place_dead_blocks: usize,
+    pub(super) in_place_dead_block_bytes: usize,
     /// Young-survival ratio (permille) this cycle measured — the input the
     /// NEXT cycle's promotion decision is taken from.
     pub(super) young_survival_permille: u64,
@@ -1070,6 +1079,8 @@ impl GcCycleTrace {
             "in_place_promoted_blocks": self.copying_nursery.in_place_promoted_blocks,
             "in_place_dead_bytes": self.copying_nursery.in_place_dead_bytes,
             "in_place_sparse_blocks": self.copying_nursery.in_place_sparse_blocks,
+            "in_place_dead_blocks": self.copying_nursery.in_place_dead_blocks,
+            "in_place_dead_block_bytes": self.copying_nursery.in_place_dead_block_bytes,
             "young_survival_permille": self.copying_nursery.young_survival_permille,
             "remembering_skipped": self.copying_nursery.remembering_skipped,
         });

--- a/crates/perry-runtime/src/gc/tests/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/tests/promote_in_place.rs
@@ -574,19 +574,20 @@ fn the_first_cycle_attempt_shares_every_guard_the_steady_state_policy_has() {
 fn first_cycle_threshold_separates_the_measured_cycle0_population() {
     // Cycle-0 young survival measured over gc-handoff/bench + gc-handoff/apps
     // (gc-handoff/c0/cycles.py, 2026-08-12). This is the claim
-    // FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE rests on, and the band between the
-    // two groups is empty — 25 to 770 — so the constant is not a tuning dial
-    // any more than the steady-state one is.
+    // FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE rests on.
     let young = 16 * 1024 * 1024usize;
     // churn, churn_alloc, push_cls, push_num, cycles, pipeline, tree,
-    // tree_wide, shapes.
-    for permille in [0u64, 1, 2, 3, 25] {
+    // tree_wide (0-1), then interp, iso_miss, shapes, asyncpipe (23-25).
+    for permille in [0u64, 1, 23, 25] {
         assert!(
             !first_cycle_promotion_holds_up(young, young * permille as usize / 1000),
             "{permille} permille at cycle 0 must roll back and evacuate"
         );
     }
-    // asyncpipe (770), then retain/retain1/retain_wide/retain_wide1/deeplist.
+    // 770 is what `asyncpipe` measured before #7959 changed its shape — a
+    // reading squarely BETWEEN the modes, which is why this threshold is set
+    // from its exposure rather than from the gap the corpus happens to have
+    // today. Then retain/retain1/retain_wide/retain_wide1/deeplist.
     for permille in [770u64, 992, 1000] {
         assert!(
             first_cycle_promotion_holds_up(young, young * permille as usize / 1000),

--- a/crates/perry-runtime/src/gc/tests/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/tests/promote_in_place.rs
@@ -664,12 +664,12 @@ fn a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates() {
             "the relocated survivor must be a live object"
         );
     }
-    // The retag is not only a relabel: it REGISTERS old-gen page metadata for
-    // every page of every young block (`register_old_block_pages`). Rolling
-    // back has to unregister them, or the whole young generation is left
-    // carrying old-gen page entries — a lie the dirty scan and the defrag page
-    // selector both read, and +4–10% peak RSS across the corpus when it was
-    // missing.
+    // The retag is not only a relabel: an `Old` retag normally MINTS one
+    // old-gen page-metadata entry per 4 KB of every block it touches, and a
+    // `HashMap` never gives that capacity back — so an attempt that may be
+    // undone must not mint them in the first place (measured: +1 MB `churn`,
+    // +3 MB `tree`, +6 MB `tree_wide` of peak RSS when it did). Registering
+    // eagerly here turns this red.
     assert_eq!(
         crate::arena::old_page_summary().pages,
         old_pages_before,

--- a/crates/perry-runtime/src/gc/tests/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/tests/promote_in_place.rs
@@ -617,6 +617,7 @@ fn a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates() {
 
     let attempts_before = first_cycle_promotion_attempts();
     let rollbacks_before = first_cycle_promotion_rollbacks();
+    let old_pages_before = crate::arena::old_page_summary().pages;
 
     // One live leaf in a nursery sized for many: survival is far under the
     // threshold, so the attempt's own trace refutes it.
@@ -663,6 +664,17 @@ fn a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates() {
             "the relocated survivor must be a live object"
         );
     }
+    // The retag is not only a relabel: it REGISTERS old-gen page metadata for
+    // every page of every young block (`register_old_block_pages`). Rolling
+    // back has to unregister them, or the whole young generation is left
+    // carrying old-gen page entries — a lie the dirty scan and the defrag page
+    // selector both read, and +4–10% peak RSS across the corpus when it was
+    // missing.
+    assert_eq!(
+        crate::arena::old_page_summary().pages,
+        old_pages_before,
+        "a rolled-back attempt must leave no old-gen page metadata behind"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/gc/tests/promote_in_place.rs
+++ b/crates/perry-runtime/src/gc/tests/promote_in_place.rs
@@ -13,12 +13,13 @@
 //!    swept-live-object crash one cycle later.
 
 use super::super::promote_in_place::{
-    clear_young_survival_for_tests, note_untraced_promotion, parse_promote_in_place,
-    promoted_dead_bytes_since_full, seed_promoted_dead_bytes_for_tests,
+    clear_young_survival_for_tests, first_cycle_promotion_holds_up, note_untraced_promotion,
+    parse_promote_in_place, promoted_dead_bytes_since_full, seed_promoted_dead_bytes_for_tests,
     seed_untraced_promoted_bytes_for_tests, seed_young_survival_for_tests,
-    untraced_promotion_budget_with, InPlacePromotionTestGuard, PROMOTED_DEAD_BUDGET_BYTES,
-    PROMOTE_SURVIVAL_THRESHOLD_PERMILLE, UNTRACED_PROMOTION_CEILING_BYTES,
-    UNTRACED_PROMOTION_FLOOR_BYTES, UNTRACED_PROMOTION_SURVIVAL_PERMILLE,
+    should_attempt_first_cycle_promotion, untraced_promotion_budget_with,
+    InPlacePromotionTestGuard, PROMOTED_DEAD_BUDGET_BYTES, PROMOTE_SURVIVAL_THRESHOLD_PERMILLE,
+    UNTRACED_PROMOTION_CEILING_BYTES, UNTRACED_PROMOTION_FLOOR_BYTES,
+    UNTRACED_PROMOTION_SURVIVAL_PERMILLE,
 };
 use super::super::*;
 use super::support::*;
@@ -526,6 +527,142 @@ fn a_low_survival_cycle_still_evacuates_and_moves_the_object() {
         "the ordinary copying path must still relocate"
     );
     assert!(crate::arena::pointer_in_nursery(after));
+}
+
+// ---------------------------------------------------------------------------
+// #7937: the FIRST copying minor decides from its own trace
+// ---------------------------------------------------------------------------
+
+#[test]
+fn only_an_unmeasured_thread_may_attempt_the_first_cycle_promotion() {
+    let _guard = InPlacePromotionTestGuard::enabled(1000);
+    clear_young_survival_for_tests();
+    assert!(
+        should_attempt_first_cycle_promotion(),
+        "no copying minor has run, so there is nothing for the steady-state \
+         policy to read and the attempt is the only way to find out"
+    );
+    // Once ANY measurement exists the steady-state policy owns the decision —
+    // including a measurement of "almost nothing survived", which is a
+    // genuinely different state from `None`.
+    for measured in [0u64, 500, 1000] {
+        seed_young_survival_for_tests(measured);
+        assert!(
+            !should_attempt_first_cycle_promotion(),
+            "{measured} permille is a measurement; the first-cycle attempt must \
+             not re-run on a thread that already has one"
+        );
+    }
+}
+
+#[test]
+fn the_first_cycle_attempt_shares_every_guard_the_steady_state_policy_has() {
+    // The dead-byte budget is the one that can differ between the two — it is
+    // read by both, and a first-cycle attempt that ignored it would park a
+    // nursery of garbage the budget exists to bound.
+    let _guard = InPlacePromotionTestGuard::enabled(1000);
+    clear_young_survival_for_tests();
+    assert!(should_attempt_first_cycle_promotion());
+    seed_promoted_dead_bytes_for_tests(PROMOTED_DEAD_BUDGET_BYTES);
+    assert!(
+        !should_attempt_first_cycle_promotion(),
+        "the running dead-byte budget must bound the first cycle too"
+    );
+}
+
+#[test]
+fn first_cycle_threshold_separates_the_measured_cycle0_population() {
+    // Cycle-0 young survival measured over gc-handoff/bench + gc-handoff/apps
+    // (gc-handoff/c0/cycles.py, 2026-08-12). This is the claim
+    // FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE rests on, and the band between the
+    // two groups is empty — 25 to 770 — so the constant is not a tuning dial
+    // any more than the steady-state one is.
+    let young = 16 * 1024 * 1024usize;
+    // churn, churn_alloc, push_cls, push_num, cycles, pipeline, tree,
+    // tree_wide, shapes.
+    for permille in [0u64, 1, 2, 3, 25] {
+        assert!(
+            !first_cycle_promotion_holds_up(young, young * permille as usize / 1000),
+            "{permille} permille at cycle 0 must roll back and evacuate"
+        );
+    }
+    // asyncpipe (770), then retain/retain1/retain_wide/retain_wide1/deeplist.
+    for permille in [770u64, 992, 1000] {
+        assert!(
+            first_cycle_promotion_holds_up(young, young * permille as usize / 1000),
+            "{permille} permille at cycle 0 must keep the promotion"
+        );
+    }
+    // An empty young generation is not a fully-live one: 0/0 must not read as
+    // 1000 permille and keep a promotion of nothing.
+    assert!(!first_cycle_promotion_holds_up(0, 0));
+}
+
+/// The rollback is the half that can corrupt the heap, so it is driven end to
+/// end rather than asserted about: an unmeasured thread whose nursery is mostly
+/// garbage must ATTEMPT the promotion, read its own trace, undo the retag, and
+/// come out the far side having EVACUATED — object relocated, still live, still
+/// in the nursery.
+///
+/// A rollback that forgot to undo the retag would leave the survivor at its old
+/// address in old-gen, so `assert_ne!` on the address is the teeth; a rollback
+/// that forgot `clear_marks` would leave the second attempt's trace unable to
+/// mark anything, so `copied_objects` would read 0.
+#[test]
+fn a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates() {
+    let _guard = CopyingNurseryTestGuard::new(4);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let _promote = InPlacePromotionTestGuard::enabled(1000);
+    clear_young_survival_for_tests();
+
+    let attempts_before = first_cycle_promotion_attempts();
+    let rollbacks_before = first_cycle_promotion_rollbacks();
+
+    // One live leaf in a nursery sized for many: survival is far under the
+    // threshold, so the attempt's own trace refutes it.
+    let child = young_leaf();
+    for _ in 0..64 {
+        let _garbage = young_leaf();
+    }
+    js_shadow_slot_set(0, ptr_bits(child));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_eq!(
+        first_cycle_promotion_attempts() - attempts_before,
+        1,
+        "the first cycle must have ATTEMPTED the promotion — a test that never \
+         entered the path proves nothing about it"
+    );
+    assert_eq!(
+        first_cycle_promotion_rollbacks() - rollbacks_before,
+        1,
+        "and its own trace must have refuted it"
+    );
+    assert!(
+        !trace.copying_nursery.in_place_promotion,
+        "the cycle that actually ran is the rolled-back-to evacuation"
+    );
+    assert!(
+        trace.copying_nursery.copied_objects >= 1,
+        "the second attempt must have marked and copied the survivor; zero here \
+         means the rollback left stale marks behind"
+    );
+
+    let after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_ne!(after, child, "a rolled-back cycle still evacuates");
+    assert!(
+        crate::arena::pointer_in_nursery(after),
+        "undoing the retag must put the block back in the young generation — a \
+         survivor in old-gen here means the rollback did not run"
+    );
+    unsafe {
+        assert_ne!(
+            (*header_from_user_ptr(after as *const u8)).size,
+            0,
+            "the relocated survivor must be a live object"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -288,6 +288,63 @@ fn test_old_reclaim_band_is_proportional_and_promotion_credits_baseline() {
     GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|b| b.set(prev));
 }
 
+/// #7937: the ABSOLUTE first-crossing arm is granularity-sensitive, and the
+/// RETAINING latch is what stops that from costing a futile full.
+///
+/// `baseline` is credited by every promotion, so `old_in_use >= T && baseline
+/// < T` is a race between two quantities moving in the same direction at
+/// different step sizes — whether it fires depends on the promotion SCHEDULE,
+/// not on the heap. The numbers below are the ones measured on `retain.ts`
+/// when the first copying minor started promoting in place: `old_in_use =
+/// 52.3 MB`, `baseline = 35.5 MB`, `T = 48 MB`, proportional arm correctly
+/// declining, and it bought two full mark-sweeps costing 588 ms.
+///
+/// Both states are asserted: with the young generation dying the arm still
+/// fires (it is the only thing that makes the first full happen at all), and
+/// with the young generation provably retaining it does not.
+#[test]
+fn the_absolute_old_reclaim_arm_stands_down_on_a_retaining_heap() {
+    let _guard = GcTestIsolationGuard::new();
+    let threshold = gc_old_gen_reclaim_threshold_dyn_bytes();
+    // The measured `retain` state, re-derived against whatever the threshold
+    // resolves to on this host so the test cannot drift away from it.
+    let old_in_use = threshold + threshold / 12;
+    let baseline = threshold - threshold / 4;
+    assert!(
+        old_in_use.saturating_sub(baseline) < gc_old_reclaim_growth_band_bytes(baseline),
+        "the proportional arm must be declining, or this test is not about the \
+         absolute one"
+    );
+
+    // Young generation dying: the arm is the only thing that can schedule the
+    // first full, so it must still fire.
+    note_copying_minor_young_survival(0);
+    assert!(!major_pacing_retaining());
+    assert!(
+        old_reclaim_pressure_due(old_in_use, baseline),
+        "on a heap whose young generation is dying the absolute crossing must \
+         still schedule a full"
+    );
+
+    // Young generation retaining: a full mark-sweep cannot lower the number
+    // being watched, so firing here is the #7592 futile-full shape.
+    note_copying_minor_young_survival(1000);
+    assert!(major_pacing_retaining());
+    assert!(
+        !old_reclaim_pressure_due(old_in_use, baseline),
+        "a retaining heap's old-gen growth is credited live data; the absolute \
+         crossing must defer to the proportional arm"
+    );
+
+    // Deferred, not removed: the proportional arm still bounds the exposure.
+    let far_past = baseline + gc_old_reclaim_growth_band_bytes(baseline);
+    assert!(
+        old_reclaim_pressure_due(far_past, baseline),
+        "the proportional arm must still fire while retaining, or old-gen \
+         growth would be unbounded"
+    );
+}
+
 /// #7592: a handoff full must not repeat without the copying minor it exists to
 /// enable.
 ///


### PR DESCRIPTION
Closes #7937.

## What cycle 0 can and cannot know

The issue asks whether the first copying minor can decide in-place promotion
*from its own trace*, mid-cycle, rather than from a prior cycle. **It can — but
not by inserting a decision point, because the trace it would decide from is not
a trace it can take without already having decided.**

`retag_young_for_in_place_promotion` runs *before* the trace and flips every
in-use Eden and survivor block to `HeapGeneration::Old`. After it no address
classifies as `Nursery`, so `move_young` is unreachable and the copying minor's
Cheney pass **degenerates into a mark-only pass** — which is exactly what
`finish_in_place_promotion(PromotionLiveness::Marked)` consumes. Without the
retag the same pass *is* the evacuation: survivors are copied as they are
discovered, so by the time liveness is known everything has already moved.

So the shape is: **attempt, trace, then decide — and roll back if the trace
disagrees.** Below `FIRST_CYCLE_PROMOTE_SURVIVAL_PERMILLE` (500) the attempt is
undone and the cycle re-runs as an ordinary copying minor. The rollback is cheap
in exactly the regime where it happens: a mark pass costs `O(live)`, and low
survival means there is almost nothing to mark.

## Measured — `gc-handoff/bench` + `gc-handoff/apps`, against `main` @ `d78efca41`

19/19 byte-exact against `node --experimental-strip-types` and exit 0 on both
arms, both built here. Instructions retired and peak RSS, both load-independent
— the dev box ran at load 35–97 all session, so **no wall clock is quoted;
absolute seconds belong to the quiet mini.**

| program | cycles | full | instructions | peak RSS |
|---|---|--:|--:|--:|
| `retain1` | 4 → **2** | 1 → **0** | **−77.0%** | **−28.3%** |
| `deeplist` | 4 → **2** | 1 → **0** | **−76.9%** | **−29.0%** |
| `retain_wide1` | 5 → **3** | 1 → **0** | **−66.0%** | **−5.1%** |
| `retain_wide` | 9 → **7** | 2 → **1** | **−41.4%** | **−2.8%** |
| `retain` | 8 → **5** | 2 → **1** | **−41.0%** | **−10.8%** |
| `asyncpipe` | 1 → 1 | 0 | +2.1% | +0.3% |
| `shapes` | 1 → 1 | 0 | +1.5% | +0.8% |
| `churn` `churn_alloc` `push_cls` `push_num` `cycles` `tree` `tree_wide` `interp` `iso_miss` `pipeline` `churn_read` `fib40` | unchanged | 0 | ±0.1% | ±0.5% |

**No program gains a cycle or a full collection**, and five lose one or two of
each. The only two regressions are the wasted mark of a rolled-back attempt over
6 536 and 6 686 live objects — the price of the measurement, paid once.

### ★★★ Read that table with a caveat: `main` regressed under me, and this partly undoes it

I started from `8260a9e50`, where the `retain` cluster ran **zero** full
collections. On `d78efca41` it does not:

| program | `8260a9e50` | `d78efca41` |
|---|--:|--:|
| `retain` | 5 cycles, **0 fulls**, 2 840 M instr, 250 MB | 8 cycles, **2 fulls**, 12 421 M, 347 MB |
| `retain1` | 3, 0, 1 396 M | 4, **1**, 3 724 M |
| `retain_wide` | 8, 0, 3 310 M | 9, **2**, 8 790 M |
| `retain_wide1` | 4, 0, 1 207 M | 5, **1**, 2 423 M |
| `deeplist` | 3, 0, 1 172 M | 4, **1**, 3 910 M |

Same corpus, both bases built here, and both fulls on `retain` are
`old_gen_bytes`. **That is a live 2.2–4.8× regression on `main` that is not
mine**, and it looks like the same granularity-sensitive arm this PR fixes —
the likely inputs are in `8260a9e50..d78efca41`, most plausibly #7901
(changes what the survival ratio is computed from) and #7902 (bounds the
untraced-promotion budget, so promotion happens in more, smaller steps). Filed
for whoever owns those.

So the honest reading is: against the earlier base this change is worth
**−14% to −31%** instructions; against today's `main` it is worth −41% to −77%
because it also suppresses one of the two futile fulls `main` has acquired. The
first number is the one to quote for the mechanism.

## Two premises in the issue are stale on `main` — worth knowing

* **`asyncpipe` no longer runs zero cycles.** It runs exactly one. The
  acceptance criterion "still at zero collections" cannot be met because it is
  already false on `main`; the criterion actually checked here is "does not gain
  cycles", and it holds. ★ Its cycle 0 also **moved under me mid-session**: at
  `8260a9e50` it evacuated 172 415 objects at 770‰ survival, and at `d78efca41`
  it evacuates 6 686 at 25‰. So it flipped from the biggest single beneficiary
  of this change to a rolled-back attempt costing +2.1%. That is why the
  threshold is justified by its exposure rather than by the gap in the corpus.
* **`tree`/`tree_wide` DO run a copying minor** (RETAIN4 recorded 0), so they
  are exposed to any cycle-0 policy change. Both are unchanged here.

## The blind version was measured and it fails two ways — do not re-derive

Behind a temporary knob (never merged), promoting cycle 0 unconditionally:

* **`retain` +142% instructions and two full mark-sweeps** (175 ms + 414 ms).
  Excluding the fulls its GC pause is *unchanged*, so the whole regression is
  the fulls.
* **+52% to +102% peak RSS** on the eleven programs with a dying nursery
  (`tree_wide` 67.8 → 137.1 MB), and `tree_wide` gains a full.

Also worth recording: the issue's *"the copy buys nothing but the survival
ratio"* is true but the copy is not what cycle 0 costs. A promoting cycle 0
still **traces** (`should_promote_young_untraced` needs a *measured* ≥990‰),
and on `retain` that mark pass is 15.2 ms of the evacuating cycle's 25.9 ms.
Removing the copy removes about a third of cycle 0, not the 58% of total GC.

## Why a pacing change is in the same PR

It is a **precondition**, not a rider: without it a *correct* first-cycle
promotion still buys `retain` two futile fulls.

`old_reclaim_pressure_due`'s absolute arm is `old_in_use >= T && baseline < T`,
and `baseline` is credited by every promotion — so it is a race between two
quantities moving in the same direction at different step sizes. **Whether it
fires depends on the size of the promotion steps, not on any property of the
heap.** Instrumented on `retain`: same program, same live set, same total
promotion, and changing the schedule from (18.7 MB, 34.6 MB) to
(17.7 MB, 17.8 MB) makes it fire twice —
`old_in_use=52.3 MB baseline=35.5 MB T=48 MB first=true second=false retaining=true`
— with the proportional arm correctly declining at `band=128 MB`. On baseline
`main` the predicate never returns true at all on this corpus.

That is the futile-full shape #7592 removed one arm over. #7592 exempted the
*proportional* arm via `GC_MAJOR_PACING_RETAINING` and left the absolute one
un-exempted; the absolute one is what fires. It now stands down while that latch
is armed, with the proportional arm still bounding growth — deferred
reclamation, not removed, the same trade the existing multiplier makes.

★ **This overlaps the pacing workstream (#7929/#7903/#7926) and should get that
reviewer's eye.** It is a measured no-op on the whole 19-program corpus today
(the arm never fires without the promotion change), and both of its states are
asserted by `the_absolute_old_reclaim_arm_stands_down_on_a_retaining_heap`.

## Correctness

* Corpus 19/19 byte-exact + exit 0, and again under
  `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`,
  `PERRY_GC_VERIFY_EVACUATION=1`, `PERRY_GC_SCHEDULE_RATE=1`, and the
  `PERRY_GC_PROMOTE_IN_PLACE=0` kill switch.
* `iso_miss` canary: `checksum 437840 misses 0`.
* `cargo test -p perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2218 passed,
  0 failed**.
* `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/gc_runtime_root_holders.py`: green. (`addr_class_inventory.py`
  reports one hit in `object/tests.rs:646`, which is **pre-existing** and not
  touched by this branch.)

### Live subject, both halves

* The **commit** half: `in_place_promotion=true` on cycle 0 with
  `in_place_promoted_objects` in the hundreds of thousands for the six promoting
  programs.
* The **rollback** half is otherwise invisible — the cycle that gets reported is
  the one it rolled back *to* — so it is reported per cycle as
  `first_cycle_promotion_attempted` / `first_cycle_promotion_rolled_back`, and
  asserted end to end by
  `a_first_cycle_attempt_that_its_own_trace_refutes_rolls_back_and_evacuates`.
  That test is **sabotage-verified twice**: deleting the retag undo fails it with
  `copied_objects: 0`, and minting the old-gen page metadata eagerly fails it
  with `old_pages: left 256, right 0`.
* ★ Under `PERRY_GC_PROTECT_FROMSPACE`, `retain` now prints **zero**
  `[gc-fromspace-protect]` lines — it no longer retires a from-space at all, so
  that arm is vacuous *on retain*. The instrument was re-checked where it still
  has a subject: `churn` 86 lines, `tree` 40, `cycles` 12.
  `PERRY_GC_VERIFY_EVACUATION` and `PERRY_GC_FORCE_EVACUATE` veto in-place
  promotion by design, so those arms are evidence about the rest of the
  collector, not about this path.

## A retracted claim, recorded because it cost a build

A retag to `Old` also **mints one zeroed `OldPageMeta` per 4 KB** of every block
it touches, so the first shipped attempt cost +4–10% peak RSS on the rolled-back
half of the corpus. My first fix — `unregister_old_block_pages` in the undo —
**changed the RSS by exactly zero**, and I had already written the changelog
claiming it as the cause. The entries really were removed (the unit test proves
256 → 0); removing them simply does not give the footprint back, because a
`HashMap` never returns its capacity. The fix is not to remove them but not to
mint them (`retag_block_space_deferring_old_page_registration`), which is sound
exactly for a retag that may be undone because such an attempt requires
`skip_remembering`.

## Not closed

* **Sparse blocks that are not fully dead.** New telemetry
  `in_place_dead_blocks` shows that on a speculatively promoting cycle 0 `churn`
  has 15 of 18 blocks *fully* dead against 17 "sparse", `tree_wide` 60 of 61.
  Recycling a fully-dead block instead of promoting it is a real per-block
  "decide from your own trace" lever, and it is blocked on the copied-minor
  dead-owner pruning being `Nursery`-classified — worth its own issue.
* **`asyncpipe` collects at ~330 ns/object** when it collects, ~4× `retain`'s
  rate. Pre-existing and unrelated (RETAIN4 flagged it too).

Full working notes, every arm and every number: `gc-handoff/CYCLE0-NOTES.md`.
