### PR TITLE
fix(codegen): announce the kept object on the statepoint compile arm

### DIFF
--- a/changelog.d/8097-keep-ir-statepoint-object.md
+++ b/changelog.d/8097-keep-ir-statepoint-object.md
@@ -19,3 +19,12 @@ changing what is kept.
 false`, so the arm serving every statepoint target had no coverage;
 `keep_ir_retains_the_whole_scratch_dir_under_native_roots` now runs the same
 contract through it.
+
+With the report restored the gate failed one step later, the same way and for
+the same reason: the compile plan records `clang_path` for the analysis
+re-compile to reuse, and the in-process backend records the string
+`(in-process)` where a driver path would go. The harness's fallback was written
+for a MISSING value, and a non-empty placeholder is truthy, so it went straight
+to `subprocess.run` — `FileNotFoundError: '(in-process)'`. The harness now
+treats the placeholder as "no driver recorded" and falls back to the clang it
+already resolved; a genuinely recorded driver still wins.

--- a/changelog.d/8097-keep-ir-statepoint-object.md
+++ b/changelog.d/8097-keep-ir-statepoint-object.md
@@ -1,0 +1,21 @@
+`compiler-output-regression` is capturing again. All 11 of its workloads failed
+with the same error — "PERRY_LLVM_KEEP_IR did not report a retained object
+path" — so none of them reached the behaviour the gate exists to measure.
+
+`PERRY_LLVM_KEEP_IR` promises that intermediates are retained *and* their
+locations printed; the harness recovers them by parsing `kept object:` off the
+compile log. The in-process backend has two success arms: the byte-returning
+arm writes the object and announces it, while the statepoint arm — taken
+whenever the plan asks for `-S`, so the ordinary path on every statepoint
+target — assembles straight to `plan.obj_path` and keeps the scratch dir. That
+arm retained the object correctly but never announced it, and the harness went
+blind the moment statepoints became the default backend.
+
+The statepoint arm now announces the kept object too; retention was already
+correct, so this restores the reporting half of the contract rather than
+changing what is kept.
+
+`keep_ir_retains_the_whole_scratch_dir` only ever ran with `native_roots:
+false`, so the arm serving every statepoint target had no coverage;
+`keep_ir_retains_the_whole_scratch_dir_under_native_roots` now runs the same
+contract through it.

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -875,7 +875,17 @@ fn compile_ll_inprocess_in(
             )?;
             let obj = fs::read(&plan.obj_path)
                 .with_context(|| format!("Failed to read assembled {}", plan.obj_path.display()))?;
-            if !policy.keep {
+            if policy.keep {
+                // This arm retains the object too — `compact_and_assemble`
+                // wrote it to `plan.obj_path` and the scratch dir survives
+                // below — but it never said so. `PERRY_LLVM_KEEP_IR`'s contract
+                // is that the location is PRINTED, and every consumer that
+                // parses `kept object:` went blind the moment statepoints
+                // became the default backend and this arm started handling the
+                // ordinary compile (#8087: all 11 compiler-output-regression
+                // workloads fail on exactly this, never reaching their subject).
+                eprintln!("[perry-codegen] kept object: {}", plan.obj_path.display());
+            } else {
                 // `remove_dir_all`, not the two names we know about — the same
                 // reason the clang path gives. This arm is the only in-process
                 // one that CREATES the scratch dir (writing the assembly), so

--- a/crates/perry-codegen/src/linker_temp_lifecycle_tests.rs
+++ b/crates/perry-codegen/src/linker_temp_lifecycle_tests.rs
@@ -266,6 +266,40 @@ fn keep_ir_retains_the_whole_scratch_dir() {
 }
 
 #[test]
+fn keep_ir_retains_the_whole_scratch_dir_under_native_roots() {
+    // The `native_roots: false` case above exercises the byte-returning arm.
+    // Under statepoints the plan asks for `-S`, so a DIFFERENT arm handles the
+    // compile: it writes assembly, assembles to `plan.obj_path`, and keeps the
+    // scratch dir. That arm is the ordinary path on every statepoint target,
+    // and it was the untested one — which is how it came to retain the object
+    // without ever printing `kept object:` (#8087).
+    let Some(root) = temp_root_if_clang_available("keep-native-roots") else {
+        return;
+    };
+    let policy = TempFilePolicy {
+        keep: true,
+        debug_symbols: false,
+    };
+    if compile_ll_to_object_in(&root, &test_ir(11), None, policy, true).is_err() {
+        // A host whose assembler cannot serve the compact-map rewrite is not a
+        // failure of this contract; skip rather than assert on a missing tool.
+        let _ = fs::remove_dir_all(&root);
+        return;
+    }
+
+    let left = entries(&root);
+    assert_eq!(left.len(), 1, "expected one kept scratch dir: {left:?}");
+    let kept = entries(&root.join(&left[0]));
+    for want in [".ll", ".o"] {
+        assert!(
+            kept.iter().any(|n| n.ends_with(want)),
+            "PERRY_LLVM_KEEP_IR must retain the {want} under native roots: {kept:?}"
+        );
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn debug_symbols_do_not_change_the_temp_file_lifetime() {
     // #7144 question (b), answered by measurement rather than by inheriting the
     // premise. `PERRY_DEBUG_SYMBOLS` was believed to make the `.ll` part of the

--- a/scripts/compiler_output_harness/capture.py
+++ b/scripts/compiler_output_harness/capture.py
@@ -114,6 +114,25 @@ def resolve_benchmark_runs(args: argparse.Namespace) -> int:
     return runs
 
 
+# The in-process LLVM backend runs no `clang` subprocess, so the compile plan
+# records this placeholder where a driver path would go. It is not a path, and
+# `or`-style fallbacks do not catch it because a non-empty string is truthy.
+IN_PROCESS_CLANG = "(in-process)"
+
+
+def _executable_clang(recorded: str | None, fallback: str) -> str:
+    """The driver to re-run analysis with, given what the compile plan recorded.
+
+    The analysis re-compile needs a real executable. Under the clang path the
+    recorded value is one. Under the in-process backend it is `IN_PROCESS_CLANG`,
+    and passing that to `subprocess.run` raises FileNotFoundError — which is how
+    every workload failed once that backend became the default.
+    """
+    if not recorded or recorded == IN_PROCESS_CLANG:
+        return fallback
+    return recorded
+
+
 def _compile_env(clang: str, *, enable_gc_trace: bool = False) -> dict[str, str]:
     env = {**os.environ, "PERRY_LLVM_KEEP_IR": "1", "PERRY_NO_CACHE": "1"}
     env["PERRY_LLVM_CLANG"] = clang
@@ -316,7 +335,7 @@ def capture(args: argparse.Namespace) -> int:
         or parse_target_triple(ir_before)
         or "x86_64-unknown-linux-gnu"
     )
-    compile_clang = compile_metadata.get("clang_path") or clang
+    compile_clang = _executable_clang(compile_metadata.get("clang_path"), clang)
     compile_clang_args = list(compile_metadata.get("clang_args") or [])
     analysis_args = _analysis_args_from_metadata(compile_metadata, analysis_extra_clang_args)
 

--- a/tests/test_compiler_output_regression.py
+++ b/tests/test_compiler_output_regression.py
@@ -1130,6 +1130,33 @@ idxset.bounded_numeric_merge.5:
             ):
                 HARNESS.verify_existing(args)
 
+    def test_in_process_clang_placeholder_falls_back_to_a_real_driver(self):
+        # #8087: the compile plan records "(in-process)" where a driver path
+        # would go when no clang subprocess ran. The analysis re-compile still
+        # needs a real executable, and the placeholder is a truthy string, so
+        # an `or`-style fallback silently kept it and `subprocess.run` raised
+        # FileNotFoundError — every workload failed there once the in-process
+        # backend became the default.
+        self.assertEqual(
+            CAPTURE_MODULE._executable_clang(CAPTURE_MODULE.IN_PROCESS_CLANG, "/usr/bin/clang"),
+            "/usr/bin/clang",
+        )
+
+    def test_recorded_clang_path_is_preferred_when_it_is_a_real_driver(self):
+        # The fallback must not override a genuine recorded driver: the analysis
+        # is supposed to re-run the compile's own clang when there was one.
+        self.assertEqual(
+            CAPTURE_MODULE._executable_clang("/opt/llvm/bin/clang", "/usr/bin/clang"),
+            "/opt/llvm/bin/clang",
+        )
+
+    def test_missing_clang_path_falls_back(self):
+        for recorded in (None, ""):
+            self.assertEqual(
+                CAPTURE_MODULE._executable_clang(recorded, "/usr/bin/clang"),
+                "/usr/bin/clang",
+            )
+
     def test_explicit_perry_path_is_repo_relative(self):
         resolved = HARNESS.resolve_perry("target/debug/perry")
         self.assertEqual(resolved, [str(REPO_ROOT / "target/debug/perry")])


### PR DESCRIPTION
## What

`compiler-output-regression` fails on **all 11** of its workloads with the same error:

```
"errors": ["PERRY_LLVM_KEEP_IR did not report a retained object path"]
```

`h1_native_rep_equivalence`, `h1_buffer_alias_negative`, `image_convolution`, `loop_data_dependent`, `numeric_arrays`, `packed_f64_loop_versioning`, `packed_f64_loop_versioning_negative`, `dynamic_fractional_array_index`, `loop_bound_semantics`, `raw_numeric_object_fields`, `scalar_replacement_literals`.

Not one of them reaches the behaviour it exists to measure — the gate fails during capture, before its subject runs.

## Root cause

`PERRY_LLVM_KEEP_IR`'s contract is that intermediates are retained **and their locations printed**. `scripts/compiler_output_harness/analyzers.py` recovers them by parsing `kept object:` off the compile log.

The in-process backend has two success arms:

- the **byte-returning** arm writes the object and announces it;
- the **statepoint** arm — taken whenever the plan asks for `-S`, which is every statepoint target, so the ordinary path on aarch64 and x86-64 — assembles straight to `plan.obj_path` and keeps the scratch dir when `keep` is set.

The statepoint arm retains the object correctly. **It just never announced it.** The harness went blind the moment statepoints became the default backend and that arm started serving the ordinary compile.

## Fix

Announce the kept object from that arm too. Retention was already correct, so this restores the reporting half of the contract rather than changing what is kept.

The `keep` and `!keep` behaviours are now the two halves of one `if`, which is what they always were — the old shape read as an unconditional cleanup with a `!policy.keep` guard bolted on, and it was easy to miss that the keep path fell through announcing nothing.

## Why it went unnoticed

`keep_ir_retains_the_whole_scratch_dir` only ever ran with `native_roots: false`, so it exercised the byte-returning arm exclusively. **The arm that actually serves every statepoint target had no coverage at all.**

This PR adds `keep_ir_retains_the_whole_scratch_dir_under_native_roots`, which runs the same contract through the statepoint arm. It skips (rather than asserts) on a host whose assembler cannot serve the compact-map rewrite, so it does not turn a missing tool into a false failure.

## Validation

- Observed the fix directly — the line the harness parses is now emitted, with a real file behind it:
  ```
  [perry-codegen] kept object: /…/perry_llvm_scratch_1588_1/perry_llvm_f00561a5da7ccfa9_1588_1.o
  ```
- New test passes through the statepoint arm; the pre-existing `native_roots: false` test still passes.
- `cargo test -p perry-codegen --lib`: **997 passed, 0 failed**.
- `cargo fmt --all --check` clean.

The gate itself is the oracle for the other 10 workloads.

---

## Measured outcome (CI, after both fixes)

Before: **all 11** workloads failed identically with
`PERRY_LLVM_KEEP_IR did not report a retained object path` — the gate died during
capture and evaluated nothing.

After: capture succeeds (`"errors": []` on every workload) and the gate reaches its
subject. **6 of 11 now pass**: `h1_buffer_alias_negative`,
`packed_f64_loop_versioning_negative`, `dynamic_fractional_array_index`,
`loop_bound_semantics`, `raw_numeric_object_fields`, `scalar_replacement_literals`.

The remaining 5 — `h1_native_rep_equivalence`, `image_convolution`,
`loop_data_dependent`, `numeric_arrays`, `packed_f64_loop_versioning` — fail on
their **gate assertions**, not on harness errors. Those are real findings about
compiler output that this gate was structurally unable to report while capture
was broken, and they are out of scope here: this PR restores the gate's ability
to see them, it does not change codegen.

So `compiler-output-regression` is still red, deliberately — but it is now red for
the reason it exists, instead of failing before it measured anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retention of LLVM intermediate files when `PERRY_LLVM_KEEP_IR` is enabled, including statepoint assembly output.
  * Improved compiler analysis when an in-process LLVM backend does not provide a driver path.
  * Preserved explicitly recorded Clang paths when available.

* **Tests**
  * Added coverage for retained intermediate files, native roots, and compiler driver selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->