### PR TITLE
perf(gc): skip descriptor probes for plain typed stores

### DIFF
--- a/changelog.d/8023-typed-store-header-proof.md
+++ b/changelog.d/8023-typed-store-header-proof.md
@@ -1,0 +1,7 @@
+### Skip GC descriptor probes for plain typed stores
+
+In-bounds plain-double writes to intact typed objects now prove layout
+compatibility from the object header and field count, avoiding both
+thread-local descriptor-map probes on the common dynamic-store path. Tagged,
+pointer-like, and out-of-bounds writes retain the descriptor fallback and its
+existing downgrade behavior.

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -130,6 +130,7 @@ pub(super) struct TypedLayoutDescriptor {
 #[cfg(test)]
 thread_local! {
     pub(super) static TRACE_SLOT_READS: Cell<usize> = const { Cell::new(0) };
+    static TYPED_SLOT_DESCRIPTOR_PROBES: Cell<usize> = const { Cell::new(0) };
 }
 
 // #6893: SHAPE-keyed canonical typed layout. Replaces the per-OBJECT
@@ -595,6 +596,33 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
         // still tolerates a `None` defensively, so a transiently desynced bit
         // can only cost an extra fall-through, never mis-track a slot.
         if (*header)._reserved & GC_OBJ_TYPED_LAYOUT_INTACT != 0 {
+            // #5094: a plain, non-pointer-bearing double is representation-
+            // compatible with every in-bounds typed object slot. A raw-f64
+            // slot consumes the bits directly; a boxed slot consumes the same
+            // bits as an ordinary NaN-boxed number; and neither case changes
+            // the pointer mask. The descriptor's slot_count was pinned equal
+            // to ObjectHeader::field_count when INTACT was installed (also a
+            // requirement of the descriptor-free pointer-free allocation
+            // bake), so this header + bounds check proves the same `Conforms`
+            // verdict without resolving either thread-local descriptor map.
+            //
+            // Keep the raw-pointer classifier in the predicate. Some aligned
+            // low words are both valid f64 bit patterns and conservatively
+            // pointer-bearing; a boxed slot outside the pointer mask must
+            // still take the descriptor path and downgrade on such a store.
+            if layout_raw_f64_bits(value_bits)
+                && !layout_pointer_bearing_bits(value_bits)
+                // ObjectFields currently has exactly one concrete type. Use
+                // the byte already in the hot header instead of walking the
+                // type-info table a second time after layout_header_for_user.
+                && (*header).obj_type == GC_TYPE_OBJECT
+            {
+                let object = parent_user as *const crate::object::ObjectHeader;
+                if slot_index < (*object).field_count as usize {
+                    return;
+                }
+            }
+
             // #6893: per-object descriptor (diverged/ambiguous objects) OR the
             // shared shape descriptor (the common INTACT case). Exactly one is
             // present for an INTACT object.
@@ -607,6 +635,8 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
             // allocates on every store. The per-object probe is also skipped
             // outright while [`PER_OBJECT_LAYOUTS_NONEMPTY`] proves that map
             // empty, which on a monomorphic workload is always.
+            #[cfg(test)]
+            TYPED_SLOT_DESCRIPTOR_PROBES.with(|c| c.set(c.get() + 1));
             let verdict = {
                 let classify = |typed: &TypedLayoutDescriptor| {
                     if slot_index >= typed.slot_count {
@@ -1799,4 +1829,14 @@ pub(super) fn test_reset_trace_slot_reads() {
 #[cfg(test)]
 pub(super) fn test_trace_slot_reads() -> usize {
     TRACE_SLOT_READS.with(|c| c.get())
+}
+
+#[cfg(test)]
+pub(super) fn test_reset_typed_slot_descriptor_probes() {
+    TYPED_SLOT_DESCRIPTOR_PROBES.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn test_typed_slot_descriptor_probes() -> usize {
+    TYPED_SLOT_DESCRIPTOR_PROBES.with(Cell::get)
 }

--- a/crates/perry-runtime/src/gc/tests/layout_trace/object_closure_slots.rs
+++ b/crates/perry-runtime/src/gc/tests/layout_trace/object_closure_slots.rs
@@ -216,6 +216,105 @@ unsafe fn typed_two_slot_object() -> (*mut crate::object::ObjectHeader, *mut u64
 }
 
 #[test]
+fn test_plain_f64_typed_stores_skip_descriptor_probes() {
+    let _guard = GcTestIsolationGuard::new();
+    let (obj, fields) = unsafe { typed_two_slot_object() };
+    test_reset_typed_slot_descriptor_probes();
+
+    // The same plain-double bits are valid in both representations: slot 0 is
+    // raw-f64 and slot 1 is a boxed, pointer-masked JSValue slot. Neither store
+    // changes pointer-ness, so both can be classified from the intact header
+    // bit and ObjectHeader::field_count without touching either descriptor map.
+    runtime_store_jsvalue_slot(obj as usize, fields as usize, 0, 12.25f64.to_bits());
+    let slot1 = unsafe { fields.add(1) };
+    runtime_store_jsvalue_slot(obj as usize, slot1 as usize, 1, 13.25f64.to_bits());
+
+    assert!(
+        layout_has_typed_descriptor(obj as usize),
+        "plain f64 stores into either typed representation must keep the descriptor intact"
+    );
+    assert_eq!(
+        test_typed_slot_descriptor_probes(),
+        0,
+        "the O(1) header proof must make the per-store descriptor lookup unreachable"
+    );
+}
+
+#[test]
+fn test_tagged_typed_store_keeps_descriptor_probe() {
+    let _guard = GcTestIsolationGuard::new();
+    let (obj, fields) = unsafe { typed_two_slot_object() };
+    test_reset_typed_slot_descriptor_probes();
+
+    // `true` is valid in the boxed pointer-masked slot, but it is not raw-f64
+    // compatible. The descriptor must still decide that this particular slot
+    // accepts it; the new header-only proof is deliberately insufficient.
+    let slot1 = unsafe { fields.add(1) };
+    runtime_store_jsvalue_slot(obj as usize, slot1 as usize, 1, crate::value::TAG_TRUE);
+
+    assert!(
+        layout_has_typed_descriptor(obj as usize),
+        "a tagged scalar in a boxed slot conforms without downgrading"
+    );
+    assert_eq!(
+        test_typed_slot_descriptor_probes(),
+        1,
+        "tagged stores must retain the descriptor fallback"
+    );
+}
+
+#[test]
+fn test_pointer_like_f64_bits_do_not_take_plain_f64_layout_proof() {
+    let _guard = GcTestIsolationGuard::new();
+    let (obj, fields) = unsafe { alloc_old_test_object(2) };
+    unsafe {
+        *fields = 0.0f64.to_bits();
+        *fields.add(1) = crate::value::TAG_UNDEFINED;
+    }
+    // Slot 0 is boxed but not pointer-masked; slot 1 is pointer-masked.
+    let pointer_mask = [0b10u64];
+    js_gc_init_typed_shape_layout(
+        obj as u64,
+        2,
+        std::ptr::null(),
+        0,
+        pointer_mask.as_ptr(),
+        pointer_mask.len() as u32,
+    );
+    assert!(layout_has_typed_descriptor(obj as usize));
+    test_reset_typed_slot_descriptor_probes();
+
+    // An aligned low word is accepted by `layout_raw_f64_bits`, but the
+    // conservative raw-pointer classifier also treats it as pointer-bearing.
+    // Slot 0 does not admit pointers, so the descriptor path must downgrade.
+    layout_note_slot(obj as usize, 0, 0x2000);
+
+    assert!(
+        !layout_has_typed_descriptor(obj as usize),
+        "pointer-like raw words outside the pointer mask must still downgrade"
+    );
+    assert_eq!(test_typed_slot_descriptor_probes(), 1);
+}
+
+#[test]
+fn test_out_of_bounds_plain_f64_store_keeps_descriptor_probe() {
+    let _guard = GcTestIsolationGuard::new();
+    let (obj, _fields) = unsafe { typed_two_slot_object() };
+    test_reset_typed_slot_descriptor_probes();
+
+    // Do not perform an actual out-of-bounds write; exercise the layout note
+    // directly. The descriptor must reject slot_count itself even though the
+    // value is an otherwise universally compatible plain double.
+    layout_note_slot(obj as usize, 2, 1.25f64.to_bits());
+
+    assert!(
+        !layout_has_typed_descriptor(obj as usize),
+        "an out-of-bounds note must still downgrade the typed layout"
+    );
+    assert_eq!(test_typed_slot_descriptor_probes(), 1);
+}
+
+#[test]
 fn test_int32_store_into_raw_f64_slot_keeps_typed_descriptor() {
     let _guard = GcTestIsolationGuard::new();
     let (obj, fields) = unsafe { typed_two_slot_object() };


### PR DESCRIPTION
## Summary

- prove in-bounds plain-double stores conform to intact typed object layouts from the GC header and object field count
- skip both thread-local descriptor-map probes on that common dynamic-store path
- keep descriptor-based validation for tagged values, pointer-like raw words, and out-of-bounds notes
- add regression counters/tests that assert both the fast path and every safety fallback

Refs #5094.

## Performance

A 5,000,000-iteration dynamic-key numeric field-store benchmark on an otherwise idle arm64 macOS host improved from a 1,207 ms median to 1,156 ms: 1.044x, or 4.2% faster. Output was identical. The regression counter also shows the targeted descriptor probe dropping from one per store to zero.

## Validation

- `cargo fmt --all -- --check`
- focused layout suite: 13 passed
- full runtime suite: 2,286 passed and 4 ignored; the sole failure was an unrelated load-sensitive promise timing assertion on a host at load 74, and that exact test passed on the quiet benchmark host
- repeated numeric stores plus pointer fallback under default GC, forced evacuation with evacuation verification and from-space scanning, and non-generational GC
- `scripts/check_file_size.sh`

No version bump.