### PR TITLE
test(fetch): gate responses in provider dylibs

### DIFF
--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -279,14 +279,16 @@ jobs:
           export RUSTFLAGS="-C force-frame-pointers=yes -C force-unwind-tables=yes"
           cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static
 
-      # #8075 is a loader shape, not another standalone-executable probe: the
+      # #8075/#8038 are loader shapes, not standalone-executable probes: the
       # runtime and stdlib are process-wide providers, generated frames live in
       # a later-loaded app-only dylib, and full GC runs from a clean host
-      # boundary. The gate owns the exact two-module JSON/Buffer fixture and
-      # requires 32,768 valid responses, >=10 full collections, retained and
-      # temporary Buffer classifications, concurrent producers serialized on
-      # one Perry executor, reclaimed temporary bytes, and a flat live slope.
-      - name: Provider dylib host-boundary full GC
+      # boundary. The gate owns the exact two-module JSON/Buffer fixture plus
+      # #8038's streamed Response fixture. It requires 32,768 valid responses,
+      # >=10 full collections, retained and temporary Buffer classifications,
+      # concurrent producers serialized on one Perry executor, reclaimed
+      # temporary bytes, a flat live slope, and exact normal/forced-GC Response
+      # output including two chunks, EOF, headers, cookies, and rejection.
+      - name: Provider dylib host-boundary GC and Response
         if: ${{ !cancelled() && runner.os != 'Windows' }}
         run: scripts/gc_provider_dylib_gate.sh
 

--- a/changelog.d/8089-next-response-provider-dylib.md
+++ b/changelog.d/8089-next-response-provider-dylib.md
@@ -1,0 +1,10 @@
+### Testing
+
+- Run the cross-module streamed `Response` regression as an app-only dynamic
+  library against separately loaded runtime and stdlib providers on Linux and
+  macOS. The native host preserves the returned Promise across collection and
+  requires exact headers, cookies, two-chunk body, EOF, subclass, and rejected
+  stream output in both normal and forced/verified GC modes.
+- Require positive moving-GC liveness for the forced provider run, and retain
+  and export the fixture's exact Headers, Response, and Streams provider
+  surface so duplicated or hidden native registries fail at load time.

--- a/scripts/gc_provider_dylib_gate.sh
+++ b/scripts/gc_provider_dylib_gate.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# #8075: exercise native stack-map roots when Perry's runtime and stdlib are
-# process-wide providers and generated code lives only in a later-loaded app
-# image. The fixture deliberately mirrors the reporter's host boundary: the
-# app is a two-module, app-only dylib; full pressure is requested only after a
-# completed invocation; and one dedicated Perry thread serializes both direct
-# and concurrently queued callers.
+# #8075/#8038: exercise native stack-map roots and streamed Response state when
+# Perry's runtime and stdlib are process-wide providers and generated code
+# lives only in a later-loaded app image. The fixtures deliberately mirror the
+# reporter's host boundary: each app is a two-module, app-only dylib; the GC
+# fixture requests full pressure only after a completed invocation; and the
+# Response fixture roots its exported Promise while sync, async, subclassed,
+# and rejected streams are drained under normal and forced/verified GC.
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
 fixture="$repo_root/tests/fixtures/issue_8075_provider_gc"
@@ -170,3 +171,74 @@ else
     "$runtime_library" "$stdlib_library" "$app" \
     "$temporary_symbol" "$retained_symbol"
 fi
+
+# #8038's executable parity fixture is also its app-only provider fixture. The
+# environment guard suppresses its ordinary top-level invocation; the native
+# host calls the exported async wrapper, roots the returned Promise in the
+# provider runtime, and pumps it until fulfillment. Comparing stdout to the
+# Node oracle proves that both chunks and EOF were observed, response/Headers/
+# body identities remained stable, cookies survived, and stream errors rejected
+# instead of hanging. Run once normally and once with moving-GC verification.
+response_app="$provider_dir/issue-8038-response.$library_extension"
+env \
+  PATH="$app_link_dir:$PATH" \
+  PERRY_ISSUE_8075_REAL_CC="$real_cc" \
+  PERRY_ISSUE_8075_RUNTIME_LIBRARY="$runtime_library" \
+  PERRY_ISSUE_8075_STDLIB_LIBRARY="$stdlib_library" \
+  PERRY_RS4GC=1 \
+  PERRY_RUNTIME_DIR="$target_dir/$profile" \
+  "$perry" compile \
+    --no-codegen --no-auto-optimize --march generic \
+    --output-type dylib -o "$response_app" \
+    "$repo_root/test-files/test_issue_8038_cross_module_response_stream.ts"
+
+if [[ "$host_os" == Darwin ]]; then
+  response_symbols=$(nm -gU "$response_app" | awk 'NF >= 3 { symbol=$3; sub(/^_/, "", symbol); print symbol }')
+else
+  response_symbols=$(nm -D --defined-only "$response_app" | awk 'NF >= 3 { print $3 }')
+fi
+response_entry=$(awk '/^__perry_wrap_perry_fn_.*__runIssue8038$/ { print; count++ } END { if (count != 1) exit 1 }' <<<"$response_symbols")
+
+response_host="$scratch/issue-8038-response-host"
+rustc --edition 2021 -O \
+  "$repo_root/tests/fixtures/issue_8038_response_dylib/host.rs" \
+  -o "$response_host"
+
+run_response_fixture() {
+  local mode=$1
+  local output="$scratch/issue-8038-$mode.out"
+  local stderr="$scratch/issue-8038-$mode.err"
+  shift
+  if [[ "$host_os" == Darwin ]]; then
+    if ! env DYLD_LIBRARY_PATH="$provider_dir" \
+      PERRY_ISSUE_8038_LIBRARY_HOST=1 "$@" \
+      "$response_host" "$runtime_library" "$stdlib_library" \
+      "$response_app" "$response_entry" >"$output" 2>"$stderr"; then
+      cat "$stderr" >&2
+      return 1
+    fi
+  else
+    if ! env LD_LIBRARY_PATH="$provider_dir" \
+      PERRY_ISSUE_8038_LIBRARY_HOST=1 "$@" \
+      "$response_host" "$runtime_library" "$stdlib_library" \
+      "$response_app" "$response_entry" >"$output" 2>"$stderr"; then
+      cat "$stderr" >&2
+      return 1
+    fi
+  fi
+  diff -u \
+    "$repo_root/test-parity/expected/test_issue_8038_cross_module_response_stream.txt" \
+    "$output"
+  if [[ "$mode" == forced ]]; then
+    python3 "$repo_root/scripts/gc_evacuation_liveness_assert.py" \
+      "$stderr" --probe "#8038 provider-dylib Response"
+  fi
+}
+
+run_response_fixture normal
+run_response_fixture forced \
+  PERRY_GC_DIAG=1 \
+  PERRY_GC_FORCE_EVACUATE=1 \
+  PERRY_GC_VERIFY_EVACUATION=1 \
+  PERRY_GC_SCHEDULE_SEED=8038 \
+  PERRY_GC_SCHEDULE_RATE=1

--- a/test-files/test_issue_8038_cross_module_response_stream.ts
+++ b/test-files/test_issue_8038_cross_module_response_stream.ts
@@ -12,7 +12,10 @@ declare function gc(): void;
 
 function forceGc(): void {
   const churn: Array<{ index: number; payload: string }> = [];
-  for (let index = 0; index < 2_000; index += 1) {
+  // Keep enough allocation between explicit collections to exercise the
+  // schedule-rate pacer without making the focused parity test exceed the
+  // harness's 10-second process timeout on loaded CI hosts.
+  for (let index = 0; index < 256; index += 1) {
     churn.push({ index, payload: `response-root-${index}` });
   }
   if (typeof gc === "function") gc();

--- a/tests/fixtures/issue_8038_response_dylib/host.rs
+++ b/tests/fixtures/issue_8038_response_dylib/host.rs
@@ -109,6 +109,14 @@ fn main() -> Result<(), String> {
         }
         unsafe { run_microtasks() };
     }
+    // The final drain may be the one that settles the Promise. Observe it
+    // while the possibly relocated Promise is still rooted before deciding
+    // that the bounded pump timed out.
+    if state == 0 {
+        let rooted_bits = unsafe { temp_root_get(root) };
+        let promise_pointer = (rooted_bits & POINTER_MASK) as *mut c_void;
+        state = unsafe { promise_state(promise_pointer) };
+    }
     unsafe { temp_root_truncate(root) };
 
     match state {

--- a/tests/fixtures/issue_8038_response_dylib/host.rs
+++ b/tests/fixtures/issue_8038_response_dylib/host.rs
@@ -1,0 +1,121 @@
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+
+#[cfg(target_os = "linux")]
+const RTLD_GLOBAL: c_int = 0x100;
+#[cfg(target_os = "macos")]
+const RTLD_GLOBAL: c_int = 0x8;
+#[cfg(target_os = "linux")]
+const RTLD_LOCAL: c_int = 0;
+#[cfg(target_os = "macos")]
+const RTLD_LOCAL: c_int = 0x4;
+const RTLD_NOW: c_int = 2;
+
+#[cfg_attr(target_os = "linux", link(name = "dl"))]
+unsafe extern "C" {
+    fn dlopen(path: *const c_char, flags: c_int) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dlerror() -> *const c_char;
+}
+
+type GcInit = unsafe extern "C" fn();
+type ModuleInit = unsafe extern "C" fn();
+type Entry = unsafe extern "C" fn(i64) -> f64;
+type PromiseState = unsafe extern "C" fn(*mut c_void) -> i32;
+type RunMicrotasks = unsafe extern "C" fn() -> i32;
+type TempRootPush = unsafe extern "C" fn(u64) -> u32;
+type TempRootGet = unsafe extern "C" fn(u32) -> u64;
+type TempRootTruncate = unsafe extern "C" fn(u32);
+type RuntimeProbe = unsafe extern "C" fn() -> usize;
+
+fn dynamic_error(context: &str) -> String {
+    let detail = unsafe {
+        let error = dlerror();
+        if error.is_null() {
+            "unknown loader error".into()
+        } else {
+            CStr::from_ptr(error).to_string_lossy().into_owned()
+        }
+    };
+    format!("{context}: {detail}")
+}
+
+fn open(path: &str, flags: c_int) -> Result<usize, String> {
+    let path = CString::new(path).map_err(|_| format!("NUL in library path {path:?}"))?;
+    let handle = unsafe { dlopen(path.as_ptr(), flags) };
+    if handle.is_null() {
+        Err(dynamic_error("dlopen failed"))
+    } else {
+        Ok(handle as usize)
+    }
+}
+
+unsafe fn symbol<T: Copy>(handle: usize, name: &str) -> Result<T, String> {
+    let name = CString::new(name).map_err(|_| format!("NUL in symbol {name:?}"))?;
+    let pointer = dlsym(handle as *mut c_void, name.as_ptr());
+    if pointer.is_null() {
+        return Err(dynamic_error("dlsym failed"));
+    }
+    Ok(std::mem::transmute_copy::<*mut c_void, T>(&pointer))
+}
+
+fn main() -> Result<(), String> {
+    let arguments: Vec<String> = std::env::args().collect();
+    if arguments.len() != 5 {
+        return Err("usage: host runtime stdlib app entry-symbol".into());
+    }
+
+    let runtime = open(&arguments[1], RTLD_NOW | RTLD_GLOBAL)?;
+    let stdlib = open(&arguments[2], RTLD_NOW | RTLD_GLOBAL)?;
+    let app = open(&arguments[3], RTLD_NOW | RTLD_LOCAL)?;
+    let gc_init: GcInit = unsafe { symbol(runtime, "js_gc_init")? };
+    let promise_state: PromiseState = unsafe { symbol(runtime, "js_promise_state")? };
+    let run_microtasks: RunMicrotasks =
+        unsafe { symbol(runtime, "js_promise_run_microtasks_event_loop")? };
+    let temp_root_push: TempRootPush = unsafe { symbol(runtime, "js_gc_temp_root_push")? };
+    let temp_root_get: TempRootGet = unsafe { symbol(runtime, "js_gc_temp_root_get")? };
+    let temp_root_truncate: TempRootTruncate =
+        unsafe { symbol(runtime, "js_gc_temp_root_truncate")? };
+    let probe: RuntimeProbe = unsafe { symbol(stdlib, "issue_8075_stdlib_runtime_probe")? };
+    if unsafe { probe() } != gc_init as usize {
+        return Err("stdlib provider is bound to a different runtime image".into());
+    }
+
+    let module_init: ModuleInit = unsafe { symbol(app, "perry_module_init")? };
+    let entry: Entry = unsafe { symbol(app, &arguments[4])? };
+    unsafe {
+        gc_init();
+        module_init();
+    }
+
+    let promise = unsafe { entry(0) };
+    let promise_bits = promise.to_bits();
+    if promise_bits & !POINTER_MASK != POINTER_TAG {
+        return Err(format!(
+            "runIssue8038 returned a non-Promise value: {promise_bits:#018x}"
+        ));
+    }
+    let root = unsafe { temp_root_push(promise_bits) };
+
+    let mut state = 0;
+    for _ in 0..10_000 {
+        let rooted_bits = unsafe { temp_root_get(root) };
+        let promise_pointer = (rooted_bits & POINTER_MASK) as *mut c_void;
+        state = unsafe { promise_state(promise_pointer) };
+        if state != 0 {
+            break;
+        }
+        unsafe { run_microtasks() };
+    }
+    unsafe { temp_root_truncate(root) };
+
+    match state {
+        1 => Ok(()),
+        2 => Err("runIssue8038 rejected".into()),
+        other => Err(format!(
+            "runIssue8038 did not settle after 10,000 microtask drains (state {other})"
+        )),
+    }
+}

--- a/tests/fixtures/issue_8075_provider_gc/stdlib-linker.sh
+++ b/tests/fixtures/issue_8075_provider_gc/stdlib-linker.sh
@@ -7,7 +7,26 @@ host_os=$(uname -s)
 arguments=()
 skip_export_list_value=false
 original_export_list=""
+original_version_script=""
 saw_runtime_rlib=false
+stdlib_provider_exports=(
+  issue_8075_stdlib_runtime_probe
+  js_fetch_response_status
+  js_fetch_response_status_text
+  js_headers_append
+  js_headers_get
+  js_headers_new
+  js_headers_set
+  js_readable_stream_get_reader_with_options
+  js_readable_stream_new_from_source_object
+  js_reader_read
+  js_response_body
+  js_response_body_init_ptr
+  js_response_get_headers
+  js_response_new
+  js_stdlib_init_dispatch
+  js_stream_unwrap_handle
+)
 
 for argument in "$@"; do
   if [[ "$skip_export_list_value" == true ]]; then
@@ -33,13 +52,18 @@ for argument in "$@"; do
     -Wl,-exported_symbols_list,*)
       original_export_list=${argument#-Wl,-exported_symbols_list,}
       ;;
+    -Wl,--version-script=*)
+      original_version_script=${argument#-Wl,--version-script=}
+      ;;
     *) arguments+=("$argument") ;;
   esac
 done
 
 custom_export_list=""
+custom_version_script=""
 cleanup() {
   [[ -z "$custom_export_list" ]] || rm -f "$custom_export_list"
+  [[ -z "$custom_version_script" ]] || rm -f "$custom_version_script"
 }
 trap cleanup EXIT
 
@@ -48,11 +72,26 @@ if [[ -n "$original_export_list" ]]; then
     custom_export_list=$(mktemp "${TMPDIR:-/tmp}/perry-8075-exports.XXXXXX")
     {
       sed -n '/issue_8075_stdlib_runtime_probe/p' "$original_export_list"
+      printf '_%s\n' "${stdlib_provider_exports[@]}"
       nm -gU "$runtime_library" | awk 'NF >= 3 { print $3 }'
     } | sort -u > "$custom_export_list"
     arguments+=('-Wl,-exported_symbols_list' "-Wl,$custom_export_list")
   else
     arguments+=('-Wl,-exported_symbols_list' "-Wl,$original_export_list")
+  fi
+fi
+
+if [[ -n "$original_version_script" ]]; then
+  if [[ "$saw_runtime_rlib" == true ]]; then
+    custom_version_script=$(mktemp "${TMPDIR:-/tmp}/perry-8075-version.XXXXXX")
+    {
+      echo '{ global:'
+      printf '  %s;\n' "${stdlib_provider_exports[@]}"
+      echo 'local: *; };'
+    } > "$custom_version_script"
+    arguments+=("-Wl,--version-script=$custom_version_script")
+  else
+    arguments+=("-Wl,--version-script=$original_version_script")
   fi
 fi
 

--- a/tests/fixtures/issue_8075_provider_gc/stdlib-provider/src/lib.rs
+++ b/tests/fixtures/issue_8075_provider_gc/stdlib-provider/src/lib.rs
@@ -12,6 +12,31 @@ unsafe extern "C" {
 #[used]
 static PIN_STDLIB: extern "C" fn() -> i32 = perry_stdlib::common::js_stdlib_process_pending;
 
+// A cdylib only retains Rust dependency code reachable from this wrapper.
+// Keep the exact Web Fetch/Streams surface used by #8038's later-loaded app;
+// otherwise the app links with dynamic lookups but dlopen fails on the first
+// missing `js_fetch_*` symbol. This function is never called, so its sentinel
+// arguments only create linker references to the provider implementations.
+#[used]
+static PIN_ISSUE_8038_RESPONSE_SURFACE: unsafe extern "C" fn() = pin_issue_8038_response_surface;
+
+unsafe extern "C" fn pin_issue_8038_response_surface() {
+    let _ = perry_stdlib::js_headers_new();
+    let _ = perry_stdlib::js_headers_set(0.0, std::ptr::null(), std::ptr::null());
+    let _ = perry_stdlib::js_headers_append(0.0, std::ptr::null(), std::ptr::null());
+    let _ = perry_stdlib::js_headers_get(0.0, std::ptr::null());
+    let _ = perry_stdlib::js_response_body_init_ptr(0.0);
+    let _ = perry_stdlib::js_response_new(std::ptr::null(), 0.0, std::ptr::null(), 0.0);
+    let _ = perry_stdlib::js_response_get_headers(0.0);
+    let _ = perry_stdlib::js_fetch_response_status(0.0);
+    let _ = perry_stdlib::js_fetch_response_status_text(0.0);
+    let _ = perry_stdlib::js_response_body(0.0);
+    let _ = perry_stdlib::js_readable_stream_new_from_source_object(0.0, 0.0);
+    let _ = perry_stdlib::js_readable_stream_get_reader_with_options(0.0, 0.0);
+    let _ = perry_stdlib::js_reader_read(0.0);
+    perry_stdlib::js_stdlib_init_dispatch();
+}
+
 /// Proves that the stdlib resolves stateful runtime calls to the provider the
 /// host loaded first, rather than embedding a second GC/runtime image.
 #[no_mangle]


### PR DESCRIPTION
## Summary

- run the #8038 cross-module streamed Response fixture as an app-only dylib against separately loaded runtime and stdlib providers
- retain and export the exact Headers, Response, and Streams provider surface on macOS and Linux
- root the exported Promise in the native host and compare normal and forced-GC output with the executable oracle
- require positive evacuation liveness so the forced-GC arm cannot pass vacuously
- keep the focused parity process below its 10-second timeout while retaining moving-GC pressure

## Validation

- scripts/gc_provider_dylib_gate.sh
  - #8075 provider gate: 32,768 calls, 11 full collections
  - #8038 provider dylib: exact normal and forced-GC output
  - forced evacuation: 147 copying minors, 32,199 objects copied
- focused parity: 1/1 passed, 100%
- bash syntax, shellcheck, rustfmt, diff check, and file-size check

No version bump.

Refs #8038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for streamed responses loaded across runtime boundaries.
  * Ensured response headers, cookies, body chunks, end-of-stream behavior, and rejected streams are handled consistently.
  * Improved memory cleanup during normal and forced garbage collection, reducing the risk of retained temporary data.

* **Tests**
  * Expanded automated coverage for concurrent response processing, moving garbage collection, promise handling, and dynamic provider loading.
  * Added validation for successful, rejected, and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->