### PR TITLE
fix(compile): register #8128's optnone knob as a build-cache input

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -39,6 +39,13 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     "PERRY_WRITE_BARRIERS",
     "PERRY_SHADOW_STACK",
     "PERRY_RS4GC",
+    // #8128: the post-RS4GC `optnone`+`noinline` instruction cap. A function
+    // past the threshold has the middle-end skipped, so flipping this changes
+    // emitted code for that function — it must invalidate the build-level
+    // no-op check, not merely per-object entries. #8128 said it registered
+    // this and did not; `codegen_env_vars_are_build_cache_inputs` caught it on
+    // main, where it had gone red.
+    "PERRY_LL_RS4GC_OPTNONE_INSTRS",
     "PERRY_GC_SAFEPOINT_ONLY",
     "PERRY_INLINE_SHADOW_SLOT",
     "PERRY_DISABLE_BUFFER_FAST_PATH",


### PR DESCRIPTION
`cargo-test` — a required context — is **red on `main`** right now.

```
these codegen env vars key neither the build cache nor an exclusion (#6394's rule):
  ["PERRY_LL_RS4GC_OPTNONE_INSTRS"]
```

Reproduced on `main` @ `8b1b4b909`, so this is not any open PR's doing. It surfaced while I was triaging #8084's red `cargo-test`, which turns out to be inheriting this.

## Cause

#8128 added the knob. Its description says it was "registered as a build-cache key per `#6394`" — it was not.

## Why `BUILD_CACHE_ENV_VARS` and not an exclusion

The knob stamps `optnone`+`noinline` on any function past its instruction threshold, so flipping it skips the middle-end for that function and changes emitted code. An exclusion asserts the opposite — that a variable *cannot* change emitted code — so the exclusion list would be the wrong home and would re-break the invariant #6394 exists to hold. Without the entry, changing the threshold leaves the build-level no-op check reporting a match and handing back the previous build's executable.

## Verification

- Failing on `main` before the change, passing after.
- `cargo test -p perry --bin perry` green.
- The test that caught it is the discriminating one: it enumerates codegen env vars and requires each to key the cache or carry a written exclusion, so it goes red again if a future knob skips registration.

Note this class is invisible to `cargo test -p perry --lib` — `perry` has no lib target, so the test only runs under `--bin perry`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build results now refresh correctly when the garbage-collection optimization setting changes, preventing stale cached builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->