### PR TITLE
fix(ci): keep TLS asyncpipe live for sampling

### DIFF
--- a/.github/workflows/tls-budget.yml
+++ b/.github/workflows/tls-budget.yml
@@ -44,7 +44,7 @@ name: TLS Budget
 #      run proves it was live: `PERRY_TLS_HOT_STATS=1` reporting
 #      `direct_tsd=1` (else `hot()` is itself calling `_tlv_get_addr` and the
 #      mechanism is inert) and `claimed` above a floor no allocation
-#      microbenchmark clears. Its `--self-test` drives all seven rejections
+#      microbenchmark clears. Its `--self-test` drives every rejection
 #      and runs on every PR, compiler-free, in the first job below.
 #
 # The one-time sabotage proof -- one hot declaration reverted to a raw
@@ -104,6 +104,8 @@ jobs:
           persist-credentials: false
       - name: Self-test the budget verdict logic
         run: python3 scripts/tls_budget_check.py --self-test
+      - name: Self-test the pre-attach liveness check
+        run: bash scripts/tls_budget_gate.sh --self-test
       - name: Self-test the thread-local policy checker
         run: python3 scripts/check_thread_locals.py --self-test
       - name: Enforce the thread-local policy ratchet

--- a/benchmarks/tls-budget/asyncpipe.ts
+++ b/benchmarks/tls-budget/asyncpipe.ts
@@ -15,6 +15,9 @@ type Ok = { id: number; user: string; amount: number; note: string };
 
 const KINDS: string[] = ["order", "refund", "adjust"];
 const USERS: string[] = ["ana", "bo", "cyd", "dee", "eli", "fay"];
+const BATCHES = 1200;
+const SIZE = 200;
+const PROFILE_MIN_MILLISECONDS = 12000;
 
 function makeReq(i: number): Req {
   return {
@@ -64,7 +67,7 @@ async function runBatch(base: number, size: number, rates: Map<string, number>):
   return done;
 }
 
-async function main(): Promise<void> {
+async function runPipeline(): Promise<string> {
   const rates = new Map<string, number>();
   rates.set("order", 3);
   rates.set("refund", 5);
@@ -76,9 +79,6 @@ async function main(): Promise<void> {
   let total = 0;
   let noteLen = 0;
   let errors = 0;
-
-  const BATCHES = 1200;
-  const SIZE = 200;
 
   for (let b = 0; b < BATCHES; b++) {
     let batch: Ok[] = [];
@@ -107,7 +107,34 @@ async function main(): Promise<void> {
     userSum = userSum + (perUser.has(name) ? (perUser.get(name) as number) : 0);
   }
 
-  console.log(`${total} ${noteLen} ${seenUsers.size} ${userSum} ${errors}`);
+  return `${total} ${noteLen} ${seenUsers.size} ${userSum} ${errors}`;
+}
+
+async function main(): Promise<void> {
+  // The gate checks one pipeline's exact result, then profiles this mode. Keep
+  // the sampled process busy with the same async/Map/Set/template-literal work
+  // instead of padding its lifetime with a timer or a narrow spin loop. Each
+  // repetition starts from the same fixed inputs and must produce the same
+  // result, so profiling cannot weaken the correctness oracle. Twelve seconds
+  // covers the one-second attach delay plus the eight-second sample with a
+  // fixed margin, while a slow host completes its current pipeline and exits.
+  const profileMode =
+    process.argv.length > 2 && process.argv[2] === "--tls-budget-profile";
+  const profileDeadline = profileMode ? Date.now() + PROFILE_MIN_MILLISECONDS : 0;
+  let result = "";
+  let repetition = 0;
+  do {
+    const next = await runPipeline();
+    if (repetition > 0 && next !== result) {
+      throw new Error(`non-deterministic pipeline result at repetition ${repetition}`);
+    }
+    result = next;
+    repetition = repetition + 1;
+  } while (profileMode && Date.now() < profileDeadline);
+  if (profileMode) {
+    console.error(`[tls-budget] completed=${repetition}`);
+  }
+  console.log(result);
 }
 
 main();

--- a/changelog.d/8066-tls-asyncpipe-profile-liveness.md
+++ b/changelog.d/8066-tls-asyncpipe-profile-liveness.md
@@ -1,0 +1,19 @@
+### TLS budget profiles now measure a live async workload (#8066)
+
+The Darwin TLS gate's `asyncpipe` subject could finish during the fixed
+one-second pre-attach delay. Its `_tlv_get_addr` share then came from an empty
+or undersampled call graph: locally the unchanged checker rejected 521 roots,
+while #8050 recorded the zero-root endpoint. The 5% budget was not the bug and
+remains unchanged, as does the 2,000-root minimum.
+
+Profile mode now repeats the same async/Map/Set/template-literal pipeline for
+at least 12 seconds, checks every completed pipeline against the first, emits
+the normal deterministic result, and reports how many pipelines completed.
+The gate runs subjects in a clean environment, clears only their named output
+artifacts before reuse, requires the process to be live and non-zombie before
+attachment, rejects a nonzero sampler status, and checks the profiled stdout.
+Compiler-free self-tests cover immediate exit, failed sampling, and an explicit
+zero-root report. A local Darwin run completed two pipelines in 20 seconds and
+collected 5,831 roots, with 17 `_tlv_get_addr` samples (0.3%), 152 claimed
+generic slots, and `direct_tsd=1`; normal and profiled stdout had identical
+SHA-256 `4059a6f4868d93a81f4064158c5a31bde6f89d1be2e683b01f2d34d45daef605`.

--- a/scripts/tls_budget_check.py
+++ b/scripts/tls_budget_check.py
@@ -194,6 +194,7 @@ def self_test() -> int:
 
     cases = [
         ("over budget", report(2000, 10000, 40), good_stats, 5.0, 2000, 20, 20),
+        ("zero-root profile", report(0, 0, 40), good_stats, 5.0, 2000, 20, 20),
         ("too few samples", report(10, 500, 40), good_stats, 5.0, 2000, 20, 20),
         ("stripped/narrow", report(10, 10000, 3), good_stats, 5.0, 2000, 20, 20),
         ("no stats line", report(10, 10000, 40), "", 5.0, 2000, 20, 20),

--- a/scripts/tls_budget_gate.sh
+++ b/scripts/tls_budget_gate.sh
@@ -34,7 +34,7 @@
 #      sixteen: `PERRY_TLS_HOT_STATS=1` must report `direct_tsd=1` (else the
 #      cache is inert and a low share means the program resolved nothing) and
 #      `claimed` above a floor no allocation microbenchmark can clear.
-#      `--self-test` drives all seven of its rejections and runs on every PR.
+#      `--self-test` drives every rejection and runs on every PR.
 #
 # SABOTAGE CHECK (the proof this can go red, re-runnable by hand)
 #
@@ -52,6 +52,50 @@
 #   scripts/tls_budget_gate.sh <perry-binary> [<out-dir>]
 
 set -euo pipefail
+
+subject_is_running() {
+    local state
+    state="$(ps -p "$1" -o state= 2>/dev/null)" || return 1
+    [[ -n "$state" && "$state" != *Z* ]]
+}
+
+sample_succeeded() {
+    [[ "$1" -eq 0 ]]
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    failures=0
+
+    ( exit 0 ) &
+    short_pid=$!
+    wait "$short_pid" || true
+    if subject_is_running "$short_pid"; then
+        echo "self-test FAILED: accepted a subject that exited before attach" >&2
+        failures=1
+    fi
+
+    sleep 0.2 &
+    live_pid=$!
+    sleep 0.05
+    if ! subject_is_running "$live_pid"; then
+        echo "self-test FAILED: rejected a live subject before attach" >&2
+        failures=1
+    fi
+    wait "$live_pid" || true
+
+    if ! sample_succeeded 0; then
+        echo "self-test FAILED: rejected a successful sample command" >&2
+        failures=1
+    fi
+    if sample_succeeded 1; then
+        echo "self-test FAILED: accepted a failed sample command" >&2
+        failures=1
+    fi
+
+    [[ "$failures" -eq 0 ]] || exit 1
+    echo "self-test: pre-attach liveness and sample-status checks reject both failure modes"
+    exit 0
+fi
 
 PERRY_BIN="${1:?usage: tls_budget_gate.sh <perry-binary> [out-dir]}"
 OUT_DIR="${2:-$(mktemp -d)}"
@@ -79,6 +123,13 @@ for entry in "${PROGRAMS[@]}"; do
     IFS='|' read -r name expected budget <<<"$entry"
     src="$FIXTURES/$name.ts"
     exe="$OUT_DIR/$name"
+    stats="$OUT_DIR/$name.stats"
+    report="$OUT_DIR/$name.sample"
+    profile_stdout="$OUT_DIR/$name.profile.stdout"
+
+    # OUT_DIR is caller-provided and may be reused. A report or stats file from
+    # an earlier run must never let a failed compile/attach inspect stale proof.
+    rm -f "$exe" "$stats" "$report" "$profile_stdout"
 
     echo "--- compiling $name"
     # Debug symbols so `sample` can name frames: an unsymbolicated profile
@@ -100,7 +151,9 @@ for entry in "${PROGRAMS[@]}"; do
 
     # Correctness BEFORE timing: a program that prints the wrong answer is not
     # a faster program.
-    actual="$("$exe")"
+    # These are shipped-default measurements. Do not let a developer shell's
+    # GC/debug/diagnostic variables silently select a different runtime mode.
+    actual="$(env -i "$exe")"
     if [[ "$actual" != "$expected" ]]; then
         echo "tls-budget: $name printed '$actual', expected '$expected'" >&2
         rc=1
@@ -108,21 +161,58 @@ for entry in "${PROGRAMS[@]}"; do
     fi
 
     echo "--- profiling $name (${SAMPLE_SECONDS}s)"
-    PERRY_TLS_HOT_STATS=1 "$exe" >/dev/null 2>"$OUT_DIR/$name.stats" &
+    if [[ "$name" == "asyncpipe" ]]; then
+        # Repeat the same correctness-checked pipeline so the sampled process
+        # remains live through Darwin's external attach delay. Its profile mode
+        # asserts every repetition returns the same result before printing it.
+        env -i PERRY_TLS_HOT_STATS=1 "$exe" --tls-budget-profile \
+            >"$profile_stdout" 2>"$stats" &
+    else
+        env -i PERRY_TLS_HOT_STATS=1 "$exe" >"$profile_stdout" 2>"$stats" &
+    fi
     pid=$!
     sleep 1
-    sample "$pid" "$SAMPLE_SECONDS" -f "$OUT_DIR/$name.sample" >/dev/null 2>&1 || true
-    wait "$pid"
+    if ! subject_is_running "$pid"; then
+        wait "$pid" || true
+        echo "tls-budget: $name exited before sample attached" >&2
+        rc=1
+        continue
+    fi
+    sample_rc=0
+    sample "$pid" "$SAMPLE_SECONDS" -f "$report" >/dev/null 2>&1 || sample_rc=$?
+    if ! wait "$pid"; then
+        echo "tls-budget: profiled $name exited unsuccessfully" >&2
+        rc=1
+        continue
+    fi
+    if ! sample_succeeded "$sample_rc"; then
+        echo "tls-budget: sample failed for $name (exit $sample_rc)" >&2
+        rc=1
+        continue
+    fi
+    if [[ "$name" == "asyncpipe" ]] \
+        && ! grep -qE '^\[tls-budget\] completed=[1-9][0-9]*$' "$stats"; then
+        echo "tls-budget: asyncpipe did not report a completed profiled pipeline" >&2
+        rc=1
+        continue
+    fi
 
-    if [[ ! -s "$OUT_DIR/$name.sample" ]]; then
+    profile_actual="$(<"$profile_stdout")"
+    if [[ "$profile_actual" != "$expected" ]]; then
+        echo "tls-budget: profiled $name printed '$profile_actual', expected '$expected'" >&2
+        rc=1
+        continue
+    fi
+
+    if [[ ! -s "$report" ]]; then
         echo "tls-budget: sample produced no report for $name" >&2
         rc=1
         continue
     fi
 
     if ! python3 "$REPO_ROOT/scripts/tls_budget_check.py" \
-        --report "$OUT_DIR/$name.sample" \
-        --stats "$OUT_DIR/$name.stats" \
+        --report "$report" \
+        --stats "$stats" \
         --budget "$budget" \
         --label "$name"; then
         rc=1


### PR DESCRIPTION
## Summary

- keep the profiled asyncpipe subject busy with the same correctness-checked async/Map/Set/template-literal pipeline for a bounded 12-second minimum
- reject exited subjects, failed sampler commands, stale artifacts, changed profiled stdout, and missing completed-pipeline evidence
- add compiler-free self-tests for zero-root profiles, pre-attach liveness, and sampler exit status without weakening the 2,000-root or TLS percentage budgets

Closes #8050.

Refs #7966.

## Causal evidence

Exact base: `fe4cd09db0f1e260fc0ff63ec2e5c0079fceac3d`.

A clean local Darwin arm64 baseline completed in 1.94–2.08 seconds after warm-up. Because the gate slept one second before attachment, `/usr/bin/sample` collected only 521 roots; `_tlv_get_addr` looked healthy at 5/521 (1.0%), but the unchanged >=2,000-root liveness floor correctly rejected the meaningless share. The issue artifact is the faster endpoint of the same mechanism: the process completes during that sleep and the report has zero roots.

## Local validation

Using a fresh isolated worktree and target, with `PERRY_RUNTIME_DIR` pinned to freshly rebuilt runtime/stdlib static archives, `PERRY_NO_AUTO_OPTIMIZE=1`, cache disabled for fixture compilation, and the measured subjects run under `env -i`:

- final asyncpipe profile: attach state `RN`, sampler exit 0, subject exit 0, 20 seconds, 2 completed pipelines
- 5,831 root samples; 17 `_tlv_get_addr` samples (0.3%, budget 5.0%); 152 claimed slots; `direct_tsd=1`
- normal/profile stdout: one 30-byte line each, identical SHA-256 `4059a6f4868d93a81f4064158c5a31bde6f89d1be2e683b01f2d34d45daef605`
- `python3 scripts/tls_budget_check.py --self-test` (all 8 rejection modes)
- `bash scripts/tls_budget_gate.sh --self-test`
- `bash -n scripts/tls_budget_gate.sh`
- `actionlint .github/workflows/tls-budget.yml`
- `git diff --check`

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Strengthened TLS profiling validation to confirm live processes, successful sampling, completed statistics, and correct output.
  - Added repeatability checks to ensure profiling produces consistent results during extended runs.
  - Improved cleanup and environment isolation for more reliable benchmark execution.
  - Added self-tests covering liveness failures, sampler errors, and profiles with no root samples.

- **Documentation**
  - Documented the updated profiling workflow, validation requirements, and local testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->