### PR TITLE
fix(nextjs): make lazy path modules deadlock-free

### DIFF
--- a/changelog.d/8043-next-dylib-lazy-path-modules.md
+++ b/changelog.d/8043-next-dylib-lazy-path-modules.md
@@ -1,8 +1,9 @@
 ### Make production Next.js lazy path modules deadlock-free
 
-Production webpack modules under `.next/server` now initialize exactly once
-when first required by canonical path, including from app-only dylibs backed by
-shared runtime providers. Concurrent callers wait without holding loader locks,
-CommonJS cycles can observe partial exports, real `undefined` exports remain
+Production webpack modules under `.next/server` now use a provider-owned
+registry for once-only initialization when first required by canonical path.
+Executable and app-only dylib entry points both emit lazy initializer
+registrations. Concurrent callers wait without holding loader locks, CommonJS
+cycles can observe partial exports, real `undefined` exports remain
 distinguishable from misses, and initialization failures are cached and replayed
 without retry.

--- a/changelog.d/8043-next-dylib-lazy-path-modules.md
+++ b/changelog.d/8043-next-dylib-lazy-path-modules.md
@@ -1,0 +1,8 @@
+### Make production Next.js lazy path modules deadlock-free
+
+Production webpack modules under `.next/server` now initialize exactly once
+when first required by canonical path, including from app-only dylibs backed by
+shared runtime providers. Concurrent callers wait without holding loader locks,
+CommonJS cycles can observe partial exports, real `undefined` exports remain
+distinguishable from misses, and initialization failures are cached and replayed
+without retry.

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -1271,7 +1271,18 @@ pub(super) fn compile_module_entry(
                     }
                     blk.call_void(&format!("{}__init", dep_prefix), &[]);
                 }
-                blk.call_void(&init_body_name, &[]);
+                // Run each module body behind a native exception boundary.
+                // A CommonJS wrapper publishes partial exports at the top of
+                // this body; if an exception escapes before final publication,
+                // the runtime caches that exact failure and wakes path-module
+                // waiters before rethrowing. Keeping the boundary here avoids
+                // adding a JavaScript `try` block that would change top-level
+                // `let`/`const`/`class` scope in flat CJS emission.
+                let init_body_addr = format!("ptrtoint (ptr @{} to i64)", init_body_name);
+                blk.call_void(
+                    "js_run_module_init_catching",
+                    &[(I64, init_body_addr.as_str())],
+                );
                 blk.ret_void();
             }
         }

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -461,18 +461,14 @@ pub(super) fn compile_module_entry(
         // `.next/server/**` module path now (before `main` borrows `llmod`); the
         // registration calls go in the block below. `(string_const_name,
         // byte_len, sanitized_prefix)`.
-        let nextjs_path_inits: Vec<(String, usize, String)> = if is_dylib {
-            Vec::new()
-        } else {
-            cross_module
-                .nextjs_path_init_modules
-                .iter()
-                .map(|(path, prefix)| {
-                    let (cn, len) = llmod.add_string_constant(path);
-                    (cn, len, prefix.clone())
-                })
-                .collect()
-        };
+        let nextjs_path_inits: Vec<(String, usize, String)> = cross_module
+            .nextjs_path_init_modules
+            .iter()
+            .map(|(path, prefix)| {
+                let (cn, len) = llmod.add_string_constant(path);
+                (cn, len, prefix.clone())
+            })
+            .collect();
         let main = if is_dylib {
             llmod.define_function("perry_module_init", VOID, vec![])
         } else {

--- a/crates/perry-codegen/src/codegen/entry/tests.rs
+++ b/crates/perry-codegen/src/codegen/entry/tests.rs
@@ -191,3 +191,24 @@ fn executable_and_app_dylib_both_register_lazy_path_initializers() {
         );
     }
 }
+
+#[test]
+fn module_init_body_runs_through_native_exception_boundary() {
+    let mut opts = entry_opts("executable");
+    opts.is_entry_module = false;
+    let ir = String::from_utf8(compile_module(&empty_module(), opts).unwrap())
+        .expect("LLVM IR should be UTF-8");
+
+    assert!(
+        ir.contains("call void @js_run_module_init_catching("),
+        "module init must cache an escaping CJS partial-export failure before rethrowing\n{ir}"
+    );
+    assert!(
+        ir.contains("__init_body to i64)"),
+        "the exception boundary must receive the generated module body address\n{ir}"
+    );
+    assert!(
+        !ir.contains("call void @gc_exit_teardown_ts__init_body()"),
+        "the generated wrapper must not bypass the exception boundary\n{ir}"
+    );
+}

--- a/crates/perry-codegen/src/codegen/entry/tests.rs
+++ b/crates/perry-codegen/src/codegen/entry/tests.rs
@@ -96,6 +96,19 @@ fn emitted_ir(output_type: &str) -> String {
         .expect("LLVM IR should be UTF-8")
 }
 
+fn emitted_path_init_ir(output_type: &str) -> String {
+    let mut opts = entry_opts(output_type);
+    opts.non_entry_module_prefixes = vec!["lazy_chunk_js".to_string()];
+    opts.deferred_module_prefixes
+        .insert("lazy_chunk_js".to_string());
+    opts.nextjs_path_init_modules = vec![(
+        "/fixture/.next/server/chunks/lazy.js".to_string(),
+        "lazy_chunk_js".to_string(),
+    )];
+    String::from_utf8(compile_module(&empty_module(), opts).unwrap())
+        .expect("LLVM IR should be UTF-8")
+}
+
 #[test]
 fn executable_exit_releases_collection_side_allocations_last() {
     let ir = emitted_ir("executable");
@@ -152,4 +165,29 @@ fn dylib_entry_does_not_release_process_owned_collection_storage() {
         !ir.contains("call void @js_gc_release_current_thread_collection_side_allocations()"),
         "a library return is not a process-exit boundary"
     );
+}
+
+#[test]
+fn executable_and_app_dylib_both_register_lazy_path_initializers() {
+    for output_type in ["executable", "dylib"] {
+        let ir = emitted_path_init_ir(output_type);
+        let entry_symbol = if output_type == "dylib" {
+            "define void @perry_module_init()"
+        } else {
+            "define i32 @main()"
+        };
+        assert!(ir.contains(entry_symbol), "missing {entry_symbol}\n{ir}");
+        assert!(
+            ir.contains("call void @js_register_path_init("),
+            "{output_type} entry omitted the provider-visible lazy path registration\n{ir}"
+        );
+        assert!(
+            ir.contains("ptrtoint (ptr @lazy_chunk_js__init to i64)"),
+            "{output_type} entry did not register the generated init function\n{ir}"
+        );
+        assert!(
+            !ir.contains("call void @lazy_chunk_js__init()"),
+            "path-only module must remain cold at {output_type} startup\n{ir}"
+        );
+    }
 }

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -364,8 +364,8 @@ pub struct CompileOptions {
     pub dynamic_import_path_to_prefix: std::collections::HashMap<String, String>,
 
     /// Next.js wall 54 (part 2): `(absolute_source_path, sanitized_prefix)` for
-    /// every Deferred `.next/server/**` module. The entry's `main` emits a
-    /// `js_register_path_init(path, &<prefix>__init)` for each so a runtime
+    /// every Deferred `.next/server/**` module. The entry's `main` or
+    /// `perry_module_init` emits a `js_register_path_init` for each so a runtime
     /// `require(absolutePath)` can lazily trigger the module's init. Only
     /// populated for the entry module; empty otherwise.
     pub nextjs_path_init_modules: Vec<(String, String)>,
@@ -957,7 +957,8 @@ pub(crate) struct CrossModuleCtx {
     pub dynamic_import_path_to_prefix: std::collections::HashMap<String, String>,
     /// Next.js wall 54 (part 2): `(absolute_source_path, sanitized_prefix)` for
     /// every Deferred `.next/server/**` module — see [`CompileOptions`]. The
-    /// entry's `main` emits one `js_register_path_init` per entry.
+    /// entry's executable or dylib initializer emits one
+    /// `js_register_path_init` per entry.
     pub nextjs_path_init_modules: Vec<(String, String)>,
     /// Issue #753: sanitized prefixes of modules reached only through
     /// dynamic `import()` edges. Their `<prefix>__init` is excluded

--- a/crates/perry-codegen/src/lower_call/native/native_runtime_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_runtime_branch.rs
@@ -93,7 +93,24 @@
                     &[(DOUBLE, &from), (DOUBLE, &specifier)],
                 ));
             }
-            // Next.js wall 54: register an AOT-compiled module by absolute path.
+            // Next.js wall 54: publish a CJS module's partial exports before
+            // its body so same-thread recursive requires can observe them.
+            "registerPathModulePartial" => {
+                let path = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                let exports = args.get(1).map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                ctx.block().call_void(
+                    "js_register_path_module_partial",
+                    &[(DOUBLE, &path), (DOUBLE, &exports)],
+                );
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
+            // Next.js wall 54: publish the final exports by absolute path.
             "registerPathModule" => {
                 let path = args.first().map_or_else(
                     || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
@@ -118,6 +135,17 @@
                 return Ok(ctx
                     .block()
                     .call(DOUBLE, "js_require_path_module", &[(DOUBLE, &path)]));
+            }
+            // Presence bit for a real path module whose export value is
+            // JavaScript `undefined` (which cannot itself signal a hit).
+            "hasPathModule" => {
+                let path = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx
+                    .block()
+                    .call(DOUBLE, "js_has_path_module", &[(DOUBLE, &path)]));
             }
             _ => {}
         }

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -337,6 +337,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     // Next.js wall 54: runtime `require(absolutePath.js)` -> AOT-compiled module.
     module.declare_function("js_register_path_module_partial", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_register_path_module", VOID, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_run_module_init_catching", VOID, &[I64]);
     module.declare_function("js_require_path_module", DOUBLE, &[DOUBLE]);
     module.declare_function("js_has_path_module", DOUBLE, &[DOUBLE]);
     // Next.js wall 54 (part 2): register a Deferred module's `__init` address by

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -335,8 +335,10 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_require_resolve_node_modules", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_globalthis_seed_async_local_storage", VOID, &[]);
     // Next.js wall 54: runtime `require(absolutePath.js)` -> AOT-compiled module.
+    module.declare_function("js_register_path_module_partial", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_register_path_module", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_require_path_module", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_has_path_module", DOUBLE, &[DOUBLE]);
     // Next.js wall 54 (part 2): register a Deferred module's `__init` address by
     // path so a runtime `require(absolutePath)` can trigger its lazy init.
     module.declare_function("js_register_path_init", VOID, &[PTR, I64, I64]);

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -262,8 +262,29 @@ pub(super) fn try_global_builtins(
                     args: vec![from, specifier],
                 }));
             }
-            // Wall 54: register an AOT-compiled module's exports under its
-            // absolute source path (emitted at the tail of each CJS wrapper).
+            // Wall 54: publish the initial CJS exports object before the body
+            // so a recursive path require can observe partial exports.
+            "__perry_register_path_module_partial" => {
+                let path = if !args.is_empty() {
+                    args.remove(0)
+                } else {
+                    Expr::Undefined
+                };
+                let exports = if !args.is_empty() {
+                    args.remove(0)
+                } else {
+                    Expr::Undefined
+                };
+                return Ok(Ok(Expr::NativeMethodCall {
+                    module: "__perry_runtime".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "registerPathModulePartial".to_string(),
+                    args: vec![path, exports],
+                }));
+            }
+            // Wall 54: publish an AOT-compiled module's final exports under
+            // its absolute source path (emitted at the tail of each wrapper).
             "__perry_register_path_module" => {
                 let path = if !args.is_empty() {
                     args.remove(0)
@@ -296,6 +317,22 @@ pub(super) fn try_global_builtins(
                     class_name: None,
                     object: None,
                     method: "requirePathModule".to_string(),
+                    args: vec![path],
+                }));
+            }
+            // Presence bit paired with `requirePathModule`: a real CommonJS
+            // module is allowed to export JavaScript `undefined`.
+            "__perry_has_path_module" => {
+                let path = if !args.is_empty() {
+                    args.remove(0)
+                } else {
+                    Expr::Undefined
+                };
+                return Ok(Ok(Expr::NativeMethodCall {
+                    module: "__perry_runtime".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "hasPathModule".to_string(),
                     args: vec![path],
                 }));
             }

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -810,6 +810,9 @@ pub fn gc_init() {
         MutableRootScannerSource::RuntimeMutableScanner,
     );
     reg_scanner!(crate::promise::scan_native_async_completion_roots_mut);
+    // Runtime path-module exports and cached initialization errors live in a
+    // provider-owned Rust registry, so moving GC must mark and rewrite them.
+    reg_scanner!(crate::module_require::scan_module_path_roots_mut);
     reg_budgeted_scanner!(
         promise_mutable_root_scanner,
         crate::promise::scan_promise_roots_mut_step,

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -1410,6 +1410,39 @@ fn full_cycle_global_root_store_after_root_scan_preserves_new_value() {
 }
 
 #[test]
+fn full_cycle_path_module_root_store_after_root_scan_preserves_new_value() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    gc_register_mutable_root_scanner(crate::module_require::scan_module_path_roots_mut);
+    let key = "gc-cycle-late-path-module-root";
+    crate::module_require::test_remove_path_module_root(key);
+
+    let child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(child);
+    }
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::BlockPersistence);
+    assert!(
+        incremental_mark_barrier_active(),
+        "full cycle should keep root barriers active after root scan"
+    );
+
+    crate::module_require::test_store_path_module_root(key, ptr_bits(child as usize));
+    run_cycle_in_single_unit_steps(&mut state);
+
+    assert!(
+        malloc_user_ptr_tracked(child),
+        "path-module export stored after root scan should survive via its persistent-root barrier"
+    );
+    crate::module_require::test_remove_path_module_root(key);
+}
+
+#[test]
 fn full_cycle_class_static_field_store_after_root_scan_preserves_new_value() {
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -247,6 +247,14 @@ enum PathModuleStatus {
     Failed(u64),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PathModuleRequireError {
+    Initializer(u64),
+    /// Defensive fail-closed result for a state that would otherwise make the
+    /// logical loader owner wait on a foreign initializer.
+    OwnershipConflict,
+}
+
 #[derive(Debug)]
 struct PathModuleEntry {
     init_addr: Option<usize>,
@@ -254,6 +262,10 @@ struct PathModuleEntry {
     /// initialized CommonJS export and must not be confused with a miss.
     exports: Option<u64>,
     status: PathModuleStatus,
+    /// A generated initializer claimed through `require_with`. Wrapper
+    /// partial/final publication also runs for eagerly initialized modules, so
+    /// `init_addr` alone cannot distinguish the two completion boundaries.
+    active_claim: Option<std::thread::ThreadId>,
 }
 
 #[derive(Default)]
@@ -275,6 +287,10 @@ struct PathModuleState {
 struct PathModuleRegistry {
     state: std::sync::Mutex<PathModuleState>,
     ready: std::sync::Condvar,
+    /// Perry heaps and mutable-root scanners are thread-local. The provider
+    /// registry is process-global for app-dylib symbol resolution, but its JS
+    /// values must remain confined to the one runtime thread that owns them.
+    runtime_owner: std::sync::OnceLock<std::thread::ThreadId>,
 }
 
 impl Default for PathModuleRegistry {
@@ -282,6 +298,7 @@ impl Default for PathModuleRegistry {
         Self {
             state: std::sync::Mutex::new(PathModuleState::default()),
             ready: std::sync::Condvar::new(),
+            runtime_owner: std::sync::OnceLock::new(),
         }
     }
 }
@@ -293,6 +310,17 @@ impl PathModuleRegistry {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
+    fn bind_runtime_owner(&self) -> bool {
+        let current = std::thread::current().id();
+        self.runtime_owner.get_or_init(|| current) == &current
+    }
+
+    fn is_runtime_owner(&self) -> bool {
+        self.runtime_owner
+            .get()
+            .is_some_and(|owner| *owner == std::thread::current().id())
+    }
+
     /// Register one canonical path -> initializer mapping. The same mapping is
     /// idempotent. A second address for the same canonical file is rejected so
     /// an alias can never create a second logical module initialization.
@@ -302,6 +330,7 @@ impl PathModuleRegistry {
             init_addr: None,
             exports: None,
             status: PathModuleStatus::Registered,
+            active_claim: None,
         });
         if let Some(existing) = entry.init_addr {
             return existing == init_addr;
@@ -313,20 +342,32 @@ impl PathModuleRegistry {
     /// Publish the initial CommonJS `exports` object before the wrapper body.
     /// Only same-thread recursive loads may observe it; unrelated waiters stay
     /// parked while the status is `Initializing`.
-    fn register_partial_exports(&self, key: String, exports: u64) {
+    fn register_partial_exports(&self, key: String, exports: u64) -> bool {
+        let current = std::thread::current().id();
         let stored = {
             let mut state = self.lock();
+            if state.loader_owner.is_some_and(|owner| owner != current) {
+                // Generated code on a second thread must not create a foreign
+                // `Initializing` entry while the logical loader is owned. If
+                // it did, the owner could wait for this entry while this
+                // thread waits for the owner's module. The FFI caller turns
+                // this rejection into a JS exception.
+                return false;
+            }
             let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
                 init_addr: None,
                 exports: None,
                 status: PathModuleStatus::Registered,
+                active_claim: None,
             });
-            if matches!(entry.status, PathModuleStatus::Failed(_)) {
+            if matches!(entry.status, PathModuleStatus::Failed(_))
+                || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
+            {
                 false
             } else {
                 entry.exports = Some(exports);
                 if entry.status == PathModuleStatus::Registered {
-                    entry.status = PathModuleStatus::Initializing(std::thread::current().id());
+                    entry.status = PathModuleStatus::Initializing(current);
                 }
                 true
             }
@@ -337,25 +378,37 @@ impl PathModuleRegistry {
         if stored {
             crate::gc::runtime_write_barrier_root_nanbox(exports);
         }
+        stored
     }
 
     /// Store the wrapper's final `module.exports`. Lazy modules remain owned by
     /// `require_with` until the generated init function returns (namespace
-    /// population can still follow the CJS body). Eager modules have no
-    /// registered init address, so this call is their completion boundary.
-    fn register_final_exports(&self, key: String, exports: u64) {
+    /// population can still follow the CJS body). A wrapper running without an
+    /// active lazy claim is eager, so this call is its completion boundary even
+    /// if path lookup also registered the initializer's address.
+    fn register_final_exports(&self, key: String, exports: u64) -> bool {
+        let current = std::thread::current().id();
         let (stored, completed_eager) = {
             let mut state = self.lock();
             let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
                 init_addr: None,
                 exports: None,
                 status: PathModuleStatus::Registered,
+                active_claim: None,
             });
-            if matches!(entry.status, PathModuleStatus::Failed(_)) {
+            if matches!(entry.status, PathModuleStatus::Failed(_))
+                || entry.active_claim.is_some_and(|owner| owner != current)
+                || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
+            {
                 (false, false)
             } else {
                 entry.exports = Some(exports);
-                let completed_eager = entry.init_addr.is_none();
+                // Every CJS wrapper publishes a partial/final pair. A final
+                // store completes an eager execution, even when an init
+                // address was also registered for path lookup. A lazy claim
+                // remains `Initializing` until its generated init returns, so
+                // a later namespace-population throw is still cached.
+                let completed_eager = entry.active_claim.is_none();
                 if completed_eager {
                     entry.status = PathModuleStatus::Initialized;
                 }
@@ -368,6 +421,7 @@ impl PathModuleRegistry {
         if completed_eager {
             self.ready.notify_all();
         }
+        stored
     }
 
     /// Return the value for `key`, initializing it once when necessary.
@@ -379,7 +433,7 @@ impl PathModuleRegistry {
         &self,
         key: &str,
         initialize: &dyn Fn(usize) -> Result<(), u64>,
-    ) -> Result<Option<u64>, u64> {
+    ) -> Result<Option<u64>, PathModuleRequireError> {
         let current = std::thread::current().id();
         let init_addr = loop {
             let mut state = self.lock();
@@ -388,12 +442,17 @@ impl PathModuleRegistry {
             };
             match entry.status {
                 PathModuleStatus::Initialized => return Ok(entry.exports),
-                PathModuleStatus::Failed(error) => return Err(error),
+                PathModuleStatus::Failed(error) => {
+                    return Err(PathModuleRequireError::Initializer(error));
+                }
                 PathModuleStatus::Initializing(owner) if owner == current => {
                     // CommonJS cycle: the owner sees its own partial exports.
                     return Ok(entry.exports);
                 }
                 PathModuleStatus::Initializing(_) => {
+                    if state.loader_owner == Some(current) {
+                        return Err(PathModuleRequireError::OwnershipConflict);
+                    }
                     drop(
                         self.ready
                             .wait(state)
@@ -404,6 +463,23 @@ impl PathModuleRegistry {
                     let Some(addr) = entry.init_addr else {
                         return Ok(entry.exports);
                     };
+                    if state.entries.values().any(|candidate| {
+                        matches!(
+                            candidate.status,
+                            PathModuleStatus::Initializing(owner) if owner != current
+                        )
+                    }) {
+                        // An eager initializer started without a lazy-loader
+                        // claim. Let it finish before granting ownership; it
+                        // can recursively claim the loader itself without
+                        // forming an A-waits-B / B-waits-A cycle.
+                        drop(
+                            self.ready
+                                .wait(state)
+                                .unwrap_or_else(std::sync::PoisonError::into_inner),
+                        );
+                        continue;
+                    }
                     match state.loader_owner {
                         Some(owner) if owner != current => {
                             drop(
@@ -424,6 +500,7 @@ impl PathModuleRegistry {
                         .get_mut(key)
                         .expect("path entry disappeared while claiming loader ownership");
                     entry.status = PathModuleStatus::Initializing(current);
+                    entry.active_claim = Some(current);
                     break addr;
                 }
             }
@@ -438,6 +515,8 @@ impl PathModuleRegistry {
                 .entries
                 .get_mut(key)
                 .expect("path initializer entry disappeared while it was running");
+            debug_assert_eq!(entry.active_claim, Some(current));
+            entry.active_claim = None;
             let (result, failed_error) = match outcome {
                 Ok(()) => {
                     entry.status = PathModuleStatus::Initialized;
@@ -446,7 +525,7 @@ impl PathModuleRegistry {
                 Err(error) => {
                     entry.exports = None;
                     entry.status = PathModuleStatus::Failed(error);
-                    (Err(error), Some(error))
+                    (Err(PathModuleRequireError::Initializer(error)), Some(error))
                 }
             };
             debug_assert_eq!(state.loader_owner, Some(current));
@@ -494,6 +573,16 @@ impl PathModuleRegistry {
 static MODULE_PATH_REGISTRY: std::sync::LazyLock<PathModuleRegistry> =
     std::sync::LazyLock::new(PathModuleRegistry::default);
 
+fn require_path_module_runtime_owner(operation: &str) {
+    if MODULE_PATH_REGISTRY.bind_runtime_owner() {
+        return;
+    }
+    let message = format!(
+        "Perry path-module {operation} must run on the runtime thread that owns the JavaScript heap"
+    );
+    crate::fs::validate::throw_error_with_code(&message, "ERR_PERRY_PATH_MODULE_THREAD")
+}
+
 fn canonicalize_module_path(path: &str) -> String {
     std::fs::canonicalize(path)
         .map(|p| p.to_string_lossy().into_owned())
@@ -510,6 +599,7 @@ fn canonicalize_module_path(path: &str) -> String {
 /// initializer (from `ptrtoint` of the symbol).
 #[no_mangle]
 pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i64, init_addr: i64) {
+    require_path_module_runtime_owner("initializer registration");
     let slice = std::slice::from_raw_parts(path_ptr, path_len as usize);
     let path = String::from_utf8_lossy(slice).into_owned();
     let key = canonicalize_module_path(&path);
@@ -524,9 +614,15 @@ pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i6
 /// generated initializer to complete.
 #[no_mangle]
 pub extern "C" fn js_register_path_module_partial(path_value: f64, exports: f64) {
+    require_path_module_runtime_owner("partial-export publication");
     let path = value_to_string(path_value, "path");
     let key = canonicalize_module_path(&path);
-    MODULE_PATH_REGISTRY.register_partial_exports(key, exports.to_bits());
+    if !MODULE_PATH_REGISTRY.register_partial_exports(key, exports.to_bits()) {
+        crate::fs::validate::throw_error_with_code(
+            "Perry rejected path-module partial exports from a non-owner initializer",
+            "ERR_PERRY_PATH_MODULE_OWNER",
+        );
+    }
 }
 
 /// Codegen FFI: register an AOT-compiled module's exports under its absolute
@@ -534,9 +630,15 @@ pub extern "C" fn js_register_path_module_partial(path_value: f64, exports: f64)
 /// [`MODULE_PATH_REGISTRY`].
 #[no_mangle]
 pub extern "C" fn js_register_path_module(path_value: f64, exports: f64) {
+    require_path_module_runtime_owner("final-export publication");
     let path = value_to_string(path_value, "path");
     let key = canonicalize_module_path(&path);
-    MODULE_PATH_REGISTRY.register_final_exports(key, exports.to_bits());
+    if !MODULE_PATH_REGISTRY.register_final_exports(key, exports.to_bits()) {
+        crate::fs::validate::throw_error_with_code(
+            "Perry rejected path-module final exports from a non-owner initializer",
+            "ERR_PERRY_PATH_MODULE_OWNER",
+        );
+    }
 }
 
 fn directory_module_candidates(key: &str) -> Vec<String> {
@@ -572,7 +674,7 @@ fn run_path_initializer(addr: usize) -> Result<(), u64> {
     .map_err(f64::to_bits)
 }
 
-fn require_path_key(key: &str) -> Result<Option<u64>, u64> {
+fn require_path_key(key: &str) -> Result<Option<u64>, PathModuleRequireError> {
     MODULE_PATH_REGISTRY.require_with(key, &run_path_initializer)
 }
 
@@ -581,18 +683,35 @@ fn require_path_key(key: &str) -> Result<Option<u64>, u64> {
 /// partial exports, while unrelated waiters receive only the final namespace.
 #[no_mangle]
 pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
+    require_path_module_runtime_owner("require");
     let path = value_to_string(path_value, "id");
     let key = canonicalize_module_path(&path);
     match require_path_key(&key) {
         Ok(Some(bits)) => return f64::from_bits(bits),
-        Err(error) => crate::exception::js_throw(f64::from_bits(error)),
+        Err(PathModuleRequireError::Initializer(error)) => {
+            crate::exception::js_throw(f64::from_bits(error))
+        }
+        Err(PathModuleRequireError::OwnershipConflict) => {
+            crate::fs::validate::throw_error_with_code(
+                "Perry rejected a cross-owner path-module initialization cycle",
+                "ERR_PERRY_PATH_MODULE_OWNER",
+            )
+        }
         Ok(None) => {}
     }
     for candidate in directory_module_candidates(&key) {
         let candidate = canonicalize_module_path(&candidate);
         match require_path_key(&candidate) {
             Ok(Some(bits)) => return f64::from_bits(bits),
-            Err(error) => crate::exception::js_throw(f64::from_bits(error)),
+            Err(PathModuleRequireError::Initializer(error)) => {
+                crate::exception::js_throw(f64::from_bits(error))
+            }
+            Err(PathModuleRequireError::OwnershipConflict) => {
+                crate::fs::validate::throw_error_with_code(
+                    "Perry rejected a cross-owner path-module initialization cycle",
+                    "ERR_PERRY_PATH_MODULE_OWNER",
+                )
+            }
             Ok(None) => {}
         }
     }
@@ -604,6 +723,7 @@ pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
 /// returned value is undefined to distinguish that value from a registry miss.
 #[no_mangle]
 pub extern "C" fn js_has_path_module(path_value: f64) -> f64 {
+    require_path_module_runtime_owner("presence lookup");
     let path = value_to_string(path_value, "id");
     let key = canonicalize_module_path(&path);
     let found = MODULE_PATH_REGISTRY.has_exports(&key)
@@ -617,12 +737,15 @@ pub extern "C" fn js_has_path_module(path_value: f64) -> f64 {
 /// Keep path-registry exports and cached exception values alive and rewrite
 /// them when a copying collection moves their referents.
 pub fn scan_module_path_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    MODULE_PATH_REGISTRY.scan_roots(visitor);
+    if MODULE_PATH_REGISTRY.is_runtime_owner() {
+        MODULE_PATH_REGISTRY.scan_roots(visitor);
+    }
 }
 
 #[cfg(test)]
 pub(crate) fn test_store_path_module_root(key: &str, value_bits: u64) {
-    MODULE_PATH_REGISTRY.register_final_exports(key.to_string(), value_bits);
+    assert!(MODULE_PATH_REGISTRY.bind_runtime_owner());
+    assert!(MODULE_PATH_REGISTRY.register_final_exports(key.to_string(), value_bits));
 }
 
 #[cfg(test)]
@@ -914,14 +1037,21 @@ mod path_module_registry_tests {
             _ => panic!("unexpected initializer address {addr}"),
         };
         calls[call_index].fetch_add(1, Ordering::Relaxed);
-        registry.register_partial_exports(key.into(), partial);
+        assert!(registry.register_partial_exports(key.into(), partial));
         let observed = registry.require_with(other_key, &|next_addr| {
             initialize_two_key_cycle(registry, gate, calls, partial_observations, next_addr)
-        })?;
+        });
+        let observed = match observed {
+            Ok(value) => value,
+            Err(PathModuleRequireError::Initializer(error)) => return Err(error),
+            Err(PathModuleRequireError::OwnershipConflict) => {
+                panic!("loader serialization admitted a cross-owner cycle")
+            }
+        };
         if observed == Some(other_partial) {
             partial_observations.fetch_add(1, Ordering::Relaxed);
         }
-        registry.register_final_exports(key.into(), final_value);
+        assert!(registry.register_final_exports(key.into(), final_value));
         Ok(())
     }
 
@@ -935,12 +1065,14 @@ mod path_module_registry_tests {
             .require_with("route.js", &|addr| {
                 assert_eq!(addr, 7);
                 calls.fetch_add(1, Ordering::Relaxed);
-                registry.register_partial_exports("route.js".into(), 0xA1);
+                assert!(registry.register_partial_exports("route.js".into(), 0xA1));
                 let recursive = registry.require_with("route.js", &|_| {
                     panic!("recursive load must not execute the initializer")
-                })?;
+                });
+                let recursive =
+                    recursive.expect("same-owner recursive load must return partial exports");
                 assert_eq!(recursive, Some(0xA1));
-                registry.register_final_exports("route.js".into(), 0xA2);
+                assert!(registry.register_final_exports("route.js".into(), 0xA2));
                 Ok(())
             })
             .unwrap();
@@ -971,10 +1103,10 @@ mod path_module_registry_tests {
                 registry.require_with("chunk.js", &|addr| {
                     assert_eq!(addr, 11);
                     calls.fetch_add(1, Ordering::Relaxed);
-                    registry.register_partial_exports("chunk.js".into(), 0xB1);
+                    assert!(registry.register_partial_exports("chunk.js".into(), 0xB1));
                     init_entered.wait();
                     release_init.wait();
-                    registry.register_final_exports("chunk.js".into(), 0xB2);
+                    assert!(registry.register_final_exports("chunk.js".into(), 0xB2));
                     Ok(())
                 })
             }));
@@ -1055,13 +1187,82 @@ mod path_module_registry_tests {
     }
 
     #[test]
+    fn foreign_partial_publication_is_rejected_while_loader_is_owned() {
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.register_init("a.js".into(), 41));
+        assert!(registry.register_init("b.js".into(), 43));
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let release = Arc::new(Barrier::new(2));
+
+        let worker_registry = Arc::clone(&registry);
+        let worker_release = Arc::clone(&release);
+        let worker = std::thread::spawn(move || {
+            worker_registry.require_with("a.js", &|addr| {
+                assert_eq!(addr, 41);
+                assert!(worker_registry.register_partial_exports("a.js".into(), 0xA1));
+                entered_tx.send(()).unwrap();
+                worker_release.wait();
+                assert_eq!(
+                    worker_registry.require_with("b.js", &|nested_addr| {
+                        assert_eq!(nested_addr, 43);
+                        assert!(worker_registry.register_partial_exports("b.js".into(), 0xB1));
+                        assert!(worker_registry.register_final_exports("b.js".into(), 0xB2));
+                        Ok(())
+                    }),
+                    Ok(Some(0xB2))
+                );
+                assert!(worker_registry.register_final_exports("a.js".into(), 0xA2));
+                Ok(())
+            })
+        });
+
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("loader owner did not enter generated initialization");
+        assert!(
+            !registry.register_partial_exports("b.js".into(), 0xDEAD),
+            "a foreign initializer must not publish while the loader is owned"
+        );
+        release.wait();
+        assert_eq!(worker.join().unwrap(), Ok(Some(0xA2)));
+    }
+
+    #[test]
+    fn registered_initializer_can_complete_through_an_eager_wrapper_pair() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("eager.js".into(), 47));
+        assert!(registry.register_partial_exports("eager.js".into(), 0xE1));
+        assert!(registry.register_final_exports("eager.js".into(), 0xE2));
+        assert_eq!(
+            registry.require_with("eager.js", &|_| panic!(
+                "eager module must already be complete"
+            )),
+            Ok(Some(0xE2))
+        );
+    }
+
+    #[test]
+    fn provider_registry_binds_to_one_runtime_thread() {
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.bind_runtime_owner());
+        assert!(registry.is_runtime_owner());
+        let worker_registry = Arc::clone(&registry);
+        assert!(
+            !std::thread::spawn(move || worker_registry.bind_runtime_owner())
+                .join()
+                .unwrap()
+        );
+        assert!(registry.is_runtime_owner());
+    }
+
+    #[test]
     fn undefined_export_is_present_and_distinct_from_a_miss() {
         let registry = PathModuleRegistry::default();
         assert!(registry.register_init("undefined.js".into(), 13));
         let value = registry
             .require_with("undefined.js", &|_| {
-                registry.register_partial_exports("undefined.js".into(), TAG_UNDEFINED);
-                registry.register_final_exports("undefined.js".into(), TAG_UNDEFINED);
+                assert!(registry.register_partial_exports("undefined.js".into(), TAG_UNDEFINED));
+                assert!(registry.register_final_exports("undefined.js".into(), TAG_UNDEFINED));
                 Ok(())
             })
             .unwrap();
@@ -1108,13 +1309,16 @@ mod path_module_registry_tests {
         init_entered.wait();
         release_init.wait();
         for worker in workers {
-            assert_eq!(worker.join().unwrap(), Err(error));
+            assert_eq!(
+                worker.join().unwrap(),
+                Err(PathModuleRequireError::Initializer(error))
+            );
         }
         assert_eq!(
             registry.require_with("throws.js", &|_| {
                 panic!("failed path modules use the explicit no-retry policy")
             }),
-            Err(error)
+            Err(PathModuleRequireError::Initializer(error))
         );
         assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
@@ -1145,7 +1349,7 @@ mod path_module_registry_tests {
         assert_eq!(
             registry.require_with(&direct, &|addr| {
                 seen.store(addr, Ordering::Relaxed);
-                registry.register_final_exports(direct.clone(), 0xC1);
+                assert!(registry.register_final_exports(direct.clone(), 0xC1));
                 Ok(())
             }),
             Ok(Some(0xC1))

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -7,7 +7,7 @@
 use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
 use crate::object::{js_object_alloc, js_object_set_field_by_name};
 use crate::string::js_string_from_bytes;
-use crate::value::{js_nanbox_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+use crate::value::{js_nanbox_pointer, JSValue, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED};
 
 fn undefined() -> f64 {
     f64::from_bits(TAG_UNDEFINED)
@@ -230,31 +230,204 @@ pub extern "C" fn js_module_create_require_devirt(filename_or_url: f64) -> f64 {
     js_module_create_require(filename_or_url)
 }
 
-/// Next.js wall 54: registry mapping an AOT-compiled CJS module's absolute
-/// source path to its evaluated `module.exports`, so a RUNTIME
-/// `require(absolutePath.js)` (Next.js / turbopack load page + chunk modules by
-/// a path computed at request time, not a static specifier) resolves to the
-/// module Perry already compiled instead of throwing `MODULE_NOT_FOUND`. Keyed
-/// by canonicalized path so `/a/../b` and symlinks normalize to one entry. Each
-/// compiled module self-registers at the end of its CJS wrapper init.
-static MODULE_PATH_REGISTRY: std::sync::RwLock<Option<std::collections::HashMap<String, u64>>> =
-    std::sync::RwLock::new(None);
+/// State of one AOT-compiled module that can be loaded by runtime path.
+///
+/// `Initializing` carries the owner thread so a CommonJS cycle on that same
+/// thread can observe the wrapper's partial `exports` object. Other callers
+/// wait for the owner to publish the final value (or failure), which prevents
+/// concurrent first requests from racing the generated module init guard.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PathModuleStatus {
+    Registered,
+    Initializing(std::thread::ThreadId),
+    Initialized,
+    /// Initializers are not retried. Every later caller receives the exact
+    /// same thrown JS value until process teardown.
+    Failed(u64),
+}
 
-/// Next.js wall 54 (part 2): registry mapping an AOT-compiled module's absolute
-/// source path to the ADDRESS of its `<prefix>__init` function, so a runtime
-/// `require(absolutePath.js)` can LAZILY trigger init of a module that was NOT
-/// run at startup (Deferred). The `.next/server/**` page/route/chunk modules are
-/// loaded by a path computed at request time; eager-initing them at startup runs
-/// React-SSR code before the server is ready (and turbopack chunks must init in
-/// the order the page loader's `R.c()` calls demand), so they are Deferred and
-/// init on first `require`. Populated once at program start by codegen-emitted
-/// `js_register_path_init` calls (no init runs there — only the address is
-/// recorded). The init function is idempotent (guarded), self-registers its
-/// exports into [`MODULE_PATH_REGISTRY`], and may recursively `require` its own
-/// dependencies (chunk loaders) — all safe because each module inits once.
-static MODULE_PATH_INIT_REGISTRY: std::sync::RwLock<
-    Option<std::collections::HashMap<String, usize>>,
-> = std::sync::RwLock::new(None);
+#[derive(Debug)]
+struct PathModuleEntry {
+    init_addr: Option<usize>,
+    /// `Option` is the presence bit: `Some(TAG_UNDEFINED)` is a real,
+    /// initialized CommonJS export and must not be confused with a miss.
+    exports: Option<u64>,
+    status: PathModuleStatus,
+}
+
+#[derive(Default)]
+struct PathModuleState {
+    entries: std::collections::HashMap<String, PathModuleEntry>,
+}
+
+/// Provider-visible path-module registry. App-only dylibs call these runtime
+/// symbols through their undefined ABI references, so the state lives in the
+/// separately loaded runtime provider rather than being duplicated per app.
+/// One mutex protects init ownership and export publication atomically; it is
+/// always released before generated code runs.
+struct PathModuleRegistry {
+    state: std::sync::Mutex<PathModuleState>,
+    ready: std::sync::Condvar,
+}
+
+impl Default for PathModuleRegistry {
+    fn default() -> Self {
+        Self {
+            state: std::sync::Mutex::new(PathModuleState::default()),
+            ready: std::sync::Condvar::new(),
+        }
+    }
+}
+
+impl PathModuleRegistry {
+    fn lock(&self) -> std::sync::MutexGuard<'_, PathModuleState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Register one canonical path -> initializer mapping. The same mapping is
+    /// idempotent. A second address for the same canonical file is rejected so
+    /// an alias can never create a second logical module initialization.
+    fn register_init(&self, key: String, init_addr: usize) -> bool {
+        let mut state = self.lock();
+        let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+            init_addr: None,
+            exports: None,
+            status: PathModuleStatus::Registered,
+        });
+        if let Some(existing) = entry.init_addr {
+            return existing == init_addr;
+        }
+        entry.init_addr = Some(init_addr);
+        true
+    }
+
+    /// Publish the initial CommonJS `exports` object before the wrapper body.
+    /// Only same-thread recursive loads may observe it; unrelated waiters stay
+    /// parked while the status is `Initializing`.
+    fn register_partial_exports(&self, key: String, exports: u64) {
+        let mut state = self.lock();
+        let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+            init_addr: None,
+            exports: None,
+            status: PathModuleStatus::Registered,
+        });
+        if matches!(entry.status, PathModuleStatus::Failed(_)) {
+            return;
+        }
+        entry.exports = Some(exports);
+        if entry.status == PathModuleStatus::Registered {
+            entry.status = PathModuleStatus::Initializing(std::thread::current().id());
+        }
+    }
+
+    /// Store the wrapper's final `module.exports`. Lazy modules remain owned by
+    /// `require_with` until the generated init function returns (namespace
+    /// population can still follow the CJS body). Eager modules have no
+    /// registered init address, so this call is their completion boundary.
+    fn register_final_exports(&self, key: String, exports: u64) {
+        let mut state = self.lock();
+        let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+            init_addr: None,
+            exports: None,
+            status: PathModuleStatus::Registered,
+        });
+        if matches!(entry.status, PathModuleStatus::Failed(_)) {
+            return;
+        }
+        entry.exports = Some(exports);
+        if entry.init_addr.is_none() {
+            entry.status = PathModuleStatus::Initialized;
+            self.ready.notify_all();
+        }
+    }
+
+    /// Return the value for `key`, initializing it once when necessary.
+    ///
+    /// The callback is invoked with every registry lock released. Its error is
+    /// cached without retry and replayed to all waiters. `Ok(None)` is a miss;
+    /// `Ok(Some(TAG_UNDEFINED))` is an initialized module exporting undefined.
+    fn require_with(
+        &self,
+        key: &str,
+        initialize: &dyn Fn(usize) -> Result<(), u64>,
+    ) -> Result<Option<u64>, u64> {
+        let current = std::thread::current().id();
+        let init_addr = loop {
+            let mut state = self.lock();
+            let Some(entry) = state.entries.get_mut(key) else {
+                return Ok(None);
+            };
+            match entry.status {
+                PathModuleStatus::Initialized => return Ok(entry.exports),
+                PathModuleStatus::Failed(error) => return Err(error),
+                PathModuleStatus::Initializing(owner) if owner == current => {
+                    // CommonJS cycle: the owner sees its own partial exports.
+                    return Ok(entry.exports);
+                }
+                PathModuleStatus::Initializing(_) => {
+                    drop(
+                        self.ready
+                            .wait(state)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner),
+                    );
+                }
+                PathModuleStatus::Registered => {
+                    let Some(addr) = entry.init_addr else {
+                        return Ok(entry.exports);
+                    };
+                    entry.status = PathModuleStatus::Initializing(current);
+                    break addr;
+                }
+            }
+        };
+
+        // Never hold the registry lock across generated module code. That code
+        // self-registers exports and may recursively require another path.
+        let outcome = initialize(init_addr);
+        let mut state = self.lock();
+        let entry = state
+            .entries
+            .get_mut(key)
+            .expect("path initializer entry disappeared while it was running");
+        let result = match outcome {
+            Ok(()) => {
+                entry.status = PathModuleStatus::Initialized;
+                Ok(entry.exports)
+            }
+            Err(error) => {
+                entry.exports = None;
+                entry.status = PathModuleStatus::Failed(error);
+                Err(error)
+            }
+        };
+        self.ready.notify_all();
+        result
+    }
+
+    fn has_exports(&self, key: &str) -> bool {
+        let state = self.lock();
+        state.entries.get(key).is_some_and(|entry| {
+            entry.exports.is_some() && !matches!(entry.status, PathModuleStatus::Failed(_))
+        })
+    }
+
+    fn scan_roots(&self, visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+        let mut state = crate::gc::lock_gc_root_registry(&self.state);
+        for entry in state.entries.values_mut() {
+            if let Some(exports) = entry.exports.as_mut() {
+                visitor.visit_nanbox_u64_slot(exports);
+            }
+            if let PathModuleStatus::Failed(error) = &mut entry.status {
+                visitor.visit_nanbox_u64_slot(error);
+            }
+        }
+    }
+}
+
+static MODULE_PATH_REGISTRY: std::sync::LazyLock<PathModuleRegistry> =
+    std::sync::LazyLock::new(PathModuleRegistry::default);
 
 fn canonicalize_module_path(path: &str) -> String {
     std::fs::canonicalize(path)
@@ -264,8 +437,8 @@ fn canonicalize_module_path(path: &str) -> String {
 
 /// Codegen FFI: record that `<prefix>__init` (address `init_addr`) initializes
 /// the module whose absolute source path is `path_value`. Emitted once per
-/// Deferred `.next/server/**` module at the top of `main`. See
-/// [`MODULE_PATH_INIT_REGISTRY`].
+/// Deferred `.next/server/**` module at the top of the executable or app-dylib
+/// entry point. The registry records the address without executing it.
 /// # Safety
 /// `path_ptr`/`path_len` describe a valid UTF-8 byte range (a codegen string
 /// constant). `init_addr` is the address of an `extern "C" fn()` module
@@ -275,10 +448,20 @@ pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i6
     let slice = std::slice::from_raw_parts(path_ptr, path_len as usize);
     let path = String::from_utf8_lossy(slice).into_owned();
     let key = canonicalize_module_path(&path);
-    let mut guard = MODULE_PATH_INIT_REGISTRY.write().unwrap();
-    guard
-        .get_or_insert_with(std::collections::HashMap::new)
-        .insert(key, init_addr as usize);
+    if !MODULE_PATH_REGISTRY.register_init(key.clone(), init_addr as usize) {
+        eprintln!("perry: rejected duplicate path-module initializer for canonical path {key}");
+    }
+}
+
+/// Codegen FFI: publish a CommonJS module's initial `exports` object before
+/// executing its body. This is visible only to recursive loads by the owning
+/// thread; concurrent callers wait for [`js_register_path_module`] and the
+/// generated initializer to complete.
+#[no_mangle]
+pub extern "C" fn js_register_path_module_partial(path_value: f64, exports: f64) {
+    let path = value_to_string(path_value, "path");
+    let key = canonicalize_module_path(&path);
+    MODULE_PATH_REGISTRY.register_partial_exports(key, exports.to_bits());
 }
 
 /// Codegen FFI: register an AOT-compiled module's exports under its absolute
@@ -288,99 +471,88 @@ pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i6
 pub extern "C" fn js_register_path_module(path_value: f64, exports: f64) {
     let path = value_to_string(path_value, "path");
     let key = canonicalize_module_path(&path);
-    let mut guard = MODULE_PATH_REGISTRY.write().unwrap();
-    guard
-        .get_or_insert_with(std::collections::HashMap::new)
-        .insert(key, exports.to_bits());
+    MODULE_PATH_REGISTRY.register_final_exports(key, exports.to_bits());
 }
 
-/// Codegen FFI: resolve a runtime `require(absolutePath.js)` to a registered
-/// AOT-compiled module's exports, or `undefined` when no module is registered
-/// for that path (caller then falls back to the `.json` disk read / throws
-/// `MODULE_NOT_FOUND`). Module exports are always objects, so `undefined`
-/// unambiguously signals "miss".
+fn directory_module_candidates(key: &str) -> Vec<String> {
+    let dir = std::path::Path::new(&key);
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+    let mut candidates = Vec::new();
+    if let Ok(manifest) = std::fs::read_to_string(dir.join("package.json")) {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&manifest) {
+            if let Some(main) = parsed.get("main").and_then(|m| m.as_str()) {
+                let main_path = dir.join(main);
+                candidates.push(main_path.to_string_lossy().into_owned());
+                if main_path.extension().is_none() {
+                    candidates.push(format!("{}.js", main_path.to_string_lossy()));
+                }
+            }
+        }
+    }
+    candidates.push(dir.join("index.js").to_string_lossy().into_owned());
+    candidates
+}
+
+fn run_path_initializer(addr: usize) -> Result<(), u64> {
+    // SAFETY: `addr` came from codegen's `ptrtoint` of an `extern "C" fn()`
+    // module initializer and was accepted once for this canonical path.
+    let init_fn: extern "C" fn() = unsafe { std::mem::transmute::<usize, _>(addr) };
+    crate::exception::js_call_catching(|| {
+        init_fn();
+        undefined()
+    })
+    .map(|_| ())
+    .map_err(f64::to_bits)
+}
+
+fn require_path_key(key: &str) -> Result<Option<u64>, u64> {
+    MODULE_PATH_REGISTRY.require_with(key, &run_path_initializer)
+}
+
+/// Codegen FFI: resolve a runtime `require(absolutePath.js)` to an AOT module.
+/// Initialization is once-only and waitable; recursive CommonJS loads receive
+/// partial exports, while unrelated waiters receive only the final namespace.
 #[no_mangle]
 pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
     let path = value_to_string(path_value, "id");
     let key = canonicalize_module_path(&path);
-    // Fast path: the module already ran (eager, or a prior require) and
-    // self-registered its exports.
-    {
-        let guard = MODULE_PATH_REGISTRY.read().unwrap();
-        if let Some(map) = guard.as_ref() {
-            if let Some(bits) = map.get(&key) {
-                return f64::from_bits(*bits);
-            }
-        }
+    match require_path_key(&key) {
+        Ok(Some(bits)) => return f64::from_bits(bits),
+        Err(error) => crate::exception::js_throw(f64::from_bits(error)),
+        Ok(None) => {}
     }
-    // Wall 54 (part 2): no exports yet — if a Deferred module is registered for
-    // this path, trigger its init now. The init self-registers its exports (and
-    // may recursively require its chunk dependencies). Crucially, all registry
-    // locks are RELEASED before calling init, since init re-enters
-    // `js_register_path_module` / `js_require_path_module`.
-    let init_addr = {
-        let guard = MODULE_PATH_INIT_REGISTRY.read().unwrap();
-        guard.as_ref().and_then(|m| m.get(&key).copied())
-    };
-    if let Some(addr) = init_addr {
-        // SAFETY: `addr` is the address of a codegen-emitted `extern "C" fn()`
-        // module initializer, recorded by `js_register_path_init` from a value
-        // produced by `ptrtoint` of the same function symbol. The initializer
-        // is idempotent (guarded by `@__perry_init_done_<prefix>`).
-        let init_fn: extern "C" fn() = unsafe { std::mem::transmute::<usize, _>(addr) };
-        init_fn();
-        let guard = MODULE_PATH_REGISTRY.read().unwrap();
-        if let Some(map) = guard.as_ref() {
-            if let Some(bits) = map.get(&key) {
-                return f64::from_bits(*bits);
-            }
-        }
-    }
-    // Node directory resolution: `require('<abs dir>')` loads the package's
-    // `main` (else `index.js`). Next's require-hook aliases `styled-jsx` to
-    // the RESOLVED PACKAGE DIRECTORY, so the eventual require arrives here
-    // with a directory path. Map it to the registered file module.
-    let dir = std::path::Path::new(&key);
-    if dir.is_dir() {
-        let mut candidates: Vec<String> = Vec::new();
-        if let Ok(manifest) = std::fs::read_to_string(dir.join("package.json")) {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&manifest) {
-                if let Some(main) = parsed.get("main").and_then(|m| m.as_str()) {
-                    let main_path = dir.join(main);
-                    candidates.push(main_path.to_string_lossy().into_owned());
-                    if main_path.extension().is_none() {
-                        candidates.push(format!("{}.js", main_path.to_string_lossy()));
-                    }
-                }
-            }
-        }
-        candidates.push(dir.join("index.js").to_string_lossy().into_owned());
-        for cand in candidates {
-            let cand_key = canonicalize_module_path(&cand);
-            let resolved = {
-                let guard = MODULE_PATH_REGISTRY.read().unwrap();
-                guard.as_ref().and_then(|m| m.get(&cand_key).copied())
-            };
-            if let Some(bits) = resolved {
-                return f64::from_bits(bits);
-            }
-            // Deferred module: trigger its init, then re-check.
-            let cand_init = {
-                let guard = MODULE_PATH_INIT_REGISTRY.read().unwrap();
-                guard.as_ref().and_then(|m| m.get(&cand_key).copied())
-            };
-            if let Some(addr) = cand_init {
-                // SAFETY: same contract as the direct-path init above.
-                let init_fn: extern "C" fn() = unsafe { std::mem::transmute::<usize, _>(addr) };
-                init_fn();
-                let guard = MODULE_PATH_REGISTRY.read().unwrap();
-                if let Some(bits) = guard.as_ref().and_then(|m| m.get(&cand_key).copied()) {
-                    return f64::from_bits(bits);
-                }
-            }
+    for candidate in directory_module_candidates(&key) {
+        let candidate = canonicalize_module_path(&candidate);
+        match require_path_key(&candidate) {
+            Ok(Some(bits)) => return f64::from_bits(bits),
+            Err(error) => crate::exception::js_throw(f64::from_bits(error)),
+            Ok(None) => {}
         }
     }
     undefined()
+}
+
+/// Presence bit paired with [`js_require_path_module`]. A real module may
+/// export JavaScript `undefined`, so the CJS wrapper calls this only when the
+/// returned value is undefined to distinguish that value from a registry miss.
+#[no_mangle]
+pub extern "C" fn js_has_path_module(path_value: f64) -> f64 {
+    let path = value_to_string(path_value, "id");
+    let key = canonicalize_module_path(&path);
+    let found = MODULE_PATH_REGISTRY.has_exports(&key)
+        || directory_module_candidates(&key)
+            .into_iter()
+            .map(|candidate| canonicalize_module_path(&candidate))
+            .any(|candidate| MODULE_PATH_REGISTRY.has_exports(&candidate));
+    f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
+}
+
+/// Keep path-registry exports and cached exception values alive and rewrite
+/// them when a copying collection moves their referents.
+pub fn scan_module_path_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    MODULE_PATH_REGISTRY.scan_roots(visitor);
 }
 
 /// Node-style `require.resolve` fallback for package-subpath specifiers that
@@ -621,5 +793,178 @@ mod builtin_allowlist_parity_tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod path_module_registry_tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier,
+    };
+
+    #[test]
+    fn recursive_load_observes_partial_exports_without_reentering_init() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("route.js".into(), 7));
+        let calls = AtomicUsize::new(0);
+
+        let result = registry
+            .require_with("route.js", &|addr| {
+                assert_eq!(addr, 7);
+                calls.fetch_add(1, Ordering::Relaxed);
+                registry.register_partial_exports("route.js".into(), 0xA1);
+                let recursive = registry.require_with("route.js", &|_| {
+                    panic!("recursive load must not execute the initializer")
+                })?;
+                assert_eq!(recursive, Some(0xA1));
+                registry.register_final_exports("route.js".into(), 0xA2);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(result, Some(0xA2));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn concurrent_first_load_runs_one_initializer_and_publishes_one_value() {
+        const THREADS: usize = 20;
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.register_init("chunk.js".into(), 11));
+        let starts = Arc::new(Barrier::new(THREADS + 1));
+        let init_entered = Arc::new(Barrier::new(2));
+        let release_init = Arc::new(Barrier::new(2));
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let mut workers = Vec::new();
+        for _ in 0..THREADS {
+            let registry = Arc::clone(&registry);
+            let starts = Arc::clone(&starts);
+            let init_entered = Arc::clone(&init_entered);
+            let release_init = Arc::clone(&release_init);
+            let calls = Arc::clone(&calls);
+            workers.push(std::thread::spawn(move || {
+                starts.wait();
+                registry.require_with("chunk.js", &|addr| {
+                    assert_eq!(addr, 11);
+                    calls.fetch_add(1, Ordering::Relaxed);
+                    registry.register_partial_exports("chunk.js".into(), 0xB1);
+                    init_entered.wait();
+                    release_init.wait();
+                    registry.register_final_exports("chunk.js".into(), 0xB2);
+                    Ok(())
+                })
+            }));
+        }
+
+        starts.wait();
+        init_entered.wait();
+        release_init.wait();
+        for worker in workers {
+            assert_eq!(worker.join().unwrap().unwrap(), Some(0xB2));
+        }
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn undefined_export_is_present_and_distinct_from_a_miss() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("undefined.js".into(), 13));
+        let value = registry
+            .require_with("undefined.js", &|_| {
+                registry.register_partial_exports("undefined.js".into(), TAG_UNDEFINED);
+                registry.register_final_exports("undefined.js".into(), TAG_UNDEFINED);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(value, Some(TAG_UNDEFINED));
+        assert!(registry.has_exports("undefined.js"));
+        assert_eq!(
+            registry.require_with("missing.js", &|_| unreachable!()),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn concurrent_initialization_failure_is_shared_and_cached_without_retry() {
+        const THREADS: usize = 20;
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.register_init("throws.js".into(), 17));
+        let starts = Arc::new(Barrier::new(THREADS + 1));
+        let init_entered = Arc::new(Barrier::new(2));
+        let release_init = Arc::new(Barrier::new(2));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let error = 0x7FFD_0000_0000_0042;
+
+        let mut workers = Vec::new();
+        for _ in 0..THREADS {
+            let registry = Arc::clone(&registry);
+            let starts = Arc::clone(&starts);
+            let init_entered = Arc::clone(&init_entered);
+            let release_init = Arc::clone(&release_init);
+            let calls = Arc::clone(&calls);
+            workers.push(std::thread::spawn(move || {
+                starts.wait();
+                registry.require_with("throws.js", &|addr| {
+                    assert_eq!(addr, 17);
+                    calls.fetch_add(1, Ordering::Relaxed);
+                    init_entered.wait();
+                    release_init.wait();
+                    Err(error)
+                })
+            }));
+        }
+
+        starts.wait();
+        init_entered.wait();
+        release_init.wait();
+        for worker in workers {
+            assert_eq!(worker.join().unwrap(), Err(error));
+        }
+        assert_eq!(
+            registry.require_with("throws.js", &|_| {
+                panic!("failed path modules use the explicit no-retry policy")
+            }),
+            Err(error)
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn canonical_alias_cannot_replace_the_first_initializer() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!(
+            "perry-path-module-alias-{}-{nonce}",
+            std::process::id()
+        ));
+        let nested = temp.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let module = temp.join("module.js");
+        std::fs::write(&module, "module.exports = 1;").unwrap();
+        let direct = canonicalize_module_path(&module.to_string_lossy());
+        let aliased =
+            canonicalize_module_path(&nested.join("..").join("module.js").to_string_lossy());
+        assert_eq!(direct, aliased);
+
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init(direct.clone(), 19));
+        assert!(!registry.register_init(aliased, 23));
+        let seen = AtomicUsize::new(0);
+        assert_eq!(
+            registry.require_with(&direct, &|addr| {
+                seen.store(addr, Ordering::Relaxed);
+                registry.register_final_exports(direct.clone(), 0xC1);
+                Ok(())
+            }),
+            Ok(Some(0xC1))
+        );
+        assert_eq!(seen.load(Ordering::Relaxed), 19);
+        std::fs::remove_dir_all(temp).unwrap();
     }
 }

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -277,6 +277,63 @@ struct PathModuleState {
     /// the registry mutex across generated code.
     loader_owner: Option<std::thread::ThreadId>,
     loader_depth: usize,
+    /// Every entry currently in `Initializing` belongs to this thread.
+    /// Counting avoids scanning thousands of registered Next modules on each
+    /// cold claim.
+    initializing_owner: Option<std::thread::ThreadId>,
+    initializing_count: usize,
+    /// Eager CJS wrappers that have published partial exports, in nesting
+    /// order. The native module-init exception boundary fails only the current
+    /// wrapper, so an inner error that user code catches does not poison its
+    /// caller.
+    eager_initializers: Vec<(std::thread::ThreadId, String, Option<u64>)>,
+    module_boundaries: Vec<(std::thread::ThreadId, u64)>,
+    next_module_boundary: u64,
+}
+
+impl PathModuleState {
+    fn begin_initializing(&mut self, owner: std::thread::ThreadId) -> bool {
+        match self.initializing_owner {
+            Some(existing) if existing != owner => false,
+            Some(_) => {
+                self.initializing_count += 1;
+                true
+            }
+            None => {
+                self.initializing_owner = Some(owner);
+                self.initializing_count = 1;
+                true
+            }
+        }
+    }
+
+    fn finish_initializing(&mut self, owner: std::thread::ThreadId) {
+        debug_assert_eq!(self.initializing_owner, Some(owner));
+        debug_assert!(self.initializing_count > 0);
+        self.initializing_count -= 1;
+        if self.initializing_count == 0 {
+            self.initializing_owner = None;
+        }
+    }
+
+    fn finish_eager(&mut self, owner: std::thread::ThreadId, key: &str) {
+        let index = self
+            .eager_initializers
+            .iter()
+            .rposition(|(candidate_owner, candidate_key, _)| {
+                *candidate_owner == owner && candidate_key == key
+            })
+            .expect("completed eager path module was missing from the init stack");
+        debug_assert_eq!(index + 1, self.eager_initializers.len());
+        self.eager_initializers.remove(index);
+    }
+
+    fn current_module_boundary(&self, owner: std::thread::ThreadId) -> Option<u64> {
+        self.module_boundaries
+            .iter()
+            .rfind(|(candidate_owner, _)| *candidate_owner == owner)
+            .map(|(_, boundary)| *boundary)
+    }
 }
 
 /// Provider-visible path-module registry. App-only dylibs call these runtime
@@ -346,7 +403,11 @@ impl PathModuleRegistry {
         let current = std::thread::current().id();
         let stored = {
             let mut state = self.lock();
-            if state.loader_owner.is_some_and(|owner| owner != current) {
+            if state.loader_owner.is_some_and(|owner| owner != current)
+                || state
+                    .initializing_owner
+                    .is_some_and(|owner| owner != current)
+            {
                 // Generated code on a second thread must not create a foreign
                 // `Initializing` entry while the logical loader is owned. If
                 // it did, the owner could wait for this entry while this
@@ -354,21 +415,39 @@ impl PathModuleRegistry {
                 // this rejection into a JS exception.
                 return false;
             }
-            let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
-                init_addr: None,
-                exports: None,
-                status: PathModuleStatus::Registered,
-                active_claim: None,
-            });
-            if matches!(entry.status, PathModuleStatus::Failed(_))
-                || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
-            {
-                false
-            } else {
+            let key_for_stack = key.clone();
+            let (began, eager) = {
+                let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+                    init_addr: None,
+                    exports: None,
+                    status: PathModuleStatus::Registered,
+                    active_claim: None,
+                });
+                if matches!(entry.status, PathModuleStatus::Failed(_))
+                    || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
+                {
+                    return false;
+                }
                 entry.exports = Some(exports);
                 if entry.status == PathModuleStatus::Registered {
                     entry.status = PathModuleStatus::Initializing(current);
+                    (true, entry.active_claim.is_none())
+                } else {
+                    (false, false)
                 }
+            };
+            if began {
+                if !state.begin_initializing(current) {
+                    return false;
+                }
+                if eager {
+                    let boundary = state.current_module_boundary(current);
+                    state
+                        .eager_initializers
+                        .push((current, key_for_stack, boundary));
+                }
+                true
+            } else {
                 true
             }
         };
@@ -390,30 +469,40 @@ impl PathModuleRegistry {
         let current = std::thread::current().id();
         let (stored, completed_eager) = {
             let mut state = self.lock();
-            let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
-                init_addr: None,
-                exports: None,
-                status: PathModuleStatus::Registered,
-                active_claim: None,
-            });
-            if matches!(entry.status, PathModuleStatus::Failed(_))
-                || entry.active_claim.is_some_and(|owner| owner != current)
-                || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
-            {
-                (false, false)
-            } else {
-                entry.exports = Some(exports);
-                // Every CJS wrapper publishes a partial/final pair. A final
-                // store completes an eager execution, even when an init
-                // address was also registered for path lookup. A lazy claim
-                // remains `Initializing` until its generated init returns, so
-                // a later namespace-population throw is still cached.
-                let completed_eager = entry.active_claim.is_none();
-                if completed_eager {
-                    entry.status = PathModuleStatus::Initialized;
+            let key_for_stack = key.clone();
+            let (stored, completed_eager, finished_initializing) = {
+                let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+                    init_addr: None,
+                    exports: None,
+                    status: PathModuleStatus::Registered,
+                    active_claim: None,
+                });
+                if matches!(entry.status, PathModuleStatus::Failed(_))
+                    || entry.active_claim.is_some_and(|owner| owner != current)
+                    || matches!(entry.status, PathModuleStatus::Initializing(owner) if owner != current)
+                {
+                    (false, false, false)
+                } else {
+                    entry.exports = Some(exports);
+                    // Every CJS wrapper publishes a partial/final pair. A final
+                    // store completes an eager execution, even when an init
+                    // address was also registered for path lookup. A lazy claim
+                    // remains `Initializing` until its generated init returns, so
+                    // a later namespace-population throw is still cached.
+                    let completed_eager = entry.active_claim.is_none();
+                    let finished_initializing = completed_eager
+                        && matches!(entry.status, PathModuleStatus::Initializing(_));
+                    if completed_eager {
+                        entry.status = PathModuleStatus::Initialized;
+                    }
+                    (true, completed_eager, finished_initializing)
                 }
-                (true, completed_eager)
+            };
+            if finished_initializing {
+                state.finish_eager(current, &key_for_stack);
+                state.finish_initializing(current);
             }
+            (stored, completed_eager)
         };
         if stored {
             crate::gc::runtime_write_barrier_root_nanbox(exports);
@@ -422,6 +511,76 @@ impl PathModuleRegistry {
             self.ready.notify_all();
         }
         stored
+    }
+
+    fn begin_module_boundary(&self) -> u64 {
+        let current = std::thread::current().id();
+        let mut state = self.lock();
+        state.next_module_boundary = state.next_module_boundary.wrapping_add(1).max(1);
+        let boundary = state.next_module_boundary;
+        state.module_boundaries.push((current, boundary));
+        boundary
+    }
+
+    /// Leave one generated module body. A normal return with a still-partial
+    /// eager CJS wrapper (for example, a legal top-level CommonJS `return`)
+    /// completes with those partial exports. An exceptional return caches the
+    /// original throw. Lazy claims are deliberately absent from this stack and
+    /// are completed by `require_with` instead.
+    fn finish_module_boundary(&self, boundary: u64, error: Option<u64>) -> usize {
+        let current = std::thread::current().id();
+        let completed = {
+            let mut state = self.lock();
+            let boundary_index = state
+                .module_boundaries
+                .iter()
+                .rposition(|(owner, candidate)| *owner == current && *candidate == boundary)
+                .expect("generated module-init boundary stack became unbalanced");
+            debug_assert!(
+                state.module_boundaries[boundary_index + 1..]
+                    .iter()
+                    .all(|(owner, _)| *owner != current),
+                "generated module-init boundaries must be LIFO per thread"
+            );
+            state.module_boundaries.remove(boundary_index);
+
+            let mut keys = Vec::new();
+            state.eager_initializers.retain(|(owner, key, candidate)| {
+                if *owner == current && *candidate == Some(boundary) {
+                    keys.push(key.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            for key in &keys {
+                let entry = state
+                    .entries
+                    .get_mut(key)
+                    .expect("eager path-module init entry disappeared while running");
+                debug_assert!(entry.active_claim.is_none());
+                debug_assert!(
+                    matches!(entry.status, PathModuleStatus::Initializing(owner) if owner == current)
+                );
+                if let Some(error) = error {
+                    entry.exports = None;
+                    entry.status = PathModuleStatus::Failed(error);
+                } else {
+                    entry.status = PathModuleStatus::Initialized;
+                }
+            }
+            for _ in 0..keys.len() {
+                state.finish_initializing(current);
+            }
+            keys.len()
+        };
+        if completed > 0 {
+            if let Some(error) = error {
+                crate::gc::runtime_write_barrier_root_nanbox(error);
+            }
+            self.ready.notify_all();
+        }
+        completed
     }
 
     /// Return the value for `key`, initializing it once when necessary.
@@ -463,12 +622,10 @@ impl PathModuleRegistry {
                     let Some(addr) = entry.init_addr else {
                         return Ok(entry.exports);
                     };
-                    if state.entries.values().any(|candidate| {
-                        matches!(
-                            candidate.status,
-                            PathModuleStatus::Initializing(owner) if owner != current
-                        )
-                    }) {
+                    if state
+                        .initializing_owner
+                        .is_some_and(|owner| owner != current)
+                    {
                         // An eager initializer started without a lazy-loader
                         // claim. Let it finish before granting ownership; it
                         // can recursively claim the loader itself without
@@ -501,6 +658,7 @@ impl PathModuleRegistry {
                         .expect("path entry disappeared while claiming loader ownership");
                     entry.status = PathModuleStatus::Initializing(current);
                     entry.active_claim = Some(current);
+                    assert!(state.begin_initializing(current));
                     break addr;
                 }
             }
@@ -528,6 +686,7 @@ impl PathModuleRegistry {
                     (Err(PathModuleRequireError::Initializer(error)), Some(error))
                 }
             };
+            state.finish_initializing(current);
             debug_assert_eq!(state.loader_owner, Some(current));
             debug_assert!(state.loader_depth > 0);
             state.loader_depth -= 1;
@@ -638,6 +797,33 @@ pub extern "C" fn js_register_path_module(path_value: f64, exports: f64) {
             "Perry rejected path-module final exports from a non-owner initializer",
             "ERR_PERRY_PATH_MODULE_OWNER",
         );
+    }
+}
+
+/// Execute a generated module-init body behind a native exception boundary.
+/// If a CommonJS wrapper published partial exports and then threw, cache the
+/// exact value and wake waiters before propagating it. The boundary lives here
+/// rather than in generated JavaScript so top-level lexical declarations keep
+/// their original module/function scope.
+///
+/// # Safety
+/// `init_addr` is codegen's `ptrtoint` of an `extern "C" fn()` module body.
+#[no_mangle]
+pub unsafe extern "C" fn js_run_module_init_catching(init_addr: i64) {
+    let init_fn: extern "C" fn() = std::mem::transmute::<usize, _>(init_addr as usize);
+    let boundary = MODULE_PATH_REGISTRY.begin_module_boundary();
+    let outcome = crate::exception::js_call_catching(|| {
+        init_fn();
+        undefined()
+    });
+    match outcome {
+        Ok(_) => {
+            MODULE_PATH_REGISTRY.finish_module_boundary(boundary, None);
+        }
+        Err(error) => {
+            MODULE_PATH_REGISTRY.finish_module_boundary(boundary, Some(error.to_bits()));
+            crate::exception::js_throw(error)
+        }
     }
 }
 
@@ -1238,6 +1424,117 @@ mod path_module_registry_tests {
                 "eager module must already be complete"
             )),
             Ok(Some(0xE2))
+        );
+    }
+
+    #[test]
+    fn eager_wrapper_throw_replaces_partial_exports_and_wakes_waiters() {
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.register_init("eager-throws.js".into(), 49));
+        let boundary = registry.begin_module_boundary();
+        assert!(registry.register_partial_exports("eager-throws.js".into(), 0xE1));
+
+        let (waiting_tx, waiting_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let waiter_registry = Arc::clone(&registry);
+        let waiter = std::thread::spawn(move || {
+            waiting_tx.send(()).unwrap();
+            let result = waiter_registry.require_with("eager-throws.js", &|_| {
+                panic!("a waiter must not retry the eager initializer")
+            });
+            result_tx.send(result).unwrap();
+        });
+        waiting_rx.recv().unwrap();
+        assert!(
+            result_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "the foreign waiter returned partial exports instead of waiting"
+        );
+
+        assert_eq!(registry.finish_module_boundary(boundary, Some(0xBAD)), 1);
+        assert_eq!(
+            result_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("eager failure did not wake the waiting require"),
+            Err(PathModuleRequireError::Initializer(0xBAD))
+        );
+        waiter.join().unwrap();
+        assert_eq!(
+            registry.require_with("eager-throws.js", &|_| {
+                panic!("failed eager module must not retry")
+            }),
+            Err(PathModuleRequireError::Initializer(0xBAD))
+        );
+        let state = registry.lock();
+        assert_eq!(state.initializing_count, 0);
+        assert_eq!(state.initializing_owner, None);
+    }
+
+    #[test]
+    fn caught_nested_eager_failure_does_not_poison_outer_wrapper() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("outer.js".into(), 51));
+        assert!(registry.register_init("inner.js".into(), 53));
+        let outer_boundary = registry.begin_module_boundary();
+        assert!(registry.register_partial_exports("outer.js".into(), 0xA1));
+        let inner_boundary = registry.begin_module_boundary();
+        assert!(registry.register_partial_exports("inner.js".into(), 0xB1));
+
+        assert_eq!(
+            registry.finish_module_boundary(inner_boundary, Some(0xBAD)),
+            1
+        );
+        assert!(registry.register_final_exports("outer.js".into(), 0xA2));
+        assert_eq!(registry.finish_module_boundary(outer_boundary, None), 0);
+        assert_eq!(
+            registry.require_with("inner.js", &|_| panic!("inner failure must be cached")),
+            Err(PathModuleRequireError::Initializer(0xBAD))
+        );
+        assert_eq!(
+            registry.require_with("outer.js", &|_| panic!("outer module completed eagerly")),
+            Ok(Some(0xA2))
+        );
+        let state = registry.lock();
+        assert_eq!(state.initializing_count, 0);
+        assert!(state.eager_initializers.is_empty());
+    }
+
+    #[test]
+    fn lazy_inner_boundary_does_not_consume_outer_eager_wrapper() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("outer.js".into(), 55));
+        let outer_boundary = registry.begin_module_boundary();
+        assert!(registry.register_partial_exports("outer.js".into(), 0xA1));
+
+        // A lazily claimed inner module does not enter the eager stack. Its
+        // native catch must leave the outer wrapper available to catch or
+        // complete independently.
+        let inner_boundary = registry.begin_module_boundary();
+        assert_eq!(
+            registry.finish_module_boundary(inner_boundary, Some(0xBAD)),
+            0
+        );
+        assert!(registry.register_final_exports("outer.js".into(), 0xA2));
+        assert_eq!(registry.finish_module_boundary(outer_boundary, None), 0);
+        assert_eq!(
+            registry.require_with("outer.js", &|_| panic!("outer module completed eagerly")),
+            Ok(Some(0xA2))
+        );
+    }
+
+    #[test]
+    fn eager_top_level_return_completes_with_partial_exports() {
+        let registry = PathModuleRegistry::default();
+        assert!(registry.register_init("returns.js".into(), 57));
+        let boundary = registry.begin_module_boundary();
+        assert!(registry.register_partial_exports("returns.js".into(), 0xC1));
+        assert_eq!(registry.finish_module_boundary(boundary, None), 1);
+        assert_eq!(
+            registry.require_with("returns.js", &|_| {
+                panic!("a normally returned eager wrapper must not retry")
+            }),
+            Ok(Some(0xC1))
         );
     }
 

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -233,9 +233,10 @@ pub extern "C" fn js_module_create_require_devirt(filename_or_url: f64) -> f64 {
 /// State of one AOT-compiled module that can be loaded by runtime path.
 ///
 /// `Initializing` carries the owner thread so a CommonJS cycle on that same
-/// thread can observe the wrapper's partial `exports` object. Other callers
-/// wait for the owner to publish the final value (or failure), which prevents
-/// concurrent first requests from racing the generated module init guard.
+/// thread can observe the wrapper's partial `exports` object. The registry's
+/// loader-wide logical owner prevents a second thread from claiming another
+/// key while generated init code is active, so concurrent A <-> B loads cannot
+/// form a wait cycle. Other callers wait for the final value or failure.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PathModuleStatus {
     Registered,
@@ -258,13 +259,19 @@ struct PathModuleEntry {
 #[derive(Default)]
 struct PathModuleState {
     entries: std::collections::HashMap<String, PathModuleEntry>,
+    /// Logical (not mutex) ownership of the lazy loader. While one thread is
+    /// running generated init code, only that thread may claim another path.
+    /// This composes concurrency with A -> B -> A cycles without ever holding
+    /// the registry mutex across generated code.
+    loader_owner: Option<std::thread::ThreadId>,
+    loader_depth: usize,
 }
 
 /// Provider-visible path-module registry. App-only dylibs call these runtime
 /// symbols through their undefined ABI references, so the state lives in the
 /// separately loaded runtime provider rather than being duplicated per app.
-/// One mutex protects init ownership and export publication atomically; it is
-/// always released before generated code runs.
+/// One mutex protects logical loader ownership and export publication
+/// atomically; it is always released before generated code runs.
 struct PathModuleRegistry {
     state: std::sync::Mutex<PathModuleState>,
     ready: std::sync::Condvar,
@@ -307,18 +314,28 @@ impl PathModuleRegistry {
     /// Only same-thread recursive loads may observe it; unrelated waiters stay
     /// parked while the status is `Initializing`.
     fn register_partial_exports(&self, key: String, exports: u64) {
-        let mut state = self.lock();
-        let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
-            init_addr: None,
-            exports: None,
-            status: PathModuleStatus::Registered,
-        });
-        if matches!(entry.status, PathModuleStatus::Failed(_)) {
-            return;
-        }
-        entry.exports = Some(exports);
-        if entry.status == PathModuleStatus::Registered {
-            entry.status = PathModuleStatus::Initializing(std::thread::current().id());
+        let stored = {
+            let mut state = self.lock();
+            let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+                init_addr: None,
+                exports: None,
+                status: PathModuleStatus::Registered,
+            });
+            if matches!(entry.status, PathModuleStatus::Failed(_)) {
+                false
+            } else {
+                entry.exports = Some(exports);
+                if entry.status == PathModuleStatus::Registered {
+                    entry.status = PathModuleStatus::Initializing(std::thread::current().id());
+                }
+                true
+            }
+        };
+        // The registry is a persistent mutable GC root. Shade the new value
+        // after releasing its lock so a full cycle that already scanned roots
+        // cannot sweep a late-published exports object.
+        if stored {
+            crate::gc::runtime_write_barrier_root_nanbox(exports);
         }
     }
 
@@ -327,18 +344,28 @@ impl PathModuleRegistry {
     /// population can still follow the CJS body). Eager modules have no
     /// registered init address, so this call is their completion boundary.
     fn register_final_exports(&self, key: String, exports: u64) {
-        let mut state = self.lock();
-        let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
-            init_addr: None,
-            exports: None,
-            status: PathModuleStatus::Registered,
-        });
-        if matches!(entry.status, PathModuleStatus::Failed(_)) {
-            return;
+        let (stored, completed_eager) = {
+            let mut state = self.lock();
+            let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
+                init_addr: None,
+                exports: None,
+                status: PathModuleStatus::Registered,
+            });
+            if matches!(entry.status, PathModuleStatus::Failed(_)) {
+                (false, false)
+            } else {
+                entry.exports = Some(exports);
+                let completed_eager = entry.init_addr.is_none();
+                if completed_eager {
+                    entry.status = PathModuleStatus::Initialized;
+                }
+                (true, completed_eager)
+            }
+        };
+        if stored {
+            crate::gc::runtime_write_barrier_root_nanbox(exports);
         }
-        entry.exports = Some(exports);
-        if entry.init_addr.is_none() {
-            entry.status = PathModuleStatus::Initialized;
+        if completed_eager {
             self.ready.notify_all();
         }
     }
@@ -377,6 +404,25 @@ impl PathModuleRegistry {
                     let Some(addr) = entry.init_addr else {
                         return Ok(entry.exports);
                     };
+                    match state.loader_owner {
+                        Some(owner) if owner != current => {
+                            drop(
+                                self.ready
+                                    .wait(state)
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+                            );
+                            continue;
+                        }
+                        Some(_) => state.loader_depth += 1,
+                        None => {
+                            state.loader_owner = Some(current);
+                            state.loader_depth = 1;
+                        }
+                    }
+                    let entry = state
+                        .entries
+                        .get_mut(key)
+                        .expect("path entry disappeared while claiming loader ownership");
                     entry.status = PathModuleStatus::Initializing(current);
                     break addr;
                 }
@@ -386,22 +432,36 @@ impl PathModuleRegistry {
         // Never hold the registry lock across generated module code. That code
         // self-registers exports and may recursively require another path.
         let outcome = initialize(init_addr);
-        let mut state = self.lock();
-        let entry = state
-            .entries
-            .get_mut(key)
-            .expect("path initializer entry disappeared while it was running");
-        let result = match outcome {
-            Ok(()) => {
-                entry.status = PathModuleStatus::Initialized;
-                Ok(entry.exports)
+        let (result, failed_error) = {
+            let mut state = self.lock();
+            let entry = state
+                .entries
+                .get_mut(key)
+                .expect("path initializer entry disappeared while it was running");
+            let (result, failed_error) = match outcome {
+                Ok(()) => {
+                    entry.status = PathModuleStatus::Initialized;
+                    (Ok(entry.exports), None)
+                }
+                Err(error) => {
+                    entry.exports = None;
+                    entry.status = PathModuleStatus::Failed(error);
+                    (Err(error), Some(error))
+                }
+            };
+            debug_assert_eq!(state.loader_owner, Some(current));
+            debug_assert!(state.loader_depth > 0);
+            state.loader_depth -= 1;
+            if state.loader_depth == 0 {
+                state.loader_owner = None;
             }
-            Err(error) => {
-                entry.exports = None;
-                entry.status = PathModuleStatus::Failed(error);
-                Err(error)
-            }
+            (result, failed_error)
         };
+        // Failed values are persistent roots too. Keep waiters asleep until
+        // the cached exception has been shaded.
+        if let Some(error) = failed_error {
+            crate::gc::runtime_write_barrier_root_nanbox(error);
+        }
         self.ready.notify_all();
         result
     }
@@ -423,6 +483,11 @@ impl PathModuleRegistry {
                 visitor.visit_nanbox_u64_slot(error);
             }
         }
+    }
+
+    #[cfg(test)]
+    fn remove_for_test(&self, key: &str) {
+        self.lock().entries.remove(key);
     }
 }
 
@@ -553,6 +618,16 @@ pub extern "C" fn js_has_path_module(path_value: f64) -> f64 {
 /// them when a copying collection moves their referents.
 pub fn scan_module_path_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     MODULE_PATH_REGISTRY.scan_roots(visitor);
+}
+
+#[cfg(test)]
+pub(crate) fn test_store_path_module_root(key: &str, value_bits: u64) {
+    MODULE_PATH_REGISTRY.register_final_exports(key.to_string(), value_bits);
+}
+
+#[cfg(test)]
+pub(crate) fn test_remove_path_module_root(key: &str) {
+    MODULE_PATH_REGISTRY.remove_for_test(key);
 }
 
 /// Node-style `require.resolve` fallback for package-subpath specifiers that
@@ -801,8 +876,54 @@ mod path_module_registry_tests {
     use super::*;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc, Barrier,
+        mpsc, Arc, Barrier, Condvar, Mutex,
     };
+
+    struct InitGate {
+        entered: mpsc::Sender<usize>,
+        released: Mutex<std::collections::HashSet<usize>>,
+        ready: Condvar,
+    }
+
+    impl InitGate {
+        fn enter_and_wait(&self, addr: usize) {
+            self.entered.send(addr).unwrap();
+            let mut released = self.released.lock().unwrap();
+            while !released.contains(&addr) {
+                released = self.ready.wait(released).unwrap();
+            }
+        }
+
+        fn release(&self, addr: usize) {
+            self.released.lock().unwrap().insert(addr);
+            self.ready.notify_all();
+        }
+    }
+
+    fn initialize_two_key_cycle(
+        registry: &PathModuleRegistry,
+        gate: &InitGate,
+        calls: &[AtomicUsize; 2],
+        partial_observations: &AtomicUsize,
+        addr: usize,
+    ) -> Result<(), u64> {
+        gate.enter_and_wait(addr);
+        let (key, other_key, partial, other_partial, final_value, call_index) = match addr {
+            31 => ("a.js", "b.js", 0xA1, 0xB1, 0xA2, 0),
+            37 => ("b.js", "a.js", 0xB1, 0xA1, 0xB2, 1),
+            _ => panic!("unexpected initializer address {addr}"),
+        };
+        calls[call_index].fetch_add(1, Ordering::Relaxed);
+        registry.register_partial_exports(key.into(), partial);
+        let observed = registry.require_with(other_key, &|next_addr| {
+            initialize_two_key_cycle(registry, gate, calls, partial_observations, next_addr)
+        })?;
+        if observed == Some(other_partial) {
+            partial_observations.fetch_add(1, Ordering::Relaxed);
+        }
+        registry.register_final_exports(key.into(), final_value);
+        Ok(())
+    }
 
     #[test]
     fn recursive_load_observes_partial_exports_without_reentering_init() {
@@ -866,6 +987,71 @@ mod path_module_registry_tests {
             assert_eq!(worker.join().unwrap().unwrap(), Some(0xB2));
         }
         assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn opposite_concurrent_cycle_serializes_generated_init_and_completes() {
+        let registry = Arc::new(PathModuleRegistry::default());
+        assert!(registry.register_init("a.js".into(), 31));
+        assert!(registry.register_init("b.js".into(), 37));
+        let starts = Arc::new(Barrier::new(3));
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let gate = Arc::new(InitGate {
+            entered: entered_tx,
+            released: Mutex::new(std::collections::HashSet::new()),
+            ready: Condvar::new(),
+        });
+        let calls = Arc::new([AtomicUsize::new(0), AtomicUsize::new(0)]);
+        let partial_observations = Arc::new(AtomicUsize::new(0));
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let mut workers = Vec::new();
+        for (key, expected) in [("a.js", 0xA2), ("b.js", 0xB2)] {
+            let registry = Arc::clone(&registry);
+            let starts = Arc::clone(&starts);
+            let gate = Arc::clone(&gate);
+            let calls = Arc::clone(&calls);
+            let partial_observations = Arc::clone(&partial_observations);
+            let result_tx = result_tx.clone();
+            workers.push(std::thread::spawn(move || {
+                starts.wait();
+                let result = registry.require_with(key, &|addr| {
+                    initialize_two_key_cycle(&registry, &gate, &calls, &partial_observations, addr)
+                });
+                result_tx.send((expected, result)).unwrap();
+            }));
+        }
+        drop(result_tx);
+
+        starts.wait();
+        let first = entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("one thread must claim the logical loader");
+        assert!(
+            entered_rx
+                .recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "opposite keys ran generated init concurrently and can deadlock"
+        );
+        gate.release(first);
+        let nested = entered_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("the loader owner must recursively initialize the opposite key");
+        assert_ne!(nested, first);
+        gate.release(nested);
+
+        for _ in 0..2 {
+            let (expected, result) = result_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("A <-> B concurrent load did not complete within the bound");
+            assert_eq!(result.unwrap(), Some(expected));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(calls[0].load(Ordering::Relaxed), 1);
+        assert_eq!(calls[1].load(Ordering::Relaxed), 1);
+        assert_eq!(partial_observations.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -6,8 +6,20 @@
 /// inside the IIFE will throw at runtime if hit.
 pub fn extract_require_specifiers(source: &str) -> Vec<String> {
     let re = regex::Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap();
+    let masked = super::detect::strip_comments_and_strings(source);
     let mut specs = Vec::new();
     for cap in re.captures_iter(source) {
+        let Some(call) = cap.get(0) else {
+            continue;
+        };
+        // The regexp runs on the original source so it can capture the quoted
+        // specifier. Require the `require` token itself to survive the
+        // comment/string masking pass, though. Otherwise text such as Next's
+        // `"unexpected require(" + request + ") ..."` is mistaken for a call
+        // whose specifier is the intervening JavaScript expression.
+        if masked.as_bytes()[call.start()..call.start() + b"require".len()] != *b"require" {
+            continue;
+        }
         if let Some(m) = cap.get(1) {
             let s = m.as_str().to_string();
             if !specs.contains(&s) {
@@ -300,10 +312,14 @@ pub fn function_local_specs(source: &str) -> std::collections::HashSet<String> {
 
     // (offset, spec) for every static `require('<spec>')` call, in source order.
     let re = regex::Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap();
+    let masked = super::detect::strip_comments_and_strings(source);
     let sbytes = source.as_bytes();
     let mut sites: Vec<(usize, &str)> = Vec::new();
     for cap in re.captures_iter(source) {
         let m0 = cap.get(0).unwrap();
+        if masked.as_bytes()[m0.start()..m0.start() + b"require".len()] != *b"require" {
+            continue;
+        }
         // Skip member-access matches (`foo.require('x')`).
         let mut p = m0.start();
         while p > 0 && (sbytes[p - 1] as char).is_whitespace() {
@@ -318,7 +334,6 @@ pub fn function_local_specs(source: &str) -> std::collections::HashSet<String> {
         return HashSet::new();
     }
 
-    let masked = super::detect::strip_comments_and_strings(source);
     let mbytes = masked.as_bytes();
     let is_ident = |c: u8| c == b'_' || c == b'$' || c.is_ascii_alphanumeric();
     let control_keywords = ["if", "for", "while", "switch", "catch", "with", "else"];

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -1209,6 +1209,10 @@ module.exports = SafeBuffer;"#;
         // The CommonJS runtime shims still run at module scope.
         assert!(wrapped.contains("const __cjs_module = { exports: {} };"));
         assert!(wrapped.contains("const _cjs = __cjs_module.exports;"));
+        let ast = perry_parser::parse_typescript(&wrapped, "stack-utils.js")
+            .expect("flat class wrap must parse");
+        perry_hir::lower_module(&ast, "stack_utils", "/tmp/test.js")
+            .expect("flat class wrap must preserve its top-level class binding");
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -76,7 +76,7 @@ mod tests {
         module_reexport_specs,
     };
     use super::extract_requires::{
-        extract_require_aliases_with_ranges, extract_require_specifiers,
+        extract_require_aliases_with_ranges, extract_require_specifiers, function_local_specs,
     };
     use super::hoist_classes::{
         extract_top_level_class_decls, source_has_top_level_return, top_level_class_names,
@@ -459,6 +459,16 @@ module.exports = inner;
         let src = r#"var a = require('./a'); var b = require("./b"); var c = require('./a');"#;
         let specs = extract_require_specifiers(src);
         assert_eq!(specs, vec!["./a".to_string(), "./b".to_string()]);
+    }
+
+    #[test]
+    fn ignores_require_text_split_across_string_concatenation() {
+        // Next's webpack HMR runtime uses this warning. The closing quote
+        // after `require(` and the opening quote before `)` look like a
+        // static string argument to a regexp-only extractor.
+        let src = r#"console.warn("[HMR] unexpected require(" + request + ") from disposed module " + moduleId);"#;
+        assert!(extract_require_specifiers(src).is_empty());
+        assert!(function_local_specs(src).is_empty());
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
@@ -187,3 +187,30 @@ fn a_module_that_was_never_cjs_wrapped_has_no_preamble() {
     assert_eq!(census.module_records, 0);
     assert_eq!(census.preamble_alloc_stmts, 0);
 }
+
+#[test]
+fn path_module_wrap_publishes_partial_then_final_exports_and_tracks_undefined() {
+    let path = Path::new("/tmp/perry-canary/.next/server/chunks/lazy.js");
+    let marker = "exports.ready = true;";
+    let wrapped = wrap_commonjs_for_target(marker, path, None);
+
+    let partial = wrapped
+        .find("__perry_register_path_module_partial(")
+        .expect("CJS wrapper must publish its initial exports object");
+    let body = wrapped
+        .find(marker)
+        .expect("fixture body must remain in the wrapper");
+    let final_publish = wrapped
+        .rfind("__perry_register_path_module(")
+        .expect("CJS wrapper must publish its final module.exports value");
+    assert!(partial < body && body < final_publish, "{wrapped}");
+    assert!(
+        wrapped.contains("__perry_path_mod !== undefined || __perry_has_path_module(specifier)"),
+        "an exported undefined value must not be mistaken for a registry miss\n{wrapped}"
+    );
+
+    // Run the real parser/lowerer as an anti-vacuity check for both new
+    // intrinsics, including the boolean presence probe in the require shim.
+    let ast = perry_parser::parse_typescript(&wrapped, "lazy.js").unwrap();
+    perry_hir::lower_module(&ast, "lazy", &path.to_string_lossy()).unwrap();
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
@@ -209,7 +209,7 @@ fn path_module_wrap_publishes_partial_then_final_exports_and_tracks_undefined() 
         "an exported undefined value must not be mistaken for a registry miss\n{wrapped}"
     );
 
-    // Run the real parser/lowerer as an anti-vacuity check for both new
+    // Run the real parser/lowerer as an anti-vacuity check for the registry
     // intrinsics, including the boolean presence probe in the require shim.
     let ast = perry_parser::parse_typescript(&wrapped, "lazy.js").unwrap();
     perry_hir::lower_module(&ast, "lazy", &path.to_string_lossy()).unwrap();

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -872,12 +872,10 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
 
     // Wall 54: self-register this compiled module's exports under its absolute
     // source path so a runtime `require(absolutePath.js)` (turbopack/Next.js
-    // page+chunk loading) resolves to it. `{:?}` debug-quotes to a valid JS
-    // string literal.
-    let path_register = format!(
-        "__perry_register_path_module({:?}, __cjs_module.exports);",
-        source_path.to_string_lossy()
-    );
+    // page+chunk loading) resolves to it. Reuse the exact literal used for the
+    // partial publication above so both registry operations have one key.
+    let path_register =
+        format!("__perry_register_path_module({module_path_literal}, __cjs_module.exports);");
     let wrapped = if let Some(flat_class) = &flat_default_class {
         // Issue #4933 — flat emission. Drop the IIFE and run the CommonJS body
         // at ESM module scope: `module.exports = {flat_class}` then resolves to

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -745,6 +745,7 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default()
     );
+    let module_path_literal = format!("{:?}", source_path.to_string_lossy());
     let cjs_preamble = format!(
         r#"    // #3527: `module`/`exports` are reassignable `var`s (mirroring Node, where
     // they are wrapper-function parameters), so CJS bodies that do
@@ -756,6 +757,10 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
     // real module ref the same way), so named/default-export resolution stays
     // correct regardless of what the body does to its `module` local.
     const __cjs_module = {{ exports: {{}} }};
+    // Publish the initial object before user code. The runtime exposes it only
+    // to same-thread recursive loads; concurrent first callers wait for the
+    // final registration at the bottom of this wrapper.
+    __perry_register_path_module_partial({module_path_literal}, __cjs_module.exports);
     var module = __cjs_module;
     var exports = __cjs_module.exports;
     function __perry_cjs_require_error(kind, code, message) {{
@@ -824,7 +829,7 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
         // registered, fall through to the `.json` read / MODULE_NOT_FOUND throw.
         {{
             const __perry_path_mod = __perry_require_path_module(specifier);
-            if (__perry_path_mod !== undefined) return __perry_path_mod;
+            if (__perry_path_mod !== undefined || __perry_has_path_module(specifier)) return __perry_path_mod;
         }}
         // Runtime `require(absolutePath)` of a `.json` file (Next.js loads
         // manifests this way: `require(this.middlewareManifestPath)`). Node's

--- a/test-files/issue_8039_path_modules/.next/server/async-work.js
+++ b/test-files/issue_8039_path_modules/.next/server/async-work.js
@@ -1,0 +1,5 @@
+globalThis.__issue8039AsyncInits = (globalThis.__issue8039AsyncInits || 0) + 1;
+
+export function checksum(index) {
+    return index * 17 + 5;
+}

--- a/test-files/issue_8039_path_modules/.next/server/cycle-a.js
+++ b/test-files/issue_8039_path_modules/.next/server/cycle-a.js
@@ -1,0 +1,8 @@
+globalThis.__issue8039AInits = (globalThis.__issue8039AInits || 0) + 1;
+exports.phase = "a-partial";
+
+const cycleBPath = process.cwd() + "/.next/server/cycle-b.js";
+const cycleB = require(cycleBPath);
+
+exports.seenByB = cycleB.sawA;
+exports.phase = "a-final";

--- a/test-files/issue_8039_path_modules/.next/server/cycle-b.js
+++ b/test-files/issue_8039_path_modules/.next/server/cycle-b.js
@@ -1,0 +1,6 @@
+globalThis.__issue8039BInits = (globalThis.__issue8039BInits || 0) + 1;
+
+const cycleAPath = process.cwd() + "/.next/server/cycle-a.js";
+const cycleA = require(cycleAPath);
+
+exports.sawA = cycleA.phase;

--- a/test-files/issue_8039_path_modules/.next/server/route.js
+++ b/test-files/issue_8039_path_modules/.next/server/route.js
@@ -1,0 +1,20 @@
+globalThis.__issue8039RouteInits = (globalThis.__issue8039RouteInits || 0) + 1;
+
+const root = process.cwd() + "/.next/server/";
+const cycle = require(root + "cycle-a.js");
+const undefinedValue = require(root + "undefined.js");
+
+exports.handle = async function handle(id) {
+    const work = await import("./async-work.js");
+    const index = Number(id.slice(id.lastIndexOf("-") + 1));
+    return {
+        id,
+        cycle: cycle.seenByB,
+        undefinedIsReal: undefinedValue === undefined,
+        checksum: work.checksum(index),
+        routeInits: globalThis.__issue8039RouteInits,
+        aInits: globalThis.__issue8039AInits,
+        bInits: globalThis.__issue8039BInits,
+        asyncInits: globalThis.__issue8039AsyncInits,
+    };
+};

--- a/test-files/issue_8039_path_modules/.next/server/undefined.js
+++ b/test-files/issue_8039_path_modules/.next/server/undefined.js
@@ -1,0 +1,1 @@
+module.exports = undefined;

--- a/test-files/issue_8039_path_modules/entry.js
+++ b/test-files/issue_8039_path_modules/entry.js
@@ -5,6 +5,9 @@ async function request(id) {
 }
 
 async function verifyPass(label) {
+    // This exercises same-event-loop re-entrancy and once-only initialization.
+    // OS-thread waiters and logical loader ownership are covered by the
+    // PathModuleRegistry tests in perry-runtime/src/module_require.rs.
     const values = await Promise.all(
         Array.from({ length: 20 }, (_, index) => request(label + "-" + index)),
     );

--- a/test-files/issue_8039_path_modules/entry.js
+++ b/test-files/issue_8039_path_modules/entry.js
@@ -1,0 +1,40 @@
+async function request(id) {
+    const routePath = process.cwd() + "/.next/server/route.js";
+    const route = require(routePath);
+    return await route.handle(id);
+}
+
+async function verifyPass(label) {
+    const values = await Promise.all(
+        Array.from({ length: 20 }, (_, index) => request(label + "-" + index)),
+    );
+    for (let index = 0; index < values.length; index += 1) {
+        const value = values[index];
+        const expectedId = label + "-" + index;
+        if (value.id !== expectedId) throw new Error("lost id " + expectedId);
+        if (value.cycle !== "a-partial") throw new Error("bad cycle " + value.cycle);
+        if (!value.undefinedIsReal) throw new Error("undefined export became a miss");
+        if (value.checksum !== index * 17 + 5) throw new Error("bad checksum " + expectedId);
+        if (
+            value.routeInits !== 1 ||
+            value.aInits !== 1 ||
+            value.bInits !== 1 ||
+            value.asyncInits !== 1
+        ) {
+            throw new Error("duplicate init " + JSON.stringify(value));
+        }
+    }
+}
+
+async function main() {
+    await verifyPass("cold");
+    await verifyPass("warm");
+    console.log("PASS: issue 8039 cold/warm path modules");
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});
+
+module.exports = {};

--- a/tests/test_issue_8039_path_module_lazy.sh
+++ b/tests/test_issue_8039_path_module_lazy.sh
@@ -15,28 +15,93 @@ fi
 run_with_timeout() {
     local secs="$1"
     shift
+    local rc
     if command -v timeout >/dev/null 2>&1; then
-        timeout "$secs" "$@"
-        return $?
+        if timeout --kill-after=1 "$secs" "$@"; then
+            return 0
+        else
+            rc=$?
+        fi
+        [[ "$rc" == "124" || "$rc" == "143" || "$rc" == "137" ]] && return 124
+        return "$rc"
     fi
     if command -v gtimeout >/dev/null 2>&1; then
-        gtimeout "$secs" "$@"
-        return $?
+        if gtimeout --kill-after=1 "$secs" "$@"; then
+            return 0
+        else
+            rc=$?
+        fi
+        [[ "$rc" == "124" || "$rc" == "143" || "$rc" == "137" ]] && return 124
+        return "$rc"
     fi
-    "$@" &
-    local pid=$!
-    ( sleep "$secs" && kill -TERM "$pid" 2>/dev/null && sleep 1 && kill -KILL "$pid" 2>/dev/null ) &
-    local watcher=$!
-    if wait "$pid" 2>/dev/null; then
-        kill -TERM "$watcher" 2>/dev/null || true
-        wait "$watcher" 2>/dev/null || true
-        return 0
-    fi
-    local rc=$?
-    kill -TERM "$watcher" 2>/dev/null || true
-    wait "$watcher" 2>/dev/null || true
-    [[ "$rc" == "143" ]] && return 124
-    return "$rc"
+    # macOS has neither GNU timeout nor gtimeout by default. Avoid a shell
+    # sleep/watchdog whose inherited stdout keeps command substitution open;
+    # Python kills and reaps the child before returning 124.
+    python3 - "$secs" "$@" <<'PY'
+import subprocess
+import os
+import signal
+import sys
+import tempfile
+
+def session_members(session_id):
+    """Return every process still belonging to the isolated child session."""
+    try:
+        listing = subprocess.check_output(
+            ["ps", "-axo", "pid="], text=True, stderr=subprocess.DEVNULL
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    members = []
+    for line in listing.splitlines():
+        try:
+            pid = int(line)
+            if os.getsid(pid) == session_id:
+                members.append(pid)
+        except (ProcessLookupError, PermissionError, ValueError):
+            pass
+    return members
+
+timed_out = False
+with tempfile.TemporaryFile() as output:
+    process = subprocess.Popen(
+        sys.argv[2:],
+        start_new_session=True,
+        stdout=output,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        rc = process.wait(timeout=float(sys.argv[1]))
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+        # A descendant may create a separate process group, so kill every
+        # process that remains in the isolated session before returning.
+        for pid in session_members(process.pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        rc = process.wait()
+    output.seek(0)
+    sys.stdout.buffer.write(output.read())
+if timed_out:
+    raise SystemExit(124)
+if rc in (-15, -9, 143, 137):
+    raise SystemExit(124)
+raise SystemExit(rc)
+PY
 }
 
 (

--- a/tests/test_issue_8039_path_module_lazy.sh
+++ b/tests/test_issue_8039_path_module_lazy.sh
@@ -12,12 +12,43 @@ if [[ ! -x "$PERRY" ]]; then
     exit 0
 fi
 
+run_with_timeout() {
+    local secs="$1"
+    shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$secs" "$@"
+        return $?
+    fi
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$secs" "$@"
+        return $?
+    fi
+    "$@" &
+    local pid=$!
+    ( sleep "$secs" && kill -TERM "$pid" 2>/dev/null && sleep 1 && kill -KILL "$pid" 2>/dev/null ) &
+    local watcher=$!
+    if wait "$pid" 2>/dev/null; then
+        kill -TERM "$watcher" 2>/dev/null || true
+        wait "$watcher" 2>/dev/null || true
+        return 0
+    fi
+    local rc=$?
+    kill -TERM "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+    [[ "$rc" == "143" ]] && return 124
+    return "$rc"
+}
+
 (
     cd "$FIXTURE"
     "$PERRY" compile --no-auto-optimize entry.js -o "$WORK/path-module-lazy"
 )
 
-OUTPUT="$(cd "$FIXTURE" && "$WORK/path-module-lazy" 2>&1)"
+if ! OUTPUT="$(cd "$FIXTURE" && run_with_timeout 30 "$WORK/path-module-lazy" 2>&1)"; then
+    echo "FAIL: path-module lazy binary timed out or exited non-zero"
+    echo "$OUTPUT"
+    exit 1
+fi
 EXPECTED="PASS: issue 8039 cold/warm path modules"
 if [[ "$OUTPUT" != *"$EXPECTED"* ]]; then
     echo "FAIL: path-module lazy graph did not pass"

--- a/tests/test_issue_8039_path_module_lazy.sh
+++ b/tests/test_issue_8039_path_module_lazy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+FIXTURE="$REPO_ROOT/test-files/issue_8039_path_modules"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: build Perry first or set PERRY_BIN"
+    exit 0
+fi
+
+(
+    cd "$FIXTURE"
+    "$PERRY" compile --no-auto-optimize entry.js -o "$WORK/path-module-lazy"
+)
+
+OUTPUT="$(cd "$FIXTURE" && "$WORK/path-module-lazy" 2>&1)"
+EXPECTED="PASS: issue 8039 cold/warm path modules"
+if [[ "$OUTPUT" != *"$EXPECTED"* ]]; then
+    echo "FAIL: path-module lazy graph did not pass"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "$EXPECTED"

--- a/tests/test_issue_8039_path_module_lazy.sh
+++ b/tests/test_issue_8039_path_module_lazy.sh
@@ -79,9 +79,14 @@ with tempfile.TemporaryFile() as output:
         except ProcessLookupError:
             pass
         try:
-            process.wait(timeout=1)
+            rc = process.wait(timeout=1)
         except subprocess.TimeoutExpired:
-            pass
+            # The child remains unreaped, so its PID/PGID cannot be reused.
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            rc = process.wait()
         # A descendant may create a separate process group, so kill every
         # process that remains in the isolated session before returning.
         for pid in session_members(process.pid):
@@ -89,11 +94,6 @@ with tempfile.TemporaryFile() as output:
                 os.kill(pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        rc = process.wait()
     output.seek(0)
     sys.stdout.buffer.write(output.read())
 if timed_out:


### PR DESCRIPTION
Refs #8039

## Summary

- replace the split path export/init maps with one provider-owned synchronized registry
- serialize generated initializers under one recursive loader owner, release the registry mutex during generated code, and prevent cross-thread `A <-> B` cycle deadlocks
- publish CJS partial exports for cycles and make concurrent callers receive the same final value or cached failure
- distinguish a real `undefined` export from a miss, canonicalize aliases, and use an explicit no-retry failure policy
- apply incremental root barriers when partial exports, final exports, and failures enter the persistent path registry
- bind provider-held JS values and mutable-root scanning to one runtime thread so thread-local GC arenas never exchange values
- track active lazy claims explicitly, allowing a registered initializer that also ran eagerly to complete and notify correctly
- run generated module bodies behind boundary-scoped native catches so eager partial-only wrappers cache the original throw, wake waiters, and cannot poison an outer wrapper that catches a nested failure
- replace the cold-claim full-map scan with constant-time initializing-owner/count state
- reject foreign partial publication while the logical loader is owned instead of admitting a cross-owner wait cycle
- register deferred `.next/server/**` initializers from executable and app-only dylib entry points
- ignore `require(...)` text inside strings while extracting Next webpack dependencies
- add focused coverage for recursive loading, a bounded two-thread opposite-key CJS cycle, concurrent first access, eager/nested failure boundaries, async import, `undefined` exports, and a post-root-scan GC insertion

## Validation

- `cargo test -p perry-runtime path_module_registry_tests --lib` (13 passed)
- `cargo test -p perry-runtime full_cycle_path_module_root_store_after_root_scan_preserves_new_value --lib` (passed)
- `cargo test -p perry-codegen executable_and_app_dylib_both_register_lazy_path_initializers` (passed)
- `cargo test -p perry-codegen module_init_body_runs_through_native_exception_boundary` (passed)
- `cargo test -p perry --bin perry path_module_wrap_publishes_partial_then_final_exports_and_tracks_undefined` (passed)
- `cargo test -p perry --bin perry wrap_flat_emits_class_module_exports_that_closes_over_top_level_const` (passed)
- `cargo test -p perry --bin perry cjs_wrap::tests::ignores_require_text_split_across_string_concatenation` (passed)
- `tests/test_issue_8039_path_module_lazy.sh` against a fresh release compiler/runtime build (passed)
- focused fixture as an app-only dylib loaded with freshly rebuilt, separate runtime and stdlib providers (cold/warm passed; not counted as the production gate)
- exact pinned Next 16.3.0 / React 19.2.4 production webpack Node oracle, two consecutive verifier runs (21 requests each; passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_file_size.sh`
- `python3 scripts/gc_runtime_root_holders.py`
- timeout fallback self-check: preserves non-timeout exit status and kills/reaps the timed-out process group with status 124

## Production gate status

The exact #8034 production source and verifier were exercised rather than treating the focused synthetic graph as a substitute. The Node oracle passed twice. The unmodified generated standalone graph reached Perry's production compiler after fixing the HMR-string extractor false positive, but the attached fixture has no Perry package-routing configuration: it first stopped on runtime-routed `nanoid`, then on `next`. An exploratory explicit pure-JS allowlist expands into Next's client/build/telemetry graph and was not treated as an acceptance result. The classic and provider-hosted app-dylib verifier matrix therefore has **not** passed, and this PR deliberately references rather than closes #8039; #8034 remains the integration gate.

No version bump; maintainers can bump at merge time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable lazy loading for Next.js path-based modules.
  - Supports concurrent requests, CommonJS circular dependencies, partial exports, and modules whose final value is `undefined`.
  - Caches initialization failures and replays them consistently.
  - Supports module discovery through directory `package.json` and `index.js` conventions.

- **Bug Fixes**
  - Prevented comments and string contents from being misidentified as `require(...)` calls.
  - Improved module state tracking during garbage collection and concurrent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->