### PR TITLE
fix(gc): prune FUNCTION_CLASS_IDS keys whose closure died (#8040)

### DIFF
--- a/changelog.d/8168-function-class-id-dead-key-prune.md
+++ b/changelog.d/8168-function-class-id-dead-key-prune.md
@@ -1,0 +1,53 @@
+### Fixed
+
+- **GC: `FUNCTION_CLASS_IDS` kept dead closure keys, so a synthetic class id
+  followed whatever object next occupied the address (#8040).**
+
+  `object::class_registry`'s `FUNCTION_CLASS_IDS` maps a synthetic-class
+  function value's NaN-boxed **bits** to a class id — i.e. its key is the raw
+  heap address of a closure. Both writers (`js_set_function_prototype` for
+  `function Base() {}; Base.prototype = {…}`, and
+  `synthetic_class_id_for_function` for `Func.prototype.x = fn` / `new Func()`)
+  require a `POINTER_TAG`'d value that passes `is_callable_function_value`, so
+  a key can only ever have been a live `GC_TYPE_CLOSURE`.
+
+  Nothing told the table when that closure died. `gc::dead_owner` — the
+  address-keyed side-table death prune written for exactly this ABA hazard —
+  covers around a dozen tables; this one was never wired into its fan-out.
+  That is worse here than a leak, because this table is **rekeyed** rather than
+  re-derived when its key object moves (`scan_function_class_id_keys_mut`):
+
+  1. the arena recycles the dead closure's address;
+  2. the recycled bytes are read as a `GcHeader`, and the byte at the
+     `gc_flags` offset happens to carry `GC_FLAG_FORWARDED`;
+  3. the rekey walk (`CopyingNurseryCollector::rewrite_raw_addr`) accepts the
+     address — `classify_heap_space` correctly reports `NurseryEden`, it really
+     is arena memory — and reads the payload word as a forwarding pointer.
+     That word is a NaN-boxed value (`0x7FFF…`), so the walk's next hop
+     classifies `Unknown` and stops there;
+  4. `visit_metadata_nanbox_key` masks the result back to 48 bits, which yields
+     a *genuine, live* survivor-space object that is itself being evacuated —
+     so the map ends the cycle holding a from-space forwarded address.
+
+  On the production Next.js App Route gate this aborted module init under
+  `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1
+  PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED=8036` with
+
+      gc evacuation verification failed: stale forwarded pointer in
+      runtime mutable root scanner: slot=0x0 old=… forwarded_to=…
+
+  The object behind the offending key was a `GC_TYPE_STRING` carrying
+  `GC_FLAG_INTERNED` — a shape a closure-only key can never legitimately name,
+  which is what identified the entry as stale rather than mis-rewritten.
+
+  Fix: `prune_dead_function_class_id_keys` joins `gc::dead_owner`'s fan-out on
+  both the post-trace (full / fallback-minor) and copied-minor from-space
+  paths, using the same `GC_TYPE_CLOSURE`-narrowed deadness predicate the
+  closure side tables already use. Live keys are unaffected — they keep being
+  rekeyed to their new address by the metadata rewrite pass.
+
+  Regression coverage (`gc::tests::dead_owner_side_tables`, sabotage-verified):
+  a dead key is pruned by a full GC; a live key is rekeyed rather than pruned;
+  and, under exact Eden reuse, an unrelated closure allocated at the recycled
+  address neither inherits the dead function's class id nor has the stale key
+  rekeyed onto it across its own move.

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -234,6 +234,11 @@ fn fan_out(
     crate::symbol::prune_dead_symbol_property_owners(is_dead_owner);
     crate::symbol::prune_dead_symbol_pointers(is_dead_symbol);
     crate::closure::prune_dead_closure_side_table_owners(is_dead_closure);
+    // #8040: `FUNCTION_CLASS_IDS` is keyed by a synthetic-class function
+    // value's closure address, and is REKEYED (not re-derived) when that
+    // closure moves — so a dead key does not merely leak, the rekey walk
+    // follows whatever the recycled bytes at that address look like.
+    crate::object::prune_dead_function_class_id_keys(is_dead_closure);
     crate::node_vm::prune_dead_vm_owner_entries(is_dead_owner);
     crate::fs::prune_dead_filehandle_fd_entries(is_dead_owner);
 }

--- a/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
@@ -1251,3 +1251,114 @@ fn test_object_meta_null_prototype_survives_full_gc_on_live_owner() {
     );
     js_shadow_slot_set(0, 0);
 }
+
+// ── FUNCTION_CLASS_IDS (#8040) ──────────────────────────────────────────────
+//
+// The synthetic-class table is keyed by a function value's NaN-boxed closure
+// ADDRESS, and — unlike every other table in this file — it is *rekeyed* when
+// its key object moves (`scan_function_class_id_keys_mut`). So a key that
+// outlives its closure does not merely leak: the next collection follows the
+// forwarding pointer of whatever object now occupies the address and rebinds
+// the class id onto it.
+
+fn alloc_nursery_test_closure() -> usize {
+    let ptr = crate::arena::arena_alloc_gc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        8,
+        GC_TYPE_CLOSURE,
+    );
+    unsafe { init_test_closure(ptr) };
+    ptr as usize
+}
+
+#[test]
+fn test_dead_function_class_id_key_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+    crate::object::test_clear_class_side_table_roots();
+
+    let addr = alloc_nursery_test_closure();
+    crate::object::test_seed_function_class_id_key(ptr_bits(addr), 0x8200_8040);
+    assert_eq!(
+        crate::object::function_class_id(f64::from_bits(ptr_bits(addr))),
+        0x8200_8040,
+        "test premise: the synthetic class id must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::object::test_function_class_id_key_for_class(0x8200_8040),
+        0,
+        "a dead closure's FUNCTION_CLASS_IDS key must be pruned"
+    );
+}
+
+#[test]
+fn test_live_function_class_id_key_survives_and_is_rekeyed_on_copied_minor() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    crate::object::test_clear_class_side_table_roots();
+    gc_register_mutable_root_scanner(crate::object::scan_class_side_table_roots_mut);
+
+    let addr = alloc_nursery_test_closure();
+    js_shadow_slot_set(0, ptr_bits(addr));
+    crate::object::test_seed_function_class_id_key(ptr_bits(addr), 0x8200_8041);
+
+    let _ = gc_collect_minor();
+
+    let moved = js_shadow_slot_get(0);
+    assert_ne!(moved, ptr_bits(addr), "test premise: the closure must move");
+    assert_eq!(
+        crate::object::test_function_class_id_key_for_class(0x8200_8041),
+        moved,
+        "a LIVE closure's key must be rekeyed to its new address, not pruned"
+    );
+}
+
+/// The #8040 shape, end to end: a dead key that survives one collection is
+/// re-pointed at the next tenant of its address, and the collection after that
+/// follows THAT object's forwarding pointer.
+#[test]
+fn test_dead_function_class_id_key_cannot_follow_exact_eden_reuse() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    crate::object::test_clear_class_side_table_roots();
+    gc_register_mutable_root_scanner(crate::object::scan_class_side_table_roots_mut);
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let dead_addr = alloc_nursery_test_closure();
+    crate::object::test_seed_function_class_id_key(ptr_bits(dead_addr), 0x8200_8042);
+
+    let _ = gc_collect_minor();
+
+    let replacement = alloc_nursery_test_closure();
+    assert_eq!(
+        replacement, dead_addr,
+        "test premise: the copied-minor Eden reset must reuse the exact address"
+    );
+    js_shadow_slot_set(0, ptr_bits(replacement));
+    assert_eq!(
+        crate::object::function_class_id(f64::from_bits(ptr_bits(replacement))),
+        0,
+        "an unrelated closure allocated at the recycled address must not inherit \
+         the dead function's synthetic class id"
+    );
+
+    let _ = gc_collect_minor();
+
+    let moved = js_shadow_slot_get(0);
+    assert_ne!(
+        moved,
+        ptr_bits(replacement),
+        "test premise: the replacement must move"
+    );
+    assert_eq!(
+        crate::object::function_class_id(f64::from_bits(moved)),
+        0,
+        "and the stale key must not have been REKEYED onto the replacement's new \
+         address by the metadata rewrite pass"
+    );
+    assert_eq!(
+        crate::object::test_function_class_id_key_count(),
+        0,
+        "no FUNCTION_CLASS_IDS entry may outlive its closure"
+    );
+}

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -124,7 +124,8 @@ pub use construct::{
 
 // ── gc_roots.rs ─────────────────────────────────────────────────────────────
 pub(crate) use gc_roots::{
-    new_class_side_table_root_scan_state, scan_class_side_table_roots_mut_step,
+    new_class_side_table_root_scan_state, prune_dead_function_class_id_keys,
+    scan_class_side_table_roots_mut_step,
 };
 pub use gc_roots::{scan_class_side_table_roots, scan_class_side_table_roots_mut};
 #[cfg(test)]
@@ -132,9 +133,10 @@ pub(crate) use gc_roots::{
     test_class_dynamic_prop_root_bits, test_class_parent_closure_root_addr,
     test_class_prototype_method_root_bits, test_class_prototype_method_value_root_bits,
     test_class_prototype_object_root_addr, test_clear_class_side_table_roots,
-    test_function_class_id_key_for_class, test_seed_class_dynamic_prop_root,
-    test_seed_class_prototype_method_root, test_seed_class_prototype_method_value_root,
-    test_seed_class_prototype_object_root, test_seed_function_class_id_key,
+    test_function_class_id_key_count, test_function_class_id_key_for_class,
+    test_seed_class_dynamic_prop_root, test_seed_class_prototype_method_root,
+    test_seed_class_prototype_method_value_root, test_seed_class_prototype_object_root,
+    test_seed_function_class_id_key,
 };
 
 // ── registration.rs ─────────────────────────────────────────────────────────

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -510,6 +510,52 @@ fn rewrite_function_class_id_key_if_forwarded(
     });
 }
 
+/// #8040: death pruning for `FUNCTION_CLASS_IDS`.
+///
+/// The table maps a synthetic-class function value's NaN-boxed **bits** to a
+/// class id, so its key is the raw heap address of a closure. Both writers
+/// (`js_set_function_prototype`, `synthetic_class_id_for_function`) require a
+/// `POINTER_TAG`'d value that passes `is_callable_function_value`, i.e. a key
+/// can only ever have been a live `GC_TYPE_CLOSURE`.
+///
+/// Nothing told the table when that closure died, and this table — unlike the
+/// other address-keyed side tables — is *rekeyed* rather than re-derived when
+/// its key object moves (`scan_function_class_id_keys_mut`). So a dead key
+/// does not merely leak: the arena recycles the address, the recycled bytes
+/// are read as a `GcHeader`, and if the byte at the `gc_flags` offset happens
+/// to carry `GC_FLAG_FORWARDED` the rekey walk follows the "forwarding
+/// pointer" out of dead memory and binds the class id to whatever that word
+/// names. See `gc::dead_owner`'s module doc for the general ABA hazard; this
+/// table was simply never wired into its fan-out.
+pub(crate) fn prune_dead_function_class_id_keys(is_dead_closure: &dyn Fn(usize) -> bool) {
+    FUNCTION_CLASS_IDS.with(|table| {
+        let Ok(mut guard) = table.write() else {
+            return;
+        };
+        let Some(map) = guard.as_mut() else {
+            return;
+        };
+        map.retain(|&bits, _| {
+            if bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
+                return true;
+            }
+            let addr = (bits & crate::value::POINTER_MASK) as usize;
+            addr == 0 || !is_dead_closure(addr)
+        });
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_function_class_id_key_count() -> usize {
+    FUNCTION_CLASS_IDS.with(|table| {
+        table
+            .read()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|map| map.len()))
+            .unwrap_or(0)
+    })
+}
+
 fn visit_metadata_nanbox_key(
     visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
     bits: &mut u64,


### PR DESCRIPTION
Closes the last blocker on #8040's production Next.js App Route gate: the
forced moving-GC arm aborted during module init under

```
PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 \
PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED=8036
```

with

```
gc evacuation verification failed: stale forwarded pointer in runtime
mutable root scanner: slot=0x0 old=0x2c8c76505f0 forwarded_to=0x2c8c9ba3160
```

## Root cause

`object::class_registry`'s `FUNCTION_CLASS_IDS` maps a synthetic-class
function value's **NaN-boxed bits** to a class id, so its key is the raw heap
address of a closure. Both writers — `js_set_function_prototype`
(`function Base() {}; Base.prototype = {…}`) and
`synthetic_class_id_for_function` (`Func.prototype.x = fn`, `new Func()`) —
require a `POINTER_TAG`'d value that passes `is_callable_function_value`, so a
key can only ever have been a live `GC_TYPE_CLOSURE`.

Nothing told the table when that closure died. `gc::dead_owner` — the
address-keyed side-table death prune written for exactly this ABA hazard, and
whose module doc names it ("a NEW object allocated at the recycled address
inherited the dead owner's entries") — prunes around a dozen tables. This one
was never wired into its fan-out.

That is worse here than a leak, because this table is **rekeyed** rather than
re-derived when its key object moves (`scan_function_class_id_keys_mut`). The
observed chain, in one copying minor:

1. A dead closure's key stays in the map. The arena recycles the address.
2. The recycled bytes are read as a `GcHeader`. The byte at the `gc_flags`
   offset happens to carry `GC_FLAG_FORWARDED` (observed: `0x86`, with
   `obj_type=104`, and the address absent from the collector's live census).
3. `CopyingNurseryCollector::rewrite_raw_addr` accepts it — `classify_heap_space`
   correctly says `NurseryEden`, the address really is in the arena — and reads
   the payload word as a forwarding pointer. That word is a **NaN-boxed
   value** (`0x7FFF…`), not a bare address, so the walk's next iteration
   classifies it `Unknown` and stops there (instrumented stop reason 2, hop 1).
4. `visit_metadata_nanbox_key` masks the result back to 48 bits, which yields a
   *genuine, live* survivor-space object — one that is itself forwarded this
   cycle. The map now holds a from-space forwarded address.
5. `PERRY_GC_VERIFY_EVACUATION`'s census-gated walk sees a live, censused,
   forwarded address and aborts.

In the App Route failure the object behind the offending key was a
`GC_TYPE_STRING` carrying `GC_FLAG_INTERNED` — a shape a closure-only key can
never legitimately name, which is what identified the entry as stale rather
than merely mis-rewritten.

## Fix

`prune_dead_function_class_id_keys` joins `gc::dead_owner`'s fan-out, on both
the post-trace (full / fallback-minor) and copied-minor from-space paths, with
the same `GC_TYPE_CLOSURE`-narrowed deadness predicate the closure side tables
already use. Live keys are unaffected — they keep being rekeyed to their new
address by the metadata rewrite pass.

## Reproducer

Reduced from the 104-module Next.js App Route to 20 lines of TypeScript that
fails in under a second (`tests/…` not added; the shape is covered by the unit
tests below):

```ts
function makeAndDrop(tag: number): number {
  function Base(this: any) {}
  (Base as any).prototype = { m() { return tag; } };
  return new (Base as any)().m();
}
const strings: string[] = [];
let sink = 0;
for (let i = 0; i < 3000; i++) {
  sink += makeAndDrop(i);
  strings.push(("key-" + i).toUpperCase());
  if (strings.length > 40) strings.shift();
  const o = { a: i, b: [i, i + 1], c: "s" + i };
  if (o.a < 0) strings.push(o.c);
}
console.log("sink", sink, strings.length);
```

A/B on one binary with the prune behind a temporary env guard, under the
fixture's exact forced-arm environment and `PERRY_GC_SCHEDULE_SEED=8036`:

| arm | exit | schedule verdict |
|---|---|---|
| prune off | 134 (SIGABRT, verifier) | `safepoints=3 scheduled_collections=2` |
| prune on | 0 | `safepoints=339 scheduled_collections=338 copying_minors=339 moved_objects=51458` |

The passing arm is not vacuous: 338 forced collections moved 51,458 objects.

## Tests

Three cases in `gc::tests::dead_owner_side_tables`, sabotage-verified (two of
three fail with the prune removed):

- `test_dead_function_class_id_key_pruned_on_full_gc`
- `test_live_function_class_id_key_survives_and_is_rekeyed_on_copied_minor`
  (safety inverse — passes both ways by design)
- `test_dead_function_class_id_key_cannot_follow_exact_eden_reuse` — the #8040
  shape end to end: under exact Eden reuse an unrelated closure at the recycled
  address must neither inherit the dead function's class id nor have the stale
  key rekeyed onto it across its own move.

Sabotage output (prune disabled):

```
test …::test_dead_function_class_id_key_cannot_follow_exact_eden_reuse ... FAILED
test …::test_dead_function_class_id_key_pruned_on_full_gc ... FAILED
test …::test_live_function_class_id_key_survives_and_is_rekeyed_on_copied_minor ... ok

assertion `left == right` failed: an unrelated closure allocated at the
recycled address must not inherit the dead function's synthetic class id
  left: 2181070914   right: 0
```

`cargo test -p perry-runtime --lib` → exit 0, `2421 passed; 0 failed; 4 ignored`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage collection cleanup for function class metadata.
  * Prevented stale closure references from persisting after objects are collected or memory addresses are reused.
  * Preserved and updated metadata for live closures when they move during collection.
* **Tests**
  * Added regression coverage for full and minor garbage collection scenarios, including address reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->