### PR TITLE
fix(ci): give the statepoints root-dominance job the node setup it needs

### DIFF
--- a/.github/workflows/gc-root-dominance.yml
+++ b/.github/workflows/gc-root-dominance.yml
@@ -473,6 +473,20 @@ jobs:
       - name: Immovable-source exemptions must still hold
         run: python3 scripts/gc_root_dominance_check.py --audit-immovable-sources
 
+      # #8170: the dependency-scale corpus this job runs (added by #8084)
+      # compiles `node_modules/zod`, so it needs the same node setup its
+      # sibling job has. Without these two steps the job dies in setup with
+      # "node_modules/zod/src/index.ts is missing" and never reaches the
+      # checker — which meant the arm covering the SHIPPED lowering
+      # (statepoints are the default on aarch64 and x86-64) reported nothing
+      # at all, while its shadow-frame sibling stayed green and made the gate
+      # look healthy.
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+      - name: Install the npm dependencies the dep corpus compiles
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       # This also puts a matched LLVM 22 `opt` on disk and exports

--- a/changelog.d/8170-statepoints-npm-ci.md
+++ b/changelog.d/8170-statepoints-npm-ci.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **`gc-root-dominance-statepoints` could not run its checker at all**, and had
+  failed on every `main` run and every PR since #8084 merged, with
+  `node_modules/zod/src/index.ts is missing; run npm ci --ignore-scripts`.
+
+  #8084 added the dependency-scale native corpus to the **statepoints** job.
+  That corpus compiles `node_modules/zod`, but the `actions/setup-node` and
+  `npm ci` steps that provide it lived only in the sibling `gc-root-dominance`
+  job. The statepoints job therefore died during setup, before the root-store
+  dominance checker ran.
+
+  This is worse than a red X. The statepoints arm is the one covering the
+  **shipped** lowering — RS4GC statepoints are the default on aarch64 and
+  x86-64 — while the green sibling covers the shadow-frame arm. So for a day
+  the gate looked like it was watching the default configuration and was
+  watching nothing, and it red-lighted every open PR, which trains reviewers
+  to ignore it. CLAUDE.md's hazards 2 and 4 at once.
+
+  The job now installs node the same way its sibling does, pinned by
+  `.node-version`, with `--ignore-scripts` for the same reason.


### PR DESCRIPTION
Closes #8170.

`gc-root-dominance-statepoints` has failed on **every `main` run and every PR since #8084 merged**, with:

```
##[error]node_modules/zod/src/index.ts is missing; run npm ci --ignore-scripts
##[error]Process completed with exit code 2.
```

## Cause

#8084 added the dependency-scale native corpus to the **statepoints** job. That corpus compiles `node_modules/zod`, but the two steps that make it available — `actions/setup-node` and `npm ci` — live only in the sibling `gc-root-dominance` job:

| step | `gc-root-dominance` | `gc-root-dominance-statepoints` |
|---|---|---|
| `actions/setup-node` | line 221 | **was absent** |
| `npm ci --ignore-scripts` | line 225 | **was absent** |
| `gc_root_dominance_dep_native_corpus.sh` | — | present |

So the job died during setup and never reached the checker.

## Why this is worse than a red X

The statepoints arm covers the **shipped** lowering — RS4GC statepoints are the default on aarch64 and x86-64 (`PERRY_RS4GC=0` is the bisection escape hatch). Its green sibling covers the shadow-frame arm, which is what watchOS `arm64_32` and ARM64 Windows use.

For a day, the gate that appears to watch the default configuration was reporting nothing about root-store dominance, while its sibling stayed green and made the pair look healthy. That is CLAUDE.md's hazard 4 — "the gate runs but its subject never did" — and because it also red-lighted every open PR, hazard 2 follows: reviewers learn to ignore the check.

Given that #7154's whole bug family is invisible to runtime GC probes and this static checker is the only instrument for it, having the statepoint arm dark is not cosmetic.

## The change

Fourteen lines: the same `actions/setup-node@v7` pinned by `.node-version` and the same `npm ci --ignore-scripts --no-audit --no-fund` the sibling job runs, placed before the Rust toolchain step. `--ignore-scripts` for the sibling's stated reason — nothing here needs a lifecycle script, and a corpus generator is a bad place to run one.

I matched the sibling at `@v7` rather than the `@v6` elsewhere in the file, since #7408 bumped that job and a version skew between two otherwise-identical steps invites drift.

## Verification

The honest limit: I can confirm the YAML parses and that both jobs now carry identical node setup, but **the real proof is this job going green in CI on this PR** — that is the first run where the statepoints arm will have executed its checker since #8084. Worth watching rather than assuming, because if the corpus then *finds* something, the job stays red for a genuine reason and that would be a real result rather than a regression from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statepoints validation reliability by ensuring required Node.js dependencies are installed before checks run.
  * Restored access to dependency corpus data used during statepoints coverage analysis.

* **Documentation**
  * Added a changelog entry describing the statepoints validation setup improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->