### PR TITLE
perf(shapes): stop paying SipHash on every ShapeId probe, and pin the id a shape resolves to

### DIFF
--- a/changelog.d/8157-shape-descriptor-siphash.md
+++ b/changelog.d/8157-shape-descriptor-siphash.md
@@ -1,0 +1,59 @@
+### Performance
+
+**The ShapeId descriptor table no longer pays SipHash on every probe, and the
+id a shape resolves to no longer depends on hash iteration order.**
+
+`ShapeTableInner::descriptors` — the map `shape_descriptor_by_id` reads — was a
+`std::collections::HashMap<u32, _>` with the default `RandomState`, i.e.
+SipHash-1-3 on a bare `u32`. It is the hottest lookup in the object model:
+`object_is_regular` runs it once per array element-shape test (3,000,000 times
+on the `retain` bench, 20,000,002 on `churn`) and `object_live_slot_count` runs
+it on every indexed field get/set. The sibling field on the same struct,
+`indices`, already used `crate::fast_hash::PtrHashMap`; `descriptors` and
+`ids_by_keys` were simply never converted, and `fast_hash`'s own module doc
+already records the identical finding ("`hash_one` was 14% leaf samples") for
+the pointer-keyed registries.
+
+`PtrHasherImpl` gains a `write_u32` fast path — without it a `u32` key falls
+into the generic byte-stream fallback, because `Hasher`'s default `write_u32`
+forwards to `write(&n.to_ne_bytes())`: four rotate/xor rounds for a key that
+needs one multiply. `ids_by_facts` is deliberately NOT converted, since
+`PtrHasher`'s `write_*` methods overwrite the accumulator rather than folding
+it — right for a one-word key, wrong for that five-field one.
+
+`rebuild_descriptor_reverse_indices` now sorts each id vector. The rebuild
+walks `descriptors` in HASH order and `shape_descriptor_ensure_with_generation`
+reuses `ids.first()`, so which ShapeId a facts key resolved to after a GC
+rewrite depended on the hasher: two objects with identical facts, one born
+before a collection and one after, carried different ids, and every id-keyed
+consumer (the typed shape-layout install, the emitted PICs) split its
+population. Latent before, exposed by the hasher swap — which alone measured
+`interp` +3.4% with `gc::layout::init_typed_shape_layout` newly doubled in the
+profile, and `interp` −5.9% once the order was pinned.
+
+Measured on the 19-program corpus, `/usr/bin/time -l`, best-of-3, per-arm
+`PERRY_RUNTIME_DIR` and object cache, archives `cmp`-verified to differ, all 19
+stdouts byte-compared and exit-checked:
+
+```
+churn -25.2%   deeplist -17.2%   retain_wide -15.2%   retain1 -15.1%
+cycles -14.9%  retain -14.7%     retain_wide1 -14.3%  tree -13.4%
+shapes  -9.4%  tree_wide  -6.5%  interp        -5.9%  iso_miss -4.7%
+pipeline -3.6% asyncpipe  -1.1%  fib40 / push_num / churn_read ~0
+```
+
+Peak memory footprint is unchanged on every row.
+
+Two discriminating tests: `u32_keys_take_the_multiplicative_fast_path` goes red
+if `write_u32` is deleted (the default forwards to the byte fold and produces a
+different digest), and `sequential_shape_ids_spread_across_low_bit_buckets`
+goes red if `mix`'s avalanche is dropped, since ShapeIds are a dense run in the
+top half of `u32` while `HashMap` indexes on the low bits.
+
+The symbol profile that found this was previously recorded as structurally
+unobtainable. It needs no debug build — only `CARGO_PROFILE_RELEASE_STRIP=none`
+plus `PERRY_DEBUG_SYMBOLS=1`, which skips perry's own post-link `strip`. The
+"zero `_ZN` frames in `nm`" observation was that `strip`, not LTO
+internalization.
+
+Refs #8125, #8113, #8122.

--- a/crates/perry-runtime/src/fast_hash.rs
+++ b/crates/perry-runtime/src/fast_hash.rs
@@ -54,6 +54,19 @@ impl Hasher for PtrHasherImpl {
         }
         self.0 = mix(h.wrapping_mul(PTR_MIX));
     }
+    /// #8125: `u32` keys must not fall into the byte-stream fallback above.
+    /// `Hash for u32` calls `write_u32`, and `Hasher`'s DEFAULT `write_u32`
+    /// forwards to `write(&n.to_ne_bytes())` — four rotate/xor iterations plus
+    /// the multiply, for a key that needs exactly one multiply. The shape
+    /// descriptor table (`object::shapes`) is keyed by a bare `u32` ShapeId and
+    /// is probed once per allocated object and once per array element-shape
+    /// test, so this override is the difference between a fast path and a
+    /// loop. Deliberately identical to `write_u64` on the same numeric value;
+    /// `u32_keys_take_the_multiplicative_fast_path` pins that.
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.0 = mix((n as u64).wrapping_mul(PTR_MIX));
+    }
     #[inline]
     fn write_u64(&mut self, n: u64) {
         self.0 = mix(n.wrapping_mul(PTR_MIX));
@@ -181,6 +194,49 @@ mod tests {
         m.insert(0x2000, "b");
         assert_eq!(m.get(&0x1000), Some(&"a"));
         assert_eq!(m.get(&0x9999), None);
+    }
+
+    /// #8125: a `u32` key must reach the single-multiply path, not the
+    /// per-byte fold. `Hash for u32` calls `write_u32`; without an override
+    /// `Hasher`'s default `write_u32` forwards to `write(&n.to_ne_bytes())`.
+    /// Deleting `PtrHasherImpl::write_u32` turns this red.
+    #[test]
+    fn u32_keys_take_the_multiplicative_fast_path() {
+        use std::hash::Hash;
+        for n in [0u32, 1, 0x8000_0000, 0x8000_02ff, u32::MAX] {
+            let mut viaHash = PtrHasher.build_hasher();
+            n.hash(&mut viaHash);
+            let mut viaU64 = PtrHasher.build_hasher();
+            viaU64.write_u64(n as u64);
+            assert_eq!(
+                viaHash.finish(),
+                viaU64.finish(),
+                "u32 key {n:#x} fell into the byte-stream fallback"
+            );
+        }
+    }
+
+    /// ShapeIds are minted sequentially from `SHAPE_ID_BASE` (0x8000_0000), so
+    /// the descriptor table's keys are a dense run in the TOP half of the u32
+    /// range. Multiplicative mixing has to spread that run across buckets —
+    /// `HashMap` indexes on the LOW bits, and a run of consecutive integers has
+    /// no entropy there. Dropping `mix` (the `^= h >> 32` avalanche) collapses
+    /// this to a handful of buckets and turns the map into a linked list.
+    #[test]
+    fn sequential_shape_ids_spread_across_low_bit_buckets() {
+        use std::collections::HashSet;
+        let base = 0x8000_0000u32;
+        let mut buckets = HashSet::new();
+        for i in 0..1024u32 {
+            let mut h = PtrHasher.build_hasher();
+            h.write_u32(base + i);
+            buckets.insert(h.finish() & 0x3ff);
+        }
+        assert!(
+            buckets.len() > 512,
+            "sequential ShapeIds hashed into only {} of 1024 buckets",
+            buckets.len()
+        );
     }
 
     /// Pointer-aligned keys collide trivially with multiply-only on the

--- a/crates/perry-runtime/src/fast_hash.rs
+++ b/crates/perry-runtime/src/fast_hash.rs
@@ -204,13 +204,13 @@ mod tests {
     fn u32_keys_take_the_multiplicative_fast_path() {
         use std::hash::Hash;
         for n in [0u32, 1, 0x8000_0000, 0x8000_02ff, u32::MAX] {
-            let mut viaHash = PtrHasher.build_hasher();
-            n.hash(&mut viaHash);
-            let mut viaU64 = PtrHasher.build_hasher();
-            viaU64.write_u64(n as u64);
+            let mut via_hash = PtrHasher.build_hasher();
+            n.hash(&mut via_hash);
+            let mut via_u64 = PtrHasher.build_hasher();
+            via_u64.write_u64(n as u64);
             assert_eq!(
-                viaHash.finish(),
-                viaU64.finish(),
+                via_hash.finish(),
+                via_u64.finish(),
                 "u32 key {n:#x} fell into the byte-stream fallback"
             );
         }

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -72,14 +72,36 @@ struct ShapeFacts {
 
 struct ShapeTableInner {
     indices: crate::fast_hash::PtrHashMap<usize, ShapeIndex>,
-    descriptors: HashMap<u32, ShapeDescriptor>,
+    /// #8125: `PtrHashMap`, not the SipHash default.
+    ///
+    /// This is the map `shape_descriptor_by_id` probes, and that probe is the
+    /// single hottest runtime lookup in the object model: `object_is_regular`
+    /// runs it once per array element-shape test (3 M times on the `retain`
+    /// bench, 20 M on `churn`) and, since #8113 deleted
+    /// `ObjectHeader::field_count`, `object_live_slot_count` runs it on every
+    /// indexed field get/set. A symbol profile of the `shapes` bench
+    /// (`PERRY_DEBUG_SYMBOLS=1` + `sample`) put `RandomState::hash_one` at the
+    /// TOP of self time with `shape_descriptor_by_id` fourth — together ~22% of
+    /// the program, nearly all of it SipHash on a bare `u32`.
+    ///
+    /// The key is a ShapeId minted by this process from a monotonic counter.
+    /// No external input reaches it, so hash-flooding resistance buys nothing
+    /// here for the same reason it buys nothing on the pointer-keyed
+    /// registries `fast_hash` already serves.
+    descriptors: crate::fast_hash::PtrHashMap<u32, ShapeDescriptor>,
     /// Exact-facts reverse index. More than one id is legal when a worker
     /// minted a local descriptor before a process-global module id arrived.
+    ///
+    /// Deliberately NOT a `PtrHashMap`: `PtrHasher`'s `write_*` methods
+    /// OVERWRITE the accumulator instead of folding it, which is exactly right
+    /// for a single-word key and wrong for this five-field one — every
+    /// `ShapeFacts` would hash to its last field alone.
     ids_by_facts: HashMap<ShapeFacts, Vec<u32>>,
     /// Keys-array address -> every descriptor id that currently names it.
     /// Same-address key-count retirement uses this index instead of scanning
-    /// every shape ever observed by the agent.
-    ids_by_keys: HashMap<u64, Vec<u32>>,
+    /// every shape ever observed by the agent. Single-word key, so `PtrHasher`
+    /// (#8125).
+    ids_by_keys: crate::fast_hash::PtrHashMap<u64, Vec<u32>>,
 }
 
 pub(crate) struct ShapeTable {
@@ -91,9 +113,9 @@ impl ShapeTable {
         ShapeTable {
             inner: RefCell::new(ShapeTableInner {
                 indices: crate::fast_hash::new_ptr_hash_map(),
-                descriptors: HashMap::new(),
+                descriptors: crate::fast_hash::new_ptr_hash_map(),
                 ids_by_facts: HashMap::new(),
-                ids_by_keys: HashMap::new(),
+                ids_by_keys: crate::fast_hash::new_ptr_hash_map(),
             }),
         }
     }
@@ -137,13 +159,30 @@ fn remove_id_from_facts_index(inner: &mut ShapeTableInner, facts: ShapeFacts, id
 fn rebuild_descriptor_reverse_indices(inner: &mut ShapeTableInner) {
     let mut ids_by_facts: HashMap<ShapeFacts, Vec<u32>> =
         HashMap::with_capacity(inner.descriptors.len());
-    let mut ids_by_keys: HashMap<u64, Vec<u32>> = HashMap::new();
+    let mut ids_by_keys: crate::fast_hash::PtrHashMap<u64, Vec<u32>> =
+        crate::fast_hash::new_ptr_hash_map();
     for (&id, &descriptor) in &inner.descriptors {
         ids_by_facts
             .entry(descriptor_facts(descriptor))
             .or_default()
             .push(id);
         ids_by_keys.entry(descriptor.keys).or_default().push(id);
+    }
+    // #8125: the rebuild walks `descriptors` in HASH order, and
+    // `shape_descriptor_ensure_with_generation` reuses `ids.first()` — so
+    // without this sort, WHICH id a facts key resolves to after a GC rewrite
+    // depends on the hasher. Two objects with identical facts, one born before
+    // a collection and one after, would then carry different ShapeIds, and
+    // every id-keyed consumer (the typed shape-layout install, the emitted
+    // PICs) splits its population. Ascending is the stable canonical choice:
+    // ids are minted monotonically, so the smallest is the oldest — the one
+    // already-published objects and already-installed layouts carry, and in
+    // practice the module-init id `install_external_shape_id` prefers.
+    for ids in ids_by_facts.values_mut() {
+        ids.sort_unstable();
+    }
+    for ids in ids_by_keys.values_mut() {
+        ids.sort_unstable();
     }
     inner.ids_by_facts = ids_by_facts;
     inner.ids_by_keys = ids_by_keys;


### PR DESCRIPTION
Closes #8125 (as far as it is reducible in code — see "What this does NOT fix").

## The finding

`ShapeTableInner::descriptors` — the map `shape_descriptor_by_id` reads — was a
`std::collections::HashMap<u32, _>` with the default `RandomState`, i.e.
**SipHash-1-3 on a bare `u32`**. That probe is the hottest lookup in the object
model:

* `object_is_regular` runs it once per array element-shape test — **3,000,000
  times on the `retain` bench, 20,000,002 on `churn`** (counts from #8113's
  per-callsite instrumentation);
* `object_live_slot_count` runs it on every indexed field get/set — which is
  what #8113/#8122 turned it into when they deleted `ObjectHeader::field_count`.

The sibling field on the very same struct, `indices`, already uses
`crate::fast_hash::PtrHashMap`. `descriptors` and `ids_by_keys` were simply
never converted, and `fast_hash`'s own module doc records the identical finding
for the pointer-keyed registries: *"`core::hash::BuildHasher::hash_one` was 14%
leaf samples on perf-comprehensive before any optimization"*.

### How it was found

The symbol profile #8113 recorded as *"structurally blocked"* is obtainable
after all, and needs no 15 GB debug build. Two knobs:

* `CARGO_PROFILE_RELEASE_STRIP=none` keeps Rust symbols in
  `libperry_{runtime,stdlib}.a`;
* **`PERRY_DEBUG_SYMBOLS=1`** at `perry` compile time skips the post-link
  `strip` (`crates/perry/src/commands/compile/post_link.rs`). Without it the
  corpus binary carries 256 symbols, all undefined libc imports — which is
  exactly the "`nm` shows zero `_ZN` frames, so LTO internalized everything"
  observation that closed the door last time. It is `strip`, not LTO.

`sample` on the `shapes` bench then reads, self time, **on `main` — before this
PR and before #8122**:

```
25  RandomState as BuildHasher>::hash_one     <- SipHash
22  gc::layout_tables::layout_addr_filter_add
15  addr_class::try_read_tracked_gc_header
14  object::shapes::shape_descriptor_by_id
...
 6  hashbrown HashMap<_, ClassVTable, RandomState>::get
 5  hash_one (second instantiation)
 5  core::hash::sip::Hasher::write
```

with the call graph showing `object_is_regular -> shape_descriptor_by_id ->
hash_one` directly. ~22% of the program in the shape/class tables, nearly all
of it SipHash.

## The change

**1. `descriptors` and `ids_by_keys` become `PtrHashMap`**, and `PtrHasherImpl`
gains a `write_u32` fast path — without it a `u32` key falls into the generic
byte-stream fallback (`Hasher`'s DEFAULT `write_u32` forwards to
`write(&n.to_ne_bytes())`): four rotate/xor rounds for a key that needs one
multiply.

`ids_by_facts` is **deliberately not** converted: `PtrHasher`'s `write_*`
methods overwrite the accumulator instead of folding it, which is right for a
one-word key and wrong for that five-field one — every `ShapeFacts` would hash
to its last field alone. A comment says so at the declaration.

DoS-resistance is not lost: ShapeIds are minted by this process from a
monotonic counter, no external input reaches them — the same argument
`fast_hash` already makes for the pointer-keyed registries.

**2. `rebuild_descriptor_reverse_indices` sorts each id vector.** The rebuild
walks `descriptors` in HASH order and `shape_descriptor_ensure_with_generation`
reuses `ids.first()`, so **which ShapeId a facts key resolves to after a GC
rewrite depended on the hasher**. Two objects with identical facts, one born
before a collection and one after, then carry different ids, and every id-keyed
consumer (the typed shape-layout install, the emitted PICs) splits its
population.

That was latent; swapping the hasher exposed it. Measured, in that order:

| arm | interp | pipeline |
|---|---:|---:|
| hasher swap only | **+3.4%** | +0.5% |
| + deterministic rebuild order | **-5.9%** | -3.6% |

and the profile of the bad arm names the mechanism —
`gc::layout::init_typed_shape_layout` roughly doubled and
`gc::shape_install::record` appeared as a new hot symbol. Ascending is the
stable canonical choice: ids are minted monotonically, so the smallest is the
oldest — the one already-published objects and already-installed layouts carry,
and in practice the module-init id that `install_external_shape_id` prefers.

## Measurements

19-program corpus + a 10x-scaled `shapes`, `/usr/bin/time -l`, best-of-3.
Both arms built from the same worktree with an identical
`-p perry -p perry-runtime-static -p perry-stdlib-static`, `PERRY_RUNTIME_DIR`
pinned per arm, `PERRY_NO_AUTO_OPTIMIZE=1`, a per-arm `PERRY_CACHE_DIR` (perry
caches compiled objects — without this both arms link the same `.o` and the A/B
is vacuous), the two `libperry_runtime.a` files `cmp`-verified to differ,
`grep -c "Compiling perry-runtime v"` = 1 on every build, and **all 19 programs
byte-compared for identical stdout and exit-checked in every arm**.

### This PR alone, against `main`

| prog | Δ instructions | Δ peak memory footprint |
|---|---:|---:|
| `churn` | -25.24% | +0.15% |
| `deeplist` | -17.18% | +0.05% |
| `retain_wide` | -15.22% | -0.01% |
| `retain1` | -15.10% | +0.02% |
| `cycles` | -14.91% | -0.08% |
| `retain` | -14.69% | +0.01% |
| `retain_wide1` | -14.26% | -0.01% |
| `tree` | -13.42% | +0.05% |
| `shapes` | -9.37% | +0.11% |
| `shapes_x10` | -9.68% | +0.10% |
| `tree_wide` | -6.47% | +0.07% |
| `interp` | -5.89% | +0.51% |
| `iso_miss` | -4.69% | +0.11% |
| `pipeline` | -3.55% | +0.00% |
| `asyncpipe` | -1.13% | -0.09% |
| `push_cls` | -0.59% | +0.08% |
| `churn_alloc` | -0.57% | +0.00% |
| `churn_read` | -0.06% | -0.56% |
| `push_num` | -0.01% | +0.08% |
| `fib40` | +0.03% | +1.52% |

Peak memory footprint is unchanged everywhere (the two nonzero rows are the
smallest binaries' run-to-run noise). No behavioural change: all 19 stdouts are
byte-identical to `main`'s.

### What it means for #8122 (the `ObjectHeader` 56 -> 48 B shrink)

`A` = `origin/main@83b6b8c69` (#8122's merge base), `B` = #8122 head,
`Afix`/`Bfix` = the same two trees with this PR applied.

| prog | #8122 today (B vs A) | fix alone (Afix vs A) | #8122 on the fixed base (Bfix vs Afix) | fix + #8122 vs today (Bfix vs A) | Δ RSS (Bfix vs A) |
|---|---:|---:|---:|---:|---:|
| `churn` | +1.88% | -25.24% | +2.32% | -23.51% | +0.15% |
| `deeplist` | +9.18% | -17.18% | +9.07% | -9.68% | -4.11% |
| `retain_wide` | +2.95% | -15.22% | +4.80% | -11.16% | -5.45% |
| `retain1` | +7.90% | -15.10% | +8.48% | -7.89% | -5.24% |
| `cycles` | +0.70% | -14.91% | +0.84% | -14.19% | -0.23% |
| `retain` | +3.28% | -14.69% | +4.26% | -11.06% | -9.08% |
| `retain_wide1` | +2.73% | -14.26% | +4.15% | -10.71% | -6.04% |
| `tree` | +0.57% | -13.42% | +0.66% | -12.84% | -12.74% |
| `shapes` | +5.16% | -9.37% | +3.02% | -6.63% | -0.61% |
| `shapes_x10` | +5.50% | -9.68% | +3.42% | -6.59% | +0.92% |
| `tree_wide` | +0.52% | -6.47% | +0.50% | -6.00% | -6.27% |
| `interp` | +0.33% | -5.89% | +0.38% | -5.54% | +0.40% |
| `iso_miss` | +0.34% | -4.69% | +0.36% | -4.34% | +0.17% |
| `pipeline` | +0.42% | -3.55% | +0.51% | -3.06% | -0.08% |
| `asyncpipe` | +0.65% | -1.13% | +0.80% | -0.35% | +0.18% |
| `push_cls` | +4.30% | -0.59% | +4.03% | +3.42% | +0.00% |
| `churn_alloc` | +4.31% | -0.57% | +3.96% | +3.38% | +0.00% |
| `churn_read` | +0.03% | -0.06% | -0.01% | -0.07% | +0.00% |
| `push_num` | +0.14% | -0.01% | +0.14% | +0.14% | +0.16% |
| `fib40` | +0.00% | +0.03% | -0.03% | -0.00% | +0.00% |

Column 1 reproduces #8122's own published table to within a few tenths
(`deeplist` +9.18 vs +8.20, `retain` +3.28 vs +3.26, `retain1` +7.90 vs +7.99,
`shapes` +5.16 vs +4.96, `tree` +0.57 vs +0.54, RSS `retain` -9.09 vs -9.10,
`tree` -12.74 vs -12.79), which is the harness's calibration.

**Column 4 is the one that matters for the hold**: with this PR in front of it,
`main` + this + #8122 is faster than `main` on 17 of 20 rows — `retain` -11.1%,
`tree` -12.8%, `deeplist` -9.7%, `churn` -23.5%, `interp` -5.5% — **while
keeping #8122's entire footprint win** (`tree` -12.8%, `retain` -9.1%,
`retain_wide1` -6.0%, `tree_wide` -6.3%, `retain1` -5.2%, `deeplist` -4.2%).

## What this does NOT fix

Column 3 says it plainly: **#8122's own delta is not removed.** Measured against
the fixed baseline it is essentially unchanged (`deeplist` +9.07%, `retain1`
+8.48%, `retain_wide` +4.80%, `retain` +4.26%) — cheaper probes shrink
`shapes` (+5.16% -> +3.02%) but the rest is not probe cost. #8113's own arm-C
partition already said why: `deeplist` is **+8.28% SIZE / -0.07% CODE** and
`retain1` **+6.75% SIZE / +1.16% CODE** — footprint-coupled, not code, and so
out of reach of anything done to the shape table.

A `class_id != 0` hoist ahead of `object_is_regular` in
`array/element_shape.rs::element_class_of_bits` was also built and measured —
strictly less work, sound conjunction — and it **regressed** `retain` +1.69%,
`retain_wide` +2.11%, `retain_wide1` +2.07%, `churn` +1.09%. Reverted, not
shipped. That is the third "semantically identical and strictly less work"
change in this campaign to measure worse.

## Tests / gates

* `cargo test -p perry-runtime --lib` — **2401 passed, 0 failed, 4 ignored**
  (2399/0/4 on `main`; +2 new `fast_hash` tests).
* On #8122's tree with this patch applied: **2391 passed, 0 failed** including
  `object::tests::object_is_regular_excludes_a_heap_class_object` — **#6595
  stays closed** (this PR does not touch `object_is_regular`'s predicate at all,
  only the hash function of the table it reads).
* Two new tests, both discriminating:
  * `u32_keys_take_the_multiplicative_fast_path` — deleting
    `PtrHasherImpl::write_u32` turns it red, because the default `write_u32`
    forwards to the byte fold and produces a different digest.
  * `sequential_shape_ids_spread_across_low_bit_buckets` — ShapeIds are a dense
    run in the TOP half of `u32` and `HashMap` indexes on the LOW bits;
    dropping `mix`'s `^= h >> 32` avalanche collapses them into a handful of
    buckets. Requires >512 distinct buckets from 1024 sequential ids.
* `cargo fmt --all -- --check`, `./scripts/check_file_size.sh`, and all 28
  runnable steps of the `lint` job (enumerated from `.github/workflows/test.yml`)
  pass. The 29th, "Raw-handle debt ratchet vs. merge base", needs
  `GITHUB_BASE_REF` and a fetched merge base, so it only runs in CI.
* `perry-codegen` untouched.

No version bump (maintainer bumps at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved ShapeId descriptor lookup performance with faster hashing.
  * Optimized reverse-index processing for more efficient shape management.
* **Reliability**
  * Reverse-index results are now sorted deterministically, ensuring consistent ID selection.
* **Testing**
  * Added coverage for hash equivalence and distribution across sequential ShapeIds.
* **Documentation**
  * Added performance benchmarks and implementation notes to the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->