### PR TITLE
fix(gc): isolate class heap registries per agent (#8001)

### DIFF
--- a/changelog.d/8001-agent-local-class-registries.md
+++ b/changelog.d/8001-agent-local-class-registries.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Class prototype and dynamic-value registries are isolated per `perry/thread`
+  agent (#8001).** Tables keyed by process-wide codegen class ids previously
+  stored raw pointers, NaN-boxed values, closure identities, or realm-created
+  Symbol keys in process-global maps. The first agent to materialize a class
+  prototype could therefore make every later agent link instances to its heap,
+  and any agent's moving collector could rewrite entries owned by another
+  agent. Pointer-bearing class side tables now use Perry's hot thread-local
+  storage, while code-only metadata such as vtables, static method pointers,
+  bind lengths, and registered class ids remains process-global. A two-live-agent
+  runtime test and a `perry/thread` behavioral probe pin distinct, non-null
+  `Class.prototype` identities and realm-local prototype mutations.

--- a/crates/perry-runtime/src/object/class_gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_gc_roots.rs
@@ -42,94 +42,118 @@ use super::class_registry::{
 /// stay as side-tables + rooted here rather than moved in-object, since the
 /// inheritance walk reads them by `class_id`, not by an in-object slot.
 pub fn scan_class_inheritance_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    if let Ok(mut guard) = CLASS_PROTOTYPE_OBJECTS.write() {
-        if let Some(map) = guard.as_mut() {
-            for ptr in map.values_mut() {
-                visitor.visit_usize_slot(ptr);
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for ptr in map.values_mut() {
+                    visitor.visit_usize_slot(ptr);
+                }
             }
         }
-    }
-    if let Ok(mut guard) = CLASS_DECL_PROTOTYPE_OBJECTS.write() {
-        if let Some(map) = guard.as_mut() {
-            for ptr in map.values_mut() {
-                visitor.visit_usize_slot(ptr);
+    });
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for ptr in map.values_mut() {
+                    visitor.visit_usize_slot(ptr);
+                }
             }
         }
-    }
-    if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
-        if let Some(map) = guard.as_mut() {
-            for ptr in map.values_mut() {
-                visitor.visit_usize_slot(ptr);
+    });
+    CLASS_PARENT_CLOSURES.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for ptr in map.values_mut() {
+                    visitor.visit_usize_slot(ptr);
+                }
             }
         }
-    }
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_seed_class_inheritance_roots(proto_cid: u32, proto_ptr: usize) {
     // GC_STORE_AUDIT(ROOT): test seed mirrors CLASS_PROTOTYPE_OBJECTS values scanned by scan_class_inheritance_roots_mut.
-    let mut guard = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
-    guard
-        .get_or_insert_with(std::collections::HashMap::new)
-        .insert(proto_cid, proto_ptr);
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        let mut guard = table.write().unwrap();
+        guard
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(proto_cid, proto_ptr);
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_seed_decl_class_prototype_root(class_id: u32, proto_ptr: usize) {
-    let mut guard = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
-    guard
-        .get_or_insert_with(std::collections::HashMap::new)
-        .insert(class_id, proto_ptr);
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        let mut guard = table.write().unwrap();
+        guard
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(class_id, proto_ptr);
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_seed_class_parent_closure_root(closure_cid: u32, closure_ptr: usize) {
     // GC_STORE_AUDIT(ROOT): test seed mirrors CLASS_PARENT_CLOSURES values scanned by scan_class_inheritance_roots_mut.
-    let mut guard = CLASS_PARENT_CLOSURES.write().unwrap();
-    guard
-        .get_or_insert_with(std::collections::HashMap::new)
-        .insert(closure_cid, closure_ptr);
+    CLASS_PARENT_CLOSURES.with(|table| {
+        let mut guard = table.write().unwrap();
+        guard
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(closure_cid, closure_ptr);
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_class_prototype_object_root(proto_cid: u32) -> usize {
-    CLASS_PROTOTYPE_OBJECTS
-        .read()
-        .unwrap()
-        .as_ref()
-        .and_then(|m| m.get(&proto_cid).copied())
-        .unwrap_or(0)
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        table
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(|m| m.get(&proto_cid).copied())
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn test_decl_class_prototype_root(class_id: u32) -> usize {
-    CLASS_DECL_PROTOTYPE_OBJECTS
-        .read()
-        .unwrap()
-        .as_ref()
-        .and_then(|m| m.get(&class_id).copied())
-        .unwrap_or(0)
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        table
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(|m| m.get(&class_id).copied())
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn test_class_parent_closure_root(closure_cid: u32) -> usize {
-    CLASS_PARENT_CLOSURES
-        .read()
-        .unwrap()
-        .as_ref()
-        .and_then(|m| m.get(&closure_cid).copied())
-        .unwrap_or(0)
+    CLASS_PARENT_CLOSURES.with(|table| {
+        table
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(|m| m.get(&closure_cid).copied())
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn test_clear_class_inheritance_roots(proto_cid: u32, closure_cid: u32) {
-    if let Some(m) = CLASS_PROTOTYPE_OBJECTS.write().unwrap().as_mut() {
-        m.remove(&proto_cid);
-    }
-    if let Some(m) = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap().as_mut() {
-        m.remove(&proto_cid);
-    }
-    if let Some(m) = CLASS_PARENT_CLOSURES.write().unwrap().as_mut() {
-        m.remove(&closure_cid);
-    }
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Some(m) = table.write().unwrap().as_mut() {
+            m.remove(&proto_cid);
+        }
+    });
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        if let Some(m) = table.write().unwrap().as_mut() {
+            m.remove(&proto_cid);
+        }
+    });
+    CLASS_PARENT_CLOSURES.with(|table| {
+        if let Some(m) = table.write().unwrap().as_mut() {
+            m.remove(&closure_cid);
+        }
+    });
 }

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -1937,23 +1937,25 @@ pub extern "C" fn js_function_prototype_value_for_read(func_value: f64) -> f64 {
 /// parent-class chain so methods registered on a base class are found
 /// via subclass instances.
 pub(crate) fn lookup_prototype_method(class_id: u32, name: &str) -> Option<f64> {
-    let guard = CLASS_PROTOTYPE_METHODS.read().ok()?;
-    let map = guard.as_ref()?;
-    let mut cid = class_id;
-    let mut depth = 0usize;
-    while depth < 32 {
-        if let Some(per_class) = map.get(&cid) {
-            if let Some(&bits) = per_class.get(name) {
-                return Some(f64::from_bits(bits));
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        let guard = table.read().ok()?;
+        let map = guard.as_ref()?;
+        let mut cid = class_id;
+        let mut depth = 0usize;
+        while depth < 32 {
+            if let Some(per_class) = map.get(&cid) {
+                if let Some(&bits) = per_class.get(name) {
+                    return Some(f64::from_bits(bits));
+                }
+            }
+            match crate::object::class_generic_origin(cid).or_else(|| get_parent_class_id(cid)) {
+                Some(p) if p != 0 && p != cid => {
+                    cid = p;
+                    depth += 1;
+                }
+                _ => break,
             }
         }
-        match crate::object::class_generic_origin(cid).or_else(|| get_parent_class_id(cid)) {
-            Some(p) if p != 0 && p != cid => {
-                cid = p;
-                depth += 1;
-            }
-            _ => break,
-        }
-    }
-    None
+        None
+    })
 }

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -84,15 +84,17 @@ pub fn scan_class_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
         }
     });
 
-    if let Ok(mut guard) = CLASS_PROTOTYPE_METHODS.write() {
-        if let Some(map) = guard.as_mut() {
-            for methods in map.values_mut() {
-                for value_bits in methods.values_mut() {
-                    visitor.visit_nanbox_u64_slot(value_bits);
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for methods in map.values_mut() {
+                    for value_bits in methods.values_mut() {
+                        visitor.visit_nanbox_u64_slot(value_bits);
+                    }
                 }
             }
         }
-    }
+    });
 
     CLASS_PROTOTYPE_METHOD_VALUES.with(|cache| {
         let mut cache = cache.borrow_mut();
@@ -101,21 +103,25 @@ pub fn scan_class_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
         }
     });
 
-    if let Ok(mut guard) = CLASS_PROTOTYPE_OBJECTS.write() {
-        if let Some(map) = guard.as_mut() {
-            for proto_addr in map.values_mut() {
-                visitor.visit_usize_slot(proto_addr);
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for proto_addr in map.values_mut() {
+                    visitor.visit_usize_slot(proto_addr);
+                }
             }
         }
-    }
+    });
 
-    if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
-        if let Some(map) = guard.as_mut() {
-            for closure_addr in map.values_mut() {
-                visitor.visit_usize_slot(closure_addr);
+    CLASS_PARENT_CLOSURES.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for closure_addr in map.values_mut() {
+                    visitor.visit_usize_slot(closure_addr);
+                }
             }
         }
-    }
+    });
 
     // The dynamic-parent value stash (`class X extends _mod.default`) holds
     // raw NaN-boxed parent-constructor bits. For a ClassRef (INT32-tagged)
@@ -123,65 +129,73 @@ pub fn scan_class_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
     // `extends <runtime value>`) is a live heap pointer that a moving GC must
     // visit + forward — otherwise `js_get_dynamic_parent_value` later hands
     // `super()` a stale pointer.
-    if let Ok(mut guard) = CLASS_DYNAMIC_PARENT_VALUE.write() {
-        if let Some(map) = guard.as_mut() {
-            for value_bits in map.values_mut() {
-                visitor.visit_nanbox_u64_slot(value_bits);
+    CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for value_bits in map.values_mut() {
+                    visitor.visit_nanbox_u64_slot(value_bits);
+                }
             }
         }
-    }
+    });
 
     // #6530: cid → per-evaluation class OBJECT (`instance.constructor`
     // identity for capture-carrying classes). Same liveness/forwarding needs
     // as the dynamic-parent stash above: the entries are heap objects a
     // moving GC must visit + forward.
-    if let Ok(mut guard) = CLASS_OBJECT_VALUES.write() {
-        if let Some(map) = guard.as_mut() {
-            for value_bits in map.values_mut() {
-                visitor.visit_nanbox_u64_slot(value_bits);
+    CLASS_OBJECT_VALUES.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                for value_bits in map.values_mut() {
+                    visitor.visit_nanbox_u64_slot(value_bits);
+                }
             }
         }
-    }
+    });
 
     scan_class_symbol_member_keys_mut(visitor);
     scan_function_class_id_keys_mut(visitor);
 }
 
 fn scan_class_symbol_member_keys_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    if let Ok(mut guard) = CLASS_SYMBOL_METHODS.write() {
-        if let Some(map) = guard.as_mut() {
-            let mut rewrites = Vec::new();
-            for key in map.keys().copied().collect::<Vec<_>>() {
-                let (class_id, sym_key, is_static) = key;
-                let mut new_sym_key = sym_key;
-                if visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != sym_key {
-                    rewrites.push((key, (class_id, new_sym_key, is_static)));
+    CLASS_SYMBOL_METHODS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                let mut rewrites = Vec::new();
+                for key in map.keys().copied().collect::<Vec<_>>() {
+                    let (class_id, sym_key, is_static) = key;
+                    let mut new_sym_key = sym_key;
+                    if visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != sym_key {
+                        rewrites.push((key, (class_id, new_sym_key, is_static)));
+                    }
                 }
-            }
-            for (old_key, new_key) in rewrites {
-                if let Some(entry) = map.remove(&old_key) {
-                    map.insert(new_key, entry);
-                }
-            }
-        }
-    }
-    if let Ok(mut guard) = CLASS_SYMBOL_ACCESSORS.write() {
-        if let Some(map) = guard.as_mut() {
-            let mut rewrites = Vec::new();
-            for key in map.keys().copied().collect::<Vec<_>>() {
-                let (class_id, sym_key, is_static) = key;
-                let mut new_sym_key = sym_key;
-                if visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != sym_key {
-                    rewrites.push((key, (class_id, new_sym_key, is_static)));
-                }
-            }
-            for (old_key, new_key) in rewrites {
-                if let Some(entry) = map.remove(&old_key) {
-                    map.insert(new_key, entry);
+                for (old_key, new_key) in rewrites {
+                    if let Some(entry) = map.remove(&old_key) {
+                        map.insert(new_key, entry);
+                    }
                 }
             }
         }
-    }
+    });
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                let mut rewrites = Vec::new();
+                for key in map.keys().copied().collect::<Vec<_>>() {
+                    let (class_id, sym_key, is_static) = key;
+                    let mut new_sym_key = sym_key;
+                    if visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != sym_key {
+                        rewrites.push((key, (class_id, new_sym_key, is_static)));
+                    }
+                }
+                for (old_key, new_key) in rewrites {
+                    if let Some(entry) = map.remove(&old_key) {
+                        map.insert(new_key, entry);
+                    }
+                }
+            }
+        }
+    });
 }
 
 fn class_side_table_root_snapshot() -> Vec<ClassSideTableRootSlot> {
@@ -199,18 +213,20 @@ fn class_side_table_root_snapshot() -> Vec<ClassSideTableRootSlot> {
         }
     });
 
-    if let Ok(guard) = CLASS_PROTOTYPE_METHODS.read() {
-        if let Some(map) = guard.as_ref() {
-            for (&class_id, methods) in map.iter() {
-                for name in methods.keys() {
-                    slots.push(ClassSideTableRootSlot::PrototypeMethod {
-                        class_id,
-                        name: name.clone(),
-                    });
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for (&class_id, methods) in map.iter() {
+                    for name in methods.keys() {
+                        slots.push(ClassSideTableRootSlot::PrototypeMethod {
+                            class_id,
+                            name: name.clone(),
+                        });
+                    }
                 }
             }
         }
-    }
+    });
 
     CLASS_PROTOTYPE_METHOD_VALUES.with(|cache| {
         let cache = cache.borrow();
@@ -222,76 +238,90 @@ fn class_side_table_root_snapshot() -> Vec<ClassSideTableRootSlot> {
         }
     });
 
-    if let Ok(guard) = CLASS_PROTOTYPE_OBJECTS.read() {
-        if let Some(map) = guard.as_ref() {
-            for &class_id in map.keys() {
-                slots.push(ClassSideTableRootSlot::PrototypeObject { class_id });
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &class_id in map.keys() {
+                    slots.push(ClassSideTableRootSlot::PrototypeObject { class_id });
+                }
             }
         }
-    }
+    });
 
-    if let Ok(guard) = CLASS_PARENT_CLOSURES.read() {
-        if let Some(map) = guard.as_ref() {
-            for &class_id in map.keys() {
-                slots.push(ClassSideTableRootSlot::ParentClosure { class_id });
+    CLASS_PARENT_CLOSURES.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &class_id in map.keys() {
+                    slots.push(ClassSideTableRootSlot::ParentClosure { class_id });
+                }
             }
         }
-    }
+    });
 
     // Step twin of the CLASS_DYNAMIC_PARENT_VALUE block in
     // `scan_class_side_table_roots_mut`. Cycle-based collections run only
     // this snapshot machine, so omitting the stash meant a heap parent
     // (`class X extends someRuntimeValue()`) reachable only through it was
     // swept/left stale — `super()` then dereferenced freed/moved memory.
-    if let Ok(guard) = CLASS_DYNAMIC_PARENT_VALUE.read() {
-        if let Some(map) = guard.as_ref() {
-            for &class_id in map.keys() {
-                slots.push(ClassSideTableRootSlot::DynamicParentValue { class_id });
+    CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &class_id in map.keys() {
+                    slots.push(ClassSideTableRootSlot::DynamicParentValue { class_id });
+                }
             }
         }
-    }
+    });
 
     // Step twin of the CLASS_OBJECT_VALUES block in
     // `scan_class_side_table_roots_mut` (#6530).
-    if let Ok(guard) = CLASS_OBJECT_VALUES.read() {
-        if let Some(map) = guard.as_ref() {
-            for &class_id in map.keys() {
-                slots.push(ClassSideTableRootSlot::ClassObjectValue { class_id });
+    CLASS_OBJECT_VALUES.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &class_id in map.keys() {
+                    slots.push(ClassSideTableRootSlot::ClassObjectValue { class_id });
+                }
             }
         }
-    }
+    });
 
-    if let Ok(guard) = CLASS_SYMBOL_METHODS.read() {
-        if let Some(map) = guard.as_ref() {
-            for &(class_id, sym_key, is_static) in map.keys() {
-                slots.push(ClassSideTableRootSlot::ClassSymbolMethod {
-                    class_id,
-                    sym_key,
-                    is_static,
-                });
+    CLASS_SYMBOL_METHODS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &(class_id, sym_key, is_static) in map.keys() {
+                    slots.push(ClassSideTableRootSlot::ClassSymbolMethod {
+                        class_id,
+                        sym_key,
+                        is_static,
+                    });
+                }
             }
         }
-    }
+    });
 
-    if let Ok(guard) = CLASS_SYMBOL_ACCESSORS.read() {
-        if let Some(map) = guard.as_ref() {
-            for &(class_id, sym_key, is_static) in map.keys() {
-                slots.push(ClassSideTableRootSlot::ClassSymbolAccessor {
-                    class_id,
-                    sym_key,
-                    is_static,
-                });
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &(class_id, sym_key, is_static) in map.keys() {
+                    slots.push(ClassSideTableRootSlot::ClassSymbolAccessor {
+                        class_id,
+                        sym_key,
+                        is_static,
+                    });
+                }
             }
         }
-    }
+    });
 
-    if let Ok(guard) = FUNCTION_CLASS_IDS.read() {
-        if let Some(map) = guard.as_ref() {
-            for &bits in map.keys() {
-                slots.push(ClassSideTableRootSlot::FunctionClassIdKey { bits });
+    FUNCTION_CLASS_IDS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                for &bits in map.keys() {
+                    slots.push(ClassSideTableRootSlot::FunctionClassIdKey { bits });
+                }
             }
         }
-    }
+    });
 
     slots
 }
@@ -313,15 +343,17 @@ fn scan_class_side_table_root_slot(
             });
         }
         ClassSideTableRootSlot::PrototypeMethod { class_id, name } => {
-            if let Ok(mut guard) = CLASS_PROTOTYPE_METHODS.write() {
-                if let Some(value_bits) = guard
-                    .as_mut()
-                    .and_then(|map| map.get_mut(class_id))
-                    .and_then(|methods| methods.get_mut(name))
-                {
-                    visitor.visit_nanbox_u64_slot(value_bits);
+            CLASS_PROTOTYPE_METHODS.with(|table| {
+                if let Ok(mut guard) = table.write() {
+                    if let Some(value_bits) = guard
+                        .as_mut()
+                        .and_then(|map| map.get_mut(class_id))
+                        .and_then(|methods| methods.get_mut(name))
+                    {
+                        visitor.visit_nanbox_u64_slot(value_bits);
+                    }
                 }
-            }
+            });
         }
         ClassSideTableRootSlot::PrototypeMethodValue { class_id, name } => {
             CLASS_PROTOTYPE_METHOD_VALUES.with(|cache| {
@@ -331,32 +363,41 @@ fn scan_class_side_table_root_slot(
             });
         }
         ClassSideTableRootSlot::PrototypeObject { class_id } => {
-            if let Ok(mut guard) = CLASS_PROTOTYPE_OBJECTS.write() {
-                if let Some(proto_addr) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
-                    visitor.visit_usize_slot(proto_addr);
+            CLASS_PROTOTYPE_OBJECTS.with(|table| {
+                if let Ok(mut guard) = table.write() {
+                    if let Some(proto_addr) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
+                        visitor.visit_usize_slot(proto_addr);
+                    }
                 }
-            }
+            });
         }
         ClassSideTableRootSlot::ParentClosure { class_id } => {
-            if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
-                if let Some(closure_addr) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
-                    visitor.visit_usize_slot(closure_addr);
+            CLASS_PARENT_CLOSURES.with(|table| {
+                if let Ok(mut guard) = table.write() {
+                    if let Some(closure_addr) = guard.as_mut().and_then(|map| map.get_mut(class_id))
+                    {
+                        visitor.visit_usize_slot(closure_addr);
+                    }
                 }
-            }
+            });
         }
         ClassSideTableRootSlot::DynamicParentValue { class_id } => {
-            if let Ok(mut guard) = CLASS_DYNAMIC_PARENT_VALUE.write() {
-                if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
-                    visitor.visit_nanbox_u64_slot(value_bits);
+            CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
+                if let Ok(mut guard) = table.write() {
+                    if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
+                        visitor.visit_nanbox_u64_slot(value_bits);
+                    }
                 }
-            }
+            });
         }
         ClassSideTableRootSlot::ClassObjectValue { class_id } => {
-            if let Ok(mut guard) = CLASS_OBJECT_VALUES.write() {
-                if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
-                    visitor.visit_nanbox_u64_slot(value_bits);
+            CLASS_OBJECT_VALUES.with(|table| {
+                if let Ok(mut guard) = table.write() {
+                    if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
+                        visitor.visit_nanbox_u64_slot(value_bits);
+                    }
                 }
-            }
+            });
         }
         ClassSideTableRootSlot::ClassSymbolMethod {
             class_id,
@@ -390,13 +431,15 @@ fn rewrite_class_symbol_method_key_if_forwarded(
     if !visitor.visit_usize_slot(&mut new_sym_key) || new_sym_key == sym_key {
         return;
     }
-    if let Ok(mut guard) = CLASS_SYMBOL_METHODS.write() {
-        if let Some(map) = guard.as_mut() {
-            if let Some(entry) = map.remove(&(class_id, sym_key, is_static)) {
-                map.insert((class_id, new_sym_key, is_static), entry);
+    CLASS_SYMBOL_METHODS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                if let Some(entry) = map.remove(&(class_id, sym_key, is_static)) {
+                    map.insert((class_id, new_sym_key, is_static), entry);
+                }
             }
         }
-    }
+    });
 }
 
 fn rewrite_class_symbol_accessor_key_if_forwarded(
@@ -409,13 +452,15 @@ fn rewrite_class_symbol_accessor_key_if_forwarded(
     if !visitor.visit_usize_slot(&mut new_sym_key) || new_sym_key == sym_key {
         return;
     }
-    if let Ok(mut guard) = CLASS_SYMBOL_ACCESSORS.write() {
-        if let Some(map) = guard.as_mut() {
-            if let Some(entry) = map.remove(&(class_id, sym_key, is_static)) {
-                map.insert((class_id, new_sym_key, is_static), entry);
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                if let Some(entry) = map.remove(&(class_id, sym_key, is_static)) {
+                    map.insert((class_id, new_sym_key, is_static), entry);
+                }
             }
         }
-    }
+    });
 }
 
 fn scan_function_class_id_keys_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
@@ -423,22 +468,24 @@ fn scan_function_class_id_keys_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         return;
     }
     let mut rewrites = Vec::new();
-    if let Ok(mut guard) = FUNCTION_CLASS_IDS.write() {
-        let Some(map) = guard.as_mut() else {
-            return;
-        };
-        for old_bits in map.keys().copied().collect::<Vec<_>>() {
-            let mut new_bits = old_bits;
-            if visit_metadata_nanbox_key(visitor, &mut new_bits) && new_bits != old_bits {
-                rewrites.push((old_bits, new_bits));
+    FUNCTION_CLASS_IDS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            let Some(map) = guard.as_mut() else {
+                return;
+            };
+            for old_bits in map.keys().copied().collect::<Vec<_>>() {
+                let mut new_bits = old_bits;
+                if visit_metadata_nanbox_key(visitor, &mut new_bits) && new_bits != old_bits {
+                    rewrites.push((old_bits, new_bits));
+                }
+            }
+            for (old_bits, new_bits) in rewrites {
+                if let Some(class_id) = map.remove(&old_bits) {
+                    map.insert(new_bits, class_id);
+                }
             }
         }
-        for (old_bits, new_bits) in rewrites {
-            if let Some(class_id) = map.remove(&old_bits) {
-                map.insert(new_bits, class_id);
-            }
-        }
-    }
+    });
 }
 
 fn rewrite_function_class_id_key_if_forwarded(
@@ -452,13 +499,15 @@ fn rewrite_function_class_id_key_if_forwarded(
     if !visit_metadata_nanbox_key(visitor, &mut new_bits) || new_bits == old_bits {
         return;
     }
-    if let Ok(mut guard) = FUNCTION_CLASS_IDS.write() {
-        if let Some(map) = guard.as_mut() {
-            if let Some(class_id) = map.remove(&old_bits) {
-                map.insert(new_bits, class_id);
+    FUNCTION_CLASS_IDS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            if let Some(map) = guard.as_mut() {
+                if let Some(class_id) = map.remove(&old_bits) {
+                    map.insert(new_bits, class_id);
+                }
             }
         }
-    }
+    });
 }
 
 fn visit_metadata_nanbox_key(
@@ -489,25 +538,37 @@ pub(crate) fn test_clear_class_side_table_roots() {
     CLASS_DYNAMIC_PROPS.with(|m| m.borrow_mut().clear());
     CLASS_DELETED_KEYS.with(|m| m.borrow_mut().clear());
     CLASS_PROTOTYPE_METHOD_VALUES.with(|cache| cache.borrow_mut().clear());
-    if let Ok(mut guard) = CLASS_PROTOTYPE_METHODS.write() {
-        *guard = None;
-    }
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
     CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED.store(false, std::sync::atomic::Ordering::Release);
-    if let Ok(mut guard) = FUNCTION_CLASS_IDS.write() {
-        *guard = None;
-    }
-    if let Ok(mut guard) = CLASS_PROTOTYPE_OBJECTS.write() {
-        *guard = None;
-    }
-    if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
-        *guard = None;
-    }
-    if let Ok(mut guard) = CLASS_SYMBOL_METHODS.write() {
-        *guard = None;
-    }
-    if let Ok(mut guard) = CLASS_SYMBOL_ACCESSORS.write() {
-        *guard = None;
-    }
+    FUNCTION_CLASS_IDS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
+    CLASS_PARENT_CLOSURES.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
+    CLASS_SYMBOL_METHODS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        if let Ok(mut guard) = table.write() {
+            *guard = None;
+        }
+    });
     if let Ok(mut guard) = CLASS_STATIC_ACCESSORS.write() {
         *guard = None;
     }
@@ -537,17 +598,19 @@ pub(crate) fn test_seed_class_prototype_method_root(class_id: u32, name: &str, v
 
 #[cfg(test)]
 pub(crate) fn test_class_prototype_method_root_bits(class_id: u32, name: &str) -> u64 {
-    CLASS_PROTOTYPE_METHODS
-        .read()
-        .ok()
-        .and_then(|guard| {
-            guard
-                .as_ref()
-                .and_then(|map| map.get(&class_id))
-                .and_then(|methods| methods.get(name))
-                .copied()
-        })
-        .unwrap_or(0)
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|guard| {
+                guard
+                    .as_ref()
+                    .and_then(|map| map.get(&class_id))
+                    .and_then(|methods| methods.get(name))
+                    .copied()
+            })
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
@@ -577,41 +640,49 @@ pub(crate) fn test_seed_class_prototype_object_root(class_id: u32, addr: usize) 
 
 #[cfg(test)]
 pub(crate) fn test_class_prototype_object_root_addr(class_id: u32) -> usize {
-    CLASS_PROTOTYPE_OBJECTS
-        .read()
-        .ok()
-        .and_then(|guard| guard.as_ref().and_then(|map| map.get(&class_id).copied()))
-        .unwrap_or(0)
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|guard| guard.as_ref().and_then(|map| map.get(&class_id).copied()))
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn test_class_parent_closure_root_addr(class_id: u32) -> usize {
-    CLASS_PARENT_CLOSURES
-        .read()
-        .ok()
-        .and_then(|guard| guard.as_ref().and_then(|map| map.get(&class_id).copied()))
-        .unwrap_or(0)
+    CLASS_PARENT_CLOSURES.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|guard| guard.as_ref().and_then(|map| map.get(&class_id).copied()))
+            .unwrap_or(0)
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn test_seed_function_class_id_key(func_bits: u64, class_id: u32) {
-    let mut guard = FUNCTION_CLASS_IDS.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
-    }
-    guard.as_mut().unwrap().insert(func_bits, class_id);
+    FUNCTION_CLASS_IDS.with(|table| {
+        let mut guard = table.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(func_bits, class_id);
+    });
 }
 
 #[cfg(test)]
 pub(crate) fn test_function_class_id_key_for_class(class_id: u32) -> u64 {
-    FUNCTION_CLASS_IDS
-        .read()
-        .ok()
-        .and_then(|guard| {
-            guard.as_ref().and_then(|map| {
-                map.iter()
-                    .find_map(|(&bits, &cid)| (cid == class_id).then_some(bits))
+    FUNCTION_CLASS_IDS.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|guard| {
+                guard.as_ref().and_then(|map| {
+                    map.iter()
+                        .find_map(|(&bits, &cid)| (cid == class_id).then_some(bits))
+                })
             })
-        })
-        .unwrap_or(0)
+            .unwrap_or(0)
+    })
 }

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -73,11 +73,13 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_val
         const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
         let bits = parent_value.to_bits();
         if bits != TAG_UNDEFINED && class_id != 0 {
-            let mut guard = CLASS_DYNAMIC_PARENT_VALUE.write().unwrap();
-            if guard.is_none() {
-                *guard = Some(HashMap::new());
-            }
-            guard.as_mut().unwrap().insert(class_id, bits);
+            CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
+                let mut guard = table.write().unwrap();
+                if guard.is_none() {
+                    *guard = Some(HashMap::new());
+                }
+                guard.as_mut().unwrap().insert(class_id, bits);
+            });
         }
     }
     // A globalThis builtin constructor closure is a valid superclass
@@ -389,11 +391,12 @@ pub extern "C" fn js_get_dynamic_parent_value(class_id: u32) -> f64 {
     if class_id == 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    {
-        let guard = CLASS_DYNAMIC_PARENT_VALUE.read().unwrap();
-        if let Some(&bits) = guard.as_ref().and_then(|m| m.get(&class_id)) {
-            return f64::from_bits(bits);
-        }
+    let dynamic_parent = CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
+        let guard = table.read().unwrap();
+        guard.as_ref().and_then(|m| m.get(&class_id).copied())
+    });
+    if let Some(bits) = dynamic_parent {
+        return f64::from_bits(bits);
     }
     // #5957/#806: no dynamic VALUE stashed — fall back to the STATIC
     // parent-id edge as a ClassRef. An `extends <call>(...)` mixin
@@ -539,8 +542,8 @@ pub unsafe extern "C" fn js_register_class_computed_method(
             return;
         }
         crate::symbol::note_symbol_key_installed(sym_key);
-        {
-            let mut guard = CLASS_SYMBOL_METHODS.write().unwrap();
+        CLASS_SYMBOL_METHODS.with(|table| {
+            let mut guard = table.write().unwrap();
             if guard.is_none() {
                 *guard = Some(HashMap::new());
             }
@@ -548,7 +551,7 @@ pub unsafe extern "C" fn js_register_class_computed_method(
                 (class_id, sym_key, is_static != 0),
                 (func_ptr as usize, param_count as u32, has_rest != 0),
             );
-        }
+        });
         // A computed key that evaluates to a WELL-KNOWN symbol — e.g. the
         // minified `[(gm = new WeakMap, Symbol.asyncIterator)]() {…}` comma
         // form, whose key expression the lowering can't see through
@@ -676,21 +679,23 @@ pub unsafe extern "C" fn js_register_class_computed_accessor(
             return;
         }
         crate::symbol::note_symbol_key_installed(sym_key);
-        let mut guard = CLASS_SYMBOL_ACCESSORS.write().unwrap();
-        if guard.is_none() {
-            *guard = Some(HashMap::new());
-        }
-        let entry = guard
-            .as_mut()
-            .unwrap()
-            .entry((class_id, sym_key, is_static != 0))
-            .or_insert((0, 0));
-        if getter_ptr != 0 {
-            entry.0 = getter_ptr as usize;
-        }
-        if setter_ptr != 0 {
-            entry.1 = setter_ptr as usize;
-        }
+        CLASS_SYMBOL_ACCESSORS.with(|table| {
+            let mut guard = table.write().unwrap();
+            if guard.is_none() {
+                *guard = Some(HashMap::new());
+            }
+            let entry = guard
+                .as_mut()
+                .unwrap()
+                .entry((class_id, sym_key, is_static != 0))
+                .or_insert((0, 0));
+            if getter_ptr != 0 {
+                entry.0 = getter_ptr as usize;
+            }
+            if setter_ptr != 0 {
+                entry.1 = setter_ptr as usize;
+            }
+        });
         VTABLE_GEN.fetch_add(1, Ordering::Release);
         return;
     }
@@ -787,23 +792,25 @@ pub(crate) fn lookup_class_symbol_method_in_chain(
     sym_key: usize,
     is_static: bool,
 ) -> Option<(usize, u32, bool)> {
-    let guard = CLASS_SYMBOL_METHODS.read().ok()?;
-    let map = guard.as_ref()?;
-    let mut cid = class_id;
-    let mut depth = 0usize;
-    while cid != 0 && depth < 32 {
-        if let Some(&entry) = map.get(&(cid, sym_key, is_static)) {
-            return Some(entry);
-        }
-        match get_parent_class_id(cid) {
-            Some(p) if p != 0 && p != cid => {
-                cid = p;
-                depth += 1;
+    CLASS_SYMBOL_METHODS.with(|table| {
+        let guard = table.read().ok()?;
+        let map = guard.as_ref()?;
+        let mut cid = class_id;
+        let mut depth = 0usize;
+        while cid != 0 && depth < 32 {
+            if let Some(&entry) = map.get(&(cid, sym_key, is_static)) {
+                return Some(entry);
             }
-            _ => break,
+            match get_parent_class_id(cid) {
+                Some(p) if p != 0 && p != cid => {
+                    cid = p;
+                    depth += 1;
+                }
+                _ => break,
+            }
         }
-    }
-    None
+        None
+    })
 }
 
 /// Presence-only check (`[[HasProperty]]`, never `[[Get]]`) for a Symbol-keyed
@@ -824,19 +831,23 @@ pub(crate) fn class_has_symbol_member_in_chain(
     let mut depth = 0usize;
     while cid != 0 && depth < 32 {
         let key = (cid, sym_key, is_static);
-        let in_methods = CLASS_SYMBOL_METHODS
-            .read()
-            .ok()
-            .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
-            .unwrap_or(false);
+        let in_methods = CLASS_SYMBOL_METHODS.with(|table| {
+            table
+                .read()
+                .ok()
+                .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
+                .unwrap_or(false)
+        });
         if in_methods {
             return true;
         }
-        let in_accessors = CLASS_SYMBOL_ACCESSORS
-            .read()
-            .ok()
-            .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
-            .unwrap_or(false);
+        let in_accessors = CLASS_SYMBOL_ACCESSORS.with(|table| {
+            table
+                .read()
+                .ok()
+                .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
+                .unwrap_or(false)
+        });
         if in_accessors {
             return true;
         }
@@ -853,24 +864,28 @@ pub(crate) fn class_has_symbol_member_in_chain(
 
 pub(crate) fn class_own_symbol_member_keys(class_id: u32, is_static: bool) -> Vec<usize> {
     let mut keys = Vec::new();
-    if let Ok(methods) = CLASS_SYMBOL_METHODS.read() {
-        if let Some(map) = methods.as_ref() {
-            for &(cid, sym_key, static_flag) in map.keys() {
-                if cid == class_id && static_flag == is_static && !keys.contains(&sym_key) {
-                    keys.push(sym_key);
+    CLASS_SYMBOL_METHODS.with(|table| {
+        if let Ok(methods) = table.read() {
+            if let Some(map) = methods.as_ref() {
+                for &(cid, sym_key, static_flag) in map.keys() {
+                    if cid == class_id && static_flag == is_static && !keys.contains(&sym_key) {
+                        keys.push(sym_key);
+                    }
                 }
             }
         }
-    }
-    if let Ok(accessors) = CLASS_SYMBOL_ACCESSORS.read() {
-        if let Some(map) = accessors.as_ref() {
-            for &(cid, sym_key, static_flag) in map.keys() {
-                if cid == class_id && static_flag == is_static && !keys.contains(&sym_key) {
-                    keys.push(sym_key);
+    });
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        if let Ok(accessors) = table.read() {
+            if let Some(map) = accessors.as_ref() {
+                for &(cid, sym_key, static_flag) in map.keys() {
+                    if cid == class_id && static_flag == is_static && !keys.contains(&sym_key) {
+                        keys.push(sym_key);
+                    }
                 }
             }
         }
-    }
+    });
     keys.sort_by_key(|sym_key| unsafe {
         let ptr = *sym_key as *const crate::symbol::SymbolHeader;
         if ptr.is_null() {
@@ -888,36 +903,38 @@ pub(crate) unsafe fn class_symbol_getter_value(
     receiver: f64,
     is_static: bool,
 ) -> Option<f64> {
-    let guard = CLASS_SYMBOL_ACCESSORS.read().ok()?;
-    let map = guard.as_ref()?;
-    let mut cid = class_id;
-    let mut depth = 0usize;
-    while cid != 0 && depth < 32 {
-        if let Some(&(getter, _)) = map.get(&(cid, sym_key, is_static)) {
-            if getter == 0 {
-                return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        let guard = table.read().ok()?;
+        let map = guard.as_ref()?;
+        let mut cid = class_id;
+        let mut depth = 0usize;
+        while cid != 0 && depth < 32 {
+            if let Some(&(getter, _)) = map.get(&(cid, sym_key, is_static)) {
+                if getter == 0 {
+                    return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+                }
+                let result = if is_static {
+                    let prev_this = crate::object::js_implicit_this_set(receiver);
+                    let f: extern "C" fn() -> f64 = std::mem::transmute(getter);
+                    let result = f();
+                    crate::object::js_implicit_this_set(prev_this);
+                    result
+                } else {
+                    let f: extern "C" fn(f64) -> f64 = std::mem::transmute(getter);
+                    f(receiver)
+                };
+                return Some(result);
             }
-            let result = if is_static {
-                let prev_this = crate::object::js_implicit_this_set(receiver);
-                let f: extern "C" fn() -> f64 = std::mem::transmute(getter);
-                let result = f();
-                crate::object::js_implicit_this_set(prev_this);
-                result
-            } else {
-                let f: extern "C" fn(f64) -> f64 = std::mem::transmute(getter);
-                f(receiver)
-            };
-            return Some(result);
-        }
-        match get_parent_class_id(cid) {
-            Some(p) if p != 0 && p != cid => {
-                cid = p;
-                depth += 1;
+            match get_parent_class_id(cid) {
+                Some(p) if p != 0 && p != cid => {
+                    cid = p;
+                    depth += 1;
+                }
+                _ => break,
             }
-            _ => break,
         }
-    }
-    None
+        None
+    })
 }
 
 pub(crate) unsafe fn class_symbol_setter_apply(
@@ -927,39 +944,41 @@ pub(crate) unsafe fn class_symbol_setter_apply(
     value: f64,
     is_static: bool,
 ) -> bool {
-    let guard = match CLASS_SYMBOL_ACCESSORS.read() {
-        Ok(g) => g,
-        Err(_) => return false,
-    };
-    let Some(map) = guard.as_ref() else {
-        return false;
-    };
-    let mut cid = class_id;
-    let mut depth = 0usize;
-    while cid != 0 && depth < 32 {
-        if let Some(&(_, setter)) = map.get(&(cid, sym_key, is_static)) {
-            if setter != 0 {
-                if is_static {
-                    let prev_this = crate::object::js_implicit_this_set(receiver);
-                    let f: extern "C" fn(f64) -> f64 = std::mem::transmute(setter);
-                    let _ = f(value);
-                    crate::object::js_implicit_this_set(prev_this);
-                } else {
-                    let f: extern "C" fn(f64, f64) -> f64 = std::mem::transmute(setter);
-                    let _ = f(receiver, value);
+    CLASS_SYMBOL_ACCESSORS.with(|table| {
+        let guard = match table.read() {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
+        let Some(map) = guard.as_ref() else {
+            return false;
+        };
+        let mut cid = class_id;
+        let mut depth = 0usize;
+        while cid != 0 && depth < 32 {
+            if let Some(&(_, setter)) = map.get(&(cid, sym_key, is_static)) {
+                if setter != 0 {
+                    if is_static {
+                        let prev_this = crate::object::js_implicit_this_set(receiver);
+                        let f: extern "C" fn(f64) -> f64 = std::mem::transmute(setter);
+                        let _ = f(value);
+                        crate::object::js_implicit_this_set(prev_this);
+                    } else {
+                        let f: extern "C" fn(f64, f64) -> f64 = std::mem::transmute(setter);
+                        let _ = f(receiver, value);
+                    }
                 }
+                return true;
             }
-            return true;
-        }
-        match get_parent_class_id(cid) {
-            Some(p) if p != 0 && p != cid => {
-                cid = p;
-                depth += 1;
+            match get_parent_class_id(cid) {
+                Some(p) if p != 0 && p != cid => {
+                    cid = p;
+                    depth += 1;
+                }
+                _ => break,
             }
-            _ => break,
         }
-    }
-    false
+        false
+    })
 }
 
 pub(crate) unsafe fn class_static_accessor_getter_value(
@@ -1657,12 +1676,14 @@ pub fn is_registered_class_prototype_object(ptr: usize) -> bool {
     if crate::value::addr_class::is_handle_band(ptr) {
         return false;
     }
-    if let Ok(guard) = CLASS_PROTOTYPE_OBJECTS.read() {
-        if let Some(map) = guard.as_ref() {
-            return map.values().any(|&p| p == ptr);
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(guard) = table.read() {
+            if let Some(map) = guard.as_ref() {
+                return map.values().any(|&p| p == ptr);
+            }
         }
-    }
-    false
+        false
+    })
 }
 
 /// Walk the prototype chain of `class_id` and return the id of the class that

--- a/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn js_class_register_static_field(
     class_dynamic_prop_root_store(class_id, name, value);
 }
 
-per_test_global! {
+crate::perry_thread_local! {
     /// Issue #838: JS-classic prototype method assignment.
     ///
     /// `Class.prototype.method = function() {…}` (and the aliased form
@@ -50,6 +50,9 @@ per_test_global! {
     /// `*ClosureHeader` shapes.
     pub static CLASS_PROTOTYPE_METHODS: RwLock<Option<HashMap<u32, HashMap<String, u64>>>> =
         RwLock::new(None);
+}
+
+per_test_global! {
     pub(crate) static CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED: std::sync::atomic::AtomicBool =
         std::sync::atomic::AtomicBool::new(false);
 }
@@ -79,8 +82,8 @@ pub(crate) fn invalidate_class_prototype_fast_guards() {
 }
 
 pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, value_bits: u64) {
-    {
-        let mut guard = CLASS_PROTOTYPE_METHODS.write().unwrap();
+    CLASS_PROTOTYPE_METHODS.with(|table| {
+        let mut guard = table.write().unwrap();
         if guard.is_none() {
             *guard = Some(HashMap::new());
         }
@@ -90,7 +93,7 @@ pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, val
             .entry(class_id)
             .or_default()
             .insert(name.clone(), value_bits);
-    }
+    });
     invalidate_class_prototype_fast_guards();
     crate::gc::runtime_write_barrier_root_nanbox(value_bits);
     // #5024: the side table makes the method dispatchable, but own-key
@@ -356,22 +359,26 @@ pub(crate) fn synthetic_class_id_for_function(func_value: f64) -> u32 {
     if !is_callable_function_value(func_value) {
         return 0;
     }
-    {
-        let read = FUNCTION_CLASS_IDS.read().unwrap();
+    let existing = FUNCTION_CLASS_IDS.with(|table| {
+        let read = table.read().unwrap();
         if let Some(map) = read.as_ref() {
             if let Some(&existing) = map.get(&func_bits) {
-                return existing;
+                return Some(existing);
             }
         }
+        None
+    });
+    if let Some(existing) = existing {
+        return existing;
     }
     let new_cid = NEXT_SYNTHETIC_CLASS_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    {
-        let mut write = FUNCTION_CLASS_IDS.write().unwrap();
+    FUNCTION_CLASS_IDS.with(|table| {
+        let mut write = table.write().unwrap();
         if write.is_none() {
             *write = Some(HashMap::new());
         }
         write.as_mut().unwrap().insert(func_bits, new_cid);
-    }
+    });
     unsafe { js_register_class_id(new_cid) };
     new_cid
 }

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -67,12 +67,14 @@ pub(crate) fn ensure_function_prototype_object(
     // them as ordinary own properties so enumeration sees them; later
     // registrations write through via class_prototype_method_root_store.
     let registered: Vec<(String, u64)> = {
-        let guard = CLASS_PROTOTYPE_METHODS.read().unwrap();
-        guard
-            .as_ref()
-            .and_then(|map| map.get(&class_id))
-            .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
-            .unwrap_or_default()
+        CLASS_PROTOTYPE_METHODS.with(|table| {
+            let guard = table.read().unwrap();
+            guard
+                .as_ref()
+                .and_then(|map| map.get(&class_id))
+                .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
+                .unwrap_or_default()
+        })
     };
     for (name, value_bits) in registered {
         let enumerable = class_prototype_method_is_enumerable(class_id, &name);
@@ -227,35 +229,39 @@ pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
     // multiple times in pathological code; we keep the FIRST mapping
     // and quietly ignore subsequent calls so existing parent edges
     // don't dangle.
-    {
-        let read = FUNCTION_CLASS_IDS.read().unwrap();
+    let existing = FUNCTION_CLASS_IDS.with(|table| {
+        let read = table.read().unwrap();
         if let Some(map) = read.as_ref() {
             if let Some(&existing) = map.get(&func_bits) {
-                // Update the prototype object (allow re-pointing)
-                // without changing the class_id.
-                class_prototype_object_root_store(existing, proto_ptr);
-                let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
-                if func_ptr != 0 {
-                    crate::closure::closure_set_dynamic_prop(func_ptr, "prototype", proto);
-                    set_builtin_property_attrs(
-                        func_ptr,
-                        "prototype".to_string(),
-                        PropertyAttrs::new(true, false, false),
-                    );
-                }
-                crate::typed_feedback::invalidate_method_change(existing);
-                return existing;
+                return Some(existing);
             }
         }
+        None
+    });
+    if let Some(existing) = existing {
+        // Update the prototype object (allow re-pointing) without changing the
+        // class_id.
+        class_prototype_object_root_store(existing, proto_ptr);
+        let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
+        if func_ptr != 0 {
+            crate::closure::closure_set_dynamic_prop(func_ptr, "prototype", proto);
+            set_builtin_property_attrs(
+                func_ptr,
+                "prototype".to_string(),
+                PropertyAttrs::new(true, false, false),
+            );
+        }
+        crate::typed_feedback::invalidate_method_change(existing);
+        return existing;
     }
     let new_cid = NEXT_SYNTHETIC_CLASS_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    {
-        let mut write = FUNCTION_CLASS_IDS.write().unwrap();
+    FUNCTION_CLASS_IDS.with(|table| {
+        let mut write = table.write().unwrap();
         if write.is_none() {
             *write = Some(HashMap::new());
         }
         write.as_mut().unwrap().insert(func_bits, new_cid);
-    }
+    });
     class_prototype_object_root_store(new_cid, proto_ptr);
     let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
     if func_ptr != 0 {
@@ -284,12 +290,14 @@ pub(crate) fn class_prototype_object(class_id: u32) -> *mut ObjectHeader {
     // must redirect or `x.constructor` and `Object.getPrototypeOf` disagree
     // about whether the specialization is `Gen`.
     let class_id = crate::object::class_generic_origin(class_id).unwrap_or(class_id);
-    if let Ok(read) = CLASS_PROTOTYPE_OBJECTS.read() {
-        if let Some(map) = read.as_ref() {
-            return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(read) = table.read() {
+            if let Some(map) = read.as_ref() {
+                return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
+            }
         }
-    }
-    std::ptr::null_mut()
+        std::ptr::null_mut()
+    })
 }
 
 /// #711 / #809: resolve `key` by walking the synthetic-class-id prototype
@@ -495,22 +503,26 @@ pub(crate) unsafe fn resolve_proto_chain_symbol(class_id: u32, sym_f64: f64) -> 
 #[inline]
 pub(crate) fn function_class_id(value: f64) -> u32 {
     let bits = value.to_bits();
-    if let Ok(read) = FUNCTION_CLASS_IDS.read() {
-        if let Some(map) = read.as_ref() {
-            return map.get(&bits).copied().unwrap_or(0);
+    FUNCTION_CLASS_IDS.with(|table| {
+        if let Ok(read) = table.read() {
+            if let Some(map) = read.as_ref() {
+                return map.get(&bits).copied().unwrap_or(0);
+            }
         }
-    }
-    0
+        0
+    })
 }
 
 pub(crate) fn function_value_for_class_id(class_id: u32) -> Option<f64> {
     if class_id == 0 {
         return None;
     }
-    FUNCTION_CLASS_IDS.read().ok().and_then(|guard| {
-        guard.as_ref().and_then(|map| {
-            map.iter()
-                .find_map(|(&bits, &cid)| (cid == class_id).then_some(f64::from_bits(bits)))
+    FUNCTION_CLASS_IDS.with(|table| {
+        table.read().ok().and_then(|guard| {
+            guard.as_ref().and_then(|map| {
+                map.iter()
+                    .find_map(|(&bits, &cid)| (cid == class_id).then_some(f64::from_bits(bits)))
+            })
         })
     })
 }

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -275,7 +275,7 @@ pub static CLASS_METHOD_BIND_LENGTHS: RwLock<Option<HashMap<(u32, String), u32>>
 pub static CLASS_STATIC_METHOD_BIND_LENGTHS: RwLock<Option<HashMap<(u32, String), u32>>> =
     RwLock::new(None);
 
-per_test_global! {
+crate::perry_thread_local! {
     pub static CLASS_SYMBOL_METHODS: RwLock<Option<HashMap<(u32, usize, bool), (usize, u32, bool)>>> =
         RwLock::new(None);
 
@@ -288,7 +288,7 @@ per_test_global! {
 /// classes without any methods. Refs #618 / #420 followup.
 pub static REGISTERED_CLASS_IDS: RwLock<Option<std::collections::HashSet<u32>>> = RwLock::new(None);
 
-per_test_global! {
+crate::perry_thread_local! {
     /// Issue #711 part 2: `function Base() {}; Base.prototype = obj` pattern.
     /// Effect's `internal/effectable.ts` declares classes via prototype
     /// assignment on a plain function, not via `class` syntax. To make
@@ -312,30 +312,34 @@ per_test_global! {
 // pointer is always converted back to `*mut ObjectHeader` at call sites
 // (`class_prototype_object` / the dispatch walk) where single-threaded
 // usage is guaranteed.
-per_test_global! {
+crate::perry_thread_local! {
     pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 }
 
-/// Lazily materialized `Class.prototype` objects for declared ES classes.
-/// These are separate from `CLASS_PROTOTYPE_OBJECTS`: that older table is
-/// intentionally overloaded for synthetic prototype sources and static
-/// inheritance shortcuts. Declared class prototypes need stable heap identity
-/// for `typeof C.prototype`, `Object.getPrototypeOf(new C())`, and
-/// `C.prototype.isPrototypeOf(instance)` without perturbing those paths.
-pub static CLASS_DECL_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
+crate::perry_thread_local! {
+    /// Lazily materialized `Class.prototype` objects for declared ES classes.
+    /// These are separate from `CLASS_PROTOTYPE_OBJECTS`: that older table is
+    /// intentionally overloaded for synthetic prototype sources and static
+    /// inheritance shortcuts. Declared class prototypes need stable heap identity
+    /// for `typeof C.prototype`, `Object.getPrototypeOf(new C())`, and
+    /// `C.prototype.isPrototypeOf(instance)` without perturbing those paths.
+    pub static CLASS_DECL_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
+}
 
-/// #5024 followup: prototype methods registered via `Object.defineProperty(
-/// Class.prototype, name, desc)` WITHOUT an explicit `enumerable: true` are
-/// non-enumerable (spec default for defineProperty). The plain
-/// `Class.prototype.m = fn` assignment path makes them enumerable. Both funnel
-/// into `CLASS_PROTOTYPE_METHODS`, which stores only the value — so the
-/// enumerability is tracked here, keyed by `(class_id, name)`. Absence means
-/// "enumerable" (the assignment default). Consulted when mirroring a method
-/// onto a prototype OBJECT so reflective `Object.keys`/`for-in` see the
-/// correct attribute.
-pub static CLASS_PROTOTYPE_METHOD_NONENUM: RwLock<
-    Option<std::collections::HashSet<(u32, String)>>,
-> = RwLock::new(None);
+crate::perry_thread_local! {
+    /// #5024 followup: prototype methods registered via `Object.defineProperty(
+    /// Class.prototype, name, desc)` WITHOUT an explicit `enumerable: true` are
+    /// non-enumerable (spec default for defineProperty). The plain
+    /// `Class.prototype.m = fn` assignment path makes them enumerable. Both funnel
+    /// into `CLASS_PROTOTYPE_METHODS`, which stores only the value — so the
+    /// enumerability is tracked here, keyed by `(class_id, name)`. Absence means
+    /// "enumerable" (the assignment default). Consulted when mirroring a method
+    /// onto a prototype OBJECT so reflective `Object.keys`/`for-in` see the
+    /// correct attribute.
+    pub static CLASS_PROTOTYPE_METHOD_NONENUM: RwLock<
+        Option<std::collections::HashSet<(u32, String)>>,
+    > = RwLock::new(None);
+}
 
 /// Record the enumerability of the prototype method `(class_id, name)`.
 /// `enumerable == false` (a `defineProperty` data descriptor without an
@@ -343,31 +347,35 @@ pub static CLASS_PROTOTYPE_METHOD_NONENUM: RwLock<
 /// `enumerable == true` removes it again, so a later redefine that flips the
 /// flag back on isn't left shadowed by a stale marker.
 pub(crate) fn class_prototype_method_set_enumerable(class_id: u32, name: &str, enumerable: bool) {
-    let mut guard = CLASS_PROTOTYPE_METHOD_NONENUM.write().unwrap();
-    if enumerable {
-        if let Some(set) = guard.as_mut() {
-            set.remove(&(class_id, name.to_string()));
+    CLASS_PROTOTYPE_METHOD_NONENUM.with(|table| {
+        let mut guard = table.write().unwrap();
+        if enumerable {
+            if let Some(set) = guard.as_mut() {
+                set.remove(&(class_id, name.to_string()));
+            }
+            return;
         }
-        return;
-    }
-    if guard.is_none() {
-        *guard = Some(std::collections::HashSet::new());
-    }
-    guard.as_mut().unwrap().insert((class_id, name.to_string()));
+        if guard.is_none() {
+            *guard = Some(std::collections::HashSet::new());
+        }
+        guard.as_mut().unwrap().insert((class_id, name.to_string()));
+    });
 }
 
 /// Whether the prototype method `(class_id, name)` should be enumerable when
 /// mirrored onto a prototype object. Defaults to `true` (assignment semantics).
 pub(crate) fn class_prototype_method_is_enumerable(class_id: u32, name: &str) -> bool {
-    if let Ok(read) = CLASS_PROTOTYPE_METHOD_NONENUM.read() {
-        if let Some(set) = read.as_ref() {
-            return !set.contains(&(class_id, name.to_string()));
+    CLASS_PROTOTYPE_METHOD_NONENUM.with(|table| {
+        if let Ok(read) = table.read() {
+            if let Some(set) = read.as_ref() {
+                return !set.contains(&(class_id, name.to_string()));
+            }
         }
-    }
-    true
+        true
+    })
 }
 
-per_test_global! {
+crate::perry_thread_local! {
     /// #36 / #321: maps a child class_id to the raw address of a parent CLOSURE
     /// (function value) when `class Child extends <function value> {}`. effect's
     /// `class Svc extends Context.Tag("Svc")<...>() {}` extends the function
@@ -381,30 +389,34 @@ per_test_global! {
     pub static CLASS_PARENT_CLOSURES: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 }
 
-/// Maps a child class_id to the raw NaN-boxed bits of the parent constructor
-/// VALUE that `js_register_class_parent_dynamic` evaluated at class-definition
-/// time. For `class X extends _mod.default {}` (the interop ESM
-/// default-export-class pattern), the extends expression references a require
-/// alias (`_mod`) that is an IIFE-local — bound only in the module-init scope.
-/// The decl-time registration evaluates it there correctly, so we stash the
-/// resulting value here keyed by the child's class id. `super()` then reads it
-/// back via `js_get_dynamic_parent_value` instead of re-evaluating the extends
-/// expression inside the constructor (where the IIFE-local alias is NOT
-/// captured and the member read would throw "Cannot read properties of
-/// undefined"). Stored as raw `u64` bits (Send + Sync), covering both ClassRef
-/// (INT32-tagged) and object/closure (POINTER-tagged) parents.
-pub static CLASS_DYNAMIC_PARENT_VALUE: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
+crate::perry_thread_local! {
+    /// Maps a child class_id to the raw NaN-boxed bits of the parent constructor
+    /// VALUE that `js_register_class_parent_dynamic` evaluated at class-definition
+    /// time. For `class X extends _mod.default {}` (the interop ESM
+    /// default-export-class pattern), the extends expression references a require
+    /// alias (`_mod`) that is an IIFE-local — bound only in the module-init scope.
+    /// The decl-time registration evaluates it there correctly, so we stash the
+    /// resulting value here keyed by the child's class id. `super()` then reads it
+    /// back via `js_get_dynamic_parent_value` instead of re-evaluating the extends
+    /// expression inside the constructor (where the IIFE-local alias is NOT
+    /// captured and the member read would throw "Cannot read properties of
+    /// undefined"). Stored as raw `u64` bits, covering both ClassRef (INT32-tagged)
+    /// and object/closure (POINTER-tagged) parents.
+    pub static CLASS_DYNAMIC_PARENT_VALUE: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
+}
 
-/// #6530: maps a template class_id to the raw NaN-boxed POINTER bits of the
-/// per-evaluation CLASS OBJECT the class statement materialized as (marked by
-/// `js_object_mark_class`). A capture-carrying class has no INT32 ClassRef
-/// value at runtime — the class VALUE is this heap object — so
-/// `instance.constructor` must hand back the same object the module scope /
-/// exports hold, or identity checks (`x.constructor === Sub`, bundled zod's
-/// `describe()` re-construction via `this.constructor`) break. Last-wins
-/// across evaluations of the same class statement, matching the template-cid
-/// compromise used by the sibling tables above.
-pub static CLASS_OBJECT_VALUES: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
+crate::perry_thread_local! {
+    /// #6530: maps a template class_id to the raw NaN-boxed POINTER bits of the
+    /// per-evaluation CLASS OBJECT the class statement materialized as (marked by
+    /// `js_object_mark_class`). A capture-carrying class has no INT32 ClassRef
+    /// value at runtime — the class VALUE is this heap object — so
+    /// `instance.constructor` must hand back the same object the module scope /
+    /// exports hold, or identity checks (`x.constructor === Sub`, bundled zod's
+    /// `describe()` re-construction via `this.constructor`) break. Last-wins
+    /// across evaluations of the same class statement, matching the template-cid
+    /// compromise used by the sibling tables above.
+    pub static CLASS_OBJECT_VALUES: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
+}
 
 /// Store the marked class object for its template class id (see
 /// `CLASS_OBJECT_VALUES`).
@@ -413,11 +425,13 @@ pub(crate) fn class_object_value_root_store(class_id: u32, obj_ptr: *mut ObjectH
         return;
     }
     let bits = crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits();
-    let mut guard = CLASS_OBJECT_VALUES.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
-    }
-    guard.as_mut().unwrap().insert(class_id, bits);
+    CLASS_OBJECT_VALUES.with(|table| {
+        let mut guard = table.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(class_id, bits);
+    });
     crate::gc::runtime_write_barrier_root_raw_ptr(obj_ptr);
 }
 
@@ -428,11 +442,13 @@ pub(crate) fn class_object_value_for_cid(class_id: u32) -> Option<f64> {
     if class_id == 0 {
         return None;
     }
-    CLASS_OBJECT_VALUES.read().ok().and_then(|guard| {
-        guard
-            .as_ref()
-            .and_then(|map| map.get(&class_id).copied())
-            .map(f64::from_bits)
+    CLASS_OBJECT_VALUES.with(|table| {
+        table.read().ok().and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(|map| map.get(&class_id).copied())
+                .map(f64::from_bits)
+        })
     })
 }
 
@@ -440,11 +456,13 @@ pub(crate) fn class_prototype_object_root_store(class_id: u32, proto_ptr: *mut O
     if class_id == 0 || proto_ptr.is_null() {
         return;
     }
-    let mut guard = CLASS_PROTOTYPE_OBJECTS.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
-    }
-    guard.as_mut().unwrap().insert(class_id, proto_ptr as usize);
+    CLASS_PROTOTYPE_OBJECTS.with(|table| {
+        let mut guard = table.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(class_id, proto_ptr as usize);
+    });
     crate::gc::runtime_write_barrier_root_raw_ptr(proto_ptr);
 }
 
@@ -452,11 +470,13 @@ pub(crate) fn class_decl_prototype_object_root_store(class_id: u32, proto_ptr: *
     if class_id == 0 || proto_ptr.is_null() {
         return;
     }
-    let mut guard = CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
-    }
-    guard.as_mut().unwrap().insert(class_id, proto_ptr as usize);
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        let mut guard = table.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(class_id, proto_ptr as usize);
+    });
     crate::gc::runtime_write_barrier_root_raw_ptr(proto_ptr);
 }
 
@@ -464,20 +484,24 @@ pub(crate) fn class_parent_closure_root_store(class_id: u32, closure_addr: usize
     if class_id == 0 || closure_addr == 0 {
         return;
     }
-    let mut guard = CLASS_PARENT_CLOSURES.write().unwrap();
-    if guard.is_none() {
-        *guard = Some(HashMap::new());
-    }
-    guard.as_mut().unwrap().insert(class_id, closure_addr);
+    CLASS_PARENT_CLOSURES.with(|table| {
+        let mut guard = table.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(HashMap::new());
+        }
+        guard.as_mut().unwrap().insert(class_id, closure_addr);
+    });
     crate::gc::runtime_write_barrier_root_raw_ptr(closure_addr as *const u8);
 }
 
 /// Look up the parent-closure address recorded for a child class_id, if any.
 pub(crate) fn class_parent_closure(class_id: u32) -> Option<usize> {
-    CLASS_PARENT_CLOSURES
-        .read()
-        .ok()
-        .and_then(|g| g.as_ref().and_then(|m| m.get(&class_id).copied()))
+    CLASS_PARENT_CLOSURES.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().and_then(|m| m.get(&class_id).copied()))
+    })
 }
 
 /// Walk the class parent chain looking for a registered parent-closure edge.
@@ -511,13 +535,15 @@ pub(crate) fn class_id_for_decl_prototype_object(ptr: usize) -> Option<u32> {
     if ptr == 0 {
         return None;
     }
-    CLASS_DECL_PROTOTYPE_OBJECTS
-        .read()
-        .ok()?
-        .as_ref()?
-        .iter()
-        .find(|(_, &p)| p == ptr)
-        .map(|(k, _)| *k)
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        table
+            .read()
+            .ok()?
+            .as_ref()?
+            .iter()
+            .find(|(_, &p)| p == ptr)
+            .map(|(k, _)| *k)
+    })
 }
 
 /// #7757: a monomorphized specialization (`Gen$num`) must present the GENERIC's
@@ -540,12 +566,14 @@ fn decl_prototype_identity_id(class_id: u32) -> u32 {
 
 pub(crate) fn class_decl_prototype_object(class_id: u32) -> *mut ObjectHeader {
     let class_id = decl_prototype_identity_id(class_id);
-    if let Ok(read) = CLASS_DECL_PROTOTYPE_OBJECTS.read() {
-        if let Some(map) = read.as_ref() {
-            return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
+    CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+        if let Ok(read) = table.read() {
+            if let Some(map) = read.as_ref() {
+                return map.get(&class_id).copied().unwrap_or(0) as *mut ObjectHeader;
+            }
         }
-    }
-    std::ptr::null_mut()
+        std::ptr::null_mut()
+    })
 }
 
 fn class_decl_prototype_method_names(class_id: u32) -> Vec<String> {
@@ -650,12 +678,14 @@ pub(crate) fn class_decl_prototype_value(class_id: u32) -> f64 {
     // write-through in `class_prototype_method_root_store` had no decl-proto to
     // target. Mirrors the existing CLASS_VTABLE_REGISTRY backfill above.
     let registered: Vec<(String, u64)> = {
-        let guard = CLASS_PROTOTYPE_METHODS.read().unwrap();
-        guard
-            .as_ref()
-            .and_then(|map| map.get(&class_id))
-            .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
-            .unwrap_or_default()
+        CLASS_PROTOTYPE_METHODS.with(|table| {
+            let guard = table.read().unwrap();
+            guard
+                .as_ref()
+                .and_then(|map| map.get(&class_id))
+                .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
+                .unwrap_or_default()
+        })
     };
     for (name, value_bits) in registered {
         let enumerable = class_prototype_method_is_enumerable(class_id, &name);
@@ -701,6 +731,73 @@ pub(crate) fn global_object_prototype_bits() -> Option<u64> {
         Some(proto_bits)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod class_realm_isolation_tests {
+    use super::*;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    /// #8001 — a declared class's lazily materialized `.prototype` belongs to
+    /// the agent that materialized it, not to whichever thread first used the
+    /// process-wide class id.
+    ///
+    /// The class id and name are codegen facts shared by both agents. The heap
+    /// object stored under that id is not: each thread owns a separate realm and
+    /// arena. Bootstraps are serialized because the test harness's globalThis
+    /// root slot is process-global, while the barrier keeps both arenas live
+    /// until both addresses have been observed. Before #8001, agent B returned
+    /// agent A's cached pointer at the first-thread-wins gate.
+    #[test]
+    fn a_second_agents_declared_prototype_address_is_its_own() {
+        const CLASS_ID: u32 = 0x7d01_8001;
+        const CLASS_NAME: &[u8] = b"Issue8001Class";
+
+        unsafe {
+            js_register_class_name(CLASS_ID, CLASS_NAME.as_ptr(), CLASS_NAME.len() as u32);
+        }
+
+        let bootstrap_gate = Arc::new(Mutex::new(()));
+        let both_alive = Arc::new(Barrier::new(2));
+        let agent = |gate: Arc<Mutex<()>>, barrier: Arc<Barrier>| {
+            move || -> usize {
+                let addr = {
+                    let _serialized = gate.lock().expect("bootstrap gate");
+                    let bits = class_decl_prototype_value(CLASS_ID).to_bits();
+                    assert_eq!(
+                        bits & crate::value::TAG_MASK,
+                        crate::value::POINTER_TAG,
+                        "the class prototype must materialize before isolation is tested"
+                    );
+                    (bits & crate::value::POINTER_MASK) as usize
+                };
+                barrier.wait();
+                addr
+            }
+        };
+        let spawn_agent = |gate: Arc<Mutex<()>>, barrier: Arc<Barrier>| {
+            std::thread::Builder::new()
+                .stack_size(16 << 20)
+                .spawn(agent(gate, barrier))
+                .expect("spawn realm agent")
+        };
+
+        let a = spawn_agent(Arc::clone(&bootstrap_gate), Arc::clone(&both_alive));
+        let b = spawn_agent(bootstrap_gate, both_alive);
+        let a_addr = a.join().expect("agent A panicked");
+        let b_addr = b.join().expect("agent B panicked");
+
+        for (label, addr) in [("agent A", a_addr), ("agent B", b_addr)] {
+            assert_ne!(
+                addr, 0,
+                "{label} did not materialize a real class prototype; distinctness would be vacuous"
+            );
+        }
+        assert_ne!(
+            a_addr, b_addr,
+            "two live agents must materialize their own Class.prototype objects (#8001)"
+        );
     }
 }
 

--- a/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
+++ b/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
@@ -261,12 +261,15 @@ pub(crate) unsafe fn try_decode_descriptor<'scope>(
         {
             return None;
         }
-        if super::super::class_registry::CLASS_PROTOTYPE_METHODS
-            .read()
-            .ok()
-            .and_then(|g| g.as_ref().map(|m| m.contains_key(&class_id)))
-            .unwrap_or(false)
-        {
+        let has_prototype_methods =
+            super::super::class_registry::CLASS_PROTOTYPE_METHODS.with(|table| {
+                table
+                    .read()
+                    .ok()
+                    .and_then(|g| g.as_ref().map(|m| m.contains_key(&class_id)))
+                    .unwrap_or(false)
+            });
+        if has_prototype_methods {
             return None;
         }
     }

--- a/crates/perry-runtime/src/proxy/metadata.rs
+++ b/crates/perry-runtime/src/proxy/metadata.rs
@@ -318,12 +318,12 @@ mod tests {
         let cid = 0x5151;
         register_test_class(cid);
         let fake_proto_ptr: usize = 0x1_0000; // arbitrary; only used as a map key
-        {
-            let mut guard = crate::object::CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
+        crate::object::CLASS_DECL_PROTOTYPE_OBJECTS.with(|table| {
+            let mut guard = table.write().unwrap();
             guard
                 .get_or_insert_with(std::collections::HashMap::new)
                 .insert(cid, fake_proto_ptr);
-        }
+        });
         let target = f64::from_bits(POINTER_TAG | (fake_proto_ptr as u64 & POINTER_MASK));
         assert_eq!(
             normalize_target_bits(target),

--- a/test-files/test_issue_8001_thread_class_prototype.ts
+++ b/test-files/test_issue_8001_thread_class_prototype.ts
@@ -1,0 +1,44 @@
+// #8001: class prototype registries used to be process-global maps keyed by a
+// codegen class id, even though each value was a raw pointer into one agent's
+// realm-local arena. The first agent to materialize `RealmBox.prototype` then
+// supplied that same object to every later agent.
+//
+// Warm the main realm first so this cannot pass merely because the spawned
+// agent wins first touch. The worker checks both failure directions: it must not
+// inherit the main realm's prototype mutation, and its own mutation must be
+// visible to its instances without changing the main realm afterward.
+//
+// perry-only (`perry/thread` has no Node equivalent), so the stored expected
+// output is the parity gate.
+import { spawn } from "perry/thread";
+
+class RealmBox {
+  value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+}
+
+type MutablePrototype = RealmBox & { owner?: string };
+
+const mainPrototype = RealmBox.prototype as MutablePrototype;
+mainPrototype.owner = "main";
+console.log("main:", String((new RealmBox(1) as MutablePrototype).owner));
+
+function agentProbe(): string {
+  const before = new RealmBox(2) as MutablePrototype;
+  const leaked = String(before.owner);
+
+  const agentPrototype = RealmBox.prototype as MutablePrototype;
+  agentPrototype.owner = "agent";
+  const after = new RealmBox(3) as MutablePrototype;
+  const ownsPrototype = Object.getPrototypeOf(after) === RealmBox.prototype;
+
+  return leaked + "/" + String(after.owner) + "/" + String(ownsPrototype);
+}
+
+const expected = "undefined/agent/true";
+const observed = await spawn((): string => agentProbe());
+console.log("spawn agent:", observed, "match:", observed === expected);
+console.log("main after:", String((new RealmBox(4) as MutablePrototype).owner));

--- a/test-parity/expected/test_issue_8001_thread_class_prototype.txt
+++ b/test-parity/expected/test_issue_8001_thread_class_prototype.txt
@@ -1,0 +1,3 @@
+main: main
+spawn agent: undefined/agent/true match: true
+main after: main


### PR DESCRIPTION
## Summary

Isolates class-registry entries that contain heap pointers, NaN-boxed values, closure identities, or realm-created Symbol keys per Perry agent. This prevents a later perry/thread agent from reusing another realm heap values and prevents one moving collector from rewriting another agent roots.

## Changes

- Move pointer/value-bearing class side tables to Perry hot thread-local storage.
- Keep process-wide code metadata such as vtables, method function pointers, bind lengths, registered class ids, and the synthetic id allocator global.
- Make both full and incremental GC root scanners visit and rewrite only the current agent class roots.
- Add a two-live-agent Rust regression that proves each agent materializes a distinct non-null Class.prototype.
- Add a perry/thread behavioral probe covering prototype mutation isolation in both directions.

## Related issue

Closes #8001

## Test plan

- [ ] cargo build --release clean (not run for the full workspace)
- [ ] Full affected-crate suite (targeted runtime regression and compile checks run instead)
- [x] cargo test --release -p perry-runtime a_second_agents_declared_prototype_address_is_its_own -- --nocapture
- [x] cargo check -p perry-runtime --tests
- [x] cargo fmt --all -- --check
- [x] parity filter 8001: 1/1 expected-output tests passed
- [x] scripts/check_file_size.sh
- [x] scripts/global_sink_isolation.py
- [x] scripts/gc_runtime_root_holders.py
- [x] Added runtime and test-files regression coverage
- [x] Docs not needed: internal runtime ownership fix with no API change

The repository quick pre-tag suite otherwise passed, but its GC store-site inventory reports an existing marker omission at crates/perry-codegen/src/expr/property_set.rs:1457. That file is unchanged by this PR.

## Screenshots / output

The new parity probe prints:

    main: main
    spawn agent: undefined/agent/true match: true
    main after: main

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the fix: prefix convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct
