### PR TITLE
fix(ci): avoid pipefail SIGPIPE in LLVM liveness checks

### DIFF
--- a/.github/workflows/llvm-inprocess.yml
+++ b/.github/workflows/llvm-inprocess.yml
@@ -125,10 +125,10 @@ jobs:
             --features llvm-inprocess --lib 2>&1) || { echo "$out"; exit 1; }
           # The corpus gates must have RUN, not skipped: a checkout missing
           # the tracked .ll corpora would otherwise green vacuously.
-          echo "$out" | grep -q "dialect::tests::corpus_spike ... ok"
-          echo "$out" | grep -q "dialect::tests::corpus_batch_kernel ... ok"
-          echo "$out" | grep -q "dialect::tests::corpus_exception_handling ... ok"
-          echo "$out" | grep -q "inprocess::tests::rs4gc_schedules_in_process ... ok"
+          grep -q "dialect::tests::corpus_spike ... ok" <<<"$out"
+          grep -q "dialect::tests::corpus_batch_kernel ... ok" <<<"$out"
+          grep -q "dialect::tests::corpus_exception_handling ... ok" <<<"$out"
+          grep -q "inprocess::tests::rs4gc_schedules_in_process ... ok" <<<"$out"
 
 
       # The tracked `.ll` corpora above are a SNAPSHOT of what the compiler

--- a/changelog.d/8063-llvm-inprocess-liveness-pipefail.md
+++ b/changelog.d/8063-llvm-inprocess-liveness-pipefail.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The `llvm-inprocess` unit gate no longer reports a false failure when
+  `grep -q` finds a required liveness test early and closes a large captured
+  output stream under `pipefail` (#8053).

--- a/scripts/gc_gate_wiring_check.py
+++ b/scripts/gc_gate_wiring_check.py
@@ -340,6 +340,31 @@ def check_schedule_group(text: str, wf_name: str) -> list[str]:
     ]
 
 
+def check_pipefail_early_exit_pipelines(text: str, wf_name: str) -> list[str]:
+    """Reject liveness checks whose successful match can fail via SIGPIPE.
+
+    `grep -q` intentionally closes its input after the first match. Under
+    `pipefail`, feeding a large captured log through `echo ... | grep -q`
+    therefore lets the upstream writer's SIGPIPE turn a successful liveness
+    match into a failed step. Use a here-string or let grep read a file.
+    """
+    problems: list[str] = []
+    for chunk in re.split(r"^      - ", text, flags=re.M)[1:]:
+        chunk = "        " + chunk
+        run = _block(chunk, "run", 8)
+        if not re.search(r"\bset\s+-[a-z]*e[a-z]*\s+pipefail\b", run):
+            continue
+        for line in run.splitlines():
+            stripped = line.strip()
+            if re.search(r"\becho\b[^|\n]*\|\s*grep\b[^\n]*\s-q(?:\s|$)", stripped):
+                problems.append(
+                    f"{wf_name}: `pipefail` liveness check can report a false "
+                    f"failure when `grep -q` closes early and `echo` receives "
+                    f"SIGPIPE: {stripped[:90]}. Use a here-string or a file."
+                )
+    return problems
+
+
 CLEAN = """\
 name: X
 on:
@@ -528,6 +553,29 @@ def _self_test() -> int:
         False,
     )
 
+    # A positive match is not a failure. With a large `$out`, however,
+    # `grep -q` closes the pipe before echo finishes and `pipefail` reports
+    # echo's SIGPIPE. This is the exact llvm-inprocess unit-gate relapse.
+    cases += 1
+    broken_pipe = CLEAN.replace(
+        "        run: ./scripts/thing.sh",
+        "        run: |\n"
+        "          set -euo pipefail\n"
+        "          echo \"$out\" | grep -q \"corpus_spike ... ok\"",
+    )
+    got = check_pipefail_early_exit_pipelines(broken_pipe, "fixture.yml")
+    if not got or "SIGPIPE" not in got[0]:
+        failures.append(f"pipefail grep-q SIGPIPE: expected a problem, got {got}")
+
+    cases += 1
+    fixed_pipe = broken_pipe.replace(
+        'echo "$out" | grep -q "corpus_spike ... ok"',
+        'grep -q "corpus_spike ... ok" <<<"$out"',
+    )
+    got = check_pipefail_early_exit_pipelines(fixed_pipe, "fixture.yml")
+    if got:
+        failures.append(f"pipefail here-string: expected clean, got {got}")
+
     if failures:
         for f in failures:
             print(f"SELF-TEST FAIL: {f}", file=sys.stderr)
@@ -571,7 +619,9 @@ def main() -> int:
     scanned = 0
     for path in sorted(wf_dir.glob("*.yml")):
         scanned += 1
-        problems.extend(check_schedule_group(path.read_text(encoding="utf-8"), path.name))
+        text = path.read_text(encoding="utf-8")
+        problems.extend(check_schedule_group(text, path.name))
+        problems.extend(check_pipefail_early_exit_pipelines(text, path.name))
 
     if problems:
         print("GC GATE WIRING: one or more gates cannot fail where it matters.\n", file=sys.stderr)


### PR DESCRIPTION
## Summary

- preserve all four llvm-inprocess corpus/RS4GC positive liveness assertions
- feed the captured test output to `grep -q` through here-strings, removing the upstream writer that received SIGPIPE under `pipefail`
- extend the required lint checker with the exact unsafe `echo "$out" | grep -q ...` shape and a clean here-string self-test

Closes #8053.

Refs #7971 and #7966.

## Causal evidence

Exact base: `bd9580e072a56234a962b432d819efa258788f0c`.

A local 1 MiB captured-output witness with the required test name at the front reproduces the workflow mechanism:

- original `echo "$out" | grep -q ...` under `pipefail`: exit `141`
- fixed `grep -q ... <<<"$out"`: exit `0`

The original positive match therefore failed only because the upstream writer received SIGPIPE after `grep -q` exited early.

## Local validation

- `python3 scripts/gc_gate_wiring_check.py --self-test`: 18/18 cases
- `python3 scripts/gc_gate_wiring_check.py`: clean; 7 gates and 31 workflows checked
- sabotage check against the exact base workflow: 4 unsafe-pipeline findings
- fixed workflow through the same checker: 0 findings
- `python3 -m py_compile scripts/gc_gate_wiring_check.py`
- `actionlint .github/workflows/llvm-inprocess.yml`
- `git diff --check`

No LLVM build is needed: this changes only the output transport and its static gate. No version bump.
