### PR TITLE
fix(ci): normalize Windows temp path before tar

### DIFF
--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -335,25 +335,27 @@ jobs:
             # archive — one directory, so opt and clang cannot skew.
             exe=".exe"
             llvm_ver=22.1.3
-            llvm_root="$RUNNER_TEMP/clang+llvm-$llvm_ver-x86_64-pc-windows-msvc"
+            # Git Bash exposes RUNNER_TEMP as a native `D:\...` path. Convert
+            # it before any Unix tool sees it: the runner's bsdtar still treats
+            # `D:` as a remote host even when passed GNU tar's --force-local.
+            runner_temp_posix="$(cygpath -u "$RUNNER_TEMP")"
+            llvm_root="$runner_temp_posix/clang+llvm-$llvm_ver-x86_64-pc-windows-msvc"
             if [ ! -x "$llvm_root/bin/opt.exe" ]; then
-              curl -sSL --retry 3 -o "$RUNNER_TEMP/llvm.tar.xz" \
+              curl -sSL --retry 3 -o "$runner_temp_posix/llvm.tar.xz" \
                 "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvm_ver/clang+llvm-$llvm_ver-x86_64-pc-windows-msvc.tar.xz"
-              # --force-local: this step runs under Git-bash, where $RUNNER_TEMP
-              # is a WINDOWS path (`D:\a\_temp`). GNU tar reads `D:` as a remote
-              # `host:path` and tries to rsh to a host named `D`, which is the
-              # 2026-08-11 failure verbatim:
+              # The old --force-local workaround was ineffective because the
+              # Windows runner supplies bsdtar, not GNU tar. Passing the
+              # cygpath-normalized archive and destination avoids the remote
+              # `host:path` grammar entirely. The previous failure was:
               #     tar (child): Cannot connect to D: resolve failed
               #     xz: (stdin): File format not recognized
               #     tar: Error is not recoverable: exiting now      (exit 2)
-              # `-C` is not parsed for a remote spec, so only the ARCHIVE path
-              # needs the flag. Verify the extraction rather than trusting it:
-              # a half-extracted tree would otherwise surface as the much more
-              # confusing "no matched opt+clang pair" error below.
-              tar --force-local -xJf "$RUNNER_TEMP/llvm.tar.xz" -C "$RUNNER_TEMP"
+              # Verify extraction rather than trusting it: a half-extracted
+              # tree otherwise becomes a misleading tool-pair error below.
+              tar -xJf "$runner_temp_posix/llvm.tar.xz" -C "$runner_temp_posix"
               if [ ! -x "$llvm_root/bin/opt.exe" ]; then
-                echo "::error::extracted $RUNNER_TEMP/llvm.tar.xz but $llvm_root/bin/opt.exe is still missing — the archive layout changed, or the download was truncated"
-                ls -la "$RUNNER_TEMP" | head -20
+                echo "::error::extracted $runner_temp_posix/llvm.tar.xz but $llvm_root/bin/opt.exe is still missing — the archive layout changed, or the download was truncated"
+                ls -la "$runner_temp_posix" | head -20
                 exit 1
               fi
             fi

--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -373,11 +373,20 @@ jobs:
             echo "::error::no matched opt+clang pair under $llvm_bin — RS4GC cannot run, and silently skipping it is exactly the gate that cannot fail"
             exit 1
           fi
-          export PERRY_LLVM_OPT="$llvm_bin/opt$exe"
-          export PERRY_LLVM_CLANG="$llvm_bin/clang$exe"
+          llvm_opt="$llvm_bin/opt$exe"
+          llvm_clang="$llvm_bin/clang$exe"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # Shell tools need the POSIX path above, while native perry.exe
+            # reads these environment values directly as Windows PathBufs.
+            export PERRY_LLVM_OPT="$(cygpath -w "$llvm_opt")"
+            export PERRY_LLVM_CLANG="$(cygpath -w "$llvm_clang")"
+          else
+            export PERRY_LLVM_OPT="$llvm_opt"
+            export PERRY_LLVM_CLANG="$llvm_clang"
+          fi
           echo "RS4GC toolchain: $llvm_bin"
-          "$PERRY_LLVM_OPT" --version | head -2
-          "$PERRY_LLVM_CLANG" --version | head -2
+          "$llvm_opt" --version | head -2
+          "$llvm_clang" --version | head -2
 
           pass=0
           total=0


### PR DESCRIPTION
## Summary

- convert the native Windows RUNNER_TEMP value with cygpath before passing it to curl, 	ar, and Unix file tests
- remove the ineffective GNU --force-local workaround from the Windows native-roots arm
- keep the post-extraction LLVM pair verification and improve its paths

The current failure is 	ar (child): Cannot connect to D: resolve failed: the Windows runner's tar parses D: as a remote host. A /d/... path avoids that grammar entirely.

## Validation

- parsed the workflow as YAML
- exercised the exact quoted cygpath -u conversion under Git for Windows against a native C:\... path
- git diff --check

No version bump.

Refs #7970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build setup by correctly handling temporary directory paths when downloading and extracting LLVM.
  * Fixed archive extraction verification to report the correct normalized location.
  * Removed an ineffective workaround that could interfere with local archive handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->