### PR TITLE
fix(object): an SSO string receiver is indexable, not unindexable (#8117)

### DIFF
--- a/changelog.d/8151-sso-string-receiver-index.md
+++ b/changelog.d/8151-sso-string-receiver-index.md
@@ -1,0 +1,35 @@
+### Fixed
+
+- **Indexing a short concatenated string returned `undefined`** (#8117, reopening
+  #6887 at a different funnel). `const s = "ab" + "c"; s[0]` read `undefined`
+  instead of `"a"`, while `s.length`, `typeof`, printing, `charAt`, `for-of`,
+  spread, `Array.from` and `split` were all correct. Every ASCII concatenation
+  of five bytes or fewer is an inline `SHORT_STRING_TAG` (SSO) value, so
+  `(a + b)[0]`, an index-accumulation loop, and `parts.join("") + "\n"` were all
+  affected; the byte-identical heap string — a non-ASCII or >5-byte
+  concatenation — was fine.
+
+  `js_object_get_index_polymorphic` opened by asking *"does this receiver's low
+  48 bits hold a heap pointer?"* and returned `undefined` for every tag that
+  does not, conflating *not a pointer* with *not indexable*. It is the recurring
+  family — a receiver-specific arm claiming the operation before the
+  receiver-kind question is asked; this dispatcher asks the *key*'s kind
+  carefully, including a dedicated SSO arm for an SSO key, and never asked the
+  receiver's. #6888 had fixed codegen's proven-`string` fast path, but a
+  receiver whose string type is not *proven* (an inferred `const`, an annotated
+  `const s: string`, or a `string` parameter) reaches the generic dispatcher
+  instead, which passes the raw NaN-boxed bits to this helper. The symptom
+  changed from #6887's segfault to a silent wrong value because
+  `is_valid_string_ptr` now rejects the bogus pointer rather than dereferencing
+  it.
+
+  Fixed by adding the `SHORT_STRING_TAG` arm, delegating to
+  `js_string_index_get_boxed` so both string representations share one copy of
+  the CanonicalNumericIndexString semantics. Fixing at the shared funnel covers
+  every call site that funnels an unboxed receiver here. Sabotage-verified:
+  removing the arm fails `an_sso_string_receiver_reads_its_characters` with
+  `left: None  right: Some("a")` — the gap test's own wrong answer — while
+  controls for the heap-string arm, non-string primitives, and
+  out-of-range/fractional/`NaN` indices stay green.
+
+  Fixes `test-files/test_gap_sso_concat_string_index.ts`.

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -120,6 +120,8 @@ pub(crate) use object_ops::{ensure_key_in_keys_array, install_builtin_getter};
 mod object_ops_frozen;
 mod polymorphic_index;
 #[cfg(test)]
+mod polymorphic_index_sso_tests;
+#[cfg(test)]
 mod polymorphic_index_symbol_tests;
 mod primitive_proto_thunks;
 mod property_key;

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -139,6 +139,28 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
         // *registered* class-id takes the class-ref arm.
         match (obj_handle as u64) >> 48 {
             0x7FFD | 0x7FFF => (obj_handle as u64) & 0x0000_FFFF_FFFF_FFFF,
+            // SHORT_STRING_TAG (0x7FF9): an SSO string IS a string receiver,
+            // it just carries its characters inline instead of a heap address
+            // (#6887/#8117). The question this match asks is "does the low 48
+            // hold a heap pointer?", and answering `undefined` for everything
+            // that does not conflates "not a pointer" with "not indexable" —
+            // so `("ab" + "c")[0]` read `undefined` while the byte-identical
+            // heap string read `"a"`. Codegen hands this helper the receiver's
+            // RAW NaN-boxed bits whenever the tag is not POINTER_TAG (see the
+            // `select` in `index_get.rs`'s generic dispatcher), so the value is
+            // intact here and the string question can still be asked.
+            //
+            // Delegate to the boxed string entry point, which materializes the
+            // SSO payload onto the heap and lands in exactly the
+            // `js_string_index_get` the 0x7FFF arm reaches below via
+            // `GC_TYPE_STRING` — so both string representations share one copy
+            // of the CanonicalNumericIndexString key semantics.
+            0x7FF9 => {
+                return crate::string::js_string_index_get_boxed(
+                    f64::from_bits(obj_handle as u64),
+                    idx,
+                );
+            }
             0x7FFE => {
                 let class_id = (obj_handle as u64 & 0xFFFF_FFFF) as u32;
                 if class_id != 0 && crate::object::class_registry::is_class_id_registered(class_id)

--- a/crates/perry-runtime/src/object/polymorphic_index_sso_tests.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index_sso_tests.rs
@@ -1,0 +1,130 @@
+//! #8117/#6887: an SSO string receiver reaching the polymorphic index funnel.
+//!
+//! `js_object_get_index_polymorphic` opens by asking "does this receiver's low
+//! 48 bits hold a heap pointer?" and answering `undefined` when they do not.
+//! That conflates *not a pointer* with *not indexable*. An inline
+//! `SHORT_STRING_TAG` (SSO) string — every ASCII concatenation of five bytes or
+//! fewer, so `"ab" + "c"` — carries its characters in the payload rather than an
+//! address, so it fell into the reject arm and `s[0]` read `undefined` while the
+//! byte-identical heap string read `"a"`.
+//!
+//! # Why a direct call witnesses this bug
+//!
+//! The sibling file `polymorphic_index_symbol_tests.rs` opens with a warning
+//! that its obvious end-to-end shape passes without the fix, because a direct
+//! call reaches a different sub-arm than the compiled path. That hazard does
+//! not apply here, and the reason is worth stating rather than assuming:
+//! codegen's generic index dispatcher hands this helper the receiver's **raw
+//! NaN-boxed bits** whenever the tag is not `POINTER_TAG` — the emitted IR is
+//!
+//! ```text
+//!   %r7 = icmp eq i64 %tag, 32765            ; POINTER_TAG?
+//!   %r9 = select i1 %r7, i64 %masked, i64 %raw_bits
+//!   %rN = call double @js_object_get_index_polymorphic(i64 %r9, double 0.0)
+//! ```
+//!
+//! so for an SSO receiver the argument these tests construct by hand is
+//! bit-for-bit the argument the compiled program passes. Verified by sabotage:
+//! with the `0x7FF9` arm removed, `an_sso_string_receiver_reads_its_characters`
+//! fails `left: None  right: Some("a")`, which is the same wrong answer
+//! `test_gap_sso_concat_string_index.ts` reports against node.
+
+use crate::builtins::jsvalue_string_content;
+use crate::value::JSValue;
+
+/// Boxed bits exactly as codegen's dispatcher passes them for a non-pointer
+/// receiver: the whole NaN-boxed value reinterpreted as `i64`, unmasked.
+fn handle_of(value: JSValue) -> i64 {
+    value.bits() as i64
+}
+
+/// THE regression. An SSO receiver must yield its characters, not `undefined`.
+#[test]
+fn an_sso_string_receiver_reads_its_characters() {
+    let _serialized = crate::array::test_serialize();
+    let sso = JSValue::try_short_string(b"abc").expect("3 ASCII bytes fit SSO");
+    assert!(
+        sso.is_short_string(),
+        "precondition: the receiver under test must really be an inline SSO \
+         value — if concat ever stops producing one, this test is measuring \
+         the wrong thing and must be updated, not deleted"
+    );
+
+    for (idx, expected) in [(0.0, "a"), (1.0, "b"), (2.0, "c")] {
+        let got = jsvalue_string_content(crate::object::js_object_get_index_polymorphic(
+            handle_of(sso),
+            idx,
+        ));
+        assert_eq!(
+            got.as_deref(),
+            Some(expected),
+            "sso[{idx}] must read the inline character; pre-fix the tag match \
+             rejected SHORT_STRING_TAG as 'not a heap pointer' and returned \
+             undefined"
+        );
+    }
+}
+
+/// Control for the 0x7FFF arm: the fix must not disturb a heap string receiver,
+/// which reaches `js_string_index_get` via the `GC_TYPE_STRING` dispatch below
+/// the tag match. A concatenation longer than the SSO threshold is heap-backed,
+/// which is why the gap test's 80-character case never regressed.
+#[test]
+fn a_heap_string_receiver_still_reads_its_characters() {
+    let _serialized = crate::array::test_serialize();
+    let bytes = b"abcdefghij";
+    let hdr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    let heap = JSValue::string_ptr(hdr);
+    assert!(
+        !heap.is_short_string() && heap.is_string(),
+        "precondition: this control must exercise the heap arm, not the new one"
+    );
+
+    let got = jsvalue_string_content(crate::object::js_object_get_index_polymorphic(
+        handle_of(heap),
+        0.0,
+    ));
+    assert_eq!(got.as_deref(), Some("a"));
+}
+
+/// Control against over-reach in the other direction: the new arm is keyed on
+/// `SHORT_STRING_TAG` alone. Every other non-pointer tag in the reject arm is
+/// a genuine primitive whose indexed read is `undefined` per JS, and widening
+/// the arm to "any non-pointer tag" would break that.
+#[test]
+fn a_non_string_primitive_receiver_still_reads_undefined() {
+    let _serialized = crate::array::test_serialize();
+    let undefined_bits = crate::value::TAG_UNDEFINED;
+
+    for handle in [
+        undefined_bits as i64,
+        crate::value::TAG_NULL as i64,
+        crate::value::TAG_TRUE as i64,
+    ] {
+        let got = crate::object::js_object_get_index_polymorphic(handle, 0.0);
+        assert_eq!(
+            got.to_bits(),
+            undefined_bits,
+            "indexing a non-string primitive is `undefined` in JS; the SSO arm \
+             must not have widened the accepted tag set"
+        );
+    }
+}
+
+/// An out-of-range index on an SSO receiver is `undefined`, same as on a heap
+/// string — the delegation must carry the CanonicalNumericIndexString
+/// semantics, not merely return *some* character.
+#[test]
+fn an_out_of_range_index_on_an_sso_receiver_reads_undefined() {
+    let _serialized = crate::array::test_serialize();
+    let sso = JSValue::try_short_string(b"abc").expect("3 ASCII bytes fit SSO");
+
+    for idx in [3.0, 99.0, -1.0, 1.5, f64::NAN] {
+        let got = crate::object::js_object_get_index_polymorphic(handle_of(sso), idx);
+        assert_eq!(
+            got.to_bits(),
+            crate::value::TAG_UNDEFINED,
+            "sso[{idx}] is not a canonical in-range array index"
+        );
+    }
+}

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -58,7 +58,7 @@ pub use char_ops::{
     js_string_at, js_string_char_at, js_string_char_code_at, js_string_code_point_at,
     js_string_end_index_to_i32, js_string_from_char_code, js_string_from_char_code_array,
     js_string_from_code_point, js_string_from_code_point_array, js_string_index_get,
-    js_string_index_to_i32, js_string_to_char_array,
+    js_string_index_get_boxed, js_string_index_to_i32, js_string_to_char_array,
 };
 pub use compare::{
     js_string_compare, js_string_ends_with, js_string_ends_with_at, js_string_equals,


### PR DESCRIPTION
## What

Indexing a short string built by concatenation returned `undefined`:

```ts
const s = "ab" + "c";
s.length   // 3           fine
s[0]       // undefined   node: "a"
```

Fixes `test-files/test_gap_sso_concat_string_index.ts` — one of the three
remaining #8117 regressions holding `conformance-smoke` red. Byte-identical to
node `v26.5.1`, exit 0.

This is a **silent wrong value**, not a crash, and it is on an ordinary shape:
every ASCII concatenation of five bytes or fewer produces an SSO string, so
`(a + b)[0]`, an index-accumulation loop, and `parts.join("") + "\n"` were all
affected.

## Root cause

`js_object_get_index_polymorphic` opens by asking *"does this receiver's low 48
bits hold a heap pointer?"* and returns `undefined` for every tag that does not:

```rust
match (obj_handle as u64) >> 48 {
    0x7FFD | 0x7FFF => (obj_handle as u64) & 0x0000_FFFF_FFFF_FFFF,
    0x7FFE => { /* class-ref arm */ }
    _ => return f64::from_bits(crate::value::TAG_UNDEFINED),   // SSO lands here
}
```

That conflates *not a pointer* with *not indexable*. An inline
`SHORT_STRING_TAG` (`0x7FF9`) string carries its characters in the payload
rather than an address, so it fell into the reject arm — while the
byte-identical **heap** string (a non-ASCII or >5-byte concatenation) reached
`js_string_index_get` through the `GC_TYPE_STRING` dispatch below and read
correctly.

It is the recurring family: **a receiver-specific arm claims the operation
before the receiver-kind question is asked.** This dispatcher asks the *key*'s
kind carefully — it has a dedicated `SHORT_STRING_TAG` arm for an SSO *key* —
and never asks the receiver's.

### Why only the indexed read

`.length`, `typeof`, printing, `charAt` / `charCodeAt` / `codePointAt` / `at`,
`for-of`, spread, `Array.from` and `split` were all correct, because each routes
through `js_get_string_pointer_unified`, which materializes SSO. Only the
indexed read hand-rolled the tag question.

### Relationship to #6887 / #6888

This is #6887 reopened at a different funnel. #6888 fixed codegen's
`is_string_expr` fast path by passing the receiver still boxed to
`js_string_index_get_boxed`. A receiver whose static string type is not *proven*
does not take that path — measured, all three of these reach the generic
dispatcher instead:

| receiver | result |
|---|---|
| `const s = a + b` (inferred) | `undefined` |
| `const s: string = a + b` (annotated) | `undefined` |
| `function f(x: string) { return x[0] }` | `undefined` |
| `("ab" + "c")[0]` (no binding) | `"a"` — takes #6888's path |

The emitted IR for the generic path passes the receiver's **raw NaN-boxed bits**
whenever the tag is not `POINTER_TAG`:

```llvm
%r7 = icmp eq i64 %tag, 32765            ; POINTER_TAG?
%r9 = select i1 %r7, i64 %masked, i64 %raw_bits
%rN = call double @js_object_get_index_polymorphic(i64 %r9, double 0.0)
```

So the bits are intact on arrival and the string question can still be asked
here — it just never was. The symptom changed from #6887's **segfault** to a
silent `undefined` because `is_valid_string_ptr` now rejects the bogus pointer
instead of dereferencing it, which is why this reads as a new bug rather than a
reopened one.

## Fix

One arm, delegating to `js_string_index_get_boxed` — which materializes the
payload and lands in exactly the `js_string_index_get` the heap arm reaches via
`GC_TYPE_STRING`. Both string representations therefore share **one** copy of
the CanonicalNumericIndexString key semantics rather than growing a second.

Fixing at this shared funnel rather than in codegen covers every call site that
funnels an unboxed receiver here, not just the one the gap test exercises.

## Tests — sabotage-verified

Four tests in `crates/perry-runtime/src/object/polymorphic_index_sso_tests.rs`.

| sabotage | result |
|---|---|
| remove the `0x7FF9` arm | `an_sso_string_receiver_reads_its_characters` FAILS `left: None  right: Some("a")` — the same wrong answer the gap test reports against node; **all three controls stay green** |
| none | 4/4 green |

The sibling `polymorphic_index_symbol_tests.rs` opens with a warning that its
obvious end-to-end shape passes without the fix, because a direct call reaches a
different sub-arm than the compiled path. **That hazard does not apply here**,
and the file says why rather than assuming it: codegen passes the raw NaN-boxed
bits verbatim for a non-`POINTER_TAG` receiver, so the hand-built argument is
bit-for-bit the one the compiled program passes.

Controls, each guarding a different way the fix could over-reach:

* **heap string receiver** must keep working (the `0x7FFF` arm is untouched);
* **non-string primitives** (`undefined` / `null` / `true`) must still read
  `undefined` — the arm is keyed on `SHORT_STRING_TAG` alone and must not widen
  to "any non-pointer tag";
* **out-of-range / negative / fractional / `NaN`** indices on an SSO receiver
  must read `undefined` — the delegation has to carry the canonical-index
  semantics, not merely return *some* character.

## Validation

Built with `--profile perry-dev`, `PERRY_RUNTIME_DIR` pinned to the freshly
built archives and `PERRY_NO_AUTO_OPTIMIZE=1`;
`grep -c "Compiling perry-runtime v"` = **1** and the `.a` mtime confirmed to
move after each edit.

* **Isolated attribution.** With this change alone the SSO gap test passes and
  the two `forEach` regressions still fail — so this PR's effect is exactly the
  one claimed, and it is not riding on anything else.
* `cargo test -p perry-runtime --lib`: **2390 passed / 0 failed / 4 ignored**,
  against a **2386 / 0 / 4** baseline. `+4` is exactly the tests added.
* **All 28 `lint` steps**, enumerated programmatically from
  `.github/workflows/test.yml` rather than from memory: clean. (`Raw-handle debt
  ratchet vs. merge base` needs the PR-context `$BASE_SHA`; re-run against
  `origin/main` it reports `baseline 992 -> 992, none raised`.)
* `cargo clippy -p perry-runtime`: no errors.
* **Targeted 110-test sweep** over every `test_gap_*` matching
  string/index/str/char/object/polymorph/record/dyn: **108 PASS**. The other two
  are environment, not regressions — `test_gap_param_prop_array_index` is a
  node-side throw (`node_rc=1`), and `test_gap_regex_replace_dyn_regex_with_http`
  is the tokio-unification guard deliberately refusing the link because my
  harness set `PERRY_NO_AUTO_OPTIMIZE=1` without building `perry-ext-http` in the
  same cargo invocation.
* The nine #8117 entries that recovered on their own re-checked green:
  `test_gap_6386_dataview_concat_regex_fastpaths`,
  `test_gap_7238_i64_specialization_exactness`, `test_gap_buffer_own_props`,
  `test_gap_zlib_4917_level`, `test_gap_array_methods`,
  `test_gap_builtin_alias_construct_7524`,
  `test_gap_dynamic_builtin_construct_dispatch`,
  `test_gap_new_globalthis_builtin_6726`, `test_gap_specabi_reassign`.

## Scope

The other two remaining #8117 regressions
(`test_gap_collection_foreach_member_receiver_thisarg`,
`test_gap_set_map_foreach_fused_receiver`) are a **different** cause — a
`Set`/`Map` receiver nulled by `clean_arr_ptr` before the fused `forEach` asks
the collection question — and are already fixed by **#8130**. I verified that
patch on top of current `main`: with #8130 and this PR applied together, all
three gap tests pass. They are kept as separate PRs because the causes are
unrelated.

## Found but not fixed

`js_object_set_index_polymorphic`, the write-side companion, strips tags with a
bare unconditional mask for **every** tag `>= 0x7FF8`, so it has no
`SHORT_STRING_TAG` arm either. I checked the behaviour rather than assuming it:
`s[0] = "Z"` and a `string`-parameter variant are both byte-identical to node
with exit 0 (a write to a primitive string's index is a silent no-op in sloppy
mode, which is the correct answer). So there is **no wrong-value bug on the
write side today** and I left it rather than widen this PR.

What I would flag for whoever extends that helper is an asymmetry I did not
fix: the read path guards its GC-header dereference with
`addr_class::is_valid_obj_ptr`, and the write path guards the same dereference
only with `gc_header_addr < 0x1000`. An SSO payload masked to an address clears
that weaker guard easily (`"abc"` -> `0x636261`, ~6.5 MB), so the write path is
one un-rejected receiver away from a wild read. It does not fire for the SSO
case today, but the guard is weaker than its sibling for no stated reason.

Refs #8117.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed indexing for short inline ASCII strings so valid numeric indices return the expected character.
  - Ensured noncanonical, out-of-range, and unsupported indices return `undefined` consistently.
  - Preserved existing behavior for heap-backed strings and non-string values.

- **Tests**
  - Added regression coverage for string indexing across supported string representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->