### PR TITLE
perf(codegen): streamline async control cells

### DIFF
--- a/changelog.d/8012-async-control-cells.md
+++ b/changelog.d/8012-async-control-cells.md
@@ -1,0 +1,18 @@
+### Faster compiler-private async control cells (#8008)
+
+Async and generator state machines now access their compiler-minted state,
+pending-type, done, and executing cells with direct typed loads and stores.
+Those cells are preallocated as single-field `I32Box` or `BoolBox` values, so
+their pointer provenance and representation are already proven; routing every
+access through the general runtime helpers redundantly checked the same pointer
+against a thread-local box registry.
+
+Ordinary user captures keep the checked runtime path, including its invalid-box
+protection. Primitive allocation and registry insertion also remain unchanged;
+only access to the four private controls bypasses repeated validation.
+
+On the refreshed async probe set this removes 7.08% of retired instructions
+from the pure async/await topology, 5.92% when plain objects flow through the
+same topology, and 2.10% from the full `asyncpipe` workload. The synchronous
+and Promise.all-only controls remain flat. An IR regression locks down both
+the narrow eligibility boundary and the direct typed accesses.

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -2297,6 +2297,40 @@ pub(crate) fn load_boxed_local_pointer(ctx: &mut FnCtx<'_>, id: u32) -> Result<O
     Ok(None)
 }
 
+/// Load a compiler-private async i32 control cell directly.
+///
+/// These cells are allocated by `Stmt::PreallocateBoxes` before the generated
+/// state-machine closures are created. Unlike a general user capture, the
+/// pointer is therefore compiler-minted and its pointee representation is
+/// proven: the `I32Box` value is the first (and only) field. Keep ordinary
+/// boxes on the checked runtime path; this helper is deliberately reachable
+/// only from the `is_compiler_private_async_i32_control_local` arms below.
+pub(crate) fn load_async_i32_control_cell(ctx: &mut FnCtx<'_>, cell: &str) -> String {
+    let ptr = ctx.block().inttoptr(I64, cell);
+    ctx.block().load(I32, &ptr)
+}
+
+/// Store a compiler-private async i32 control cell directly. See
+/// `load_async_i32_control_cell` for the allocation/provenance proof.
+pub(crate) fn store_async_i32_control_cell(ctx: &mut FnCtx<'_>, cell: &str, value: &str) {
+    let ptr = ctx.block().inttoptr(I64, cell);
+    ctx.block().store(I32, value, &ptr);
+}
+
+/// Load a compiler-private async boolean control cell directly. `BoolBox`'s
+/// value is a Rust `bool`, represented as LLVM i1 at the FFI boundary.
+pub(crate) fn load_async_i1_control_cell(ctx: &mut FnCtx<'_>, cell: &str) -> String {
+    let ptr = ctx.block().inttoptr(I64, cell);
+    ctx.block().load(I1, &ptr)
+}
+
+/// Store a compiler-private async boolean control cell directly. See
+/// `load_async_i1_control_cell` for the representation proof.
+pub(crate) fn store_async_i1_control_cell(ctx: &mut FnCtx<'_>, cell: &str, value: &str) {
+    let ptr = ctx.block().inttoptr(I64, cell);
+    ctx.block().store(I1, value, &ptr);
+}
+
 pub(crate) fn box_i1_for_compat_shadow(ctx: &mut FnCtx<'_>, value: &str) -> String {
     let bits = ctx.block().select(
         I1,
@@ -2381,7 +2415,7 @@ fn lower_async_i32_control_const_compare(
     let Some(ptr) = load_boxed_local_pointer(ctx, id)? else {
         return Ok(None);
     };
-    let value = ctx.block().call(I32, "js_i32_box_get", &[(I64, &ptr)]);
+    let value = load_async_i32_control_cell(ctx, &ptr);
     let constant_s = constant.to_string();
     let (lhs, rhs) = if local_on_left {
         (value.as_str(), constant_s.as_str())
@@ -2921,7 +2955,7 @@ pub(crate) fn lower_expr_value(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<Optio
             let Some(ptr) = load_boxed_local_pointer(ctx, *id)? else {
                 return Ok(None);
             };
-            let value = ctx.block().call(I32, "js_i32_box_get", &[(I64, &ptr)]);
+            let value = load_async_i32_control_cell(ctx, &ptr);
             let lowered = LoweredValue::i32(value);
             ctx.record_lowered_value(
                 "LocalGet",
@@ -2941,8 +2975,7 @@ pub(crate) fn lower_expr_value(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<Optio
             let Some(ptr) = load_boxed_local_pointer(ctx, *id)? else {
                 return Ok(None);
             };
-            let value_i32 = ctx.block().call(I32, "js_bool_box_get", &[(I64, &ptr)]);
-            let value = ctx.block().icmp_ne(I32, &value_i32, "0");
+            let value = load_async_i1_control_cell(ctx, &ptr);
             let lowered = LoweredValue::i1(value);
             ctx.record_lowered_value(
                 "LocalGet",
@@ -3009,8 +3042,7 @@ pub(crate) fn lower_expr_value(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<Optio
                 return Ok(None);
             };
             let value_i32 = lower_i32_control_store_value(ctx, value)?;
-            ctx.block()
-                .call_void("js_i32_box_set", &[(I64, &ptr), (I32, &value_i32)]);
+            store_async_i32_control_cell(ctx, &ptr, &value_i32);
             record_native_arena_owner_assignment(ctx, *id, value.as_ref());
             record_int_facts_for_local_set(ctx, *id, value);
             let lowered = LoweredValue::i32(value_i32);
@@ -3035,9 +3067,7 @@ pub(crate) fn lower_expr_value(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<Optio
                 return Ok(None);
             };
             let value_i1 = lower_i1_control_store_value(ctx, value)?;
-            let value_i32 = ctx.block().zext(I1, &value_i1, I32);
-            ctx.block()
-                .call_void("js_bool_box_set", &[(I64, &ptr), (I32, &value_i32)]);
+            store_async_i1_control_cell(ctx, &ptr, &value_i1);
             record_native_arena_owner_assignment(ctx, *id, value.as_ref());
             let lowered = LoweredValue::i1(value_i1);
             ctx.record_lowered_value(

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -1154,13 +1154,10 @@ pub(crate) fn lower_let(
                 let bptr = blk.load(I64, &slot_clone);
                 if crate::expr::is_compiler_private_async_i32_control_local(ctx, id) {
                     let init_i32 = crate::expr::lower_i32_control_store_value(ctx, init_expr)?;
-                    ctx.block()
-                        .call_void("js_i32_box_set", &[(I64, &bptr), (I32, &init_i32)]);
+                    crate::expr::store_async_i32_control_cell(ctx, &bptr, &init_i32);
                 } else if crate::expr::is_compiler_private_async_i1_control_local(ctx, id) {
                     let init_i1 = crate::expr::lower_i1_control_store_value(ctx, init_expr)?;
-                    let init_i32 = ctx.block().zext(I1, &init_i1, I32);
-                    ctx.block()
-                        .call_void("js_bool_box_set", &[(I64, &bptr), (I32, &init_i32)]);
+                    crate::expr::store_async_i1_control_cell(ctx, &bptr, &init_i1);
                 } else {
                     let init_val =
                         lower_expr_with_expected_type(ctx, init_expr, Some(&refined_ty))?;

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -7095,19 +7095,31 @@ fn compiler_private_async_control_cells_use_primitive_heap_boxes() {
         compiler_private_async_control_body(),
     );
 
-    for symbol in [
-        "call i64 @js_i32_box_alloc",
-        "call i32 @js_i32_box_get",
-        "call void @js_i32_box_set",
-        "call i64 @js_bool_box_alloc",
-        "call i32 @js_bool_box_get",
-        "call void @js_bool_box_set",
-    ] {
+    for symbol in ["call i64 @js_i32_box_alloc", "call i64 @js_bool_box_alloc"] {
         assert!(
             ir.contains(symbol),
             "expected compiler-private control lowering to emit {symbol}:\n{ir}"
         );
     }
+    for checked_access in [
+        "call i32 @js_i32_box_get",
+        "call void @js_i32_box_set",
+        "call i32 @js_bool_box_get",
+        "call void @js_bool_box_set",
+    ] {
+        assert!(
+            !ir.contains(checked_access),
+            "proven compiler-private control cells must bypass checked box access ({checked_access}):\n{ir}"
+        );
+    }
+    assert!(
+        ir.contains("inttoptr i64")
+            && ir.contains("load i32, ptr")
+            && ir.contains("store i32")
+            && ir.contains("load i1, ptr")
+            && ir.contains("store i1"),
+        "compiler-private controls should use direct typed cell loads/stores:\n{ir}"
+    );
     assert!(
         ir.contains("icmp eq i32"),
         "__gen_state constant comparisons should stay as i32 compares:\n{ir}"


### PR DESCRIPTION
Closes #8008.

## Summary

- lower compiler-private async/generator state, pending-type, done, and executing cells as direct typed loads/stores
- retain the checked runtime box path for ordinary user captures
- add an IR regression proving the private controls keep their primitive allocations while bypassing registry-checked access

## Mechanism and sized lever

The async transform preallocates these four control cells and proves both their identity and primitive type. Their `I32Box`/`BoolBox` allocations are stable, single-field `#[repr(C, align(8))]` objects, but every state-machine get/set still called a runtime helper that revalidated the pointer against a thread-local registry.

On the refreshed pure-async profile, `is_registered_i32_box_ptr` and `is_registered_bool_box_ptr` account for 7.13% of leaf samples. Direct typed access to only the compiler-minted controls removes that lookup; allocation and registry insertion remain unchanged, and unproven/user boxes retain the #4898 checked path. The measured pure-async instruction reduction is 7.08%.

## Current-main decomposition and A/B

Current `main` is `f58b73f` (0.5.1508). Both arms use the exact same `f58b73f` runtime/stdlib archives with auto-optimize disabled, isolating compiler codegen from runtime and feature-set drift. Retired instructions and cycles are best of 13 interleaved runs; wall is median of the same 13. The host load was high, so retired instructions are the primary result and wall is reported as required directional evidence.

| probe | current main instr | this PR instr | delta instr | delta cycles | wall (main -> PR) |
|---|---:|---:|---:|---:|---:|
| `a2_full1x` | 1207.2 M | 1181.9 M | -2.10% | -0.61% | 97.35 -> 95.35 ms (-2.06%) |
| `a2_sync1x` | 247.1 M | 247.0 M | -0.02% | -1.22% | 23.86 -> 24.24 ms (+1.59%) |
| `a2_pure1x` | 622.4 M | 578.3 M | -7.08% | -5.97% | 47.64 -> 45.94 ms (-3.57%) |
| `a2_pureobj1x` | 748.4 M | 704.1 M | -5.92% | -5.97% | 62.05 -> 60.33 ms (-2.77%) |
| `a2_pall1x` | 397.3 M | 397.0 M | -0.07% | -1.97% | 39.91 -> 38.65 ms (-3.16%) |

The original 85.2% async share is now 79.5% on current main (`1 - 247.1 / 1207.2`) after #7927, #7924, #7939, and subsequent mainline work. This patch reduces the full probe another 2.10%, while the synchronous and Promise.all-only instruction controls are flat. The selective pure-async result sizes the named control-cell validation mechanism rather than attributing the remaining gap to undifferentiated “async overhead.”

## Validation

- `cargo test --release -p perry-codegen` (939 unit tests, 263 native proof regressions, integrations and doctests)
- post-rebase focused native proof regression
- `cargo clippy -p perry-codegen --lib --tests`
- `./scripts/pre-tag-check.sh --quick`
- generator parity: 6/6
- async parity: 40/42; the two issue-915 cases were environment-only failures because local Node dependencies `fastify`/`jsonwebtoken` were absent (the other 40 passed)
- full probe under forced evacuation + verification + from-space protection

No version bump is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved async and generator control-cell access for more efficient execution.
  * Reduced generated instructions for internal control operations.

* **Bug Fixes**
  * Preserved safe checked access for user-managed captured values.
  * Added regression coverage to ensure async control-cell reads and writes remain correctly typed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->