### PR TITLE
fix(gc): do not start a budgeted cycle for a nursery-cap trigger it cannot discharge (#7909)

### DIFF
--- a/changelog.d/7972-gc-nursery-cap-budgeted-deferral.md
+++ b/changelog.d/7972-gc-nursery-cap-budgeted-deferral.md
@@ -1,0 +1,37 @@
+**fix(gc): a host safepoint no longer starts a budgeted cycle for a nursery-cap trigger it cannot discharge (#7909).**
+
+`gc_budgeted_due_trigger()` reported the young-generation scavenge cap as
+`BudgetedGcTrigger::ArenaBytes`, so a host safepoint or mutator assist started a
+**budgeted** cycle for it. A budgeted cycle is `low_pause_non_moving` by
+construction — it sweeps in place and cannot lower
+`copying_from_space_in_use_bytes()`, the exact quantity `young_scavenge_cap_due()`
+tests — while `gc_safepoint_moving_minor` rejects every precise safepoint at its
+`budgeted` entry guard for as long as the cycle is open. The two compose into a
+self-sustaining stall (cap due → cycle started → moving minor locked out →
+nothing reclaims → cap still due) that keeps the SATB mark barrier armed for the
+rest of the process and reports **nothing**, because the `[gc]` trace is written
+by the completion path. Measured on `gc-handoff/apps/asyncpipe.ts` when it was
+filed: 1 cycle started, 15 steps, 0 completions, barrier armed 37 ms of a 127 ms
+program, zero collections.
+
+The cap is now its own trigger variant, `YoungScavengeCap`. Every collection site
+treats it identically to `ArenaBytes`; the split exists solely so the budgeted
+stepper can tell them apart at the moment it decides whether to **start** a cycle.
+When the cap is the only due trigger and the cycle would be budgeted, no cycle is
+started and the pressure is deferred to the precise safepoint — arena baseline
+included, so the `moving_defer_within_slack` valve is not left reading a stale,
+already-exceeded baseline — exactly as `gc_check_trigger`'s alloc-point arm has
+always done. That asymmetry between the two paths was the bug. No new knob;
+`PERRY_GC_DIAG=1`'s `[gc-incremental]` line gains `nursery_cap_deferred=N` so the
+refusal is distinguishable from "nothing was due".
+
+The regression test drives the real host-safepoint path with a per-thread cap
+override and pairs the refusal with a control phase on the same fixture — same
+thread, same heap, only the due trigger differs, and the control must still start
+a cycle — so the pair discriminates "declines this trigger" from "declines
+everything". It is a unit test rather than an end-to-end fixture because the
+issue's named reproducer is not durable: `PERRY_GC_SCAVENGE_NURSERY_MB=4` on
+`apps/asyncpipe.ts` reproduced the filed signature at 0.5.1490 and reproduces
+nothing at 0.5.1495; swept across the whole dial the defect now presents one
+notch lower, at cap 2, where a budgeted cycle is still started for the cap and
+arms the mark barrier for 87.9 ms of a ~127 ms program.

--- a/crates/perry-runtime/src/gc/instruments.rs
+++ b/crates/perry-runtime/src/gc/instruments.rs
@@ -216,12 +216,24 @@ pub(crate) enum BudgetedStepSkip {
     NoTrigger,
     StartBlocked,
     ResumeBlocked,
+    /// #7909: a cycle was NOT started because the only due trigger was the
+    /// young-generation scavenge cap, which a budgeted (low-pause non-moving)
+    /// cycle cannot discharge. The pressure is deferred to the precise
+    /// safepoint instead, where the copying minor can evacuate it.
+    ///
+    /// This is the one arm that is a *refusal*, not a stall: every other arm
+    /// leaves the trigger owned by a cycle that will eventually run, while this
+    /// one hands ownership to a different collector. It is counted because the
+    /// alternative — starting the cycle — is invisible in the `[gc]` trace, so
+    /// without a counter neither state can be told from "nothing was due".
+    NurseryCapUndischargeable,
 }
 
 static SKIP_REENTRANT: AtomicU64 = AtomicU64::new(0);
 static SKIP_NO_TRIGGER: AtomicU64 = AtomicU64::new(0);
 static SKIP_START_BLOCKED: AtomicU64 = AtomicU64::new(0);
 static SKIP_RESUME_BLOCKED: AtomicU64 = AtomicU64::new(0);
+static SKIP_NURSERY_CAP_UNDISCHARGEABLE: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
 pub(crate) fn note_budgeted_step_skip(reason: BudgetedStepSkip) {
@@ -230,6 +242,7 @@ pub(crate) fn note_budgeted_step_skip(reason: BudgetedStepSkip) {
         BudgetedStepSkip::NoTrigger => &SKIP_NO_TRIGGER,
         BudgetedStepSkip::StartBlocked => &SKIP_START_BLOCKED,
         BudgetedStepSkip::ResumeBlocked => &SKIP_RESUME_BLOCKED,
+        BudgetedStepSkip::NurseryCapUndischargeable => &SKIP_NURSERY_CAP_UNDISCHARGEABLE,
     }
     .fetch_add(1, Ordering::Relaxed);
 }
@@ -242,6 +255,12 @@ pub fn budgeted_step_skips() -> (u64, u64, u64, u64) {
         SKIP_START_BLOCKED.load(Ordering::Relaxed),
         SKIP_RESUME_BLOCKED.load(Ordering::Relaxed),
     )
+}
+
+/// #7909: budgeted cycles declined because only the undischargeable young-gen
+/// scavenge cap was due. Each one is a stalled cycle that did NOT happen.
+pub fn budgeted_step_nursery_cap_deferrals() -> u64 {
+    SKIP_NURSERY_CAP_UNDISCHARGEABLE.load(Ordering::Relaxed)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -1164,7 +1164,8 @@ fn emit_incremental_liveness_diag() {
         "[gc-incremental] cycle_starts={} steps={} completions={} active_at_exit={} \
          mark_barrier_arms={} mark_barrier_armed_us={} \
          skips(reentrant={reentrant} no_trigger={no_trigger} start_blocked={start_blocked} \
-         resume_blocked={resume_blocked}) safepoints_blocked_by_budgeted={} \
+         resume_blocked={resume_blocked} nursery_cap_deferred={}) \
+         safepoints_blocked_by_budgeted={} \
          safepoints_blocked(in_alloc={blocked_alloc} unsafe_zone={blocked_unsafe_zone} \
          root_lock={blocked_root_lock}) \
          copying_minors={} loop_polls={} poll_arm_events={} \
@@ -1175,6 +1176,7 @@ fn emit_incremental_liveness_diag() {
         policy::gc_budgeted_cycle_active(),
         instruments::mark_barrier_arm_events(),
         instruments::mark_barrier_armed_us(),
+        instruments::budgeted_step_nursery_cap_deferrals(),
         instruments::moving_safepoints_blocked_by_budgeted(),
         instruments::copying_minor_cycles(),
         instruments::loop_polls_reached(),

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -108,8 +108,55 @@ pub(super) fn young_scavenge_cap_due() -> bool {
     if !nursery_cap_active() {
         return false;
     }
-    crate::arena::copying_from_space_in_use_bytes()
-        >= super::tenuring::scavenge_nursery_cap_effective_bytes()
+    crate::arena::copying_from_space_in_use_bytes() >= scavenge_nursery_cap_dueness_bytes()
+}
+
+/// The cap value [`young_scavenge_cap_due`] compares against.
+///
+/// Split out only so a test can make the cap due without allocating the real
+/// 16 MB — a PER-THREAD override next to the reader, the shape support.rs
+/// mandates for anything a test needs to move (never the process environment,
+/// which is shared by every libtest thread; see #7946). It deliberately does
+/// NOT feed `effective_next_arena_trigger`: this is about *dueness*, and a test
+/// that also moved the trigger clamp would be changing two things at once.
+fn scavenge_nursery_cap_dueness_bytes() -> usize {
+    #[cfg(test)]
+    if let Some(bytes) = GC_NURSERY_CAP_TEST_DUE_BYTES.with(Cell::get) {
+        return bytes;
+    }
+    super::tenuring::scavenge_nursery_cap_effective_bytes()
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override for [`scavenge_nursery_cap_dueness_bytes`].
+    static GC_NURSERY_CAP_TEST_DUE_BYTES: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// RAII override making the young-gen scavenge cap due at `bytes` of from-space
+/// occupancy on this thread (#7909).
+#[cfg(test)]
+pub(super) struct ScavengeNurseryCapTestGuard {
+    previous: Option<usize>,
+}
+
+#[cfg(test)]
+impl ScavengeNurseryCapTestGuard {
+    pub(super) fn due_at_bytes(bytes: usize) -> Self {
+        let previous = GC_NURSERY_CAP_TEST_DUE_BYTES.with(|cell| {
+            let previous = cell.get();
+            cell.set(Some(bytes));
+            previous
+        });
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScavengeNurseryCapTestGuard {
+    fn drop(&mut self) {
+        GC_NURSERY_CAP_TEST_DUE_BYTES.with(|cell| cell.set(self.previous));
+    }
 }
 
 /// Is the scavenge nursery cap in force?
@@ -2344,7 +2391,14 @@ pub fn gc_check_trigger() {
             || super::roots::registered_root_scanners_block_budgeted_gc())
     {
         let direct_kind = match gc_budgeted_due_trigger() {
-            Some(BudgetedGcTrigger::ArenaBytes) => Some(GcTriggerKind::ArenaBytes),
+            // #7909: `YoungScavengeCap` is a nursery-churn trigger exactly like
+            // `ArenaBytes` here — this arm's whole job is to route nursery
+            // pressure to a collection that can actually reclaim it, so the two
+            // must not diverge at THIS site. They diverge only at the budgeted
+            // stepper's start decision.
+            Some(BudgetedGcTrigger::ArenaBytes | BudgetedGcTrigger::YoungScavengeCap) => {
+                Some(GcTriggerKind::ArenaBytes)
+            }
             Some(BudgetedGcTrigger::MallocCount) => Some(GcTriggerKind::MallocCount),
             _ => None,
         };
@@ -2551,10 +2605,20 @@ struct BudgetedGcCycle {
     rebaseline: BudgetedGcRebaseline,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BudgetedGcTrigger {
     OldReclaim,
     ArenaBytes,
+    /// The young-generation scavenge cap ([`young_scavenge_cap_due`]).
+    ///
+    /// Split out of `ArenaBytes` by #7909. Every *collection* treats the two
+    /// identically — the split exists solely so the budgeted stepper can tell
+    /// them apart at the moment it decides whether to START a cycle, because
+    /// the quantity this one tests (`copying_from_space_in_use_bytes`) is one
+    /// a budgeted low-pause NON-MOVING cycle cannot lower. See
+    /// [`nursery_cap_active`] for why: a non-moving minor sweeps in place and
+    /// leaves from-space occupied.
+    YoungScavengeCap,
     MallocCount,
 }
 
@@ -2612,7 +2676,7 @@ fn gc_budgeted_due_trigger() -> Option<BudgetedGcTrigger> {
         return Some(BudgetedGcTrigger::ArenaBytes);
     }
     if young_scavenge_cap_due() {
-        return Some(BudgetedGcTrigger::ArenaBytes);
+        return Some(BudgetedGcTrigger::YoungScavengeCap);
     }
 
     let malloc_count = malloc_object_count();
@@ -2679,7 +2743,11 @@ pub(crate) fn gc_safepoint_moving_minor() -> bool {
     set_safepoint_pending(false);
     let _declared = DeclaredSafepointGuard::enter();
     let kind = match gc_budgeted_due_trigger() {
-        Some(BudgetedGcTrigger::ArenaBytes) => GcTriggerKind::ArenaBytes,
+        // #7909: the nursery cap and the whole-arena trigger are the same
+        // collection here — this IS the evacuating collector the cap is for.
+        Some(BudgetedGcTrigger::ArenaBytes | BudgetedGcTrigger::YoungScavengeCap) => {
+            GcTriggerKind::ArenaBytes
+        }
         Some(BudgetedGcTrigger::MallocCount) => GcTriggerKind::MallocCount,
         // ★ #7148: old-gen reclaim used to be the alloc-point arm's business
         // exclusively — it ran a direct full mark-sweep behind a forced
@@ -3127,7 +3195,10 @@ fn gc_start_budgeted_cycle_for_pressure(progress_kind: GcProgressKind) -> Option
                 progress_kind,
             )
         }
-        BudgetedGcTrigger::ArenaBytes => {
+        // #7909: identical treatment — a cycle that DOES start for nursery
+        // pressure (a non-budgeted one, which can evacuate) is the same
+        // arena-bytes collection it always was.
+        BudgetedGcTrigger::ArenaBytes | BudgetedGcTrigger::YoungScavengeCap => {
             let rebaseline = BudgetedGcRebaseline::ArenaBytes {
                 pre_in_use: crate::arena::arena_in_use_bytes(),
             };
@@ -3300,6 +3371,19 @@ fn gc_budgeted_step_work_units_inner(work_units: usize) -> JsGcStepResult {
     gc_budgeted_step_work_units_inner_with_progress(work_units, GcProgressKind::NormalIncremental)
 }
 
+/// #7909: arm the precise-root safepoint for nursery pressure the budgeted
+/// stepper just declined, mirroring `gc_check_trigger`'s deferral arm exactly
+/// (including the arena baseline the slack valve measures from — leaving that
+/// stale would make `moving_defer_within_slack` read an already-exceeded
+/// baseline and disable deferral for the rest of the process, the #7024 shape).
+fn defer_nursery_cap_to_precise_safepoint() {
+    if GC_SAFEPOINT_PENDING.with(Cell::get) {
+        return;
+    }
+    GC_SAFEPOINT_DEFER_ARENA_BASE.with(|base| base.set(crate::arena::arena_total_bytes()));
+    set_safepoint_pending(true);
+}
+
 fn gc_budgeted_step_work_units_inner_with_progress(
     work_units: usize,
     start_progress_kind: GcProgressKind,
@@ -3316,10 +3400,52 @@ fn gc_budgeted_step_work_units_inner_with_progress(
     };
 
     if !gc_budgeted_cycle_active() {
-        if gc_budgeted_due_trigger().is_none() {
+        let Some(due) = gc_budgeted_due_trigger() else {
             super::instruments::note_budgeted_step_skip(
                 super::instruments::BudgetedStepSkip::NoTrigger,
             );
+            return gc_idle_step_result();
+        };
+        if due == BudgetedGcTrigger::YoungScavengeCap && start_progress_kind.is_budgeted() {
+            // ★ #7909. Starting a budgeted cycle here is strictly worse than
+            // starting nothing, and it is self-sustaining.
+            //
+            // A budgeted cycle is `low_pause_non_moving` by construction
+            // (`progress_kind.is_budgeted()` at the collection site), so it
+            // sweeps in place and CANNOT lower
+            // `copying_from_space_in_use_bytes()` — the exact quantity
+            // `young_scavenge_cap_due()` tests. So the trigger it was started
+            // for survives the cycle. Worse, while the cycle is open
+            // `gc_safepoint_moving_minor` rejects every precise safepoint at
+            // its `budgeted` entry guard, so the ONE collector that can lower
+            // that quantity is locked out for the cycle's whole life. If the
+            // host's step cadence cannot finish the cycle — 2048 work units
+            // per microtask drain, and `asyncpipe` reaches ~15 drains after the
+            // cap goes due — the cycle never completes, is never cancelled, and
+            // the composition is permanent: cap due -> cycle started -> moving
+            // minor blocked -> nothing reclaims -> cap still due. The mutator
+            // then pays the SATB mark barrier for the rest of the process
+            // (measured: 22.9-42.5 ms of a ~127 ms program) for a collection
+            // that reclaims nothing, and the `[gc]` trace stays EMPTY because
+            // it is written by the completion path.
+            //
+            // The alloc-point arm already routes nursery pressure away from
+            // this stepper for the same reason (`gc_check_trigger`'s direct /
+            // deferred arm, which runs before the mutator assist). This is that
+            // asymmetry closed: the host-safepoint path now defers nursery
+            // pressure to the precise safepoint too, where the copying minor
+            // runs with rewritable roots and actually reclaims it.
+            //
+            // Note what is NOT skipped: `young_scavenge_cap_due()` is false
+            // unless `nursery_cap_active()`, which IS
+            // `gc_moving_loop_polls_enabled()`. So the cap can only be the due
+            // trigger in exactly the configuration where the precise route
+            // exists. When it does not, this branch is unreachable and the cap
+            // never fires at all.
+            super::instruments::note_budgeted_step_skip(
+                super::instruments::BudgetedStepSkip::NurseryCapUndischargeable,
+            );
+            defer_nursery_cap_to_precise_safepoint();
             return gc_idle_step_result();
         }
         if gc_budgeted_start_blocked() {

--- a/crates/perry-runtime/src/gc/tests/host_safepoints.rs
+++ b/crates/perry-runtime/src/gc/tests/host_safepoints.rs
@@ -314,12 +314,14 @@ fn host_safepoint_trace_reports_normal_incremental_budgeted_steps() {
 /// completions, still active at exit, mark barrier armed 37 ms of a 127 ms
 /// program, zero collections** — 11.8 % of the program's instructions.
 ///
-/// This test does not assert the stall is *fixed* — it is not; the fix
-/// (unblocking the moving minor) costs +51 % on that program because of the
-/// per-cycle root-scanning price tracked in #7915. It pins the composition, so
-/// that a change to either half is a deliberate change to a documented
-/// interaction rather than a silent one, and it pins the instrument that makes
-/// the state observable.
+/// This test pins the **lockout half only**, on a trigger the budgeted cycle
+/// CAN discharge (whole-arena bytes). That composition is intended: a cycle
+/// that will finish owns the collector while it runs. What was the defect is
+/// the *other* trigger — the young-gen scavenge cap, which no budgeted cycle
+/// can lower — and that arm is closed by
+/// `a_nursery_cap_only_trigger_is_deferred_to_the_collector_that_can_discharge_it`
+/// below. Keep both: this one states what the lockout costs, that one states
+/// when it is allowed to be paid.
 #[test]
 fn an_active_budgeted_cycle_locks_out_the_moving_minor_and_keeps_the_barrier_armed() {
     let _guard = CopyingNurseryTestGuard::new(1);
@@ -383,5 +385,152 @@ fn an_active_budgeted_cycle_locks_out_the_moving_minor_and_keeps_the_barrier_arm
         "the instrument must count the completion too, or `starts > completions` \
          could never be read as a stall"
     );
+    assert!(!gc_budgeted_cycle_active());
+}
+
+/// ★ #7909: a host safepoint must NOT start a budgeted cycle whose only due
+/// trigger is the young-generation scavenge cap.
+///
+/// # The defect this closes
+///
+/// `young_scavenge_cap_due()` tests `copying_from_space_in_use_bytes()`. A
+/// budgeted cycle is `low_pause_non_moving` by construction, sweeps in place,
+/// and therefore **cannot lower that quantity** — so the trigger survives the
+/// cycle it started. Meanwhile the cycle blocks `gc_safepoint_moving_minor` at
+/// its `budgeted` entry guard, which is the one collector that *can* lower it.
+/// If the host cadence cannot finish the cycle (2048 work units per microtask
+/// drain; `gc-handoff/apps/asyncpipe.ts` reaches ~15 drains after the cap goes
+/// due) the composition is permanent and completely silent: `cycle_starts=1
+/// steps=14 completions=0 active_at_exit=true`, the SATB mark barrier armed for
+/// 22.9 ms of a 127 ms program, and **zero** `[gc]` lines because the trace is
+/// written by the completion path.
+///
+/// # Why this is a test and not a knob
+///
+/// The defect is currently *unreached* on the shipped corpus — #7933/#7939 took
+/// `asyncpipe`'s young survival to ~25‰, so the 16 MB cap never goes due there.
+/// That is a property of one week's allocation profile, not of the collector:
+/// `PERRY_GC_SCAVENGE_NURSERY_MB=4` reproduces the original signature exactly on
+/// today's `main`. Closing the issue on those numbers would delete the knowledge
+/// and let the next allocation-rate change silently re-expose it.
+///
+/// # Why the control phase is not optional
+///
+/// "No cycle was started" is satisfied by a fixture where nothing was due at
+/// all, which is the failure mode this repo keeps paying for. So phase 1 asserts
+/// the cap is due *and* that neither other trigger is, and phase 2 then makes
+/// the whole-arena trigger due **on the same thread, with the same heap** and
+/// asserts a cycle DOES start. Only the trigger differs between the two phases,
+/// so the pair discriminates "declines this trigger" from "declines everything".
+#[test]
+fn a_nursery_cap_only_trigger_is_deferred_to_the_collector_that_can_discharge_it() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_old_reclaim_pressure();
+
+    // Real young-gen occupancy, then a cap that the occupancy clears. The
+    // override is per-thread and next to its reader (support.rs's rule); moving
+    // `PERRY_GC_SCAVENGE_NURSERY_MB` would be a process-wide environment write.
+    let live = live_test_string(b"nursery_cap_7909_live");
+    js_shadow_slot_set(0, string_bits(live));
+    for _ in 0..6_000 {
+        let _ = young_leaf();
+    }
+    let _cap = super::super::policy::ScavengeNurseryCapTestGuard::due_at_bytes(1);
+
+    // ── phase 1: cap-only pressure ───────────────────────────────────────────
+    // ★ Live subject: the cap is genuinely due...
+    assert!(
+        crate::arena::copying_from_space_in_use_bytes() > 0,
+        "fixture must have young-gen occupancy for the cap to test"
+    );
+    assert!(
+        super::super::policy::young_scavenge_cap_due(),
+        "fixture must present a due young-gen scavenge cap"
+    );
+    // ...and it is the ONLY thing due, so the refusal below can only be about it.
+    assert!(
+        crate::arena::arena_total_bytes() < super::super::policy::next_arena_trigger_base(),
+        "the whole-arena trigger must NOT be due in phase 1"
+    );
+    assert!(
+        malloc_object_count() < GC_NEXT_MALLOC_TRIGGER.with(|trigger| trigger.get()),
+        "the malloc trigger must NOT be due in phase 1"
+    );
+
+    let starts_before = super::super::instruments::incremental_cycle_starts();
+    let deferrals_before = super::super::instruments::budgeted_step_nursery_cap_deferrals();
+
+    let declined = gc_runtime_safepoint();
+
+    assert_eq!(
+        declined.status, JS_GC_STEP_STATUS_IDLE,
+        "a cap-only host safepoint must report idle, not an active cycle"
+    );
+    assert_eq!(
+        super::super::instruments::incremental_cycle_starts(),
+        starts_before,
+        "no budgeted cycle may be started for a trigger it cannot discharge"
+    );
+    assert!(
+        !gc_budgeted_cycle_active(),
+        "no budgeted cycle may be left active by a cap-only safepoint"
+    );
+    // ★ The refusal is attributed, not merely absent: without this the assertion
+    // above is also satisfied by every other reason a start can be skipped
+    // (reentrant, start-blocked, nothing due).
+    assert_eq!(
+        super::super::instruments::budgeted_step_nursery_cap_deferrals(),
+        deferrals_before + 1,
+        "the refusal must be counted as the nursery-cap deferral specifically"
+    );
+    // The deferral hands the pressure to the precise safepoint, exactly as the
+    // alloc-point arm does — otherwise a compute loop would never poll for it.
+    assert!(
+        GC_SAFEPOINT_PENDING.with(|pending| pending.get()),
+        "declining the cycle must arm the precise safepoint instead"
+    );
+
+    // ★ The point of the whole fix: the collector that CAN discharge the cap is
+    // reachable. Under the defect this returns false, for the `budgeted` reason.
+    let blocked_before = super::super::instruments::moving_safepoints_blocked_by_budgeted();
+    assert!(
+        super::super::gc_safepoint_moving_minor(),
+        "the moving minor must not be locked out by a cycle that was never started"
+    );
+    assert_eq!(
+        super::super::instruments::moving_safepoints_blocked_by_budgeted(),
+        blocked_before,
+        "no safepoint may be rejected for `budgeted` when no cycle is active"
+    );
+
+    // ── phase 2 (control): the SAME fixture, a discharge-able trigger ────────
+    // Same thread, same heap, same guards — only the due trigger differs. A
+    // cycle must start here, or phase 1 proves nothing.
+    trigger_guard.make_arena_trigger_due();
+    assert!(
+        crate::arena::arena_total_bytes() >= super::super::policy::next_arena_trigger_base(),
+        "control phase must present a due whole-arena trigger"
+    );
+
+    let started = gc_runtime_safepoint();
+    assert_eq!(
+        started.status, JS_GC_STEP_STATUS_ACTIVE,
+        "a whole-arena trigger IS discharge-able by a budgeted cycle and must still start one"
+    );
+    assert_eq!(
+        super::super::instruments::incremental_cycle_starts(),
+        starts_before + 1,
+        "the control must start exactly one cycle"
+    );
+    assert_eq!(
+        super::super::instruments::budgeted_step_nursery_cap_deferrals(),
+        deferrals_before + 1,
+        "the control must NOT be counted as a nursery-cap deferral"
+    );
+
+    // Leave the shared thread state clean.
+    let completed = complete_host_safepoint_cycle();
+    assert_eq!(completed.status, JS_GC_STEP_STATUS_COMPLETED);
     assert!(!gc_budgeted_cycle_active());
 }


### PR DESCRIPTION
Closes #7909.

## The defect

`gc_budgeted_due_trigger()` reported the young-generation scavenge cap as
`BudgetedGcTrigger::ArenaBytes`, so a host safepoint (and a mutator assist)
started a **budgeted** cycle for it. A budgeted cycle is `low_pause_non_moving`
by construction: it sweeps in place and **cannot lower
`copying_from_space_in_use_bytes()`**, which is the exact quantity
`young_scavenge_cap_due()` tests. Meanwhile `gc_safepoint_moving_minor` rejects
every precise safepoint at its `budgeted` entry guard for the cycle's whole
life.

The two compose into a stall that sustains itself and reports nothing:

```
cap due -> budgeted cycle started -> moving minor locked out
        -> nothing reclaims -> cap still due
```

The SATB mark barrier stays armed for the duration (every heap store, every
shadow-slot root store, allocate-black on every birth) and the `[gc]` trace
stays **empty**, because the trace is written by the completion path.

## The fix

Split the cap out as `BudgetedGcTrigger::YoungScavengeCap`. Every *collection*
site treats it exactly as `ArenaBytes` — the split exists only so the budgeted
stepper can tell them apart at the moment it decides whether to **start** a
cycle. When the only due trigger is the cap and the cycle would be budgeted, no
cycle is started; the pressure is deferred to the precise safepoint (arena
baseline included, so the `moving_defer_within_slack` valve is not left reading
a stale, already-exceeded baseline — the #7024 shape) exactly as
`gc_check_trigger`'s alloc-point arm has always done. **That asymmetry between
the two paths was the bug.**

No new knob. `PERRY_GC_DIAG=1`'s `[gc-incremental]` line gains
`nursery_cap_deferred=N`, so the refusal is distinguishable from "nothing was
due".

Unreachable by construction in the configuration where it would be wrong:
`young_scavenge_cap_due()` is false unless `nursery_cap_active()`, which **is**
`gc_moving_loop_polls_enabled()` — so the cap can only be the due trigger in
exactly the configuration where the precise route exists.

## The test, and why it is a unit test

`a_nursery_cap_only_trigger_is_deferred_to_the_collector_that_can_discharge_it`
drives the real host-safepoint path with a per-thread cap override (the shape
`support.rs` mandates — never a process-wide environment write, #7946) and pairs
the refusal with a **control phase on the same fixture**: same thread, same
heap, only the due trigger differs, and the control must still start a cycle. So
the pair discriminates "declines this trigger" from "declines everything", which
a bare `cycle_starts == 0` cannot.

★ The issue's named end-to-end reproducer is **stale** and this is why the test
does not use one. `PERRY_GC_SCAVENGE_NURSERY_MB=4` on `apps/asyncpipe.ts`
reproduced the filed signature at `ac52a5c38` (0.5.1490). Swept across the whole
dial on `a769fafc6`, it does not:

| cap MB | cycle_starts | steps | completions | active_at_exit | barrier armed us | copying minors |
|--:|--:|--:|--:|---|--:|--:|
| 1 | 0 | 0 | 0 | false | 0 | 9 |
| **2** | **1** | **20** | **1** | false | **87 939** | 3 |
| 3 | 0 | 0 | 0 | false | 0 | 6 |
| 4 | 0 | 0 | 0 | false | 0 | 4 |
| 8 | 0 | 0 | 0 | false | 0 | 2 |
| 16 (default) | 0 | 0 | 0 | false | 0 | 1 |
| 24 / 32 | 0 | 0 | 0 | false | 0 | 0 |

The *stall* half is no longer reachable on that program at any cap; the
*defect* half is fully intact one notch lower, at cap 2 — a budgeted non-moving
cycle started for a trigger it cannot discharge, arming the mark barrier for
87.9 ms of a ~127 ms program. A fixture pinned to one knob value on one
benchmark moved twice in five patch versions, so it is not a durable gate.

## Validation

Own build, own worktree (`wt-hdr`), own `CARGO_TARGET_DIR`, base `a769fafc6`
(0.5.1495). Both arms built with the identical `-p` set and
`PERRY_RUNTIME_DIR` pinned; the two `libperry_runtime.a` archives differ, so the
A/B is not vacuous.

**Correctness.** 19/19 corpus programs byte-exact vs `m0810/expected/`
(node 26.5.1), exit 0 — and again under
`PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800
PERRY_GC_VERIFY_EVACUATION=1`. `iso_miss` canary: `checksum 437840 misses 0`.
`cargo test --release -p perry-runtime` (`RUST_TEST_THREADS=1`):
**2229 passed, 0 failed, 4 ignored.**

**Sabotage-proved.** With the new branch disabled (`if false && …`, the fix
committed first), the test fails on the intended assertion —
`a cap-only host safepoint must report idle, not an active cycle` — and
`grep -c "Compiling perry-runtime v"` on the sabotage log reads **1**, so the red
verdict is about the sabotaged code and not a stale unit. (The pre-existing
`an_active_budgeted_cycle_locks_out_…` also goes red under the sabotage: the new
test panics before completing the cycle it opened, and these run single-threaded
in one process. It is green in both non-sabotaged runs.)

**Cost on the shipped corpus: zero, for a stated reason.** Every GC counter is
bit-identical across all 19 programs — same `minors`, same `fulls`, same
`copied_objects`, same `promoted_objects` — and RSS matches to 0.06 %.
Instructions span −0.48 % … +0.63 %, inside the base arm's own best-of-3 spread.
`nursery_cap_deferred=0` on all 19: at default settings **no budgeted cycle is
started anywhere in the corpus** (`cycle_starts=0`, `no_trigger=6`), so there is
nothing for the new branch to decline.

**In the regime where it IS live it is a large win — which refutes the recorded
blocker.** `GC7909-NOTES.md` §4.2 measured the equivalent unblocking at
`c109b089d` as **+51 % instructions / +57 % RSS** and concluded "#7909 cannot be
closed before #7915". Re-measured on `a769fafc6` at
`PERRY_GC_SCAVENGE_NURSERY_MB=2` (the value that still reaches the defect),
`ab_instr.py` best of 5, output byte-exact and exit 0 on both arms:

| arm | instr (M) | cycles (M) | RSS (MB) | Δ instr |
|---|--:|--:|--:|--:|
| base | 1573.8 | 369.5 | 37.7 | — |
| **fix** | **1317.0** | **337.6** | **24.2** | **−16.31 %** |

| counter | base | fix |
|---|--:|--:|
| `cycle_starts` | 1 | **0** |
| `steps` | 20 | 0 |
| `mark_barrier_armed_us` | **87 939** | **0** |
| `nursery_cap_deferred` | — | **2** |
| `copying_minors` | 3 | **9** |

−16 % instructions **and** −13.5 MB RSS. The state removed (88 ms of armed SATB
barrier plus a locked-out collector) is now more expensive than the state created
(six more copying minors). The blocker was a price, and the price has moved.

Full write-up and the harnesses: `gc-handoff/HDR-NOTES.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection behavior when nursery-cap pressure cannot be resolved during a budgeted cycle.
  * Defers collection to precise safepoints instead of starting ineffective cycles.
  * Preserves availability of moving minor collections for later use.
  * Ensures budgeted collection still starts when reclaimable arena pressure is present.

* **Diagnostics**
  * Added `nursery_cap_deferred` reporting to incremental garbage collection diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->