### PR TITLE
fix(runtime): root JS values retained in Rust containers across allocations (#7949)

### DIFF
--- a/changelog.d/7962-root-container-values.md
+++ b/changelog.d/7962-root-container-values.md
@@ -1,0 +1,52 @@
+**Fixed: JS values retained in ordinary Rust containers across allocating calls (#7949).**
+
+`Object.groupBy` / `Map.groupBy` / `Object.defineProperties` — and, found by the
+same sweep, the Proxy own-key builders — accumulated raw NaN-boxed JS values
+into plain `Vec`s and then kept filling or walking them across calls that can
+allocate: a user callback, a `[[Get]]` accessor, a key coercion, a result-array
+build. A `Vec` on the Rust heap is neither a shadow slot nor a temp root nor
+reachable from any registered scanner, so an evacuating collection could
+neither keep those objects alive nor rewrite their addresses.
+`scripts/gc_root_dominance_check.py` cannot see this class at all — it reads
+emitted LLVM IR, and the container is Rust-side.
+
+Root causes, per site:
+
+- `object/groupby.rs` — `group_by_collect` returned `Vec<(f64, f64)>` filled
+  across `js_closure_call2`. Three further holes in the same family: the
+  materialized input array and the closure were hoisted out of the loop and
+  re-dereferenced across the callback; `Object.groupBy`'s result object had **no
+  root at all** (it is reachable from nothing else until it is returned) while
+  spanning one array build and one key-string intern per group; and
+  `group_by_make_array` returned a fresh array across
+  `rebuild_array_layout_from_slots`. Symbol keys were also coalesced through a
+  `HashMap` keyed on the symbol's *address*, so a symbol that moved mid-loop
+  started a duplicate group — now keyed on `SymbolHeader::id`, which an
+  evacuation copies verbatim (the #7246 argument).
+- `object/object_ops/define_properties.rs` — `keys: Vec<f64>` was walked across
+  `js_string_coerce`, a user getter on the properties bag
+  (`js_dynamic_object_get_property`) and `js_object_define_property`, with the
+  receiver, the bag, the own-names array and the coerced key string all bare
+  locals in the same window.
+- `proxy/own_keys.rs` — `alloc_key_array` grew the result array between key
+  pushes, and `proxy_enum_own_keys` held the trap's key list across the proxy's
+  `getOwnPropertyDescriptor` trap.
+
+New `gc::RootedValues` (`gc/roots/rooted_values.rs`) is the reusable answer: a
+growable list whose elements are `RuntimeHandle`s, so the registered
+runtime-handle mutable-root scanner marks them and rewrites their slots. It
+adds no root holder of its own and no `get_raw_*_ptr` sites.
+
+Proof, not absence of a crash. `gc/tests/rooted_container_values.rs` runs every
+assertion under a forced copying minor and gates on `copied_objects > 0`, on the
+element addresses having *changed*, and on the post-collection pointer still
+reading the original bytes; `plain_vec_of_values_is_not_a_root` is the sabotage
+arm that shows the instrument distinguishes rooted from unrooted. Reverting only
+`object/groupby.rs` to `main` makes the two end-to-end tests abort with
+`TypeError: value is not a function`. The two new gap probes
+(`test_gap_gc_container_value_rooting.ts`,
+`test_gap_gc_define_properties_key_rooting.ts`) each exit 138 with a
+`[gc-fromspace-protect] FAULT` on a pristine `main` build under
+`PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_PROTECT_FROMSPACE=1
+PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, and are byte-exact against node 26.5.1
+with the fix.

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::any::Any;
 
+mod rooted_values;
 mod runtime_handles;
 mod scan_mode;
 mod scanner_shims;
@@ -11,6 +12,7 @@ pub(super) use stack_maps::initialize as initialize_stack_maps;
 pub(super) use stack_maps::native_maps_active as native_stack_maps_active;
 pub(super) use stack_maps::record_native_stack_walk_source;
 
+pub use rooted_values::RootedValues;
 pub(super) use runtime_handles::{
     new_runtime_handle_root_scan_state, scan_runtime_handle_roots_mut,
     scan_runtime_handle_roots_mut_step,

--- a/crates/perry-runtime/src/gc/roots/rooted_values.rs
+++ b/crates/perry-runtime/src/gc/roots/rooted_values.rs
@@ -1,0 +1,116 @@
+//! `RootedValues` — a growable list of NaN-boxed JS values that the collector
+//! can actually see.
+//!
+//! # The bug class this exists to close (#7949, third shape of #6949)
+//!
+//! A runtime helper that accumulates JS values into a plain `Vec<f64>` and then
+//! keeps filling it across calls that can allocate has written a GC root the
+//! collector does not know about:
+//!
+//! ```ignore
+//! let mut out: Vec<(f64, f64)> = Vec::with_capacity(length);
+//! for i in 0..length {
+//!     let item = js_array_get_f64(raw, i as u32);
+//!     let key = js_closure_call2(cb, item, i as f64); // runs user JS -> may evacuate
+//!     out.push((key, item));                          // everything already in `out` is stale
+//! }
+//! ```
+//!
+//! The `Vec` lives on the Rust heap. It is not a shadow slot, not a temp root,
+//! and not reachable from any registered scanner, so an evacuating minor can
+//! neither keep those objects alive nor rewrite the addresses. Nothing faults
+//! at the collection — the nursery recycles the bytes, the stale word reads a
+//! valid *unrelated* object, and the program dies cycles later somewhere else
+//! (`TypeError: value is not a function`). `scripts/gc_root_dominance_check.py`
+//! is structurally blind to it: it reads emitted LLVM IR, and this container is
+//! Rust-side.
+//!
+//! `RootedValues` stores each element as a [`RuntimeHandle`] instead of a raw
+//! word. The handle stack is a registered *mutable* root scanner
+//! (`MutableRootScannerSource::RuntimeHandles`), so every element is marked and
+//! every element's slot is rewritten when its object moves. `get` re-reads the
+//! slot, so a caller cannot accidentally name a pre-collection address unless
+//! it deliberately stashes the returned word across a call.
+//!
+//! # What it does NOT do
+//!
+//! It is not a proof, for the same reason [`RuntimeHandle::across_mut`] is not:
+//! Rust has no effect system to mark "this call may allocate". `get` hands back
+//! a bare `f64`, and holding *that* across an allocating call is still wrong.
+//! What this type buys is that the *container* stops being the hole, so the
+//! remaining review question is local to a single expression.
+//!
+//! # Scope-nesting hazard
+//!
+//! [`RuntimeHandleScope::drop`] truncates the handle stack to the depth it was
+//! created at. So **never push to an outer `RootedValues` while an inner
+//! `RuntimeHandleScope` is alive** — the inner scope's drop would silently
+//! truncate away the handles the outer container just took, and every later
+//! `get` on them would panic (`runtime handle used after its scope was
+//! dropped`) or, worse, alias a handle a later push reused. Either give the
+//! whole helper one scope, or finish the inner scope before pushing again.
+
+use super::*;
+
+/// A `Vec<f64>` of NaN-boxed JS values that is a real GC root. See the module
+/// docs for the bug class and the scope-nesting hazard.
+pub struct RootedValues<'scope> {
+    scope: &'scope RuntimeHandleScope,
+    handles: Vec<RuntimeHandle<'scope>>,
+}
+
+impl<'scope> RootedValues<'scope> {
+    #[inline]
+    pub fn new(scope: &'scope RuntimeHandleScope) -> Self {
+        Self {
+            scope,
+            handles: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn with_capacity(scope: &'scope RuntimeHandleScope, capacity: usize) -> Self {
+        Self {
+            scope,
+            handles: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Root `value` and append it. The element is a GC root from this point
+    /// until the owning scope is dropped.
+    #[inline]
+    pub fn push(&mut self, value: f64) {
+        let handle = self.scope.root_nanbox_f64(value);
+        self.handles.push(handle);
+    }
+
+    /// Re-read element `index` **after** whatever has run since it was pushed.
+    /// This is the only supported way to get the word back out: the returned
+    /// `f64` is a copy and goes stale the moment anything else can allocate.
+    #[inline]
+    pub fn get(&self, index: usize) -> f64 {
+        self.handles[index].get_nanbox_f64()
+    }
+
+    /// Overwrite element `index`, keeping it rooted.
+    #[inline]
+    pub fn set(&self, index: usize, value: f64) {
+        self.handles[index].set_nanbox_f64(value);
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.handles.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.handles.is_empty()
+    }
+
+    /// Iterate the current values. Same caveat as [`Self::get`]: the yielded
+    /// words are copies, so do not let one span an allocating call.
+    pub fn iter(&self) -> impl Iterator<Item = f64> + '_ {
+        self.handles.iter().map(RuntimeHandle::get_nanbox_f64)
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -34,6 +34,7 @@ mod oldgen;
 mod os_tag;
 mod promote_in_place;
 mod root_words;
+mod rooted_container_values;
 mod roots;
 mod runtime_roots;
 mod scan_fallback;

--- a/crates/perry-runtime/src/gc/tests/rooted_container_values.rs
+++ b/crates/perry-runtime/src/gc/tests/rooted_container_values.rs
@@ -1,0 +1,259 @@
+//! #7949 — JS values retained in ordinary Rust containers across allocating
+//! calls.
+//!
+//! ## What these tests have to prove
+//!
+//! Not "the program didn't crash". A rooting fix is only proven by a value that
+//! **survived a collection that actually moved it**: every assertion here runs
+//! under a `CopyingNurseryTestGuard`, forces a copying minor with
+//! `collect_minor_trace`, and asserts `copied_objects > 0` before believing the
+//! survival assertions. A cycle that moved nothing would satisfy the survival
+//! assertions vacuously — that is the shape CLAUDE.md calls a presence check
+//! rather than a proof.
+//!
+//! `plain_vec_of_values_is_not_a_root` is the sabotage arm, and it is what makes
+//! the rest non-vacuous: the *same* objects, held in a bare `Vec<f64>` instead
+//! of a `RootedValues`, keep naming their pre-collection addresses. If the
+//! instrument could not tell the two apart, that test would fail.
+
+use super::super::*;
+use super::support::*;
+
+use crate::gc::{RootedValues, RuntimeHandleScope};
+
+/// Allocate a young string whose bytes identify it, so a survival assertion can
+/// check the value is still the *same object* rather than merely a plausible
+/// address.
+fn young_named_string(name: &str) -> usize {
+    crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32) as usize
+}
+
+fn string_value(name: &str) -> f64 {
+    f64::from_bits(string_bits(young_named_string(name)))
+}
+
+unsafe fn string_ptr_of(value: f64) -> *const crate::StringHeader {
+    (value.to_bits() & POINTER_MASK) as *const crate::StringHeader
+}
+
+fn register_handle_scanner() {
+    gc_register_mutable_root_scanner_with_source(
+        scan_runtime_handle_roots_mut,
+        MutableRootScannerSource::RuntimeHandles,
+    );
+}
+
+#[test]
+fn rooted_values_elements_survive_a_collection_that_moved_them() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_handle_scanner();
+
+    let scope = RuntimeHandleScope::new();
+    let mut values = RootedValues::new(&scope);
+    let mut before = Vec::new();
+    for i in 0..8 {
+        let name = format!("rooted_values_{i}");
+        let value = string_value(&name);
+        before.push((value.to_bits() & POINTER_MASK) as usize);
+        values.push(value);
+    }
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert!(
+        trace.copying_nursery.copied_objects > 0,
+        "the cycle moved nothing -- the survival assertions below would be vacuous"
+    );
+    for (i, old) in before.iter().enumerate() {
+        let value = values.get(i);
+        let new = (value.to_bits() & POINTER_MASK) as usize;
+        assert_ne!(
+            new, *old,
+            "element {i} was not relocated -- this cycle proves nothing about rooting"
+        );
+        unsafe {
+            assert_string_bytes(
+                string_ptr_of(value),
+                format!("rooted_values_{i}").as_bytes(),
+            );
+        }
+    }
+}
+
+#[test]
+fn plain_vec_of_values_is_not_a_root() {
+    // The sabotage arm for the test above: the *identical* workload with a bare
+    // `Vec<f64>` accumulator. The collector cannot see the Rust heap, so the
+    // words are left naming from-space. This is #7949 in one assertion, and it
+    // is what proves the rooted test is measuring rooting rather than an
+    // allocator that happened not to move anything.
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_handle_scanner();
+
+    // One rooted witness so the cycle has something to relocate and we can
+    // prove relocation happened at all.
+    let scope = RuntimeHandleScope::new();
+    let witness = scope.root_nanbox_f64(string_value("witness"));
+    let witness_before = (witness.get_nanbox_f64().to_bits() & POINTER_MASK) as usize;
+
+    let mut unrooted: Vec<f64> = Vec::new();
+    for i in 0..8 {
+        unrooted.push(string_value(&format!("unrooted_{i}")));
+    }
+    let before: Vec<usize> = unrooted
+        .iter()
+        .map(|v| (v.to_bits() & POINTER_MASK) as usize)
+        .collect();
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert!(trace.copying_nursery.copied_objects > 0);
+    assert_ne!(
+        (witness.get_nanbox_f64().to_bits() & POINTER_MASK) as usize,
+        witness_before,
+        "a rooted value did not move -- this cycle cannot demonstrate the unrooted hazard"
+    );
+    for (i, value) in unrooted.iter().enumerate() {
+        assert_eq!(
+            (value.to_bits() & POINTER_MASK) as usize,
+            before[i],
+            "a plain Vec<f64> element was rewritten -- if this ever passes, the \
+             collector grew a way to see the Rust heap and RootedValues can be retired"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: `Object.groupBy` / `Map.groupBy` with a collection inside the
+// user callback -- the exact window #7949 names.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static GROUP_BY_COPIED_OBJECTS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Stands in for a user callback that allocates enough to trigger a GC: it
+/// forces a copying minor on every element, which is where a `Vec<f64>` of
+/// already-collected `(key, item)` pairs goes stale.
+extern "C" fn group_by_moving_callback(
+    _closure: *const crate::closure::ClosureHeader,
+    _item: f64,
+    index: f64,
+) -> f64 {
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    GROUP_BY_COPIED_OBJECTS.with(|c| c.set(c.get() + trace.copying_nursery.copied_objects));
+    // A freshly allocated key string per call, so the key path allocates too.
+    if (index as u64) % 2 == 0 {
+        string_value("even")
+    } else {
+        string_value("odd")
+    }
+}
+
+const GROUP_BY_ELEMENTS: usize = 6;
+
+/// Build `["gb_0", ..., "gb_5"]` rooted in `scope`, plus the callback closure.
+fn group_by_inputs(scope: &RuntimeHandleScope) -> (f64, f64) {
+    let items = crate::array::js_array_alloc(GROUP_BY_ELEMENTS as u32);
+    let items_handle = scope.root_nanbox_f64(f64::from_bits(ptr_bits(items as usize)));
+    for i in 0..GROUP_BY_ELEMENTS {
+        // Allocate the element FIRST, then re-read the array out of its root:
+        // `js_string_from_bytes` can move the array, and `js_array_push` can
+        // move it again by growing it.
+        let element = crate::value::JSValue::from_bits(string_value(&format!("gb_{i}")).to_bits());
+        let arr = (items_handle.get_nanbox_f64().to_bits() & POINTER_MASK)
+            as *mut crate::array::ArrayHeader;
+        let grown = crate::array::js_array_push(arr, element);
+        items_handle.set_nanbox_f64(f64::from_bits(ptr_bits(grown as usize)));
+    }
+    let closure = crate::closure::js_closure_alloc(group_by_moving_callback as *const u8, 0);
+    let callback_handle = scope.root_nanbox_f64(f64::from_bits(ptr_bits(closure as usize)));
+    (
+        items_handle.get_nanbox_f64(),
+        callback_handle.get_nanbox_f64(),
+    )
+}
+
+unsafe fn assert_group_contents(group_value: f64, expected: &[usize]) {
+    let arr = (group_value.to_bits() & POINTER_MASK) as *const crate::array::ArrayHeader;
+    assert!(!arr.is_null(), "group is not an array");
+    assert_eq!(
+        crate::array::js_array_length(arr) as usize,
+        expected.len(),
+        "group length"
+    );
+    for (slot, original_index) in expected.iter().enumerate() {
+        let element = crate::array::js_array_get_f64(arr, slot as u32);
+        assert_string_bytes(
+            string_ptr_of(element),
+            format!("gb_{original_index}").as_bytes(),
+        );
+    }
+}
+
+#[test]
+fn object_group_by_items_survive_a_moving_minor_in_the_callback() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_handle_scanner();
+    GROUP_BY_COPIED_OBJECTS.with(|c| c.set(0));
+
+    let scope = RuntimeHandleScope::new();
+    let (items_value, callback) = group_by_inputs(&scope);
+
+    let result = crate::object::js_object_group_by(items_value, callback);
+    let result_handle = scope.root_nanbox_f64(result);
+
+    assert!(
+        GROUP_BY_COPIED_OBJECTS.with(|c| c.get()) > 0,
+        "no object was relocated during the callback -- the run proves nothing"
+    );
+    unsafe {
+        let even = crate::value::js_get_property(
+            result_handle.get_nanbox_f64(),
+            b"even".as_ptr() as i64,
+            4,
+        );
+        let odd = crate::value::js_get_property(
+            result_handle.get_nanbox_f64(),
+            b"odd".as_ptr() as i64,
+            3,
+        );
+        assert_group_contents(even, &[0, 2, 4]);
+        assert_group_contents(odd, &[1, 3, 5]);
+    }
+}
+
+#[test]
+fn map_group_by_items_survive_a_moving_minor_in_the_callback() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_handle_scanner();
+    GROUP_BY_COPIED_OBJECTS.with(|c| c.set(0));
+
+    let scope = RuntimeHandleScope::new();
+    let (items_value, callback) = group_by_inputs(&scope);
+
+    let result = crate::object::js_map_group_by(items_value, callback);
+    let result_handle = scope.root_nanbox_f64(result);
+
+    assert!(
+        GROUP_BY_COPIED_OBJECTS.with(|c| c.get()) > 0,
+        "no object was relocated during the callback -- the run proves nothing"
+    );
+    unsafe {
+        let map =
+            (result_handle.get_nanbox_f64().to_bits() & POINTER_MASK) as *mut crate::map::MapHeader;
+        assert_eq!(crate::map::js_map_size(map), 2);
+        let even = crate::map::js_map_get(map, string_value("even"));
+        let map =
+            (result_handle.get_nanbox_f64().to_bits() & POINTER_MASK) as *mut crate::map::MapHeader;
+        let odd = crate::map::js_map_get(map, string_value("odd"));
+        assert_group_contents(even, &[0, 2, 4]);
+        assert_group_contents(odd, &[1, 3, 5]);
+    }
+}

--- a/crates/perry-runtime/src/object/groupby.rs
+++ b/crates/perry-runtime/src/object/groupby.rs
@@ -1,8 +1,30 @@
 //! `Object.groupBy` / `Map.groupBy` (#2777/#2779) — split out of
 //! `object_ops.rs` to keep it under the 2000-line cap. Pure relocation;
 //! `use super::*` gives the same visibility the parent module has.
+//!
+//! ## Rooting (#7949)
+//!
+//! Every JS value this module holds between two calls that can allocate lives
+//! in a [`RootedValues`] or a [`RuntimeHandle`], never in a bare `f64` local or
+//! a `Vec<f64>`. Three separate windows made that mandatory here:
+//!
+//! * `group_by_collect` calls a **user callback** once per element. That runs
+//!   arbitrary JS, so it can evacuate — while the materialized input array, the
+//!   closure, and every already-collected `(key, item)` pair are live.
+//! * `Object.groupBy` coerces each non-Symbol key with `js_string_coerce`
+//!   (allocates for every shape except an already-heap string), builds one
+//!   result array per group, and interns one key string per group — all while
+//!   the result object and every remaining group's items are live.
+//! * `Map.groupBy` allocates a result array per group and inserts it into the
+//!   Map, while the Map, the keys, and the remaining groups are live.
+//!
+//! The Symbol coalescing key is `SymbolHeader::id`, not the symbol's address,
+//! for the same reason `#7246` interns descriptions by id: an evacuation copies
+//! the id verbatim, so a symbol that moves mid-loop still lands in its own
+//! group instead of starting a duplicate one.
 
 use super::*;
+use crate::gc::{RootedValues, RuntimeHandle, RuntimeHandleScope};
 
 /// `Object.groupBy(items, callback)` — Node 22+ static method.
 ///
@@ -18,47 +40,50 @@ use super::*;
 #[no_mangle]
 pub extern "C" fn js_object_group_by(items_value: f64, callback: f64) -> f64 {
     unsafe {
-        let pairs = group_by_collect(items_value, callback, b"Object.groupBy");
+        let scope = RuntimeHandleScope::new();
+        let (keys, items) = group_by_collect(&scope, items_value, callback, b"Object.groupBy");
 
         // Coalesce by ToPropertyKey. String keys group by string contents;
-        // Symbol keys group by Symbol identity (pointer).
+        // Symbol keys group by Symbol identity (`SymbolHeader::id`, which
+        // survives evacuation — the address does not).
         use std::collections::HashMap;
-        enum Key {
+        enum GroupKey<'scope> {
             Str(String),
-            Sym(f64),
+            Sym(RuntimeHandle<'scope>),
         }
         let mut str_index: HashMap<String, usize> = HashMap::new();
         let mut sym_index: HashMap<u64, usize> = HashMap::new();
-        let mut order: Vec<Key> = Vec::new();
-        let mut groups: Vec<Vec<f64>> = Vec::new();
+        let mut order: Vec<GroupKey<'_>> = Vec::new();
+        let mut groups: Vec<RootedValues<'_>> = Vec::new();
 
-        for (key_val, item) in pairs {
-            if group_by_value_is_symbol(key_val) {
-                let raw = crate::value::js_nanbox_get_pointer(key_val) as u64;
-                let idx = *sym_index.entry(raw).or_insert_with(|| {
-                    order.push(Key::Sym(key_val));
-                    groups.push(Vec::new());
-                    groups.len() - 1
-                });
-                groups[idx].push(item);
-            } else {
-                let key_ptr = crate::builtins::js_string_coerce(key_val);
-                let key_string = if key_ptr.is_null() {
-                    "undefined".to_string()
-                } else {
-                    let len = (*key_ptr).byte_len as usize;
-                    let data = (key_ptr as *const u8)
-                        .add(std::mem::size_of::<crate::string::StringHeader>());
-                    let bytes = std::slice::from_raw_parts(data, len);
-                    std::str::from_utf8(bytes).unwrap_or("").to_string()
+        for i in 0..keys.len() {
+            // Re-read both words on every use: `js_string_coerce` below can run
+            // a user `toString`/`valueOf`, and the handles are what survive it.
+            if let Some(symbol_id) = group_by_symbol_identity(keys.get(i)) {
+                let idx = match sym_index.get(&symbol_id) {
+                    Some(idx) => *idx,
+                    None => {
+                        let idx = groups.len();
+                        sym_index.insert(symbol_id, idx);
+                        order.push(GroupKey::Sym(scope.root_nanbox_f64(keys.get(i))));
+                        groups.push(RootedValues::new(&scope));
+                        idx
+                    }
                 };
-                let key_clone = key_string.clone();
-                let idx = *str_index.entry(key_string).or_insert_with(|| {
-                    order.push(Key::Str(key_clone));
-                    groups.push(Vec::new());
-                    groups.len() - 1
-                });
-                groups[idx].push(item);
+                groups[idx].push(items.get(i));
+            } else {
+                let key_string = group_by_key_string(keys.get(i));
+                let idx = match str_index.get(&key_string) {
+                    Some(idx) => *idx,
+                    None => {
+                        let idx = groups.len();
+                        str_index.insert(key_string.clone(), idx);
+                        order.push(GroupKey::Str(key_string));
+                        groups.push(RootedValues::new(&scope));
+                        idx
+                    }
+                };
+                groups[idx].push(items.get(i));
             }
         }
 
@@ -67,22 +92,36 @@ pub extern "C" fn js_object_group_by(items_value: f64, callback: f64) -> f64 {
         if obj.is_null() {
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
-        let obj_boxed = f64::from_bits((obj as u64) | 0x7FFD_0000_0000_0000);
+        // The result object is reachable from nothing else until we return it,
+        // so this handle is its only root across the per-group allocations
+        // below.
+        let obj_handle = scope.root_nanbox_f64(group_by_box_pointer(obj as usize));
         for (idx, key) in order.iter().enumerate() {
-            let arr = group_by_make_array(&groups[idx]);
-            let arr_boxed = f64::from_bits((arr as u64) | 0x7FFD_0000_0000_0000);
+            let arr_handle = scope
+                .root_nanbox_f64(group_by_box_pointer(
+                    group_by_make_array(&scope, &groups[idx]) as usize,
+                ));
             match key {
-                Key::Str(s) => {
+                GroupKey::Str(s) => {
+                    // Intern the key string FIRST; it is the last allocation in
+                    // this iteration, so the receiver and value reads after it
+                    // are the post-collection addresses.
                     let key_str_ptr =
                         crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-                    js_object_set_field_by_name(obj, key_str_ptr, arr_boxed);
+                    let obj_ptr = crate::value::js_nanbox_get_pointer(obj_handle.get_nanbox_f64())
+                        as *mut ObjectHeader;
+                    js_object_set_field_by_name(obj_ptr, key_str_ptr, arr_handle.get_nanbox_f64());
                 }
-                Key::Sym(sym_val) => {
-                    crate::symbol::js_object_set_symbol_property(obj_boxed, *sym_val, arr_boxed);
+                GroupKey::Sym(sym_handle) => {
+                    crate::symbol::js_object_set_symbol_property(
+                        obj_handle.get_nanbox_f64(),
+                        sym_handle.get_nanbox_f64(),
+                        arr_handle.get_nanbox_f64(),
+                    );
                 }
             }
         }
-        obj_boxed
+        obj_handle.get_nanbox_f64()
     }
 }
 
@@ -99,37 +138,45 @@ pub extern "C" fn js_object_group_by(items_value: f64, callback: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_map_group_by(items_value: f64, callback: f64) -> f64 {
     unsafe {
-        let pairs = group_by_collect(items_value, callback, b"Map.groupBy");
+        let scope = RuntimeHandleScope::new();
+        let (keys, items) = group_by_collect(&scope, items_value, callback, b"Map.groupBy");
 
         let map = crate::map::js_map_alloc(0);
         if map.is_null() {
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
+        let map_handle = scope.root_nanbox_f64(group_by_box_pointer(map as usize));
 
         // Coalesce by SameValueZero. Collect groups in first-seen order, then
         // materialize into the Map at the end so per-push array reallocation
         // never invalidates a value stored inside the Map.
-        let mut order: Vec<f64> = Vec::new();
-        let mut groups: Vec<Vec<f64>> = Vec::new();
+        let mut order = RootedValues::new(&scope);
+        let mut groups: Vec<RootedValues<'_>> = Vec::new();
 
-        'outer: for (key_val, item) in pairs {
-            for (idx, existing) in order.iter().enumerate() {
-                if crate::value::js_jsvalue_same_value_zero(*existing, key_val) != 0 {
-                    groups[idx].push(item);
+        'outer: for i in 0..keys.len() {
+            for idx in 0..order.len() {
+                if crate::value::js_jsvalue_same_value_zero(order.get(idx), keys.get(i)) != 0 {
+                    groups[idx].push(items.get(i));
                     continue 'outer;
                 }
             }
-            order.push(key_val);
-            groups.push(vec![item]);
+            order.push(keys.get(i));
+            let mut group = RootedValues::new(&scope);
+            group.push(items.get(i));
+            groups.push(group);
         }
 
-        for (idx, key_val) in order.iter().enumerate() {
-            let arr = group_by_make_array(&groups[idx]);
-            let arr_boxed = f64::from_bits((arr as u64) | 0x7FFD_0000_0000_0000);
-            crate::map::js_map_set(map, *key_val, arr_boxed);
+        for idx in 0..order.len() {
+            // `group_by_make_array` allocates, so read the Map and the key back
+            // out of their roots afterwards, not before.
+            let arr_value =
+                group_by_box_pointer(group_by_make_array(&scope, &groups[idx]) as usize);
+            let map_ptr = crate::value::js_nanbox_get_pointer(map_handle.get_nanbox_f64())
+                as *mut crate::map::MapHeader;
+            crate::map::js_map_set(map_ptr, order.get(idx), arr_value);
         }
 
-        f64::from_bits((map as u64) | 0x7FFD_0000_0000_0000)
+        map_handle.get_nanbox_f64()
     }
 }
 
@@ -143,10 +190,55 @@ static KEEP_OBJECT_GROUP_BY: extern "C" fn(f64, f64) -> f64 = js_object_group_by
 #[used]
 static KEEP_MAP_GROUP_BY: extern "C" fn(f64, f64) -> f64 = js_map_group_by;
 
+/// NaN-box a heap address with `POINTER_TAG`.
+#[inline]
+fn group_by_box_pointer(addr: usize) -> f64 {
+    f64::from_bits((addr as u64) | 0x7FFD_0000_0000_0000)
+}
+
 /// Returns true if `value` is a Symbol (registered SymbolHeader pointer).
 unsafe fn group_by_value_is_symbol(value: f64) -> bool {
     let raw = crate::value::js_nanbox_get_pointer(value);
     raw != 0 && crate::symbol::is_registered_symbol(raw as usize)
+}
+
+/// Move-stable coalescing identity for a Symbol key, or `None` if `value` is
+/// not a Symbol.
+///
+/// `SymbolHeader::id` is a monotonic `u64` that an evacuation copies verbatim,
+/// so it stays a valid `HashMap` key across a collection. The symbol's
+/// *address* does not: a fresh `Symbol(desc)` is a GC allocation, and keying on
+/// its address would start a second group for the same symbol the first time a
+/// collection moved it mid-loop.
+unsafe fn group_by_symbol_identity(value: f64) -> Option<u64> {
+    if !group_by_value_is_symbol(value) {
+        return None;
+    }
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    let sym = raw as *const crate::symbol::SymbolHeader;
+    if (*sym).magic != crate::symbol::SYMBOL_MAGIC {
+        // Registered but not header-shaped: fall back to the address. Nothing
+        // in the tree produces this today; the branch exists so an unexpected
+        // shape degrades to the previous behaviour instead of panicking.
+        return Some(raw as u64);
+    }
+    Some((*sym).id)
+}
+
+/// ToPropertyKey a non-Symbol group key into an owned Rust `String`.
+///
+/// The returned `String` is Rust-heap and therefore move-immune, which is the
+/// point: the *key* stops being a GC value the instant it is coerced, so the
+/// `HashMap` that coalesces groups holds no heap addresses at all.
+unsafe fn group_by_key_string(key_val: f64) -> String {
+    let key_ptr = crate::builtins::js_string_coerce(key_val);
+    if key_ptr.is_null() {
+        return "undefined".to_string();
+    }
+    let len = (*key_ptr).byte_len as usize;
+    let data = (key_ptr as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    let bytes = std::slice::from_raw_parts(data, len);
+    std::str::from_utf8(bytes).unwrap_or("").to_string()
 }
 
 /// Shared grouping core for `Object.groupBy` / `Map.groupBy`.
@@ -154,10 +246,21 @@ unsafe fn group_by_value_is_symbol(value: f64) -> bool {
 /// Validates `items` (nullish → TypeError) and `callback` (non-callable →
 /// TypeError), materializes `items` through the iterator protocol (so Sets,
 /// strings, and custom iterables all work), then calls
-/// `callback(value, index)` for each element. Returns the per-element
-/// `(raw_key, item)` pairs in iteration order. The caller decides how to
-/// coalesce keys (ToPropertyKey for Object, SameValueZero for Map).
-unsafe fn group_by_collect(items_value: f64, callback: f64, callee_name: &[u8]) -> Vec<(f64, f64)> {
+/// `callback(value, index)` for each element. Returns the per-element keys and
+/// items as two parallel [`RootedValues`] — index `i` of each is one pair. The
+/// caller decides how to coalesce keys (ToPropertyKey for Object,
+/// SameValueZero for Map).
+///
+/// #7949: the callback is user JS, so every iteration is a collection point.
+/// The materialized array, the closure, and every pair collected so far are
+/// rooted across it; the array and closure pointers are re-derived from their
+/// handles on each iteration rather than hoisted out of the loop.
+unsafe fn group_by_collect<'scope>(
+    scope: &'scope RuntimeHandleScope,
+    items_value: f64,
+    callback: f64,
+    callee_name: &[u8],
+) -> (RootedValues<'scope>, RootedValues<'scope>) {
     let items_jv = crate::value::JSValue::from_bits(items_value.to_bits());
     if items_jv.is_null() || items_jv.is_undefined() {
         // Match Node: "X.groupBy called on null or undefined"
@@ -169,36 +272,58 @@ unsafe fn group_by_collect(items_value: f64, callback: f64, callee_name: &[u8]) 
         throw_group_by_type_error(b"callback is not a function");
     }
 
-    // Materialize any iterable into an Array via the iterator protocol.
-    let arr_boxed = crate::array::js_for_of_to_array(items_value);
-    let raw = crate::value::js_nanbox_get_pointer(arr_boxed) as *const ArrayHeader;
-    if raw.is_null() {
-        return Vec::new();
-    }
-    let length = crate::array::js_array_length(raw) as usize;
-    let cb_ptr =
-        crate::value::js_nanbox_get_pointer(callback) as *const crate::closure::ClosureHeader;
+    let callback_handle = scope.root_nanbox_f64(callback);
+    // Materialize any iterable into an Array via the iterator protocol. This
+    // can run a user iterator, so root the callback before it.
+    let array_handle = scope.root_nanbox_f64(crate::array::js_for_of_to_array(items_value));
 
-    let mut out: Vec<(f64, f64)> = Vec::with_capacity(length);
+    let length = {
+        let raw = crate::value::js_nanbox_get_pointer(array_handle.get_nanbox_f64())
+            as *const ArrayHeader;
+        if raw.is_null() {
+            0
+        } else {
+            crate::array::js_array_length(raw) as usize
+        }
+    };
+
+    let mut keys = RootedValues::with_capacity(scope, length);
+    let mut items = RootedValues::with_capacity(scope, length);
     for i in 0..length {
-        let item = crate::array::js_array_get_f64(raw, i as u32);
-        let key_val = crate::closure::js_closure_call2(cb_ptr, item, i as f64);
-        out.push((key_val, item));
+        let raw = crate::value::js_nanbox_get_pointer(array_handle.get_nanbox_f64())
+            as *const ArrayHeader;
+        // Root the item BEFORE the callback runs — `items.get(i)` below is the
+        // post-collection word, and the pair stays in sync because keys are
+        // pushed only after a successful call.
+        items.push(crate::array::js_array_get_f64(raw, i as u32));
+        let cb_ptr = crate::value::js_nanbox_get_pointer(callback_handle.get_nanbox_f64())
+            as *const crate::closure::ClosureHeader;
+        let key_val = crate::closure::js_closure_call2(cb_ptr, items.get(i), i as f64);
+        keys.push(key_val);
     }
-    out
+    (keys, items)
 }
 
-/// Build an Array<f64> from a slice of grouped element values.
-unsafe fn group_by_make_array(items_for_key: &[f64]) -> *mut ArrayHeader {
-    let arr = crate::array::js_array_alloc(items_for_key.len() as u32);
-    (*arr).length = items_for_key.len() as u32;
+/// Build an Array<f64> from a rooted group of element values.
+///
+/// The element words are read out of their handles only after `js_array_alloc`
+/// has run, and the array itself is rooted across `rebuild_array_layout_from_slots`
+/// so the returned pointer is never a pre-collection address.
+unsafe fn group_by_make_array(
+    scope: &RuntimeHandleScope,
+    items_for_key: &RootedValues<'_>,
+) -> *mut ArrayHeader {
+    let len = items_for_key.len();
+    let arr = crate::array::js_array_alloc(len as u32);
+    (*arr).length = len as u32;
     let arr_data = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-    for (i, v) in items_for_key.iter().enumerate() {
+    for i in 0..len {
         // GC_STORE_AUDIT(INIT): groupBy result array is unpublished; layout is rebuilt before publication.
-        std::ptr::write(arr_data.add(i), *v);
+        std::ptr::write(arr_data.add(i), items_for_key.get(i));
     }
+    let arr_handle = scope.root_nanbox_f64(group_by_box_pointer(arr as usize));
     super::rebuild_array_layout_from_slots(arr);
-    arr
+    crate::value::js_nanbox_get_pointer(arr_handle.get_nanbox_f64()) as *mut ArrayHeader
 }
 
 fn throw_group_by_type_error(message: &[u8]) -> ! {

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -43,8 +43,21 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
     if desc_obj.is_null() || !is_valid_obj_ptr(desc_obj as *const u8) {
         return target;
     }
+    // #7949: everything below spans allocations — `propertyIsEnumerable` and
+    // the `[[Get]]` can run user accessors, `str_from_value` coerces (and so
+    // allocates for every key shape except an already-heap string), and
+    // `js_object_define_property` grows the target. The receiver, the
+    // properties bag, the own-names array and the collected key list are all
+    // rooted for the duration, and each is re-read out of its root after every
+    // call that could have moved it. A bare `Vec<f64>` of keys is invisible to
+    // every scanner, so under an evacuating collection the second loop used to
+    // define properties under stale key strings.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let descriptors_handle = scope.root_nanbox_f64(descriptors);
+
     // Snapshot the descriptor object's own keys array. We collect into a
-    // Vec<f64> first so adding properties via `js_object_define_property`
+    // rooted list first so adding properties via `js_object_define_property`
     // (which can resize the target's keys_array) can't perturb iteration
     // — descriptors and target are usually different objects, but a
     // defensive copy costs ~ngc and protects against a user who passes
@@ -55,25 +68,37 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
     // (so accessors on the properties bag run). Using the full own-key set is
     // wrong for native namespaces like `Math` (whose `E`/`PI`/... are
     // non-enumerable) and for any object with non-enumerable own props.
-    let names_value = js_object_get_own_property_names(descriptors);
-    let names_arr =
-        crate::value::js_nanbox_get_pointer(names_value) as *const crate::array::ArrayHeader;
-    let mut keys: Vec<f64> = Vec::new();
-    if !names_arr.is_null() {
-        let len = crate::array::js_array_length(names_arr) as usize;
-        for i in 0..len {
-            let k = crate::array::js_array_get(names_arr, i as u32);
-            let k_f64 = f64::from_bits(k.bits());
-            // Skip non-enumerable own keys (spec step: descriptor must be
-            // enumerable). `propertyIsEnumerable` returns false for absent or
-            // non-enumerable keys.
-            const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
-            if js_object_property_is_enumerable(descriptors, k_f64).to_bits() == TAG_TRUE {
-                keys.push(k_f64);
-            }
+    let names_handle = scope.root_nanbox_f64(js_object_get_own_property_names(
+        descriptors_handle.get_nanbox_f64(),
+    ));
+    let mut keys = crate::gc::RootedValues::new(&scope);
+    let names_len = {
+        let names_arr = crate::value::js_nanbox_get_pointer(names_handle.get_nanbox_f64())
+            as *const crate::array::ArrayHeader;
+        if names_arr.is_null() {
+            0
+        } else {
+            crate::array::js_array_length(names_arr) as usize
+        }
+    };
+    for i in 0..names_len {
+        let names_arr = crate::value::js_nanbox_get_pointer(names_handle.get_nanbox_f64())
+            as *const crate::array::ArrayHeader;
+        let k = crate::array::js_array_get(names_arr, i as u32);
+        let k_handle = scope.root_nanbox_f64(f64::from_bits(k.bits()));
+        // Skip non-enumerable own keys (spec step: descriptor must be
+        // enumerable). `propertyIsEnumerable` returns false for absent or
+        // non-enumerable keys.
+        const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+        let enumerable = js_object_property_is_enumerable(
+            descriptors_handle.get_nanbox_f64(),
+            k_handle.get_nanbox_f64(),
+        );
+        if enumerable.to_bits() == TAG_TRUE {
+            keys.push(k_handle.get_nanbox_f64());
         }
     }
-    for k in keys {
+    for i in 0..keys.len() {
         // Read the descriptor through `[[Get]]` so accessors on the properties
         // bag are honored, then ToPropertyDescriptor + DefinePropertyOrThrow.
         //
@@ -83,8 +108,9 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
         // instance, etc. `Object.create({}, new Date(0))` previously bit-cast the
         // Date's `DateCell` pointer to an `ObjectHeader` and segfaulted. The
         // dynamic getter dispatches on the receiver's real type.
-        let key_str = str_from_value(k);
+        let key_str_handle = scope.root_nanbox_f64(box_string_ptr(str_from_value(keys.get(i))));
         let descriptor = unsafe {
+            let key_str = unbox_string_ptr(key_str_handle.get_nanbox_f64());
             if key_str.is_null() {
                 f64::from_bits(crate::value::TAG_UNDEFINED)
             } else {
@@ -92,15 +118,42 @@ pub extern "C" fn js_object_define_properties(target: f64, descriptors: f64) -> 
                     (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let name_len = (*key_str).byte_len as usize;
                 crate::value::js_dynamic_object_get_property(
-                    descriptors,
+                    descriptors_handle.get_nanbox_f64(),
                     name_ptr as *const i8,
                     name_len,
                 )
             }
         };
-        js_object_define_property(target, k, descriptor);
+        let descriptor_handle = scope.root_nanbox_f64(descriptor);
+        js_object_define_property(
+            target_handle.get_nanbox_f64(),
+            keys.get(i),
+            descriptor_handle.get_nanbox_f64(),
+        );
     }
-    target
+    target_handle.get_nanbox_f64()
+}
+
+/// NaN-box a coerced key string so a `RuntimeHandleScope` can root it (the
+/// handle stack rewrites STRING_TAG slots on evacuation). A null pointer boxes
+/// as `undefined`, which [`unbox_string_ptr`] maps back to null.
+fn box_string_ptr(ptr: *const crate::string::StringHeader) -> f64 {
+    if ptr.is_null() {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    } else {
+        f64::from_bits(0x7FFF_0000_0000_0000 | (ptr as u64 & 0x0000_FFFF_FFFF_FFFF))
+    }
+}
+
+/// Inverse of [`box_string_ptr`]. Read this immediately before the use — the
+/// pointer is a copy, and the next allocation can move the string.
+fn unbox_string_ptr(value: f64) -> *const crate::string::StringHeader {
+    let bits = value.to_bits();
+    if bits >> 48 == 0x7FFF {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::string::StringHeader
+    } else {
+        std::ptr::null()
+    }
 }
 
 /// Coerce an arbitrary key value (f64 — usually a STRING_TAG NaN-box) to a

--- a/crates/perry-runtime/src/proxy/own_keys.rs
+++ b/crates/perry-runtime/src/proxy/own_keys.rs
@@ -10,12 +10,31 @@ use super::{
     revoked_return, throw_type_error, POINTER_MASK, POINTER_TAG, PROXIES, TAG_NULL, TAG_UNDEFINED,
 };
 
+/// #7949: root the caller's key list before touching the heap.
+///
+/// `js_array_push_f64` grows the result array, and growing it allocates — so
+/// with a plain `&[f64]` every key *after* the first collection point named
+/// from-space. The keys are strings and symbols the caller usually obtained
+/// from a user `ownKeys` trap, so they are exactly the young objects a copying
+/// minor relocates.
 fn alloc_key_array(keys: &[f64]) -> f64 {
-    let mut arr = crate::array::js_array_alloc(keys.len() as u32);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let mut rooted = crate::gc::RootedValues::with_capacity(&scope, keys.len());
     for &k in keys {
-        arr = crate::array::js_array_push_f64(arr, k);
+        rooted.push(k);
     }
-    f64::from_bits(POINTER_TAG | ((arr as u64) & POINTER_MASK))
+    let arr_handle = scope.root_nanbox_f64(f64::from_bits(
+        POINTER_TAG | ((crate::array::js_array_alloc(keys.len() as u32) as u64) & POINTER_MASK),
+    ));
+    for i in 0..rooted.len() {
+        let arr = (arr_handle.get_nanbox_f64().to_bits() & POINTER_MASK)
+            as *mut crate::array::ArrayHeader;
+        let grown = crate::array::js_array_push_f64(arr, rooted.get(i));
+        arr_handle.set_nanbox_f64(f64::from_bits(
+            POINTER_TAG | ((grown as u64) & POINTER_MASK),
+        ));
+    }
+    arr_handle.get_nanbox_f64()
 }
 
 fn is_string_key(v: f64) -> bool {
@@ -228,27 +247,46 @@ pub(crate) fn proxy_own_property_symbols(proxy_boxed: f64) -> f64 {
 
 /// `Object.keys(proxy)` — EnumerableOwnPropertyNames: string keys whose proxy
 /// `[[GetOwnProperty]]` reports `enumerable: true`.
+///
+/// #7949: `js_reflect_get_own_property_descriptor` fires the proxy's
+/// `getOwnPropertyDescriptor` trap — arbitrary user JS, once per key — and the
+/// `enumerable` probe allocates a string. Both the not-yet-visited keys and the
+/// keys already accepted into the result have to survive that, so they live in
+/// rooted lists rather than `Vec<f64>`s.
 pub(crate) fn proxy_enum_own_keys(proxy_boxed: f64) -> f64 {
-    let keys = read_array(js_proxy_own_keys(proxy_boxed));
-    let mut out: Vec<f64> = Vec::new();
-    for k in keys {
-        if !is_string_key(k) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let proxy_handle = scope.root_nanbox_f64(proxy_boxed);
+    let mut keys = crate::gc::RootedValues::new(&scope);
+    for k in read_array(js_proxy_own_keys(proxy_handle.get_nanbox_f64())) {
+        keys.push(k);
+    }
+    let mut out = crate::gc::RootedValues::new(&scope);
+    for i in 0..keys.len() {
+        if !is_string_key(keys.get(i)) {
             continue;
         }
-        let desc = super::js_reflect_get_own_property_descriptor(proxy_boxed, k);
+        let desc = super::js_reflect_get_own_property_descriptor(
+            proxy_handle.get_nanbox_f64(),
+            keys.get(i),
+        );
         if desc.to_bits() == TAG_UNDEFINED {
             continue;
         }
-        let ptr = (desc.to_bits() & POINTER_MASK) as *const crate::ObjectHeader;
+        let desc_handle = scope.root_nanbox_f64(desc);
+        // Intern "enumerable" first; the descriptor read after it is then the
+        // post-collection address.
+        let ek = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+        let ptr =
+            (desc_handle.get_nanbox_f64().to_bits() & POINTER_MASK) as *const crate::ObjectHeader;
         if ptr.is_null() {
             continue;
         }
-        let ek = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
         if crate::value::js_is_truthy(crate::object::js_object_get_field_by_name_f64(ptr, ek)) != 0
         {
-            out.push(k);
+            out.push(keys.get(i));
         }
     }
     let _ = TAG_NULL;
-    alloc_key_array(&out)
+    let snapshot: Vec<f64> = out.iter().collect();
+    alloc_key_array(&snapshot)
 }

--- a/gc-handoff/ROOTVEC-NOTES.md
+++ b/gc-handoff/ROOTVEC-NOTES.md
@@ -130,10 +130,14 @@ failure mode is the exact late-surfacing shape the class is known for.
 
 ### Compiled probe
 
-`test-files/test_gap_gc_container_value_rooting.ts` drives all three helpers
-from compiled TypeScript, with `churn()` inside every callback so a back-edge
-poll is emitted in user JS *and* the retired from-space bytes are recycled after
-it. Run under `PERRY_GC_SCHEDULE_RATE=1`.
+Two programs — `test-files/test_gap_gc_container_value_rooting.ts` (the two
+`groupBy` helpers) and `test-files/test_gap_gc_define_properties_key_rooting.ts`
+— each with `churn()` inside every callback so a back-edge poll is emitted in
+user JS *and* the retired from-space bytes are recycled after it. They are
+separate programs on purpose; see #7963 and the note at the bottom of the second
+file. Under the witness configuration each exits **138** with a
+`[gc-fromspace-protect] FAULT` on a pristine `origin/main` build and **0**,
+byte-exact against node 26.5.1, on this branch.
 
 ## Sweep (issue item 5): the rest of the population
 

--- a/gc-handoff/ROOTVEC-NOTES.md
+++ b/gc-handoff/ROOTVEC-NOTES.md
@@ -156,6 +156,68 @@ was already converted by #6943/#7341 and needs nothing.
 The broader "cold arms never root anything" population the #6949 scope note
 describes is still open and is not what this branch claims to close.
 
-## #7803
+## Validation results
 
-See the PR body / final report.
+| check | result |
+|---|---|
+| `cargo test -p perry-runtime --lib` | 2215 passed, 0 failed, 4 ignored (#7946's flakiness did not appear; nothing to A/B) |
+| gap corpus: all 36 `test_gap_gc_*.ts` + 5 `test_gap_{proxy,reflect}*.ts`, byte-exact vs node 26.5.1, default **and** `PERRY_GC_PROTECT_FROMSPACE=1 DEPTH=800` | **41/41** |
+| the two new probes under `PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_PROTECT_FROMSPACE=1 DEPTH=800` | exit 0, byte-exact; pristine `main` exits **138** with a from-space FAULT |
+| the two new probes under `PERRY_GC_VERIFY_EVACUATION=1` (+ schedule) | exit 0, output byte-exact |
+| `cargo fmt --check`, `scripts/check_file_size.sh`, `scripts/gc_runtime_root_holders.py`, `scripts/raw_handle_debt.py` | all clean (debt reads 3 *below* baseline) |
+
+**Instrument liveness** — a run with zero copying minors protects nothing, so it
+is reported rather than assumed:
+
+* `test_gap_gc_container_value_rooting`: 164 safepoints / 164 copying minors /
+  **67,889 objects moved**, 164 quarantined retired sets.
+* `test_gap_gc_define_properties_key_rooting`: 60 / 60 / **33,302 moved**, 60
+  retired sets.
+* Across the 41-program corpus the quarantine printed a retired-set line in 20
+  of the 41 programs (185 sets total). The other 21 ran no copying minor at all,
+  so for those the protected arm is a no-regression check and not a rooting
+  witness. Stated rather than glossed.
+
+One corpus row (`test_gap_gc_string_literal_operand_rooting`) first read as a
+`protect-diff`; the diff was a `[gc]` heap-accounting line my stderr filter
+missed (`^\[gc-` did not match `[gc] blocks: …`). Re-filtered it is identical.
+
+## #7803 — could not be reproduced; shares a *candidate* cause
+
+`test-files/gc-dep-corpus/main.ts` **does not link** on this box, identically on
+a pristine `origin/main` build and on this branch:
+
+```
+Undefined symbols for architecture arm64:
+  "_perry_fn_node_modules_zod_src_v4_core_index_ts__NEVER", ...
+  "_perry_fn_node_modules_zod_src_v4_core_index_ts___brand", ...
+```
+
+— the `export * from "./core.js"` re-export set in the currently pinned
+`zod@4.3.5` (`package.json` has `"zod": "^4.3.5"`; the corpus was written
+against the zod of #7280/#7311, 2026-05). Same failure with and without
+auto-optimize, and with `PERRY_RUNTIME_DIR` pinned to either arm. So #7803's
+reproducer is not runnable as written and I could not confirm or refute it.
+
+What *is* established: the zod workload routes through
+`js_object_define_properties` — `node_modules/zod/src/v4/core/util.ts:316`
+(`return Object.defineProperties({}, mergedDescriptors)`) and
+`node_modules/zod/src/v4/classic/errors.ts:28` — which is one of the two sites
+this branch fixes. #7803's symptom is
+`Cannot read properties of undefined (reading 'toString')`, i.e. a property read
+that came back `undefined` where an object was expected, which is exactly what a
+stale key string in that loop produces: the property gets defined under a
+garbage name and the later read misses. That makes #7949 a **candidate** cause
+of #7803, not a confirmed one. Retest #7803 once the corpus links again.
+
+## Left open
+
+* **#7963** (filed) — a separate, pre-existing from-space fault in the
+  `Object.defineProperty` / descriptor-getter family. Reproduces with a
+  hand-written `Object.defineProperty` loop, i.e. with none of this branch's
+  code on the path; it is the wider window #6949's scope note defers. This is
+  why the #7949 gap coverage ships as two programs instead of one.
+* `js_typed_array_filter` (see the sweep table) — real, deliberately not fixed
+  here.
+* The `gc-dep-corpus` link break described above; worth its own issue or a
+  corpus regeneration.

--- a/gc-handoff/ROOTVEC-NOTES.md
+++ b/gc-handoff/ROOTVEC-NOTES.md
@@ -1,0 +1,161 @@
+# #7949 — JS values retained in Rust containers across allocating calls
+
+Working notes for the `fix/7949-root-container-values` branch. Written
+incrementally; the PR body is the summary, this is the audit trail.
+
+## The class
+
+A runtime helper accumulates NaN-boxed JS values into a plain `Vec` and keeps
+filling or walking it across calls that can allocate. The `Vec` lives on the
+Rust heap: it is not a shadow slot, not a temp root, and not reachable from any
+registered scanner, so an evacuating minor can neither keep those objects alive
+nor rewrite their addresses.
+
+Two properties make it the worst class to debug, both of which held here:
+
+* **`scripts/gc_root_dominance_check.py` is structurally blind to it.** It reads
+  emitted LLVM IR. A Rust-side container is not in the IR.
+* **Nothing faults at the collection.** The nursery recycles the address and the
+  stale word reads a valid *unrelated* object. Both end-to-end sabotage runs
+  below surfaced as `TypeError: value is not a function` — the canonical
+  late-surfacing form — not as a segfault at the offending read.
+
+The reproducibility heuristic in CLAUDE.md held exactly: this is a *container*,
+not a register, so it goes bad at collection #0 and stays bad. Both end-to-end
+tests fail deterministically on the pristine build, every run.
+
+## Sites fixed
+
+### 1. `crates/perry-runtime/src/object/groupby.rs`
+
+`group_by_collect` returned `Vec<(f64, f64)>` filled across a **user callback**
+(`js_closure_call2`) run once per element. Everything already in the vector was
+stale from the first collection onward. Three more holes in the same function
+family, all of which the issue's summary did not name:
+
+* the materialized input array pointer (`raw`) and the closure pointer
+  (`cb_ptr`) were hoisted out of the loop and re-dereferenced on every
+  iteration, across the callback;
+* `Object.groupBy`'s result object (`obj` / `obj_boxed`) was a bare local across
+  one `group_by_make_array` + one `js_string_from_bytes` per group — and it is
+  reachable from nothing else, so it had **no root at all**;
+* `group_by_make_array`'s freshly allocated array was returned across
+  `rebuild_array_layout_from_slots`, and the caller's `arr_boxed` then spanned
+  the key-string interning.
+* `Map.groupBy` held the result `Map` and every key across per-group array
+  allocation and `js_map_set`.
+
+Also: `Object.groupBy` coalesced Symbol keys through a
+`HashMap<u64 /* symbol address */, usize>`. A fresh `Symbol(desc)` is a GC
+allocation, so a symbol that moved mid-loop hashed to a new bucket and started a
+**duplicate group**. Now keyed on `SymbolHeader::id`, a monotonic `u64` that an
+evacuation copies verbatim — the same reasoning #7246 used to intern symbol
+descriptions by id.
+
+### 2. `crates/perry-runtime/src/object/object_ops/define_properties.rs`
+
+`keys: Vec<f64>` collected the descriptor bag's own names, then walked them
+across, per key: `str_from_value` (a `js_string_coerce`, which allocates for
+every shape except an already-heap string), `js_dynamic_object_get_property`
+(runs a **user getter** on the properties bag), and `js_object_define_property`
+(grows the target). The receiver, the properties bag, the own-names array and
+the coerced key string were all bare locals across the same window.
+
+### 3. `crates/perry-runtime/src/proxy/own_keys.rs` (sweep, item 5)
+
+* `alloc_key_array(&[f64])` is the shared builder for `Object.keys` /
+  `getOwnPropertyNames` / `getOwnPropertySymbols` / `Reflect.ownKeys` on a
+  Proxy. It pushed each key into a growing array — and growing allocates — so
+  every key after the first collection point named from-space.
+* `proxy_enum_own_keys` held the trap's key list and the accepted-so-far list
+  across `js_reflect_get_own_property_descriptor`, i.e. across the proxy's
+  `getOwnPropertyDescriptor` trap: arbitrary user JS, once per key.
+
+## The reusable rule
+
+`crates/perry-runtime/src/gc/roots/rooted_values.rs` adds `gc::RootedValues`: a
+growable list whose elements are `RuntimeHandle`s. The handle stack is a
+registered *mutable* root scanner (`MutableRootScannerSource::RuntimeHandles`),
+so elements are marked **and** their slots rewritten. `get(i)` re-reads the slot,
+so the correct shape is shorter than the incorrect one.
+
+It is not a proof — Rust has no effect system for "this call may allocate", and
+`get` still hands back a bare `f64`. What it removes is the *container* as the
+hole.
+
+**Documented hazard (module docs):** never push to an outer `RootedValues` while
+an inner `RuntimeHandleScope` is alive. `RuntimeHandleScope::drop` truncates the
+stack to its base, which would silently discard the outer container's newest
+handles. Every helper touched here uses exactly one scope.
+
+`RootedValues` holds no `static`/`thread_local!`, so
+`scripts/gc_runtime_root_holders.py` requires no verdict for it — it borrows the
+existing, already-registered handle stack rather than adding a new root holder.
+No new `get_raw_{mut,const}_ptr` sites either, so
+`scripts/raw_handle_debt.py`'s ratchet is unmoved.
+
+## How the fix is proven
+
+`crates/perry-runtime/src/gc/tests/rooted_container_values.rs`, four tests, all
+under `CopyingNurseryTestGuard` + a forced `collect_minor_trace`:
+
+1. `rooted_values_elements_survive_a_collection_that_moved_them` — asserts
+   `copied_objects > 0` **and** that every element's address changed **and**
+   that the post-collection pointer still reads the original bytes. Address
+   change is the "actually moved it" half; the byte check is the "still the same
+   object" half.
+2. `plain_vec_of_values_is_not_a_root` — the sabotage arm. The identical
+   workload in a bare `Vec<f64>` keeps naming pre-collection addresses while a
+   rooted witness in the same cycle moves. This is what makes (1) non-vacuous:
+   if the instrument could not tell rooted from unrooted, this test would fail.
+3. / 4. `object_group_by_…` / `map_group_by_…` — end to end through the real
+   `#[no_mangle]` entry points with a callback that forces an evacuating minor
+   on **every** element, then asserts each group's contents by string bytes.
+
+### Sabotage verification (fix committed first)
+
+With `crates/perry-runtime/src/object/groupby.rs` reverted to `origin/main` and
+everything else left in place:
+
+```
+test gc::tests::rooted_container_values::map_group_by_items_survive_a_moving_minor_in_the_callback
+  ... TypeError: value is not a function
+test gc::tests::rooted_container_values::object_group_by_items_survive_a_moving_minor_in_the_callback
+  ... TypeError: value is not a function
+```
+
+Both abort the harness process; with the fix restored all four pass. The
+sabotage arm therefore proves the tests exercise the fixed code path, and the
+failure mode is the exact late-surfacing shape the class is known for.
+
+### Compiled probe
+
+`test-files/test_gap_gc_container_value_rooting.ts` drives all three helpers
+from compiled TypeScript, with `churn()` inside every callback so a back-edge
+poll is emitted in user JS *and* the retired from-space bytes are recycled after
+it. Run under `PERRY_GC_SCHEDULE_RATE=1`.
+
+## Sweep (issue item 5): the rest of the population
+
+A scan of `perry-runtime/src` for functions that (a) declare a `Vec<f64>` /
+`Vec<(f64…)>` / `Vec<JSValue>` accumulator, (b) push inside a loop, (c) call
+something that can allocate or run user JS, and (d) have no
+`RuntimeHandleScope`, returns 14 functions. Triage:
+
+| site | verdict |
+|---|---|
+| `proxy/own_keys.rs` `alloc_key_array`, `proxy_enum_own_keys` | **FIXED here** — user traps per key |
+| `typedarray/iterate.rs:52` `js_typed_array_filter` | **REAL, not fixed.** `kept: Vec<f64>` spans a user callback per element (BigInt64/BigUint64 elements are `BIGINT_TAG` heap pointers), and `ta`/`recv` are hoisted raw locals across the same callback. The `ta` half is #6949 shape (a), not the container shape; both want one change. Follow-up. |
+| `closure/dispatch/value_call.rs` (`js_native_call_value`, `js_closure_call_array`), `closure/dispatch/bound.rs` `dispatch_bound_function`, `object/class_constructors.rs` ×5, `object/class_registry/parent_static.rs` ×2, `proxy/apply_construct.rs` `forward_apply` | argument-gathering: the `Vec` is filled from an already-materialized source with no allocating call *between* pushes, then handed to one call. Not the accumulate-across-a-callback shape. Left alone deliberately — converting them would cost a handle push per argument on the hottest dispatch paths for no demonstrated window. |
+| `array/splice_slice.rs` `js_array_splice` | removed-element buffer; the loop that fills it does not call user code. |
+
+`object/descriptors.rs`'s `js_object_get_own_property_descriptors` — the one the
+issue quotes as carrying the "builder helpers follow this convention" comment —
+was already converted by #6943/#7341 and needs nothing.
+
+The broader "cold arms never root anything" population the #6949 scope note
+describes is still open and is not what this branch claims to close.
+
+## #7803
+
+See the PR body / final report.

--- a/test-files/test_gap_gc_container_value_rooting.ts
+++ b/test-files/test_gap_gc_container_value_rooting.ts
@@ -1,13 +1,15 @@
 // #7949: JS values retained in ordinary Rust containers across allocating calls.
 //
 // `Object.groupBy` / `Map.groupBy` accumulate every `(key, item)` pair into a
-// `Vec<(f64, f64)>` while calling a USER CALLBACK once per element, and
-// `Object.defineProperties` accumulates the descriptor bag's own keys into a
-// `Vec<f64>` and then walks them across a `[[Get]]` that can run a user getter.
-// A `Vec` on the Rust heap is neither a shadow slot nor a temp root nor
-// reachable from any registered scanner, so an evacuating minor landing inside
-// one of those callbacks can neither keep the already-collected values alive
-// nor rewrite their addresses.
+// `Vec<(f64, f64)>` while calling a USER CALLBACK once per element. A `Vec` on
+// the Rust heap is neither a shadow slot nor a temp root nor reachable from any
+// registered scanner, so an evacuating minor landing inside one of those
+// callbacks can neither keep the already-collected values alive nor rewrite
+// their addresses.
+//
+// (`Object.defineProperties`, the third helper #7949 names, is covered by
+// `test_gap_gc_define_properties_key_rooting.ts` — deliberately a separate
+// program, see the note at the bottom of that file.)
 //
 // Why this class needs a hand-built probe: `scripts/gc_root_dominance_check.py`
 // reads emitted LLVM IR, and a Rust-side container is structurally invisible to
@@ -75,31 +77,6 @@ function mapGroupBy(): string {
   return parts.join("|");
 }
 
-// Object.defineProperties: the own-key list is collected first, then each key
-// spans a `[[Get]]` on the properties bag (a user getter here, so a safepoint
-// poll lands inside it) plus the define itself.
-function definePropertiesWithGetters(): string {
-  const bag: any = {};
-  for (let i = 0; i < 12; i++) {
-    const index = i;
-    Object.defineProperty(bag, "prop-" + index, {
-      enumerable: true,
-      configurable: true,
-      get: function (): any {
-        churn(index);
-        return { value: "value-" + index, enumerable: true, configurable: true };
-      },
-    });
-  }
-  const target: any = {};
-  Object.defineProperties(target, bag);
-  const parts: string[] = [];
-  for (const key of Object.keys(target).sort()) {
-    parts.push(key + "=" + target[key]);
-  }
-  return parts.join("|");
-}
-
 function expectedObjectGroupBy(): string {
   const buckets: string[][] = [[], [], []];
   for (let i = 0; i < 18; i++) {
@@ -124,18 +101,5 @@ function expectedMapGroupBy(): string {
   return parts.join("|");
 }
 
-function expectedDefineProperties(): string {
-  const parts: string[] = [];
-  for (let i = 0; i < 12; i++) {
-    parts.push("prop-" + i + "=value-" + i);
-  }
-  parts.sort();
-  return parts.join("|");
-}
-
 console.log("objectGroupBy", objectGroupBy() === expectedObjectGroupBy() ? "ok" : "BAD");
 console.log("mapGroupBy", mapGroupBy() === expectedMapGroupBy() ? "ok" : "BAD");
-console.log(
-  "defineProperties",
-  definePropertiesWithGetters() === expectedDefineProperties() ? "ok" : "BAD",
-);

--- a/test-files/test_gap_gc_container_value_rooting.ts
+++ b/test-files/test_gap_gc_container_value_rooting.ts
@@ -1,0 +1,141 @@
+// #7949: JS values retained in ordinary Rust containers across allocating calls.
+//
+// `Object.groupBy` / `Map.groupBy` accumulate every `(key, item)` pair into a
+// `Vec<(f64, f64)>` while calling a USER CALLBACK once per element, and
+// `Object.defineProperties` accumulates the descriptor bag's own keys into a
+// `Vec<f64>` and then walks them across a `[[Get]]` that can run a user getter.
+// A `Vec` on the Rust heap is neither a shadow slot nor a temp root nor
+// reachable from any registered scanner, so an evacuating minor landing inside
+// one of those callbacks can neither keep the already-collected values alive
+// nor rewrite their addresses.
+//
+// Why this class needs a hand-built probe: `scripts/gc_root_dominance_check.py`
+// reads emitted LLVM IR, and a Rust-side container is structurally invisible to
+// it. Nothing faults at the collection either — the nursery recycles the bytes
+// and the stale word reads a valid but unrelated object, so the failure surfaces
+// cycles later as wrong data or `TypeError: … is not a function`.
+//
+// LIVE BY CONSTRUCTION. Each callback runs `churn`, which (a) contains a loop
+// back-edge, so a GC safepoint poll is emitted inside user JS — the only place
+// polls fire — and (b) keeps allocating AFTER that poll, so the retired
+// from-space bytes are recycled before the runtime reads its accumulator again.
+// A stale element therefore returns wrong text rather than the right answer out
+// of memory nobody has reused yet.
+//
+// Run the vulnerable window with `PERRY_GC_SCHEDULE_RATE=1`, which collects at
+// every safepoint, so the first back-edge poll inside the first callback
+// already evacuates.
+
+function churn(n: number): number {
+  const bits: any[] = [];
+  for (let i = 0; i < 120; i++) {
+    bits.push({ i: i, s: "y" + i, pad: [i, i + 1, i + 2] });
+  }
+  return bits.length === 120 ? n : -1;
+}
+
+function items(count: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push("item-" + i);
+  }
+  return out;
+}
+
+// Object.groupBy: string keys. The items are freshly allocated strings (always
+// young, so every evacuating minor moves them) and the callback allocates.
+function objectGroupBy(): string {
+  const grouped = Object.groupBy(items(18), (s: string, i: number): string => {
+    churn(i);
+    return "bucket-" + (i % 3);
+  });
+  const parts: string[] = [];
+  for (const key of Object.keys(grouped).sort()) {
+    parts.push(key + "=" + (grouped as any)[key].join(","));
+  }
+  return parts.join("|");
+}
+
+// Map.groupBy: no key coercion at all, so the KEYS are retained as raw values
+// in the same container alongside the items.
+function mapGroupBy(): string {
+  const grouped = Map.groupBy(items(18), (s: string, i: number): string => {
+    churn(i);
+    return "k" + (i % 4);
+  });
+  const keys: string[] = [];
+  for (const key of grouped.keys()) {
+    keys.push(key);
+  }
+  keys.sort();
+  const parts: string[] = [];
+  for (const key of keys) {
+    parts.push(key + "=" + (grouped.get(key) as string[]).join(","));
+  }
+  return parts.join("|");
+}
+
+// Object.defineProperties: the own-key list is collected first, then each key
+// spans a `[[Get]]` on the properties bag (a user getter here, so a safepoint
+// poll lands inside it) plus the define itself.
+function definePropertiesWithGetters(): string {
+  const bag: any = {};
+  for (let i = 0; i < 12; i++) {
+    const index = i;
+    Object.defineProperty(bag, "prop-" + index, {
+      enumerable: true,
+      configurable: true,
+      get: function (): any {
+        churn(index);
+        return { value: "value-" + index, enumerable: true, configurable: true };
+      },
+    });
+  }
+  const target: any = {};
+  Object.defineProperties(target, bag);
+  const parts: string[] = [];
+  for (const key of Object.keys(target).sort()) {
+    parts.push(key + "=" + target[key]);
+  }
+  return parts.join("|");
+}
+
+function expectedObjectGroupBy(): string {
+  const buckets: string[][] = [[], [], []];
+  for (let i = 0; i < 18; i++) {
+    buckets[i % 3].push("item-" + i);
+  }
+  const parts: string[] = [];
+  for (let b = 0; b < 3; b++) {
+    parts.push("bucket-" + b + "=" + buckets[b].join(","));
+  }
+  return parts.join("|");
+}
+
+function expectedMapGroupBy(): string {
+  const buckets: string[][] = [[], [], [], []];
+  for (let i = 0; i < 18; i++) {
+    buckets[i % 4].push("item-" + i);
+  }
+  const parts: string[] = [];
+  for (let b = 0; b < 4; b++) {
+    parts.push("k" + b + "=" + buckets[b].join(","));
+  }
+  return parts.join("|");
+}
+
+function expectedDefineProperties(): string {
+  const parts: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    parts.push("prop-" + i + "=value-" + i);
+  }
+  parts.sort();
+  return parts.join("|");
+}
+
+console.log("objectGroupBy", objectGroupBy() === expectedObjectGroupBy() ? "ok" : "BAD");
+console.log("mapGroupBy", mapGroupBy() === expectedMapGroupBy() ? "ok" : "BAD");
+console.log(
+  "defineProperties",
+  definePropertiesWithGetters() === expectedDefineProperties() ? "ok" : "BAD",
+);

--- a/test-files/test_gap_gc_define_properties_key_rooting.ts
+++ b/test-files/test_gap_gc_define_properties_key_rooting.ts
@@ -1,0 +1,95 @@
+// #7949: `Object.defineProperties` collected the descriptor bag's own names
+// into a plain `Vec<f64>` and then walked that list across, per key:
+//
+//   * `str_from_value` -> `js_string_coerce`, which allocates for every key
+//     shape except an already-heap string;
+//   * `js_dynamic_object_get_property`, which runs a USER GETTER on the
+//     properties bag;
+//   * `js_object_define_property`, which grows the target.
+//
+// The receiver, the properties bag, the own-names array and the coerced key
+// string were bare Rust locals across the same window. A `Vec` on the Rust heap
+// is neither a shadow slot nor a temp root nor reachable from any registered
+// scanner, so an evacuating minor can neither keep those strings alive nor
+// rewrite their addresses — and `scripts/gc_root_dominance_check.py` reads
+// emitted LLVM IR, so it cannot see a Rust-side container at all.
+//
+// LIVE BY CONSTRUCTION. Every getter runs `churn`, which (a) has a loop
+// back-edge, so a GC safepoint poll is emitted inside user JS — the only place
+// polls fire — and (b) keeps allocating after that poll, so the retired
+// from-space bytes are recycled before `defineProperties` reads its key list
+// again.
+//
+// Witness configuration (both needed; the second is what makes it precise):
+//
+//   PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 \
+//   PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800
+//
+// Before the fix that faults with `[gc-fromspace-protect] FAULT` naming a
+// retired from-space address; after it, this program is byte-identical to node
+// in every configuration.
+
+function churn(n: number): number {
+  const bits: any[] = [];
+  for (let i = 0; i < 120; i++) {
+    bits.push({ i: i, s: "y" + i, pad: [i, i + 1, i + 2] });
+  }
+  return bits.length === 120 ? n : -1;
+}
+
+function definePropertiesWithGetters(): string {
+  const bag: any = {};
+  for (let i = 0; i < 12; i++) {
+    const index = i;
+    Object.defineProperty(bag, "prop-" + index, {
+      enumerable: true,
+      configurable: true,
+      get: function (): any {
+        churn(index);
+        return { value: "value-" + index, enumerable: true, configurable: true };
+      },
+    });
+  }
+  const target: any = {};
+  Object.defineProperties(target, bag);
+  const parts: string[] = [];
+  for (const key of Object.keys(target).sort()) {
+    parts.push(key + "=" + target[key]);
+  }
+  return parts.join("|");
+}
+
+function expectedDefineProperties(): string {
+  // Sort the KEYS, exactly like `Object.keys(target).sort()` does — sorting the
+  // joined "key=value" strings orders "prop-10=" before "prop-1=" and would
+  // disagree with the observed side for a reason that has nothing to do with GC.
+  const keys: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    keys.push("prop-" + i);
+  }
+  keys.sort();
+  const parts: string[] = [];
+  for (const key of keys) {
+    parts.push(key + "=value-" + key.substring(5));
+  }
+  return parts.join("|");
+}
+
+console.log(
+  "defineProperties",
+  definePropertiesWithGetters() === expectedDefineProperties() ? "ok" : "BAD",
+);
+
+// WHY THIS IS ITS OWN PROGRAM, and not another arm of
+// `test_gap_gc_container_value_rooting.ts`:
+//
+// Running a `groupBy` arm first and this one second faults under the witness
+// configuration above even WITH #7949 fixed — and it faults identically when
+// `Object.defineProperties` is replaced by a hand-written
+// `Object.defineProperty` loop, i.e. with none of the code #7949 touches on the
+// path. That is a separate, pre-existing rooting defect in the
+// `defineProperty`/getter family (the wider window #6949's scope note names and
+// defers: `js_object_define_property` holds `obj` / `descriptor_value` and the
+// six raw `JSValue`s inside `DescView` across its own later
+// `js_string_from_bytes` calls). Keeping the two programs apart means each gap
+// test fails for its own reason.


### PR DESCRIPTION
Closes #7949.

Raw NaN-boxed JS values were retained in ordinary Rust containers across calls that can allocate — a user callback, a `[[Get]]` accessor, a key coercion, a result-array build. Those `Vec` elements are neither runtime roots nor mutable shadow slots, so an evacuating collection could neither keep them alive nor rewrite their addresses. `scripts/gc_root_dominance_check.py` is structurally blind to this: it reads emitted LLVM IR, and a Rust-side container is not in the IR.

## Sites

**`object/groupby.rs`** — `group_by_collect` returned `Vec<(f64, f64)>` filled across `js_closure_call2`, i.e. across arbitrary user JS, once per element. The audit found three more holes in the same family that the issue's summary did not name:

- the materialized input array and the closure were hoisted out of the loop and re-dereferenced on every iteration, across the callback;
- `Object.groupBy`'s result object had **no root at all** — it is reachable from nothing else until it is returned, and it spanned one array build plus one key-string intern per group;
- `group_by_make_array` returned a freshly allocated array across `rebuild_array_layout_from_slots`, and the caller's boxed copy then spanned the key interning.

Also: Symbol keys were coalesced through a `HashMap` keyed on the symbol's **address**. A fresh `Symbol(desc)` is a GC allocation, so a symbol that moved mid-loop hashed to a new bucket and started a duplicate group. Now keyed on `SymbolHeader::id`, which an evacuation copies verbatim — the same reasoning #7246 used for symbol descriptions.

**`object/object_ops/define_properties.rs`** — `keys: Vec<f64>` was walked across `js_string_coerce`, `js_dynamic_object_get_property` (a **user getter** on the properties bag) and `js_object_define_property`, with the receiver, the bag, the own-names array and the coerced key string all bare locals in the same window.

**`proxy/own_keys.rs`** (issue item 5, found by sweeping for the same convention) — `alloc_key_array` grew the result array between key pushes, and `proxy_enum_own_keys` held the trap's key list and the accepted-so-far list across the proxy's `getOwnPropertyDescriptor` trap.

## The reusable rule

`gc::RootedValues` (`gc/roots/rooted_values.rs`): a growable list whose elements are `RuntimeHandle`s. The handle stack is a registered *mutable* root scanner, so elements are marked **and** their slots rewritten, and `get(i)` re-reads the slot. It is not a proof — Rust has no effect system for "this call may allocate" — but it removes the container as the hole and makes the correct shape the short one. The module docs record the one footgun: never push to an outer `RootedValues` while an inner `RuntimeHandleScope` is alive, because the inner scope's drop truncates the stack.

No new root holder (it borrows the existing handle stack, so `gc_runtime_root_holders.py` needs no verdict) and no new `get_raw_{mut,const}_ptr` sites (`raw_handle_debt.py` unmoved — it reads 3 *below* baseline).

## How the fix is proven

**Not** "it didn't crash". Every assertion is gated on a collection that actually moved something.

`gc/tests/rooted_container_values.rs`, four tests under `CopyingNurseryTestGuard` with a forced `collect_minor_trace`:

1. `rooted_values_elements_survive_a_collection_that_moved_them` — asserts `copied_objects > 0`, that every element's address changed, **and** that the post-collection pointer still reads the original bytes.
2. `plain_vec_of_values_is_not_a_root` — the sabotage arm. The identical workload in a bare `Vec<f64>` keeps naming pre-collection addresses while a rooted witness in the same cycle moves. This is what makes (1) non-vacuous.
3./4. `object_group_by_…` / `map_group_by_…` — end to end through the real `#[no_mangle]` entry points, callback forcing an evacuating minor on **every** element, groups verified by string bytes.

**Sabotage verification** (fix committed first): with `object/groupby.rs` reverted to `origin/main` and nothing else changed, both end-to-end tests abort with `TypeError: value is not a function` — the canonical late-surfacing form of this class. With the fix restored, all four pass.

**Compiled witness.** Two gap tests, each A/B'd against a pristine `origin/main` build with identical `-p` sets and a pinned `PERRY_RUNTIME_DIR`, under

```
PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 \
PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800
```

| probe | pristine | this branch |
|---|---|---|
| `test_gap_gc_container_value_rooting.ts` | exit 138, `[gc-fromspace-protect] FAULT: signal 10` naming a retired from-space address | exit 0, byte-exact vs node 26.5.1 |
| `test_gap_gc_define_properties_key_rooting.ts` | exit 138, same | exit 0, byte-exact vs node 26.5.1 |

The instrument is shown live in both runs (`retired_set=#N … bytes_protected=…`), so a green arm is a protected arm and not a run with zero copying minors.

## Why the two probes are separate programs

A `groupBy` arm followed by *any* `defineProperty`-with-getter work faults under the witness configuration **even with this fix in** — and it faults identically when `Object.defineProperties` is replaced by a hand-written `Object.defineProperty` loop, i.e. with none of the code this PR touches on the path. That is a separate pre-existing defect in the `defineProperty`/getter family — the wider window #6949's scope note names and defers (`js_object_define_property` holds `obj` / `descriptor_value` and the six raw `JSValue`s inside `DescView` across its own later `js_string_from_bytes` calls). Keeping the programs apart means each gap test fails for its own reason. Filed separately.

## Validation

| check | result |
|---|---|
| `cargo test -p perry-runtime --lib` | **2215 passed, 0 failed**, 4 ignored (#7946's flakiness did not appear) |
| gap corpus — all 36 `test_gap_gc_*.ts` + 5 `test_gap_{proxy,reflect}*.ts`, byte-exact vs node 26.5.1, in the default config **and** under `PERRY_GC_PROTECT_FROMSPACE=1 DEPTH=800` | **41/41** |
| both new probes under `PERRY_GC_VERIFY_EVACUATION=1` (+ seeded schedule) | exit 0, byte-exact |
| `cargo fmt --check`, `check_file_size.sh`, `gc_runtime_root_holders.py`, `raw_handle_debt.py` | clean (debt reads 3 *below* baseline) |

**Instrument liveness**, because a run with zero copying minors protects nothing:

- `test_gap_gc_container_value_rooting`: 164 safepoints / 164 copying minors / **67,889 objects moved**, 164 quarantined retired sets.
- `test_gap_gc_define_properties_key_rooting`: 60 / 60 / **33,302 moved**, 60 retired sets.
- Across the 41-program corpus the quarantine printed a retired-set line in 20 of 41 programs (185 sets). The other 21 ran no copying minor, so for those the protected arm is a no-regression check, not a rooting witness — stated rather than glossed.

## Sweep (issue item 5)

A scan for the shape — a `Vec<f64>`/`Vec<(f64…)>` accumulator pushed inside a loop that also calls something allocating or user-facing, with no `RuntimeHandleScope` — returns 14 functions. `proxy/own_keys.rs` (2) are fixed here. `js_typed_array_filter` is real and deliberately deferred (its `kept` vector spans a user callback, and `ta`/`recv` are hoisted raw locals across the same callback — the `ta` half is #6949 shape (a), so both want one change). The remaining 11 are argument-gathering: the `Vec` is filled from an already-materialized source with no allocating call *between* pushes, and converting them would cost a handle push per argument on the hottest dispatch paths for no demonstrated window. `object/descriptors.rs` — the function the issue quotes as carrying the "builder helpers follow this convention" comment — was already converted by #6943/#7341. Full table in `gc-handoff/ROOTVEC-NOTES.md`.

## #7803

Could **not** be reproduced: `test-files/gc-dep-corpus/main.ts` does not link on this box (`Undefined symbols: _perry_fn_node_modules_zod_src_v4_core_index_ts__NEVER`, `…__brand`, … — the `export *` re-export set in the currently pinned `zod@4.3.5`), identically on a pristine `origin/main` build, so #7803's reproducer is not runnable as written.

What is established: the zod workload does route through `js_object_define_properties` (`node_modules/zod/src/v4/core/util.ts:316`, `node_modules/zod/src/v4/classic/errors.ts:28`), one of the two sites fixed here, and #7803's symptom — `Cannot read properties of undefined (reading 'toString')` — is exactly what a stale key string in that loop produces (the property is defined under a garbage name, the later read misses). That makes this a **candidate** cause of #7803, not a confirmed one. Retest once the corpus links again.
