### PR TITLE
test(gc): pin the #7990 Map comparison regression

### DIFF
--- a/changelog.d/8021-7990-map-comparison-regression.md
+++ b/changelog.d/8021-7990-map-comparison-regression.md
@@ -1,0 +1,15 @@
+**Fixed: the zod dependency corpus no longer reaches the young-pin latch
+through a stale comparison operand (#7990).**
+
+The abort's `GC_TYPE_MAP | GC_FLAG_INTERNED` header was internally impossible:
+the interned flag is only created on strings. A comparison operand had kept an
+old SSA address across an allocating right-hand operand, then handed recycled
+bytes to the copying collector. The comparison-rooting fix in #8011 removed
+that window; a patch-only A/B completed 26 of 26 rate-1 corpus runs clean, with
+about 6,400 copying minors and 855,000 moved objects per run.
+
+An LLVM-dataflow regression now covers the reported typed-Map population and
+proves that its value is re-read from a GC root below the allocating operand.
+The collector still aborts before an unsafe relocation, but its internal
+documentation no longer assumes an incomplete pin latch is the only possible
+cause.

--- a/crates/perry-codegen/src/expr/compare_tests.rs
+++ b/crates/perry-codegen/src/expr/compare_tests.rs
@@ -101,6 +101,31 @@ fn strict_eq_rereads_its_left_operand_below_an_allocating_right_operand() {
     );
 }
 
+/// #7990 surfaced the same stale comparison-operand class through a different
+/// consumer: the copier reached bytes reporting the impossible combination
+/// `GC_TYPE_MAP | GC_FLAG_INTERNED`. Keep the reported typed-Map population in
+/// the regression. The generic object case above would stay green if a future
+/// type-analysis shortcut accidentally classified Maps as non-pointers.
+#[test]
+fn strict_eq_rereads_a_map_operand_below_an_allocating_right_operand() {
+    let ir = cmp_ir(
+        "streq_rooted_map_operand_7990",
+        CompareOp::Eq,
+        Expr::MapNew,
+        Expr::Object(vec![("right".to_string(), Expr::Number(2.0))]),
+    );
+    let left = call_operand_of(&ir, "js_eq", 0);
+    let right = call_operand_of(&ir, "js_eq", 1);
+    let left_producer = producer_line(&ir, &left);
+    let right_producer = producer_line(&ir, &right);
+    assert!(
+        left_producer > right_producer,
+        "js_eq's Map operand ({left}) is produced at line {left_producer}, above the right \
+         operand ({right}) at line {right_producer}. An intervening collection would leave \
+         the comparison holding a retired Map address (#7990).\n{ir}"
+    );
+}
+
 /// The complementary cost assertion: even with an allocating right operand,
 /// a proven-number left operand cannot be invalidated by relocation and must
 /// stay in its original register. A blanket "root every comparison" fix would

--- a/crates/perry-codegen/src/expr/compare_tests.rs
+++ b/crates/perry-codegen/src/expr/compare_tests.rs
@@ -120,7 +120,7 @@ fn strict_eq_rereads_a_map_operand_below_an_allocating_right_operand() {
     let right_producer = producer_line(&ir, &right);
     assert!(
         left_producer > right_producer,
-        "js_eq's Map operand ({left}) is produced at line {left_producer}, above the right \
+        "js_eq's Map operand ({left}) is produced at line {left_producer}, below the right \
          operand ({right}) at line {right_producer}. An intervening collection would leave \
          the comparison holding a retired Map address (#7990).\n{ir}"
     );

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1033,8 +1033,11 @@ pub(super) fn scan_remembered_dirty_slots_copying(
 }
 
 /// The young-pin latch was clear, the preflight was skipped on that proof, and
-/// the copier then met a pinned young object anyway — so the latch is
-/// incomplete and a pin site exists that does not go through `gc::pin_object`.
+/// the copier then met bytes that describe a pinned young object anyway.
+/// This is the instant relocation would become unsafe, but it does not by
+/// itself identify the violated invariant. In #7990 the header was internally
+/// impossible (`GC_TYPE_MAP | GC_FLAG_INTERNED`), and the fault disappeared
+/// when comparison operands were rooted; the pin latch itself was complete.
 ///
 /// There is no recovery: leaving the object in from-space strands the
 /// referring slot on memory `copying_reset_from_spaces_and_flip` is about to


### PR DESCRIPTION
Closes #7990.

## Root cause

The reported `obj_type=8 flags=0x37` header was internally impossible: `GC_FLAG_INTERNED` is only created on strings, never Maps. The copier had followed a stale comparison operand into recycled bytes; the young-pin latch itself was complete.

The causal zod A/B is the comparison-operand rooting fix that landed in #8011: the pre-fix corpus failed 3 of 16 rate-1, quarantine-off runs (including #7990's latch abort), while that patch alone completed 26 of 26 clean runs. Each clean run executed about 6,400 copying minors and moved roughly 855,000 objects, so the collector path remained saturated.

## Changes

- add a deterministic LLVM-dataflow regression for a typed `Map` left operand across an allocating comparison RHS; this complements #8011's generic-object coverage and prevents type analysis from accidentally treating Maps as non-pointers
- correct the remaining `move_young` comment that still declared an incomplete pin latch as the only possible cause

There is no collector-policy change: aborting before an unsafe relocation remains correct. The behavioral fix is #8011; this follow-up records and gates #7990's exact population.

## Validation

- `cargo test -p perry-codegen --lib compare_tests` — 11 passed
- `rustfmt --edition 2021 --check crates/perry-codegen/src/expr/compare_tests.rs crates/perry-runtime/src/gc/copying.rs`
- `git diff --check`
- zod dependency corpus with the #8011 patch only: 26/26 clean rate-1, quarantine-off runs; no latch aborts or late-surfacing TypeErrors

No version bump is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression affecting strict equality comparisons between maps and objects when memory allocation occurs during comparison.
  * Prevented stale map references from causing incorrect behavior or exposing invalid memory during garbage collection.
  * Added regression coverage for the affected comparison scenario.

* **Documentation**
  * Clarified diagnostics for inconsistent or dangling memory references detected during garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->