### PR TITLE
fix(gc): a doc comment on a macro invocation fails -D warnings

### DIFF
--- a/changelog.d/8176-unused-doc-comment.md
+++ b/changelog.d/8176-unused-doc-comment.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **`Warnings (product)` and `Warnings (host-compatible)` are green again.** Both
+  legs of the `rustc-warnings` gate ran with `RUSTFLAGS: -D warnings` and failed
+  on `main` and every PR with `error: unused doc comment`.
+
+  A `///` block sat directly above a `crate::perry_thread_local!` invocation in
+  `gc/roots/stack_maps.rs`. rustdoc discards a doc comment on a macro
+  invocation, so rustc warns — harmless as a warning everywhere else, fatal
+  under `-D warnings`. It arrived with #8084's #7803 native-slot verifier.
+
+  The text is worth keeping, so it becomes a plain `//` comment rather than
+  being deleted, with a note saying why it cannot be `///`.

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -206,15 +206,19 @@ impl StackMapIndexStore {
 
 static STACK_MAPS: StackMapIndexStore = StackMapIndexStore::new();
 
-/// #7803 creation-cycle verifier (diagnostic, `PERRY_GC_NATIVE_SLOT_VERIFY=1`).
-///
-/// Runs a SECOND, non-rewriting native-slot walk after the rewrite passes of
-/// a copying minor, while from-space is still classifiable, and aborts on the
-/// FIRST slot still naming a from-space address. A stale native slot whose
-/// target later becomes unclassifiable is skipped silently by every ordinary
-/// walk (`mark_addr` returns `None`), so the cycle that CREATED the staleness
-/// never printed anything — this names it, with the owning frame from the
-/// pin-latch context.
+// #7803 creation-cycle verifier (diagnostic, `PERRY_GC_NATIVE_SLOT_VERIFY=1`).
+//
+// Runs a SECOND, non-rewriting native-slot walk after the rewrite passes of
+// a copying minor, while from-space is still classifiable, and aborts on the
+// FIRST slot still naming a from-space address. A stale native slot whose
+// target later becomes unclassifiable is skipped silently by every ordinary
+// walk (`mark_addr` returns `None`), so the cycle that CREATED the staleness
+// never printed anything — this names it, with the owning frame from the
+// pin-latch context.
+//
+// `//` not `///`: rustdoc discards a doc comment on a macro invocation, and
+// `rustc-warnings` runs with `-D warnings`, so `///` here is a hard error in
+// that job (#8176). The text is worth keeping, so keep it as a plain comment.
 crate::perry_thread_local! {
     /// The rewrite walk's stats for the CURRENT cycle, published so the
     /// #7803 native-slot verifier can compare its own traversal against the


### PR DESCRIPTION
Closes #8176.

Both legs of `rustc-warnings` — `Warnings (product)` and `Warnings (host-compatible)` — have been red on `main` and every PR:

```
error: unused doc comment
error: could not compile `perry-runtime` (lib) due to 1 previous error
```

## Cause

A `///` block directly above a `crate::perry_thread_local!` invocation at `crates/perry-runtime/src/gc/roots/stack_maps.rs:209`. rustdoc discards a doc comment attached to a macro invocation, so rustc emits `unused_doc_comments`. That is cosmetic in every other job and **fatal** in this one, which runs `RUSTFLAGS: -D warnings`.

It arrived with #8084's #7803 native-slot verifier.

## The fix

`//` instead of `///`. The text explains why the verifier exists and is worth keeping, so it stays as a plain comment with a line recording why it cannot be a doc comment — otherwise the next person restores `///` and re-breaks the gate.

## Verified both directions

```
$ RUSTFLAGS="-D warnings" cargo check -p perry-runtime --lib     # on main
error: unused doc comment ... exit 101

$ RUSTFLAGS="-D warnings" cargo check -p perry-runtime --lib     # on this branch
exit 0, zero warnings
```

`cargo fmt --all -- --check` clean.

## Note on why this sat for a day

I saw this warning while validating #8084 and recorded it as pre-existing on the strength of it appearing in an unrelated build log. It was not pre-existing — it came in with that PR, and I merged it. The gate that would have caught it is the one it broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compiler warnings caused by documentation comments placed above macro invocations.
  * Preserved the existing diagnostic guidance while ensuring warning-free builds.

* **Documentation**
  * Added a changelog entry describing the warning fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->