### PR TITLE
Scope split unknown-function fallback wrappers by module

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -17,7 +17,9 @@ use super::closure::{
     compile_typed_i32_closure, compile_typed_string_closure,
 };
 use super::entry::compile_module_entry;
-use super::helpers::{function_body_returns_generator_object, sanitize, scoped_fn_name};
+use super::helpers::{
+    function_body_returns_generator_object, sanitize, scoped_fn_name, unknown_func_wrapper_name,
+};
 use super::method::{
     compile_method, compile_static_method, compile_typed_f64_method,
     compile_typed_f64_receiver_method, compile_typed_i1_method, compile_typed_i32_method,
@@ -1220,15 +1222,15 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         }
     }
 
-    // #337: emit an always-defined fallback wrapper for the
-    // `perry_unknown_func` sentinel. `expr.rs::Expr::FuncRef` falls
-    // through to `wrap_name = "__perry_wrap_perry_unknown_func"` when the
+    // #337: emit an always-defined fallback wrapper for the module-scoped
+    // `perry_unknown_func_<module>` sentinel. `expr.rs::Expr::FuncRef` falls
+    // through to the matching wrapper when the
     // FuncRef's id isn't in `func_names` (cross-module reference whose
     // Source HIR wasn't lowered into THIS LLVM module — should normally
     // route to ExternFuncRef instead, but some HIR shapes still emit
-    // FuncRef with an unresolvable id). Pre-fix the wrapper was never
-    // defined and clang errored with `use of undefined value
-    // @__perry_wrap_perry_unknown_func`. This stub returns TAG_UNDEFINED
+    // FuncRef with an unresolvable id). Before #337, the wrapper was never
+    // defined and clang rejected the unresolved reference during IR
+    // validation. This stub returns TAG_UNDEFINED
     // (encoded as `f64::from_bits(0x7FFC_0000_0000_0001)` =
     // 1.7800590868057611e-307 — the canonical undefined sentinel matching
     // `value::TAG_UNDEFINED`); any runtime-side `js_closure_callN`
@@ -1238,11 +1240,14 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
     // imported classes (see the existing comment block below).
     //
     // Emitted unconditionally — link-time DCE strips it when no
-    // `Expr::FuncRef(unknown_id)` site exists in this module.
+    // `Expr::FuncRef(unknown_id)` site exists in this module. The stable
+    // module suffix is load-bearing under codegen-unit splitting: splitting
+    // promotes this internal definition for cross-unit calls, and a shared
+    // final link may contain split objects from many source modules (#8064).
     {
-        let wrap_name = "__perry_wrap_perry_unknown_func";
+        let wrap_name = unknown_func_wrapper_name(module_prefix);
         let wf = llmod.define_function(
-            wrap_name,
+            &wrap_name,
             DOUBLE,
             vec![
                 (I64, "%this_closure".to_string()),
@@ -1253,14 +1258,10 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                 (DOUBLE, "%a4".to_string()),
             ],
         );
-        // Fix #420 (v0.5.576): internal linkage so multi-module
-        // programs (drizzle-orm has 5+ modules each emitting this
-        // fallback) don't fail link with `duplicate symbol
-        // ___perry_wrap_perry_unknown_func`. Same pattern as the
-        // `__perry_wrap_extern_*` wrappers below — comment block at
-        // line ~1957 explicitly calls out that wrappers like this
-        // should be `internal` linkage so each module gets its own
-        // dead-code-eliminable copy.
+        // Fix #420 (v0.5.576): internal linkage keeps unsplit modules' copies
+        // dead-code-eliminable. Split units promote the definition so calls
+        // from sibling units can bind; #8064's module-scoped name keeps those
+        // promoted copies distinct at the application link.
         wf.linkage = "internal".to_string();
         let _ = wf.create_block("entry");
         let blk = wf.block_mut(0).unwrap();

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -563,6 +563,21 @@ pub(super) fn scoped_fn_name(module_prefix: &str, hir_name: &str) -> String {
     format!("perry_fn_{}__{}", module_prefix, sanitize_member(hir_name))
 }
 
+/// Stable, module-scoped sentinel used when a [`perry_hir::Expr::FuncRef`]
+/// cannot be resolved in the module's function registry.
+///
+/// The fallback wrapper is emitted once per source module. Keeping the module
+/// prefix in the sentinel name is required when codegen-unit splitting
+/// promotes that wrapper from internal to external linkage for cross-unit
+/// calls: independently compiled modules must not publish the same symbol.
+pub(crate) fn unknown_func_name(module_prefix: &str) -> String {
+    format!("perry_unknown_func_{module_prefix}")
+}
+
+pub(crate) fn unknown_func_wrapper_name(module_prefix: &str) -> String {
+    format!("__perry_wrap_{}", unknown_func_name(module_prefix))
+}
+
 pub(super) fn scoped_static_method_name(
     module_prefix: &str,
     class_id: u32,

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -203,6 +203,8 @@ mod string_pool;
 mod testing_feature_gate_tests;
 mod typed_abi;
 mod typed_abi_opt_report;
+#[cfg(test)]
+mod unknown_func_tests;
 
 pub(crate) use closure::emit_typed_capture_guard;
 pub use helpers::resolve_target_triple;

--- a/crates/perry-codegen/src/codegen/unknown_func_tests.rs
+++ b/crates/perry-codegen/src/codegen/unknown_func_tests.rs
@@ -1,0 +1,50 @@
+//! #8064: unknown-`FuncRef` fallback wrappers are scoped to their source
+//! module. Split codegen promotes internal functions for cross-unit calls, so
+//! a process-global fallback name makes otherwise independent module objects
+//! collide at the application link.
+
+use crate::{compile_module, CompileOptions};
+use perry_hir::{Expr, Module, Stmt};
+
+fn fallback_ir(module_name: &str) -> String {
+    let mut module = Module::new(module_name);
+    module.init = vec![Stmt::Expr(Expr::FuncRef(0x8064))];
+    let options = CompileOptions {
+        emit_ir_only: true,
+        output_type: "executable".to_string(),
+        ..CompileOptions::default()
+    };
+    String::from_utf8(compile_module(&module, options).expect("fallback module compiles"))
+        .expect("LLVM IR is UTF-8")
+}
+
+#[test]
+fn unknown_funcref_uses_its_module_scoped_wrapper() {
+    let alpha = fallback_ir("alpha.ts");
+    let beta = fallback_ir("beta.ts");
+    let alpha_wrapper = "__perry_wrap_perry_unknown_func_alpha_ts";
+    let beta_wrapper = "__perry_wrap_perry_unknown_func_beta_ts";
+
+    assert!(
+        alpha.contains(&format!("define internal double @{alpha_wrapper}(")),
+        "alpha must define its own internal fallback wrapper"
+    );
+    assert!(
+        alpha.contains(&format!("ptr @{alpha_wrapper}")),
+        "alpha's unresolved FuncRef must reference alpha's wrapper"
+    );
+    assert!(
+        beta.contains(&format!("define internal double @{beta_wrapper}(")),
+        "beta must define its own internal fallback wrapper"
+    );
+    assert!(
+        beta.contains(&format!("ptr @{beta_wrapper}")),
+        "beta's unresolved FuncRef must reference beta's wrapper"
+    );
+    assert!(!alpha.contains(beta_wrapper));
+    assert!(!beta.contains(alpha_wrapper));
+    assert!(
+        !alpha.contains("@__perry_wrap_perry_unknown_func("),
+        "the process-global fallback symbol must not be emitted"
+    );
+}

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -535,12 +535,10 @@ pub(crate) fn lower(
         // `(closure_ptr, arg0, arg1, ...)` and forwards to the
         // underlying function.
         Expr::FuncRef(id) => {
-            let func_name = ctx
-                .func_names
-                .get(id)
-                .cloned()
-                .unwrap_or_else(|| "perry_unknown_func".to_string());
-            let wrap_name = format!("__perry_wrap_{}", func_name);
+            let wrap_name = ctx.func_names.get(id).map_or_else(
+                || crate::codegen::helpers::unknown_func_wrapper_name(ctx.strings.module_prefix()),
+                |func_name| format!("__perry_wrap_{func_name}"),
+            );
             let blk = ctx.block();
             let wrap_ptr = format!("@{}", wrap_name);
             // FuncRef wrappers always have 0 captures, so we can route

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -1301,6 +1301,75 @@ mod tests {
     }
 
     #[test]
+    fn split_modules_keep_unknown_fallback_wrappers_distinct_at_shared_link() {
+        // #8064: splitting promotes internal definitions so sibling units can
+        // call them. Before the fallback name was module-scoped, each module's
+        // merged object therefore exported the same
+        // `__perry_wrap_perry_unknown_func` symbol and the application link
+        // failed only after every module had emitted successfully.
+        fn split_object(module_prefix: &str) -> Vec<u8> {
+            let mut module = LlModule::new(crate::codegen::default_target_triple());
+            let wrapper_name = crate::codegen::helpers::unknown_func_wrapper_name(module_prefix);
+
+            let wrapper = module.define_function(
+                &wrapper_name,
+                DOUBLE,
+                vec![
+                    (I64, "%this_closure".to_string()),
+                    (DOUBLE, "%a0".to_string()),
+                    (DOUBLE, "%a1".to_string()),
+                    (DOUBLE, "%a2".to_string()),
+                    (DOUBLE, "%a3".to_string()),
+                    (DOUBLE, "%a4".to_string()),
+                ],
+            );
+            wrapper.linkage = "internal".to_string();
+            wrapper
+                .create_block("entry")
+                .ret(DOUBLE, "0x7FFC000000000001");
+
+            let caller = module.define_function(
+                format!("perry_fn_{module_prefix}__use_unknown"),
+                DOUBLE,
+                vec![],
+            );
+            let entry = caller.create_block("entry");
+            let result = entry.call(
+                DOUBLE,
+                &wrapper_name,
+                &[
+                    (I64, "0"),
+                    (DOUBLE, "0.0"),
+                    (DOUBLE, "0.0"),
+                    (DOUBLE, "0.0"),
+                    (DOUBLE, "0.0"),
+                    (DOUBLE, "0.0"),
+                ],
+            );
+            entry.ret(DOUBLE, &result);
+
+            let units = module.render_codegen_units(2);
+            assert_eq!(units.len(), 2, "fixture must exercise split units");
+            assert_eq!(
+                units
+                    .iter()
+                    .filter(|unit| unit.contains(&format!("define double @{wrapper_name}(")))
+                    .count(),
+                1,
+                "the internal fallback must be promoted in exactly one split unit"
+            );
+            crate::linker::compile_units_to_object(&units, None)
+                .expect("split module units emit and partial-link")
+        }
+
+        let alpha = split_object("alpha_ts");
+        let beta = split_object("beta_ts");
+        let linked = crate::linker::merge_unit_objects(&[alpha, beta])
+            .expect("two split module objects must share a final link");
+        assert!(!linked.is_empty(), "shared link must emit an object");
+    }
+
+    #[test]
     fn owner_only_global_declares_cross_unit_function_from_initializer() {
         // An unreferenced generated global is retained in unit 0. If its
         // initializer names a function assigned to another unit, unit 0 must


### PR DESCRIPTION
## Summary

- derive the unknown FuncRef sentinel and fallback wrapper name from the stable module prefix
- share that naming helper between expression lowering and wrapper emission
- preserve internal linkage for unsplit modules while keeping split-unit promotion collision-free
- add emitted-IR coverage plus a two-module split-object final-link regression
- make no version, manifest, lockfile, or changelog changes

## Validation

- cargo fmt --all -- --check
- cargo test -p perry-codegen --lib (994 passed)
- the focused object regression compiles two codegen-unit-split modules and merges both module objects in one final link

I also attempted the preserved 91-module Next.js graph while priming its specialized archives. It collected all 91 modules, completed the three-unit webpack object, and entered the two-unit jsonwebtoken object. The memory-capped run was stopped after 30 minutes while still inside an LLVM function pass at 12/91, before the application link, so no full replay verdict is claimed.

Refs #8064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unresolved function fallback symbols from colliding across modules and split compilation units.
  * Preserved correct linking behavior for both split and unsplit modules.
  * Ensured each module references its own fallback wrapper.

* **Tests**
  * Added regression coverage for separate module compilation, LLVM output, and combined linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->