### PR TITLE
fix(typedarray): dispatch, not just validate, when the element-read receiver is not a typed array

### DIFF
--- a/changelog.d/8109-typed-array-read-receiver.md
+++ b/changelog.d/8109-typed-array-read-receiver.md
@@ -1,0 +1,97 @@
+### Fixed
+
+**A reassigned `new Int32Array` binding made every element READ return `0`** (#8100)
+
+```ts
+let P: Int32Array = new Int32Array(1);
+P[0] = 123;
+console.log("ta:", P[0], P.length);
+P = [99, 101] as any;
+console.log("plain:", P[0], P[1], P.length);
+```
+
+```
+perry (before):  ta: 123 1     plain: 0 0 2
+node v26.5.1:    ta: 123 1     plain: 99 101 2
+perry (after):   ta: 123 1     plain: 99 101 2
+```
+
+Exit status was 0 on both sides and `P.length` was already correct — the
+binding really did hold the plain array. Only the element reads were wrong,
+silently, in the shipped default configuration. All five representation-
+selection kill switches (`PERRY_SPECIALIZED_ABI`, `PERRY_PTR_NUMARRAY_LOCALS`,
+`PERRY_PTR_SHAPE_LOCALS`, `PERRY_INT_VALUED_LOCALS`,
+`PERRY_CANONICAL_I32_LOCALS`) left it broken, which is why
+`scripts/gc_repsel_matrix.sh` failed the `specabi_reassign` row in 22 of 22
+arms including `shipped_default`, and why `gc-stress` was red on every `main`
+nightly since 2026-08-10.
+
+#### Root cause: the receiver was validated, but the answer was not dispatched
+
+`perry-codegen`'s `is_width_tracked_typed_array_receiver`
+(`expr/index_get.rs`, #7494) deliberately keeps a local's DECLARED typed-array
+kind even after the binding is reassigned. That is the right call — dropping
+the hint sends a REAL typed array on to `is_array_expr`'s plain-array layout
+(element 0 at byte 8 instead of the data region at byte 16), which is a
+type-confused *write*, not merely a missed optimization. #7494 pays for the
+hint with an explicit promise, written in its comment: the runtime helper
+"re-validates the object's actual GC kind before touching memory".
+
+`js_typed_array_get` did not. Its only receiver check was `clean_ta_ptr`,
+which rejects nothing but an address below `0x1000`. So a plain array was read
+**as** a `TypedArrayHeader`:
+
+* `TypedArrayHeader::length` and `ArrayHeader::length` are both `u32` at
+  offset 0, so the bounds check passed against the plain array's real length;
+* `kind` (offset 8) and `elem_size` (offset 9) came from the low two bytes of
+  element 0's NaN box — for `99.0` both are `0`, i.e. `KIND_INT8` with a zero
+  stride;
+* `data_ptr(ta)` is `ta + size_of::<TypedArrayHeader>()` = `ta+16`, which is
+  element **1** of a plain array (whose slots start at `ta+8`).
+
+The uniform `0` was a memory read, not a constant: with a plain *object*
+receiver the same expression returned `8`.
+
+#### Fix: `classify_element_read_receiver`, asked before anything dereferences
+
+New `classify_element_read_receiver` (`typedarray/mod.rs`) is the READ-side
+mirror of #8090's `array/header.rs` `typed_array_receiver`: it answers from the
+raw, tag-masked argument **before** `clean_ta_ptr`.
+
+* A registered %TypedArray% keeps the typed element path unchanged. A
+  `GC_TYPE_TYPED_ARRAY` / `GC_TYPE_NATIVE_TYPED_VIEW` managed header also wins,
+  so a registry miss can only cost the diversion, never the element read.
+* Anything else takes the ordinary `[[Get]]` (`js_dyn_index_get`). Codegen
+  masks the NaN-box tag off the receiver (`and i64 %bits, POINTER_MASK`), so
+  the tag is RECONSTRUCTED from the managed header — which matters for exactly
+  one case: a heap string must be re-boxed `STRING_TAG` or `js_dyn_index_get`
+  walks a `StringHeader` as an `ObjectHeader` instead of taking its string arm.
+  (Symbols share `GC_TYPE_STRING` and stay POINTER-tagged, which is what
+  `js_is_symbol` separates.)
+* A masked-away non-pointer (`P = 42 as any`) answers `undefined`, node's
+  answer, instead of the old `0.0`.
+
+Applied to both READ helpers: `js_typed_array_get` (constant index) and
+`js_typed_array_index_get_dynamic` (variable / string key, via
+`typedarray_props::typed_array_index_get_dynamic`, generalizing the #5989
+buffer-only fallback that already sat there). The STORE side was already
+correct — codegen's store path consults `ctx.buffer_view_slots`, which
+invalidates on assignment, so a reassigned binding never reaches
+`js_typed_array_set`.
+
+#### Verified
+
+`node --experimental-strip-types` at the `.node-version` pin (v26.5.1), every
+exit code checked. An 11-section probe covering constant-index reads,
+variable-key reads, canonical string keys, constant and dynamic stores, and
+receivers that are a plain array / plain object / string / number / a real
+typed array diverged from node on 9 lines before and is byte-identical after.
+`test-files/test_gap_specabi_reassign.ts` is byte-identical to node.
+
+10 unit tests in
+`crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs`. They
+assert element VALUES, not absence of a panic; the typed-array controls store
+`70000` into a `Uint16Array` and require `4464` back, so a fallback that
+hijacked the typed path into boxed-f64 slots fails them. Sabotage-verified:
+with the two dispatch call sites reverted and the tests unchanged, 4 of the 10
+go red.

--- a/crates/perry-runtime/src/typedarray/access.rs
+++ b/crates/perry-runtime/src/typedarray/access.rs
@@ -24,12 +24,28 @@ pub extern "C" fn js_typed_array_length(ta: *const TypedArrayHeader) -> i32 {
 }
 
 /// `ta[i]` — returns plain f64 numeric value (NOT NaN-boxed).
+///
+/// #8100: codegen emits this for a local whose DECLARED type is a typed array
+/// even after the binding was reassigned (`is_width_tracked_typed_array_
+/// receiver` keeps the hint on purpose — see its #7494 comment — and pays for
+/// that with the promise that this helper re-validates the receiver's actual
+/// GC kind). `clean_ta_ptr` does not validate anything but the magnitude, so
+/// a plain array landing here was read AS a `TypedArrayHeader` and every
+/// element came back `0`. Classify first, then dispatch: a non-typed-array
+/// receiver takes the ordinary `[[Get]]`, exactly as if the static hint had
+/// never existed.
 #[no_mangle]
 pub extern "C" fn js_typed_array_get(ta: *const TypedArrayHeader, index: i32) -> f64 {
-    let ta = clean_ta_ptr(ta);
-    if ta.is_null() {
-        return 0.0;
-    }
+    let ta = match classify_element_read_receiver(ta as u64) {
+        ElementReadReceiver::TypedArray(addr) => addr as *const TypedArrayHeader,
+        ElementReadReceiver::Ordinary(receiver) => {
+            return crate::value::js_dyn_index_get(receiver, f64::from(index))
+        }
+        // Was `0.0`. `undefined` is the ECMAScript answer and the one node
+        // prints: `let P: Int32Array = new Int32Array(1); P = 42 as any; P[0]`
+        // is `undefined`, not `0`.
+        ElementReadReceiver::Absent => return f64::from_bits(crate::value::TAG_UNDEFINED),
+    };
     unsafe {
         if crate::native_arena::is_native_typed_view(ta) {
             crate::native_arena::validate_view_alive(

--- a/crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs
+++ b/crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs
@@ -1,0 +1,221 @@
+//! #8100: an element **READ** helper handed a receiver that is not a
+//! %TypedArray% must fall back to the ordinary `[[Get]]`, not read foreign
+//! memory as a `TypedArrayHeader`.
+//!
+//! ## Why this file exists
+//!
+//! `perry-codegen`'s `is_width_tracked_typed_array_receiver` (#7494) keeps a
+//! local's DECLARED typed-array kind even after the binding is reassigned —
+//! deliberately, because dropping the hint sends a REAL typed array through
+//! `is_array_expr`'s plain-array layout (element 0 at byte 8 instead of the
+//! data region at byte 16). It pays for that with an explicit promise that the
+//! runtime helper "re-validates the object's actual GC kind before touching
+//! memory".
+//!
+//! `js_typed_array_get` did not. Its only receiver check was `clean_ta_ptr`,
+//! which rejects nothing but an address below `0x1000`. So
+//!
+//! ```text
+//! let P: Int32Array = new Int32Array(1);
+//! P = [99, 101] as any;
+//! P[0]                                   // perry 0, node 99
+//! ```
+//!
+//! read an `ArrayHeader` as a `TypedArrayHeader`: `length` matched (offset 0
+//! in both), `kind`/`elem_size` came from the low bytes of element 0's NaN
+//! box, and the data pointer sat 8 bytes past the real element region. Every
+//! read answered `0`, with no error and no diagnostic, in the shipped default
+//! configuration.
+//!
+//! ## What each test asserts, and how it can fail
+//!
+//! * `clean_ta_ptr_does_not_validate_a_plain_array_receiver` pins the
+//!   *precondition*. If `clean_ta_ptr` ever starts rejecting non-typed-array
+//!   receivers on its own, the classifier below is redundant — that test
+//!   failing is a signal to re-read the guard, not to delete the test.
+//! * the plain-array read tests assert the ELEMENT VALUES (`99`, `101`), not
+//!   merely "did not panic". The pre-#8100 code returns `0.0` for both, so a
+//!   regression cannot pass them (CLAUDE.md's fourth way a gate cannot fail).
+//! * the typed-array controls store a value that only survives per-kind
+//!   truncation (`70000 & 0xFFFF == 4464`), so a fallback that hijacked the
+//!   typed path — reading boxed f64 slots instead of 16-bit lanes — fails
+//!   them.
+//! * `classify_element_read_receiver_retags_a_heap_string` covers the one
+//!   branch the end-to-end tests cannot distinguish cheaply: codegen masks the
+//!   NaN-box tag off the receiver, so a heap string must be RE-tagged
+//!   `STRING_TAG` or `js_dyn_index_get` walks a `StringHeader` as an
+//!   `ObjectHeader`.
+
+use super::*;
+
+use crate::array::{js_array_alloc, js_array_push_f64, ArrayHeader};
+use crate::value::{POINTER_MASK, SHORT_STRING_TAG, STRING_TAG, TAG_UNDEFINED};
+
+const UINT16: u8 = KIND_UINT16;
+
+fn plain_array(values: &[f64]) -> *mut ArrayHeader {
+    let mut arr = js_array_alloc(values.len() as u32);
+    for v in values {
+        arr = js_array_push_f64(arr, *v);
+    }
+    arr
+}
+
+/// A plain array handed to a typed-array element helper, exactly as codegen
+/// emits it: the NaN-box tag is masked off (`and i64 %bits, POINTER_MASK`), so
+/// the helper receives a bare address.
+fn as_typed(arr: *mut ArrayHeader) -> *const TypedArrayHeader {
+    ((arr as u64) & POINTER_MASK) as *const TypedArrayHeader
+}
+
+fn typed(kind: u8, values: &[f64]) -> *mut TypedArrayHeader {
+    let ta = typed_array_alloc(kind, values.len() as u32);
+    for (i, v) in values.iter().enumerate() {
+        js_typed_array_set(ta, i as i32, *v);
+    }
+    ta
+}
+
+fn is_undefined(v: f64) -> bool {
+    v.to_bits() == TAG_UNDEFINED
+}
+
+fn top16(v: f64) -> u64 {
+    v.to_bits() >> 48
+}
+
+#[test]
+fn clean_ta_ptr_does_not_validate_a_plain_array_receiver() {
+    let _serialized = crate::array::test_serialize();
+    let arr = plain_array(&[99.0, 101.0]);
+
+    // The registry knows this is NOT a typed array...
+    assert!(
+        lookup_typed_array_kind(arr as usize).is_none(),
+        "a plain array must not be in the typed-array registry, or the \
+         classifier below is being asked the wrong question"
+    );
+    // ...and yet the receiver funnel every element helper used to rely on
+    // waves it straight through. This is WHY the classifier has to run first:
+    // there is no later point at which the wrong receiver is caught.
+    assert!(
+        !clean_ta_ptr(as_typed(arr)).is_null(),
+        "clean_ta_ptr only rejects addresses below 0x1000 — if it starts \
+         validating the receiver, re-read the guard before touching #8100"
+    );
+}
+
+#[test]
+fn js_typed_array_get_reads_a_plain_array_receiver() {
+    let _serialized = crate::array::test_serialize();
+    let arr = plain_array(&[99.0, 101.0]);
+
+    // Pre-#8100 both of these were 0.0: `(*ta).length` read the ArrayHeader's
+    // length (2, so the bounds check passed), `(*ta).kind` read the low byte
+    // of element 0's NaN box (0 == KIND_INT8) and `elem_size` the next (0).
+    assert_eq!(js_typed_array_get(as_typed(arr), 0), 99.0);
+    assert_eq!(js_typed_array_get(as_typed(arr), 1), 101.0);
+}
+
+#[test]
+fn js_typed_array_get_is_undefined_past_a_plain_array_receiver() {
+    let _serialized = crate::array::test_serialize();
+    let arr = plain_array(&[99.0, 101.0]);
+
+    assert!(is_undefined(js_typed_array_get(as_typed(arr), 2)));
+    assert!(is_undefined(js_typed_array_get(as_typed(arr), -1)));
+}
+
+#[test]
+fn js_typed_array_get_is_undefined_for_a_non_pointer_receiver() {
+    // `let P: Int32Array = new Int32Array(1); P = 42 as any; P[0]` — codegen
+    // masks POINTER_MASK over the f64 bits of `42`, which leaves 0. The
+    // answer is `undefined` (what node prints), not the `0.0` this used to
+    // return.
+    assert!(is_undefined(js_typed_array_get(std::ptr::null(), 0)));
+}
+
+#[test]
+fn js_typed_array_get_still_reads_a_real_typed_array_element_typed() {
+    let ta = typed(UINT16, &[1.0, 2.0]);
+    js_typed_array_set(ta, 0, 70000.0);
+    // 70000 truncated to 16 bits == 4464: proof the per-kind lane load ran and
+    // the new fallback did not hijack the typed path into boxed-f64 slots.
+    assert_eq!(js_typed_array_get(ta, 0), 4464.0);
+    assert_eq!(js_typed_array_get(ta, 1), 2.0);
+    assert!(is_undefined(js_typed_array_get(ta, 2)));
+}
+
+#[test]
+fn js_typed_array_index_get_dynamic_reads_a_plain_array_receiver() {
+    let _serialized = crate::array::test_serialize();
+    let arr = plain_array(&[99.0, 101.0]);
+    let recv = as_typed(arr);
+
+    // Numeric key — pre-#8100 this answered `undefined` for every index.
+    assert_eq!(js_typed_array_index_get_dynamic(recv, 0.0), 99.0);
+    assert_eq!(js_typed_array_index_get_dynamic(recv, 1.0), 101.0);
+    assert!(is_undefined(js_typed_array_index_get_dynamic(recv, 2.0)));
+
+    // Canonical numeric-index STRING key is an element read, not a named
+    // property (IntegerIndexedExotic `[[Get]]`).
+    let key = crate::string::js_string_from_str("1");
+    let key_value = crate::value::js_nanbox_string(key as i64);
+    assert_eq!(js_typed_array_index_get_dynamic(recv, key_value), 101.0);
+}
+
+#[test]
+fn js_typed_array_index_get_dynamic_still_reads_a_real_typed_array() {
+    let ta = typed(UINT16, &[1.0, 2.0]);
+    js_typed_array_set(ta, 1, 70000.0);
+    assert_eq!(js_typed_array_index_get_dynamic(ta, 1.0), 4464.0);
+    assert!(is_undefined(js_typed_array_index_get_dynamic(ta, 9.0)));
+}
+
+#[test]
+fn classify_element_read_receiver_keeps_a_registered_typed_array() {
+    let ta = typed(UINT16, &[1.0]);
+    match classify_element_read_receiver(ta as u64) {
+        ElementReadReceiver::TypedArray(addr) => assert_eq!(addr, ta as usize),
+        _ => panic!("a registered typed array must stay on the typed path"),
+    }
+}
+
+#[test]
+fn classify_element_read_receiver_retags_a_heap_string() {
+    // Codegen masked the tag off, so the classifier has to reconstruct it from
+    // the managed header. Boxing a StringHeader as POINTER_TAG would send
+    // `js_dyn_index_get` down its ObjectHeader walk instead of its string arm.
+    let s = crate::string::js_string_from_str("perry element read");
+    match classify_element_read_receiver((s as u64) & POINTER_MASK) {
+        ElementReadReceiver::Ordinary(value) => assert_eq!(
+            top16(value),
+            STRING_TAG >> 48,
+            "a heap string receiver must come back STRING_TAG'd, not \
+             POINTER_TAG'd"
+        ),
+        _ => panic!("a heap string is an ordinary indexable receiver"),
+    }
+
+    // End-to-end: the read answers a one-character string, not `0.0`.
+    let ch = js_typed_array_get(((s as u64) & POINTER_MASK) as *const TypedArrayHeader, 0);
+    assert!(
+        top16(ch) == STRING_TAG >> 48 || top16(ch) == SHORT_STRING_TAG >> 48,
+        "`s[0]` on a string receiver must be a string, got bits {:#x}",
+        ch.to_bits()
+    );
+}
+
+#[test]
+fn classify_element_read_receiver_rejects_garbage_bits() {
+    // Neither a plausible heap address nor a registered anything: the answer
+    // is `undefined`, and nothing is dereferenced on the way there.
+    assert!(matches!(
+        classify_element_read_receiver(0),
+        ElementReadReceiver::Absent
+    ));
+    assert!(matches!(
+        classify_element_read_receiver(0x3F),
+        ElementReadReceiver::Absent
+    ));
+}

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -22,6 +22,10 @@ pub use format::format_typed_array;
 
 mod access;
 mod construct;
+/// #8100: the element READ helpers against a receiver the static typed-array
+/// hint no longer describes — the shape codegen emits for a reassigned local.
+#[cfg(test)]
+mod element_read_receiver_tests;
 mod iterate;
 mod slice_ops;
 mod transform;
@@ -427,6 +431,103 @@ pub fn clean_ta_ptr(ptr: *const TypedArrayHeader) -> *const TypedArrayHeader {
         return ptr::null();
     }
     addr as *const TypedArrayHeader
+}
+
+/// What an element-READ helper (`js_typed_array_get`,
+/// `js_typed_array_index_get_dynamic`) was ACTUALLY handed.
+///
+/// See [`classify_element_read_receiver`].
+pub(crate) enum ElementReadReceiver {
+    /// A registered %TypedArray% (or a `GC_TYPE_TYPED_ARRAY` /
+    /// `GC_TYPE_NATIVE_TYPED_VIEW` allocation the registry does not know)
+    /// at this de-NaN-boxed address. Stay on the typed element path.
+    TypedArray(usize),
+    /// NOT a typed array. Read it through the ordinary `[[Get]]`
+    /// ([`crate::value::js_dyn_index_get`]) with this NaN-boxed receiver,
+    /// re-tagged the way the value reached codegen before codegen masked
+    /// the tag off.
+    Ordinary(f64),
+    /// Nothing indexable — a masked-away non-pointer tag (`42 as any`), a
+    /// null receiver, or an address no managed header backs. `undefined`.
+    Absent,
+}
+
+/// Classify the raw receiver word an element-READ helper was handed, BEFORE
+/// anything dereferences it as a `TypedArrayHeader`.
+///
+/// **Ask this before `clean_ta_ptr`, never after** — the mirror of
+/// `array/header.rs`'s [`crate::array::header`] `typed_array_receiver`
+/// (#8090), which had to ask the typed-array question before
+/// `clean_arr_ptr` rejected the receiver. Here the direction is reversed
+/// and the failure is worse, because `clean_ta_ptr` performs **no registry
+/// check at all**: it only rejects addresses below `0x1000`. So a plain
+/// array or object that arrives through a stale *static* typed-array hint
+/// was read AS a `TypedArrayHeader` — `(*ta).length` landed on
+/// `ArrayHeader::length` (both at offset 0, so bounds checks "passed"),
+/// `(*ta).kind` / `elem_size` on the low bytes of element 0's NaN box, and
+/// `data_ptr(ta)` 8 bytes past the real element region. The observable
+/// result was a silent `0` for every element read (#8100).
+///
+/// This is reachable in the shipped default configuration:
+/// `perry-codegen`'s `is_width_tracked_typed_array_receiver` (#7494)
+/// deliberately keeps a reassigned local's declared typed-array kind — see
+/// its comment, which explains that dropping the hint sends a REAL typed
+/// array through the plain-array layout instead — and pays for that by
+/// promising the runtime helper "re-validates the object's actual GC kind
+/// before touching memory". This function is that validation, and it
+/// dispatches instead of only rejecting.
+///
+/// Codegen masks the NaN-box tag off the receiver (`and i64 %bits,
+/// 0x0000_FFFF_FFFF_FFFF`) before the call, so the tag cannot simply be
+/// read back: it is RECONSTRUCTED from the managed header. That matters for
+/// exactly one case — a heap string must be re-boxed with `STRING_TAG`, or
+/// `js_dyn_index_get` walks a `StringHeader` as an `ObjectHeader` instead of
+/// taking its string arm. Symbols share `GC_TYPE_STRING` and are
+/// POINTER-tagged, which is what `js_is_symbol` separates.
+///
+/// The registry is the authority for "is a typed array", the same gate
+/// `js_typed_array_read_int32` and `strict_typed_array_from_raw` already
+/// use. A `GC_TYPE_TYPED_ARRAY` / `GC_TYPE_NATIVE_TYPED_VIEW` header still
+/// wins on a registry miss, so a lookup failure can only cost the diversion,
+/// never the element read.
+pub(crate) fn classify_element_read_receiver(raw: u64) -> ElementReadReceiver {
+    // No hand-rolled address floor: every probe below is either a side-table
+    // lookup (safe for any bit pattern) or `try_read_gc_header`, which
+    // magnitude-classifies — handle band included — before it dereferences.
+    let addr = strip_nanbox(raw);
+    if lookup_typed_array_kind(addr).is_some() {
+        return ElementReadReceiver::TypedArray(addr);
+    }
+    // Only a POSITIVELY identified receiver is diverted. `try_read_gc_header`
+    // magnitude-classifies before it dereferences, so garbage bits that
+    // survived the mask never reach a managed-header read.
+    let obj_type = match unsafe { crate::value::addr_class::try_read_gc_header(addr) } {
+        Some(header) => header.obj_type,
+        None => {
+            // Small-buffer slab entries are heap-plausible but carry NO
+            // GcHeader, so the registry is the only way to see a Buffer /
+            // `Uint8Array`-backed receiver here.
+            return if crate::buffer::is_registered_buffer(addr) {
+                ElementReadReceiver::Ordinary(crate::value::js_nanbox_pointer(addr as i64))
+            } else {
+                ElementReadReceiver::Absent
+            };
+        }
+    };
+    match obj_type {
+        crate::gc::GC_TYPE_TYPED_ARRAY | crate::gc::GC_TYPE_NATIVE_TYPED_VIEW => {
+            ElementReadReceiver::TypedArray(addr)
+        }
+        crate::gc::GC_TYPE_STRING => {
+            let boxed = crate::value::js_nanbox_pointer(addr as i64);
+            if unsafe { crate::symbol::js_is_symbol(boxed) } != 0 {
+                ElementReadReceiver::Ordinary(boxed)
+            } else {
+                ElementReadReceiver::Ordinary(crate::value::js_nanbox_string(addr as i64))
+            }
+        }
+        _ => ElementReadReceiver::Ordinary(crate::value::js_nanbox_pointer(addr as i64)),
+    }
 }
 
 #[inline]

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -655,7 +655,20 @@ pub(crate) unsafe fn typed_array_index_get_dynamic(owner_bits: usize, key: f64) 
                 key,
             );
         }
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        // #8100: the variable-key twin of the `js_typed_array_get` bug. Codegen
+        // emits this helper for a reassigned local whose DECLARED type is a
+        // typed array, so the receiver is routinely a plain array/object; the
+        // pre-#8100 arm answered `undefined` for all of them. Classify the raw
+        // address and take the ordinary `[[Get]]` when it is not a typed
+        // array. No recursion: `js_dyn_index_get` re-enters this function only
+        // when `lookup_typed_array_kind` succeeds, which is precisely the case
+        // `classify_element_read_receiver` keeps on the typed path.
+        return match crate::typedarray::classify_element_read_receiver(owner_bits as u64) {
+            crate::typedarray::ElementReadReceiver::Ordinary(receiver) => {
+                crate::value::js_dyn_index_get(receiver, key)
+            }
+            _ => f64::from_bits(crate::value::TAG_UNDEFINED),
+        };
     };
     // A Symbol key is never an integer-indexed element — read it from the symbol
     // side table, exactly as the ordinary `obj[sym]` path does. Without this a


### PR DESCRIPTION
Closes #8100.

`js_typed_array_get` and `js_typed_array_index_get_dynamic` are what codegen
emits for a local whose DECLARED type is a typed array but whose binding was
reassigned. `is_width_tracked_typed_array_receiver` (`expr/index_get.rs`,
#7494) keeps that hint on purpose — dropping it sends a REAL typed array on to
`is_array_expr`'s plain-array layout, a type-confused *write* — and pays for it
with an explicit promise in its own comment: the runtime helper "re-validates
the object's actual GC kind before touching memory".

It did not.

## The root cause is a type confusion, not a `0.0` return

The issue reads `clean_ta_ptr` as *rejecting* the plain array. It does not — it
rejects nothing but an address below `0x1000`:

```rust
pub fn clean_ta_ptr(ptr: *const TypedArrayHeader) -> *const TypedArrayHeader {
    let addr = strip_nanbox(ptr as u64);
    if addr < 0x1000 { return ptr::null(); }
    addr as *const TypedArrayHeader
}
```

So a plain array was read **as** a `TypedArrayHeader`:

* `TypedArrayHeader::length` and `ArrayHeader::length` are both `u32` at offset
  0, so the bounds check passed against the plain array's real length;
* `kind` (offset 8) and `elem_size` (offset 9) came from the low two bytes of
  element 0's NaN box — for `99.0` both are `0`, i.e. `KIND_INT8` with a zero
  stride;
* `data_ptr(ta)` is `ta + size_of::<TypedArrayHeader>()` = `ta+16`, which is
  element **1** of a plain array (whose slots start at `ta+8`).

The uniform `0` is a memory read, not a constant. Proof, from the probe below:
a plain **object** receiver returned `8`, and a string receiver returned `0 0`
where node prints `h i`.

## The fix

New `classify_element_read_receiver` (`typedarray/mod.rs`) — the READ-side
mirror of #8090's `array/header.rs` `typed_array_receiver`. It answers from the
raw, tag-masked argument **before** anything dereferences it:

* a registered %TypedArray% keeps the typed element path, byte-for-byte
  unchanged. A `GC_TYPE_TYPED_ARRAY` / `GC_TYPE_NATIVE_TYPED_VIEW` managed
  header also wins, so a registry miss can only cost the diversion, never the
  element read;
* anything else takes the ordinary `[[Get]]` (`js_dyn_index_get`). Codegen
  masks the NaN-box tag off (`and i64 %bits, POINTER_MASK`), so the tag is
  RECONSTRUCTED from the managed header — which matters for exactly one case: a
  heap string must be re-boxed `STRING_TAG`, or `js_dyn_index_get` walks a
  `StringHeader` as an `ObjectHeader` instead of taking its string arm.
  (Symbols share `GC_TYPE_STRING` and stay POINTER-tagged; `js_is_symbol`
  separates them.)
* a masked-away non-pointer (`P = 42 as any`) answers `undefined` — node's
  answer — instead of the old `0.0`.

Applied to both READ helpers. `js_typed_array_index_get_dynamic` generalizes
the #5989 buffer-only fallback already sitting in that arm. No recursion:
`js_dyn_index_get` re-enters the dynamic helper only when
`lookup_typed_array_kind` succeeds, which is exactly the case the classifier
keeps on the typed path.

The classifier uses no hand-rolled address floor — every probe is a side-table
lookup (safe for any bit pattern) or `try_read_gc_header`, which
magnitude-classifies (handle band included) before it dereferences. The first
draft had `if addr < 0x1000` and `scripts/addr_class_inventory.py` correctly
failed it 6-vs-5; the check was removed, not ceiling-raised.

## Why not the codegen side

Invalidating `local_type_hint` on reassignment is the alternative the issue
names. It is worse:

* #7494 documents the regression it produces: with the hint gone the access
  falls THROUGH to `is_array_expr`, which still answers true for a
  typed-array-named receiver, and lowers a REAL typed array with the
  plain-array layout (element 0 at byte 8 instead of the data region at byte
  16). That is a type-confused unboxed access — strictly worse than a
  wrong-answer read;
* `is_width_tracked_typed_array_receiver` has a second consumer in
  `expr/index_set.rs`, so the change would have to be re-argued for stores;
* the runtime fix covers every emitter of these helpers at once
  (`index_get.rs` x2, `arrays_finds.rs`, and the inline / proven-view fallback
  tiers).

## Verification

Oracle: `node --experimental-strip-types` at the `.node-version` pin, **v26.5.1**
(verified with `node --version`). Perry: `--profile perry-dev`,
`PERRY_RUNTIME_DIR` pinned to the freshly built archive pair,
`--no-auto-optimize --no-cache`. Every exit code checked; all three sides
exit 0.

The issue's reducer:

```
node        ta: 123 1     plain: 99 101 2
perry pre   ta: 123 1     plain: 0 0 2
perry post  ta: 123 1     plain: 99 101 2      <- byte-identical to node
```

An 11-section probe (constant-index reads, variable-key reads, canonical
string keys, constant and dynamic stores, and receivers that are a plain array
/ plain object / string / number / a real typed array) diverged from node on 9
lines before and is byte-identical after. A second probe covering `.at()`,
`for…of`, a loop-counter index, and reassignment inside a function is
byte-identical too.

`test-files/test_gap_specabi_reassign.ts` — the test that has been red on every
`main` nightly since 2026-08-10, and the only remaining reason `gc-stress` is
red — is now byte-identical to node.

10 unit tests in `crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs`.
They assert element VALUES, and the typed-array controls store `70000` into a
`Uint16Array` and require `4464` back, so a fallback that hijacked the typed
path into boxed-f64 slots fails them.

**Sabotage-verified twice**, each with a real rebuild confirmed by
`grep -c "Compiling perry-runtime v" == 1` and a moved `libperry_runtime.a`
mtime:

* revert the two dispatch call sites, keep the classifier and the tests — 4 of
  10 unit tests go red, and the reducer and gap test both return to
  `plain: 0 0 2`;
* restore, then sabotage ONLY the `GC_TYPE_STRING` re-tag arm — exactly 1 test
  goes red, and it is the one that claims to guard it.

### Representation arms

`test_gap_specabi_reassign.ts` compiled AND run under each kill switch the
issue reports as failing, diffed against node v26.5.1, all exit codes 0:

| arm | before (#8100) | after |
|---|---|---|
| shipped default | FAIL | **PASS** |
| `PERRY_SPECIALIZED_ABI=0` | FAIL | **PASS** |
| `PERRY_PTR_NUMARRAY_LOCALS=0` | FAIL | **PASS** |
| `PERRY_PTR_SHAPE_LOCALS=0` | FAIL | **PASS** |
| `PERRY_INT_VALUED_LOCALS=0` | FAIL | **PASS** |
| `PERRY_CANONICAL_I32_LOCALS=0` | FAIL | **PASS** |

I did **not** complete a full `scripts/gc_repsel_matrix.sh --arms all` run, and
am not claiming one. `--no-build` skips the cargo build but line 437 then
invokes the compiler *without* `--no-auto-optimize`, so the warm-up triggers a
full auto-optimize rebuild of perry-runtime and its dependency tree — into the
worktree's default `target/`, not `CARGO_TARGET_DIR`. On a host with 18 GiB
free shared with three other agents that is an ENOSPC risk, so I stopped it
after ~12 min and cleaned up. The table above is the substance of that row; the
remaining arms are GC-mode arms orthogonal to a receiver-classification change,
and CI's `gc-stress` runs the real matrix on this PR.

### No regressions

`cargo test --profile perry-dev -p perry-runtime --lib` (the whole lib, not a
filter): **2361 passed, 0 failed, 4 ignored**, plus 6 serialized single-test
runs. 167 `typedarray::*` / `array::*` tests green, including the 8
`array::typed_array_receiver_tests` #8090 added yesterday.

Static gates, real exit codes at this HEAD: `scripts/check_file_size.sh` OK,
`gc_store_site_inventory.py` passed, `raw_handle_debt.py` 992 == baseline 992,
`addr_class_inventory.py` exit 0, `cargo fmt --all -- --check` exit 0.

## Two notes for the reviewer

**1. `test_gap_specabi_reassign` must stay ABSENT from `test-parity/gap_snapshot.json`.**
#8006 (closed as superseded) recorded its absence as a blind spot, and #8100
carries that forward. The inference is inverted: the snapshot's own schema says
"Lists every gap test that is NOT passing; a test absent from `tests` is
expected to pass. CI fails on any divergence in EITHER direction." Absence IS
the tracking state. Measured at `0d7fe21b0` with no edits:

```
$ python3 scripts/gap_snapshot.py check --report <report with the test failing> \
      --snapshot test-parity/gap_snapshot.json
REGRESSIONS — these were expected to pass:
  - test_gap_specabi_reassign: pass -> parity_fail
EXIT=1
```

Adding an entry would (a) disarm that and (b) fail `gap_snapshot.py check` the
moment this fix lands, as "in snapshot, now passing". So this PR adds no
snapshot entry — deliberately.

Why no CI artifact shows the failure, then: the test is index 484 of the sorted
`test_gap_*.ts` set, so `483 % 8 == 3` puts it in **shard 4**, and every recent
`conformance-smoke` run cancelled shard 4 early — the journal from run
`31838286790` stops after 56 results.

**2. An adjacent, PRE-EXISTING bug this PR deliberately does NOT fix.**
The `Uint8Array`-specialized helpers have the same disease and are not touched
here:

```ts
let Q: Uint8Array = new Uint8Array(2);
Q = [9, 10] as any;
Q[0] = 5;
console.log(JSON.stringify(Q), Q[0], Q[1]);
// node   [5,10] 5 10
// perry  [9,10] undefined undefined
```

`js_uint8array_index_get_value` / `js_uint8array_set`
(`typedarray/access.rs`) fall off the end into `undefined` / a dropped store
for a receiver that is neither a registered typed array nor a registered
buffer. Measured pre-fix and post-fix on the same probe: byte-identical, so
this PR neither causes nor fixes it. It is out of #8100's stated scope (the
issue scopes to the two READ helpers and explicitly excludes stores), and the
store half needs its own semantics review, so it is filed separately as
#8111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indexed reads after a typed-array reference is reassigned to a regular array.
  * Regular arrays and other ordinary values now use standard property access.
  * Invalid or out-of-bounds reads correctly return `undefined`.
  * Preserved expected behavior for valid typed arrays, strings, dynamic indexes, and different typed-array kinds.
  * Added regression coverage for receiver handling, including invalid and garbage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->