### PR TITLE
fix(gc): PERRY_GC_STACKMAP_TRACE must parse its value, not its presence

### DIFF
--- a/changelog.d/8164-stackmap-trace-knob-polarity.md
+++ b/changelog.d/8164-stackmap-trace-knob-polarity.md
@@ -1,0 +1,12 @@
+`PERRY_GC_STACKMAP_TRACE` parses its value instead of its presence, restoring
+the `lint` gate. The knob arrived in #8131 reading `var_os(..).is_some()`, which
+inverts the spelling a reader is most likely to try: `PERRY_GC_STACKMAP_TRACE=0`
+still sets the variable, so it turned the trace ON. `check_gc_env_knobs` — a
+required-check audit that exists to keep every GC knob on the shared parser —
+failed on it, and a red `lint` on main blocks every open PR.
+
+It now uses `gc::env_flag_enabled`, the default-OFF parser (the same shape as
+`policy.rs`'s `PERRY_GC_TRACE`), which fails toward the knob's documented
+default so a typo leaves the instrument off rather than silently arming it.
+`=1`/`on`/`true` still enable it and unset still leaves it off; `=0`/`off`/
+`false`/`no` now disable it.

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -1114,7 +1114,11 @@ mod unwind {
 
     fn walk_trace_enabled() -> bool {
         static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        *ON.get_or_init(|| std::env::var_os("PERRY_GC_STACKMAP_TRACE").is_some())
+        // `env_flag_enabled`, not `var_os(..).is_some()`: presence-testing makes
+        // `PERRY_GC_STACKMAP_TRACE=0` ENABLE the trace, which is the opposite of
+        // what every other GC knob does and what anyone typing `=0` means. The
+        // shared parser fails toward the knob's documented default (OFF here).
+        *ON.get_or_init(|| crate::gc::env_flag_enabled("PERRY_GC_STACKMAP_TRACE"))
     }
 
     unsafe extern "C" fn walk_frame<F: FnMut(ResolvedRoot)>(


### PR DESCRIPTION
`lint` is **red on main**, which blocks every open PR — it is a required check.

`check_gc_env_knobs` fails on:

```
PERRY_GC_STACKMAP_TRACE: read for presence (var_os(..).is_some()) in
crates/perry-runtime/src/gc/roots/stack_maps.rs;
'PERRY_GC_STACKMAP_TRACE=0' would ENABLE it.
```

The knob arrived in #8131 reading `var_os(..).is_some()`. Presence-testing inverts the one spelling a reader is most likely to try: `=0` still sets the variable, so it turns the trace **on**. Every other GC knob routes through the shared parser for exactly this reason, and the audit exists to keep that uniform.

## Fix

Use `gc::env_flag_enabled` — the default-OFF parser, same shape as `policy.rs`'s `PERRY_GC_TRACE`. It fails toward the knob's documented default, so a typo leaves the instrument off rather than silently arming it.

Behaviour is unchanged for the spellings that already worked (`=1`/`on`/`true` enable, unset stays off); `=0`/`off`/`false`/`no` now disable it instead of enabling it.

## Validation

- `python3 scripts/check_gc_env_knobs.py`: one failure → "30 claimed knobs, 197 live env parsers, 3 historical documents exempt, **0 presence-only GC reads**"
- `cargo build -p perry-runtime` clean; `cargo fmt --all --check` clean
- Verified against `main` that this is not from my other PRs: the offending read is on `main` and no branch of mine touches `stack_maps.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `PERRY_GC_STACKMAP_TRACE` handling so tracing is disabled by default.
  * Explicit false values, including `0`, now reliably disable tracing.
  * Invalid or unset values no longer enable tracing accidentally.

* **Documentation**
  * Documented the supported behavior for enabling and disabling stack map tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->