### PR TITLE
perf(repsel): propagate return shapes across modules

### DIFF
--- a/changelog.d/8025-cross-module-return-shapes.md
+++ b/changelog.d/8025-cross-module-return-shapes.md
@@ -1,0 +1,11 @@
+### Representation selection: propagate fresh return shapes across modules (#7170 R2)
+
+Native compilation now carries proven fresh anonymous-record return shapes
+through exact import bindings and re-exports. Consumer modules can keep those
+results as `Ptr<Shape>` values and use guard-free fixed-offset field loads and
+stores instead of boxing at the module boundary.
+
+A final-HIR prepass establishes the facts before parallel codegen, and imported
+return-shape bindings participate in object-cache keys. Named classes, indirect
+calls, unknown externals, and modules with representation-selection barriers
+remain fail-closed.

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1559,7 +1559,18 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // proven-`this` admission consults them (§5.2 shape barriers, the
     // freeze family, and `prototype_is_stable`). Moved into `CrossModuleCtx`
     // below — computed exactly once per module either way.
-    let module_dispatch_facts = crate::collectors::collect_module_dispatch_facts(hir);
+    let mut module_dispatch_facts = crate::collectors::collect_module_dispatch_facts(hir);
+    let imported_return_shapes = opts
+        .imported_classes
+        .iter()
+        .flat_map(|class| {
+            class
+                .return_shape_imports
+                .iter()
+                .map(move |local| (local.clone(), class.name.clone()))
+        })
+        .collect();
+    module_dispatch_facts.install_imported_return_shapes(imported_return_shapes);
     // Representation-selection Phase 5a: proven-`this` method clones.
     let mut pshape_methods: std::collections::HashMap<
         (String, String),

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -555,6 +555,12 @@ pub struct ImportedClass {
     /// instances by the source module's constructor. `None` falls back
     /// to a freshly-assigned id (legacy behavior).
     pub source_class_id: Option<u32>,
+    /// #7170 R2: LOCAL imported function bindings whose source proof returns
+    /// this exact anonymous-record class. Codegen projects these entries into
+    /// `ModuleDispatchFacts::imported_return_shapes` before collecting region
+    /// facts. Kept beside the class metadata so the proof and the field layout
+    /// it names enter the consumer atomically and share one object-cache key.
+    pub return_shape_imports: Vec<String>,
 }
 
 /// Constructor metadata for a class imported from another module.

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -82,6 +82,7 @@ pub(crate) use proven_this::{
 };
 pub(crate) use ptr_numarray::{NumArrayDensity, NumArrayLocal};
 pub(crate) use ptr_shape::{ptr_shape_locals_enabled, PtrShapeLocal};
+pub(crate) use ptr_shape_returns::collect_exported_return_shapes;
 pub(crate) use refs::{
     collect_let_ids, collect_ref_ids_in_expr, collect_ref_ids_in_stmts, is_clamp_call,
 };

--- a/crates/perry-codegen/src/collectors/ptr_shape_returns.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_returns.rs
@@ -248,6 +248,46 @@ pub(crate) fn collect_return_shape_functions(
     out
 }
 
+/// Export name -> anonymous-record class for source functions whose final HIR
+/// carries a return-shape fact.
+///
+/// This is the producer half of #7170 R2's cross-module increment. It is run
+/// by the compile driver before parallel codegen, so an importing module never
+/// depends on whether its producer happened to compile first. Only direct HIR
+/// functions are exported here: imported `const` closures are live bindings
+/// fetched through variable getters, not the statically-named function symbol
+/// an `ExternFuncRef` call denotes. The first increment also restricts the
+/// payload to content-addressed anonymous shapes; equal names then mean equal
+/// field layouts across modules, while user-class name collisions remain
+/// fail-closed.
+pub(crate) fn collect_exported_return_shapes(hir: &Module) -> HashMap<String, String> {
+    let facts = super::scalar_method_dispatch::collect_module_dispatch_facts(hir);
+    let mut out = HashMap::new();
+
+    let mut insert = |export_name: &str, func_id: u32| {
+        let Some(class_name) = facts.return_shape_class(func_id) else {
+            return;
+        };
+        if !class_name.starts_with("__AnonShape_")
+            || !hir.classes.iter().any(|class| class.name == class_name)
+        {
+            return;
+        }
+        out.insert(export_name.to_string(), class_name.to_string());
+    };
+
+    for function in &hir.functions {
+        if function.is_exported {
+            insert(&function.name, function.id);
+        }
+    }
+    for (export_name, func_id) in &hir.exported_functions {
+        insert(export_name, *func_id);
+    }
+
+    out
+}
+
 /// Visit every expression of every executable body in the module, including
 /// inside nested closure bodies.
 ///
@@ -703,10 +743,12 @@ pub(crate) fn find_return_shape_candidates(
         if boxed_vars.contains(id) || module_globals.contains_key(id) {
             return;
         }
-        let Some(func_id) = callee_names_one_function(callee, module_dispatch) else {
-            return;
+        let class_name = match callee.as_ref() {
+            Expr::ExternFuncRef { name, .. } => module_dispatch.imported_return_shape_class(name),
+            _ => callee_names_one_function(callee, module_dispatch)
+                .and_then(|func_id| module_dispatch.return_shape_class(func_id)),
         };
-        if let Some(class_name) = module_dispatch.return_shape_class(func_id) {
+        if let Some(class_name) = class_name {
             candidates.insert(*id, class_name.to_string());
             seeded.insert(*id);
         }
@@ -735,8 +777,9 @@ pub(crate) fn find_return_shape_candidates(
 ///   `js_typed_feedback_closure_direct_call_guard` because it is populated in
 ///   statement order and a later rebinding invalidates it.
 ///
-/// Anything else — a property get, a computed callee, an `ExternFuncRef` —
-/// could resolve to a different body, and yields `None`.
+/// An `ExternFuncRef` is handled separately by the driver-built import
+/// whitelist: unlike a raw name, that table is keyed by the unique local
+/// import binding and already resolved through aliases/re-exports.
 fn callee_names_one_function(callee: &Expr, module_dispatch: &ModuleDispatchFacts) -> Option<u32> {
     match callee {
         Expr::FuncRef(func_id) => Some(*func_id),

--- a/crates/perry-codegen/src/collectors/ptr_shape_returns_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_returns_tests.rs
@@ -286,6 +286,106 @@ fn call_to_a_return_shape_producer_is_provenance() {
     );
 }
 
+/// #7170 R2: the compile driver resolves an imported function binding to a
+/// source return-shape fact before parallel codegen. An `ExternFuncRef`
+/// carrying that exact LOCAL binding is therefore the same rule-1 provenance
+/// seed as the local `FuncRef` case above.
+///
+/// Sabotage: remove the `ExternFuncRef` arm in
+/// `find_return_shape_candidates`, or key it by an origin/export name instead
+/// of the HIR's local binding, and the positive/alias controls fail.
+#[test]
+fn imported_return_shape_is_provenance_by_exact_local_binding() {
+    let mut facts = super::super::collect_module_dispatch_facts(&Module::new("consumer"));
+    facts.install_imported_return_shapes(HashMap::from([(
+        "makeLocal".to_string(),
+        "C".to_string(),
+    )]));
+    let c = class_c();
+    let classes = classes_of(&c);
+
+    let caller = |callee_name: &str, local_id: u32| {
+        vec![
+            Stmt::Let {
+                id: local_id,
+                name: "r".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::ExternFuncRef {
+                        name: callee_name.to_string(),
+                        param_types: Vec::new(),
+                        return_type: Type::Any,
+                    }),
+                    args: Vec::new(),
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                }),
+            },
+            store_x(local_id),
+        ]
+    };
+
+    let promoted = promote(&caller("makeLocal", 20), &classes, &facts);
+    assert_eq!(
+        promoted.get(&20).map(|fact| fact.class_name.as_str()),
+        Some("C")
+    );
+    assert!(
+        !promote(&caller("makeAtOrigin", 21), &classes, &facts).contains_key(&21),
+        "an origin/export spelling must not match a differently-named local import"
+    );
+}
+
+/// The whole-program pre-pass exports only direct function symbols returning
+/// content-addressed anonymous records. Named user classes remain fail-closed
+/// in this first cross-module increment, and aliases in `exported_functions`
+/// carry the same proven body under their consumer-visible export name.
+#[test]
+fn exported_return_shape_prepass_is_anon_only_and_alias_aware() {
+    const ANON: &str = "__AnonShape_0123456789abcdef";
+
+    let mut anon = class_c();
+    anon.name = ANON.to_string();
+    let mut producer = function(
+        70,
+        "makeRecord",
+        vec![Stmt::Return(Some(Expr::New {
+            class_name: ANON.to_string(),
+            args: Vec::new(),
+            type_args: Vec::new(),
+            byte_offset: 0,
+            cap_args_appended: 0,
+        }))],
+    );
+    producer.is_exported = true;
+
+    let mut hir = Module::new("producer");
+    hir.classes = vec![anon, class_c()];
+    hir.functions = vec![
+        producer,
+        function(71, "makeNamed", vec![Stmt::Return(Some(new_c()))]),
+    ];
+    hir.exported_functions = vec![
+        ("recordAlias".to_string(), 70),
+        ("namedAlias".to_string(), 71),
+    ];
+
+    let exports = super::collect_exported_return_shapes(&hir);
+    assert_eq!(exports.get("makeRecord").map(String::as_str), Some(ANON));
+    assert_eq!(exports.get("recordAlias").map(String::as_str), Some(ANON));
+    assert!(!exports.contains_key("namedAlias"));
+
+    // The source module's barrier must suppress the exported fact just as it
+    // suppresses a same-module caller fact; the driver may not resurrect it.
+    hir.init = vec![Stmt::Expr(Expr::Delete(Box::new(Expr::PropertyGet {
+        object: Box::new(Expr::LocalGet(999)),
+        property: "x".to_string(),
+        byte_offset: 0,
+    })))];
+    assert!(super::collect_exported_return_shapes(&hir).is_empty());
+}
+
 /// `return new C()` directly is fresh by construction — no body proof needed.
 #[test]
 fn direct_new_return_is_a_fact() {

--- a/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
+++ b/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
@@ -88,6 +88,11 @@ pub struct ModuleDispatchFacts {
     /// (`collectors/ptr_shape_returns.rs`); a call to such a function is then
     /// a rule-1 provenance seed exactly as `new C(...)` is.
     return_shape_functions: HashMap<u32, String>,
+    /// Representation-selection Phase 3b, #7170 R2: LOCAL imported function
+    /// name -> exact anonymous-record class returned by its source body.
+    /// Populated by the compile driver from a whole-program pre-pass over
+    /// final HIR, after this module's own barrier/producer facts are collected.
+    imported_return_shapes: HashMap<String, String>,
     /// Representation-selection Phase 3b, #7170 R1: `LocalId` -> `FuncId` for
     /// every local that provably names one closure literal, module-wide.
     ///
@@ -115,6 +120,7 @@ impl Default for ModuleDispatchFacts {
             numarray_prototype_index_barriers: true,
             freeze_barrier_sites: true,
             return_shape_functions: HashMap::new(),
+            imported_return_shapes: HashMap::new(),
             closure_bindings: HashMap::new(),
         }
     }
@@ -191,6 +197,22 @@ impl ModuleDispatchFacts {
             .map(String::as_str)
     }
 
+    /// The anonymous-record class returned by one statically-resolved native
+    /// import, if the whole-program pre-pass proved that source body.
+    pub(crate) fn imported_return_shape_class(&self, local_name: &str) -> Option<&str> {
+        self.imported_return_shapes
+            .get(local_name)
+            .map(String::as_str)
+    }
+
+    /// Install the driver-resolved import whitelist after the module-local
+    /// barrier and producer scan has finished. Keeping this out of
+    /// [`collect_module_dispatch_facts`] preserves its module-only contract
+    /// for unit tests and producer pre-passes.
+    pub(crate) fn install_imported_return_shapes(&mut self, shapes: HashMap<String, String>) {
+        self.imported_return_shapes = shapes;
+    }
+
     /// Representation-selection Phase 3b, #7170 R1: the `FuncId` that
     /// `LocalGet(local_id)` in callee position provably names, or `None`.
     ///
@@ -212,6 +234,7 @@ pub fn collect_module_dispatch_facts(hir: &Module) -> ModuleDispatchFacts {
         numarray_prototype_index_barriers: false,
         freeze_barrier_sites: false,
         return_shape_functions: HashMap::new(),
+        imported_return_shapes: HashMap::new(),
         // #7170 R1. Purely structural — no barrier flag feeds it, and it is
         // read only through `closure_binding_func`, whose every consumer treats
         // `None` as "take no seed". Computed here rather than lazily so the one
@@ -679,6 +702,7 @@ mod tests {
             numarray_prototype_index_barriers: false,
             freeze_barrier_sites: false,
             return_shape_functions: HashMap::new(),
+            imported_return_shapes: HashMap::new(),
             closure_bindings: HashMap::new(),
         }
     }

--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -159,6 +159,18 @@ pub fn module_has_ptr_shape_barrier(hir: &perry_hir::Module) -> bool {
     collectors::collect_module_dispatch_facts(hir).has_shape_barrier_sites()
 }
 
+/// #7170 R2 whole-program pre-pass: exported native function name -> fresh
+/// anonymous-record class returned by that function's final HIR.
+///
+/// Public only for the `perry` compile driver, which resolves these source
+/// facts through imports/re-exports before modules are code-generated in
+/// parallel. Consumers should treat absence as "no proof".
+pub fn module_exported_return_shapes(
+    hir: &perry_hir::Module,
+) -> std::collections::HashMap<String, String> {
+    collectors::collect_exported_return_shapes(hir)
+}
+
 /// #7152 template-change canary: what the `Ptr<Shape>` report suppresses in
 /// `hir` as Perry's own `cjs_wrap` scaffolding.
 ///

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -607,6 +607,13 @@ fn compute_object_cache_key_with_env(
                     .collect::<Vec<_>>()
                     .join(","),
             );
+            // #7170 R2: these facts derive from producer HIR, not the
+            // consumer HIR hashed by this cache entry. Keep them in the
+            // ImportedClass record so proof + layout invalidate atomically.
+            buf.push_str(":return_shape_imports=");
+            let mut return_shape_imports = c.return_shape_imports.clone();
+            return_shape_imports.sort();
+            buf.push_str(&return_shape_imports.join(","));
             buf.push('|');
         }
         h.field("imported_classes", &buf);

--- a/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
+++ b/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
@@ -362,6 +362,7 @@ fn key_stable_for_nested_type_hashmap_order() {
         field_types: vec![field_type],
         static_field_names: vec![],
         source_class_id: Some(7),
+        return_shape_imports: vec![],
     };
 
     a = empty_opts();
@@ -397,6 +398,7 @@ fn key_changes_with_imported_class_signature() {
         field_types: vec![],
         static_field_names: vec![],
         source_class_id: Some(42),
+        return_shape_imports: vec![],
     });
     b.imported_classes.push(ImportedClass {
         name: "Foo".into(),
@@ -417,6 +419,7 @@ fn key_changes_with_imported_class_signature() {
         field_types: vec![],
         static_field_names: vec![],
         source_class_id: Some(42),
+        return_shape_imports: vec![],
     });
     assert_ne!(
         compute_object_cache_key(&a, 1, "0.5.156"),
@@ -445,6 +448,7 @@ fn key_changes_with_imported_class_codegen_surface() {
         field_types: vec![perry_hir::types::Type::Number],
         static_field_names: vec![],
         source_class_id: Some(42),
+        return_shape_imports: vec![],
     };
     let key_for = |class: ImportedClass| {
         let mut opts = empty_opts();
@@ -468,6 +472,16 @@ fn key_changes_with_imported_class_codegen_surface() {
     let mut changed = base.clone();
     changed.static_method_names = vec!["make".into()];
     assert_ne!(base_key, key_for(changed));
+
+    let mut changed = base.clone();
+    changed.return_shape_imports = vec!["makeRow".into()];
+    assert_ne!(base_key, key_for(changed));
+
+    let mut first_order = base.clone();
+    first_order.return_shape_imports = vec!["makeB".into(), "makeA".into()];
+    let mut second_order = base.clone();
+    second_order.return_shape_imports = vec!["makeA".into(), "makeB".into()];
+    assert_eq!(key_for(first_order), key_for(second_order));
 
     let mut changed = base.clone();
     changed.static_field_names = vec!["VERSION".into()];

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -279,6 +279,7 @@ fn imported_class_from_hir(
             .map(|field| field.ty.clone())
             .collect(),
         source_class_id: Some(class.id),
+        return_shape_imports: Vec::new(),
     }
 }
 
@@ -994,6 +995,15 @@ pub fn run_with_parse_cache(
     // Build a map of all exported functions with their return types from all modules
     let mut exported_func_return_types: BTreeMap<(String, String), perry_hir::types::Type> =
         BTreeMap::new();
+    // #7170 R2: final-HIR return-shape facts for directly exported native
+    // functions. Values are content-addressed anonymous-record class names;
+    // keys use the declaring path + exported symbol name, exactly like the
+    // function return-type metadata beside it. Import resolution later walks
+    // aliases/re-exports to this origin key before installing a consumer fact.
+    //
+    // Harvest all modules before rayon starts codegen so the result is
+    // independent of module compile order.
+    let mut exported_return_shapes: BTreeMap<(String, String), &perry_hir::Class> = BTreeMap::new();
     // Set of exported functions that were declared `async` in their source module.
     // We track this separately because users routinely write `async function f() { ... }`
     // without an explicit `Promise<T>` annotation, in which case `func.return_type` is the
@@ -1001,6 +1011,15 @@ pub fn run_with_parse_cache(
     let mut exported_async_funcs: BTreeSet<(String, String)> = BTreeSet::new();
     for (path, hir_module) in &ctx.native_modules {
         let path_str = path.to_string_lossy().to_string();
+        for (export_name, class_name) in perry_codegen::module_exported_return_shapes(hir_module) {
+            if let Some(class) = hir_module
+                .classes
+                .iter()
+                .find(|class| class.name == class_name)
+            {
+                exported_return_shapes.insert((path_str.clone(), export_name), class);
+            }
+        }
         for func in &hir_module.functions {
             if func.is_exported {
                 exported_func_param_counts
@@ -3769,6 +3788,45 @@ pub fn run_with_parse_cache(
                     // Imported return types
                     if let Some(return_type) = exported_func_return_types.get(&key) {
                         imported_return_types.insert(local_name.clone(), return_type.clone());
+                    }
+
+                    // #7170 R2: cross-module return-shape provenance. Resolve
+                    // the same exact origin path/name the call-symbol plumbing
+                    // above uses, then install both halves atomically:
+                    //
+                    //  * LOCAL ExternFuncRef name -> returned shape, and
+                    //  * the source class's field metadata in imported_classes.
+                    //
+                    // The producer pre-pass exports anonymous record shapes
+                    // only. Their names content-address the complete field
+                    // shape, so a same-named local class is the same layout;
+                    // named user classes remain fail-closed in this increment.
+                    let return_shape_origin_name = resolved_origin_name
+                        .as_ref()
+                        .unwrap_or(&exported_name)
+                        .clone();
+                    let return_shape_key = (origin_path.clone(), return_shape_origin_name);
+                    if let Some(class) = exported_return_shapes.get(&return_shape_key).copied() {
+                        let imported_index = match imported_classes
+                            .iter()
+                            .position(|imported| imported.name == class.name)
+                        {
+                            Some(index) => index,
+                            None => {
+                                let class_prefix =
+                                    compute_module_prefix(&origin_path, &ctx.project_root);
+                                imported_classes.push(imported_class_from_hir(
+                                    class,
+                                    class_prefix,
+                                    None,
+                                ));
+                                imported_classes.len() - 1
+                            }
+                        };
+                        let imported = &mut imported_classes[imported_index];
+                        if !imported.return_shape_imports.contains(&local_name) {
+                            imported.return_shape_imports.push(local_name.clone());
+                        }
                     }
 
                     // Imported async functions

--- a/test-files/_helpers/repsel_cross_module_return_shape.ts
+++ b/test-files/_helpers/repsel_cross_module_return_shape.ts
@@ -1,0 +1,14 @@
+// Cross-module return-shape producer for `test_gap_repsel_return_shape.ts`
+// (#7170 R2). Keep this as an anonymous-record return: its content-addressed
+// `__AnonShape_*` class is the identity the importing module can prove without
+// relying on a module-local `FuncId`.
+
+export interface CrossModuleRow {
+  key: string;
+  value: number;
+  tag: string;
+}
+
+export function makeCrossModuleRow(i: number): CrossModuleRow {
+  return { key: "xm" + i, value: i * 3, tag: "cross" };
+}

--- a/test-files/_helpers/repsel_cross_module_return_shape_barrel.ts
+++ b/test-files/_helpers/repsel_cross_module_return_shape_barrel.ts
@@ -1,0 +1,5 @@
+// Exercise origin-path and origin-name resolution together: the consumer uses
+// a third spelling, while the return-shape proof belongs to the leaf export.
+export {
+  makeCrossModuleRow as makeBarrelRow,
+} from "./repsel_cross_module_return_shape.ts";

--- a/test-files/test_gap_repsel_return_shape.ts
+++ b/test-files/test_gap_repsel_return_shape.ts
@@ -9,9 +9,10 @@
 //
 // The promotions this file is *about* are asserted structurally, not here:
 // `perry test-files/test_gap_repsel_return_shape.ts --opt-report` must list
-// `producedRec`, `shaped`, `survivor`, `acc`, `poisoned` and friends as
-// `Ptr<Shape>`. A green run of this file with zero promotions would be a
-// vacuous pass (#7024/#7025), so the count is checked in review, not inferred.
+// `producedRec`, `shaped`, `survivor`, `imported`, `acc`, `poisoned` and
+// friends as `Ptr<Shape>`. A green run of this file with zero promotions would
+// be a vacuous pass (#7024/#7025), so the count is checked in review, not
+// inferred.
 //
 // Covered:
 //  1. producer-side: a contained local whose only escape is `return o`,
@@ -24,7 +25,13 @@
 //     slot must be re-derived and rewritten, RFC §5.6),
 //  6. `finally` running after the return value is computed,
 //  7. producers that must NOT carry a fact: an aliased cache, a
-//     fall-through-to-undefined path, an indirect callee.
+//     fall-through-to-undefined path, an indirect callee,
+//  8. an anonymous-record producer imported under a renamed local binding,
+//     kept live across collection-triggering churn before its fields are read.
+
+import {
+  makeBarrelRow as makeImportedRow,
+} from "./_helpers/repsel_cross_module_return_shape_barrel.ts";
 
 class Rec {
   id: number;
@@ -161,6 +168,20 @@ function survivesGc(n: number): string {
   return survivor.name + "/" + survivor.score.toFixed(2) + "/" + sink;
 }
 
+// 8. The callee is an ExternFuncRef rather than a module-local FuncRef. The
+// driver resolves the export back to its source module and installs the
+// content-addressed anonymous shape under this exact renamed local binding.
+function importedSurvivesGc(n: number): string {
+  const imported = makeImportedRow(5);
+  imported.value = imported.value + 1;
+  let sink = 0;
+  for (let i = 0; i < n; i++) {
+    churn(i);
+    sink = sink + imported.value;
+  }
+  return imported.key + "/" + imported.tag + "/" + imported.value + "/" + sink;
+}
+
 // 6. `finally` runs after the return value is computed but before the caller
 // resumes — the ordering the return exemption's soundness argument rests on.
 function returnThenFinally(): string {
@@ -209,6 +230,7 @@ out.push(readMixed(1));
 out.push(readMixed(2));
 out.push(readMixed(3));
 out.push(survivesGc(120000));
+out.push(importedSurvivesGc(120000));
 out.push(returnThenFinally());
 
 const c1 = getCached();


### PR DESCRIPTION
## Summary

Propagate proven fresh anonymous-record return shapes across native module boundaries so callers can keep exact `Ptr<Shape>` representations instead of boxing at imports.

## Changes

- Harvest anonymous-record return-shape facts from every final-HIR module before parallel codegen.
- Resolve facts through exact import aliases and re-exports, then attach the proven class layout to consumer modules.
- Keep named classes, indirect calls, unknown externals, and barriered modules fail-closed.
- Include imported return-shape bindings in object-cache keys.
- Add unit and parity coverage for a renamed re-export, local import alias, field stores/loads, and collection-triggering churn.

## Related issue

Refs #7170

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --profile perry-dev -p perry-codegen -p perry`
- [x] `cargo test --profile perry-dev -p perry-codegen --lib ptr_shape_returns --no-fail-fast` — 37 passed
- [x] `cargo test --profile perry-dev -p perry --bin perry object_cache --no-fail-fast` — 46 passed
- [x] Filtered parity fixture — 1/1 byte-exact against Node
- [x] Filtered seven-arm GC stress matrix — 7/7 byte-exact; the shipped-default arm observed productive collections. The narrow moving-GC arms observed no moved objects, so this does not claim moving-object liveness coverage.
- [ ] `cargo build --release` clean
- [ ] Full affected-crate suite passes
- [x] Added or updated a test under `test-files/`
- [ ] Documentation update — not applicable; no CLI, configuration, stdlib, or runtime API change
- [ ] Platform UI build — not applicable

## Screenshots / output

The optimization report selects `Ptr<Shape>` for the imported result and records `class_field_get.shape_proven_load` plus `ptr_shape_set` consumers.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the repository commit-prefix convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct