### PR TITLE
fix(gc): denominate the nursery constant band in objects (#7929)

### DIFF
--- a/changelog.d/7961-gc-object-denominated-nursery-band.md
+++ b/changelog.d/7961-gc-object-denominated-nursery-band.md
@@ -1,0 +1,52 @@
+**GC: the nursery constant band is denominated in objects, not bytes (#7929).**
+
+The scavenge nursery trigger compared from-space *bytes* against a constant
+16 MB band while the copying minor's cost is per *object*, so shrinking a
+representation silently bought the collector more work per cycle: #7928 took a
+two-field object literal 72 B → 56 B and every minor then moved **1.286×
+(= 72/56)** as many objects for the same bytes, costing `deeplist` +10.5% and
+`retain1` +8.8%. The band is now scaled by the mean size of the objects the last
+copying minor actually moved, so it buys a constant object budget. The mean comes
+from the census the collector already produces — nothing is added to the
+allocation fast path, and the arena still needs no nursery object counter.
+
+Only the constant band is re-denominated. The two `tenuring.rs` ratios
+(`desired_survivor_bytes` = cap/16, `retune_nursery_cap_scale`'s cap/25 and
+cap/100 bands) and the tenured-proportional arm of the cap are
+representation-invariant by cancellation — `tenured_bytes / 2` is
+`tenured_objects / 2` objects — so scaling them too would double-count.
+
+The scaling is **one-sided** (clamped at 1.0): a mean above the 72 B calibration
+reference keeps today's band. That neutralises an array-dominated mean —
+`push_num` measures 3600 B because it survives arrays, the documented blocker on
+the issue — and leaves every program at or above the reference bit-identical,
+because *raising* a cap is the direction that pushes a program across
+`GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES` or into a #7909 budgeted stall.
+
+Measured on the shipped 19-program corpus against `origin/main`, all 19
+byte-exact vs `node --experimental-strip-types` 26.5.1 and exit 0 (also under
+`PERRY_GC_PROTECT_FROMSPACE=1` + `PERRY_GC_VERIFY_EVACUATION=1`), instructions
+retired: `deeplist` −72.3% / RSS −27.2%, `retain` −62.9% / RSS −26.4%, `retain1`
+−11.3% / RSS −6.5%, `churn` family −1.0%. The five programs whose factor is
+exactly 1.000 form a built-in control set; their −0.3%…−3.5% spread is this A/B's
+link-layout noise floor, and `interp` (+0.2%) and `iso_miss` (+0.4%) sit inside
+it. `retain1` is the clean cell — identical cycle kinds in both arms, −11.8%
+object work for −11.3% instructions, against the +12.0% #7928 cost it.
+
+The blocker recorded on the issue — "an object term fires the collector earlier
+and every extra cycle pays a fixed root scan" — is refuted by measurement: an
+extra copying minor costs **~0.5 M instructions** (consistent with #7915's 218 455
+pointer roots) while an object moved costs **~1050**, so an extra cycle pays for
+itself if it avoids ≥ ~500 object-moves. On the taxed programs the trade is
+~500:1 in favour, and on `cycles` and `pipeline` more cycles is outright cheaper.
+
+New coverage: a pure-function test that the band buys a representation-invariant
+*object budget* (with its own inline sabotage arm, so it declares itself
+meaningless rather than passing quietly if the un-denominated band ever stops
+differing), one-sided-clamp endpoints named after the failures they prevent, a
+carry-forward test for cycles that moved nothing, and an end-to-end test driving
+a real copying minor whose discriminating assertion is that the recorded mean
+equals *that cycle's* measured mean and differs from the seed — a "mean is
+nonzero" check would be satisfied by the seed itself. Both sabotage arms (delete
+the `copying.rs` call site; delete the factor from the band) were run and fail
+the intended tests.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1856,6 +1856,21 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     // re-baseline sees post-collection live allocation rather than high-water.
     note_copying_minor_young_survival(collector.stats.young_survival_permille);
     maybe_schedule_old_reclaim_after_copied_minor();
+    // #7929: the object denomination of the nursery constant band, fed BEFORE
+    // the tenuring loop so every number `retune_after_scavenge` derives from
+    // the effective cap (desired survivor occupancy, the cap-scale band) reads
+    // one consistent factor. Both tenuring ratios are representation-invariant
+    // by cancellation, so this only re-denominates the constant band itself.
+    super::tenuring::note_surviving_object_census(
+        collector
+            .stats
+            .copied_bytes
+            .saturating_add(collector.stats.promoted_bytes),
+        collector
+            .stats
+            .copied_objects
+            .saturating_add(collector.stats.promoted_objects),
+    );
     retune_after_scavenge(
         collector.stats.eden_live_bytes,
         collector.stats.copied_bytes,

--- a/crates/perry-runtime/src/gc/tenuring.rs
+++ b/crates/perry-runtime/src/gc/tenuring.rs
@@ -222,9 +222,16 @@ pub(super) fn scavenge_nursery_cap_effective_bytes() -> usize {
 pub(super) fn influx_driven_nursery_cap_bytes() -> usize {
     let constant_band =
         gc_scavenge_nursery_cap_bytes().saturating_mul(NURSERY_CAP_SCALE.with(Cell::get) as usize);
-    constant_band.saturating_mul(nursery_cap_object_scale_permille(
-        mean_surviving_object_bytes(),
-    )) / 1000
+    // The multiply is done in u64 deliberately. `usize::saturating_mul` on an
+    // ILP32 target (watchOS/visionOS are 32-bit) would saturate a 64 MB band
+    // against a 1000-per-mille factor at `u32::MAX` and the following divide
+    // would then hand back ~4 MB — a silent 16x cap collapse on exactly the
+    // devices with the least headroom. A 64-bit intermediate cannot overflow:
+    // the band is bounded by 4 GB and the factor by 1000.
+    let scaled = constant_band as u64
+        * nursery_cap_object_scale_permille(mean_surviving_object_bytes()) as u64
+        / 1000;
+    scaled.min(usize::MAX as u64) as usize
 }
 
 /// #7929: the mean size of the objects the last copying minor actually moved,

--- a/crates/perry-runtime/src/gc/tenuring.rs
+++ b/crates/perry-runtime/src/gc/tenuring.rs
@@ -166,6 +166,11 @@ thread_local! {
     static NURSERY_CAP_SCALE: Cell<u8> = const { Cell::new(1) };
     static CAP_GROW_STREAK: Cell<u8> = const { Cell::new(0) };
     static CAP_SHRINK_STREAK: Cell<u8> = const { Cell::new(0) };
+    /// #7929: mean size of the objects the last copying minor moved. Seeded at
+    /// the calibration reference so a process with no completed copying minor
+    /// paces exactly as it did before the object denomination existed.
+    static MEAN_SURVIVING_OBJECT_BYTES: Cell<usize> =
+        const { Cell::new(NURSERY_CAP_REFERENCE_OBJECT_BYTES) };
 }
 
 /// The survivals threshold the next copying minor should promote at:
@@ -211,10 +216,100 @@ pub(super) fn scavenge_nursery_cap_effective_bytes() -> usize {
 }
 
 /// The influx-driven half of the cap on its own: the configured base times
-/// the debounced `NURSERY_CAP_SCALE`. Named so the composition below reads as
-/// the two-term policy it is.
-fn influx_driven_nursery_cap_bytes() -> usize {
-    gc_scavenge_nursery_cap_bytes().saturating_mul(NURSERY_CAP_SCALE.with(Cell::get) as usize)
+/// the debounced `NURSERY_CAP_SCALE`, **re-denominated in objects** by
+/// [`nursery_cap_object_scale_permille`]. Named so the composition below reads
+/// as the two-term policy it is.
+pub(super) fn influx_driven_nursery_cap_bytes() -> usize {
+    let constant_band =
+        gc_scavenge_nursery_cap_bytes().saturating_mul(NURSERY_CAP_SCALE.with(Cell::get) as usize);
+    constant_band.saturating_mul(nursery_cap_object_scale_permille(
+        mean_surviving_object_bytes(),
+    )) / 1000
+}
+
+/// #7929: the mean size of the objects the last copying minor actually moved,
+/// in bytes — `(copied + promoted) bytes / (copied + promoted) objects`.
+///
+/// Seeded at [`NURSERY_CAP_REFERENCE_OBJECT_BYTES`] so a process that has never
+/// completed a copying minor paces bit-identically to the pre-#7929 collector.
+pub(super) fn mean_surviving_object_bytes() -> usize {
+    MEAN_SURVIVING_OBJECT_BYTES.with(Cell::get)
+}
+
+/// Mean surviving object size the 16 MB constant band was calibrated against.
+///
+/// #7056 (the cap) and #7377/#7592 (its scale ladder) were measured on a heap
+/// whose two-field object literal was **72 bytes**; #7928 right-sized that to
+/// 56. The constant is the *calibration anchor*, not a claim about any current
+/// representation — moving it re-tunes the cap for every program at once.
+pub(super) const NURSERY_CAP_REFERENCE_OBJECT_BYTES: usize = 72;
+/// Floor for the object-denomination factor (per mille). At the corpus's
+/// smallest measured mean (32.8 B on `tree_wide`) the unclamped factor is 456;
+/// the floor bounds how far a shrinking representation may pull the cap down,
+/// so the collection *count* cannot run away on a workload whose survivors are
+/// atypically small.
+const NURSERY_CAP_OBJECT_SCALE_MIN_PERMILLE: usize = 500;
+
+/// #7929: how much of the byte-denominated constant band this representation
+/// should get, in per mille, so the band buys a **constant number of objects**.
+///
+/// The collector's trigger is denominated in bytes and its per-cycle cost is
+/// per object, so a fixed byte band silently buys more collector work as
+/// objects shrink: #7928 took a two-field object 72 B → 56 B and every minor
+/// then moved 1.286× (= 72/56) as many objects for the same bytes, costing
+/// `deeplist` +10.5% and `retain1` +8.8% wall. Scaling the band by
+/// `mean / reference` restores `band / mean` — the object budget — to what the
+/// band was calibrated to buy.
+///
+/// **Deliberately one-sided.** The factor is clamped at 1000, so a
+/// representation *larger* than the reference gets the unchanged band rather
+/// than a proportionally larger one. Two reasons, both measured:
+///
+/// * The byte-weighted mean is not a representative object size on a workload
+///   whose survivors are dominated by large allocations — `push_num`'s mean is
+///   **3600 B** because it survives arrays, not objects (the documented blocker
+///   on #7929). One-sided clamping turns that from a ×50 cap explosion into
+///   exactly today's behaviour.
+/// * The corpus response to the cap is threshold-dominated (which cycle *kinds*
+///   fire), so *raising* a cap is the risky direction: it is how a program
+///   crosses `GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES` or lands in a #7909 budgeted
+///   stall. Every program at or above the reference — `retain_wide`,
+///   `retain_wide1`, `push_num`, `shapes` — is left bit-identical.
+pub(super) fn nursery_cap_object_scale_permille(mean_surviving_object_bytes: usize) -> usize {
+    if mean_surviving_object_bytes == 0 {
+        return 1000;
+    }
+    (mean_surviving_object_bytes * 1000 / NURSERY_CAP_REFERENCE_OBJECT_BYTES)
+        .clamp(NURSERY_CAP_OBJECT_SCALE_MIN_PERMILLE, 1000)
+}
+
+/// Feed one finished copying minor's move census into the object denomination.
+///
+/// Called from the copying minor immediately before [`retune_after_scavenge`],
+/// so everything that end-of-cycle computes is policy for the *next* cycle and
+/// sees one consistent factor. A cycle that moved nothing carries the previous
+/// estimate forward rather than resetting it — `tree`/`cycles` move single
+/// digits of objects per minor and a zero denominator there is a missing
+/// measurement, not a measurement of zero.
+pub(super) fn note_surviving_object_census(moved_bytes: usize, moved_objects: usize) {
+    if moved_objects == 0 {
+        return;
+    }
+    let mean = moved_bytes / moved_objects;
+    if mean == 0 {
+        return;
+    }
+    let previous = MEAN_SURVIVING_OBJECT_BYTES.replace(mean);
+    if previous != mean && std::env::var_os("PERRY_GC_DIAG").is_some() {
+        eprintln!(
+            "[gc-tenuring] nursery cap object denomination: mean_surviving_object_bytes {} -> {} \
+             (scale {} permille, band {} B)",
+            previous,
+            mean,
+            nursery_cap_object_scale_permille(mean),
+            influx_driven_nursery_cap_bytes()
+        );
+    }
 }
 
 /// The cap policy as a **pure function of its two inputs**, so it is testable
@@ -478,6 +573,7 @@ pub(super) fn reset_for_test() {
     NURSERY_CAP_SCALE.with(|s| s.set(1));
     CAP_GROW_STREAK.with(|s| s.set(0));
     CAP_SHRINK_STREAK.with(|s| s.set(0));
+    MEAN_SURVIVING_OBJECT_BYTES.with(|s| s.set(NURSERY_CAP_REFERENCE_OBJECT_BYTES));
 }
 
 #[cfg(test)]
@@ -485,6 +581,117 @@ mod tests {
     use super::*;
 
     const MB: usize = 1024 * 1024;
+
+    /// #7929: the constant band must buy a CONSTANT NUMBER OF OBJECTS.
+    ///
+    /// The discriminating quantity is deliberately `band / mean` (the object
+    /// budget), not "the band changed". A test that only asserted the band
+    /// moved would pass under any scaling at all — including one that made the
+    /// mismatch worse. Only a band proportional to the mean holds this ratio
+    /// fixed, and the final assertion shows the *un*-denominated band does not:
+    /// without the term this test cannot pass.
+    #[test]
+    fn constant_band_buys_a_constant_object_count() {
+        reset_for_test();
+        let base = gc_scavenge_nursery_cap_bytes();
+        let band_of = |mean: usize| base * nursery_cap_object_scale_permille(mean) / 1000;
+
+        // The two representations #7928 moved between.
+        let reference = NURSERY_CAP_REFERENCE_OBJECT_BYTES; // 72 B
+        let shrunk = 56; // #7928's two-field literal
+        let objects_at_reference = band_of(reference) / reference;
+        let objects_at_shrunk = band_of(shrunk) / shrunk;
+        let drift = objects_at_reference.abs_diff(objects_at_shrunk) * 1000 / objects_at_reference;
+        assert!(
+            drift <= 5,
+            "object budget must be representation-invariant: {objects_at_reference} objects at \
+             {reference} B vs {objects_at_shrunk} at {shrunk} B ({drift} permille drift)"
+        );
+
+        // The band this replaces does NOT hold the ratio: 72 -> 56 is exactly
+        // the 1.286x the issue measured. This is the sabotage arm inline — it
+        // is what the assertion above is distinguishing itself from.
+        let undenominated = base / shrunk * 1000 / (base / reference);
+        assert!(
+            undenominated >= 1250,
+            "a byte-denominated band must inflate the object budget by ~72/56; measured \
+             {undenominated} permille — if this is 1000 the two arms are the same and the \
+             assertion above proves nothing"
+        );
+        reset_for_test();
+    }
+
+    /// The clamp is one-sided, and each endpoint is a named failure it exists
+    /// to prevent.
+    #[test]
+    fn object_scale_clamps_are_one_sided() {
+        // No measurement yet: exactly today's band.
+        assert_eq!(nursery_cap_object_scale_permille(0), 1000);
+        // The calibration anchor is a no-op by construction.
+        assert_eq!(
+            nursery_cap_object_scale_permille(NURSERY_CAP_REFERENCE_OBJECT_BYTES),
+            1000
+        );
+        // Shrunk representations scale proportionally.
+        assert_eq!(nursery_cap_object_scale_permille(56), 777);
+        assert_eq!(nursery_cap_object_scale_permille(54), 750);
+        // Larger-than-reference is NOT scaled up: retain_wide (104 B) keeps
+        // the band it has today...
+        assert_eq!(nursery_cap_object_scale_permille(104), 1000);
+        // ...and push_num's 3600 B array-dominated mean — the documented
+        // #7929 blocker — cannot explode the cap ~50x.
+        assert_eq!(nursery_cap_object_scale_permille(3600), 1000);
+        // The floor bounds how far a small-survivor workload pulls the band
+        // down (tree_wide measures 32.8 B; unclamped that is 456 permille).
+        assert_eq!(nursery_cap_object_scale_permille(32), 500);
+        assert_eq!(nursery_cap_object_scale_permille(8), 500);
+    }
+
+    /// The census is the only writer, and a cycle that moved nothing must not
+    /// be read as "mean size zero" — `tree`/`cycles` move single digits of
+    /// objects per minor and skip cycles entirely.
+    #[test]
+    fn census_carries_forward_across_a_cycle_that_moved_nothing() {
+        reset_for_test();
+        let base = gc_scavenge_nursery_cap_bytes();
+        assert_eq!(
+            influx_driven_nursery_cap_bytes(),
+            base,
+            "unmeasured process must pace exactly as the pre-#7929 collector did"
+        );
+
+        note_surviving_object_census(56 * 1000, 1000);
+        let after_measurement = influx_driven_nursery_cap_bytes();
+        assert_eq!(after_measurement, base * 777 / 1000);
+
+        note_surviving_object_census(0, 0);
+        note_surviving_object_census(4096, 0);
+        assert_eq!(
+            influx_driven_nursery_cap_bytes(),
+            after_measurement,
+            "a cycle with no moved objects is a missing measurement, not a zero one"
+        );
+        reset_for_test();
+        assert_eq!(influx_driven_nursery_cap_bytes(), base);
+    }
+
+    /// The tenured-proportional term is representation-invariant by
+    /// cancellation (`tenured_bytes / 2` is `tenured_objects / 2` objects), so
+    /// the object denomination must apply to the constant band ONLY. If it
+    /// leaked into `scavenge_nursery_cap_from` the proportional arm would be
+    /// scaled twice.
+    #[test]
+    fn only_the_constant_band_is_re_denominated() {
+        reset_for_test();
+        note_surviving_object_census(56 * 1000, 1000);
+        let tenured = 512 * MB;
+        assert_eq!(
+            scavenge_nursery_cap_from(influx_driven_nursery_cap_bytes(), tenured),
+            tenured / TENURED_EDEN_DIVISOR,
+            "the proportional arm must reach the max() unscaled"
+        );
+        reset_for_test();
+    }
 
     #[test]
     fn target_formula_matches_projected_occupancy() {

--- a/crates/perry-runtime/src/gc/tests/copying/adaptive_tenuring.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/adaptive_tenuring.rs
@@ -62,6 +62,70 @@ fn heavy_influx_lowers_threshold_and_promotes_next_cycle() {
     }
 }
 
+/// #7929: a real copying minor must feed its move census into the nursery
+/// band's object denomination.
+///
+/// The pure-function coverage lives in `gc::tenuring::tests`; that coverage
+/// passes with the `copying.rs` call site deleted, which is exactly the "the
+/// gate runs but its subject never did" shape. This test drives a real cycle.
+///
+/// ★ The discriminating quantity is **the recorded mean equals THIS cycle's
+/// measured mean, and differs from the seed**. Asserting only that the mean is
+/// nonzero would be satisfied by the seed itself, so an unwired build would
+/// pass it — a presence check, not a proof.
+#[test]
+fn copying_minor_feeds_the_object_denomination_census() {
+    let _guard = CopyingNurseryTestGuard::new(SLOTS);
+    let base = crate::gc::tenuring::influx_driven_nursery_cap_bytes();
+    let seed = crate::gc::tenuring::mean_surviving_object_bytes();
+    assert_eq!(
+        seed,
+        crate::gc::tenuring::NURSERY_CAP_REFERENCE_OBJECT_BYTES,
+        "an unmeasured process must pace as the pre-#7929 collector did"
+    );
+
+    // Two-field object literals: the representation #7928 took 72 B -> 56 B,
+    // i.e. the one whose object budget this term exists to hold constant.
+    for slot in 0..SLOTS {
+        let obj = crate::object::js_object_alloc(0, 2);
+        crate::object::js_object_set_field(obj, 0, crate::value::JSValue::number(slot as f64));
+        crate::object::js_object_set_field(obj, 1, crate::value::JSValue::number(-1.0));
+        js_shadow_slot_set(slot, ptr_bits(obj as usize));
+    }
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    let moved_objects =
+        trace.copying_nursery.copied_objects + trace.copying_nursery.promoted_objects;
+    let moved_bytes = trace.copying_nursery.copied_bytes + trace.copying_nursery.promoted_bytes;
+    assert!(
+        moved_objects >= SLOTS as usize,
+        "the cycle must actually have moved the cohort: {moved_objects} objects"
+    );
+
+    let recorded = crate::gc::tenuring::mean_surviving_object_bytes();
+    assert_eq!(
+        recorded,
+        moved_bytes / moved_objects,
+        "the census must carry THIS cycle's measured mean ({moved_bytes} B over \
+         {moved_objects} objects)"
+    );
+    assert_ne!(
+        recorded, seed,
+        "fixture is vacuous: a measured mean equal to the seed cannot distinguish a wired \
+         build from an unwired one"
+    );
+    assert!(
+        recorded < crate::gc::tenuring::NURSERY_CAP_REFERENCE_OBJECT_BYTES,
+        "fixture must exercise the SCALING arm, not the one-sided clamp (mean {recorded} B)"
+    );
+
+    // And the band moved with it, proportionally.
+    assert_eq!(
+        crate::gc::tenuring::influx_driven_nursery_cap_bytes(),
+        base * crate::gc::tenuring::nursery_cap_object_scale_permille(recorded) / 1000
+    );
+}
+
 #[test]
 fn quiet_cycles_restore_power_on_threshold_debounced() {
     let _guard = CopyingNurseryTestGuard::new(SLOTS);


### PR DESCRIPTION
Closes #7929.

## The mismatch

The scavenge nursery trigger compares from-space **bytes** against a constant
16 MB band (`young_scavenge_cap_due`), while the copying minor's cost is per
**object**. Shrinking a representation therefore silently buys the collector more
work per cycle. #7928 took a two-field object literal 72 B → 56 B and every minor
then moved **1.286× (= 72/56)** as many objects for the same bytes, costing
`deeplist` +10.5% and `retain1` +8.8% wall on the quiet mini.

This scales the constant band by the mean size of the objects the last copying
minor actually moved, so the band buys a constant **object** budget.

## Why this is a single comparison

Of the four byte-denominated valves, the two `tenuring.rs` ratios are
representation-invariant by cancellation — `desired_survivor_bytes` is `cap/16`
and `retune_nursery_cap_scale` compares eden against `cap/25`, both of which scale
with the object size on *both* sides. The tenured-proportional arm of the cap is
invariant for the same reason: `tenured_bytes / 2` is `tenured_objects / 2`
objects. Only the constant band converts a fixed byte budget into a variable
object count, so only the constant band is re-denominated here.

## The measurement that unblocked it

#7929's recorded blocker was that an object term fires the collector earlier and
every extra cycle pays a fixed root scan. Both sides are now priced, on the shipped
corpus, by sweeping the existing `PERRY_GC_SCAVENGE_NURSERY_MB` dial (instructions
retired; the dev box ran at load 77–92, so no wall clock is quoted):

* **Marginal cost per object moved: ~1050 instructions.** Three `deeplist` cells
  with an identical cycle-kind profile (2 minors, 0 fulls) — 805 137 objects at
  1203 M, 954 929 at 1366 M, 1 254 513 at 1669 M — give slopes of 1088 and 1011
  instr/object.
* **Fixed cost per extra copying minor: ~0.5 M instructions.** `churn` at caps
  8/16/32 MB runs 172/86/43 minors for 3205.7/3093.3/3078.0 M instructions;
  netting out the object term leaves ~0.49 M per cycle. That is consistent with
  #7915's own number (218 455 pointer roots at ~2 instructions each).

So an extra minor pays for itself if it avoids ≥ ~500 object-moves, and on the
taxed programs the trade is ~500:1 in favour. On `cycles` and `pipeline` more
cycles is outright *cheaper* (1763.6 M at 23 minors vs 1837.6 M at 6).

## One-sided by design

The factor is clamped at 1.0, so a representation *larger* than the reference gets
today's band rather than a proportionally larger one. Two measured reasons:

* The byte-weighted mean is not a representative object size when survivors are
  dominated by large allocations — `push_num`'s mean is **3600 B** because it
  survives arrays. That was the documented blocker on #7929; one-sided clamping
  turns a ×50 cap explosion into exactly today's behaviour.
* Raising a cap is the dangerous direction: it is how a program crosses
  `GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES` (48 MB) or lands in a #7909 budgeted stall.

Every program at or above the reference is left bit-identical, which is also what
makes the A/B below self-calibrating.

## A/B — per program, both arms, cycle kinds included

`origin/main` @ `ac52a5c38` vs this branch, same target dir, same `-p` set,
`PERRY_RUNTIME_DIR` pinned, `.a` mtimes verified to have moved. All 19 programs
**byte-identical to the base arm and to `node --experimental-strip-types` 26.5.1,
exit 0**.

| program | minors b→f | fulls b→f | objects moved | instructions | peak RSS |
|---|---|---|--:|--:|--:|
| **deeplist** | 3→3 | **1→0** | −11.8% | **−72.3%** | **−27.2%** |
| **retain** | 6→5 | **2→1** | −24.5% | **−62.9%** | **−26.4%** |
| **retain1** | 3→3 | 1→1 | −11.8% | **−11.3%** | **−6.5%** |
| churn / churn_alloc / push_cls | 86→88 | 0→0 | −7.2% | −0.9…−1.1% | ±0.3% |
| cycles | 12→22 | 0→0 | 0 | −0.8% | +0.1% |
| pipeline | 6→7 | 0→0 | +1.6% | −0.9% | −0.3% |
| tree | 40→40 | 0→0 | 0 | −0.2% | −0.1% |
| tree_wide | 40→40 | 0→0 | 0 | −0.1% | 0.0% |
| shapes | 1→1 | 0→0 | 0 | −3.2% | 0.0% |
| asyncpipe | 1→1 | 0→0 | 0 | −2.5% | +0.3% |
| interp | 31→44 | 0→0 | +3.7% | +0.2% | +0.1% |
| iso_miss | 43→61 | 0→0 | +7.4% | +0.4% | −0.1% |
| *push_num* | 18→18 | 0→0 | 0 | −2.1% | +0.2% |
| *retain_wide* | 7→7 | 2→2 | 0 | −0.3% | 0.0% |
| *retain_wide1* | 4→4 | 1→1 | 0 | −0.8% | −0.1% |
| *churn_read* | 0→0 | 0→0 | 0 | −3.5% | −0.9% |
| *fib40* | 0→0 | 0→0 | 0 | −0.3% | +1.4% |

*Italic rows are the control set*: their factor is exactly 1.000 (clamped, or no
copying minor ever ran), so their policy is bit-identical and their spread —
**−0.3% to −3.5%** — is this A/B's link-layout noise floor, not an effect.
`interp` +0.2% and `iso_miss` +0.4% sit inside it; the three large deltas do not.
`retain1` is the clean cell: identical cycle kinds in both arms, −11.8% object
work for −11.3% instructions, against the +12.0% instructions #7928 cost it.

`deeplist`'s and `retain`'s larger wins are a threshold crossing on top of the
object effect: both were running an `old_gen_bytes`-triggered `full` whose
`sweep.freed_bytes` is **0** — a futile mark-sweep over a heap that is live by
construction — and the smaller band keeps old-gen under the 48 MB one-shot arm of
`old_reclaim_pressure_due`. Isolating that (interpolating `deeplist`'s 3-minor
cells) leaves the object-denomination effect alone at **−10.5%**, which is exactly
the +10.5% regression #7928 caused on that program.

## Gate

Four tests. The two pure-function tests still pass with the `copying.rs` call site
deleted — the #7024 shape — so the wiring is covered separately by a band-level
test and by `copying_minor_feeds_the_object_denomination_census`, which drives a
real copying minor.

★ The discriminating quantity in that test is **"the recorded mean equals THIS
cycle's measured mean AND differs from the seed"**. A "the mean is nonzero"
assertion is satisfied by the seed itself, so an unwired build would pass it — a
presence check, not a proof. The test also refuses to run vacuously: it asserts
the fixture's mean is strictly below the reference, so a future representation
change that made the fixture 72 B fails the test rather than silently exercising
the clamp instead of the scaling arm.

Both sabotage arms were **run**, not argued:

| sabotage | result |
|---|---|
| delete the `note_surviving_object_census` call in `copying.rs` | end-to-end test FAILS (`the census must carry THIS cycle's measured mean (19040 B over 340 objects)`) |
| delete the factor from `influx_driven_nursery_cap_bytes` | band-level test **and** end-to-end test FAIL |

`constant_band_buys_a_constant_object_count` additionally carries an inline
sabotage arm: it asserts the *un*-denominated band inflates the object budget by
≥1250 permille, so if that ever reads 1000 the test declares its own main
assertion meaningless instead of passing quietly.

## Validation

* Corpus **19/19 byte-exact vs node 26.5.1, exit 0**, in the ordinary run and
  again under `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800
  PERRY_GC_VERIFY_EVACUATION=1`.
* `iso_miss` canary: `checksum 437840 misses 0`.
* `cargo test --release -p perry-runtime`: **2216 passed, 0 failed**.
* `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/check_gc_doc_claims.py` (17 facts re-derived),
  `scripts/gc_runtime_root_holders.py`: all clean.
* No new env knob (CLAUDE.md GC knob kill-policy). Diagnosis rides the existing
  `PERRY_GC_DIAG` path. Nothing is added to the allocation fast path — the mean
  comes from the census the collector already produces.

Full working: `gc-handoff/BUDGET-NOTES.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nursery capacity now adapts to the average size of objects moved during garbage collection.
  * Capacity adjustments preserve existing tenuring behavior while improving consistency of object budgets.
  * Added diagnostics for measured object sizes and adaptive capacity scaling.

* **Bug Fixes**
  * Empty collection cycles now retain the previous valid measurement.

* **Tests**
  * Added coverage for scaling limits, measurement carry-forward, proportional capacity behavior, and end-to-end updates.

* **Documentation**
  * Added changelog details, safety rationale, and benchmark results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->