### PR TITLE
style(array): restore rustfmt on the files #8090 landed unformatted

### DIFF
--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -202,18 +202,17 @@ pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codep
 pub(crate) use self::flat_clone::{dense_spread_copy, dense_spread_source, flattenable_array_ptr};
 pub(crate) use self::header::{
     array_byte_size, array_is_frozen, array_is_sealed_or_no_extend, array_named_property_delete,
-    array_receiver_addr,
     array_named_property_get, array_named_property_get_by_name, array_named_property_has,
     array_named_property_names, array_named_property_set, array_numeric_raw_f64_get,
     array_numeric_raw_f64_push_inbounds, array_numeric_raw_f64_set_inbounds, array_object_flags,
-    array_object_flags_from_tag, array_ptr_as_proxy, array_receiver_gc_tag,
+    array_object_flags_from_tag, array_ptr_as_proxy, array_receiver_addr, array_receiver_gc_tag,
     canonicalize_array_numeric_store_value, clean_arr_ptr, clean_arr_ptr_mut,
     clear_array_numeric_layout, clear_array_numeric_layout_ptr, gc_element_slot_range,
     mark_array_layout_unknown, mark_array_raw_f64_holes_fresh, normalize_array_receiver,
     note_array_slot, note_array_slot_layout_only, rebuild_array_layout, rebuild_array_layout_exact,
     refresh_array_numeric_layout, replay_array_growth_write_barriers, set_array_numeric_layout,
-    store_array_slot, transfer_array_numeric_layout, typed_array_receiver,
-    value_bits_to_number, NumericArrayLayout, MIN_ARRAY_CAPACITY,
+    store_array_slot, transfer_array_numeric_layout, typed_array_receiver, value_bits_to_number,
+    NumericArrayLayout, MIN_ARRAY_CAPACITY,
 };
 
 // Sole caller is the regex-engine-gated `regex::exec_array`, so the helper and

--- a/crates/perry-runtime/src/array/typed_array_receiver_tests.rs
+++ b/crates/perry-runtime/src/array/typed_array_receiver_tests.rs
@@ -41,9 +41,11 @@
 //!   ordinary path.
 
 use super::*;
-use crate::array::{js_array_alloc, js_array_copy_within, js_array_fill, js_array_fill_range,
-    js_array_push_f64, js_array_reverse};
-use crate::typedarray::{TypedArrayHeader, js_typed_array_get, js_typed_array_set};
+use crate::array::{
+    js_array_alloc, js_array_copy_within, js_array_fill, js_array_fill_range, js_array_push_f64,
+    js_array_reverse,
+};
+use crate::typedarray::{js_typed_array_get, js_typed_array_set, TypedArrayHeader};
 
 /// `Uint16Array` (kind 4 per `elem_size_for_kind`) — 2-byte elements, so a
 /// value above 0xFFFF proves the store went through the per-kind accessor.
@@ -141,7 +143,10 @@ fn js_array_copy_within_copies_typed_elements() {
     // `c.copyWithin(0, 2)` — no end argument (has_end == 0 means "to length").
     let ta = typed(UINT16, &[1.0, 2.0, 3.0, 4.0]);
     let out = js_array_copy_within(as_array(ta), 0.0, 2.0, 0, 0.0);
-    assert!(!out.is_null(), "copyWithin must return its receiver, not null");
+    assert!(
+        !out.is_null(),
+        "copyWithin must return its receiver, not null"
+    );
     assert_eq!(read_back(ta, 4), vec![3.0, 4.0, 3.0, 4.0]);
 
     // Negative target/start, and an out-of-range end that clamps to length.


### PR DESCRIPTION
`cargo fmt --all -- --check` is red on `main` at `0d7fe21b0`, in exactly the two files #8090 touched — the `array::header` re-export list in `array/mod.rs` and the import block in `typed_array_receiver_tests.rs`.

`lint` is a required context and #8087 had only just restored it, so this put it back to red for every open PR, one day after #8092 documented that pattern.

Formatting only. No code change, no change to the re-export set. `cargo fmt --all -- --check` is clean afterwards, and the other four gates (`check_file_size.sh`, `gc_store_site_inventory.py`, `raw_handle_debt.py`, `addr_class_inventory.py`) were already green and stay green.

Mine to own: I merged #8090 after running those four static gates on the landing tree and did not run `cargo fmt --check`, which is the one that catches this. Refs #8092.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal array imports and test assertions for improved readability.
  * Reordered internal declarations without changing functionality or observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->