### PR TITLE
fix(gc): prune the buffer own-property table when its buffer dies

### DIFF
--- a/changelog.d/8136-buffer-own-props-death-prune.md
+++ b/changelog.d/8136-buffer-own-props-death-prune.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A dead buffer's own-property entry was never pruned, so the GC kept retaining its expando closure forever.** `finalize_collected_dead_buffer` prunes eleven address-keyed side tables under the banner "drop every registry/side-table entry keyed by a dead buffer's address"; the own-property table added by #6406 (`buf.foo = v`) was not one of them. Its only clear site was `register_buffer`, which fires only when the recycled address is re-issued to another *buffer* — so an entry whose address is never reused, or is reused by a plain object, survived for the life of the process.
+
+  That leaked one permanent entry per property-carrying `Buffer`/`DataView` ever created, and — unlike the identity registries beside it — this table is *traced*: `scan_buffer_own_props_roots_mut` visits the stored values in every GC phase, so a dead buffer's expando closure and everything it captured stayed reachable. The surviving entry's key is also a dead address that the scanner keeps handing to `visit_metadata_usize_slot`, which resolves it against whatever now occupies those bytes — the #6080 ABA class this function exists to prevent, in the one table it did not cover.
+
+  Three tests in `crates/perry-runtime/src/gc/tests/buffer_side_tables.rs`, each watched fail with the prune reverted: `test_dead_buffer_own_property_entry_pruned_on_full_gc` (`left: Some(7.0)`, `right: None`), `test_buffer_own_props_table_drains_after_owners_die` (the leak regression — "514 owners remain, expected at most the pre-test 2", which a per-address probe cannot show), and `test_live_buffer_keeps_its_own_properties_across_full_gc`, the control that keeps the prune from passing by dropping everything and which stays green under the same sabotage.
+
+  Found while bisecting #8117's two `pass -> crash` gap regressions; it is **not** a fix for those. They are Linux-only SIGSEGVs that bisect to #7314, and neither has been shown to depend on this table.

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -754,6 +754,22 @@ pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
     // through the hook it installs at startup. The callback only removes a
     // HashMap entry — no allocation, so it is safe to run inside the sweep.
     notify_crypto_key_death(addr);
+    // The own-property table (`buf.foo = v`, #6406) was missing from this list.
+    // It is the same shape as every table above — a plain address-keyed map that
+    // does not root the `BufferHeader` — but it had only ONE clear site,
+    // `register_buffer`, so an entry was dropped only when the recycled address
+    // was re-issued to another *buffer*. Two consequences, both real:
+    //
+    //  * an unbounded leak — one permanent entry per property-carrying
+    //    Buffer/DataView ever created — made worse than the registries above by
+    //    the fact that `scan_buffer_own_props_roots_mut` TRACES the stored
+    //    values in every GC phase, so a dead buffer's expando closure (and
+    //    everything it captures) stayed reachable for the life of the process;
+    //  * the #6080 ABA class this function exists to prevent. The surviving
+    //    entry's key is a dead address that the scanner keeps handing to
+    //    `visit_metadata_usize_slot`, which resolves it against whatever now
+    //    occupies those bytes and rewrites the key to the new tenant's address.
+    super::own_props::clear_buffer_own_props(addr);
     super::detach::remove_detached_entry_for_dead_buffer(addr);
     super::view::remove_entries_for_dead_buffer(addr);
 }

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -62,6 +62,8 @@ pub(crate) use header::{test_data_view_registry_len, test_shared_array_buffer_re
 // part of the public surface.
 pub use detach::is_detached_buffer;
 pub(crate) use detach::{array_buffer_transfer, detach_array_buffer};
+#[cfg(test)]
+pub(crate) use own_props::test_buffer_own_props_owner_count;
 pub use own_props::{
     buffer_get_own_prop, buffer_has_own_prop, buffer_own_props_possible, buffer_set_own_prop,
     clear_buffer_own_props, scan_buffer_own_props_roots_mut,

--- a/crates/perry-runtime/src/buffer/own_props.rs
+++ b/crates/perry-runtime/src/buffer/own_props.rs
@@ -110,8 +110,30 @@ pub fn scan_buffer_own_props_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
     }
 }
 
-/// Drop every own prop recorded for `addr`. Called when a buffer is registered
-/// (freed storage is recycled, and the table is address-keyed).
+/// Live owner count. Test-only: the leak regression asserts the table DRAINS
+/// after the owning buffers are collected, which a per-address
+/// `buffer_get_own_prop` probe cannot show.
+#[cfg(test)]
+pub(crate) fn test_buffer_own_props_owner_count() -> usize {
+    buffer_props().lock().map(|props| props.len()).unwrap_or(0)
+}
+
+/// Drop every own prop recorded for `addr`.
+///
+/// Two callers, and they cover different halves of the address-keyed table's
+/// lifetime:
+///
+/// * `register_buffer` — a *recycled* address must not inherit the previous
+///   tenant's expandos.
+/// * `finalize_collected_dead_buffer` — the owning buffer DIED. Registration
+///   alone is not enough: it only fires if the address is re-issued to another
+///   *buffer*, so an entry whose address is never reused, or is reused by a
+///   plain object, used to survive for the life of the process. That leaked one
+///   entry per property-carrying Buffer/DataView ever created, and
+///   `scan_buffer_own_props_roots_mut` kept tracing the stored values in every
+///   GC phase — so a dead buffer's expando closure stayed reachable forever, and
+///   its dead owner key kept being re-resolved against whatever now occupies
+///   that address.
 pub fn clear_buffer_own_props(addr: usize) {
     if addr == 0 {
         return;

--- a/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
@@ -234,3 +234,90 @@ fn test_process_global_sab_backing_survives_full_gc_unrooted() {
         "the SAB must still answer as a registered buffer"
     );
 }
+
+/// A dead buffer's OWN-PROPERTY entry must go too (#6406's table).
+///
+/// `finalize_collected_dead_buffer` prunes eleven address-keyed tables; this
+/// one was missing. Its only clear site was `register_buffer`, which fires
+/// only when the recycled address is re-issued to another *buffer* — so an
+/// entry whose address is never reused, or is reused by a plain object,
+/// survived for the life of the process. That matters more here than for the
+/// identity registries above, because `scan_buffer_own_props_roots_mut` traces
+/// the stored VALUES in every GC phase: the dead buffer's expando closure, and
+/// everything it captures, stayed reachable forever.
+#[test]
+fn test_dead_buffer_own_property_entry_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let addr = crate::buffer::buffer_alloc(32) as usize;
+    crate::buffer::buffer_set_own_prop(addr, "tag", 7.0);
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "tag"),
+        Some(7.0),
+        "test premise: the own property is recorded"
+    );
+
+    // No roots: dead at the full trace. (Buffers are TENURED old-gen residents,
+    // so only a FULL trace can prove them dead.)
+    full_gc();
+
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "tag"),
+        None,
+        "a dead buffer's own-property entry must be pruned — the table is \
+         address-keyed, so a recycled address inherits the dead buffer's \
+         expandos, and the GC root scanner keeps retaining their values"
+    );
+}
+
+/// A LIVE buffer keeps its own properties across a full collection. Without
+/// this the prune above could pass by dropping everything unconditionally.
+///
+/// `CopyingNurseryTestGuard::new(1)` — not `GcTestIsolationGuard` — because
+/// only it pushes the shadow frame that makes `js_shadow_slot_set` an actual
+/// root; see the note on the DataView/SAB survival test above.
+#[test]
+fn test_live_buffer_keeps_its_own_properties_across_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let addr = crate::buffer::buffer_alloc(32) as usize;
+    crate::buffer::buffer_set_own_prop(addr, "tag", 7.0);
+    js_shadow_slot_set(0, ptr_bits(addr));
+
+    full_gc();
+
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "tag"),
+        Some(7.0),
+        "a live (rooted) buffer must keep its own properties"
+    );
+}
+
+/// The leak regression: N property-carrying buffers, all references dropped,
+/// one full collection, and the table must DRAIN. A per-address probe cannot
+/// show this — before the fix the table grew monotonically for the life of the
+/// process.
+#[test]
+fn test_buffer_own_props_table_drains_after_owners_die() {
+    let _guard = GcTestIsolationGuard::new();
+
+    const N: usize = 512;
+    let base = crate::buffer::test_buffer_own_props_owner_count();
+    for i in 0..N {
+        let addr = crate::buffer::buffer_alloc(32) as usize;
+        crate::buffer::buffer_set_own_prop(addr, "tag", i as f64);
+    }
+    assert!(
+        crate::buffer::test_buffer_own_props_owner_count() >= base + N,
+        "test premise: {N} owners were recorded"
+    );
+
+    full_gc();
+
+    let after = crate::buffer::test_buffer_own_props_owner_count();
+    assert!(
+        after <= base,
+        "the own-property table must drain when its owners die: {after} owners \
+         remain, expected at most the pre-test {base}"
+    );
+}


### PR DESCRIPTION
`finalize_collected_dead_buffer` (`crates/perry-runtime/src/buffer/header.rs`) exists to *"drop every registry/side-table entry keyed by a dead buffer's address"* — its own docstring — and it prunes eleven of them: `BUFFER_REGISTRY`, `ARRAY_BUFFER_REGISTRY`, `SHARED_ARRAY_BUFFER_REGISTRY`, `DATA_VIEW_REGISTRY`, `BUFFER_AB_ALIAS`, `CRYPTO_KEY_META_REGISTRY`, `SECRET_KEY_REGISTRY`, `UINT8ARRAY_FROM_CTOR`, the three `external_*` maps, plus the detach and view registries.

The **own-property table** (`buf.foo = v`, #6406) was not one of them. Its only clear site is `register_buffer`, which fires only when the recycled address is re-issued to another *buffer* — so an entry whose address is never reused, or is reused by a plain object, survived for the life of the process.

Two consequences, and the second is why this table matters more than the identity registries beside it:

* **An unbounded leak** — one permanent entry per property-carrying `Buffer`/`DataView` ever created.
* **`scan_buffer_own_props_roots_mut` traces the stored VALUES in every GC phase.** So a dead buffer's expando closure — and everything it captures — stayed reachable forever. And its dead owner key kept being handed to `visit_metadata_usize_slot`, which re-resolves it against whatever now occupies those bytes: the #6080 ABA class this function exists to prevent, in the one table that was not covered.

The fix is one line plus the doc comments that explain why the table needs two clear sites rather than one.

## Testing

Three tests, in `crates/perry-runtime/src/gc/tests/buffer_side_tables.rs` — the file that already exists to cover exactly this function's coverage gaps (#6337 added it for `DATA_VIEW_REGISTRY` and `SHARED_ARRAY_BUFFER_REGISTRY`, which had the identical "no `.remove` site anywhere in the tree" shape).

Each was watched fail with the one-line prune reverted:

```
---- test_dead_buffer_own_property_entry_pruned_on_full_gc ----
assertion `left == right` failed: a dead buffer's own-property entry must be pruned …
  left: Some(7.0)
 right: None

---- test_buffer_own_props_table_drains_after_owners_die ----
the own-property table must drain when its owners die: 514 owners remain,
expected at most the pre-test 2
```

* `test_dead_buffer_own_property_entry_pruned_on_full_gc` — the per-address probe.
* `test_buffer_own_props_table_drains_after_owners_die` — the leak regression. 512 property-carrying buffers, all references dropped, one full collection; a per-address probe cannot show a monotonically growing table.
* `test_live_buffer_keeps_its_own_properties_across_full_gc` — **the control.** Without it the prune could pass by dropping entries unconditionally. It uses `CopyingNurseryTestGuard::new(1)` rather than `GcTestIsolationGuard`, because only that guard pushes the shadow frame that makes `js_shadow_slot_set` an actual root — the same trap the neighbouring DataView/SAB survival test documents. It stays **green** under the sabotage, so the two failures above are the prune and not the harness.

Results:

* `cargo test -p perry-runtime --lib` → **2392 passed, 0 failed, 4 ignored** (repo baseline 2389 + these three), exit 0. The restore build recompiled `perry-runtime` exactly once.
* `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean; all sixteen `lint`-gate scripts run individually, all exit 0.

## Scope — this is NOT a fix for #8117

Found while bisecting #8117's two `pass -> crash` gap regressions (`test_gap_buffer_own_props`, `test_gap_6386_dataview_concat_regex_fastpaths`). It is **not** a fix for them and is not claimed as one:

* those are SIGSEGVs that reproduce only on Linux (30 clean runs each on macOS/arm64, including under `PERRY_GC_ZEAL`, forced evacuation, from-space protect and scan, and `PERRY_GC_SCHEDULE_RATE=1`);
* they bisect to #7314 (2026-08-03), twelve days before this table came under suspicion — see https://github.com/PerryTS/perry/issues/8117#issuecomment-5300864212;
* nothing has shown either fixture's fault to depend on this table.

Landing separately on its own merits. A second divergence in the same file is left for a follow-up and deliberately not folded in here: `scan_buffer_own_props_roots_mut` claims to mirror `closure::dynamic_props` "(same locked side table + GC root scanner contract)", but the closure version falls back to `forwarded_heap_owner(owner)` when the visitor did not rewrite the key and re-inserts through `merge_closure_prop_map` so a post-rewrite key collision merges instead of clobbering; the buffer version does a bare `props.insert(new_owner, entries)`. With dead owners now pruned, the collision window that divergence opens is much narrower.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale buffer properties being retained after garbage collection.
  * Prevented collected buffers from leaving behind data that could interfere with reused memory addresses.
  * Preserved properties for buffers that remain active.

* **Tests**
  * Added regression coverage for cleanup after collection, multiple unreachable buffers, and live-buffer preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->