### PR TITLE
fix(gc): list the five buffer/typed-array constructors as poll-capable

### DIFF
--- a/changelog.d/8127-poll-capable-buffer-ctors.md
+++ b/changelog.d/8127-poll-capable-buffer-ctors.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`gc-root-dominance` has been red on `main` since 2026-08-14, and the reason was that the gate was silently not checking part of what it claims to.** Its own `--audit-poll-reach` self-audit exits 2 naming five exported symbols that match `ALLOC_RE` (their result is a heap value the checker must track) *and* call something already in `POLL_CAPABLE_RUNTIME`, while not being listed there themselves: `js_buffer_alloc_fill_value`, `js_buffer_from_array`, `js_buffer_from_value`, `js_typed_array_new_from_array`, `js_uint8array_new`.
+
+  The consequence is the #7616 shape: a window whose only collection point is one of those five classified `MOVING: no`, so **every `--moving-only` arm — which is every gated arm, in all four modes — dropped it**. Those windows were never checked, and the gate could not have reported a rooting bug in them.
+
+  All five are real `pub extern "C"` exports in the buffer / typed-array construction paths, and each reaches a JS-reentrant helper (`js_array_get_f64` and `js_typed_array_get` can both run a user getter). Adding them makes the checker **stricter**, not looser: it now classifies those windows as moving and audits them.
+
+  Verified by A/B with real exit codes rather than a pipeline's: `--audit-poll-reach` exits **2** before and **0** after, printing `no ALLOC_RE symbol reaches a poll-capable one unlisted`. `--audit-alloc-re`, `--audit-poll-capable`, `--audit-immovable-sources` and `--self-test` all still exit 0.

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -1179,6 +1179,18 @@ def is_collecting(callee):
 #          count and are deliberately NOT folded in here — same reasoning as
 #          ALLOC_RE's deleted `bigint_\w+_op`.
 POLL_CAPABLE_RUNTIME = {
+    # #8117 follow-up: the checker's own poll-reach audit derived these five
+    # from real intra-runtime call edges and exited 2 asking for them. Each
+    # matches ALLOC_RE (its result is a heap value the checker must track) AND
+    # calls something already listed here, so a window whose only collection
+    # point is one of them classified `MOVING: no` and was DROPPED from every
+    # `--moving-only` arm -- which is every gated arm in all four modes. The
+    # gate was silently not checking those windows. That is #7616's shape.
+    "js_buffer_alloc_fill_value",     # -> js_buffer_from_value
+    "js_buffer_from_array",           # -> js_array_get_f64 (can run a getter)
+    "js_buffer_from_value",           # -> js_buffer_from_array
+    "js_typed_array_new_from_array",  # -> js_array_get_f64
+    "js_uint8array_new",              # -> js_typed_array_get, js_uint8array_from_array
     "js_call_function",
     # Calling a JS closure. The four names this replaces
     # (`js_call_closure`, `js_invoke_closure`, `js_function_call`,


### PR DESCRIPTION
## `gc-root-dominance` has been red on `main` for ~24 hours, and the reason is that the gate was silently not checking part of what it claims to

Last green on `main` was `3381e1b89` (2026-08-13T19:27); every run since `0da668c95` (08-14T02:48) has failed. This is **not** from any of last night's merges — it predates all of them.

The gate's own `--audit-poll-reach` names the cause and the fix:

```
error: ALLOC_RE symbols that CALL a POLL_CAPABLE_RUNTIME symbol but are not in POLL_CAPABLE_RUNTIME:
  js_buffer_alloc_fill_value      -> js_buffer_from_value
  js_buffer_from_array            -> js_array_get_f64
  js_buffer_from_value            -> js_buffer_from_array
  js_typed_array_new_from_array   -> js_array_get_f64
  js_uint8array_new               -> js_typed_array_get, js_uint8array_from_array
```

## Why it matters more than "a list is missing five entries"

This is #7616's shape. The checker knows each of these returns a heap value it must track (`ALLOC_RE`) **and** knows it calls something that can re-enter JS or run a moving minor — and refused to put the two together. So a window whose only collection point is one of the five classified `MOVING: no`, and **every `--moving-only` arm — which is every gated arm, in all four modes — dropped it.**

Those windows were not being audited. The gate could not have reported a rooting bug in them, and would have stayed green if one existed.

That makes this a *"gate can't fail"* instance the gate detected about itself, which is the good case — it exited 2 rather than passing quietly.

## The fix makes the checker stricter

All five are real `pub extern "C"` exports in the buffer / typed-array construction paths, and each reaches a JS-reentrant helper — both `js_array_get_f64` and `js_typed_array_get` can run a user getter. Listing them means those windows are now classified moving and **audited**, rather than skipped.

## Verification, with real exit codes

Captured from the script itself, not from a pipeline's last stage — a `tail` swallowing an exit code is a mistake that has cost this repo twice in two days:

```
--audit-poll-reach          BEFORE exit 2   AFTER exit 0
                            AFTER prints: "no ALLOC_RE symbol reaches a poll-capable one unlisted"
--audit-alloc-re            exit 0
--audit-poll-capable        exit 0
--audit-immovable-sources   exit 0
--self-test                 exit 0
```

## One thing to watch on this PR

Because the change makes the gate stricter, the full corpus run may now surface **real** violations in the newly-audited windows. That would be the gate doing its job for the first time on those paths rather than a regression from this change — but it does mean a red `gc-root-dominance` here needs reading carefully rather than reverting. I could not run the full corpus locally (it needs the IR corpus the CI job builds).

Refs #8117, #7616.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated garbage-collection reachability auditing to correctly account for additional buffer and typed-array operations.
  * Fixed self-audit behavior for poll-reach checks while preserving existing audit and self-test results.

* **Documentation**
  * Added a changelog entry describing the expanded buffer and typed-array audit coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->