### PR TITLE
fix(lint): use the approved GcHeader accessor in the inline-slot-floor probe

### DIFF
--- a/changelog.d/7977-lint-red-gcheader-cast.md
+++ b/changelog.d/7977-lint-red-gcheader-cast.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **`lint` was red on `main`**, so every merge was bypassing a required context. `scripts/addr_class_inventory.py` flagged one violation — `crates/perry-runtime/src/object/tests.rs:646` `[gcheader-cast]`, a bare `(obj as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader` added by #7928's inline-slot-floor probe.
+
+  Replaced with the approved accessor `addr_class::try_read_gc_header`, which takes the object address and performs the header arithmetic behind its plausibility and slab checks. The audit passes again (1056 files, 546 ratcheted sites), with no new allowlist entry — the ratchet's whole point is that a fix deletes the violation rather than exempting it.
+
+  Worth stating plainly because it is the shape CLAUDE.md warns about: a **required** context that is red trains everyone to bypass it, and a genuinely new violation would then land invisibly behind the old one.

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -643,8 +643,14 @@ fn two_field_literal_footprint_is_exactly_accounted() {
     let obj = js_object_alloc_with_shape(0x7916_0001, 2, keys.as_ptr(), keys.len() as u32);
     assert!(!obj.is_null());
     let recorded = unsafe {
-        let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        (*gc).size as usize
+        // #7928 added this probe with a bare `as *const GcHeader`, which the
+        // addr-class ratchet rejects (and which turned required `lint` red on
+        // `main`). `try_read_gc_header` is the approved accessor: it takes the
+        // OBJECT address and does the header arithmetic itself, behind the
+        // plausibility and slab checks.
+        crate::value::addr_class::try_read_gc_header(obj as usize)
+            .expect("a freshly allocated object must carry a readable GcHeader")
+            .size as usize
     };
     let expected = crate::gc::GC_HEADER_SIZE
         + std::mem::size_of::<ObjectHeader>()


### PR DESCRIPTION
`lint` is **red on `main`** — `scripts/addr_class_inventory.py` exits 1 on one violation introduced by #7928:

```
crates/perry-runtime/src/object/tests.rs:646: [gcheader-cast] let gc = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
```

Verified by running the checker in a clean worktree at `origin/main` (my own working tree is on another branch, which is why a local run initially passed and nearly had me dismiss the report).

**Fix**: use `addr_class::try_read_gc_header`, the accessor the checker's own error message names. It takes the *object* address and does the `- GC_HEADER_SIZE` arithmetic itself, behind its plausibility and small-slab checks — so the probe also stops assuming a header is present rather than asserting it.

**No allowlist entry added.** The ratchet exists so a fix deletes the violation; exempting it would be the thing the file's own README says not to do.

## Why this matters beyond one line

A required context that is red means **every merge bypasses it**, and a genuinely new violation lands invisibly behind the stale one. That is CLAUDE.md's documented failure mode, and it was live: ~20 PRs merged into the collector today with admin bypass.

## Validation

- `python3 scripts/addr_class_inventory.py` — **passes** (1056 files scanned, 284 allowlisted, 546 ratcheted sites); fails on `origin/main`.
- `cargo check -p perry-runtime --lib --tests` — 0 errors.
- `cargo fmt --all -- --check` — clean.

Found by the #7955/#7956 agent while validating #7974.