### PR TITLE
feat(runtime): #6759 C3 rung 1 — make the shape word uniform

### DIFF
--- a/changelog.d/7983-6759-rung1-uniform-shape-word.md
+++ b/changelog.d/7983-6759-rung1-uniform-shape-word.md
@@ -1,0 +1,59 @@
+### #6759 C3 rung 1 — the shape word is uniform (runtime)
+
+`ObjectHeader.parent_class_id` **is** the shape word, but the stamp was gated on
+`class_id == 0` — so a **class instance had no shape word at all**, and its only
+header evidence of a key-set change was the `keys_array` POINTER. That is why
+`class_field_inline_guard` compares that pointer, and why the #7916 header
+shrink cannot delete it yet.
+
+Rung 0 (#7981) removed the last reader of the header word as inheritance data,
+which unblocked this. The `class_id` conjunct is gone; the rule is now uniformly
+`the word is a ShapeId ⟺ is_shape_id(word)`.
+
+★ **The emitted IR already spelled it that way.** All three PICs
+(`property_get/generic_dispatch.rs`, `expr/proxy_reflect.rs` ×2) derive the
+receiver token as `is_stamp ? (id | 1<<62) : keys_array`, where `is_stamp` is the
+ShapeId *range* test and **no `class_id` is loaded at all**. This change makes
+the runtime agree with the IR rather than introducing a new mode. The write-PIC
+token derivations in `proxy/put_value.rs` never had the gate either.
+
+`object/shapes.rs` grows `shape_word_is_writable` / `object_shape_stamp` /
+`stamp_object_shape` / `clear_object_shape_stamp`, and the two clear sites
+(`set_object_keys_array`, `delete_rest`), the two mint sites (`ic_miss`,
+`get_field_by_name_tail`), the null→first-key birth stamp
+(`field_set_by_name/tail`) and the `FIELD_CACHE` key route through them. A class
+instance is stamped **lazily** at its first by-name resolve (codegen still
+writes a constant `parent_cid` at `new C()`; eager birth stamping is rung 2),
+and a `delete` on it now clears the stamp and re-mints a *distinct* id exactly
+as a plain object's does.
+
+**Free correctness rider:** two of the four mint sites had no RegExp-alias
+check. A `RegExpHeader` aliases `GC_TYPE_OBJECT` with a different layout — its
+offset 4 is the high half of `regex_ptr` (reads as `class_id == 0`, so the old
+gate never excluded it) and **offset 8 is the low half of `pattern_ptr`**. All
+four now refuse the alias.
+
+★ **`typed_feedback::object_shape()` deliberately keeps its `class_id == 0`
+gate**, and that is the finding rather than an omission. Its token is not a PIC
+token: the guard family compares it against a **codegen-supplied keys pointer**
+(`typed_feedback/guards.rs::method_direct_call_contract` requires
+`shape_addr == expected_keys as usize`; the class-field and element-shape
+contracts do the same). An id can never equal that pointer, so returning one
+fails every such guard **closed** — memory-safe, no output difference, but it
+silently deletes the direct-method-call route and the class-field fast paths.
+Two existing tests catch it, and the site now names them. Migrating those nine
+consumers is rung 3.
+
+The entry gate
+`delete_leaves_a_class_instance_with_no_shape_word_to_transition` went red as
+designed and was replaced by the assertion its own failure message specified
+(`delete_mints_a_fresh_shape_id_for_a_class_instance`), keeping the two halves
+of it that are still true. New alongside it: same-class siblings share one
+ShapeId and a delete moves only the deleted-from instance; a 3-level
+`instanceof` chain still resolves after the header word is clobbered by a stamp;
+and a stamped class instance primes the **id** token the emitted PIC computes
+for it (priming a keys pointer there would be a permanent miss).
+`pointer_token_prime_stamps_epoch_and_goes_stale_on_bump` lost its production
+population — class instances were the last receivers priming raw keys pointers —
+so it was split: the epoch mechanics now drive `pic_prime_get` directly, keeping
+the `cache[2] == @PERRY_IC_EPOCH` guard provably able to fail.

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -389,9 +389,13 @@ pub extern "C" fn js_object_delete_field(
         //    object. Ids are never reused, so clearing here (plus the
         //    record drop above) makes every stale id-keyed cache entry a
         //    permanent miss; the next resolve stamps a fresh id.
-        if (*obj).class_id == 0 && crate::object::shapes::is_shape_id((*obj).parent_class_id) {
-            (*obj).parent_class_id = 0;
-        }
+        //
+        //    #6759 C3 rung 1: this now fires for CLASS INSTANCES too — the
+        //    whole point of the rung. A delete on a class instance is exactly
+        //    the case the shape word had no way to express: `class_id` is
+        //    preserved by design (vtable/instanceof identity) and the keys
+        //    pointer was the only compaction evidence in the header.
+        crate::object::shapes::clear_object_shape_stamp(obj);
 
         1
     }
@@ -604,8 +608,8 @@ pub extern "C" fn js_object_rest(
 #[cfg(test)]
 mod shape_transition_tests_6759 {
     //! #6759 C3: what a `delete` does to an object's SHAPE IDENTITY, pinned for
-    //! both object representations — because they differ, and the difference is
-    //! the entry gate for the header shrink (#7916).
+    //! both object representations — because rung 1 made them AGREE, and that
+    //! agreement is the entry gate for the header shrink (#7916).
     //!
     //! `perry-codegen`'s `class_field_inline_guard` speculates that a receiver's
     //! packed slot layout is its class's canonical one. `delete` breaks that
@@ -614,11 +618,20 @@ mod shape_transition_tests_6759 {
     //! the class's `@perry_class_keys_*` token. Replacing that pointer compare
     //! with a one-word ShapeId compare — which is what makes the header shrink
     //! a load *removal* instead of a load-for-probe trade — requires a class
-    //! instance to HAVE a shape word. It does not: `parent_class_id` is the
-    //! shape word only when `class_id == 0`.
+    //! instance to HAVE a shape word.
     //!
-    //! These tests state both facts so that a future change to either is a
-    //! deliberate edit rather than a silent drift.
+    //! Before rung 1 it did not: `parent_class_id` was the shape word only when
+    //! `class_id == 0`, so the sibling test below asserted the ABSENCE of one
+    //! and named its own replacement. Rung 1 removed the `class_id` gate, so
+    //! both representations now mint a fresh id across a delete and these tests
+    //! state the same property twice, once per representation.
+    //!
+    //! Rung 1 is deliberately runtime-only: the guard has NOT switched to the
+    //! id compare (that is rung 3), and codegen's inline `new C()` still writes
+    //! a constant `parent_cid`, so an instance is stamped LAZILY at its first
+    //! by-name resolve rather than at birth (rung 2). The tests below therefore
+    //! resolve a field before reading the stamp — a fresh instance legitimately
+    //! reads as unstamped.
     use super::*;
     use crate::object::shapes::is_shape_id;
 
@@ -669,14 +682,20 @@ mod shape_transition_tests_6759 {
         }
     }
 
-    /// The gap. A class instance has NO shape word to mint into: `class_id` is
-    /// preserved by design (it is the vtable/instanceof identity) and
-    /// `parent_class_id` is inheritance data, so the ONLY header evidence that a
-    /// compaction happened is the `keys_array` pointer. That is why
-    /// `class_field_inline_guard` loads it, and why the #7916 header shrink
-    /// cannot delete it before #6759 C3 gives class instances a shape word.
+    /// #6759 C3 rung 1 — the replacement the pre-rung-1 test named.
+    ///
+    /// This is the assertion `delete_leaves_a_class_instance_with_no_shape_word_to_transition`
+    /// asked to be replaced by. A class instance now HAS a shape word, so a
+    /// `delete` on it transitions the same way a plain object's does: the
+    /// compaction clears the stamp, and the next resolve mints a genuinely
+    /// fresh id (ids are never reused) rather than reviving the class's
+    /// canonical one.
+    ///
+    /// The old test's other half — that `class_id` is preserved and the keys
+    /// POINTER moves — is kept below, because both are still true and both are
+    /// still what `class_field_inline_guard` compares until rung 3.
     #[test]
-    fn delete_leaves_a_class_instance_with_no_shape_word_to_transition() {
+    fn delete_mints_a_fresh_shape_id_for_a_class_instance() {
         let _lock = crate::gc::global_side_table_test_lock();
         const CID: u32 = 0x0C3C_6760;
         const PARENT: u32 = 0x0C3C_6761;
@@ -693,11 +712,21 @@ mod shape_transition_tests_6759 {
                 js_object_set_field(obj, i as u32, JSValue::from_bits(v.to_bits()));
             }
             let keys_before = (*obj).keys_array;
-            let parent_before = (*obj).parent_class_id;
             assert_eq!((*obj).class_id, CID, "test premise: a class instance");
             assert!(
-                !is_shape_id(parent_before),
-                "test premise: the header word is inheritance data, not a shape stamp"
+                !is_shape_id((*obj).parent_class_id),
+                "test premise: a FRESH instance carries its allocation-time \
+                 parent_class_id — rung 1's stamp is lazy, not a birth stamp"
+            );
+
+            // Lazy stamp: the first by-name resolve installs a ShapeId over the
+            // (now readerless — rung 0/#7981) inheritance word.
+            let _ = crate::object::js_object_get_field_by_name(obj, key("del6759_y"));
+            let before = (*obj).parent_class_id;
+            assert!(
+                is_shape_id(before),
+                "a class instance was NOT stamped by its first by-name resolve \
+                 (got {before:#x}) — rung 1's whole subject is inert"
             );
 
             assert_eq!(js_object_delete_field(obj, key("del6759_x")), 1);
@@ -708,23 +737,146 @@ mod shape_transition_tests_6759 {
                 30.0,
                 "test premise: the delete did not compact the slots"
             );
-            // Only the keys pointer records it.
+            // The stamp is cleared eagerly …
+            assert_eq!(
+                (*obj).parent_class_id,
+                0,
+                "the stamp still describes the PRE-delete key list"
+            );
+            // … and re-minted, distinctly, on the next resolve.
+            let _ = crate::object::js_object_get_field_by_name(obj, key("del6759_z"));
+            let after = (*obj).parent_class_id;
+            assert!(
+                is_shape_id(after),
+                "no shape id re-minted after the delete (got {after:#x})"
+            );
+            assert_ne!(
+                after, before,
+                "the delete re-used the pre-delete ShapeId — a shape-id compare \
+                 would accept a compacted class instance as its own class's shape"
+            );
+
+            // Still true, and still what the guard compares until rung 3.
             assert_ne!(
                 (*obj).keys_array,
                 keys_before,
-                "the keys pointer is the guard's ONLY compaction evidence and it did not change"
+                "the keys pointer is the guard's compaction evidence and it did not change"
             );
             assert_eq!(
                 (*obj).class_id,
                 CID,
-                "class_id changed — a class-id compare would now catch the delete"
+                "class_id must survive a delete — it is the vtable/instanceof identity"
+            );
+        }
+    }
+
+    /// Two pristine instances of the same class share ONE ShapeId (their
+    /// canonical keys array is shared), and a delete on one moves only that
+    /// one. This is the property a rung-3 id compare rests on, stated
+    /// separately from the mint test so a regression names which half broke.
+    #[test]
+    fn class_siblings_share_one_shape_id_until_one_is_deleted_from() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const CID: u32 = 0x0C3C_6762;
+        let packed = b"sib6759_a\0sib6759_b\0sib6759_c";
+        unsafe {
+            let mk = || {
+                crate::object::js_object_alloc_class_with_keys(
+                    CID,
+                    0,
+                    3,
+                    packed.as_ptr(),
+                    packed.len() as u32,
+                )
+            };
+            let a = mk();
+            let b = mk();
+            let _ = crate::object::js_object_get_field_by_name(a, key("sib6759_b"));
+            let _ = crate::object::js_object_get_field_by_name(b, key("sib6759_b"));
+            let id_a = (*a).parent_class_id;
+            let id_b = (*b).parent_class_id;
+            assert!(
+                is_shape_id(id_a) && is_shape_id(id_b),
+                "both must be stamped"
             );
             assert_eq!(
-                (*obj).parent_class_id,
-                parent_before,
-                "the header word changed — if this is now a minted ShapeId, \
-                 class_field_inline_guard can switch to a one-word compare and \
-                 this test should be replaced by that assertion (#6759 C3)"
+                id_a, id_b,
+                "same-class siblings must share one ShapeId — otherwise an \
+                 id-comparing PIC is monomorphic-per-OBJECT and never hits"
+            );
+
+            assert_eq!(js_object_delete_field(a, key("sib6759_a")), 1);
+            let _ = crate::object::js_object_get_field_by_name(a, key("sib6759_c"));
+            assert_ne!(
+                (*a).parent_class_id,
+                id_b,
+                "the compacted instance kept its siblings' ShapeId"
+            );
+            assert_eq!(
+                (*b).parent_class_id,
+                id_b,
+                "the untouched sibling's stamp moved — a delete is not a \
+                 class-wide shape transition"
+            );
+        }
+    }
+
+    /// #6759 C3 rung 1 risk check: stamping OVERWRITES the header's
+    /// `parent_class_id`, so the class-parent chain must be served entirely by
+    /// the class-id-keyed registry (rung 0 / #7981 removed the last header
+    /// reader). A 3-level chain must still resolve after every level's header
+    /// word has been clobbered by a stamp.
+    #[test]
+    fn a_stamped_class_instance_still_resolves_a_three_level_parent_chain() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const BASE: u32 = 0x0C3C_6770;
+        const MID: u32 = 0x0C3C_6771;
+        const LEAF: u32 = 0x0C3C_6772;
+        let packed = b"chain6759_p\0chain6759_q";
+        unsafe {
+            let leaf = crate::object::js_object_alloc_class_with_keys(
+                LEAF,
+                MID,
+                2,
+                packed.as_ptr(),
+                packed.len() as u32,
+            );
+            // The registry edges are registered by the allocator (codegen's
+            // inline `new C()` path registers them from the module-init
+            // prelude instead); MID→BASE has no instance here, so register it
+            // the way that prelude does.
+            crate::object::register_class(MID, BASE);
+            assert_eq!(
+                (*leaf).parent_class_id,
+                MID,
+                "test premise: the header word starts as inheritance data"
+            );
+
+            let boxed = crate::value::js_nanbox_pointer(leaf as i64);
+            let truthy = |v: f64| crate::value::js_is_truthy(v) != 0;
+            assert!(truthy(crate::object::js_instanceof(boxed, LEAF)));
+            assert!(truthy(crate::object::js_instanceof(boxed, MID)));
+            assert!(truthy(crate::object::js_instanceof(boxed, BASE)));
+
+            // Clobber the word with a stamp.
+            let _ = crate::object::js_object_get_field_by_name(leaf, key("chain6759_p"));
+            assert!(
+                is_shape_id((*leaf).parent_class_id),
+                "test premise: the resolve did not stamp, so nothing is being tested"
+            );
+
+            assert!(
+                truthy(crate::object::js_instanceof(boxed, LEAF)),
+                "own class lost after stamping"
+            );
+            assert!(
+                truthy(crate::object::js_instanceof(boxed, MID)),
+                "direct parent lost after the header word was overwritten — the \
+                 parent edge is not coming from the registry"
+            );
+            assert!(
+                truthy(crate::object::js_instanceof(boxed, BASE)),
+                "grandparent lost after the header word was overwritten"
             );
         }
     }

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -395,6 +395,17 @@ pub extern "C" fn js_object_delete_field(
         //    the case the shape word had no way to express: `class_id` is
         //    preserved by design (vtable/instanceof identity) and the keys
         //    pointer was the only compaction evidence in the header.
+        //
+        //    ★ REDUNDANT ON EVERY CURRENT PATH, deliberately kept. The clone
+        //    above is a FRESH `js_array_alloc`, so `set_object_keys_array`
+        //    already saw a pointer CHANGE and cleared the stamp there. Per-site
+        //    sabotage confirms it: gating either clear alone breaks no test;
+        //    gating BOTH breaks
+        //    `delete_mints_a_fresh_shape_id_for_a_class_instance`. This one is
+        //    the only clear that would still fire if a future path compacts
+        //    IN PLACE (which is what the comment above describes and what
+        //    `shape_slot_lookup`'s shrink check already anticipates), so
+        //    deleting it would silently make that path wrong.
         crate::object::shapes::clear_object_shape_stamp(obj);
 
         1

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1510,15 +1510,17 @@ pub(crate) fn get_field_by_name_object_tail(
         // #6759 C3c: prefer the header-stamped stable shape id as the cache
         // key — it survives owned grow-reallocs AND GC moves of the keys
         // array, both of which change `keys_id` and orphaned the entry.
-        // Unstamped objects (stamp 0 / class instances) keep the address
-        // key; either way every hit below re-validates the stored key, so a
-        // colliding or foreign key can only miss, never mis-resolve.
-        let stamp = (*obj).parent_class_id;
-        let shape_key = if (*obj).class_id == 0 && super::super::shapes::is_shape_id(stamp) {
-            stamp as usize
-        } else {
-            keys_id
-        };
+        // Unstamped objects keep the address key; either way every hit below
+        // re-validates the stored key, so a colliding or foreign key can only
+        // miss, never mis-resolve.
+        //
+        // #6759 C3 rung 1: `object_shape_stamp` has no `class_id` gate, so a
+        // stamped CLASS INSTANCE keys on its id here too — which is the point
+        // of the rung: a delete-compacted instance clears its stamp and mints
+        // a fresh id, so it can no longer collide with a pristine sibling's
+        // cache entries.
+        let stamp = super::super::shapes::object_shape_stamp(obj);
+        let shape_key = if stamp != 0 { stamp as usize } else { keys_id };
 
         // Clamp the keys length to capacity so a bogus/oversized length can't
         // drive the wide-key map build or the linear scan below into unbounded
@@ -1629,19 +1631,14 @@ pub(crate) fn get_field_by_name_object_tail(
                 // object's stable shape id (allocating the record on first
                 // touch) and key the entry on it, so the entry survives the
                 // grow-reallocs and GC moves that retire `keys_id`.
+                // #6759 C3 rung 1: class instances are stamped here too.
                 {
-                    let store_key = if (*obj).class_id == 0 {
-                        let id =
-                            super::super::shapes::shape_id_for_keys_ensure(keys, key_count as u32);
-                        if id != 0 {
-                            (*(obj as *mut ObjectHeader)).parent_class_id = id;
-                            id as usize
-                        } else {
-                            keys_id
-                        }
-                    } else {
-                        keys_id
-                    };
+                    let id = super::super::shapes::stamp_object_shape(
+                        obj as *mut ObjectHeader,
+                        keys,
+                        key_count as u32,
+                    );
+                    let store_key = if id != 0 { id as usize } else { keys_id };
                     let store_idx =
                         (store_key.wrapping_add(key_hash as usize)) % super::FIELD_CACHE_SIZE;
                     let cache = &mut *st.field_lookup.field_cache.get();

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -709,14 +709,13 @@ pub extern "C" fn js_object_get_field_ic_miss(
             // #6804: stamp the receiver's stable ShapeId at PIC-miss
             // resolution, so the id-keyed FIELD_CACHE (and the future
             // id-comparing PIC) see a stamped object from its first read.
-            if (*obj).class_id == 0
-                && !crate::object::shapes::is_shape_id((*obj).parent_class_id)
-                && !crate::regex::regex_header_has_magic(obj as *const crate::regex::RegExpHeader)
-            {
-                let id = crate::object::shapes::shape_id_for_keys_ensure(keys, key_count as u32);
-                if id != 0 {
-                    (*(obj as *mut ObjectHeader)).parent_class_id = id;
-                }
+            // #6759 C3 rung 1: class instances are stamped here too.
+            if crate::object::shapes::object_shape_stamp(obj) == 0 {
+                crate::object::shapes::stamp_object_shape(
+                    obj as *mut ObjectHeader,
+                    keys,
+                    key_count as u32,
+                );
             }
             for i in 0..key_count {
                 let k_bits = (*keys_data.add(i)).to_bits();
@@ -753,14 +752,21 @@ pub extern "C" fn js_object_get_field_ic_miss(
                     // process-rooted, address-stable), because that compare
                     // is unvalidated and a recycled owned-array address
                     // would read the wrong slot.
-                    let stamp = (*obj).parent_class_id;
+                    //
+                    // #6759 C3 rung 1: `object_shape_stamp` carries no
+                    // `class_id` discriminant, so a stamped CLASS INSTANCE
+                    // primes an id token too — which is what the emitted PIC
+                    // already computes for it (its `is_stamp` test is the
+                    // range test alone). Priming the keys pointer for a
+                    // stamped receiver would be a permanent miss.
+                    let stamp = crate::object::shapes::object_shape_stamp(obj);
                     // #6080a: stamp the current GC epoch alongside either
                     // token kind. The emitted hit predicate only consults it
                     // for pointer tokens, but priming it unconditionally
                     // keeps `cache[2]` coherent when a site re-primes from
                     // one token kind to the other.
                     let epoch = PERRY_IC_EPOCH.load(std::sync::atomic::Ordering::Relaxed) as i64;
-                    if (*obj).class_id == 0 && crate::object::shapes::is_shape_id(stamp) {
+                    if stamp != 0 {
                         let token = (stamp as u64 | crate::object::shapes::PIC_ID_TOKEN_BIT) as i64;
                         pic_prime_get(cache, token, i as i64, epoch);
                     } else if keys_cacheable_for_pic(keys) {
@@ -1413,36 +1419,32 @@ mod c3c_pic_tests {
     /// exact inputs of the emitted `cache[2] == @PERRY_IC_EPOCH` guard, so
     /// this proves the guard CAN fail (a primed entry goes stale), not just
     /// that priming writes something.
+    ///
+    /// ★ #6759 C3 rung 1 shrank this path's PRODUCTION population to nothing
+    /// reachable from source. Class instances used to be the last receivers
+    /// priming a raw keys pointer (plain objects took the #6804 id token since
+    /// then); rung 1 stamps them too, so `js_object_get_field_ic_miss` now
+    /// mints-then-primes an id for every receiver whose mint succeeds. The
+    /// pointer arm survives as the id-exhaustion fallback (`alloc_shape_id`
+    /// returns 0 after 2^30 shape births) and as what the emitted hit
+    /// predicate still computes for an as-yet-unstamped receiver — neither is
+    /// constructible from a `.ts` fixture, so the epoch mechanics are driven
+    /// through `pic_prime_get` directly. The end-to-end half below asserts the
+    /// rung-1 behaviour instead: a class instance primes an ID token, which is
+    /// what the emitted PIC computes for it once it carries a stamp.
     #[test]
     fn pointer_token_prime_stamps_epoch_and_goes_stale_on_bump() {
         let _lock = crate::gc::global_side_table_test_lock();
         unsafe {
             use std::sync::atomic::Ordering;
-            // A CLASS instance (class_id != 0) is the population that still
-            // primes raw keys pointers — plain objects take the #6804
-            // shape-ID token, which the epoch guard deliberately skips.
-            let obj = crate::object::js_object_alloc(0x6080, 8);
-            let key = crate::string::js_string_from_bytes(b"pic6080_x".as_ptr(), 9);
-            crate::object::js_object_set_field_by_name(obj, key, 7.0);
-            let keys = (*obj).keys_array;
-            assert!(!keys.is_null(), "test premise: field append built keys");
-            let gc = (keys as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
-            (*gc).gc_flags |= crate::gc::GC_FLAG_SHAPE_SHARED;
-
+            // The pointer arm, driven directly (see the note above).
             let mut cache = [0i64; super::PIC_CACHE_WORDS];
-            let v = super::js_object_get_field_ic_miss(obj, key, &mut cache);
-            assert_eq!(v, 7.0);
-            assert_eq!(
-                cache[0], keys as i64,
-                "class instance must prime the raw keys pointer token"
-            );
-            let primed_epoch = cache[2];
-            assert_eq!(
-                primed_epoch,
-                super::PERRY_IC_EPOCH.load(Ordering::Relaxed) as i64,
-                "prime must snapshot the LIVE epoch"
-            );
-            assert!(primed_epoch >= 1, "epoch starts at 1, never 0");
+            let fake_keys = 0x6080_0000_1000i64;
+            let live = super::PERRY_IC_EPOCH.load(Ordering::Relaxed) as i64;
+            super::pic_prime_get(&mut cache, fake_keys, 3, live);
+            assert_eq!(cache[0], fake_keys, "pointer token must land in way 0");
+            assert_eq!(cache[2], live, "prime must snapshot the LIVE epoch");
+            assert!(cache[2] >= 1, "epoch starts at 1, never 0");
 
             super::pic_epoch_bump();
             assert_ne!(
@@ -1451,14 +1453,51 @@ mod c3c_pic_tests {
                 "a bump must strand every pointer-token prime (the emitted \
                  hit predicate then misses and re-primes)"
             );
+        }
+    }
 
-            // Re-priming heals: the miss handler stamps the NEW epoch.
+    /// #6759 C3 rung 1: a CLASS instance is stamped at its first by-name
+    /// resolve and therefore primes an ID token, not its keys pointer. The
+    /// emitted PIC discriminates on the ShapeId RANGE alone (it never loads
+    /// `class_id` for this), so priming the keys pointer for a stamped
+    /// receiver would be a permanent miss — this test is what keeps the
+    /// runtime's choice and the IR's choice the same.
+    #[test]
+    fn a_class_instance_primes_an_id_token_after_rung1() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        unsafe {
+            use std::sync::atomic::Ordering;
+            let obj = crate::object::js_object_alloc(0x6080, 8);
+            let key = crate::string::js_string_from_bytes(b"pic6080_x".as_ptr(), 9);
+            crate::object::js_object_set_field_by_name(obj, key, 7.0);
+            let keys = (*obj).keys_array;
+            assert!(!keys.is_null(), "test premise: field append built keys");
+            assert_eq!((*obj).class_id, 0x6080, "test premise: a class instance");
+
+            let mut cache = [0i64; super::PIC_CACHE_WORDS];
             let v = super::js_object_get_field_ic_miss(obj, key, &mut cache);
             assert_eq!(v, 7.0);
+
+            let stamp = crate::object::shapes::object_shape_stamp(obj);
+            assert!(
+                stamp != 0,
+                "the miss handler did not stamp a class instance — rung 1 is inert"
+            );
+            assert_eq!(
+                cache[0] as u64,
+                stamp as u64 | crate::object::shapes::PIC_ID_TOKEN_BIT,
+                "a stamped class instance must prime the ID token the emitted \
+                 PIC computes for it, not its keys pointer"
+            );
+            assert_ne!(
+                cache[0], keys as i64,
+                "primed the keys pointer for a stamped receiver — every hit at \
+                 this site would miss forever"
+            );
             assert_eq!(
                 cache[2],
                 super::PERRY_IC_EPOCH.load(Ordering::Relaxed) as i64,
-                "re-prime must heal the epoch snapshot"
+                "cache[2] must stay coherent across token kinds"
             );
         }
     }

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -1501,6 +1501,80 @@ mod c3c_pic_tests {
             );
         }
     }
+
+    /// ★ #6759 C3 rung 1 opens a NEW correctness surface, and this is it.
+    ///
+    /// Before rung 1 a delete-compacted class instance was UNCACHEABLE by the
+    /// read PIC: its keys array is a private clone, so `keys_cacheable_for_pic`
+    /// (SHAPE_SHARED only) refused it and the site fell through to the slow
+    /// path forever. Rung 1 stamps it, so it primes an id token and the emitted
+    /// hit path starts serving it. A token that failed to move across the
+    /// compaction would therefore be read as a pristine sibling's shape at a
+    /// site that has both — the one-slot shift the whole ladder is about.
+    ///
+    /// Pins: the compacted instance's primed token differs from a pristine
+    /// sibling's, AND the slot it primes is the post-compaction slot.
+    #[test]
+    fn a_compacted_class_instance_primes_a_token_a_pristine_sibling_cannot_match() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        unsafe {
+            let packed = b"picdel_a\0picdel_b\0picdel_c";
+            let mk = || {
+                crate::object::js_object_alloc_class_with_keys(
+                    0x6081,
+                    0,
+                    3,
+                    packed.as_ptr(),
+                    packed.len() as u32,
+                )
+            };
+            let key = |n: &str| crate::string::js_string_from_bytes(n.as_ptr(), n.len() as u32);
+            let pristine = mk();
+            let compacted = mk();
+            for (i, v) in [1.0f64, 2.0, 3.0].iter().enumerate() {
+                crate::object::js_object_set_field(
+                    pristine,
+                    i as u32,
+                    crate::JSValue::from_bits(v.to_bits()),
+                );
+                crate::object::js_object_set_field(
+                    compacted,
+                    i as u32,
+                    crate::JSValue::from_bits(v.to_bits()),
+                );
+            }
+            assert_eq!(
+                crate::object::js_object_delete_field(compacted, key("picdel_a")),
+                1
+            );
+
+            let mut c_pristine = [0i64; super::PIC_CACHE_WORDS];
+            let vp = super::js_object_get_field_ic_miss(pristine, key("picdel_c"), &mut c_pristine);
+            assert_eq!(vp, 3.0, "pristine `c` is slot 2");
+
+            let mut c_compacted = [0i64; super::PIC_CACHE_WORDS];
+            let vc =
+                super::js_object_get_field_ic_miss(compacted, key("picdel_c"), &mut c_compacted);
+            assert_eq!(
+                vc, 3.0,
+                "compacted `c` shifted to slot 1 and must still read 3"
+            );
+
+            assert_ne!(
+                c_compacted[0], 0,
+                "the compacted instance primed nothing — rung 1's new surface is inert"
+            );
+            assert_ne!(
+                c_compacted[0], c_pristine[0],
+                "the compacted instance primed its pristine sibling's token — an \
+                 id-comparing PIC would read slot {} for a receiver whose `c` is \
+                 at slot {}",
+                c_pristine[1], c_compacted[1]
+            );
+            assert_eq!(c_pristine[1], 2, "pristine `c` slot");
+            assert_eq!(c_compacted[1], 1, "compacted `c` slot");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/object/field_set_by_name/tail.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name/tail.rs
@@ -550,12 +550,10 @@ pub(super) fn set_field_by_name_object_tail(
             transition_cache_insert(0, interned_key, new_keys as usize, 0);
             // #6804: birth-stamp the new dynamic shape (once per shape
             // birth — the transition edge above serves the siblings).
-            if (*obj).class_id == 0 {
-                let id = super::shapes::shape_id_for_keys_ensure(new_keys, 1);
-                if id != 0 {
-                    (*obj).parent_class_id = id;
-                }
-            }
+            // #6759 C3 rung 1: no `class_id == 0` gate — a keyless class
+            // instance gaining its first by-name property is stamped like
+            // any other receiver.
+            super::shapes::stamp_object_shape(obj, new_keys, 1);
             return;
         }
 

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1667,19 +1667,21 @@ pub(crate) unsafe fn gc_object_meta_slot(user_ptr: usize) -> Option<*mut u64> {
 
 #[inline]
 unsafe fn set_object_keys_array(obj: *mut ObjectHeader, keys_array: *mut ArrayHeader) {
-    // #6759 C3c: a stamped shape id (plain objects reuse the otherwise-dead
-    // `parent_class_id` word) described the OLD keys array — clear it on a
-    // pointer CHANGE so the stamp invariant (`stamp != 0 ⟹ stamp == id of
-    // current keys`) holds; the resolve paths re-stamp on their next
-    // successful lookup. A same-pointer update (in-place append) keeps the
-    // stamp: slots are append-only, existing mappings stay valid — and the
-    // C3a grow-migration keeps the id itself alive across reallocs, so the
-    // fresh stamp after a grow resolves to the SAME id.
-    if (*obj).class_id == 0
-        && (*obj).keys_array != keys_array
-        && shapes::is_shape_id((*obj).parent_class_id)
-    {
-        (*obj).parent_class_id = 0;
+    // #6759 C3c: a stamped shape id (carried in the `parent_class_id` word)
+    // described the OLD keys array — clear it on a pointer CHANGE so the stamp
+    // invariant (`stamp != 0 ⟹ stamp == id of current keys`) holds; the resolve
+    // paths re-stamp on their next successful lookup. A same-pointer update
+    // (in-place append) keeps the stamp: slots are append-only, existing
+    // mappings stay valid — and the C3a grow-migration keeps the id itself
+    // alive across reallocs, so the fresh stamp after a grow resolves to the
+    // SAME id.
+    //
+    // #6759 C3 rung 1: no `class_id == 0` gate. The word is a ShapeId iff
+    // `is_shape_id` says so, for class instances too — and `clear_object_shape_stamp`
+    // tests exactly that, so an instance still carrying its allocation-time
+    // `parent_class_id` (never in the ShapeId range) is left alone.
+    if (*obj).keys_array != keys_array {
+        shapes::clear_object_shape_stamp(obj);
     }
     // #6893: the object's typed-shape layout descriptor is keyed by its
     // keys_array (shared per shape via SHAPE_LAYOUTS). A keys_array pointer

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -126,6 +126,100 @@ pub(crate) fn shape_id_for_keys_ensure(keys: *const ArrayHeader, key_count: u32)
         .shape_id
 }
 
+// ---------------------------------------------------------------------------
+// #6759 C3 rung 1 — THE SHAPE WORD IS UNIFORM.
+//
+// `ObjectHeader.parent_class_id` IS the shape word. Before this rung the stamp
+// was additionally gated on `class_id == 0`, so a CLASS INSTANCE had no shape
+// word at all: its only header evidence of a key-set change was the
+// `keys_array` POINTER, which is exactly why `class_field_inline_guard`
+// compares that pointer, and why the #7916 header shrink could not delete it.
+//
+// The gate is gone. The rule is now, for every receiver kind:
+//
+//     the word is a ShapeId  <=>  is_shape_id(word)
+//
+// which is already what all three emitted PICs test — they discriminate on the
+// range alone (`property_get/generic_dispatch.rs`, `expr/proxy_reflect.rs` ×2),
+// never on `class_id`. So relaxing the runtime gates makes the runtime agree
+// with the IR rather than introducing a new mode.
+//
+// This is only sound because rung 0 (#7981) removed the LAST reader of the
+// header word as inheritance data (`thread.rs::serialize_object` now takes the
+// parent edge from the class-id-keyed registry). Every parent-chain walk in the
+// tree goes through `get_parent_class_id(class_id)`; nothing reads the header
+// word for inheritance. Overwriting a class instance's `parent_class_id` with a
+// ShapeId therefore loses no information — the registry still has the edge, and
+// it was registered from a compile-time constant either by the allocator or by
+// the `js_register_class_parent` module-init prelude.
+//
+// The stamp is LAZY: a class instance is stamped at its first by-name resolve,
+// so a freshly `new`'d instance still reads as unstamped and falls back to the
+// keys-pointer token. Eager birth stamping in codegen is rung 2.
+// ---------------------------------------------------------------------------
+
+/// True when `obj` really is an `ObjectHeader` whose word 2 may be written.
+///
+/// A `RegExpHeader` aliases `GC_TYPE_OBJECT` with a DIFFERENT layout — its
+/// offset 8 is the low half of `pattern_ptr`, and offset 4 is the high half of
+/// `regex_ptr`, which reads as `class_id == 0` on every 48-bit-address target.
+/// So the old `class_id == 0` gate never excluded a RegExp either; two of the
+/// four mint sites carried an explicit magic check and two did not. Routing
+/// every site through this predicate closes that gap in the same edit that
+/// removes the `class_id` discriminant.
+#[inline]
+pub(crate) unsafe fn shape_word_is_writable(obj: *const crate::object::ObjectHeader) -> bool {
+    !crate::regex::regex_header_has_magic(obj as *const crate::regex::RegExpHeader)
+}
+
+/// The receiver's ShapeId, or 0 when it carries none (unstamped, or the word
+/// still holds inheritance data left over from allocation).
+#[inline]
+pub(crate) unsafe fn object_shape_stamp(obj: *const crate::object::ObjectHeader) -> u32 {
+    let word = (*obj).parent_class_id;
+    if is_shape_id(word) {
+        word
+    } else {
+        0
+    }
+}
+
+/// Stamp `obj` with the stable ShapeId of `keys`, minting the shape record on
+/// first touch. Returns the id, or 0 when the receiver is not stampable (a
+/// RegExp alias) or the id range is exhausted — in which case the caller keeps
+/// its keys-address fallback, which is never a correctness difference.
+#[inline]
+pub(crate) unsafe fn stamp_object_shape(
+    obj: *mut crate::object::ObjectHeader,
+    keys: *const ArrayHeader,
+    key_count: u32,
+) -> u32 {
+    if !shape_word_is_writable(obj) {
+        return 0;
+    }
+    let id = shape_id_for_keys_ensure(keys, key_count);
+    if id != 0 {
+        (*obj).parent_class_id = id;
+    }
+    id
+}
+
+/// Drop the stamp iff the word currently holds one, leaving a real
+/// `parent_class_id` untouched. Returns true when a stamp was cleared.
+///
+/// Ids are never reused, so clearing makes every stale id-keyed cache entry a
+/// permanent miss; the next resolve re-stamps from whatever record the live
+/// keys array has then.
+#[inline]
+pub(crate) unsafe fn clear_object_shape_stamp(obj: *mut crate::object::ObjectHeader) -> bool {
+    if is_shape_id((*obj).parent_class_id) {
+        (*obj).parent_class_id = 0;
+        true
+    } else {
+        false
+    }
+}
+
 /// Build (or extend) the slot map for `keys` covering `key_count` keys.
 unsafe fn index_range(shape: &mut Shape, keys: *const ArrayHeader, key_count: u32) {
     let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -768,11 +768,30 @@ fn object_shape(addr: usize) -> (usize, u32, u16) {
         // ShapeId. Shape-cached literals are stamped at birth; anything
         // else is stamped HERE on first observation (self-healing), so one
         // logical shape can never split into a pre-stamp address token and
-        // a post-stamp id token within a site. Class instances keep the
-        // keys-address token (their `parent_class_id` is inheritance data).
+        // a post-stamp id token within a site.
+        //
+        // ★ #6759 C3 rung 1 deliberately does NOT relax this `class_id == 0`
+        // gate, even though rung 1 gives class instances a shape word. This
+        // token is not a PIC token — it is compared against a CODEGEN-SUPPLIED
+        // KEYS POINTER (`@perry_class_keys_C`) by the typed_feedback guard
+        // family: `guards.rs::method_direct_call_contract` requires
+        // `shape_addr == expected_keys as usize`, and the class-field /
+        // element-shape contracts do the same. An id can never equal that
+        // pointer, so returning one here fails every such guard CLOSED —
+        // memory-safe, but it silently deletes the direct-method-call route
+        // and the class-field fast paths. (Both are pinned:
+        // `typed_feedback_method_direct_guard_passes_for_exact_registered_method`
+        // and `typed_feedback_class_field_get_guard_requires_raw_f64_layout_when_requested`
+        // go red the moment this gate is dropped.)
+        //
+        // Switching those consumers from a keys pointer to a ShapeId is
+        // rung 3 — nine unvalidated consumers, its own review. The PIC-token
+        // half of the observable rung 1 wanted comes from `ic_miss.rs`, which
+        // primes what the emitted PIC actually computes; this function feeds
+        // observation and guards, which are a different population.
         let shape = if class_id == 0 {
-            let stamp = (*ptr).parent_class_id;
-            if crate::object::shapes::is_shape_id(stamp) {
+            let stamp = crate::object::shapes::object_shape_stamp(ptr);
+            if stamp != 0 {
                 stamp as usize
             } else if crate::regex::regex_header_has_magic(
                 addr as *const crate::regex::RegExpHeader,
@@ -789,10 +808,12 @@ fn object_shape(addr: usize) -> (usize, u32, u16) {
                     if keys_header.obj_type == crate::gc::GC_TYPE_ARRAY
                         || keys_header.obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
                     {
-                        let id =
-                            crate::object::shapes::shape_id_for_keys_ensure(keys, (*keys).length);
+                        let id = crate::object::shapes::stamp_object_shape(
+                            ptr as *mut ObjectHeader,
+                            keys,
+                            (*keys).length,
+                        );
                         if id != 0 {
-                            (*(ptr as *mut ObjectHeader)).parent_class_id = id;
                             id as usize
                         } else {
                             keys as usize

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -1,0 +1,231 @@
+# `rung1` agent — #6759 C3 ladder, **rung 1**: make the shape word uniform
+
+Scope, per brief: rung 1 ONLY. Not rung 2 (eager birth stamping in codegen),
+not rung 3 (switching the nine keys-token consumers), not rung 4 (#7916's
+header shrink). Branch `gc/6759-rung1-uniform-shape-word`, worktree
+`/Users/amlug/projects/perry/wt-rung1`, target `$HOME/cargo-targets/rung1`.
+
+Reads: `CLAUDE.md`, `gc-handoff/SHAPE-NOTES.md` §§1–5,8, `docs/shape-tree-plan.md`,
+#6759, #7916.
+
+---
+
+## 0. What "uniform" turned out to mean concretely
+
+**One sentence:** the shape WORD became uniform; the observation TOKEN did not,
+and could not, because they have different consumers.
+
+`ObjectHeader.parent_class_id` already *was* the shape word — the stamp was
+just additionally gated on `class_id == 0` at nine sites. Rung 1 deletes that
+conjunct and routes every site through three new accessors in
+`object/shapes.rs`, so the rule is now literally one predicate:
+
+```
+the word is a ShapeId  <=>  is_shape_id(word)
+```
+
+★ **The emitted IR already spelled it that way.** All three PICs
+(`property_get/generic_dispatch.rs:536-546`, `expr/proxy_reflect.rs:536-546`
+and `:862-871`) derive their receiver token as
+
+```
+is_stamp = (parent_class_id - 0x8000_0000) <u 0x4000_0000
+token    = is_stamp ? (zext parent_class_id | 1<<62) : keys_array
+```
+
+with **no `class_id` load at all**. So rung 1 is not "introduce a new mode" —
+it is "make the runtime agree with the IR". Before rung 1 the two disagreed
+harmlessly only because nothing ever put a ShapeId in a class instance's word.
+
+### 0a. The split that made rung 1 smaller than the plan assumed
+
+SHAPE-NOTES §5's rung-1 sketch lists `typed_feedback.rs:770-806` among the
+gates to relax, and predicts the observable as "`typed_feedback::object_shape()`
+starts returning **id tokens** for class instances, which makes their PIC tokens
+survive GC moves".
+
+**That conflates two different token populations, and doing it breaks the
+build.** Measured, not argued — see §3.
+
+| population | producer | compared against | rung-1 verdict |
+|---|---|---|---|
+| **PIC tokens** | `field_get_set/ic_miss.rs::js_object_get_field_ic_miss` | the *same site's* previously primed token, and the IR's own re-derivation | **switch to ids** — required, else a stamped receiver never hits |
+| **observation / guard tokens** | `typed_feedback.rs::object_shape()` | a **codegen-supplied keys POINTER** (`@perry_class_keys_C`), passed in as `expected_keys` | **keep the keys address** — an id can never equal that pointer |
+
+`object_shape()` does NOT feed `generic_dispatch`'s PIC. It feeds
+`typed_feedback` observation and the guard family in `typed_feedback/guards.rs`,
+whose contracts require `shape_addr == expected_keys as usize`
+(`method_direct_call_contract:131`, and the class-field / element-shape
+contracts at `:268` and `:523`). Returning an id there fails **every** such
+guard **closed** — memory-safe, but it silently deletes the direct-method-call
+route and the class-field fast paths, i.e. exactly the tier this ladder exists
+to make cheaper.
+
+So: **rung 1 changes the header word, not the observation token.** Migrating
+the nine consumers off keys pointers is rung 3, which is what SHAPE-NOTES §3c
+already says. `object_shape()` keeps its `class_id == 0` gate with a comment
+naming the two tests that go red if anyone drops it.
+
+---
+
+## 1. The change
+
+`crates/perry-runtime/src/object/shapes.rs` (+~95 LOC incl. the block comment):
+
+```rust
+shape_word_is_writable(obj) -> bool        // refuses a RegExpHeader alias
+object_shape_stamp(obj)     -> u32         // 0 = unstamped
+stamp_object_shape(obj, keys, key_count) -> u32   // mint + write, 0 = refused
+clear_object_shape_stamp(obj) -> bool      // clears iff the word holds a stamp
+```
+
+Nine sites routed through them, all by deleting a `class_id == 0` conjunct:
+
+| # | site | role |
+|---|---|---|
+| 1 | `object/mod.rs::set_object_keys_array` | CLEAR on keys-pointer change |
+| 2 | `object/delete_rest.rs:392` | CLEAR on in-place compaction |
+| 3 | `field_get_set/ic_miss.rs:713` | MINT at PIC-miss resolution |
+| 4 | `field_get_set/ic_miss.rs:762` | token KIND primed into the PIC cache |
+| 5 | `field_get_set/get_field_by_name_tail.rs:1516` | FIELD_CACHE key (read) |
+| 6 | `field_get_set/get_field_by_name_tail.rs:1636` | MINT + FIELD_CACHE key (store) |
+| 7 | `field_set_by_name/tail.rs:553` | birth stamp on the null→first-key edge |
+| 8–9 | `proxy/put_value.rs:396,504,629` | **already uniform** — no change needed |
+
+Sites 8–9 are worth stating: the dynamic/static write-PIC token derivations
+never had a `class_id` gate. They were already spelling the rung-1 rule, which
+is independent evidence the rule is the right one.
+
+### 1a. Free correctness rider
+
+Two of the four mint sites (`get_field_by_name_tail`, `field_set_by_name/tail`)
+had **no RegExp-alias check**; the other two did. A `RegExpHeader` aliases
+`GC_TYPE_OBJECT` with a different layout — offset 4 is the high half of
+`regex_ptr` (reads as `class_id == 0` on every 48-bit-address target, so the old
+gate never excluded it) and **offset 8 is the low half of `pattern_ptr`**.
+Routing all four through `stamp_object_shape` closes that in the same edit.
+
+### 1b. What did NOT change
+
+- `class_field_inline_guard` still compares `keys_array`. It loads offsets
+  0/4/12/16 and **never offset 8**, so rung 1 cannot affect it. Switching it is
+  rung 3.
+- Codegen is untouched. `lower_call/new_alloc.rs:543` still writes `parent_cid`
+  as a constant, so a fresh `new C()` reads as **unstamped** until its first
+  by-name resolve. The stamp is LAZY by construction; eager birth stamping is
+  rung 2.
+- `perry/thread` serialization: rung 0 (#7981) already reads the parent edge
+  from the class-id-keyed registry, so a stamped instance serializes its real
+  parent. That is the dependency that made rung 1 possible at all.
+
+---
+
+## 2. Cost
+
+`git diff --stat origin/main`: **7 files, +411 / −108** — of which ~150 lines
+are new tests and ~90 are the shapes.rs doc block. Production logic delta is
+roughly **60 lines net**, well inside the brief's ~150 estimate. Runtime-only,
+as costed.
+
+---
+
+## 3. The entry gate tripped, exactly as predicted
+
+`object/delete_rest.rs::delete_leaves_a_class_instance_with_no_shape_word_to_transition`
+went red the moment class instances gained a stamp. Its final assertion carried
+its own replacement instruction:
+
+> "the header word changed — if this is now a minted ShapeId,
+> `class_field_inline_guard` can switch to a one-word compare and **this test
+> should be replaced by that assertion** (#6759 C3)"
+
+Replaced by `delete_mints_a_fresh_shape_id_for_a_class_instance`, which is the
+class-instance twin of the plain-object test directly above it: stamp present
+after the first by-name resolve → `delete` clears it → next resolve mints a
+**different** id. The old test's other two assertions (`class_id` preserved,
+keys pointer moved) are **kept inside the new test**, because both are still
+true and both are still what the guard compares until rung 3.
+
+Two more added beside it:
+
+- `class_siblings_share_one_shape_id_until_one_is_deleted_from` — pristine
+  siblings share ONE id (else an id-comparing PIC would be monomorphic per
+  OBJECT and never hit), and a delete moves only the deleted-from instance.
+- `a_stamped_class_instance_still_resolves_a_three_level_parent_chain` — the
+  brief's risk assertion. Stamping OVERWRITES `parent_class_id`; a 3-level
+  `js_instanceof` chain must still resolve after the word is clobbered. It
+  asserts the pre-state (`parent_class_id == MID`) and that the resolve
+  actually stamped, so it cannot pass vacuously.
+
+### 3a. Two other tests went red — and they are the finding
+
+Running the full `perry-runtime` lib suite after the first (naive) pass:
+
+```
+typed_feedback::tests::typed_feedback_method_direct_guard_passes_for_exact_registered_method
+    left: 0, right: 1                       # guard returned FAIL
+typed_feedback::tests::typed_feedback_class_field_get_guard_requires_raw_f64_layout_when_requested
+    assertion failed: site.representation_invalidations >= 1
+```
+
+Both are downstream of relaxing `object_shape()`. This is what §0a is about:
+they are the pinning tests for the keys-pointer contract, and they did their
+job. Reverting that one site (keeping the other eight relaxed) makes both green
+again with no other change.
+
+★ **Had I only run the new tests, this would have shipped as a silent
+performance cliff** — the guards fail closed, so nothing crashes and no output
+differs. Worth recording as another instance of "the gate runs but its subject
+never did": a `.ts` probe cannot see a guard that merely stopped firing.
+
+### 3b. A third test's population disappeared
+
+`ic_miss.rs::pointer_token_prime_stamps_epoch_and_goes_stale_on_bump` asserted
+"class instance must prime the raw keys pointer token" — and named class
+instances as *"the population that still primes raw keys pointers"* (plain
+objects took the #6804 id token). Rung 1 stamps class instances, so
+`js_object_get_field_ic_miss` now mints-then-primes an id for every receiver
+whose mint succeeds, and the pointer arm has **no source-constructible
+production population left**. It survives as the id-exhaustion fallback
+(`alloc_shape_id` returns 0 after 2^30 shape births) and as what the emitted hit
+predicate computes for an as-yet-unstamped receiver.
+
+Split into two tests rather than deleted:
+
+- the epoch mechanics (prime snapshots the live epoch; a bump strands it) now
+  drive `pic_prime_get` directly, so the `cache[2] == @PERRY_IC_EPOCH` guard is
+  still proved able to FAIL;
+- `a_class_instance_primes_an_id_token_after_rung1` asserts the rung-1
+  behaviour end-to-end, including `assert_ne!(cache[0], keys)` — priming a keys
+  pointer for a stamped receiver would be a permanent miss at that site, so this
+  is the test that keeps the runtime's choice and the IR's choice the same.
+
+**Consequence worth flagging for rung 3:** the read PIC's epoch guard
+(`epoch_ok = is_stamp || epoch_eq`) is now bypassed on essentially every hit,
+because essentially every primed token is an id. Id-token soundness therefore
+rests entirely on `shapes::prune_dead_shape_keys` dropping a dead keys array's
+record before its address is recycled (wired into both
+`gc/copying.rs:1962` and `gc/oldgen.rs:1171`, so it runs on every collection).
+That was already true for plain objects since #6804; rung 1 extends the
+population. For a class instance the keys array is the process-rooted canonical
+one, so the added population is on immortal arrays — the mortal case is the
+post-delete clone, identical in kind to a plain object's.
+
+---
+
+## 4. Validation
+
+### 4a. The discriminating shape (§4b of SHAPE-NOTES) — see §5 below
+
+### 4b. Unit suite
+
+`cargo test -p perry-runtime --lib`: **2249 passed, 0 failed, 4 ignored**.
+
+---
+
+## 5. Sabotage-verify — fix committed FIRST
+
+Commit `c0d26ba72` landed before any sabotage, so `git checkout --` restores the
+sabotage, never the fix.
+
+(filled in below as it runs)

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -333,3 +333,36 @@ null→first-key edge) than the resolve paths would; sabotaging it only delays t
 stamp. Neither has a behavioural assertion, and building a hit-counter probe for
 them was judged out of proportion for rung 1. Rung 3, which makes the id
 load-bearing in a guard, will need E pinned.
+
+---
+
+## 6. Handoff — what rung 2 and rung 3 inherit
+
+1. ★ **Rung 3's first job is `object_shape()`, not the guard.** SHAPE-NOTES §3c
+   lists nine consumers of the keys token; the one that *blocks* is
+   `typed_feedback::object_shape()`, because the guard contracts compare its
+   return against a codegen keys pointer. Until those contracts take an id,
+   `object_shape()` cannot return one, and rung 1 leaves that gate in place with
+   a comment naming the two tests. Do that migration and the guard switch
+   together, or the intermediate state is a silent fast-path deletion.
+2. **Rung 2's stamp must reach the same word rung 1 clears.** Eager birth
+   stamping writes `@perry_class_shape_C | (field_count << 32)` at
+   `new_alloc.rs:543`. `set_object_keys_array` and `delete_rest` already clear
+   it for class instances after this PR, so rung 2 is purely "arrive stamped"
+   — no new invalidation is needed.
+3. **The read PIC's epoch guard is now nearly bypassed** (§3b). If rung 3 makes
+   ids load-bearing in a *guard* (not just a cache), the trust chain is
+   `shapes::prune_dead_shape_keys` + `scan_shape_table_rekey_mut`, not the
+   epoch. Worth an explicit test that a recycled keys-array address cannot
+   inherit a dead record's id.
+4. **Per-thread shape tables, process-global ids, process-global PIC caches.**
+   Two threads adopting the same `CLASS_KEYS_BY_ID` array mint *different* ids
+   for it (each thread's table allocates from the shared monotonic counter), so
+   a `@perry_ic_N` global can thrash between two ids for one shape. Not a
+   correctness bug (ids are globally unique, so no false hit) and pre-existing
+   for plain objects since #6804 — but rung 3 should measure it before relying
+   on id-token hit rates.
+5. **SHAPE-NOTES §8's four loose ends are all still open**, including the static
+   write PIC's missing epoch check — which matters *less* after rung 1 (that PIC
+   now mostly sees id tokens) but is still an unintended asymmetry.
+6. Sites E and G have no behavioural pin (§5b). Rung 3 needs E pinned.

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -446,3 +446,35 @@ no `delete`, no keys array. But a prior is not evidence, so the control arm
 (all seven rung-1 `class_id` gates restored, same tree otherwise — a tighter
 control than a pristine `main` build, and it costs no extra disk) is being built
 and both tests re-run on it. Verdict recorded below.
+
+### 7e. Control-arm A/B verdict: **zero of the eight are rung 1**
+
+Control arm = all seven rung-1 `class_id` gates restored (§5b's A–G applied
+together), same tree otherwise, same target dir, same `node_modules` symlink,
+ext archives evicted, `PERRY_NO_AUTO_OPTIMIZE=1`, `PERRY_RUNTIME_DIR` pinned.
+A tighter control than a pristine `main` build, and it costs no extra disk.
+
+| test | control | rung 1 | stdout |
+|---|---|---|---|
+| `test_gap_specabi_reassign` | DIFF vs node | DIFF vs node | **byte-identical between arms** |
+| `test_gap_zlib_3285_params` | DIFF vs node | DIFF vs node | **byte-identical between arms** |
+
+★ **The A/B asserts its own subject was live**, which is the part that makes it
+a proof rather than a presence check: on the control build the five rung-1
+acceptance tests all FAIL
+(`delete_mints_a_fresh_shape_id_for_a_class_instance`,
+`class_siblings_share_one_shape_id_…`,
+`a_stamped_class_instance_still_resolves_a_three_level_parent_chain`,
+`a_class_instance_primes_an_id_token_after_rung1`,
+`a_compacted_class_instance_primes_a_token_…`) while
+`delete_mints_a_fresh_shape_id_for_a_plain_object` still PASSES — i.e. the arm
+is genuinely *pre-rung-1*, not merely broken. Had I run the A/B without that
+check, "identical on both arms" would have been consistent with the control
+never having been built.
+
+**Conclusion: 8 of 8 reported regressions are pre-existing.** Six are
+#7932/#7629 by exact panic signature; two are byte-identical across an A/B whose
+control is proven live. The 10 status changes are oracle coverage (§7c) and the
+1 improvement is unattributed. `gap_snapshot.json` is deliberately NOT updated —
+accepting these would launder six tracked crashes through the expected-output
+channel, which `run_gap_tests.sh` explicitly forbids.

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -307,6 +307,24 @@ mappings stay valid), and a *clone*-on-append re-mints an id that describes the
 same prefix. The one key-set change a stamp must not survive is the
 **compaction**, and that is exactly where A and B overlap.
 
+### 5c. ★ Near-miss worth recording: I nearly gated on a sabotaged binary
+
+After §5a I ran `git checkout --` on `class_field_inline_guard.rs` and moved
+straight on to launching the gap suite with `PERRY_SKIP_BUILD=1`. **The source
+was restored; the release binary was not.** `$HOME/cargo-targets/rung1/release/perry`
+was still the `ka_ok`-sabotaged compiler, and the gap run was 54/554 tests into
+grading my change against it before I noticed. Killed and rebuilt.
+
+This is CLAUDE.md's "Verifying a runtime change" trap in a shape the section
+does not name: not a stale ARCHIVE from the wrong `cargo build` line, but a
+stale BINARY from a sabotage I had already reverted in source. `git status`
+was clean, which is precisely the tell that means nothing. The corpus numbers
+in §4 were taken *before* the sabotage and are unaffected; the gap run was
+restarted against a freshly built clean compiler.
+
+Rule for the next agent: **a sabotage cycle ends with a rebuild, not with
+`git checkout --`.** Treat the restore and the rebuild as one step.
+
 **E and G are accelerator-only and I am not claiming otherwise.** E swaps the
 FIELD_CACHE key from the keys address to the stamp; every hit re-validates the
 stored key, so the delta is that entries survive grow-reallocs and GC moves —

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -25,8 +25,8 @@ the word is a ShapeId  <=>  is_shape_id(word)
 ```
 
 ★ **The emitted IR already spelled it that way.** All three PICs
-(`property_get/generic_dispatch.rs:536-546`, `expr/proxy_reflect.rs:536-546`
-and `:862-871`) derive their receiver token as
+(`property_get/generic_dispatch.rs:479-491`, `expr/proxy_reflect.rs:536-546`
+and `:862-872`) derive their receiver token as
 
 ```
 is_stamp = (parent_class_id - 0x8000_0000) <u 0x4000_0000
@@ -56,7 +56,7 @@ build.** Measured, not argued — see §3.
 `typed_feedback` observation and the guard family in `typed_feedback/guards.rs`,
 whose contracts require `shape_addr == expected_keys as usize`
 (`method_direct_call_contract:131`, and the class-field / element-shape
-contracts at `:268` and `:523`). Returning an id there fails **every** such
+contracts at `:271` and `:525`). Returning an id there fails **every** such
 guard **closed** — memory-safe, but it silently deletes the direct-method-call
 route and the class-field fast paths, i.e. exactly the tier this ladder exists
 to make cheaper.
@@ -122,10 +122,16 @@ Routing all four through `stamp_object_shape` closes that in the same edit.
 
 ## 2. Cost
 
-`git diff --stat origin/main`: **7 files, +411 / −108** — of which ~150 lines
-are new tests and ~90 are the shapes.rs doc block. Production logic delta is
-roughly **60 lines net**, well inside the brief's ~150 estimate. Runtime-only,
-as costed.
+`git diff --stat origin/main`, code only (the 7 `crates/perry-runtime/src`
+files): **+494 / −106**. Of that, ~225 lines are new tests, ~95 is the
+shapes.rs doc block, and the rest is comment. **Production logic delta is
+roughly 60 lines net** — well inside the brief's ~150 estimate, and runtime-only
+exactly as costed. No public API changed (every new item is `pub(crate)`; no
+`#[no_mangle]`/`pub extern` signature moved), so no dependent crate can break on
+it.
+
+Rung 1 did **not** turn out to be larger than costed, so there was no reason to
+stop and hand back.
 
 ---
 

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -372,3 +372,77 @@ load-bearing in a guard, will need E pinned.
    write PIC's missing epoch check — which matters *less* after rung 1 (that PIC
    now mostly sees id tokens) but is still an unintended asymmetry.
 6. Sites E and G have no behavioural pin (§5b). Rung 3 needs E pinned.
+
+---
+
+## 7. Gap-suite triage (`scripts/run_gap_tests.sh`, 532/554 = 96.0 %)
+
+The snapshot ratchet reported 8 regressions, 10 status changes and 1 improvement.
+None of it may be attributed without an A/B, so:
+
+### 7a. Six of the eight are #7932 — signature-matched, not assumed
+
+| test | exit | panic site |
+|---|--:|---|
+| `test_gap_fetch_request_from_node_incoming_message` | 134 | `perry-ext-http/src/server/server.rs:911` |
+| `test_gap_http_client_no_redirect_follow` | 134 | `perry-ext-http/src/server/server.rs:911` |
+| `test_gap_http_overloads_3226plus` | 134 | `perry-ext-http/src/server/server.rs:911` |
+| `test_gap_http_req_async_iterator` | 134 | `perry-ext-http/src/server/server.rs:911` |
+| `test_gap_http_res_socket_writable_onfinished` | 134 | `perry-ext-http/src/server/server.rs:911` |
+| `test_gap_net_connect_bound_value` | 134 | `tokio-1.53.1/.../net/tcp/listener.rs:304` |
+
+All six: *"there is no reactor running, must be called from the context of a
+Tokio 1.x runtime"*, zero stdout before aborting. This reproduces #7932's table
+**exactly**, including the one detail that discriminates it from a generic
+"http tests crash" — five share `server.rs:911` while `net_connect_bound_value`
+aborts one frame lower inside tokio's own `TcpListener`. #7932 was A/B'd against
+two compilers when filed (3 runs each, `exit=134` 6/6) and closed as a duplicate
+of #7629 (release-profile ext-staticlib link defect). It is deliberately **not**
+in `gap_snapshot.json`, which is why the gate reads it as `pass -> crash` and why
+`run_gap_tests.sh` is red on `main`.
+
+Retired: pre-existing, tracked, not rung 1.
+
+### 7b. ★ A stale-archive trap I walked into inside my own target dir
+
+`libperry_ext_http.a` (20:06) and `libperry_ext_zlib.a` (20:07) in
+`$HOME/cargo-targets/rung1/release` were built during my FIRST gap run — the one
+against the `ka_ok`-sabotaged compiler (§5c) — and the second run **reused them**
+rather than rebuilding, because they already existed. CI evicts exactly these
+before its parity job (`rm -rf target/perry-auto-* target/debug/libperry_ext_*.a`,
+#5892); an ad-hoc `PERRY_SKIP_BUILD=1` run does not.
+
+Every "regression" and every status change maps to one of the ten ext archives
+present in that directory (http, net, zlib, cron, dayjs, moment, ratelimit,
+slugify, exponential_backoff, events), which is what made the mapping visible.
+Re-running the two parity failures with `PERRY_RUNTIME_DIR` pointed at a clean
+directory (no ext archives, `PERRY_NO_AUTO_OPTIMIZE=1`) still diverges, so those
+two are NOT stale-archive artifacts — but the general lesson stands and is worth
+adding to the runbook: **a reused target dir carries ext staticlibs across arms,
+and they are invisible to `git status` just like the runtime `.a`.**
+
+### 7c. Ten `node_fail -> parity_fail` are oracle-coverage, not Perry
+
+A fresh worktree has no `node_modules`, a known phantom-regression source for
+this harness, so I symlinked the main checkout's. That changes which tests the
+NODE oracle can run, which is exactly the shape of a `node_fail -> parity_fail`
+transition. Both arms share the symlink, so the A/B controls for it. (Running
+those tests' node command by hand from the worktree root still gives
+`ERR_MODULE_NOT_FOUND`, so the harness resolves modules from a different CWD —
+either way it is oracle coverage, not Perry behaviour.)
+
+### 7d. Two remain under A/B
+
+`test_gap_specabi_reassign` (`plain: 0 0 2` vs node `99 101 2`) and
+`test_gap_zlib_3285_params` (zlib argument validation: `no-throw` vs
+`ERR_OUT_OF_RANGE`/`ERR_INVALID_ARG_TYPE`). Neither is in `gap_snapshot.json`,
+which — per #7932 — neither convicts nor exonerates, since the snapshot demonstrably
+does not enumerate every currently-red test. Both reproduce deterministically.
+
+Prior: neither touches an object-shape surface. `zlib_3285_params` is argument
+validation; `specabi_reassign` is a typed-array binding reassigned via `as any`,
+whose subject is the #6906/#7052 spec-ABI invalidation in codegen — no classes,
+no `delete`, no keys array. But a prior is not evidence, so the control arm
+(all seven rung-1 `class_id` gates restored, same tree otherwise — a tighter
+control than a pristine `main` build, and it costs no extra disk) is being built
+and both tests re-run on it. Verdict recorded below.

--- a/gc-handoff/RUNG1-NOTES.md
+++ b/gc-handoff/RUNG1-NOTES.md
@@ -215,17 +215,103 @@ post-delete clone, identical in kind to a plain object's.
 
 ## 4. Validation
 
-### 4a. The discriminating shape (§4b of SHAPE-NOTES) — see §5 below
+Compiler `$HOME/cargo-targets/rung1/release/perry` (106 MB — the size that
+confirms the `-p perry -p perry-runtime-static -p perry-stdlib-static` set;
+100 MB would mean the wrappers were dropped and cargo features re-unified),
+`PERRY_RUNTIME_DIR` pinned to the same dir, `.a` mtimes verified after the edit.
 
-### 4b. Unit suite
+| gate | result |
+|---|---|
+| `cargo test --lib -p perry-runtime` (CI's per-PR scope for this diff) | **2250 passed, 0 failed, 4 ignored** |
+| 19-app corpus, byte-exact + exit 0 | **19/19** |
+| …under `PERRY_GC_PROTECT_FROMSPACE=1 _DEPTH=800` | **19/19** |
+| …under `PERRY_GC_VERIFY_EVACUATION=1` | **19/19** |
+| `probe_delete_isolate_ka.ts` vs node 26.5.1 | byte-identical |
 
-`cargo test -p perry-runtime --lib`: **2249 passed, 0 failed, 4 ignored**.
+### 4a. The discriminating shape — and why it is NOT vacuous for rung 1
+
+SHAPE-NOTES §4b's fixture (`≥4 fields, delete the FIRST, read a mid field,
+non-numeric declared types`) was built to isolate `ka_ok` for rung 3. It earns
+its place here for a **different** reason:
+
+★ **Rung 1 makes a delete-compacted class instance read-PIC-cacheable for the
+first time.** Before it, such an instance's keys array is a private clone, so
+`keys_cacheable_for_pic` (SHAPE_SHARED only) refused it and every read fell to
+the slow path forever. Rung 1 stamps it, so it primes an id token and the
+emitted hit path starts serving it. `probe_delete_isolate_ka.ts` is precisely a
+program that reads `s.b` / `s.c` off a compacted instance — i.e. the first
+program in which that new surface is exercised. It is a real gate here, not a
+borrowed one.
+
+The runtime twin is
+`ic_miss::a_compacted_class_instance_primes_a_token_a_pristine_sibling_cannot_match`,
+which asserts the compacted instance primes a token a pristine sibling cannot
+match **and** that the slots really differ (2 vs 1), so it cannot pass by both
+being unprimed.
 
 ---
 
 ## 5. Sabotage-verify — fix committed FIRST
 
-Commit `c0d26ba72` landed before any sabotage, so `git checkout --` restores the
-sabotage, never the fix.
+Commits `c0d26ba72` / `63c44b23e` landed before any sabotage, so
+`git checkout --` restores the sabotage, never the fix.
 
-(filled in below as it runs)
+### 5a. `ka_ok` sabotage ON TOP of rung 1 — the fixture still discriminates
+
+Dropped `ka_ok` from all three emitters in
+`perry-codegen/src/expr/class_field_inline_guard.rs` (the `acc &= ka_ok`
+conjunctions and the two subclass-arm halves), rebuilt the compiler only, same
+runtime archives.
+
+| arm | `S post b/c` | `S2 after write` | `N post b/c` (control) |
+|---|---|---|---|
+| node 26.5.1 | `B C` | `B2 C` | `2 3` |
+| **rung 1, base** | `B C` | `B2 C` | `2 3` |
+| **rung 1, `ka_ok` sabotaged** | **`C D`** | **`B2 D`** | `2 3` |
+
+Exactly SHAPE-NOTES §4b's table, reproduced on top of rung 1. Two things follow:
+rung 1 did not change what `ka_ok` uniquely covers (so rung 3's gate is still
+the right one), and the numeric twin stays correct on BOTH arms, which is the
+control proving the fixture measures `ka_ok` and not something else.
+
+### 5b. Per-site sabotage of rung 1 itself — which test pins which site
+
+Each relaxed site had its pre-rung-1 `class_id == 0` gate restored **one at a
+time**, then `cargo test --lib -p perry-runtime`:
+
+| site | catcher(s) |
+|---|---|
+| A `set_object_keys_array` clear | **none alone** — see below |
+| B `delete_rest` clear | **none alone** — see below |
+| **A + B together** (= the pre-rung-1 state) | `delete_mints_a_fresh_shape_id_for_a_class_instance` |
+| C `ic_miss` mint | `a_compacted_class_instance_primes_a_token_…` |
+| D `ic_miss` token kind | `a_class_instance_primes_an_id_token_after_rung1`, `a_compacted_class_instance_primes_a_token_…` |
+| E `get_field_by_name_tail` FIELD_CACHE key | **none** — accelerator-only, by construction |
+| F `get_field_by_name_tail` mint | `delete_mints_…`, `class_siblings_share_one_shape_id_…`, `a_stamped_class_instance_still_resolves_a_three_level_parent_chain` |
+| G `field_set_by_name/tail` first-key stamp | **none** — earliness-only, by construction |
+
+★ **A and B are each other's backup, and the sabotage is how I learned it.**
+`js_object_delete_field` **always** allocates a fresh clone
+(`js_array_alloc` → `set_object_keys_array`, `delete_rest.rs:302-322`), so the
+keys POINTER always changes on a delete and site A fires. Site B exists for an
+in-place compaction that no current path produces. SHAPE-NOTES §1b calls B "the
+whole of today's shape transition on delete"; that is half right — A does it
+first. Both were present (class-gated) before this PR, so the redundancy is
+pre-existing, not introduced here. Recorded rather than removed: B is the only
+clear that would still fire if a future path compacts without reallocating, and
+deleting it would silently make that path wrong.
+
+The append case is why A alone is not load-bearing: SHAPE-NOTES' invariant
+allows a same-pointer append to KEEP its stamp (slots are append-only, existing
+mappings stay valid), and a *clone*-on-append re-mints an id that describes the
+same prefix. The one key-set change a stamp must not survive is the
+**compaction**, and that is exactly where A and B overlap.
+
+**E and G are accelerator-only and I am not claiming otherwise.** E swaps the
+FIELD_CACHE key from the keys address to the stamp; every hit re-validates the
+stored key, so the delta is that entries survive grow-reallocs and GC moves —
+faster, never different. G moves a class instance's stamp earlier (to the
+null→first-key edge) than the resolve paths would; sabotaging it only delays the
+stamp. Neither has a behavioural assertion, and building a hit-counter probe for
+them was judged out of proportion for rung 1. Rung 3, which makes the id
+load-bearing in a guard, will need E pinned.


### PR DESCRIPTION
## What

**#6759 C3 ladder, rung 1 of 4: make the shape word uniform.** Runtime-only.

`ObjectHeader.parent_class_id` **is** the shape word — but the stamp was
additionally gated on `class_id == 0`, so a **class instance had no shape word
at all**. Its only header evidence of a key-set change was the `keys_array`
POINTER, which is exactly why `class_field_inline_guard` compares that pointer,
and why the #7916 header shrink cannot delete it.

Rung 0 (#7981) removed the last reader of the header word as inheritance data
(`thread.rs::serialize_object` now takes the class-parent edge from the
registry). That was the blocking dependency. This PR deletes the `class_id`
conjunct, so the rule is uniformly:

```
the word is a ShapeId  <=>  is_shape_id(word)
```

★ **The emitted IR already spelled it that way.** All three PICs
(`property_get/generic_dispatch.rs`, `expr/proxy_reflect.rs` ×2) derive the
receiver token as `is_stamp ? (id | 1<<62) : keys_array` where `is_stamp` is the
ShapeId *range* test, with **no `class_id` load at all**. So this is not a new
mode — it makes the runtime agree with the IR. The two agreed harmlessly before
only because nothing ever put a ShapeId in a class instance's word.

## What changed

`object/shapes.rs` grows four accessors (`shape_word_is_writable`,
`object_shape_stamp`, `stamp_object_shape`, `clear_object_shape_stamp`) that
carry the invariant; nine sites route through them by deleting a
`class_id == 0` conjunct:

| site | role |
|---|---|
| `object/mod.rs::set_object_keys_array` | CLEAR on keys-pointer change |
| `object/delete_rest.rs` | CLEAR on in-place compaction |
| `field_get_set/ic_miss.rs` ×2 | MINT at PIC-miss + the primed token KIND |
| `field_get_set/get_field_by_name_tail.rs` ×2 | FIELD_CACHE key + MINT |
| `field_set_by_name/tail.rs` | birth stamp on the null→first-key edge |
| `proxy/put_value.rs` ×3 | **already uniform** — no change needed |

The last row is independent evidence the rule is right: the write-PIC token
derivations never had a `class_id` gate.

Stamping stays **lazy** — codegen's inline `new C()` still writes a constant
`parent_cid`, so a fresh instance reads as unstamped until its first by-name
resolve. Eager birth stamping is rung 2; switching the guard to an id compare is
rung 3.

### Free correctness rider

Two of the four mint sites had **no RegExp-alias check**. A `RegExpHeader`
aliases `GC_TYPE_OBJECT` with a different layout: offset 4 is the high half of
`regex_ptr` (so it reads `class_id == 0` — the old gate never excluded it) and
**offset 8 is the low half of `pattern_ptr`**. All four now go through
`stamp_object_shape`, which refuses the alias.

## ★ `typed_feedback::object_shape()` deliberately keeps its gate

The costed plan listed it among the gates to relax. **Doing that breaks the
build, and the breakage is the finding.** `object_shape()` does not feed the
PIC; it feeds observation and the guard family, whose contracts compare its
token against a **codegen-supplied keys pointer** (`expected_keys`):

* `typed_feedback/guards.rs::method_direct_call_contract` requires
  `shape_addr == expected_keys as usize`;
* the class-field and element-shape contracts do the same.

An id can never equal that pointer, so returning one fails **every** such guard
**closed** — memory-safe, no output difference, but it silently deletes the
direct-method-call route and the class-field fast paths. Two existing tests
catch it (`typed_feedback_method_direct_guard_passes_for_exact_registered_method`,
`typed_feedback_class_field_get_guard_requires_raw_f64_layout_when_requested`),
and the site now carries a comment naming them. Migrating those nine consumers
off keys pointers is **rung 3**.

So: rung 1 changes the header **word**, not the observation **token**.

## Tests

The entry gate `delete_leaves_a_class_instance_with_no_shape_word_to_transition`
went red as designed — its own failure message named the replacement. Replaced
by `delete_mints_a_fresh_shape_id_for_a_class_instance` (the class-instance twin
of the plain-object test above it), which **keeps** the old test's other two
assertions (`class_id` preserved, keys pointer moved) since both are still true
and still what the guard compares until rung 3. Added beside it:

* `class_siblings_share_one_shape_id_until_one_is_deleted_from` — pristine
  siblings share ONE id (else an id-comparing PIC is monomorphic per *object*
  and never hits); a delete moves only the deleted-from instance.
* `a_stamped_class_instance_still_resolves_a_three_level_parent_chain` — the
  risk assertion: stamping OVERWRITES `parent_class_id`, so a 3-level
  `js_instanceof` chain must still resolve from the registry. Asserts the
  pre-state and that the resolve actually stamped, so it cannot pass vacuously.
* `a_class_instance_primes_an_id_token_after_rung1` — asserts
  `cache[0] == stamp | PIC_ID_TOKEN_BIT` **and** `cache[0] != keys`: priming a
  keys pointer for a stamped receiver would be a permanent miss at that site,
  so this keeps the runtime's token choice and the IR's identical.

`pointer_token_prime_stamps_epoch_and_goes_stale_on_bump` lost its production
population (class instances were the last receivers priming raw keys pointers;
they are stamped now). Split rather than deleted: the epoch mechanics drive
`pic_prime_get` directly so the `cache[2] == @PERRY_IC_EPOCH` guard is still
proved able to FAIL, and the end-to-end half became the id-token test above.

`cargo test -p perry-runtime --lib`: 2249 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime shape tracking for class instances and dynamic objects.
  * Fixed shape invalidation after property deletion and key compaction.
  * Preserved class identity and inheritance behavior after object mutations.
  * Improved inline-cache reliability and invalidation for updated objects.
  * Prevented shape updates from affecting RegExp objects.

* **Documentation**
  * Added technical documentation covering shape handling, validation, and related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->