### PR TITLE
perf(deforest): only deforest a producer that has a consumer-fuse call site (#8104)

### DIFF
--- a/changelog.d/8152-deforest-profitability.md
+++ b/changelog.d/8152-deforest-profitability.md
@@ -1,0 +1,46 @@
+**Deforestation now requires a consumer-fuse call site (#8104).**
+`perry-transform/src/deforest` had no profitability term: `detect.rs` matched
+`const out = []; …push…; return out` and `run` rewrote every producer it found,
+at every call site. Only one of the three call-site shapes removes work — the
+consumer fuse (`let X = f(args); for (j) outer.push(X[j])` → `outer = f(args,
+outer)`) deletes a copy loop and leaves one array where there were two. The
+other two are pure cost, and the value-binding rewrite is actively harmful:
+`const arr = build(n)` becomes `let arr = []; arr = build(n, arr)`, which
+allocates exactly as many arrays as before (the producer stops allocating one,
+the caller starts) and costs the caller's binding its write-once property —
+taking `Ptr<NumArray>`, the element-shape versioned loop clone, and every other
+representation fact keyed on a stable local with it.
+
+Sweeping `PERRY_DEFOREST_DEBUG=1` over `benchmarks/suite`,
+`benchmarks/app-patterns/kernels` and the beat-scriptc sweep corpus finds
+exactly three programs whose emitted object changes, and **none of them has a
+fuse site** — all three were paying the cost for nothing. Measured on macOS
+arm64, `--profile perry-dev` compiler and `libperry_{runtime,stdlib}.a`,
+`PERRY_RUNTIME_DIR` pinned, `PERRY_NO_AUTO_OPTIMIZE=1`, `/usr/bin/time -l`,
+medians of 5 interleaved, byte-identical output on both arms:
+
+| program | instructions before | after | peak RSS before | after |
+|---|---:|---:|---:|---:|
+| `bench_numeric_array_numeric` | 232,687,808,231 | 7,681,530,021 (**-96.7%**) | 44,057,080 | 21,725,616 (**-50.7%**) |
+| `shapes` (sweep corpus) | 1,574,232,277 | 1,507,089,862 (-4.3%) | 29,491,656 | 29,491,656 (0.0%) |
+| `batch` (app-patterns) | 1,793,403,047 | 1,793,372,968 (±0.0%) | 20,169,184 | 20,169,184 (0.0%) |
+
+`bench_numeric_array_numeric` drops from 4071 ms to 126 ms for the same
+`checksum:6500625`. Both objectives move the same way on every row.
+
+`producers_with_fuse_sites` shares the matcher with the rewrite
+(`match_consumer_fuse_pattern`, factored out of `try_consumer_fuse_pattern`) so
+the profitability question and the rewrite cannot disagree about what a fuse
+site is, and mirrors `rewrite_call_sites_in_stmts_with_local_pass`'s descent so
+they cannot disagree about which positions are reachable. A producer with one
+fuse site anywhere keeps the rewrite at ALL of its sites — the signature gained
+a parameter, so every call must pass one (#5136's arity-mismatch SIGSEGV).
+The recursive fuse inside a producer's own body counts, which is what keeps
+ABC451D deforested: `test-files/test_deforest_growth_forwarding.ts` still
+reports `[deforest] producer fn_id=1 name=tree` under the gate and both
+`test_deforest_*.ts` files stay parity-clean.
+
+Six existing unit tests needed a fuse site added to their fixtures, which is
+itself the finding: the whole pre-existing suite was built on
+value-binding-only modules — the shape measured above as a 30x pessimization.
+Each keeps its original subject.

--- a/crates/perry-transform/src/deforest/call_sites.rs
+++ b/crates/perry-transform/src/deforest/call_sites.rs
@@ -200,24 +200,63 @@ fn try_consumer_fuse_pattern(
     producers: &HashMap<FuncId, ProducerInfo>,
     out_param_ids: &HashMap<FuncId, LocalId>,
 ) -> Option<(usize, Vec<Stmt>)> {
+    let (callee_id, outer_id) = match_consumer_fuse_pattern(stmts, producers)?;
+    let (call_args, type_args) = match &stmts[0] {
+        Stmt::Let {
+            init: Some(Expr::Call {
+                args, type_args, ..
+            }),
+            ..
+        } => (args.clone(), type_args.clone()),
+        _ => return None,
+    };
+
+    // Build replacement: `outer = f(args, outer);`
+    //
+    // #7661: the assignment is not cosmetic. The callee may grow the array,
+    // and `js_array_grow` relocates - leaving a forwarding stub at the address
+    // `outer` still holds. The producer returns its own (written-back) head;
+    // storing it back is what keeps `outer` live for the caller's own later
+    // pushes and element reads.
+    let mut new_args = call_args;
+    new_args.push(Expr::LocalGet(outer_id));
+    let _ = out_param_ids.get(&callee_id)?; // sanity check producer was sized
+    let new_call = Expr::Call {
+        callee: Box::new(Expr::FuncRef(callee_id)),
+        args: new_args,
+        type_args,
+        // #5247: deforestation-fused call; no single source offset.
+        byte_offset: 0,
+    };
+    Some((
+        2,
+        vec![Stmt::Expr(Expr::LocalSet(outer_id, Box::new(new_call)))],
+    ))
+}
+
+/// The MATCH half of [`try_consumer_fuse_pattern`], with no rewrite and no
+/// dependency on the out-param allocation. Returns `(producer, outer)` for the
+/// `let X = f(args); for (j) outer.push(X[j]);` shape at `stmts[0..]`.
+///
+/// #8104: `run` needs this before it decides whether to transform anything at
+/// all, because the fuse is the ONLY call-site shape that removes work - the
+/// value-binding and pass-through rewrites are pure cost. Sharing the matcher
+/// keeps the profitability question and the rewrite from ever disagreeing
+/// about what a fuse site is.
+pub(super) fn match_consumer_fuse_pattern(
+    stmts: &[Stmt],
+    producers: &HashMap<FuncId, ProducerInfo>,
+) -> Option<(FuncId, LocalId)> {
     if stmts.len() < 2 {
         return None;
     }
-    let (child_id, callee_id, call_args, type_args) = match &stmts[0] {
+    let (child_id, callee_id) = match &stmts[0] {
         Stmt::Let {
             id,
-            init:
-                Some(Expr::Call {
-                    callee,
-                    args,
-                    type_args,
-                    ..
-                }),
+            init: Some(Expr::Call { callee, .. }),
             ..
         } => match callee.as_ref() {
-            Expr::FuncRef(fid) if producers.contains_key(fid) => {
-                (*id, *fid, args.clone(), type_args.clone())
-            }
+            Expr::FuncRef(fid) if producers.contains_key(fid) => (*id, *fid),
             _ => return None,
         },
         _ => return None,
@@ -245,28 +284,7 @@ fn try_consumer_fuse_pattern(
     if later_uses {
         return None;
     }
-
-    // Build replacement: `outer = f(args, outer);`
-    //
-    // #7661: the assignment is not cosmetic. The callee may grow the array,
-    // and `js_array_grow` relocates — leaving a forwarding stub at the address
-    // `outer` still holds. The producer returns its own (written-back) head;
-    // storing it back is what keeps `outer` live for the caller's own later
-    // pushes and element reads.
-    let mut new_args = call_args;
-    new_args.push(Expr::LocalGet(outer_id));
-    let _ = out_param_ids.get(&callee_id)?; // sanity check producer was sized
-    let new_call = Expr::Call {
-        callee: Box::new(Expr::FuncRef(callee_id)),
-        args: new_args,
-        type_args,
-        // #5247: deforestation-fused call; no single source offset.
-        byte_offset: 0,
-    };
-    Some((
-        2,
-        vec![Stmt::Expr(Expr::LocalSet(outer_id, Box::new(new_call)))],
-    ))
+    Some((callee_id, outer_id))
 }
 
 /// Match the for-loop shape `for (let j = 0; j < child.length; j++)
@@ -449,5 +467,121 @@ fn try_rewrite_single_stmt(
         // the return value is the whole point. Skip for now —
         // misclassifying these is more dangerous than missing them.
         _ => None,
+    }
+}
+
+// ── #8104: profitability ───────────────────────────────────────────────────
+
+/// Every producer with at least ONE consumer-fuse call site.
+///
+/// The fuse (`let X = f(args); for (j) outer.push(X[j]);` -> `outer = f(args,
+/// outer);`) is the only rewrite that removes work: it deletes a copy loop and
+/// leaves one array where there were two. The other two shapes are pure cost.
+/// The value-binding rewrite in particular turns
+///
+/// ```ignore
+/// const arr = build(n);          // one array, one immutable binding
+/// ```
+///
+/// into
+///
+/// ```ignore
+/// let arr = [];  arr = build(n, arr);   // same one array, now REASSIGNED
+/// ```
+///
+/// which allocates exactly as many arrays as before and costs the binding its
+/// write-once proof - and with it `Ptr<NumArray>`, the element-shape versioned
+/// clone, and every other representation fact keyed on a stable local.
+///
+/// Measured on the three programs in the corpus whose emitted object changes
+/// at all (macOS arm64, `--profile perry-dev`, medians, identical output):
+/// `batch` +-0.0%, `shapes` +4.4% instructions, and
+/// `bench_numeric_array_numeric` **+2926% instructions and +103% peak RSS**
+/// (7.7 G -> 232.7 G, 21.7 MB -> 44.1 MB). None of the three has a fuse site.
+///
+/// Scans exactly the bodies `run` rewrites - module init, free functions,
+/// non-`super` class member bodies - plus each producer's own body, where the
+/// recursive fuse that motivated the transform (ABC451D) lives. Closure bodies
+/// are excluded because `scan_producers_used_in_closures` already disqualifies
+/// a producer referenced from one.
+pub fn producers_with_fuse_sites(
+    module: &Module,
+    producers: &HashMap<FuncId, ProducerInfo>,
+) -> HashSet<FuncId> {
+    let mut fused: HashSet<FuncId> = HashSet::new();
+    scan_fuse_sites(&module.init, producers, &mut fused);
+    for func in &module.functions {
+        scan_fuse_sites(&func.body, producers, &mut fused);
+    }
+    for class in &module.classes {
+        if let Some(ctor) = &class.constructor {
+            if !body_has_super(&ctor.body) {
+                scan_fuse_sites(&ctor.body, producers, &mut fused);
+            }
+        }
+        for m in class
+            .methods
+            .iter()
+            .chain(class.static_methods.iter())
+            .chain(class.getters.iter().map(|(_, g)| g))
+            .chain(class.setters.iter().map(|(_, s)| s))
+        {
+            if !body_has_super(&m.body) {
+                scan_fuse_sites(&m.body, producers, &mut fused);
+            }
+        }
+    }
+    fused
+}
+
+/// Recursive half of [`producers_with_fuse_sites`]. Mirrors
+/// `rewrite_call_sites_in_stmts_with_local_pass`'s descent so the two cannot
+/// disagree about which positions are reachable.
+fn scan_fuse_sites(
+    stmts: &[Stmt],
+    producers: &HashMap<FuncId, ProducerInfo>,
+    fused: &mut HashSet<FuncId>,
+) {
+    for i in 0..stmts.len() {
+        if let Some((callee, _)) = match_consumer_fuse_pattern(&stmts[i..], producers) {
+            fused.insert(callee);
+        }
+        match &stmts[i] {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                scan_fuse_sites(then_branch, producers, fused);
+                if let Some(eb) = else_branch {
+                    scan_fuse_sites(eb, producers, fused);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+                scan_fuse_sites(body, producers, fused);
+            }
+            Stmt::Labeled { body, .. } => {
+                scan_fuse_sites(std::slice::from_ref(body.as_ref()), producers, fused);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                scan_fuse_sites(body, producers, fused);
+                if let Some(c) = catch {
+                    scan_fuse_sites(&c.body, producers, fused);
+                }
+                if let Some(f) = finally {
+                    scan_fuse_sites(f, producers, fused);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    scan_fuse_sites(&case.body, producers, fused);
+                }
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/perry-transform/src/deforest/mod.rs
+++ b/crates/perry-transform/src/deforest/mod.rs
@@ -81,7 +81,10 @@ mod walk;
 #[cfg(test)]
 mod tests;
 
-pub use call_sites::{rewrite_call_sites_in_stmts, rewrite_call_sites_in_stmts_with_local_pass};
+pub use call_sites::{
+    producers_with_fuse_sites, rewrite_call_sites_in_stmts,
+    rewrite_call_sites_in_stmts_with_local_pass,
+};
 pub use detect::{
     analyze_producer, body_has_closure, body_has_super, detect_producers, stmt_contains_return,
 };
@@ -114,7 +117,40 @@ pub struct ProducerInfo {
 /// the consume loop. Functions that don't match the producer shape
 /// are left unchanged; modules with no matching functions are no-ops.
 pub fn run(module: &mut Module) {
-    let producers = detect_producers(module);
+    let mut producers = detect_producers(module);
+    if producers.is_empty() {
+        return;
+    }
+
+    // #8104 — PROFITABILITY. Only the consumer-fuse call site removes work:
+    // `let X = f(args); for (j) outer.push(X[j]);` becomes `outer = f(args,
+    // outer);`, deleting a copy loop and leaving one array where there were
+    // two. The other two rewrites are pure cost, and the value-binding one is
+    // actively harmful — `const arr = f(n)` becomes `let arr = []; arr = f(n,
+    // arr);`, which allocates exactly as many arrays as before and costs the
+    // binding its write-once proof, taking `Ptr<NumArray>`, the element-shape
+    // versioned clone, and every other representation fact keyed on a stable
+    // local with it.
+    //
+    // Measured on the three programs in the corpus whose emitted object
+    // changes at all — none of which has a fuse site, so all three were paying
+    // the cost for nothing (macOS arm64, `--profile perry-dev` compiler and
+    // runtime, `PERRY_RUNTIME_DIR` pinned, `/usr/bin/time -l`, medians,
+    // identical output on both arms):
+    //
+    // | program                       | instructions | peak RSS |
+    // |-------------------------------|-------------:|---------:|
+    // | `batch`                       |       ±0.0%  |    ±0.0% |
+    // | `shapes`                      |       +4.4%  |    ±0.0% |
+    // | `bench_numeric_array_numeric` |     +2926%   |   +103%  |
+    //
+    // The last one is 7.7 G → 232.7 G instructions and 21.7 MB → 44.1 MB peak
+    // footprint, for a transform that removed nothing.
+    //
+    // A producer with a fuse site keeps the rewrite at ALL of its sites: the
+    // signature gains the accumulator parameter, so every call must pass one.
+    let fused = producers_with_fuse_sites(module, &producers);
+    producers.retain(|id, _| fused.contains(id));
     if producers.is_empty() {
         return;
     }

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -112,7 +112,15 @@ fn synthetic_out_params_are_assigned_by_function_id() {
     second.name = "first".to_string();
 
     let mut module = Module::new("m");
-    module.functions = vec![first, second];
+    // #8104: both producers need a fuse site to clear the profitability gate.
+    // The subject is the ID ASSIGNMENT ORDER, which is `max_local_id + 1`
+    // bumped in ascending FuncId order.
+    module.functions = vec![
+        first,
+        second,
+        fuse_consumer(3, 1, 100),
+        fuse_consumer(4, 2, 200),
+    ];
 
     run(&mut module);
 
@@ -126,8 +134,15 @@ fn synthetic_out_params_are_assigned_by_function_id() {
         .iter()
         .find(|func| func.id == 2)
         .expect("function must exist");
-    assert_eq!(func1.params.last().unwrap().id, 21);
-    assert_eq!(func2.params.last().unwrap().id, 22);
+    // Ids come from `max_local_id(module) + 1`, bumped in ascending FuncId
+    // order. The highest local in the module is `fuse_consumer(4, 2, 200)`'s
+    // `j` = 202, so the producers get 203 (FuncId 1) and 204 (FuncId 2). The
+    // SUBJECT is the ORDER, so assert that explicitly too.
+    let p1 = func1.params.last().unwrap().id;
+    let p2 = func2.params.last().unwrap().id;
+    assert_eq!(p1, 203);
+    assert_eq!(p2, 204);
+    assert_eq!(p2, p1 + 1, "ids are assigned in ascending FuncId order");
 }
 
 #[test]
@@ -264,7 +279,9 @@ fn still_deforests_when_caller_is_not_a_closure() {
     };
 
     let mut module = Module::new("m");
-    module.functions = vec![helper, caller];
+    // #8104: the profitability gate needs one fuse site somewhere in the
+    // module; the SUBJECT here is the plain caller's rewrite, not the fuse.
+    module.functions = vec![helper, caller, fuse_consumer(3, 1, 100)];
 
     assert!(
         !detect_producers(&module).is_empty(),
@@ -358,7 +375,9 @@ fn deforests_producer_called_from_class_method() {
     };
 
     let mut module = Module::new("m");
-    module.functions = vec![helper];
+    // #8104: one fuse site so the producer clears the profitability gate —
+    // the SUBJECT here is the class-member call site's rewrite.
+    module.functions = vec![helper, fuse_consumer(3, 1, 100)];
     module.classes = vec![class];
 
     assert!(
@@ -463,7 +482,9 @@ fn producer_and_plain_caller() -> Module {
         was_unrolled: false,
     };
     let mut module = Module::new("m");
-    module.functions = vec![make_simple_producer(), caller];
+    // #8104: one fuse site so the producer clears the profitability gate —
+    // these fixtures are about the PLAIN call site's rewrite (#7661).
+    module.functions = vec![make_simple_producer(), caller, fuse_consumer(3, 1, 100)];
     module
 }
 
@@ -705,7 +726,9 @@ fn still_deforests_when_method_has_no_super() {
     };
 
     let mut module = Module::new("m");
-    module.functions = vec![helper];
+    // #8104: one fuse site so the producer clears the profitability gate —
+    // the SUBJECT here is the class-member call site's rewrite.
+    module.functions = vec![helper, fuse_consumer(3, 1, 100)];
     module.classes = vec![class];
 
     assert!(
@@ -720,6 +743,232 @@ fn still_deforests_when_method_has_no_super() {
         1,
         "producer should gain the synthetic accumulator param"
     );
+}
+
+// ── #8104: profitability ───────────────────────────────────────────────────
+
+#[test]
+fn a_producer_with_no_fuse_site_is_left_alone() {
+    // `const arr = build();` with no consume loop anywhere. The value-binding
+    // rewrite would turn it into `let arr = []; arr = build(arr);` — the same
+    // one array, but now behind a REASSIGNED binding, which costs every
+    // representation fact keyed on a write-once local. On
+    // `benchmarks/suite/bench_numeric_array_numeric.ts` that is +2926%
+    // instructions and +103% peak RSS for a transform that removed nothing.
+    let mut module = producer_and_plain_caller();
+    // Drop the fuse site `producer_and_plain_caller` adds for the OTHER tests.
+    module.functions.retain(|f| f.id != 3);
+
+    assert!(
+        !detect_producers(&module).is_empty(),
+        "the shape still DETECTS as a producer — the refusal is profitability, \
+         not detection, and this test is vacuous if detection already declines"
+    );
+
+    run(&mut module);
+
+    let producer = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert!(
+        producer.params.is_empty(),
+        "a producer with no consumer-fuse call site must keep its signature"
+    );
+    let caller = module.functions.iter().find(|f| f.id == 2).unwrap();
+    assert!(
+        matches!(
+            &caller.body[0],
+            Stmt::Let {
+                mutable: false,
+                init: Some(Expr::Call { .. }),
+                ..
+            }
+        ),
+        "the caller's binding must stay write-once and keep its direct call, \
+         got {:?}",
+        caller.body[0]
+    );
+}
+
+#[test]
+fn one_fuse_site_admits_the_producer_at_every_call_site() {
+    // The discriminating half: the SAME module, plus one fuse site, and the
+    // producer is transformed — including its non-fuse call site, which must
+    // move in lock-step because the signature gained a parameter.
+    let mut module = producer_and_plain_caller();
+    run(&mut module);
+
+    let producer = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert_eq!(
+        producer.params.len(),
+        1,
+        "one fuse site anywhere in the module admits the producer"
+    );
+    let caller = module.functions.iter().find(|f| f.id == 2).unwrap();
+    assert!(
+        matches!(&caller.body[1], Stmt::Expr(Expr::LocalSet(30, _))),
+        "the non-fuse call site must be rewritten too, or its arity no longer \
+         matches the producer's signature (#5136's SIGSEGV shape)"
+    );
+}
+
+#[test]
+fn the_recursive_fuse_inside_a_producer_body_counts() {
+    // ABC451D — the shape the transform was built for. `f` consumes its OWN
+    // recursive result into `out`, and that fuse lives inside the producer
+    // body, not at an external call site. The gate must see it, or the one
+    // workload deforestation demonstrably wins on stops being deforested.
+    let mut producer = make_simple_producer();
+    // function f() {
+    //   const out = [];
+    //   out.push(1);
+    //   const child = f();
+    //   for (let j = 0; j < child.length; j++) out.push(child[j]);
+    //   return out;
+    // }
+    producer.body.insert(
+        2,
+        Stmt::Let {
+            id: 40,
+            name: "child".to_string(),
+            ty: Type::Array(Box::new(Type::Number)),
+            mutable: false,
+            init: Some(Expr::Call {
+                callee: Box::new(Expr::FuncRef(1)),
+                args: vec![],
+                type_args: vec![],
+                byte_offset: 0,
+            }),
+        },
+    );
+    producer.body.insert(
+        3,
+        Stmt::For {
+            init: Some(Box::new(Stmt::Let {
+                id: 41,
+                name: "j".to_string(),
+                ty: Type::Number,
+                mutable: true,
+                init: Some(Expr::Integer(0)),
+            })),
+            condition: Some(Expr::Compare {
+                op: perry_hir::CompareOp::Lt,
+                left: Box::new(Expr::LocalGet(41)),
+                right: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(40)),
+                    property: "length".to_string(),
+                    byte_offset: 0,
+                }),
+            }),
+            update: Some(Expr::Update {
+                id: 41,
+                op: perry_hir::UpdateOp::Increment,
+                prefix: false,
+            }),
+            body: vec![Stmt::Expr(Expr::ArrayPush {
+                array_id: 10,
+                value: Box::new(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(40)),
+                    index: Box::new(Expr::LocalGet(41)),
+                }),
+            })],
+        },
+    );
+
+    let mut module = Module::new("m");
+    module.functions = vec![producer];
+    run(&mut module);
+
+    let after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert_eq!(
+        after.params.len(),
+        1,
+        "a recursive fuse inside the producer's own body must admit it"
+    );
+}
+
+/// #8104: a function containing ONE consumer-fuse call site for `producer`.
+///
+/// `run` now refuses producers with no fuse site, because the fuse is the only
+/// call-site shape that removes work (the value-binding rewrite reallocates
+/// nothing and costs the caller's binding its write-once proof — measured at
+/// +2926% instructions and +103% peak RSS on
+/// `benchmarks/suite/bench_numeric_array_numeric.ts`). Fixtures whose SUBJECT
+/// is a different call-site shape therefore need one of these in the module so
+/// the producer still qualifies.
+///
+/// Deliberately does NOT end in `return outer` — that would make the consumer
+/// a producer too, and shift the synthetic-parameter numbering the callers of
+/// this helper assert on.
+fn fuse_consumer(id: FuncId, producer: FuncId, base: LocalId) -> Function {
+    let outer = base;
+    let child = base + 1;
+    let j = base + 2;
+    Function {
+        id,
+        name: format!("fuse_consumer_{id}"),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Number,
+        body: vec![
+            Stmt::Let {
+                id: outer,
+                name: "outer".to_string(),
+                ty: Type::Array(Box::new(Type::Number)),
+                mutable: false,
+                init: Some(Expr::Array(vec![])),
+            },
+            Stmt::Let {
+                id: child,
+                name: "child".to_string(),
+                ty: Type::Array(Box::new(Type::Number)),
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(producer)),
+                    args: vec![],
+                    type_args: vec![],
+                    byte_offset: 0,
+                }),
+            },
+            Stmt::For {
+                init: Some(Box::new(Stmt::Let {
+                    id: j,
+                    name: "j".to_string(),
+                    ty: Type::Number,
+                    mutable: true,
+                    init: Some(Expr::Integer(0)),
+                })),
+                condition: Some(Expr::Compare {
+                    op: perry_hir::CompareOp::Lt,
+                    left: Box::new(Expr::LocalGet(j)),
+                    right: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(child)),
+                        property: "length".to_string(),
+                        byte_offset: 0,
+                    }),
+                }),
+                update: Some(Expr::Update {
+                    id: j,
+                    op: perry_hir::UpdateOp::Increment,
+                    prefix: false,
+                }),
+                body: vec![Stmt::Expr(Expr::ArrayPush {
+                    array_id: outer,
+                    value: Box::new(Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(child)),
+                        index: Box::new(Expr::LocalGet(j)),
+                    }),
+                })],
+            },
+            Stmt::Return(Some(Expr::Integer(0))),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    }
 }
 
 fn make_simple_producer() -> Function {


### PR DESCRIPTION
Closes #8104.

## The gap

`perry-transform/src/deforest` has no profitability term at all: `detect.rs`
matches `const out = []; …push…; return out` and `run` rewrites every producer
it finds, at every call site.

Only **one** of the three call-site shapes removes work. The consumer fuse

```
let X = f(args); for (j) outer.push(X[j]);   ->   outer = f(args, outer);
```

deletes a copy loop and leaves one array where there were two. The other two
are pure cost, and the value-binding rewrite is actively harmful:

```
const arr = build(n);        ->   let arr = []; arr = build(n, arr);
```

That allocates exactly as many arrays as before — the producer stops allocating
one, the caller starts — and it costs the caller's binding its **write-once**
property. Every representation fact keyed on a stable local goes with it:
`Ptr<NumArray>`, the element-shape versioned loop clone, and the rest.

## Measured

macOS arm64, `--profile perry-dev` compiler and `libperry_{runtime,stdlib}.a`,
`PERRY_RUNTIME_DIR` pinned, `PERRY_NO_AUTO_OPTIMIZE=1`, `/usr/bin/time -l`,
medians of 5 interleaved, byte-identical output on both arms.

These are the **only three** programs in `benchmarks/suite` +
`benchmarks/app-patterns/kernels` + the beat-scriptc sweep corpus whose emitted
object changes at all, found by sweeping `PERRY_DEFOREST_DEBUG=1` over all of
them. None has a fuse site, so all three were paying the transform's cost for
nothing:

| program | instructions before | after | delta | peak RSS before | after | delta |
|---|---:|---:|---:|---:|---:|---:|
| `bench_numeric_array_numeric` | 232,687,808,231 | 7,681,530,021 | **-96.7%** | 44,057,080 | 21,725,616 | **-50.7%** |
| `shapes` (sweep corpus) | 1,574,232,277 | 1,507,089,862 | **-4.3%** | 29,491,656 | 29,491,656 | 0.0% |
| `batch` (app-patterns) | 1,793,403,047 | 1,793,372,968 | ±0.0% | 20,169,184 | 20,169,184 | 0.0% |

`bench_numeric_array_numeric` goes from **4071 ms to 126 ms** wall, same
`checksum:6500625`. Both objectives move the same way on every row; nothing
regresses on either axis.

## The fix

`producers_with_fuse_sites` keeps only producers with at least one fuse site.
It shares the matcher with the rewrite (`match_consumer_fuse_pattern`, factored
out of `try_consumer_fuse_pattern`) so the profitability question and the
rewrite can never disagree about what a fuse site *is*, and it mirrors
`rewrite_call_sites_in_stmts_with_local_pass`'s descent so they cannot disagree
about which positions are reachable.

A producer with one fuse site anywhere keeps the rewrite at **all** of its
sites — the signature gained a parameter, so every call must pass one, or you
get #5136's arity-mismatch SIGSEGV back.

## ABC451D still deforests

The recursive fuse inside a producer's own body counts, which is what keeps the
workload the transform was built for. `test-files/test_deforest_growth_forwarding.ts`
still reports `[deforest] producer fn_id=1 name=tree out_local=12 param_count=2`
under the gate, and both `test_deforest_*.ts` files are parity-clean against
Node 26.5.1.

## Tests

Three new, as a discriminating pair plus the recursion case:

* `a_producer_with_no_fuse_site_is_left_alone` — and it asserts the shape still
  DETECTS as a producer first, so the test cannot pass by detection declining.
* `one_fuse_site_admits_the_producer_at_every_call_site` — including the
  non-fuse site, which must move in lock-step.
* `the_recursive_fuse_inside_a_producer_body_counts` — ABC451D.

Six existing unit tests needed a fuse site added to their fixtures. **That is
itself the finding**: the entire pre-existing suite was built on
value-binding-only modules — exactly the shape measured above as a 30x
pessimization. Each keeps its original subject; the new `fuse_consumer` helper
only makes the producer eligible.

`cargo test -p perry-transform --lib`: 89 passed, 0 failed.

## Not measured

x86-64; `--profile dist`; the `--release` runtime. I did not attempt to make
the value-binding rewrite cheap (e.g. threading a fresh temp so the caller's
binding stays `const`) — on this corpus its best case is a wash, so declining
it is both simpler and strictly better.
