### PR TITLE
fix(array): resolve a Buffer-backed Uint8Array receiver before the array-only iterator funnel (#8117)

### DIFF
--- a/changelog.d/8140-buffer-receiver-array-iterators.md
+++ b/changelog.d/8140-buffer-receiver-array-iterators.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- `.values()` / `.keys()` / `.entries()` on a Buffer-backed `Uint8Array` no
+  longer yield an empty iterator when codegen cannot statically prove the
+  receiver (`holder.u.values()`, or any fully dynamic receiver).
+  `array_iter_obj_raw` opens with `clean_arr_ptr`, which #8041 widened to reject
+  every *tracked* non-array; `buffer_alloc` stamps a real `GC_TYPE_BUFFER`
+  header, so a Buffer receiver was nulled exactly as a `GC_TYPE_TYPED_ARRAY` one
+  is and every branch below the funnel became unreachable. `keys` is the proof
+  this was a regression rather than a standing gap — it only reads `length`, so
+  it answered correctly before #8041. The receiver is now resolved in
+  `typed_array_iter_arr`, above that funnel, and receiver-tag gated so an
+  ordinary array reaches neither registry — strictly fewer probes than before,
+  which asked `lookup_typed_array_kind` unconditionally. `ArrayBuffer` /
+  `SharedArrayBuffer` / `DataView` are excluded, matching node's `TypeError`
+  (#8117).

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -197,18 +197,58 @@ unsafe fn array_iter_obj_raw(arr: *const ArrayHeader, kind: i32) -> i64 {
     js_nanbox_get_pointer(nanboxed)
 }
 
-/// #3148: materialize a TypedArray receiver to a plain Array (element-typed
-/// reads) before building the iterator object, so `int32arr.values()` /
-/// `.keys()` / `.entries()` yield the numeric elements rather than the raw
-/// byte buffer reinterpreted as f64.
+/// #3148/#8140: materialize a %TypedArray% *or* Buffer-backed `Uint8Array`
+/// receiver to a plain Array (element-typed reads) before building the iterator
+/// object, so `int32arr.values()` / `.keys()` / `.entries()` yield the numeric
+/// elements rather than the raw byte buffer reinterpreted as f64.
+///
+/// **This MUST stay above `array_iter_obj_raw`**, which opens with
+/// `clean_arr_ptr`. Since #8041 that funnel returns null for every *tracked*
+/// non-`GC_TYPE_ARRAY` allocation, and `buffer_alloc` stamps `GC_TYPE_BUFFER`
+/// through `arena_alloc_gc_old` — so a Buffer receiver is nulled exactly as a
+/// `GC_TYPE_TYPED_ARRAY` one is, and every branch below that funnel (including
+/// its own Map/Set arm) is unreachable for it. The observable was an EMPTY
+/// iterator: `u8.values()`, `.keys()` and `.entries()` all yielded nothing.
+/// `keys` in particular was *correct* before #8041 — it only ever reads
+/// `length` — so this is a regression, not a standing gap.
+///
+/// Perry's `new Uint8Array([…])` is a `BufferHeader`, not a
+/// `TypedArrayHeader` (`buffer::js_uint8array_new`), so it is absent from the
+/// typed-array registry and `lookup_typed_array_kind` never answers for it.
+/// That is the same registry gap `buffer_receiver_as_uint8_typed_array`
+/// documents for `sort`/`with`/`toSorted`/`toReversed`; here the plain-array
+/// materialization the typed-array arm already performs is the natural answer,
+/// so no `TypedArrayHeader` copy is needed.
+///
+/// `ArrayBuffer` / `SharedArrayBuffer` / `DataView` are deliberately excluded:
+/// none has `%TypedArray%.prototype`, so node throws
+/// `… is not a function` rather than answering elements, and routing them here
+/// would invent an iterator node does not have.
+///
+/// Receiver-tag gated with the #7765 idiom (`js_array_get_f64`, and #8130's
+/// `collection_foreach_reroute`): an ordinary array is excluded by one
+/// already-warm GC-header byte and reaches NEITHER registry — strictly fewer
+/// probes than before this change, which asked `lookup_typed_array_kind`
+/// unconditionally. The registries remain the layout proof for everything else.
 #[inline]
 fn typed_array_iter_arr(arr: *const ArrayHeader) -> *const ArrayHeader {
-    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
-        crate::typedarray::typed_array_to_array(arr as *const crate::typedarray::TypedArrayHeader)
-            as *const ArrayHeader
-    } else {
-        arr
+    if crate::array::array_receiver_gc_tag(arr).0 == crate::gc::GC_TYPE_ARRAY {
+        return arr;
     }
+    let addr = arr as usize;
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        return crate::typedarray::typed_array_to_array(
+            arr as *const crate::typedarray::TypedArrayHeader,
+        ) as *const ArrayHeader;
+    }
+    if crate::buffer::is_registered_buffer(addr)
+        && !crate::buffer::is_any_array_buffer(addr)
+        && !crate::buffer::is_data_view(addr)
+    {
+        return crate::buffer::buffer_to_array(addr as *const crate::buffer::BufferHeader)
+            as *const ArrayHeader;
+    }
+    arr
 }
 
 /// `%TypedArray%.prototype.values/keys/entries` begin with `ValidateTypedArray`

--- a/crates/perry-runtime/src/array/typed_array_receiver_tests.rs
+++ b/crates/perry-runtime/src/array/typed_array_receiver_tests.rs
@@ -516,3 +516,194 @@ fn an_array_buffer_receiver_is_not_treated_as_a_uint8array() {
         "a DataView receiver must not be served as a Uint8Array"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #8140: the `.values()` / `.keys()` / `.entries()` iterator entry points must
+// resolve a Buffer-backed `Uint8Array` receiver BEFORE the array-only funnel.
+//
+// The precondition is already pinned by
+// `a_new_uint8array_is_a_buffer_not_a_registry_typed_array` above: perry's
+// `new Uint8Array([…])` is a `BufferHeader`, absent from the typed-array
+// registry (so the #3148 `lookup_typed_array_kind` delegations never answer for
+// it) and nulled by `clean_arr_ptr` (so a post-clean branch is unreachable).
+// `buffer_alloc` stamps a real `GC_TYPE_BUFFER` GcHeader through
+// `arena_alloc_gc_old`, which is why #8041's "reject every TRACKED non-array"
+// catches it and its predecessor "reject GC_TYPE_OBJECT / GC_TYPE_CLOSURE"
+// did not.
+//
+// `array_iter_obj_raw` opens with that funnel, so EVERY branch below it — the
+// fs-dir arm, the Map/Set arm, and the iterator construction itself — was
+// unreachable for a Buffer receiver, and all three methods yielded an EMPTY
+// iterator. Measured against node v26.5.1 on `new Uint8Array([3,1,2])`:
+//
+//   method      node                    perry pre-fix
+//   .values()   [3,1,2]                 []
+//   .keys()     [0,1,2]                 []
+//   .entries()  [[0,3],[1,1],[2,2]]     []
+//
+// `keys` is the sharpest evidence this is a REGRESSION and not a standing gap:
+// it only ever reads `length`, so it answered correctly before #8041.
+//
+// Reachable from BOTH a property-read receiver (`holder.u.values()`, which
+// codegen fuses to `js_array_values_iter_obj`) and a fully dynamic one
+// (`opaque(u).values()`), so it is not a narrow static-typing corner.
+// ---------------------------------------------------------------------------
+
+/// Drive an iterator object returned by `js_array_*_iter_obj` to exhaustion,
+/// rendering each yielded value so the expectations below read as the node
+/// output they were taken from.
+fn drain_iter(iter: i64) -> Vec<String> {
+    let mut out = Vec::new();
+    unsafe {
+        let obj = iter as *mut crate::object::ObjectHeader;
+        assert!(!obj.is_null(), "iter_obj must return an iterator object");
+        for _ in 0..64 {
+            let result = crate::array::dispatch_array_iterator_method(obj, "next");
+            let robj =
+                crate::value::js_nanbox_get_pointer(result) as *mut crate::object::ObjectHeader;
+            assert!(!robj.is_null(), "next() must return a result object");
+            let value = crate::object::js_object_get_field(robj, 0);
+            let done = crate::object::js_object_get_field(robj, 1);
+            if done.bits() == crate::value::TAG_TRUE {
+                break;
+            }
+            out.push(render(f64::from_bits(value.bits())));
+        }
+    }
+    out
+}
+
+/// `3` for a number, `[0,3]` for a 2-element pair array — enough to tell the
+/// three iterator kinds apart, and to tell a correct element from a raw byte
+/// reinterpreted as an f64 (which renders as `1.5e-323`, never as `3`).
+fn render(v: f64) -> String {
+    let bits = v.to_bits();
+    if (bits >> 48) == 0x7FFD {
+        let inner = crate::value::js_nanbox_get_pointer(v) as *const ArrayHeader;
+        let cleaned = crate::array::header::clean_arr_ptr(inner);
+        if !cleaned.is_null() {
+            let n = unsafe { (*cleaned).length } as usize;
+            let parts: Vec<String> = (0..n)
+                .map(|i| render(crate::array::js_array_get_f64(cleaned, i as u32)))
+                .collect();
+            return format!("[{}]", parts.join(","));
+        }
+    }
+    let n = f64::from_bits(bits);
+    if n.is_finite() && n.fract() == 0.0 {
+        format!("{}", n as i64)
+    } else {
+        format!("{n:?}")
+    }
+}
+
+#[test]
+fn js_array_values_iter_obj_yields_a_buffer_receivers_bytes() {
+    let _serialized = crate::array::test_serialize();
+    let buf = uint8_buffer(&[3.0, 1.0, 2.0]);
+    assert_eq!(
+        drain_iter(crate::array::js_array_values_iter_obj(buf)),
+        vec!["3", "1", "2"],
+        "node yields [3,1,2]; an EMPTY list is #8140 — the funnel nulled the \
+         receiver before the Buffer question was ever asked"
+    );
+}
+
+#[test]
+fn js_array_keys_iter_obj_yields_a_buffer_receivers_indices() {
+    let _serialized = crate::array::test_serialize();
+    let buf = uint8_buffer(&[3.0, 1.0, 2.0]);
+    assert_eq!(
+        drain_iter(crate::array::js_array_keys_iter_obj(buf)),
+        vec!["0", "1", "2"],
+        "node yields [0,1,2]. `keys` reads only `length`, so it was CORRECT \
+         before #8041 — this case is the proof that #8140 is a regression"
+    );
+}
+
+#[test]
+fn js_array_entries_iter_obj_yields_a_buffer_receivers_pairs() {
+    let _serialized = crate::array::test_serialize();
+    let buf = uint8_buffer(&[3.0, 1.0, 2.0]);
+    assert_eq!(
+        drain_iter(crate::array::js_array_entries_iter_obj(buf)),
+        vec!["[0,3]", "[1,1]", "[2,2]"],
+        "node yields [[0,3],[1,1],[2,2]]"
+    );
+}
+
+#[test]
+fn a_typed_array_receiver_still_yields_element_typed_values() {
+    let _serialized = crate::array::test_serialize();
+    // The pre-existing #3148 arm must survive the reordering. `70000 & 0xFFFF`
+    // is 4464, so a raw-f64 reinterpretation cannot produce this answer.
+    let ta = typed(UINT16, &[70000.0, 2.0]);
+    assert_eq!(
+        drain_iter(crate::array::js_array_values_iter_obj(as_array(ta))),
+        vec!["4464", "2"],
+        "the typed-array materialization must still run element-typed reads"
+    );
+}
+
+#[test]
+fn a_plain_array_iterator_never_probes_the_typed_array_registry() {
+    let _serialized = crate::array::test_serialize();
+    let mut arr = js_array_alloc(3);
+    for v in [7.0, 8.0, 9.0] {
+        arr = js_array_push_f64(arr, v);
+    }
+
+    // Prime anything built lazily on first touch, then measure ONLY the
+    // receiver-resolution call. `drain_iter`/`render` read elements through
+    // `js_array_get_f64`, which runs its own #8109 typed-array probe once per
+    // element — measuring across the drain counts those and says nothing about
+    // the subject. (Measured: it reports exactly +1 per element, so a naive
+    // window would have "failed" here for the wrong reason.)
+    let _ = drain_iter(crate::array::js_array_values_iter_obj(arr));
+    let before = crate::typedarray::test_typed_array_registry_probe_count();
+    let iter = crate::array::js_array_values_iter_obj(arr);
+    let after = crate::typedarray::test_typed_array_registry_probe_count();
+
+    assert_eq!(
+        drain_iter(iter),
+        vec!["7", "8", "9"],
+        "the control receiver must keep iterating its own elements"
+    );
+    assert_eq!(
+        after, before,
+        "a GC_TYPE_ARRAY receiver must never reach lookup_typed_array_kind — \
+         delete the receiver-tag gate at the top of `typed_array_iter_arr` and \
+         this is what fails, even though the ANSWER above stays correct"
+    );
+}
+
+#[test]
+fn an_array_buffer_or_data_view_receiver_gets_no_element_iterator() {
+    let _serialized = crate::array::test_serialize();
+    // `ArrayBuffer` / `SharedArrayBuffer` / `DataView` have no
+    // %TypedArray%.prototype, so node throws `… is not a function` rather than
+    // answering elements. The Buffer arm must decline them and leave the
+    // pre-existing behaviour untouched, exactly as
+    // `buffer_receiver_as_uint8_typed_array` does.
+    let ab = crate::buffer::buffer_alloc(4);
+    unsafe { (*ab).length = 4 };
+    crate::buffer::mark_as_array_buffer(ab as usize);
+    assert!(
+        drain_iter(crate::array::js_array_values_iter_obj(
+            ab as *mut ArrayHeader
+        ))
+        .is_empty(),
+        "an ArrayBuffer receiver must not be served a Uint8Array iterator"
+    );
+
+    let dv = crate::buffer::buffer_alloc(4);
+    unsafe { (*dv).length = 4 };
+    crate::buffer::mark_as_data_view(dv as usize);
+    assert!(
+        drain_iter(crate::array::js_array_values_iter_obj(
+            dv as *mut ArrayHeader
+        ))
+        .is_empty(),
+        "a DataView receiver must not be served a Uint8Array iterator"
+    );
+}

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -350,10 +350,31 @@ pub fn unregister_typed_array(ptr: *const TypedArrayHeader) {
     crate::typedarray_props::typed_array_clear_no_extend(owner);
 }
 
+#[cfg(test)]
+thread_local! {
+/// Every entry into [`lookup_typed_array_kind`], i.e. every caller that could
+/// not rule a typed array out more cheaply. Mirrors
+/// `map::TEST_MAP_REGISTRY_PROBES` (#7765) and exists for the same reason: the
+/// receiver-tag gates that let a `GC_TYPE_ARRAY` receiver skip this probe are
+/// asserted against it, so deleting a gate fails a test even though the ANSWER
+/// stays correct. A fast path nobody can prove ran is not a fast path.
+///
+/// Per THREAD, not per process: the registry is thread-local and `cargo test`
+/// runs each case on its own thread in one process.
+    static TEST_TA_REGISTRY_PROBES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn test_typed_array_registry_probe_count() -> u64 {
+    TEST_TA_REGISTRY_PROBES.with(|c| c.get())
+}
+
 /// Returns Some(kind) if the (already-stripped) address is a registered
 /// typed array, else None.
 #[inline]
 pub fn lookup_typed_array_kind(addr: usize) -> Option<u8> {
+    #[cfg(test)]
+    TEST_TA_REGISTRY_PROBES.with(|c| c.set(c.get().wrapping_add(1)));
     // Nothing has ever been registered ⟹ nothing to find. Checked ahead of the
     // #5525 cache because it is the only arm that costs neither a cache-slot
     // load nor a negative-entry write-back: a program with no typed arrays runs


### PR DESCRIPTION
## What

`.values()`, `.keys()` and `.entries()` on a Buffer-backed `Uint8Array` yielded
an **empty iterator** whenever codegen could not statically prove the receiver.

```ts
const holder = { u: new Uint8Array([3, 1, 2]) };
for (const v of holder.u.values())  { /* node: 3,1,2   perry: nothing */ }
for (const k of holder.u.keys())    { /* node: 0,1,2   perry: nothing */ }
for (const p of holder.u.entries()) { /* node: [0,3],[1,1],[2,2]  perry: nothing */ }
```

Reachable from a property-read receiver (`holder.u`, fused straight to
`js_array_values_iter_obj`) **and** from a fully dynamic one
(`opaque(u).values()`), so it is not a narrow static-typing corner.

## Root cause

`array_iter_obj_raw` (`array/iter_object.rs:174`) opens with `clean_arr_ptr`.
Since **#8041** (`971d6ffb6`) that funnel rejects every *tracked* non-array:

```rust
if obj_type != crate::gc::GC_TYPE_ARRAY {
    return std::ptr::null();
}
```

where it previously rejected only `GC_TYPE_OBJECT` / `GC_TYPE_CLOSURE` and
explicitly waved registered Buffers through. `buffer_alloc`
(`buffer/header.rs:592`) allocates via `arena_alloc_gc_old(…, GC_TYPE_BUFFER)`,
so a Buffer **is** tracked — it is nulled exactly as a `GC_TYPE_TYPED_ARRAY` is,
and every branch below the funnel (the fs-dir arm, the Map/Set arm, and the
iterator construction itself) became unreachable for it.

`keys` is the sharpest evidence this is a regression rather than a standing gap:
it only ever reads `length`, so it answered **correctly** before #8041.

Same ordering hazard as #8090/#8119 (`fill`/`sort`/`toSorted`/…), #8109/#8120
(element reads) and #8130 (fused `forEach`). This is the iterator arm.

## Fix

Resolve the receiver in `typed_array_iter_arr`, which already runs *above* that
funnel for registry typed arrays — the Buffer case is the one it never learned
about, because perry's `new Uint8Array([…])` is a `BufferHeader` and so is
absent from the typed-array registry that helper probes.

Gated on the #7765 receiver tag (`array_receiver_gc_tag`, the idiom
`js_array_get_f64` and #8130's `collection_foreach_reroute` use), so an ordinary
array now reaches **neither** registry. That is strictly fewer probes than
before this change, which asked `lookup_typed_array_kind` unconditionally.

`ArrayBuffer` / `SharedArrayBuffer` / `DataView` are excluded — none has
`%TypedArray%.prototype`, so node throws rather than answering elements, and
routing them here would invent an iterator node does not have.

## Tests — sabotage-verified in both directions

Six tests in `array/typed_array_receiver_tests.rs`, which is where the
#8090/#8119 receiver tests already live. (Deliberately **not**
`collection_tag_tests.rs` — PR #8130 is editing that file.)

| sabotage | result |
|---|---|
| restore the pre-fix ordering (delete the Buffer arm) | the 3 iterator tests FAIL with `left: []  right: ["3","1","2"]` — the exact production symptom; **all controls green** |
| delete the receiver-tag gate | `a_plain_array_iterator_never_probes_the_typed_array_registry` FAILS `left: 25129  right: 25126`; **the 3 iterator tests stay green** |
| neither | 25/25 green in this module |

The second sabotage is what makes the control non-vacuous: deleting the gate
leaves every *answer* correct, so only a probe-count assertion can notice. That
required a test-only probe counter on `lookup_typed_array_kind`, mirroring the
existing `map::test_map_registry_probe_count` (#7765) one-for-one.

The precondition — Buffer is registered, is *not* in the typed-array registry,
and *is* nulled by `clean_arr_ptr` — is already pinned by the existing
`a_new_uint8array_is_a_buffer_not_a_registry_typed_array`, so this PR does not
duplicate it.

**A measurement trap worth recording:** the probe-count window must wrap only
the `js_array_values_iter_obj` call, not the drain. `drain_iter`/`render` read
elements through `js_array_get_f64`, which runs its own #8109 typed-array probe
once per element — a naive window measured `+3` on a 3-element control and
"failed" for a reason that had nothing to do with the subject.

## Validation

Built with `--profile perry-dev`, `PERRY_RUNTIME_DIR` pinned to the freshly
built archives, `PERRY_NO_AUTO_OPTIMIZE=1`.
`grep -c "Compiling perry-runtime v" build.log` = **1**, and
`libperry_runtime.a` mtime moved 07:56 → 08:29 after the edit.

* **Three-way control**, node `v26.5.1` (matches `.node-version`) / pre-fix
  perry / post-fix perry, across five probe programs. The fix moved **exactly
  12 lines**, every one of them an `entries`/`keys`/`values` case going from
  empty to **byte-identical to node**:

  ```
  U8 entries    = []  ->  [[0,3],[1,1],[2,2]]
  U8 keys       = []  ->  [0,1,2]
  U8 values     = []  ->  [3,1,2]
  u8.entries    = []  ->  [[0,3],[1,1],[2,2]]        (property receiver)
  u8.keys       = []  ->  [0,1,2]
  u8.values     = []  ->  [3,1,2]
  u8.* forof    = ""  ->  the three for-of forms
  opaque u8.*   = ""  ->  the three dynamic forms
  ```

* **Plain-array controls correct in both arms.** ~40 plain-array lines across
  the probes (`P entries`/`keys`/`values`/`map`/`sort`/`toSorted`/… and
  `opaque a.*`) are byte-unchanged pre- and post-fix, as are every
  `Int32Array` and `Float64Array` line. The fix is specific, not blanket.

* `cargo test -p perry-runtime --lib` (perry-dev): baseline on this branch point
  **2383 passed / 0 failed / 4 ignored**; with this change **2389 / 0 / 4**. +6
  is exactly the tests added, nothing lost. (Baseline measured in *this*
  profile — the number differs across profiles.)

* **`lint` gates enumerated from `.github/workflows/test.yml`** rather than
  remembered, and all run locally: `cargo fmt --all -- --check`,
  `check_file_size.sh`, and 18 python/node gates
  (`local_binding_type_audit`, `gc_store_site_inventory`, `addr_class_inventory`,
  `gc_pin_sites`, `gc_runtime_root_holders`, `check_gc_env_knobs`,
  `check_llvm_corpus_currency`, `check_gc_doc_claims`,
  `check_locale_independent_io`, `check_node_version_consistency`,
  `raw_handle_debt`, `gc_gate_wiring_check`, `gc_matrix_liveness_check`,
  `check_test_registration`, `global_sink_isolation`, `class_id_collisions`,
  `workspace_architecture`, `binding_pins.mjs`) — all clean.

## Scope — this is one row of a finished sweep

This PR came out of an exhaustive audit of every `Array.prototype`-reachable
runtime entry point, checking each for the #8041 funnel-ordering hazard. The
finite result, 34 rows covering all 38 `Array.prototype` methods:

* **3 rows are this regression** and are fixed here.
* **9 rows are a different, pre-existing bug** — the fused callback/reduce
  helpers read a Buffer receiver as *garbage* because their re-dispatch is
  reached but has no Buffer arm. Filed as **#8137**; it needs a live-view vs
  copy decision (the copy helper would hand the callback the wrong 3rd
  argument), so it is deliberately not in this PR.
* **8 rows are non-conformant independent of #8041** — methods absent from
  `%TypedArray%.prototype` that answer instead of throwing. Filed as **#8138**.
  `js_array_concat` is the worked example the brief called out and is owned by
  **#8124**; no overlap with this PR.
* **2 stringification rows** (`toLocaleString` is wrong for a *plain array*
  too) filed as **#8139**.
* **2 rows are latent-unreachable** (`js_array_set_f64*`, the bulk-fill loop
  helpers): textually dead below the funnel, but codegen never routes a typed
  array to them, and I measured both correct. 1 row is dead code below a dead
  branch (the eager `js_array_{entries,keys,values}`).
* The remaining **11 are already correct**, eight of them because
  #8090/#8109/#8119/#8120 already walked them. That includes every other
  receiver kind the audit was asked to check — generic array-like objects,
  `arguments`, strings, Proxies over arrays and `Set` — all measured
  node-identical, all reaching `js_arraylike_*` or an above-funnel arm
  (`array_ptr_as_proxy`, `normalize_array_receiver`'s `GC_TYPE_OBJECT`
  materialization). Recording the negative result rather than omitting it.

The full table — entry point, arity, which receivers reach it and via which
codegen path, re-dispatch above/below the funnel, and the measured node diff —
is in `gc-handoff/ARRAY-SWEEP-NOTES.md`, along with the two structural facts
that organise it:

1. **The two funnels are not the same.** `clean_arr_ptr` *rejects*;
   `normalize_array_receiver` *returns the raw address* for a typed array or
   Buffer. A re-dispatch below the latter still works, so a purely textual
   "re-dispatch comes after the funnel" scan over-reports by ~15 entries. Only
   `clean_arr_ptr` kills.
2. **Argument count and receiver provability both select the entry point.** The
   `js_array_X` / `js_arraylike_X` split is `args.len() >= 2`, re-implemented in
   five independent places; and a *provable* receiver goes to the dynamic
   dispatcher (correct) while a non-provable one is fused to the generic helper
   (where these bugs live).

### A vacuous probe this sweep generated, recorded so it is not repeated

`holder.u.every((x) => x > 0)` returns `true` under **both** node and perry —
but perry gets there by evaluating the predicate against reinterpreted garbage
(`1.29e-318` &c.), which is also `> 0`. A probe of that shape reports PASS on a
broken path. The discriminating predicate is `(x) => x === 3 || x === 1 || x === 2`,
which measures `false`.

## Caveats

* The Buffer materialization is a **snapshot**, so an iterator will not observe
  a write made to the Buffer mid-iteration. That is not a new divergence: it is
  exactly what `typed_array_iter_arr` already does for a real `Int32Array` via
  `typed_array_to_array`. Matching the existing precedent was the deliberate
  choice over routing to `js_buffer_values`, which returns a different iterator
  class.
* `array_iter_obj_raw`'s own Map/Set arm (`iter_object.rs:187`) is **still dead**
  below its `clean_arr_ptr` — #8130's shape, in one more place. I left it: Map
  and Set receivers are intercepted earlier by
  `collection_iter_obj_for_receiver`, so I could not produce a failing case from
  TypeScript, and I did not want to add a fix I could only justify with a unit
  test that calls the private path directly. Noted in the sweep table (row 32).
* I did not run the gap or parity suites; this change is confined to one
  runtime function and its behaviour is pinned by the three-way probe diff plus
  the full `perry-runtime` lib suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected iterator behavior for Buffer-backed `Uint8Array` values.
  * `.values()`, `.keys()`, and `.entries()` now return bytes, indices, and index-value pairs correctly.
  * Preserved expected errors for `ArrayBuffer`, `SharedArrayBuffer`, and `DataView` receivers.
  * Improved handling of ordinary arrays without unnecessary typed-array checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->