### PR TITLE
ci: repair three broken gates — Windows cp1252, llvm-inprocess vacuous green, gc-native-roots (#7977, #7971, #7970)

### DIFF
--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -104,6 +104,40 @@
 #                               an entry reading "deleted" for a name still
 #                               greppable in the tree makes the whole list
 #                               look stale.
+# ── STATUS as of #7970 (read before believing a red run) ───────────────────
+#
+# This workflow had NEVER had a successful run on any branch. Three of its four
+# arms failed, for three unrelated reasons, and they are NOT one bug:
+#
+#   macos-14      GATE DEFECT, fixed here. The in-process step asserted
+#                 evacuation liveness without setting `PERRY_GC_DIAG=1`, and
+#                 `[gc-copy-minor]` — the assert's only input — is printed only
+#                 under that flag. So the arm reported "evacuated NOTHING (0
+#                 copying minors)" on every run since it was written. Measured
+#                 on macOS aarch64 at b847afd1c: with the flag, the same binary
+#                 under the same GC env reports 75 copying minors and 16277
+#                 objects copied, and the whole step passes. The collector was
+#                 never the problem.
+#
+#   ubuntu-24.04-arm  REAL DEFECT, filed as #7984. `PERRY_STACKMAP_WALKER=verify`
+#                 caught the fast fp-chain walker and the unwinder resolving the
+#                 same root to addresses 96 bytes apart. This arm is red because
+#                 it found the bug it was built to find; it must STAY red until
+#                 #7984 is fixed. Do not skip it.
+#
+#   windows-latest    REAL DEFECT, filed as #7985 (`perry.exe` cannot link
+#                 against the official LLVM 22 release: /MT-vs-/MD CRT mismatch,
+#                 bundled rpmalloc redefining malloc, and inkwell referencing
+#                 target backends the release does not build). A SECOND,
+#                 separate failure in the same arm — Git-bash `tar` reading
+#                 `D:\a\_temp` as a remote host — was a workflow bug and is
+#                 fixed here with `--force-local`.
+#
+# So: after #7970 the macOS and ubuntu-latest arms should pass and the other two
+# should remain red on their filed defects. This workflow is therefore NOT a
+# promotion candidate yet — promoting it while #7984/#7985 are open would block
+# every PR. Promote only once all four arms are green, and per CLAUDE.md, run it
+# green once BEFORE adding it to branch protection.
 name: gc-native-roots
 on:
   # Must run where it can actually gate something. Branch-scoped triggers were
@@ -256,7 +290,23 @@ jobs:
             if [ ! -x "$llvm_root/bin/opt.exe" ]; then
               curl -sSL --retry 3 -o "$RUNNER_TEMP/llvm.tar.xz" \
                 "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvm_ver/clang+llvm-$llvm_ver-x86_64-pc-windows-msvc.tar.xz"
-              tar -xJf "$RUNNER_TEMP/llvm.tar.xz" -C "$RUNNER_TEMP"
+              # --force-local: this step runs under Git-bash, where $RUNNER_TEMP
+              # is a WINDOWS path (`D:\a\_temp`). GNU tar reads `D:` as a remote
+              # `host:path` and tries to rsh to a host named `D`, which is the
+              # 2026-08-11 failure verbatim:
+              #     tar (child): Cannot connect to D: resolve failed
+              #     xz: (stdin): File format not recognized
+              #     tar: Error is not recoverable: exiting now      (exit 2)
+              # `-C` is not parsed for a remote spec, so only the ARCHIVE path
+              # needs the flag. Verify the extraction rather than trusting it:
+              # a half-extracted tree would otherwise surface as the much more
+              # confusing "no matched opt+clang pair" error below.
+              tar --force-local -xJf "$RUNNER_TEMP/llvm.tar.xz" -C "$RUNNER_TEMP"
+              if [ ! -x "$llvm_root/bin/opt.exe" ]; then
+                echo "::error::extracted $RUNNER_TEMP/llvm.tar.xz but $llvm_root/bin/opt.exe is still missing — the archive layout changed, or the download was truncated"
+                ls -la "$RUNNER_TEMP" | head -20
+                exit 1
+              fi
             fi
             llvm_bin="$llvm_root/bin"
           else
@@ -560,12 +610,31 @@ jobs:
           ./target/perry-dev/perry "$probe" -o /tmp/inproc-09-control
           PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off \
             /tmp/inproc-09-control > /tmp/inproc-09.control.out 2>/dev/null
+          # PERRY_GC_DIAG=1 is LOAD-BEARING, not decoration: `[gc-copy-minor]`
+          # is emitted only under it, and that line is the entire input to
+          # `gc_evacuation_liveness_assert.py`. Without it the assert reads an
+          # empty trace and reports "evacuated NOTHING (0 copying minors, 0
+          # objects copied)" no matter what the collector actually did — so
+          # this arm could never pass, which is a large part of why
+          # `gc-native-roots` has never had a green run (#7970).
+          #
+          # Measured on macOS aarch64 at this commit: with the flag, the same
+          # binary under the same GC env reports 75 copying minors and 16277
+          # objects copied. The collector was evacuating the whole time; the
+          # gate was asserting on telemetry it had not switched on. The sibling
+          # call site in the walker-trace step above always set it — this one
+          # was missed.
+          #
+          # `--probe` likewise: without it the failure message says the literal
+          # `<probe>`, which is what the 2026-08-11 logs show.
+          PERRY_GC_DIAG=1 \
           PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 \
           PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off \
             /tmp/inproc-09 > /tmp/inproc-09.out 2> /tmp/inproc-09.err
           diff /tmp/inproc-09.control.out /tmp/inproc-09.out \
             || { echo "::error::in-process RS4GC diverged from the shadow-stack control"; exit 1; }
-          python3 scripts/gc_evacuation_liveness_assert.py /tmp/inproc-09.err
+          python3 scripts/gc_evacuation_liveness_assert.py /tmp/inproc-09.err \
+            --probe "09_try_catch_roots (in-process RS4GC)"
 
           # And it must be RS4GC doing the lowering, not a per-function bail to
           # the bridge -- which would make this arm green while testing the

--- a/.github/workflows/llvm-inprocess.yml
+++ b/.github/workflows/llvm-inprocess.yml
@@ -120,28 +120,126 @@ jobs:
           echo "$out" | grep -q "dialect::tests::corpus_exception_handling ... ok"
           echo "$out" | grep -q "inprocess::tests::rs4gc_schedules_in_process ... ok"
 
+
+      # The tracked `.ll` corpora above are a SNAPSHOT of what the compiler
+      # emitted when they were last refreshed (#7302/#7307/#7310, 2026-08-03).
+      # `corpus_spike ... ok` therefore proves the dialect reader can build
+      # THAT IR — not the IR this commit emits. When the end-to-end arm below
+      # goes red while these stay green, that gap is the first thing to check,
+      # so print it rather than leaving the next reader to rediscover it.
+      - name: Corpus currency (diagnostic, not a gate)
+        if: ${{ !cancelled() }}
+        run: |
+          set -uo pipefail
+          newest=$(git log -1 --format=%ct -- experiments/llvm-inprocess-spike/*.ll)
+          behind=$(git log --oneline --since="@${newest}" -- crates/perry-codegen/src \
+            crates/perry-hir/src crates/perry-transform/src | wc -l | tr -d ' ')
+          echo "tracked .ll corpora last refreshed: $(git log -1 --format='%h %ad' \
+            --date=short -- experiments/llvm-inprocess-spike/*.ll)"
+          echo "IR-affecting commits since then (codegen+hir+transform): ${behind}"
+          {
+            echo "### llvm-inprocess corpus currency"
+            echo ""
+            echo "- corpora refreshed: \`$(git log -1 --format='%h %ad' --date=short \
+              -- experiments/llvm-inprocess-spike/*.ll)\`"
+            echo "- IR-affecting commits since: **${behind}**"
+            echo ""
+            echo "The unit corpus gates assert the reader handles that snapshot."
+            echo "Only the end-to-end smoke below exercises the IR this commit emits."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Native-mode smoke — liveness, behavior parity, object-byte verdicts
         run: |
-          set -euo pipefail
+          # NOTE: deliberately NOT `set -e`. Every check below reports what it
+          # was doing and dumps the captured output before exiting. The previous
+          # version used bare `grep -q` / `cmp` under `set -euo pipefail`, so the
+          # 2026-08-11 `main` failures ended at "Generating code..." with a naked
+          # `exit 1` and no diagnostic at all — three runs, untriageable (#7971).
+          # The compiler's own message was fine and named the offending IR line;
+          # it went to a captured file that nothing ever printed. That is #7982.
+          # The compilers' stderr carries the liveness banner, so it is captured
+          # to a file; that file is what went unread. It is now always dumped on
+          # failure, and the failing COMMAND is named.
+          set -uo pipefail
           export PERRY_RUNTIME_DIR="$PWD/target/perry-dev"
           export PERRY_NO_AUTO_OPTIMIZE=1
           BIN=target/perry-dev/perry
           SRC=experiments/llvm-inprocess-spike/spike.ts
+          EH=test-files/test_gap_7302_invoke_eh_paths.ts
+          W=/tmp/inproc; mkdir -p "$W"
 
-          "$BIN" "$SRC" -o /tmp/spike_text
-          /tmp/spike_text > /tmp/text.out
+          dump() {
+            for f in "$@"; do
+              [ -s "$f" ] || continue
+              echo "--- $f (last 80 lines) ---"
+              tail -80 "$f"
+            done
+          }
 
-          PERRY_LLVM_INPROCESS=native "$BIN" "$SRC" -o /tmp/spike_native 2> /tmp/native.err
-          grep -q "in-process LLVM backend active" /tmp/native.err
-          /tmp/spike_native > /tmp/native.out
-          cmp /tmp/text.out /tmp/native.out
+          # run <label> -- <command...>   ; stdout/stderr captured per label
+          run() {
+            local label="$1"; shift; [ "$1" = "--" ] && shift
+            echo "==> ${label}: $*"
+            # Capture the status BEFORE any other command runs. `if ! cmd; then
+            # rc=$?` would record the NEGATED status (always 0) — the failing
+            # exit code is the one thing this whole step exists to report.
+            "$@" > "${W}/${label}.out" 2> "${W}/${label}.err"
+            local rc=$?
+            if [ "${rc}" -ne 0 ]; then
+              echo "::error::${label} FAILED (exit ${rc}): $*"
+              dump "${W}/${label}.out" "${W}/${label}.err"
+              exit 1
+            fi
+          }
 
-          PERRY_LLVM_INPROCESS=diff "$BIN" "$SRC" -o /tmp/spike_diff 2> /tmp/diff.err
-          grep -q "ir-diff. OK" /tmp/diff.err
+          # assert_grep <pattern> <file> <why this matters>
+          assert_grep() {
+            if ! grep -q "$1" "$2"; then
+              echo "::error::liveness assert failed — expected /$1/ in $2. $3"
+              dump "$2"
+              exit 1
+            fi
+            echo "    ok: /$1/ present in $(basename "$2")"
+          }
 
-          PERRY_LLVM_INPROCESS=diff PERRY_CODEGEN_UNITS=3 "$BIN" \
-            benchmarks/app-patterns/kernels/batch.ts -o /tmp/batch_diff 2> /tmp/diffu.err
-          grep -q "ir-diff. OK.*3 units" /tmp/diffu.err
+          # assert_same <a> <b> <why>
+          assert_same() {
+            if ! cmp -s "$1" "$2"; then
+              echo "::error::behavior parity failed: $3"
+              echo "--- diff $1 vs $2 ---"
+              diff -u "$1" "$2" | head -60 || true
+              exit 1
+            fi
+            echo "    ok: $(basename "$1") == $(basename "$2")"
+          }
+
+          echo "::group::spike.ts — textual baseline"
+          run spike_text -- "$BIN" "$SRC" -o "${W}/spike_text"
+          run spike_text_exec -- "${W}/spike_text"
+          cp "${W}/spike_text_exec.out" "${W}/text.out"
+          echo "::endgroup::"
+
+          echo "::group::spike.ts — PERRY_LLVM_INPROCESS=native"
+          run spike_native -- env PERRY_LLVM_INPROCESS=native "$BIN" "$SRC" -o "${W}/spike_native"
+          assert_grep "in-process LLVM backend active" "${W}/spike_native.err" \
+            "The native path must announce itself; without the banner this arm would pass while silently serving the textual backend."
+          run spike_native_exec -- "${W}/spike_native"
+          assert_same "${W}/text.out" "${W}/spike_native_exec.out" \
+            "the natively-constructed module behaves differently from the textual one"
+          echo "::endgroup::"
+
+          echo "::group::spike.ts — PERRY_LLVM_INPROCESS=diff"
+          run spike_diff -- env PERRY_LLVM_INPROCESS=diff "$BIN" "$SRC" -o "${W}/spike_diff"
+          assert_grep "ir-diff. OK" "${W}/spike_diff.err" \
+            "The object-byte verdict is the whole point of diff mode; no verdict means nothing was compared."
+          echo "::endgroup::"
+
+          echo "::group::batch.ts — diff mode across 3 codegen units"
+          run batch_diff -- env PERRY_LLVM_INPROCESS=diff PERRY_CODEGEN_UNITS=3 \
+            "$BIN" benchmarks/app-patterns/kernels/batch.ts -o "${W}/batch_diff"
+          assert_grep "ir-diff. OK.*3 units" "${W}/batch_diff.err" \
+            "The multi-unit split must be exercised; a single-unit verdict here would be a narrower test wearing the same name."
+          echo "::endgroup::"
 
           # #7302: exception handling. try/catch lowers to invoke/landingpad
           # with a personality on the define, so a reader that cannot build
@@ -149,12 +247,91 @@ jobs:
           # textual path — which is exactly how this arm went red once the
           # EH migration landed. Assert the EH program takes the native path
           # AND behaves identically.
-          EH=test-files/test_gap_7302_invoke_eh_paths.ts
-          "$BIN" "$EH" -o /tmp/eh_text
-          /tmp/eh_text > /tmp/eh_text.out
-          PERRY_LLVM_INPROCESS=native "$BIN" "$EH" -o /tmp/eh_native 2> /tmp/eh_native.err
-          grep -q "in-process LLVM backend active" /tmp/eh_native.err
-          /tmp/eh_native > /tmp/eh_native.out
-          cmp /tmp/eh_text.out /tmp/eh_native.out
-          PERRY_LLVM_INPROCESS=diff "$BIN" "$EH" -o /tmp/eh_diff 2> /tmp/eh_diff.err
-          grep -q "ir-diff. OK" /tmp/eh_diff.err
+          echo "::group::EH program — textual, native, diff"
+          run eh_text -- "$BIN" "$EH" -o "${W}/eh_text"
+          run eh_text_exec -- "${W}/eh_text"
+          run eh_native -- env PERRY_LLVM_INPROCESS=native "$BIN" "$EH" -o "${W}/eh_native"
+          assert_grep "in-process LLVM backend active" "${W}/eh_native.err" \
+            "A try-containing module must take the native path, not fall back to text (#7302)."
+          run eh_native_exec -- "${W}/eh_native"
+          assert_same "${W}/eh_text_exec.out" "${W}/eh_native_exec.out" \
+            "exception-handling behavior differs between the textual and native backends"
+          run eh_diff -- env PERRY_LLVM_INPROCESS=diff "$BIN" "$EH" -o "${W}/eh_diff"
+          assert_grep "ir-diff. OK" "${W}/eh_diff.err" \
+            "The EH module must reach a byte verdict, not be skipped by the differ."
+          echo "::endgroup::"
+
+          echo "native-mode smoke: all arms exercised and green"
+
+  # ── Fan-in verdict ─────────────────────────────────────────────────────────
+  #
+  # #7971: WITHOUT this job the workflow reported `success` on a PR where
+  # `changes=success, native-backend=skipped` — i.e. green while executing
+  # nothing. Three sampled PR "successes" (31505530279, 31499833415,
+  # 31476724152) were all of that shape. That is CLAUDE.md's fourth way a gate
+  # cannot fail, and the most dangerous one, because the job is genuinely green.
+  #
+  # A path filter is a COST control, not a verdict. This job separates the two:
+  # it re-states in the log and the summary whether the backend was actually
+  # exercised, so "llvm-inprocess ✓" can no longer be read as "the in-process
+  # backend passed" when nothing ran.
+  #
+  # It can fail, in two directions that matter:
+  #   * `native-backend` failed or was cancelled -> red.
+  #   * `native-backend` was SKIPPED on a non-PR event -> red. The scheduled
+  #     sweep, a release tag and a manual dispatch all set `relevant=true`
+  #     unconditionally; if one of them ever skips, the post-merge anchor has
+  #     silently stopped anchoring, which is exactly how #7856 starved this
+  #     gate for eight days without anyone noticing.
+  llvm-inprocess-complete:
+    needs: [changes, native-backend]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verdict
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          BACKEND: ${{ needs.native-backend.result }}
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          echo "changes=${CHANGES} relevant=${RELEVANT} native-backend=${BACKEND} event=${EVENT}"
+
+          if [ "${CHANGES}" != "success" ]; then
+            echo "::error::the relevance filter itself did not succeed (${CHANGES});"\
+                 "no statement can be made about the in-process backend."
+            exit 1
+          fi
+
+          case "${BACKEND}" in
+            success)
+              echo "EXERCISED: the in-process LLVM backend ran and passed."
+              echo "✅ **EXERCISED** — in-process LLVM backend ran and passed." \
+                >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            skipped)
+              if [ "${EVENT}" != "pull_request" ]; then
+                echo "::error::native-backend was SKIPPED on a ${EVENT} run."\
+                     "Every non-PR event sets relevant=true unconditionally, so this"\
+                     "means the post-merge anchor has stopped anchoring (#7856/#7971)."
+                exit 1
+              fi
+              echo "NOT EXERCISED: no IR-affecting path changed, so the backend did not run."
+              echo "This run asserts NOTHING about the in-process LLVM backend."
+              {
+                echo "⚠️ **NOT EXERCISED** — no IR-affecting path changed in this PR."
+                echo ""
+                echo "The in-process LLVM backend did **not** run. This green result"
+                echo "is a statement about relevance, not about the backend."
+                echo "The post-merge sweep of \`main\` is what anchors this gate."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "::error::native-backend concluded '${BACKEND}'."
+              echo "❌ **${BACKEND}** — in-process LLVM backend did not pass." \
+                >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,6 +280,19 @@ jobs:
           python3 scripts/check_locale_independent_io.py --self-test
           python3 scripts/check_locale_independent_io.py
 
+      # #7970. `gc_evacuation_liveness_assert.py` is the liveness gate for every
+      # forced-evacuation arm, and it reads ONLY `[gc-copy-minor]` lines, which
+      # exist only under `PERRY_GC_DIAG=1`. When an arm forgot that flag the
+      # assert reported "the forced-evacuation arm evacuated NOTHING" — sending
+      # readers to debug a collector that was in fact evacuating 16277 objects
+      # per run. It now separates "the instrument was off" from "the subject was
+      # dead", and this proves it still can, in both directions. Hermetic and
+      # instant, so it belongs in `lint` (a REQUIRED context) rather than only
+      # in the GC gate it serves — which is itself still red.
+      - name: GC evacuation-liveness assert can say no
+        if: ${{ !cancelled() }}
+        run: python3 scripts/gc_evacuation_liveness_assert.py --self-test
+
       # Node is a correctness input (see CLAUDE.md "TypeScript Parity Status"):
       # an oracle that cannot run a gap test drops it from the gate instead of
       # failing it. #6367 made `.node-version` the single pin, and the pin has

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,6 +263,23 @@ jobs:
           python3 scripts/check_gc_doc_claims.py --self-test
           python3 scripts/check_gc_doc_claims.py
 
+      # #7977. The audits above ALSO run as `windows-build`'s first step, where
+      # a bare `read_text()` decodes cp1252 and dies on the 15 runtime sources
+      # carrying 0x81/0x8d/0x8f/0x90/0x9d. That took the whole Windows job down
+      # — including the only Windows run of the perry-runtime unit tests —
+      # before any of it executed. #7882 fixed three of the four readers; this
+      # is what stops the fourth miss from being found on Windows again.
+      #
+      # It runs HERE, on Linux, in a REQUIRED context, precisely because the
+      # defect is invisible on Linux at runtime: the scan is static, so the
+      # class is caught per-PR rather than only when a Windows runner gets to
+      # it. `--self-test` plants each shape, so the checker can say no.
+      - name: Windows-portable text I/O in the Windows-CI audits
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/check_locale_independent_io.py --self-test
+          python3 scripts/check_locale_independent_io.py
+
       # Node is a correctness input (see CLAUDE.md "TypeScript Parity Status"):
       # an oracle that cannot run a gap test drops it from the gate instead of
       # failing it. #6367 made `.node-version` the single pin, and the pin has
@@ -1111,6 +1128,15 @@ jobs:
 
       - name: GC structural audits (Windows)
         shell: bash
+        env:
+          # #7977 belt-and-braces. These scripts read Rust sources that contain
+          # bytes cp1252 has no mapping for; the ACTUAL fix is an explicit
+          # `encoding="utf-8"` at every call site, enforced on Linux by
+          # `scripts/check_locale_independent_io.py` in `lint`. This makes a
+          # future miss in a script that gate does not yet cover degrade to
+          # "works anyway" instead of taking the whole job — and with it the
+          # only Windows run of the perry-runtime unit tests — down at step one.
+          PYTHONUTF8: "1"
         run: |
           set -euo pipefail
           python scripts/gc_runtime_root_holders.py --self-test

--- a/changelog.d/7986-ci-gate-repair.md
+++ b/changelog.d/7986-ci-gate-repair.md
@@ -1,0 +1,72 @@
+### CI: three broken gates repaired, three real defects filed (#7977, #7971, #7970)
+
+Three gates were unable to do their job. None was fixed by weakening what it
+asserts; where an arm was red because it had found a real defect, the defect was
+filed and the arm left red.
+
+**`windows-build` was red before it ran anything (#7977).**
+`scripts/check_thread_locals.py` read Rust sources with a bare
+`Path.read_text()`, which decodes with the host locale — cp1252 on a Windows
+runner. Fifteen files under `crates/perry-runtime/src` carry a byte cp1252 cannot
+map; `i18n.rs` is reached first at offset 31552 with 923 newlines before it, so
+`core.autocrlf` puts the failure at position 32475, matching the traceback to the
+byte. That is the job's *first* step, so the seven behind it — including the only
+Windows run of the `perry-runtime` unit tests, the only Windows build of the
+runtime, stdlib and both Windows UI crates, the Windows parity smoke, the
+VERSIONINFO check and the COFF-trimming test — were `skipped` on every PR. #7882
+fixed the path-separator half of this class in the same file and the encoding in
+`gc_runtime_root_holders.py`; these four readers were missed. Every call site now
+passes `encoding="utf-8"` explicitly, and a new
+`scripts/check_locale_independent_io.py` AST-scans the six Python files the
+Windows audit step runs and fails on locale-defaulted text I/O. It runs in `lint`
+— Linux, per-PR, already required — so the class is caught before it can reach
+Windows. Static rather than `PYTHONWARNDEFAULTENCODING` because that only fires
+on calls that execute, and because `tests/test_gc_ratchet.py` embeds `open(...)`
+inside probe source *literals* that an AST correctly ignores.
+
+**`llvm-inprocess` reported green while skipping its only real job (#7971).**
+On PRs it ran `changes=success, native-backend=skipped` and concluded `success` —
+CLAUDE.md's fourth way a gate cannot fail, in its purest form. A new
+`llvm-inprocess-complete` fan-in now states EXERCISED or NOT EXERCISED in the log
+and step summary, and fails when the real job failed, was cancelled, or was
+skipped on a non-PR event (every non-PR event sets `relevant=true`
+unconditionally, so a skip there means the post-merge anchor stopped anchoring).
+When the job did run on `main` it failed with a naked `exit 1`: the smoke step
+used bare `grep -q`/`cmp` under `set -euo pipefail` with each compile's stderr
+redirected to a file nothing ever printed. It now names the failing command with
+its real exit status, dumps the captured output, and diffs on a parity failure.
+
+**`gc-native-roots` had never had a green run on any branch (#7970).** Its three
+failing arms had three unrelated causes. The `macos-14` arm was a *gate* defect:
+it asserted evacuation liveness without setting `PERRY_GC_DIAG=1`, and
+`[gc-copy-minor]` — the only input `gc_evacuation_liveness_assert.py` reads — is
+printed only under that flag, so the arm reported "evacuated NOTHING" on every
+run since it was written and could never pass. With the flag, the same binary
+under the same GC env reports 75 copying minors and 16277 objects copied and the
+whole step passes; the collector had been evacuating the whole time. That assert
+now separates "the instrument was off" from "the subject was dead", and gained a
+five-direction `--self-test` wired into `lint`. The Windows arm's second failure
+was Git-bash GNU tar reading `$RUNNER_TEMP` (`D:\a\_temp`) as a remote
+`host:path`; fixed with `--force-local` plus a post-extraction check.
+
+**Defects found and filed rather than silenced:**
+
+- **#7982** — `PERRY_LLVM_INPROCESS=native` cannot build RS4GC `ptr addrspace(1)`
+  root slots; `dialect/mod.rs::basic_type` has no `addrspace(N)` arm, and it is
+  not a one-line fix. The unit corpus gates stayed green throughout because all
+  three tracked `.ll` corpora were frozen on 2026-08-03, 151 codegen commits ago,
+  and contain zero `addrspace(1)` — so `corpus_spike ... ok` proved the tests ran,
+  not that they test the IR the compiler emits today.
+- **#7984** — on aarch64 Linux, `PERRY_STACKMAP_WALKER=verify` catches the fast
+  fp-chain walker and the unwinder resolving the same root to addresses 96 bytes
+  apart. The fast walker is the one that runs when verify is off.
+- **#7985** — `perry.exe` cannot link against the official LLVM 22 Windows
+  release: `/MT`-vs-`/MD` CRT mismatch, the bundled rpmalloc redefining
+  `malloc`/`free`, and inkwell referencing target backends the release does not
+  build. Probably latent in `windows-build` too, whose build step has not executed
+  since #7977.
+
+Nothing was promoted to a required context. `gc-native-roots` in particular must
+not be, while #7984 and #7985 keep two arms legitimately red; a STATUS block at
+the top of that workflow now records which arm is which so the next reader does
+not re-derive it.

--- a/gc-handoff/CIFIX-NOTES.md
+++ b/gc-handoff/CIFIX-NOTES.md
@@ -1,0 +1,114 @@
+# CI gate repair: #7977, #7971, #7970
+
+Working notes. Written incrementally; the PR body is the summary.
+
+---
+
+## #7977 — `windows-build` red before it runs anything  [FIXED]
+
+### What this gate covers (and what was therefore unprotected)
+
+`windows-build` is the **only Windows execution of anything** in per-PR CI. Its
+step list, in order:
+
+1. GC structural audits (Windows)  <- died here, 27 s in
+2. Install Rust toolchain / LLVM 22 / Node
+3. Build compiler + runtime + `perry-ui-windows` + `perry-ui-windows-winui`
+4. **`perry-runtime` unit tests** (`RUST_TEST_THREADS=1`, #7356)  <- the big one
+5. Windows parity harness smoke
+6. `perry.exe` VERSIONINFO resource check
+7. COFF duplicate-symbol archive trimming test
+
+Steps 2-7 were `skipped` on **every** PR whose Windows run executed the current
+`test.yml`. So for the duration: **no Windows compile of the runtime, the stdlib
+or either Windows UI crate; no Windows run of the `perry-runtime` unit tests; no
+Windows parity smoke; no VERSIONINFO check; no COFF-trimming test.** A Windows-only
+miscompile, a Windows-only test failure, or a broken `perry-ui-windows` build would
+all have merged green-by-skipping.
+
+### Root cause (confirmed to the byte)
+
+`scripts/check_thread_locals.py` reads Rust sources with a bare
+`Path.read_text()`, which decodes with `locale.getencoding()` — **cp1252** on a
+GitHub Windows runner. 15 files under `crates/perry-runtime/src` carry a byte
+cp1252 has no mapping for (0x81/0x8d/0x8f/0x90/0x9d). Reproduced locally:
+
+```
+15 files undecodable as cp1252
+   crates/perry-runtime/src/i18n.rs                 offset 31552  0x8d
+   crates/perry-runtime/src/intl/duration_format.rs offset 17349  0x81
+   ...
+i18n.rs: offset=31552 newlines_before=923 crlf_position=32475   (issue says 32475)
+```
+
+The issue's arithmetic is exact: `core.autocrlf` widens 923 `\n` to `\r\n`, so
+31552 + 923 = **32475**, the position in the traceback.
+
+`#7882` ("make GC structural audits portable") fixed the *path-separator* half of
+this class in this same file and the *encoding* in `gc_runtime_root_holders.py`,
+but missed these four readers. Same shape, one file over.
+
+### Changed
+
+- `scripts/check_thread_locals.py` — all 5 reads and 15 writes now go through
+  `read_source()` / `write_source()` helpers that pass `encoding="utf-8"`
+  (and `newline=""` on write, so `--update` is byte-stable across hosts).
+  The gated content is **unchanged**: the `files` map the checker verifies is
+  identical before and after (asserted, see validation).
+- `scripts/gc_runtime_root_holders.py` — one **latent** instance of the same
+  class in the self-test's fixture writer. ASCII today, so it has not bitten;
+  fixed with the rest.
+- `tests/test_gc_ratchet.py:1369` — bare `read_text()` on the shipped baseline.
+- `scripts/check_locale_independent_io.py` — **new gate** (below).
+- `.github/workflows/test.yml` — new `lint` step running that gate;
+  `PYTHONUTF8: "1"` on the Windows audit step as belt-and-braces.
+
+### The new gate, and why it is static
+
+`scripts/check_locale_independent_io.py` AST-scans exactly the six Python files
+`windows-build`'s audit step executes, and fails on `open()` / `read_text()` /
+`write_text()` / `Path.open()` without an explicit `encoding=` (binary modes
+exempt).
+
+Static, not `PYTHONWARNDEFAULTENCODING`, for two reasons:
+
+- `EncodingWarning` only fires on a call that **executes**. A bare `read_text()`
+  on an error path or in a subcommand CI does not invoke warns nobody and ships.
+- `tests/test_gc_ratchet.py` writes Python probes as *string literals* containing
+  `open(...)`. Those are not calls; the AST correctly ignores them, a grep would not.
+
+It runs in **`lint`** — Linux, per-PR, and a **required** context — because the
+defect is invisible on Linux at runtime. That is the point: the class is now
+caught before it can reach Windows, rather than by taking the Windows job down.
+
+### Validation
+
+| check | result |
+|---|---|
+| reproduce main's failure under a non-UTF-8 locale | `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2`, exit **1** |
+| same command, fixed | exit **0**, `thread-local policy OK: 173 hot declarations, 129 raw blocks in 91 recorded cold files` |
+| full 8-command Windows audit sequence, non-UTF-8 locale | all **PASS** |
+| `--update` output vs shipped allowlist | `files` map **identical** |
+| **sabotage**: replant the exact #7977 defect | new gate exits **1** and names `check_thread_locals.py:115` |
+| remove the replant | new gate exits **0** |
+| new gate `--self-test` | OK — 6 flagged shapes, accepted shapes clean, scope asserted |
+
+The sabotage arm is the one that matters: a green run of this gate means the
+detector works, not that nothing was tried.
+
+### Not changed (deliberate)
+
+- `_hot_declarations` in `thread_local_cold_allowlist.json` reads 163 against an
+  actual 173. **Pre-existing drift on `main`, not caused by this change**, and
+  `verify()` does not gate on that field — only on `files`. Left alone to keep
+  the diff reviewable; worth a one-line `--update` in a separate change.
+- `gc_runtime_root_holders.py` raises `UnicodeEncodeError` when *printing* an
+  em-dash under an ASCII locale. Measured: its output **is** cp1252-encodable, so
+  this is an artifact of the stricter ASCII simulation and **not** a Windows
+  defect. `PYTHONUTF8=1` on the step covers it regardless.
+
+### Promotion
+
+Nothing promoted. `lint` is **already** a required context; this adds a step to it.
+That is deliberate — CLAUDE.md hazard 2 is the step people forget, so the gate is
+placed where that step does not exist. It is green locally on this tree.

--- a/gc-handoff/CIFIX-NOTES.md
+++ b/gc-handoff/CIFIX-NOTES.md
@@ -112,3 +112,161 @@ detector works, not that nothing was tried.
 Nothing promoted. `lint` is **already** a required context; this adds a step to it.
 That is deliberate — CLAUDE.md hazard 2 is the step people forget, so the gate is
 placed where that step does not exist. It is green locally on this tree.
+
+---
+
+## #7971 — `llvm-inprocess` green-by-skipping on PRs, red when it runs  [GATE FIXED; defect filed as #7982]
+
+### What this gate covers (and what was unprotected)
+
+It is the CI exercise for `PERRY_LLVM_INPROCESS` — the GC knob kill-policy's
+required arm for that mode — and #7966 calls it "the promotion prerequisite" for
+the in-process LLVM backend. It covers: building with the feature, 528 unit gates
+incl. the `.ll` corpus construction tests and the RS4GC pin, and an end-to-end
+smoke over textual / `native` / `diff` modes plus a multi-unit split and the
+#7302 exception-handling program.
+
+Unprotected: on PRs, **everything** — `native-backend` was `skipped` and the
+workflow still reported `success`. On `main` the job ran and failed, so its three
+most recent executions asserted nothing either. Net: the in-process backend has
+had no effective CI coverage, and `PERRY_LLVM_INPROCESS=native` is in fact broken.
+
+### Root causes (three, independent)
+
+1. **Vacuous green.** `changes` is a path filter; when it says "not relevant" the
+   real job is skipped and the workflow concludes `success`. Sampled PR runs
+   31505530279 / 31499833415 / 31476724152 are all `changes=success,
+   native-backend=skipped`. A cost control was standing in for a verdict.
+2. **No diagnostic.** `Native-mode smoke` ran bare `grep -q` / `cmp` under
+   `set -euo pipefail` with each compile's stderr redirected to a file that was
+   never printed. The three 2026-08-11 `main` failures therefore ended at
+   `Generating code...` + `exit 1`.
+3. **Frozen corpora.** The unit gate asserts `corpus_spike ... ok` to prove the
+   corpus tests *ran*, but nothing asserts they are *current*.
+
+### Changed
+
+- New `llvm-inprocess-complete` fan-in (`if: always()`): prints EXERCISED /
+  NOT EXERCISED to the log and step summary. Fails when `native-backend` failed
+  or was cancelled, **and** when it was `skipped` on a non-PR event (every non-PR
+  event sets `relevant=true` unconditionally, so a skip there means the
+  post-merge anchor stopped anchoring — the #7856 shape).
+- `Native-mode smoke` rebuilt around `run` / `assert_grep` / `assert_same`: names
+  the failing command with its real exit status, dumps captured stdout+stderr,
+  prints a diff on parity failure, and states what each liveness assert protects.
+  Status is captured *after* the command — inside an `if ! cmd` branch `$?` is
+  the negated status and is always 0.
+- New "Corpus currency" diagnostic step printing corpus age and the count of
+  IR-affecting commits since.
+
+### The defect it was correctly reporting → #7982
+
+Reproduced locally (LLVM 22 + `--features perry/llvm-inprocess`, 3m17s build):
+
+```
+native IR construction failed in @perry_closure_spike_ts__8:
+in line: %r5 = alloca ptr addrspace(1)
+```
+
+`dialect/mod.rs::basic_type` handles `"ptr"` but has no `ptr addrspace(N)` arm.
+Today's codegen emits **five** such shapes (alloca / load / store / inttoptr /
+ptrtoint; 116 occurrences in `spike.ts` alone) for RS4GC root slots.
+
+**Not a one-liner**: I added an `addrspace(N)` arm and rebuilt — `alloca` then
+succeeds and the reader fails on `store ptr addrspace(1) null, ptr %r5`. Probe
+reverted; filed as #7982 rather than folded into a CI change.
+
+**Why the unit gate never saw it**: all three corpora were frozen 2026-08-03
+(#7307/#7310), **151 codegen commits ago**, and contain **zero** `addrspace(1)`.
+The gate asserting "the corpus tests ran" is green; its subject — the IR this
+commit emits — never ran. Hazard 4 inside the liveness assert written to prevent it.
+
+### Not done
+
+- The `changes` filter does not include `crates/perry-hir` or
+  `crates/perry-transform`, which also determine emitted IR. Widening it costs a
+  90-minute macOS job on many more PRs, so it is a policy call, not a fix I made.
+  Noted here rather than changed.
+- Nothing promoted to required. It cannot be promoted while #7982 is open.
+
+---
+
+## #7970 — `gc-native-roots` has never been green  [1 arm fixed, 2 arms = real defects, filed]
+
+### What this gate covers (and what was unprotected)
+
+Native-frame GC roots (RS4GC) across every host shape Perry supports: aarch64
+Mach-O, x86-64 ELF, x86-64 PE/COFF, aarch64 ELF. Per arm it asserts the compact
+root map section exists, that `__llvm_stackmaps` did NOT survive, byte-parity
+against the pinned Node oracle, walker-trace location telemetry, and evacuation
+liveness — plus, on Windows, that the funclet-EH refusal stays a refusal.
+
+Unprotected the whole time: **everything except the x86-64 ELF arm**. No green
+evidence has ever existed for native roots on aarch64 Mach-O, aarch64 ELF or PE.
+
+### Arm 1 — `macos-14` zero-evacuation: GATE DEFECT, FIXED
+
+The in-process step ran the forced-evacuation binary **without
+`PERRY_GC_DIAG=1`**, and `[gc-copy-minor]` is emitted only under that flag. It is
+the only input `gc_evacuation_liveness_assert.py` reads, so the assert saw an
+empty trace and reported "evacuated NOTHING (0 copying minors, 0 objects
+copied)". The arm could never pass.
+
+Reproduced and fixed locally on macOS aarch64, byte-for-byte including the
+literal `<probe>` in the CI message (the step also omitted `--probe`):
+
+| run | `[gc-copy-minor]` lines | assert |
+|---|---|---|
+| workflow env as-was (no `PERRY_GC_DIAG`) | 0 (stderr was 98 bytes of `#gcmetric`) | `evacuated NOTHING` — exit 1 |
+| `+ PERRY_GC_DIAG=1` | 150 | `evacuation live — 75 copying minor(s), 16277 objects copied` — exit 0 |
+
+Full step re-run locally with the fix: `__perry_gcmap` present, `__llvm_stackmaps`
+absent, control-vs-forced stdout identical, assert green.
+
+**#7970 hypothesised this might be #7965-shaped ("the collector stopped running
+copying minors"). It is not.** The collector was evacuating the whole time; the
+gate was asserting on telemetry it had not switched on.
+
+To stop the misdiagnosis recurring, `gc_evacuation_liveness_assert.py` now
+separates *instrument off* from *subject dead*: a trace with no `[gc-...]` marker
+at all is reported as "`PERRY_GC_DIAG=1` was NOT set … fix the RUN, not the
+collector", never as a statement about the GC. It gained a `--self-test` covering
+5 directions, wired into `lint`.
+
+### Arm 2 — `ubuntu-24.04-arm`: REAL DEFECT → #7984
+
+Not a SIGSEGV (the issue read `Aborted (core dumped)` as one) — a Rust assertion:
+
+```
+stack_maps.rs:507: PERRY_STACKMAP_WALKER=verify: fast walk visited 1 unique slots, unwinder visited 1
+  left:  [281474742909688]
+  right: [281474742909592]      # 96 bytes apart
+```
+
+Both walkers found one slot and disagree on **where** it is. `fp_chain` is the
+walker that runs when `verify` is off, so on aarch64 Linux the collector may be
+marking and rewriting the wrong stack word — the CLAUDE.md "root-store dominance"
+class, invisible at collection time. **This arm must stay red until #7984 is
+fixed.** It is the gate working.
+
+### Arm 3 — `windows-latest`: TWO problems
+
+- **Real defect → #7985.** `link.exe` exit 1120: `/MT`-vs-`/MD` CRT mismatch
+  (llvm-sys vs mimalloc), `LNK2005` on malloc/free/calloc/realloc from the
+  rpmalloc LLVM's release bundles, and `LNK2019` for Mips/Lanai/Sparc/MSP430/
+  XCore init symbols inkwell references. Filed, not fixed — it needs a
+  Windows-toolchain decision.
+  **Likely also latent in `test.yml`'s `windows-build`**, whose build step has not
+  executed on any recent PR because of #7977. Expect it to surface once #7977 lands.
+- **Workflow bug, FIXED here.** The second failure (exit 2) was Git-bash GNU tar
+  reading `$RUNNER_TEMP` (`D:\a\_temp`) as a remote `host:path`:
+  `tar (child): Cannot connect to D: resolve failed`. Fixed with
+  `tar --force-local` plus a post-extraction existence check, so a bad archive
+  reports itself instead of surfacing later as "no matched opt+clang pair".
+
+### Promotion
+
+**Nothing promoted, and gc-native-roots must NOT be promoted yet** — two arms are
+legitimately red on filed defects, so making it required would block every PR. A
+STATUS block at the top of the workflow records which arm is which, so the next
+reader does not have to re-derive it.

--- a/scripts/check_locale_independent_io.py
+++ b/scripts/check_locale_independent_io.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Keep host-locale text I/O out of the scripts CI runs on Windows (#7977).
+
+WHY THIS EXISTS
+===============
+
+`open()`, `Path.read_text()` and `Path.write_text()` decode and encode with
+`locale.getencoding()` when no `encoding=` is given. On Linux and macOS that is
+UTF-8, so a bare call is indistinguishable from a correct one; on a GitHub
+Windows runner it is **cp1252**, which has no mapping for 0x81/0x8d/0x8f/0x90/
+0x9d. Fifteen files under `crates/perry-runtime/src` contain one of those bytes.
+
+`scripts/check_thread_locals.py::cfg_test_module_files` walked the crate with a
+bare `read_text()` and died on `i18n.rs` with `UnicodeDecodeError: 'charmap'
+codec can't decode byte 0x8d in position 32475` — offset 31552 plus the 923
+newlines `core.autocrlf` had widened, to the byte. That was the FIRST step of
+`windows-build`, so the eleven steps behind it — including the only Windows run
+of the `perry-runtime` unit tests — were `skipped` on every PR.
+
+#7882 ("make GC structural audits portable") fixed the path-separator half of
+this class and the encoding in `gc_runtime_root_holders.py`, but missed this one
+call site. This checker is what stops the next miss: a locale-dependent call is
+now a **Linux** failure in the per-PR `lint` job, so it can no longer reach
+Windows and take the job down before the audits it gates have run.
+
+WHY STATIC AND NOT `PYTHONWARNDEFAULTENCODING`
+==============================================
+
+Python's own `EncodingWarning` (`-X warn_default_encoding`) reports the same
+defect, and is used here as the self-test's oracle. But it only fires on a call
+that actually *executes*: a bare `read_text()` on an error path, or in a
+subcommand CI does not invoke, warns nobody and ships. The scan below reads the
+AST, so an unexecuted branch is caught exactly like a hot one.
+
+Strings are not code: an `open(...)` inside a probe's source-code *literal* (as
+in `tests/test_gc_ratchet.py`, which writes Python probes as text) is invisible
+to the AST and correctly not flagged. That is the second reason not to grep.
+
+THIS CHECK IS DESIGNED TO BE ABLE TO FAIL
+=========================================
+
+`--self-test` plants each flagged shape and each accepted shape in a synthetic
+module and asserts the scan separates them, so the checker cannot quietly stop
+being able to say no. It also asserts the scanned file list is non-empty and
+that every named file exists — a scope that silently shrinks to nothing is
+CLAUDE.md's fourth way a gate cannot fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Exactly the Python that `windows-build`'s "GC structural audits (Windows)"
+# step executes, plus this checker. Keep in lockstep with that step: a script
+# added there and not here is unguarded, and `--self-test` fails if a name here
+# stops existing.
+SCANNED = (
+    "scripts/check_locale_independent_io.py",
+    "scripts/check_thread_locals.py",
+    "scripts/check_gc_doc_claims.py",
+    "scripts/gc_runtime_root_holders.py",
+    "benchmarks/gc_ratchet/gc_ratchet.py",
+    "tests/test_gc_ratchet.py",
+)
+
+# `open(...)` and the `Path` text helpers. `Path.open()` is included: it is the
+# same defaulting. Binary modes are exempt (there is no encoding to get wrong),
+# which the mode check below establishes.
+TEXT_METHODS = {"read_text", "write_text", "open"}
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+        if kw.arg is None:  # `**kwargs` — cannot prove absence, treat as given.
+            return kw.value
+    return None
+
+
+def _is_binary(call: ast.Call, func_name: str) -> bool:
+    """True when the call cannot have an encoding (binary mode)."""
+    if func_name == "read_text" or func_name == "write_text":
+        return False
+    mode: ast.expr | None = _keyword(call, "mode")
+    if mode is None:
+        # Positional mode: `open(p, "rb")` / `p.open("rb")`.
+        idx = 1 if func_name == "open" and not _is_method(call) else 0
+        if func_name == "open" and _is_method(call):
+            idx = 0
+        elif func_name == "open":
+            idx = 1
+        if len(call.args) > idx:
+            mode = call.args[idx]
+    return isinstance(mode, ast.Constant) and isinstance(mode.value, str) and "b" in mode.value
+
+
+def _is_method(call: ast.Call) -> bool:
+    return isinstance(call.func, ast.Attribute)
+
+
+def _func_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    return None
+
+
+def scan_source(src: str, rel: str) -> list[str]:
+    """Flagged call sites in one module, as human-readable problems."""
+    problems: list[str] = []
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _func_name(node)
+        if name not in TEXT_METHODS:
+            continue
+        # A bare `open(...)` that is not `builtins.open` (e.g. `zipfile.open`)
+        # still defaults the same way when it is a text stream; flagging it is
+        # the safe direction and the fix is identical.
+        if _is_binary(node, name):
+            continue
+        if _keyword(node, "encoding") is not None:
+            continue
+        problems.append(
+            f"{rel}:{node.lineno}: `{name}(...)` without `encoding=`. "
+            f"It decodes with the host locale — cp1252 on a Windows runner, "
+            f"which cannot read the 15 runtime sources carrying 0x81/0x8d/"
+            f"0x8f/0x90/0x9d (#7977). Pass `encoding=\"utf-8\"`."
+        )
+    return sorted(problems)
+
+
+def verify(root: Path, scanned: tuple[str, ...]) -> list[str]:
+    problems: list[str] = []
+    if not scanned:
+        return ["nothing was scanned — the gate's scope is empty (see hazard 4)"]
+    for rel in scanned:
+        path = root / rel
+        if not path.exists():
+            problems.append(
+                f"{rel}: listed in SCANNED but missing. Either it moved (update "
+                f"the list) or the Windows audit step no longer runs it — a "
+                f"stale entry is scope nobody has to justify."
+            )
+            continue
+        problems.extend(scan_source(path.read_text(encoding="utf-8"), rel))
+    return problems
+
+
+GOOD_SOURCE = '''
+import io
+from pathlib import Path
+
+def ok(p: Path, q):
+    a = p.read_text(encoding="utf-8")
+    p.write_text(a, encoding="utf-8", newline="")
+    with open(q, "r", encoding="utf-8") as fh:
+        fh.read()
+    with open(q, "rb") as fh:          # binary: no encoding to get wrong
+        fh.read()
+    with p.open("rb") as fh:
+        fh.read()
+    p.write_bytes(b"x")
+    embedded = """
+        body = open(source).read()
+        with open(out, "w") as handle:
+            handle.write(body)
+    """                                # a STRING, not a call — must not flag
+    return a, embedded
+'''
+
+BAD_SHAPES = (
+    ("read_text", "def f(p):\n    return p.read_text()\n"),
+    ("write_text", "def f(p):\n    p.write_text('x')\n"),
+    ("open-builtin", "def f(q):\n    return open(q).read()\n"),
+    ("open-mode-w", "def f(q):\n    return open(q, 'w')\n"),
+    ("path-open", "def f(p):\n    return p.open()\n"),
+    ("unreached", "def f(p):\n    if False:\n        return p.read_text()\n    return ''\n"),
+)
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    if scan_source(GOOD_SOURCE, "good.py"):
+        failures.append(
+            "the accepted shapes were flagged: " + "; ".join(scan_source(GOOD_SOURCE, "good.py"))
+        )
+    for label, src in BAD_SHAPES:
+        if not scan_source(src, "bad.py"):
+            failures.append(f"a bare `{label}` call passed the scan")
+
+    # Scope liveness: an empty or stale list is the failure mode this gate is
+    # least able to notice about itself.
+    if verify(REPO, ()) == []:
+        failures.append("an empty scan scope was reported clean")
+    missing = verify(REPO, ("scripts/definitely-not-here.py",))
+    if not missing:
+        failures.append("a missing scanned file was reported clean")
+
+    if failures:
+        for f in failures:
+            print(f"self-test FAILED: {f}", file=sys.stderr)
+        return 1
+    print(
+        f"check_locale_independent_io self-test: OK "
+        f"({len(BAD_SHAPES)} flagged shapes, accepted shapes clean, scope asserted)"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="prove the checker can say no")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+
+    problems = verify(REPO, SCANNED)
+    if problems:
+        print("locale-dependent text I/O in a Windows-CI script:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            "\nThese run in `windows-build`'s GC structural audits, which is the "
+            "FIRST step of the job — a UnicodeDecodeError there skips the only "
+            "Windows run of the perry-runtime unit tests (#7977).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"locale-independent I/O OK: {len(SCANNED)} Windows-CI scripts scanned")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_thread_locals.py
+++ b/scripts/check_thread_locals.py
@@ -100,6 +100,30 @@ def repo_relative(path: PurePath, root: PurePath) -> str:
     """Return a stable repository-relative key on every host platform."""
     return path.relative_to(root).as_posix()
 
+
+def read_source(path: Path) -> str:
+    """Read a repository file as UTF-8 on every host (#7977).
+
+    A bare `Path.read_text()` decodes with `locale.getencoding()`, which is
+    cp1252 on a GitHub Windows runner. Fifteen files under
+    `crates/perry-runtime/src` carry a byte that cp1252 has no mapping for
+    (0x81/0x8d/0x8f/0x90/0x9d), so the walk died on `i18n.rs` with a
+    `UnicodeDecodeError` before the checker examined a single declaration —
+    taking the whole `windows-build` job, and the eleven steps behind it,
+    down with it. The sources are UTF-8; say so.
+    """
+    return path.read_text(encoding="utf-8")
+
+
+def write_source(path: Path, text: str) -> None:
+    """Write a file as UTF-8 with LF endings on every host (#7977).
+
+    `newline=""` suppresses Windows' `\\n` -> `\\r\\n` translation so
+    `--update` produces the same allowlist bytes everywhere.
+    """
+    path.write_text(text, encoding="utf-8", newline="")
+
+
 # `#[cfg(test)] mod <stem>;` — the whole file is a test module.
 CFG_TEST_MOD_RE = re.compile(
     r"(?m)^[ \t]*#\[cfg\(test\)\]\s*\n[ \t]*(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_0-9]+)\s*;"
@@ -165,7 +189,7 @@ def cfg_test_module_files(root: Path, crates: list[str]) -> set[str]:
                     continue
                 path = Path(dirpath) / name
                 rel = repo_relative(path, root)
-                src = path.read_text()
+                src = read_source(path)
                 parent = path.parent if name in ("lib.rs", "mod.rs") else path.with_suffix("")
                 gated = set(CFG_TEST_MOD_RE.findall(src))
                 edges = []
@@ -219,7 +243,7 @@ def scan(root: Path, crates: list[str]) -> tuple[dict[str, int], int]:
                     continue
                 path = Path(dirpath) / name
                 rel = repo_relative(path, root)
-                src = path.read_text()
+                src = read_source(path)
                 hot_declarations += sum(
                     len(DECL_RE.findall(body)) for body in block_bodies(src, HOT_RE)
                 )
@@ -232,7 +256,7 @@ def scan(root: Path, crates: list[str]) -> tuple[dict[str, int], int]:
 
 
 def hot_slot_capacity(root: Path) -> int:
-    src = (root / "crates/perry-runtime/src/tls_hot.rs").read_text()
+    src = read_source(root / "crates/perry-runtime/src/tls_hot.rs")
     m = re.search(r"pub const HOT_SLOT_CAPACITY: usize = (\d+);", src)
     if not m:
         raise SystemExit("could not read HOT_SLOT_CAPACITY from tls_hot.rs")
@@ -241,7 +265,7 @@ def hot_slot_capacity(root: Path) -> int:
 
 def verify(root: Path, crates: list[str], allowlist_path: Path) -> list[str]:
     raw, hot_declarations = scan(root, crates)
-    recorded = json.loads(allowlist_path.read_text())["files"]
+    recorded = json.loads(read_source(allowlist_path))["files"]
     problems = []
 
     for rel, count in sorted(raw.items()):
@@ -283,7 +307,7 @@ def verify(root: Path, crates: list[str], allowlist_path: Path) -> list[str]:
 
 def write_allowlist(root: Path, crates: list[str], allowlist_path: Path) -> None:
     raw, hot_declarations = scan(root, crates)
-    allowlist_path.write_text(
+    write_source(allowlist_path, 
         json.dumps(
             {
                 "_comment": (
@@ -313,18 +337,18 @@ def self_test() -> int:
         root = Path(tmp)
         src_dir = root / "crates/perry-runtime/src"
         src_dir.mkdir(parents=True)
-        (src_dir / "tls_hot.rs").write_text(
+        write_source(src_dir / "tls_hot.rs", 
             "pub const HOT_SLOT_CAPACITY: usize = 768;\n"
             "thread_local! { static HOT: u8 = const { 0 }; }\n"
         )
-        (src_dir / "cold.rs").write_text("thread_local! { static A: u8 = const { 0 }; }\n")
-        (src_dir / "hot.rs").write_text(
+        write_source(src_dir / "cold.rs", "thread_local! { static A: u8 = const { 0 }; }\n")
+        write_source(src_dir / "hot.rs", 
             "crate::perry_thread_local! { static B: u8 = const { 0 }; }\n"
         )
         allowlist = root / "allow.json"
 
         write_allowlist(root, CRATES, allowlist)
-        recorded = json.loads(allowlist.read_text())
+        recorded = json.loads(read_source(allowlist))
         if "crates/perry-runtime/src/tls_hot.rs" in recorded["files"]:
             failures.append("tls_hot.rs must be excluded from the allowlist")
         if recorded["_hot_declarations"] != 1:
@@ -335,13 +359,13 @@ def self_test() -> int:
             failures.append("a freshly written allowlist must verify clean")
 
         # 1. A new raw declaration in an unlisted file must fail.
-        (src_dir / "new.rs").write_text("thread_local! { static C: u8 = const { 0 }; }\n")
+        write_source(src_dir / "new.rs", "thread_local! { static C: u8 = const { 0 }; }\n")
         if not verify(root, CRATES, allowlist):
             failures.append("a new raw `thread_local!` in an unlisted file passed")
         (src_dir / "new.rs").unlink()
 
         # 2. A second raw declaration in an already-listed file must fail.
-        (src_dir / "cold.rs").write_text(
+        write_source(src_dir / "cold.rs", 
             "thread_local! { static A: u8 = const { 0 }; }\n"
             "thread_local! { static D: u8 = const { 0 }; }\n"
         )
@@ -349,7 +373,7 @@ def self_test() -> int:
             failures.append("a raw `thread_local!` added to a listed file passed")
 
         # 3. A stale entry must fail.
-        (src_dir / "cold.rs").write_text(
+        write_source(src_dir / "cold.rs", 
             "crate::perry_thread_local! { static A: u8 = const { 0 }; }\n"
         )
         if not verify(root, CRATES, allowlist):
@@ -357,20 +381,20 @@ def self_test() -> int:
 
         # 4. Blowing the slot ceiling must fail.
         write_allowlist(root, CRATES, allowlist)
-        (src_dir / "hot.rs").write_text(
+        write_source(src_dir / "hot.rs", 
             "crate::perry_thread_local! {\n"
             + "".join(f"    static H{i}: u8 = const {{ 0 }};\n" for i in range(800))
             + "}\n"
         )
         if not any("HOT_SLOT_CAPACITY" in p for p in verify(root, CRATES, allowlist)):
             failures.append("exceeding HOT_SLOT_CAPACITY passed")
-        (src_dir / "hot.rs").write_text(
+        write_source(src_dir / "hot.rs", 
             "crate::perry_thread_local! { static B: u8 = const { 0 }; }\n"
         )
 
         # 5. The three `#[cfg(test)]` shapes are out of scope — and, the half
         #    that can go wrong quietly, REMOVING the gate puts them back in it.
-        (src_dir / "cold.rs").write_text("thread_local! { static A: u8 = const { 0 }; }\n")
+        write_source(src_dir / "cold.rs", "thread_local! { static A: u8 = const { 0 }; }\n")
         write_allowlist(root, CRATES, allowlist)
         gated = {
             "attribute": "#[cfg(test)]\nthread_local! { static G: u8 = const { 0 }; }\n",
@@ -381,23 +405,23 @@ def self_test() -> int:
             ),
         }
         for shape, body in gated.items():
-            (src_dir / "gated.rs").write_text(body)
+            write_source(src_dir / "gated.rs", body)
             if verify(root, CRATES, allowlist):
                 failures.append(f"a `#[cfg(test)]` {shape} declaration was counted")
-            (src_dir / "gated.rs").write_text(body.replace("#[cfg(test)]\n", ""))
+            write_source(src_dir / "gated.rs", body.replace("#[cfg(test)]\n", ""))
             if not verify(root, CRATES, allowlist):
                 failures.append(f"an UNGATED {shape} declaration passed")
         (src_dir / "gated.rs").unlink()
 
         # 6. A whole file declared `#[cfg(test)] mod <stem>;` is out of scope,
         #    and drops back in when the parent stops gating it.
-        (src_dir / "probes.rs").write_text(
+        write_source(src_dir / "probes.rs", 
             "thread_local! { static G: u8 = const { 0 }; }\n"
         )
-        (src_dir / "lib.rs").write_text("#[cfg(test)]\nmod probes;\n")
+        write_source(src_dir / "lib.rs", "#[cfg(test)]\nmod probes;\n")
         if verify(root, CRATES, allowlist):
             failures.append("a `#[cfg(test)] mod <stem>;` file was counted")
-        (src_dir / "lib.rs").write_text("mod probes;\n")
+        write_source(src_dir / "lib.rs", "mod probes;\n")
         if not verify(root, CRATES, allowlist):
             failures.append("an ungated `mod <stem>;` file passed")
 

--- a/scripts/gc_evacuation_liveness_assert.py
+++ b/scripts/gc_evacuation_liveness_assert.py
@@ -36,38 +36,147 @@ ELIGIBLE = re.compile(r"\[gc-copy-minor\] eligible=(\w+)(?: fallback=(\S+))?")
 # scan, so that line is gone and the tell is the absence of any copying-minor
 # line at all.
 COPY_MINOR_ANY = re.compile(r"\[gc-copy-minor\]")
+# ANY `[gc-…]` diagnostic marker. These exist only under `PERRY_GC_DIAG=1`;
+# `#gcmetric` summary lines are printed unconditionally, so their presence
+# says the program ran but says nothing about whether diagnostics were on.
+DIAG_MARKER = re.compile(r"\[gc-[a-z0-9-]+\]")
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("trace")
-    ap.add_argument("--probe", default="<probe>")
-    ap.add_argument("--min-copied", type=int, default=1)
-    args = ap.parse_args()
-
-    text = open(args.trace, "r", errors="replace").read()
+def check(text: str, probe: str, min_copied: int) -> tuple[int, list[str]]:
+    """Return (exit_code, messages). Split out so `--self-test` can drive it."""
     copied = sum(int(m) for m in COPIED.findall(text))
     ran = text.count("[gc-copy-minor] ran ")
     ineligible = [m for m in ELIGIBLE.findall(text) if m[0] != "true"]
 
-    if copied >= args.min_copied and ran > 0:
-        print(f"{args.probe}: evacuation live — {ran} copying minor(s), {copied} objects copied")
-        return 0
+    if copied >= min_copied and ran > 0:
+        return 0, [f"{probe}: evacuation live — {ran} copying minor(s), {copied} objects copied"]
 
-    print(f"::error::{args.probe}: the forced-evacuation arm evacuated NOTHING "
-          f"({ran} copying minors, {copied} objects copied). The arm is vacuous: "
-          f"it proves the program ran, not that a moving collector did (#7336).")
+    # ── Instrument off, or subject dead? ───────────────────────────────────
+    # These are DIFFERENT failures and must not share a message. A trace with
+    # no `[gc-…]` marker at all was produced without `PERRY_GC_DIAG=1`, so it
+    # carries no evidence either way — blaming the collector there sends the
+    # reader to debug a GC that may well have been evacuating the whole time.
+    #
+    # That is not hypothetical: it is #7970. `gc-native-roots`' in-process arm
+    # omitted `PERRY_GC_DIAG=1` and this script reported "evacuated NOTHING (0
+    # copying minors)" on every run since the arm was written. With the flag,
+    # the same binary under the same GC env reported 75 copying minors and
+    # 16277 objects copied.
+    if not DIAG_MARKER.search(text):
+        msgs = [
+            f"::error::{probe}: this trace contains no `[gc-...]` diagnostic line at "
+            f"all, so it cannot answer whether evacuation happened. "
+            f"`PERRY_GC_DIAG=1` was NOT set on the run that produced it — that flag "
+            f"is what emits `[gc-copy-minor]`, and this assert reads nothing else "
+            f"(#7970).",
+            "::error::Fix the RUN, not the collector: add `PERRY_GC_DIAG=1` to the "
+            "command whose stderr is captured here. Only if the markers are present "
+            "and still show zero copying minors is this a statement about the GC.",
+        ]
+        if not text.strip():
+            msgs.append(
+                "::error::(The trace is also completely empty — check the "
+                "redirection, and that the program ran at all.)"
+            )
+        return 1, msgs
+
+    msgs = [
+        f"::error::{probe}: the forced-evacuation arm evacuated NOTHING "
+        f"({ran} copying minors, {copied} objects copied). The arm is vacuous: "
+        f"it proves the program ran, not that a moving collector did (#7336)."
+    ]
     if not COPY_MINOR_ANY.search(text):
-        print("::error::No `[gc-copy-minor]` line at all — every collection in this "
-              "run was a FULL cycle, which is what a probe that drives GC with `gc()` "
-              "gets. PERRY_GC_FORCE_EVACUATE is read only on the MINOR path "
-              "(#6942/#6946). Drive the minor path instead: PERRY_GC_HEAP_LIMIT=8 "
-              "PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off.")
+        msgs.append(
+            "::error::No `[gc-copy-minor]` line at all — every collection in this "
+            "run was a FULL cycle, which is what a probe that drives GC with `gc()` "
+            "gets. PERRY_GC_FORCE_EVACUATE is read only on the MINOR path "
+            "(#6942/#6946). Drive the minor path instead: PERRY_GC_HEAP_LIMIT=8 "
+            "PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off."
+        )
     if ineligible:
-        kinds = sorted({f or '?' for _, f in ineligible})
-        print(f"::error::Copying minor was ineligible; fallback(s): {', '.join(kinds)}. "
-              "PERRY_CONSERVATIVE_STACK_SCAN=off is usually what makes it eligible (#7255).")
-    return 1
+        kinds = sorted({f or "?" for _, f in ineligible})
+        msgs.append(
+            f"::error::Copying minor was ineligible; fallback(s): {', '.join(kinds)}. "
+            "PERRY_CONSERVATIVE_STACK_SCAN=off is usually what makes it eligible (#7255)."
+        )
+    return 1, msgs
+
+
+# Real shapes, abbreviated. `#gcmetric` prints WITHOUT PERRY_GC_DIAG; every
+# `[gc-...]` marker prints only WITH it. That asymmetry is the whole discriminator.
+NO_DIAG = (
+    "#gcmetric heap_used_bytes=213400\n"
+    "#gcmetric heap_total_bytes=12582912\n"
+    "#gcmetric rss_bytes=24363008\n"
+)
+DIAG_LIVE = (
+    "[gc-tenuring] promoted=12\n"
+    "[gc-copy-minor] eligible=true\n"
+    "[gc-copy-minor] ran from_space=1048576 copied_objects=16277\n"
+)
+DIAG_FULL_CYCLES_ONLY = "[gc-tenuring] promoted=12\n[gc-old-free] blocks=3\n"
+DIAG_INELIGIBLE = "[gc-copy-minor] eligible=false fallback=conservative_scan\n"
+
+
+def self_test() -> int:
+    """Prove the checker separates 'instrument off' from 'nothing evacuated'."""
+    failures = []
+
+    rc, msgs = check(DIAG_LIVE, "p", 1)
+    if rc != 0:
+        failures.append(f"a live evacuation trace failed: {msgs}")
+
+    rc, msgs = check(NO_DIAG, "p", 1)
+    blob = " ".join(msgs)
+    if rc == 0:
+        failures.append("a trace with PERRY_GC_DIAG off was reported clean")
+    elif "PERRY_GC_DIAG=1` was NOT set" not in blob:
+        failures.append(f"diag-off was not named as the cause: {blob}")
+    elif "evacuated NOTHING" in blob:
+        failures.append("diag-off was blamed on the collector — the #7970 misdiagnosis")
+
+    rc, msgs = check("", "p", 1)
+    if rc == 0 or "completely empty" not in " ".join(msgs):
+        failures.append("an empty trace was not called out")
+
+    rc, msgs = check(DIAG_FULL_CYCLES_ONLY, "p", 1)
+    blob = " ".join(msgs)
+    if rc == 0:
+        failures.append("diag-on with zero copying minors was reported clean")
+    elif "evacuated NOTHING" not in blob or "PERRY_GC_DIAG=1` was NOT set" in blob:
+        failures.append(f"diag-on/no-evacuation must blame the COLLECTOR: {blob}")
+
+    rc, msgs = check(DIAG_INELIGIBLE, "p", 1)
+    if rc == 0 or "ineligible" not in " ".join(msgs):
+        failures.append("an ineligible copying minor was not reported")
+
+    if failures:
+        for f in failures:
+            print(f"self-test FAILED: {f}", file=sys.stderr)
+        return 1
+    print("gc_evacuation_liveness_assert self-test: OK (5 directions)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("trace", nargs="?")
+    ap.add_argument("--probe", default="<probe>")
+    ap.add_argument("--min-copied", type=int, default=1)
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.trace:
+        ap.error("a trace path is required (or --self-test)")
+
+    with open(args.trace, "r", errors="replace", encoding="utf-8") as fh:
+        text = fh.read()
+    rc, msgs = check(text, args.probe, args.min_copied)
+    for m in msgs:
+        print(m)
+    return rc
 
 
 if __name__ == "__main__":

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -709,7 +709,11 @@ def _scan_tree(extra: dict[str, str] | None = None) -> list[dict]:
         for rel, body in tree.items():
             path = root / rel
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(body)
+            # Explicit UTF-8: a bare write_text() encodes with the host locale
+            # (cp1252 on a Windows runner), which is the #7977 class. The
+            # fixtures are ASCII today, so this is the latent half — the read
+            # side of the same shape is what took `windows-build` down.
+            path.write_text(body, encoding="utf-8", newline="")
         holders, _ = scan(root)
         return holders
 

--- a/tests/test_gc_ratchet.py
+++ b/tests/test_gc_ratchet.py
@@ -1366,7 +1366,7 @@ class RebaseStableProvenanceTests(unittest.TestCase):
 
     def test_the_shipped_baseline_records_a_code_tree(self):
         baseline = Path(__file__).resolve().parents[1] / "benchmarks" / "gc_ratchet" / "baseline" / "gc-ratchet-v1.json"
-        artifact = json.loads(baseline.read_text())
+        artifact = json.loads(baseline.read_text(encoding="utf-8"))
         self.assertIn(
             "code_tree",
             artifact,


### PR DESCRIPTION
Repairs three broken CI gates. They are independent; the commits are separate and
can be read in any order.

**No arm was disabled or weakened.** Two arms are red because they found real
defects; those are filed (#7984, #7985) and the arms stay red. A third defect
(#7982) was found by making a gate report what it was doing.

## #7977 — `windows-build` was red before it ran anything

`scripts/check_thread_locals.py` walked `crates/perry-runtime/src` with a bare
`Path.read_text()`, which decodes with the host locale — **cp1252** on a Windows
runner. 15 runtime sources carry a byte cp1252 cannot map; `i18n.rs` is reached
first at offset 31552 with 923 newlines before it, so under `core.autocrlf` the
failure lands at position **32475**, matching the traceback to the byte.

That is the *first* step of `windows-build`, so the seven steps behind it were
`skipped` on every PR. **Unprotected:** the only Windows build of the runtime,
stdlib and both Windows UI crates; the only Windows run of the `perry-runtime`
unit tests; the Windows parity smoke; the VERSIONINFO check; the COFF-trimming
test.

#7882 fixed the path-separator half of this class *in this same file*, and the
encoding in `gc_runtime_root_holders.py`. These four readers were missed.

- explicit `encoding="utf-8"` at every call site (plus `newline=""` on write, so
  `--update` is byte-stable across hosts). The verified `files` map is unchanged.
- one latent instance in `gc_runtime_root_holders.py`, one in `tests/test_gc_ratchet.py`.
- **new gate** `scripts/check_locale_independent_io.py`: AST-scans exactly the six
  Python files the Windows audit step runs. Static rather than
  `PYTHONWARNDEFAULTENCODING` because that only fires on *executed* calls, and
  because `test_gc_ratchet.py` embeds `open(...)` inside probe source *literals*
  that an AST correctly ignores and a grep would not. Runs in `lint` — Linux,
  per-PR, already required — so the class is caught before it reaches Windows.
- `PYTHONUTF8=1` on the Windows step as belt-and-braces.

**Validation:** main's version exits 1 with `UnicodeDecodeError` under a non-UTF-8
locale, the fixed version exits 0, and the full eight-command Windows audit
sequence passes under that locale. **Sabotage-tested:** replanting the exact
defect makes the new gate exit 1 naming the call site, so a green run means the
detector works rather than that nothing was tried.

## #7971 — `llvm-inprocess` reported green while skipping its only real job

Three independent problems:

1. **Vacuous green.** `changes=success, native-backend=skipped` concluded
   `success` (runs 31505530279 / 31499833415 / 31476724152). A path filter is a
   cost control, not a verdict. New `llvm-inprocess-complete` fan-in prints
   EXERCISED / NOT EXERCISED and fails when `native-backend` failed, was
   cancelled, **or was skipped on a non-PR event** — every non-PR event sets
   `relevant=true` unconditionally, so a skip there means the post-merge anchor
   stopped anchoring (the #7856 shape).
2. **No diagnostic.** Bare `grep -q` / `cmp` under `set -euo pipefail` with each
   compile's stderr redirected to a file nothing printed, so three `main`
   failures ended at `Generating code...` + `exit 1`. Rebuilt around
   `run`/`assert_grep`/`assert_same`: names the failing command with its real
   exit status, dumps captured output, diffs on parity failure. (Status is
   captured after the command — inside an `if ! cmd` branch `$?` is the negated
   status and always 0.)
3. **Frozen corpora, invisibly.** New currency diagnostic step.

**The defect this arm was correctly reporting → #7982.** Reproduced locally:
`native IR construction failed … in line: %r5 = alloca ptr addrspace(1)`.
`dialect/mod.rs::basic_type` has no `ptr addrspace(N)` arm. Not a one-liner — I
added one, rebuilt, and the reader then fails on `store ptr addrspace(1)`. Probe
reverted; filed rather than folded into a CI change.

The unit gate never caught it because all three tracked `.ll` corpora were frozen
on 2026-08-03, **151 codegen commits ago**, and contain **zero** `addrspace(1)`.
`corpus_spike ... ok` proves the tests ran, not that they test today's IR —
hazard 4 inside the liveness assert written to prevent hazard 4.

## #7970 — `gc-native-roots` had never been green on any branch

Three failing arms, three unrelated causes.

**`macos-14` — gate defect, FIXED.** The step asserted evacuation liveness without
`PERRY_GC_DIAG=1`, and `[gc-copy-minor]` — the assert's only input — prints only
under that flag. Reproduced exactly on macOS aarch64:

| run | `[gc-copy-minor]` | assert |
|---|---|---|
| workflow env as-was | 0 (98 bytes of `#gcmetric`) | `evacuated NOTHING` — exit 1 |
| `+ PERRY_GC_DIAG=1` | 150 | `evacuation live — 75 copying minors, 16277 objects copied` — exit 0 |

The whole step then passes locally. **#7970 wondered if this was #7965-shaped
("the collector stopped running copying minors"). It is not** — the collector was
evacuating throughout; the gate was asserting on telemetry it had not enabled.
`gc_evacuation_liveness_assert.py` now separates *instrument off* from *subject
dead* and gained a 5-direction `--self-test`, wired into `lint`.

**`ubuntu-24.04-arm` — REAL DEFECT → #7984.** Not a SIGSEGV; a Rust assertion.
Under `PERRY_STACKMAP_WALKER=verify` the fast fp-chain walker and the unwinder
resolve the same root to addresses **96 bytes apart**. The fast walker is what
runs when verify is off. **This arm must stay red until #7984 is fixed.**

**`windows-latest` — REAL DEFECT → #7985, plus one workflow bug fixed here.**
`link.exe` 1120: `/MT`-vs-`/MD` CRT mismatch, `LNK2005` on malloc/free from the
rpmalloc bundled in the LLVM release, `LNK2019` for target backends inkwell
references. Filed — it needs a Windows-toolchain decision. **Likely also latent in
`windows-build`, whose build step has not executed since #7977; expect it to
surface when this PR lands.** The arm's *second* failure was a workflow bug and is
fixed: Git-bash GNU tar read `$RUNNER_TEMP` (`D:\a\_temp`) as a remote
`host:path` (`Cannot connect to D: resolve failed`) — now `tar --force-local`
with a post-extraction check.

A STATUS block at the top of the workflow records which arm is which.

## Promotion

**Nothing was promoted to a required context.**

- `lint` is *already* required; this adds three steps to it, all green locally.
- `llvm-inprocess` cannot be promoted while #7982 is open.
- `gc-native-roots` **must not** be promoted while #7984/#7985 are open — two
  legitimately-red arms would block every PR. Per CLAUDE.md: run it green once,
  then promote.

## Notes

Working notes, including every measurement above: `gc-handoff/CIFIX-NOTES.md`.

Per repo convention this PR carries no version bump and no `CHANGELOG.md` edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows, macOS, and LLVM continuous-integration checks with more reliable diagnostics and failure reporting.
  - Fixed platform-dependent text encoding issues to ensure consistent validation across environments.
  - Improved garbage-collection liveness checks and native-root test reliability.

- **Tests**
  - Added broader coverage for LLVM execution modes, output consistency, exception handling, and skipped or incomplete test runs.
  - Added validation for locale-independent file handling and garbage-collection diagnostics.

- **Documentation**
  - Documented CI repairs, workflow status, known limitations, and related backend/toolchain issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->