### PR TITLE
fix(next): make computed relative chunk requires resolve in a compiled App Route

### DIFF
--- a/changelog.d/8040-runtime-relative-chunk-require.md
+++ b/changelog.d/8040-runtime-relative-chunk-require.md
@@ -1,0 +1,9 @@
+A compiled production Next.js App Route no longer dies at startup with `Cannot find module './chunks/2.js'`.
+
+Next's production webpack runtime loads lazy chunks by a *computed* relative specifier — `.next/server/webpack-runtime.js` calls `require("./chunks/" + g.u(a))`. Perry's CJS `require` shim passed that string straight to the path→module registry, which is keyed by each module's **absolute** source path, so the lookup could never hit. Statically-known relative specifiers are resolved at compile time and never reach that branch; only computed ones do, which is why this only showed up on the real production route.
+
+The result was that every lazy chunk was unreachable at runtime even though it had been compiled into the image — all 104 modules of the #8034 fixture produced object files, `chunks/2.js` among them, and the host still exited during startup.
+
+Computed relative specifiers are now joined against the requiring module's own directory before the registry lookup. The `./` prefix is stripped textually rather than left to `std::fs::canonicalize`, which only normalizes paths that exist on disk while registration falls back to the raw string when they do not — relying on it would work from a source tree and silently fail in the deployed case the dylib packaging exists for.
+
+Refs #8040, #5438.

--- a/changelog.d/8040-runtime-relative-chunk-require.md
+++ b/changelog.d/8040-runtime-relative-chunk-require.md
@@ -7,3 +7,9 @@ The result was that every lazy chunk was unreachable at runtime even though it h
 Computed relative specifiers are now joined against the requiring module's own directory before the registry lookup. The `./` prefix is stripped textually rather than left to `std::fs::canonicalize`, which only normalizes paths that exist on disk while registration falls back to the raw string when they do not — relying on it would work from a source tree and silently fail in the deployed case the dylib packaging exists for.
 
 Refs #8040, #5438.
+
+A second defect sat behind the first. Even with the correct absolute key, the lookup missed: `perry_module_init` ran every eager module init *before* recording the path→init addresses, so a module performing a runtime path-require during its own init — which is exactly when Next's `webpack-runtime` loads a chunk — queried an init registry that was still empty. The addresses it needed were recorded a few instructions later.
+
+Recording is pure bookkeeping (no init runs at that point), so it now happens before the eager-init loop.
+
+Both defects had to be fixed to get past startup; either alone still fails, which is why the first fix alone showed no improvement.

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -630,12 +630,14 @@ pub(super) fn compile_module_entry(
             if !nextjs_path_inits.is_empty() {
                 blk.call_void("js_globalthis_seed_async_local_storage", &[]);
             }
-            for prefix in non_entry_module_prefixes {
-                if cross_module.deferred_module_prefixes.contains(prefix) {
-                    continue;
-                }
-                blk.call_void(&format!("{}__init", prefix), &[]);
-            }
+            // #8040: record the path->init addresses BEFORE the eager init
+            // loop below. Recording is pure bookkeeping — "No init runs here,
+            // only the address is recorded" — but a module that performs a
+            // runtime path-require DURING its own eager init (Next's
+            // webpack-runtime loads chunk 2 while initializing) previously hit
+            // an empty init registry and died with MODULE_NOT_FOUND, even
+            // though the chunk was compiled and its init address was about to
+            // be recorded a few instructions later.
             // Next.js wall 54 (part 2): record each Deferred `.next/server/**`
             // module's `__init` address under its absolute path so a runtime
             // `require(absolutePath)` (turbopack page/chunk loading) can trigger
@@ -654,6 +656,12 @@ pub(super) fn compile_module_entry(
                         (I64, init_addr.as_str()),
                     ],
                 );
+            }
+            for prefix in non_entry_module_prefixes {
+                if cross_module.deferred_module_prefixes.contains(prefix) {
+                    continue;
+                }
+                blk.call_void(&format!("{}__init", prefix), &[]);
             }
         }
         // Mark the boundary between init prelude and user code so

--- a/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
@@ -204,8 +204,15 @@ fn path_module_wrap_publishes_partial_then_final_exports_and_tracks_undefined() 
         .rfind("__perry_register_path_module(")
         .expect("CJS wrapper must publish its final module.exports value");
     assert!(partial < body && body < final_publish, "{wrapped}");
+    // #8040: both the value lookup and the presence probe must consult the
+    // SAME resolved specifier. A computed relative request is joined against
+    // the module's directory before either call (`__perry_path_spec`), so a
+    // mismatch here would resolve the value from one path and the
+    // exists-but-undefined bit from another.
     assert!(
-        wrapped.contains("__perry_path_mod !== undefined || __perry_has_path_module(specifier)"),
+        wrapped.contains(
+            "__perry_path_mod !== undefined || __perry_has_path_module(__perry_path_spec)"
+        ),
         "an exported undefined value must not be mistaken for a registry miss\n{wrapped}"
     );
 

--- a/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/preamble_canary_tests.rs
@@ -214,3 +214,43 @@ fn path_module_wrap_publishes_partial_then_final_exports_and_tracks_undefined() 
     let ast = perry_parser::parse_typescript(&wrapped, "lazy.js").unwrap();
     perry_hir::lower_module(&ast, "lazy", &path.to_string_lossy()).unwrap();
 }
+
+/// #8040: Next's production webpack runtime loads lazy chunks with a *computed*
+/// relative specifier — `.next/server/webpack-runtime.js` calls
+/// `require("./chunks/" + g.u(a))`. The path->module registry is keyed by each
+/// module's ABSOLUTE source path, so handing it the raw `./chunks/2.js` could
+/// never hit: the compiled App Route died at startup with
+/// `Cannot find module './chunks/2.js'` even though that chunk had been
+/// compiled into the image alongside the other 103 modules.
+///
+/// Statically-known relative specifiers are resolved at compile time and never
+/// reach that branch, which is why only the real production route exposed it.
+#[test]
+fn computed_relative_requires_are_joined_against_the_module_dir() {
+    let path = Path::new("/tmp/perry-canary/.next/server/webpack-runtime.js");
+    let wrapped = wrap_commonjs_for_target(CJS_FIXTURE, path, None);
+
+    // Anti-vacuity: if the wrap stops consulting the registry at all, the
+    // assertions below would be about a branch that no longer exists.
+    assert!(
+        wrapped.contains("__perry_require_path_module("),
+        "the wrap no longer consults the path->module registry:\n{wrapped}"
+    );
+    // The join needs the module's own directory as a literal.
+    assert!(
+        wrapped.contains("/tmp/perry-canary/.next/server"),
+        "the wrap lost the module-dir literal the join needs:\n{wrapped}"
+    );
+    // The registry lookup must use the JOINED path...
+    assert!(
+        wrapped.contains("__perry_require_path_module(__perry_path_spec)"),
+        "computed relative requires are not joined before the registry lookup (#8040):\n{wrapped}"
+    );
+    // ...and must not still be handed the raw specifier, which is the shape
+    // that made every lazy chunk miss.
+    assert!(
+        !wrapped.contains("__perry_require_path_module(specifier)"),
+        "the raw-specifier registry lookup is still present; a computed \
+         './chunks/N.js' will miss it (#8040)"
+    );
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -828,8 +828,31 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
         // compiled module self-registers into at init; `undefined` = not
         // registered, fall through to the `.json` read / MODULE_NOT_FOUND throw.
         {{
-            const __perry_path_mod = __perry_require_path_module(specifier);
-            if (__perry_path_mod !== undefined || __perry_has_path_module(specifier)) return __perry_path_mod;
+            // A runtime-COMPUTED *relative* specifier never matches that
+            // registry, which is keyed by absolute source path. Next's
+            // production webpack runtime does exactly this — `.next/server/
+            // webpack-runtime.js` calls `require("./chunks/" + g.u(a))` — so
+            // every lazy chunk missed and the App Route died at startup with
+            // `Cannot find module './chunks/2.js'` even though that chunk WAS
+            // compiled into the image. Statically-known relative specifiers are
+            // already handled by the cases above; only computed ones reach
+            // here, so join them against this module's own directory.
+            //
+            // The `./` prefix is stripped textually rather than left to
+            // `std::fs::canonicalize`: that only normalizes a path that exists
+            // on disk, and registration falls back to the raw string when it
+            // does not, so `<dir>/./chunks/2.js` would miss `<dir>/chunks/2.js`
+            // in exactly the deployed case where the sources are absent.
+            var __perry_path_spec = specifier;
+            if (specifier.charCodeAt(0) === 46) {{
+                if (specifier.charCodeAt(1) === 47) {{
+                    __perry_path_spec = {module_dir_literal} + '/' + specifier.slice(2);
+                }} else if (specifier.charCodeAt(1) === 46 && specifier.charCodeAt(2) === 47) {{
+                    __perry_path_spec = {module_dir_literal} + '/' + specifier;
+                }}
+            }}
+            const __perry_path_mod = __perry_require_path_module(__perry_path_spec);
+            if (__perry_path_mod !== undefined || __perry_has_path_module(__perry_path_spec)) return __perry_path_mod;
         }}
         // Runtime `require(absolutePath)` of a `.json` file (Next.js loads
         // manifests this way: `require(this.middlewareManifestPath)`). Node's


### PR DESCRIPTION
## Two stacked defects that stopped a compiled production App Route at startup

The #8034 fixture compiled all 104 modules into an app-only dylib and then died before serving anything:

```
Error: Cannot find module './chunks/2.js'
```

`chunks/2.js` **was** compiled into the image. Two independent bugs kept it unreachable, and **either one alone still fails** — which is why fixing the first showed no visible improvement at all.

### 1. A computed relative specifier never matched the registry

Next's production webpack runtime loads lazy chunks with a *computed* relative specifier — `.next/server/webpack-runtime.js` does `require("./chunks/" + g.u(a))`. The CJS shim handed that raw string to the path→module registry, which is keyed by each module's **absolute** source path, so the lookup could never hit. Statically-known relative specifiers are resolved at compile time and never reach that branch; only computed ones do, which is why only the real production route exposed it.

Computed relative specifiers are now joined against the requiring module's own directory. The `./` prefix is stripped textually rather than left to `std::fs::canonicalize`, which only normalizes paths that exist on disk while registration falls back to the raw string when they do not — relying on it would work from a source tree and silently fail in the deployed case the dylib packaging exists for.

Measured, via a temporary diagnostic on the lookup's miss path:

| build | key looked up |
|---|---|
| before | `"./chunks/2.js"` — raw, unresolvable |
| after | `"/…/.next/server/chunks/2.js"` — correct |

### 2. Path→init addresses were recorded after the inits that need them

With the correct key the lookup **still** missed. `perry_module_init` ran every non-entry module's `__init` first and only then emitted the `js_register_path_init` calls, so a module performing a runtime path-require *during its own init* — exactly when webpack loads a chunk — queried an empty init registry. The address it needed was recorded a few instructions later.

Recording runs no init, only `ptrtoint` bookkeeping, so it now happens before the eager-init loop.

**Verified in the emitted object, not the source.** A first attempt at this hoist nested the eager-init loop *inside* the registration loop — valid Rust, so it compiled and looked right — and emitted `register, init, register, init…`. `otool -tV` on the app dylib showed 103 `js_register_path_init` call sites with only **one** executing at runtime, because the first module's init threw before the rest were recorded. Reading the emitted call sequence is what caught it.

### Result

| | before | after |
|---|---|---|
| `js_register_path_init` executed | 1 | **103** |
| `chunks/2.js` registered | no | **yes** |
| path-require misses | 1 | **0** |

The route now gets past chunk resolution. It does not yet serve requests — the next boundary is a separate exception-transport defect (a provider workspace missing `panic = "abort"`, #7302's third instance), tracked apart from this PR.

### Test

`computed_relative_requires_are_joined_against_the_module_dir` asserts the registry lookup uses the joined path **and** that the raw-`specifier` form is gone, so a revert fails it in both directions. It also asserts the registry branch and the module-dir literal still exist, so it cannot pass by being about code that no longer exists.

Refs #8040, #5438.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed production App Route startup failures involving runtime-computed relative module imports.
  - Relative `require()` paths now resolve from the current module’s directory, including both `./` and `../` paths.
  - Improved module initialization so runtime imports are available during startup.
- **Tests**
  - Added regression coverage to ensure resolved paths are used consistently and raw relative paths are not looked up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->