### PR TITLE
fix(gc): refuse a forwarding walk out of, or into, a non-object, and give every rekeyed table a death story (#8174)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,6 +271,24 @@ jobs:
           python3 scripts/gc_runtime_root_holders.py --self-test
           python3 scripts/gc_runtime_root_holders.py
 
+      # #8174. A side table whose KEY is a raw heap address, REKEYED in place by
+      # `visit_metadata_*` (rewritten if the object moved, deliberately not
+      # marked), depends on `gc::dead_owner` dropping that key when the object
+      # dies. #8168 wired up the one table that had been missed; the invariant
+      # was otherwise maintained by a hand-written list happening to be
+      # complete, and a table added without a prune reappears days later as a
+      # `TypeError: value is not a function` in an unrelated function (#8040).
+      # This adjudicates every rekey site against the runtime registry: an
+      # unclassified site fails, and so does an exemption that matches nothing.
+      #
+      # Cheap and build-free, so it belongs in `lint`, which IS a required
+      # context (CLAUDE.md hazard 2).
+      - name: Rekeyed side-table custody audit
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/gc_rekeyed_key_tables.py --self-test
+          python3 scripts/gc_rekeyed_key_tables.py
+
       # #7877. A deleted GC knob left executable CI arms that still looked
       # distinct but selected the same collector. Derive the accepted names
       # from live runtime/codegen parsers; historical journals are path-exact

--- a/changelog.d/8196-rekeyed-side-table-custody.md
+++ b/changelog.d/8196-rekeyed-side-table-custody.md
@@ -1,0 +1,105 @@
+### `fix(gc)`: refuse a forwarding walk out of, or into, something that is not an object — and make the rekeyed-table prune structural (#8174)
+
+`GC_FLAG_FORWARDED` means "the first payload word is where this object moved
+to". Both forwarding walkers — `CopyingNurseryCollector::rewrite_raw_addr` and
+`gc::verify::try_rewrite_raw_addr` — trusted that byte for **any** address in a
+known heap region, and trusted whatever word they found behind it.
+
+For a slot the collector already proved is a live reference, both are safe. For
+a **metadata key** they are not. `RuntimeRootVisitor::visit_metadata_usize_slot`
+and its siblings rewrite a recorded raw heap address if a moving collection
+forwarded it and deliberately do **not** mark it — the key is a side table's
+key, not a reference the program can reach, so rooting it would leak. The price
+of that choice is that the key's object can die and the arena can recycle the
+address under it.
+
+#8040 is what that looks like, instrumented: recycled payload bytes at a dead
+`FUNCTION_CLASS_IDS` key presenting `gc_flags = 0x86` (`GC_FLAG_FORWARDED` set by
+coincidence), `obj_type = 104` — a type id no `GcTypeInfo` entry exists for — and
+a "forwarding pointer" that was really a NaN-boxed value (`0x7FFF…`). The walk
+followed it, could not classify the next hop, **stopped and returned it**, and
+`visit_metadata_nanbox_key` masked it to 48 bits into a live, unrelated
+survivor. A synthetic class's id was bound to an interned string, and the
+program failed several collections later, in a different function, with
+`TypeError: value is not a function`.
+
+#8168 removed that one dead key. This closes the following.
+
+**Two discriminators, one at each end of the hop** (`gc/forwarding.rs`, new):
+
+* `forwarding_walk_header` refuses to read a forwarding pointer out of an
+  address that does not read back as a real arena object header
+  (`plausible_gc_header`: registered `obj_type`, sane size, `GC_FLAG_ARENA`).
+  #8040's recycled bytes fail on `obj_type = 104`. Every real forwarding source
+  passes: `set_forwarding_address` overwrites one payload word and ORs one flag
+  bit, and all four production installers (`copying::move_young`, promotion,
+  `gc::oldgen` defrag, and `array::push_pop`'s growth stub, which requires
+  `GC_FLAG_ARENA` at install time) operate on arena objects. This is **not** the
+  `self.ptrs.classify()` gate that `rewrite_raw_addr`'s own doc records as
+  having un-rekeyed legitimate `shapes.entries` keys — that one additionally
+  narrows on SPACE and resolves the survivor thread-locals; the header test
+  carries none of that.
+* `accept_forwarding_target` refuses a target that is not the start of a heap
+  object, so a bogus word can no longer become the answer by virtue of the walk
+  merely stopping at it. On a registered arena range the target must read back
+  as a real object header; off-arena (an array-growth stub whose new head
+  outgrew the arena) it must at least pass `is_plausible_heap_addr`, which
+  rejects the handle band and everything at or above `HEAP_MAX` — which is what
+  the `0x7FFF…` word fails.
+
+Both are applied to the verifier too. That is not symmetry for its own sake:
+`try_rewrite_raw_addr` is what `RuntimeRootVisitMode::Verify` runs, and it panics
+whenever it can rewrite a slot the rewrite pass left alone, so tightening only
+one walker would have converted a silent corruption into a
+`PERRY_GC_VERIFY_EVACUATION` abort blaming an innocent scanner.
+
+Refusals are counted and, under `PERRY_GC_DIAG=1`, reported as
+`[gc-forwarding] <phase> refused_sources=… refused_targets=…` — printed **only**
+when non-zero, so a healthy run adds nothing to any log a gate parses and a line
+is a positive report that a stale forwarding header reached a rewrite walk.
+
+**The structural half.** `gc::dead_owner` is the real fix for this class: drop
+the entry before its dead key can be walked. Its fan-out covered a dozen tables
+and #8168 made it thirteen, but nothing checked that the list was complete —
+the invariant was maintained by hand, and a rekeyed table added without a prune
+reopens #8040 in a form that takes days to trace back.
+
+* `DEAD_KEY_PRUNES` (`gc/dead_owner.rs`) is now the registry `fan_out` iterates,
+  15 entries, each naming the tables it prunes and which of the pass's three
+  deadness predicates it takes.
+* `scripts/gc_rekeyed_key_tables.py` (wired into `lint`, a required context)
+  enumerates every `visit_metadata_*` call site in `perry-runtime` /
+  `perry-stdlib` — 38 of them — and requires a written verdict for each in
+  `scripts/gc_rekeyed_key_tables.json`. A `dead_owner:<fn>` verdict must name a
+  prune that is actually in the registry; a `self_pruned:<fn>` verdict must name
+  a function that exists; a new unclassified site fails; **an exemption that
+  matches nothing fails too**, so a fix must delete its own entry. Floors on the
+  site count and the registry parse make a broken regex exit 2 rather than
+  report a clean, empty, green run. `--self-test` plants twelve shapes — a new
+  site, a stale entry, a prune deleted from the registry, a `self_pruned` naming
+  a ghost, a verdict with no reasoning, an over-cap gap, an issue-less gap, both
+  floor rots, and a doc comment that must NOT count as a site — and requires the
+  checker to adjudicate each correctly.
+
+**What the audit found.** Six tables are rekeyed with no prune and no rooting.
+They are declared `open_gap` and capped at the count they land at, so the number
+can only go down: `CONSOLE_INSTANCES` (#8190), `BOXED_PRIMITIVE_PAYLOADS`
+(#8191), `TRANSITION_CACHE_GLOBAL`'s `prev_keys`/`key_ptr` (#8192),
+`ASYNC_STEP_GUARD.last_closure` (#8193), `REFLECT_METADATA.target_bits` (#8194),
+and `SYMBOL_ACCESSOR_PROPERTIES`'s owner half (#8195, which also leaks its
+accessor closures). Each closure must delete its own manifest entry.
+
+**Tests** (`gc/tests/forwarding_target_validation.rs`, 5 cases). The two
+sabotage cases plant #8040's shape verbatim and **assert the premise first** —
+that the pre-#8174 gate would have accepted the planted bytes — so a green run
+says the discriminator works rather than that nothing was tried. The premise
+case asserts the opposite direction: a genuine evacuation still rewrites and
+neither refusal counter moves, which is the property the rejected
+`classify()`-based tightening broke. The registry case asserts `DEAD_KEY_PRUNES`
+has not shrunk, that its labels are unique, and that #8168's `FUNCTION_CLASS_IDS`
+entry is still present with its `GC_TYPE_CLOSURE` narrowing.
+
+`scripts/gc_pin_sites.py` gains one allowlist entry: the planted `gc_flags =
+0x86` carries bit 2, but nothing is being pinned — the address is payload
+interior of a live allocation with no object at it, and rewriting the byte as
+named flags would misreport what #8040 actually observed.

--- a/changelog.d/8196-rekeyed-side-table-custody.md
+++ b/changelog.d/8196-rekeyed-side-table-custody.md
@@ -65,11 +65,11 @@ the invariant was maintained by hand, and a rekeyed table added without a prune
 reopens #8040 in a form that takes days to trace back.
 
 * `DEAD_KEY_PRUNES` (`gc/dead_owner.rs`) is now the registry `fan_out` iterates,
-  15 entries, each naming the tables it prunes and which of the pass's three
+  19 entries, each naming the tables it prunes and which of the pass's three
   deadness predicates it takes.
 * `scripts/gc_rekeyed_key_tables.py` (wired into `lint`, a required context)
   enumerates every `visit_metadata_*` call site in `perry-runtime` /
-  `perry-stdlib` — 38 of them — and requires a written verdict for each in
+  `perry-stdlib` — 37 of them — and requires a written verdict for each in
   `scripts/gc_rekeyed_key_tables.json`. A `dead_owner:<fn>` verdict must name a
   prune that is actually in the registry; a `self_pruned:<fn>` verdict must name
   a function that exists; a new unclassified site fails; **an exemption that
@@ -81,13 +81,44 @@ reopens #8040 in a form that takes days to trace back.
   floor rots, and a doc comment that must NOT count as a site — and requires the
   checker to adjudicate each correctly.
 
-**What the audit found.** Six tables are rekeyed with no prune and no rooting.
-They are declared `open_gap` and capped at the count they land at, so the number
-can only go down: `CONSOLE_INSTANCES` (#8190), `BOXED_PRIMITIVE_PAYLOADS`
-(#8191), `TRANSITION_CACHE_GLOBAL`'s `prev_keys`/`key_ptr` (#8192),
-`ASYNC_STEP_GUARD.last_closure` (#8193), `REFLECT_METADATA.target_bits` (#8194),
-and `SYMBOL_ACCESSOR_PROPERTIES`'s owner half (#8195, which also leaks its
-accessor closures). Each closure must delete its own manifest entry.
+**What the audit found, and what happened to it.** The gate's first run turned
+up six more rekeyed tables with no death story — live #8040 exposure, in six
+places, none of them previously named. All six are fixed here, so the manifest
+lands with **zero** declared gaps and `MAX_OPEN_GAPS = 0`:
+
+| table | fix | issue |
+|---|---|---|
+| `CONSOLE_INSTANCES` | `prune_dead_console_instance_owners` | #8190 |
+| `BOXED_PRIMITIVE_PAYLOADS` | `prune_dead_boxed_primitive_payload_owners` | #8191 |
+| `TRANSITION_CACHE_GLOBAL` (`prev_keys`, `key_ptr`) | `prune_dead_transition_cache_entries` | #8192 |
+| `ASYNC_STEP_GUARD.last_closure` | **field deleted** | #8193 |
+| `REFLECT_METADATA.target_bits` | `prune_dead_reflect_metadata_targets` | #8194 |
+| `SYMBOL_ACCESSOR_PROPERTIES` (owner half) | folded into `prune_dead_symbol_property_owners` | #8195 |
+
+#8193 is the one that is not a prune. `AsyncStepGuard::last_closure` held the
+address of the closure that took the last erroring async step, for a
+same-closure check that was **deleted** when #712/#921/#922 showed a runaway
+loop alternates between two closures. Nothing has read it since. It was not
+inert, though: it was a raw heap address the promise scanner rekeyed without
+marking, and nothing pruned it. Writing a prune to maintain state nobody reads
+would be its own dead code, so the field goes, and with it the
+`PROMISE_SCAN_ASYNC_STEP_GUARD` budgeted phase, whose only slot it was.
+
+#8195 is not a new prune either: the accessor table shares its owner key with
+`SYMBOL_PROPERTIES` and `SYMBOL_PROPERTY_ATTRS`, both pruned since the
+2026-07-09 audit, and was simply left out. It now takes the same pass's
+memoized owner verdict, so all three tables agree about every owner. That also
+closes a leak — the accessor closures in a dead owner's descriptors were
+immortal.
+
+Each of the four new prunes has a pair of cases in
+`gc/tests/dead_owner_side_tables.rs`: the prune **fires** (dead owner, one
+collection, the table observably shrinks) and its inverse (a rooted owner's
+entry survives — a prune that drops live entries is worse than the stale key it
+removes). The transition-cache case allocates its rooted `next_keys` in OLD-GEN
+on purpose: a reachable neighbour in the dead array's own nursery block would
+force-mark it (#7975) and the prune would correctly decline, which would have
+read as a failure of the prune.
 
 **Tests** (`gc/tests/forwarding_target_validation.rs`, 5 cases). The two
 sabotage cases plant #8040's shape verbatim and **assert the premise first** —

--- a/changelog.d/8196-rekeyed-side-table-custody.md
+++ b/changelog.d/8196-rekeyed-side-table-custody.md
@@ -134,3 +134,40 @@ entry is still present with its `GC_TYPE_CLOSURE` narrowing.
 0x86` carries bit 2, but nothing is being pinned — the address is payload
 interior of a live allocation with no object at it, and rewriting the byte as
 named flags would misreport what #8040 actually observed.
+
+**Evidence the six were real, not theoretical.** With only the two forwarding
+discriminators above and none of the prunes, the production Next App Route
+forced-evacuation workload (`tests/release/packages/next-app-route`, arm
+`PERRY_NEXT_ROUTE_FORCED_GC=1`) logged **988** `[gc-forwarding] refused_sources`
+events — stale forwarding headers reaching a rewrite walk, which before #8174
+would have been followed silently. With the six prunes in, the same workload
+logs **0**, across 458 copying minors and 182,977 copied objects. (Not a
+controlled A/B — the two runs did different amounts of GC work — but the
+refusals began on the first minors of the earlier run and are absent
+throughout the later one.)
+
+**End-to-end validation.** A churn fixture exercising every rekeyed surface
+(varied shapes, symbol properties, accessor descriptors, `Map`/`Set` +
+iterators, synthetic classes via plain-function prototypes, closure dynamic
+props, proxies with a `get` trap, `Reflect.get`, promises), 60 rounds × 120
+objects with a 3-round liveness window, under
+`PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED={8174,8040,1}
+PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1
+PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_DIAG=1`: 3,605–5,060 copying minors and
+296k–411k copied objects per seed (`gc_evacuation_liveness_assert.py` green, so
+the subject was live), a `[gc-fromspace-protect] retired_set=#N` line on every
+cycle, zero verify-evacuation panics, output byte-identical to the Node oracle,
+and **zero** `[gc-forwarding]` refusals — i.e. on a healthy workload the new
+discriminators refuse nothing, which is the evidence that no legitimate rewrite
+was lost.
+
+`cargo test -p perry-runtime --lib` 2514/0/4; `cargo test -p perry --bin perry`
+987/0; `cargo test -p perry-codegen --no-fail-fast` 1483/9, the same 9 by name
+as `main`.
+
+**Not fixed here**: #8163 is unaffected and stays open. Retested on
+`53e8a21e3`, the production App Route fixture's forced-evacuation arm still
+fails with `TypeError: value is not a function` (243 copying minors, 117,579
+objects copied, zero verify panics, normal arm green). This narrows what a
+stale key can be *followed* into; the holder losing that closure is a different
+defect.

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -645,6 +645,35 @@ thread_local! {
 
 pub(crate) const CONSOLE_INSTANCE_CLASS_ID: u32 = 0xFFFF_0083;
 
+/// #8190: death pruning for `CONSOLE_INSTANCES`.
+///
+/// The table is keyed by the raw heap address of a `new console.Console(...)`
+/// instance object, and `scan_console_log_singleton_roots_mut` **rekeys** that
+/// address when the object moves. A rekeyed table's dead key is not merely a
+/// leak — the arena recycles the address and the next rewrite pass reads the
+/// recycled bytes as a `GcHeader`. See `gc::dead_owner`'s module doc.
+pub(crate) fn prune_dead_console_instance_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    CONSOLE_INSTANCES.with(|instances| {
+        instances
+            .borrow_mut()
+            .retain(|&owner, _| !is_dead_owner(owner));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_console_instance_count() -> usize {
+    CONSOLE_INSTANCES.with(|instances| instances.borrow().len())
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_console_instance(owner: usize) {
+    CONSOLE_INSTANCES.with(|instances| {
+        instances
+            .borrow_mut()
+            .insert(owner, ConsoleInstanceState::default());
+    });
+}
+
 pub(crate) fn is_console_instance_method_name(method_name: &str) -> bool {
     matches!(
         method_name,
@@ -679,6 +708,7 @@ pub(crate) fn is_console_instance_value(value: f64) -> bool {
     unsafe { (*obj).class_id == CONSOLE_INSTANCE_CLASS_ID }
 }
 
+#[derive(Default)]
 struct ConsoleInstanceState {
     stdout: f64,
     stderr: f64,

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -14,10 +14,15 @@ mod boxed_primitives;
 mod collection_equality;
 pub(crate) use boxed_primitives::{
     boxed_primitive_json_value, boxed_primitive_payload, boxed_primitive_to_string_tag,
+    prune_dead_boxed_primitive_payload_owners,
 };
 pub use boxed_primitives::{
     js_boxed_bigint_new, js_boxed_boolean_new, js_boxed_number_new, js_boxed_string_new,
     js_boxed_symbol_new, scan_boxed_primitive_payload_roots_mut,
+};
+#[cfg(test)]
+pub(crate) use boxed_primitives::{
+    test_boxed_primitive_payload_count, test_seed_boxed_primitive_payload,
 };
 mod collections;
 mod identity_equality;

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -91,6 +91,30 @@ unsafe fn boxed_primitive_payload_for_object(
     Some((class_id, payload))
 }
 
+/// #8191: death pruning for `BOXED_PRIMITIVE_PAYLOADS`.
+///
+/// Keyed by a boxed-primitive wrapper's `ObjectHeader` address, and **rekeyed**
+/// by `scan_boxed_primitive_payload_roots_mut` when that object moves. A dead
+/// key on a rekeyed table is the #8040 shape, not a leak — see
+/// `gc::dead_owner`'s module doc.
+pub(crate) fn prune_dead_boxed_primitive_payload_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    BOXED_PRIMITIVE_PAYLOADS.with(|m| {
+        m.borrow_mut().retain(|&owner, _| !is_dead_owner(owner));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_boxed_primitive_payload_count() -> usize {
+    BOXED_PRIMITIVE_PAYLOADS.with(|m| m.borrow().len())
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_boxed_primitive_payload(owner: usize, payload_bits: u64) {
+    BOXED_PRIMITIVE_PAYLOADS.with(|m| {
+        m.borrow_mut().insert(owner, payload_bits);
+    });
+}
+
 fn register_boxed_primitive_payload(obj: *mut crate::object::ObjectHeader, payload: f64) {
     if obj.is_null() {
         return;

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -74,9 +74,11 @@ pub use console::{
 };
 
 pub(crate) use console::{
-    is_console_instance_method_name, is_console_instance_value,
+    is_console_instance_method_name, is_console_instance_value, prune_dead_console_instance_owners,
     try_console_instance_method_dispatch, CONSOLE_INSTANCE_CLASS_ID,
 };
+#[cfg(test)]
+pub(crate) use console::{test_console_instance_count, test_seed_console_instance};
 
 pub use formatting::{
     function_name_for_ptr, function_source_for_func_ptr, function_source_for_ptr, js_array_print,
@@ -90,8 +92,13 @@ pub use formatting::{
 pub(crate) use formatting::{
     boxed_primitive_json_value, boxed_primitive_payload, boxed_primitive_to_string_tag,
     format_finite_number_js, format_jsvalue, is_negative_zero, jsvalue_string_content,
-    InspectCompactGuard, InspectCustomInspectGuard, InspectDepthLimitGuard, InspectGettersGuard,
-    InspectShowHiddenGuard, InspectSortedGuard, INT_EXACT_FASTPATH_LIMIT,
+    prune_dead_boxed_primitive_payload_owners, InspectCompactGuard, InspectCustomInspectGuard,
+    InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard, InspectSortedGuard,
+    INT_EXACT_FASTPATH_LIMIT,
+};
+#[cfg(test)]
+pub(crate) use formatting::{
+    test_boxed_primitive_payload_count, test_seed_boxed_primitive_payload,
 };
 
 pub use globals::{

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -315,6 +315,34 @@ impl CopyingNurseryCollector {
     /// `try_rewrite_raw_addr`'s 64-hop cap and `next == 0 || next == current`
     /// stops, returning `rewrote.then_some(current)` (Some only when the
     /// address actually moved).
+    ///
+    /// #8174: the heap-region gate answers "could this address carry a
+    /// forwarding header", NOT "is this a live object" — mid-cycle there is no
+    /// census to ask, which is why `self.ptrs.classify()` cannot be used here.
+    /// So a DEAD key whose address the arena recycled reaches the header read,
+    /// and the recycled payload bytes can carry `GC_FLAG_FORWARDED` by
+    /// coincidence (#8040: `gc_flags = 0x86`, `obj_type = 104`). What made that
+    /// corrupt rather than merely useless was the *target*: the walk accepted a
+    /// NaN-boxed word as a forwarding pointer, stopped one hop later because it
+    /// did not classify, and RETURNED it — after which
+    /// `visit_metadata_nanbox_key` masked it to 48 bits and named a live,
+    /// unrelated survivor.
+    ///
+    /// Two discriminators close that, at both ends of the hop:
+    ///
+    /// * [`forwarding_walk_header`] refuses to read a forwarding pointer out of
+    ///   an address that does not read back as a real arena object header.
+    ///   #8040's recycled bytes carried `obj_type = 104`, which no `GcTypeInfo`
+    ///   entry exists for, so the walk now stops before the flag test. This is
+    ///   NOT the `self.ptrs.classify()` gate rejected above — that one narrows
+    ///   on SPACE as well, which is what un-rekeyed legitimate `shapes.entries`
+    ///   keys; the header test carries none of that.
+    /// * [`accept_forwarding_target`] refuses a target that is not the start of
+    ///   a heap object, so a bogus word cannot become the answer by virtue of
+    ///   the walk merely stopping at it.
+    ///
+    /// The in-loop `current < GC_HEADER_SIZE` guard went with them: every value
+    /// `current` can take has passed one of the two checks on the way in.
     pub(super) fn rewrite_raw_addr(&self, addr: usize) -> Option<usize> {
         if addr < GC_HEADER_SIZE {
             return None;
@@ -322,17 +350,9 @@ impl CopyingNurseryCollector {
         let mut current = addr;
         let mut rewrote = false;
         for _ in 0..64 {
-            if current < GC_HEADER_SIZE {
+            let Some(header) = forwarding_walk_header(current) else {
                 return rewrote.then_some(current);
-            }
-            let header_addr = current - GC_HEADER_SIZE;
-            if matches!(
-                crate::arena::classify_heap_space(header_addr),
-                crate::arena::HeapSpace::Unknown
-            ) {
-                return rewrote.then_some(current);
-            }
-            let header = header_addr as *mut GcHeader;
+            };
             unsafe {
                 if (*header).gc_flags & GC_FLAG_FORWARDED == 0 {
                     return rewrote.then_some(current);
@@ -340,6 +360,9 @@ impl CopyingNurseryCollector {
                 let next = forwarding_address(header) as usize;
                 if next == 0 || next == current {
                     return rewrote.then_some(current);
+                }
+                if !accept_forwarding_target(next) {
+                    return None;
                 }
                 current = next;
                 rewrote = true;
@@ -1746,6 +1769,7 @@ pub(super) fn run_copied_minor_attempt(
             super::policy::GC_AT_DECLARED_SAFEPOINT.with(std::cell::Cell::get)
         );
     }
+    report_forwarding_refusals("copying_minor");
     super::scanner_profile::report_and_reset("copying_minor");
     CopiedMinorAttempt::Done(Some(CopiedMinorFastPathOutcome {
         freed_bytes,

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -1,10 +1,13 @@
 //! Death pruning for object-ADDRESS-keyed side tables (2026-07-09 GC audit,
 //! wave 2 batch B).
 //!
-//! Around a dozen runtime side tables are keyed by the raw address of an
-//! owning heap object (descriptor tables, symbol-keyed properties, closure
+//! Nineteen runtime side tables are keyed by the raw address of an owning heap
+//! object (descriptor tables, symbol-keyed properties and accessors, closure
 //! dynamic props, arguments metadata, recorded prototypes, exotic expandos,
-//! array expandos and iterator brands, `node:vm` metadata, fs FileHandle fds).
+//! array expandos and iterator brands, the shape and transition caches,
+//! synthetic class ids, console instances, boxed-primitive payloads,
+//! reflect-metadata targets, `node:vm` metadata, fs FileHandle fds) — see
+//! [`DEAD_KEY_PRUNES`], which is the authoritative list.
 //! The owning GC types mostly have no
 //! finalize hook, so nothing told those tables when the owner died: entries —
 //! and any strongly-rooted values inside them (accessor closures, symbol
@@ -359,6 +362,30 @@ pub(super) const DEAD_KEY_PRUNES: &[DeadKeyPrune] = &[
         table: "FILEHANDLE_OBJECT_FDS",
         owner: DeadKeyOwner::Any,
         prune: crate::fs::prune_dead_filehandle_fd_entries,
+    },
+    // #8190/#8191/#8192/#8194: four more REKEYED tables that the #8174 audit
+    // found had no death story at all. Each is the #8040 shape — see this
+    // module's doc — and each entry is what
+    // `scripts/gc_rekeyed_key_tables.json` now points its verdict at.
+    DeadKeyPrune {
+        table: "CONSOLE_INSTANCES",
+        owner: DeadKeyOwner::Any,
+        prune: crate::builtins::prune_dead_console_instance_owners,
+    },
+    DeadKeyPrune {
+        table: "BOXED_PRIMITIVE_PAYLOADS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::builtins::prune_dead_boxed_primitive_payload_owners,
+    },
+    DeadKeyPrune {
+        table: "TRANSITION_CACHE_GLOBAL",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::prune_dead_transition_cache_entries,
+    },
+    DeadKeyPrune {
+        table: "REFLECT_METADATA",
+        owner: DeadKeyOwner::Any,
+        prune: crate::proxy::prune_dead_reflect_metadata_targets,
     },
 ];
 

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -12,6 +12,28 @@
 //! allocated at the recycled address inherited the dead owner's entries (the
 //! ABA hazard behind e.g. "read-only property" errors on fresh objects).
 //!
+//! ★ #8174 — WHY THE LIST IS A REGISTRY NOW. For a table that is REKEYED
+//! rather than re-derived (its key slot is rewritten in place by
+//! `RuntimeRootVisitor::visit_metadata_*`), a missing prune is not a leak. The
+//! arena recycles the dead key's address, the recycled bytes are read as a
+//! `GcHeader`, and a coincidental `GC_FLAG_FORWARDED` byte makes the next
+//! cycle's rewrite pass follow a garbage forwarding pointer — #8040, which cost
+//! days to trace back from a `TypeError: value is not a function` in an
+//! unrelated function. #8168 wired up the one table that had been missed, and
+//! nothing was checking for the next one. [`DEAD_KEY_PRUNES`] below is the list
+//! `fan_out` iterates, and `scripts/gc_rekeyed_key_tables.py` reads it: every
+//! rekey site in the tree needs a written verdict in
+//! `scripts/gc_rekeyed_key_tables.json`, a `dead_owner:` verdict must name a
+//! prune that is actually in this array, and an exemption that matches nothing
+//! fails too. Adding a rekeyed table without a prune is now a build failure.
+//!
+//! Note the ORDER on the copying minor: the rewrite pass runs BEFORE this
+//! prune (`copying.rs` rewrites, then
+//! `finalize_dead_copied_minor_from_space_side_allocations` prunes). A prune
+//! therefore protects the NEXT cycle, which is sound only because the address
+//! is not recycled until `copying_reset_from_spaces_and_flip`, strictly later
+//! still.
+//!
 //! This module supplies the two deadness predicates and the fan-out passes,
 //! mirroring the proven Map/Set pattern (`map.rs`:
 //! `collect_dead_registered_maps_post_trace` /
@@ -208,6 +230,138 @@ pub(super) fn prune_dead_owner_side_tables_copied_minor() {
     );
 }
 
+/// Which of the pass's three deadness predicates a registered prune is handed.
+///
+/// Narrowing is not cosmetic: `Closure` and `Symbol` additionally require the
+/// header's `obj_type` to match, which is what stops a prune from adjudicating
+/// an address that has already been recycled as some other kind of object.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DeadKeyOwner {
+    /// Any registered GC type.
+    Any,
+    /// `GC_TYPE_CLOSURE` only.
+    Closure,
+    /// `GC_TYPE_STRING` only — symbols are `gc_malloc`'d with that type.
+    Symbol,
+}
+
+/// One address-keyed side table whose dead keys this pass drops.
+pub(super) struct DeadKeyPrune {
+    /// The declaration this prunes, as `scripts/gc_rekeyed_key_tables.py`
+    /// names it. Several prunes cover more than one table; the label lists
+    /// them so the registry reads as an inventory rather than a call list.
+    /// Read by that script and by `gc::tests::dead_owner_side_tables`, neither
+    /// of which is a compilation unit the dead-code pass can see.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(super) table: &'static str,
+    pub(super) owner: DeadKeyOwner,
+    pub(super) prune: fn(&dyn Fn(usize) -> bool),
+}
+
+/// THE REGISTRY (#8174).
+///
+/// `fan_out` iterates this instead of naming a dozen prunes inline, and
+/// `scripts/gc_rekeyed_key_tables.py` reads it: a `dead_owner:<fn>` verdict in
+/// `scripts/gc_rekeyed_key_tables.json` must name a prune that is in here, so
+/// deleting an entry fails the gate rather than silently reopening #8040.
+///
+/// A table that is REKEYED (`RuntimeRootVisitor::visit_metadata_*` rewrites its
+/// key without marking it) and is NOT in here has no death story, and a dead
+/// key on such a table is not merely a leak — see `rewrite_raw_addr`'s #8174
+/// note. The gate's job is to make that a build failure the day the table is
+/// added, instead of a `TypeError: value is not a function` days later.
+///
+/// The converse is deliberately NOT required: three of these prune tables that
+/// are re-keyed by a per-object move hook (`gc_type_after_payload_move`) rather
+/// than by a metadata visitor, so they have no `visit_metadata_*` site at all.
+pub(super) const DEAD_KEY_PRUNES: &[DeadKeyPrune] = &[
+    DeadKeyPrune {
+        table: "ARRAY_NAMED_PROPS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::array::prune_dead_array_named_property_owners,
+    },
+    // Re-keyed by the per-object move hook, not by a metadata visitor.
+    DeadKeyPrune {
+        table: "ELEMENT_SHAPES",
+        owner: DeadKeyOwner::Any,
+        prune: crate::array::prune_dead_element_shape_owners,
+    },
+    DeadKeyPrune {
+        table: "MAP_ITERATOR_ARRAYS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::map::prune_dead_map_iterator_array_owners,
+    },
+    DeadKeyPrune {
+        table: "SET_ITERATOR_ARRAYS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::set::prune_dead_set_iterator_array_owners,
+    },
+    DeadKeyPrune {
+        table: "state().descriptors.property_descriptors + .accessor_descriptors",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::prune_dead_descriptor_owner_entries,
+    },
+    DeadKeyPrune {
+        table: "ARGUMENTS_OBJECTS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::prune_dead_arguments_object_entries,
+    },
+    // Re-keyed by the per-object move hook, not by a metadata visitor.
+    DeadKeyPrune {
+        table: "OBJECT_PROTOTYPES",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::prototype_chain::prune_dead_object_prototype_owners,
+    },
+    // #6759 C1: shape records are keyed on keys_array addresses; drop the
+    // ones whose keys_array died (memory only — per-hit validation covers
+    // correctness for anything this misses).
+    DeadKeyPrune {
+        table: "state().shapes.inner (descriptors + indices)",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::shapes::prune_dead_shape_keys,
+    },
+    // Re-keyed by the per-object move hook, not by a metadata visitor.
+    DeadKeyPrune {
+        table: "state().exotic_expando.entries",
+        owner: DeadKeyOwner::Any,
+        prune: crate::object::exotic_expando::prune_dead_exotic_expando_owners,
+    },
+    DeadKeyPrune {
+        table: "SYMBOL_PROPERTIES + SYMBOL_PROPERTY_ATTRS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::symbol::prune_dead_symbol_property_owners,
+    },
+    DeadKeyPrune {
+        table: "SYMBOL_POINTERS",
+        owner: DeadKeyOwner::Symbol,
+        prune: crate::symbol::prune_dead_symbol_pointers,
+    },
+    DeadKeyPrune {
+        table: "CLOSURE_PROPS + CLOSURE_STATIC_PROTOTYPES + CLOSURE_DELETED_KEYS",
+        owner: DeadKeyOwner::Closure,
+        prune: crate::closure::prune_dead_closure_side_table_owners,
+    },
+    // #8040: `FUNCTION_CLASS_IDS` is keyed by a synthetic-class function
+    // value's closure address, and is REKEYED (not re-derived) when that
+    // closure moves — so a dead key does not merely leak, the rekey walk
+    // follows whatever the recycled bytes at that address look like.
+    DeadKeyPrune {
+        table: "FUNCTION_CLASS_IDS",
+        owner: DeadKeyOwner::Closure,
+        prune: crate::object::prune_dead_function_class_id_keys,
+    },
+    DeadKeyPrune {
+        table: "VM_CONTEXTS + VM_SCRIPTS + VM_FUNCTIONS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::node_vm::prune_dead_vm_owner_entries,
+    },
+    DeadKeyPrune {
+        table: "FILEHANDLE_OBJECT_FDS",
+        owner: DeadKeyOwner::Any,
+        prune: crate::fs::prune_dead_filehandle_fd_entries,
+    },
+];
+
 fn fan_out(
     is_dead_owner: &dyn Fn(usize) -> bool,
     is_dead_closure: &dyn Fn(usize) -> bool,
@@ -219,26 +373,12 @@ fn fan_out(
     // object's property lookup changes its answer. See
     // `prop_plan_gc_epoch_bump`.
     crate::object::prop_plan::prop_plan_gc_epoch_bump();
-    crate::array::prune_dead_array_named_property_owners(is_dead_owner);
-    crate::array::prune_dead_element_shape_owners(is_dead_owner);
-    crate::map::prune_dead_map_iterator_array_owners(is_dead_owner);
-    crate::set::prune_dead_set_iterator_array_owners(is_dead_owner);
-    crate::object::prune_dead_descriptor_owner_entries(is_dead_owner);
-    crate::object::prune_dead_arguments_object_entries(is_dead_owner);
-    crate::object::prototype_chain::prune_dead_object_prototype_owners(is_dead_owner);
-    // #6759 C1: shape records are keyed on keys_array addresses; drop the
-    // ones whose keys_array died (memory only — per-hit validation covers
-    // correctness for anything this misses).
-    crate::object::shapes::prune_dead_shape_keys(is_dead_owner);
-    crate::object::exotic_expando::prune_dead_exotic_expando_owners(is_dead_owner);
-    crate::symbol::prune_dead_symbol_property_owners(is_dead_owner);
-    crate::symbol::prune_dead_symbol_pointers(is_dead_symbol);
-    crate::closure::prune_dead_closure_side_table_owners(is_dead_closure);
-    // #8040: `FUNCTION_CLASS_IDS` is keyed by a synthetic-class function
-    // value's closure address, and is REKEYED (not re-derived) when that
-    // closure moves — so a dead key does not merely leak, the rekey walk
-    // follows whatever the recycled bytes at that address look like.
-    crate::object::prune_dead_function_class_id_keys(is_dead_closure);
-    crate::node_vm::prune_dead_vm_owner_entries(is_dead_owner);
-    crate::fs::prune_dead_filehandle_fd_entries(is_dead_owner);
+    for entry in DEAD_KEY_PRUNES {
+        let is_dead: &dyn Fn(usize) -> bool = match entry.owner {
+            DeadKeyOwner::Any => is_dead_owner,
+            DeadKeyOwner::Closure => is_dead_closure,
+            DeadKeyOwner::Symbol => is_dead_symbol,
+        };
+        (entry.prune)(is_dead);
+    }
 }

--- a/crates/perry-runtime/src/gc/forwarding.rs
+++ b/crates/perry-runtime/src/gc/forwarding.rs
@@ -50,6 +50,31 @@ pub(crate) fn refused_forwarding_target_count() -> u64 {
 crate::perry_thread_local! {
     static REPORTED_SOURCES: Cell<u64> = const { Cell::new(0) };
     static REPORTED_TARGETS: Cell<u64> = const { Cell::new(0) };
+    /// Refusals attributed to the named root-scanner walk that produced them
+    /// (`pin::CopyingWalkPhaseGuard`), reset at each report.
+    ///
+    /// The aggregate says a stale key reached a rewrite walk. This says WHICH
+    /// TABLE's key it was, which is the whole distance between "there is a bug
+    /// of the #8040 shape somewhere in the tree" and a fix — #8040 itself took
+    /// days to attribute. Bounded by the registered-scanner count, and only
+    /// populated when diagnostics are on.
+    static REFUSALS_BY_WALK: RefCell<Vec<(&'static str, u64)>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+fn note_refusal_walk() {
+    if !crate::gc::gc_diag_enabled() {
+        return;
+    }
+    let name = super::pin::copying_walk_phase().unwrap_or("(outside a named walk)");
+    REFUSALS_BY_WALK.with(|rows| {
+        let mut rows = rows.borrow_mut();
+        if let Some(row) = rows.iter_mut().find(|(n, _)| *n == name) {
+            row.1 += 1;
+        } else {
+            rows.push((name, 1));
+        }
+    });
 }
 
 /// Report the refusals since the last call, and only when there were any.
@@ -69,22 +94,34 @@ pub(super) fn report_forwarding_refusals(phase: &str) {
     let new_targets = targets - REPORTED_TARGETS.with(Cell::get);
     REPORTED_SOURCES.with(|c| c.set(sources));
     REPORTED_TARGETS.with(|c| c.set(targets));
+    let by_walk = REFUSALS_BY_WALK.with(|rows| std::mem::take(&mut *rows.borrow_mut()));
     if new_sources == 0 && new_targets == 0 {
         return;
     }
+    let mut attribution = String::new();
+    for (name, count) in &by_walk {
+        if !attribution.is_empty() {
+            attribution.push(',');
+        }
+        attribution.push_str(name);
+        attribution.push('=');
+        attribution.push_str(&count.to_string());
+    }
     eprintln!(
-        "[gc-forwarding] {phase} refused_sources={new_sources}          refused_targets={new_targets} total_sources={sources}          total_targets={targets}"
+        "[gc-forwarding] {phase} refused_sources={new_sources} refused_targets={new_targets} total_sources={sources} total_targets={targets} by_walk=[{attribution}]"
     );
 }
 
 #[cold]
 fn note_refused_forwarding_source() {
     REFUSED_FORWARDING_SOURCES.with(|c| c.set(c.get().saturating_add(1)));
+    note_refusal_walk();
 }
 
 #[cold]
 fn note_refused_forwarding_target() {
     REFUSED_FORWARDING_TARGETS.with(|c| c.set(c.get().saturating_add(1)));
+    note_refusal_walk();
 }
 
 /// The header to read a forwarding pointer out of, or `None` to stop the walk.

--- a/crates/perry-runtime/src/gc/forwarding.rs
+++ b/crates/perry-runtime/src/gc/forwarding.rs
@@ -1,0 +1,174 @@
+//! Validation for the *target* of a forwarding pointer (#8174).
+//!
+//! `GC_FLAG_FORWARDED` says "the first payload word of this object is the
+//! address it moved to". Both forwarding walkers —
+//! [`CopyingNurseryCollector::rewrite_raw_addr`](super::copying) and
+//! [`try_rewrite_raw_addr`](super::verify) — used to trust that word
+//! unconditionally: whatever it held became the answer, and if it did not
+//! classify as heap the walk simply *stopped there* and returned it.
+//!
+//! That is safe for a slot the collector already proved is a live reference,
+//! and it is not safe for a **metadata key** (`RuntimeRootVisitor::
+//! visit_metadata_*`), which is deliberately NOT a root: its object may have
+//! died, the arena may have recycled the address, and the recycled payload
+//! bytes then get read as a `GcHeader`. #8040 hit exactly that — recycled
+//! bytes with `gc_flags = 0x86` (`GC_FLAG_FORWARDED` set), `obj_type = 104`,
+//! whose "forwarding pointer" was a NaN-boxed value (`0x7FFF…`). The walk
+//! stopped after one hop and returned it; the caller masked it to 48 bits and
+//! got a live, unrelated survivor. The class id of a synthetic class was then
+//! bound to an interned string, and the program failed several collections
+//! later with `TypeError: value is not a function`.
+//!
+//! #8168 removed the one dead key that reached this. This module removes the
+//! *following*: a forwarding target that is not the start of a heap object is
+//! refused outright rather than returned as an address.
+
+use super::*;
+
+crate::perry_thread_local! {
+    /// Forwarding walks refused because the address being walked did not read
+    /// back as a real arena object header.
+    static REFUSED_FORWARDING_SOURCES: Cell<u64> = const { Cell::new(0) };
+    /// Forwarding walks refused because the *target* word was not an object
+    /// start.
+    static REFUSED_FORWARDING_TARGETS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Running count of addresses this thread declined to read a forwarding
+/// header out of. Non-zero means a stale key reached a forwarding walk — the
+/// shape of #8040 — so a test that plants one can assert it moved, and a fix
+/// can assert it went back to zero.
+pub(crate) fn refused_forwarding_source_count() -> u64 {
+    REFUSED_FORWARDING_SOURCES.with(Cell::get)
+}
+
+/// Running count of forwarding targets this thread declined to follow.
+pub(crate) fn refused_forwarding_target_count() -> u64 {
+    REFUSED_FORWARDING_TARGETS.with(Cell::get)
+}
+
+crate::perry_thread_local! {
+    static REPORTED_SOURCES: Cell<u64> = const { Cell::new(0) };
+    static REPORTED_TARGETS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Report the refusals since the last call, and only when there were any.
+///
+/// A healthy run prints nothing at all, so this cannot perturb a log any gate
+/// parses. A line here is a POSITIVE report that a stale or corrupt
+/// `GC_FLAG_FORWARDED` header reached a rewrite walk — the #8040 signal, which
+/// until now was invisible until it corrupted something several collections
+/// later in an unrelated function.
+pub(super) fn report_forwarding_refusals(phase: &str) {
+    if !crate::gc::gc_diag_enabled() {
+        return;
+    }
+    let sources = refused_forwarding_source_count();
+    let targets = refused_forwarding_target_count();
+    let new_sources = sources - REPORTED_SOURCES.with(Cell::get);
+    let new_targets = targets - REPORTED_TARGETS.with(Cell::get);
+    REPORTED_SOURCES.with(|c| c.set(sources));
+    REPORTED_TARGETS.with(|c| c.set(targets));
+    if new_sources == 0 && new_targets == 0 {
+        return;
+    }
+    eprintln!(
+        "[gc-forwarding] {phase} refused_sources={new_sources}          refused_targets={new_targets} total_sources={sources}          total_targets={targets}"
+    );
+}
+
+#[cold]
+fn note_refused_forwarding_source() {
+    REFUSED_FORWARDING_SOURCES.with(|c| c.set(c.get().saturating_add(1)));
+}
+
+#[cold]
+fn note_refused_forwarding_target() {
+    REFUSED_FORWARDING_TARGETS.with(|c| c.set(c.get().saturating_add(1)));
+}
+
+/// The header to read a forwarding pointer out of, or `None` to stop the walk.
+///
+/// The previous gate was `classify_heap_space(addr - 8) != Unknown`, i.e.
+/// "could this address be in the heap". That admits any recycled byte in the
+/// arena, and #8040's recycled bytes duly presented `gc_flags = 0x86` with
+/// `obj_type = 104` — a type id no `GcTypeInfo` entry exists for.
+/// [`plausible_gc_header`] rejects exactly that, and every real forwarding
+/// source passes it: `set_forwarding_address` overwrites the first payload
+/// word and ORs one flag bit, leaving `obj_type`, `size` and `GC_FLAG_ARENA`
+/// intact, and the only production installers of a forwarding pointer
+/// (`copying::move_young`, promotion, `gc::oldgen` defrag, and
+/// `array::push_pop`'s growth stub, which requires `GC_FLAG_ARENA` at install
+/// time) all operate on arena objects.
+///
+/// This is NOT the `self.ptrs.classify()` gate that
+/// `CopyingNurseryCollector::rewrite_raw_addr` documents as having broken
+/// `shapes.entries`. That one additionally narrows on SPACE and resolves the
+/// active/inactive survivor thread-locals, which is what rejected legitimate
+/// from-space keys. The header test carries none of that.
+pub(super) fn forwarding_walk_header(user_addr: usize) -> Option<*mut GcHeader> {
+    if user_addr < GC_HEADER_SIZE {
+        return None;
+    }
+    // #7742: one page-map probe answers both classifications. The range base
+    // is the guard that keeps a garbage candidate at the very start of a
+    // registered range from becoming a read of the unmapped page below it.
+    let (_space, range_base) = crate::arena::classify_heap_space_in_range(user_addr)?;
+    let header_addr = user_addr - GC_HEADER_SIZE;
+    if header_addr < range_base {
+        return None;
+    }
+    let header = header_addr as *mut GcHeader;
+    if !unsafe { plausible_gc_header(header, true) } {
+        note_refused_forwarding_source();
+        return None;
+    }
+    Some(header)
+}
+
+/// Is `user_addr` a plausible destination for a forwarding pointer — the
+/// start of a heap object, rather than a word that merely happens to sit
+/// where a forwarding pointer would?
+///
+/// Two arms, because the two kinds of legitimate target admit different
+/// evidence:
+///
+/// * **On a registered arena range** the header is mapped by construction, so
+///   the strongest test available applies: it must read back as a real arena
+///   object header ([`plausible_gc_header`] — registered `obj_type`, sane
+///   size, `GC_FLAG_ARENA`). Every GC-installed forwarding pointer (evacuation
+///   in `copying::move_young`, promotion, old-gen defrag in `gc::oldgen`)
+///   lands here.
+/// * **Off-arena**, the one legitimate target is a malloc'd allocation: an
+///   array-growth stub whose new head outgrew the arena
+///   (`array::push_pop::install_array_growth_forwarding_with`, #233). The
+///   malloc registry cannot be consulted from here without forcing the
+///   registry build that `gc::dead_owner`'s `PostTraceProbe` documents as a
+///   state transition the fallback mark-sweep path must not make, so this arm
+///   keeps the magnitude test and no more. That is still strictly more than
+///   the previous code did: `is_plausible_heap_addr` rejects the handle band
+///   and everything at or above `HEAP_MAX` (`0x8000_0000_0000`), which is what
+///   makes the NaN-boxed `0x7FFF…` word from #8040 fail here.
+pub(super) fn forwarding_target_is_object_start(user_addr: usize) -> bool {
+    if user_addr < GC_HEADER_SIZE {
+        return false;
+    }
+    if let Some((_space, range_base)) = crate::arena::classify_heap_space_in_range(user_addr) {
+        let header_addr = user_addr - GC_HEADER_SIZE;
+        return header_addr >= range_base
+            && unsafe { plausible_gc_header(header_addr as *mut GcHeader, true) };
+    }
+    crate::value::addr_class::is_plausible_heap_addr(user_addr)
+}
+
+/// [`forwarding_target_is_object_start`] plus the refusal census. Call this
+/// from a forwarding walk; `false` means "do not follow, and do not return
+/// this address either".
+#[inline]
+pub(super) fn accept_forwarding_target(user_addr: usize) -> bool {
+    if forwarding_target_is_object_start(user_addr) {
+        return true;
+    }
+    note_refused_forwarding_target();
+    false
+}

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -141,6 +141,8 @@ mod prefetch;
 mod copying;
 mod copying_first_cycle;
 mod copying_pointer_set;
+/// #8174: shared validation for the TARGET of a forwarding pointer.
+mod forwarding;
 /// Per-scanner root attribution for the copied-minor root scan (#7915).
 mod scanner_profile;
 mod sticky_remembered;
@@ -149,6 +151,7 @@ use copying_first_cycle::*;
 // Named rather than glob-imported: a glob does not propagate through the
 // transitive re-exports the gc submodules reach these through.
 use copying_pointer_set::{plausible_gc_header, CopyingPointer, CopyingPointerKind};
+use forwarding::*;
 use sticky_remembered::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry
 // pass in `crate::weakref` (#6182), which lives outside the gc module.

--- a/crates/perry-runtime/src/gc/pin.rs
+++ b/crates/perry-runtime/src/gc/pin.rs
@@ -106,7 +106,7 @@ impl Drop for CopyingWalkPhaseGuard {
     }
 }
 
-fn copying_walk_phase() -> Option<&'static str> {
+pub(super) fn copying_walk_phase() -> Option<&'static str> {
     COPYING_WALK_PHASE.with(|c| c.get())
 }
 

--- a/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
@@ -1362,3 +1362,269 @@ fn test_dead_function_class_id_key_cannot_follow_exact_eden_reuse() {
         "no FUNCTION_CLASS_IDS entry may outlive its closure"
     );
 }
+
+// ── The four tables the #8174 audit found REKEYED with no death story ───────
+//
+// #8168 wired `FUNCTION_CLASS_IDS` into the fan-out above. The registry gate
+// that came with #8174 (`scripts/gc_rekeyed_key_tables.py`) then enumerated
+// every `visit_metadata_*` site in the tree and asked the same question of each
+// — and found four more tables with no prune and no rooting, plus a fifth
+// (`SYMBOL_ACCESSOR_PROPERTIES`) whose sibling tables were pruned while it was
+// not. Each is the same hazard: the key is rewritten if the object moves and
+// deliberately not marked, so it can go stale, and a stale key on a REKEYED
+// table is followed into recycled bytes.
+//
+// Every case below asserts the prune FIRES (a dead owner's entry is gone) and
+// is paired with the inverse (a live owner's entry is not), because a prune
+// that drops live entries is a worse bug than the one it fixes.
+
+fn alloc_nursery_test_object_addr() -> usize {
+    let (obj, _) = unsafe { alloc_nursery_test_object(0) };
+    obj as usize
+}
+
+/// #8190. `CONSOLE_INSTANCES` is keyed by a `new console.Console(...)`
+/// instance's heap address and rekeyed by
+/// `scan_console_log_singleton_roots_mut`.
+#[test]
+fn test_dead_console_instance_owner_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let dead = alloc_nursery_test_object_addr();
+    crate::builtins::test_seed_console_instance(dead);
+    assert_eq!(
+        crate::builtins::test_console_instance_count(),
+        1,
+        "test premise: the instance entry must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::builtins::test_console_instance_count(),
+        0,
+        "a dead console instance's CONSOLE_INSTANCES entry must be pruned"
+    );
+}
+
+#[test]
+fn test_live_console_instance_owner_survives_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let live = alloc_nursery_test_object_addr();
+    js_shadow_slot_set(0, ptr_bits(live));
+    crate::builtins::test_seed_console_instance(live);
+
+    full_gc();
+
+    assert_eq!(
+        crate::builtins::test_console_instance_count(),
+        1,
+        "a ROOTED console instance's entry must survive — a prune that drops \
+         live entries is worse than the stale key it removes"
+    );
+    js_shadow_slot_set(0, 0);
+}
+
+/// #8191. `BOXED_PRIMITIVE_PAYLOADS` is keyed by a boxed `Number`/`String`/…
+/// wrapper's `ObjectHeader` address and rekeyed by
+/// `scan_boxed_primitive_payload_roots_mut`.
+#[test]
+fn test_dead_boxed_primitive_payload_owner_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let dead = alloc_nursery_test_object_addr();
+    crate::builtins::test_seed_boxed_primitive_payload(dead, 42f64.to_bits());
+    assert_eq!(
+        crate::builtins::test_boxed_primitive_payload_count(),
+        1,
+        "test premise: the payload entry must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::builtins::test_boxed_primitive_payload_count(),
+        0,
+        "a dead wrapper's BOXED_PRIMITIVE_PAYLOADS entry must be pruned"
+    );
+}
+
+#[test]
+fn test_live_boxed_primitive_payload_owner_survives_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let live = alloc_nursery_test_object_addr();
+    js_shadow_slot_set(0, ptr_bits(live));
+    crate::builtins::test_seed_boxed_primitive_payload(live, 42f64.to_bits());
+
+    full_gc();
+
+    assert_eq!(
+        crate::builtins::test_boxed_primitive_payload_count(),
+        1,
+        "a ROOTED wrapper's payload entry must survive"
+    );
+    js_shadow_slot_set(0, 0);
+}
+
+/// #8192. A transition-cache entry carries TWO metadata-only keys — the
+/// pre-transition `keys_array` and the interned property-name string — while
+/// only `next_keys` is a strong root. Either weak half dying is enough to make
+/// the entry's rekey read recycled bytes, so either is enough to drop it.
+#[test]
+fn test_dead_transition_cache_prev_keys_pruned_on_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    gc_register_mutable_root_scanner(crate::object::scan_transition_cache_roots_mut);
+
+    // `next_keys` is a strong root of the entry and must stay live, or the test
+    // would be measuring the wrong pointer. It goes in OLD-GEN on purpose:
+    // arena block reset is all-or-nothing, so a reachable neighbour in
+    // `dead_prev`'s own nursery block would force-MARK it (#7975,
+    // `mark_block_persisting_arena_objects`) and the prune would correctly
+    // decline — the test would then blame the prune for something it got right.
+    let next_keys = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_ARRAY) as usize;
+    js_shadow_slot_set(0, ptr_bits(next_keys));
+    crate::arena::arena_reset_all_blocks_to_zero();
+    let dead_prev = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_ARRAY) as usize;
+
+    let occupancy_before = crate::object::test_transition_cache_occupancy();
+    crate::object::test_seed_transition_cache_entry(dead_prev, 0, next_keys);
+    assert_eq!(
+        crate::object::test_transition_cache_occupancy(),
+        occupancy_before + 1,
+        "test premise: the transition entry must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::object::test_transition_cache_occupancy(),
+        occupancy_before,
+        "a transition entry whose prev_keys array died must be dropped, not \
+         rekeyed out of the bytes that replaced it"
+    );
+    js_shadow_slot_set(0, 0);
+}
+
+#[test]
+fn test_live_transition_cache_entry_survives_full_gc() {
+    // Two shadow slots: both halves of the entry have to be rooted.
+    let _guard = CopyingNurseryTestGuard::new(2);
+    gc_register_mutable_root_scanner(crate::object::scan_transition_cache_roots_mut);
+
+    let next_keys = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_ARRAY) as usize;
+    let live_prev = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_ARRAY) as usize;
+    js_shadow_slot_set(0, ptr_bits(next_keys));
+    js_shadow_slot_set(1, ptr_bits(live_prev));
+
+    let occupancy_before = crate::object::test_transition_cache_occupancy();
+    crate::object::test_seed_transition_cache_entry(live_prev, 0, next_keys);
+
+    full_gc();
+
+    assert_eq!(
+        crate::object::test_transition_cache_occupancy(),
+        occupancy_before + 1,
+        "an entry whose prev_keys array is still ROOTED must survive"
+    );
+    js_shadow_slot_set(0, 0);
+    js_shadow_slot_set(1, 0);
+}
+
+/// #8194. `REFLECT_METADATA`'s key carries the decorator target's NaN-boxed
+/// bits, rekeyed by `rewrite_metadata_target_bits`. Only `Reflect.deleteMetadata`
+/// ever removed an entry, so an unreachable target left its address behind.
+#[test]
+fn test_dead_reflect_metadata_target_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let len_before = crate::proxy::test_reflect_metadata_len();
+    let dead = alloc_nursery_test_object_addr();
+    crate::proxy::test_seed_reflect_metadata(ptr_bits(dead), "design:type");
+    assert_eq!(
+        crate::proxy::test_reflect_metadata_len(),
+        len_before + 1,
+        "test premise: the metadata entry must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::proxy::test_reflect_metadata_len(),
+        len_before,
+        "a dead decorator target's REFLECT_METADATA entry must be pruned"
+    );
+}
+
+#[test]
+fn test_live_reflect_metadata_target_survives_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let len_before = crate::proxy::test_reflect_metadata_len();
+    let live = alloc_nursery_test_object_addr();
+    js_shadow_slot_set(0, ptr_bits(live));
+    crate::proxy::test_seed_reflect_metadata(ptr_bits(live), "design:type");
+
+    full_gc();
+
+    assert_eq!(
+        crate::proxy::test_reflect_metadata_len(),
+        len_before + 1,
+        "a ROOTED decorator target's metadata entry must survive"
+    );
+    js_shadow_slot_set(0, 0);
+}
+
+/// #8195. The accessor table shares its owner key with `SYMBOL_PROPERTIES` and
+/// `SYMBOL_PROPERTY_ATTRS`, both of which `prune_dead_symbol_property_owners`
+/// has pruned since the 2026-07-09 audit. It was the one left out, which also
+/// made every accessor closure it held immortal.
+#[test]
+fn test_dead_symbol_accessor_owner_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let count_before = crate::symbol::test_symbol_accessor_property_count();
+    let dead = alloc_nursery_test_object_addr();
+    crate::symbol::test_seed_symbol_accessor_property(
+        dead,
+        0x8195_0001,
+        crate::value::TAG_UNDEFINED,
+    );
+    assert_eq!(
+        crate::symbol::test_symbol_accessor_property_count(),
+        count_before + 1,
+        "test premise: the accessor descriptor must be installed"
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::symbol::test_symbol_accessor_property_count(),
+        count_before,
+        "a dead owner's SYMBOL_ACCESSOR_PROPERTIES entry must be pruned"
+    );
+}
+
+#[test]
+fn test_live_symbol_accessor_owner_survives_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let count_before = crate::symbol::test_symbol_accessor_property_count();
+    let live = alloc_nursery_test_object_addr();
+    js_shadow_slot_set(0, ptr_bits(live));
+    crate::symbol::test_seed_symbol_accessor_property(
+        live,
+        0x8195_0002,
+        crate::value::TAG_UNDEFINED,
+    );
+
+    full_gc();
+
+    assert_eq!(
+        crate::symbol::test_symbol_accessor_property_count(),
+        count_before + 1,
+        "a ROOTED owner's accessor descriptor must survive"
+    );
+    js_shadow_slot_set(0, 0);
+}

--- a/crates/perry-runtime/src/gc/tests/forwarding_target_validation.rs
+++ b/crates/perry-runtime/src/gc/tests/forwarding_target_validation.rs
@@ -1,0 +1,229 @@
+//! #8174 — a forwarding walk must not step out of, or into, a non-object.
+//!
+//! `GC_FLAG_FORWARDED` means "the first payload word is where this object moved
+//! to". The two forwarding walkers (`CopyingNurseryCollector::rewrite_raw_addr`
+//! and `gc::verify::try_rewrite_raw_addr`) used to trust that byte for any
+//! address in a known heap region, and to trust whatever word it found.
+//!
+//! For a slot the collector already proved is a live reference, both are safe.
+//! For a **metadata key** — `RuntimeRootVisitor::visit_metadata_*`, rewritten
+//! but deliberately not marked — neither is: the key's object can die, the
+//! arena recycles the address, and the recycled payload bytes get read as a
+//! `GcHeader`. #8040 is that, observed: `gc_flags = 0x86` (`GC_FLAG_FORWARDED`
+//! set by coincidence), `obj_type = 104`, and a "forwarding pointer" that was
+//! really a NaN-boxed value. The walk stopped one hop later because the word
+//! did not classify — and RETURNED it. `visit_metadata_nanbox_key` masked it to
+//! 48 bits and got a live, unrelated survivor.
+//!
+//! These cases plant that exact shape. Each SABOTAGE case first asserts the
+//! premise — that the gate the old code used would have accepted the planted
+//! bytes — so a green run says the discriminator works, not that nothing was
+//! tried.
+
+use super::super::*;
+use super::support::*;
+
+/// #8040's observed word: a NaN-boxed value sitting where a forwarding pointer
+/// would be. `0x7FFF…` is above `is_valid_obj_ptr`'s `HEAP_MAX`, so it is not
+/// an address at all — but 48-bit masking turns it into one.
+const NAN_BOXED_NON_ADDRESS: u64 = crate::value::STRING_TAG | 0x0000_1234_5678_9AB0;
+
+/// THE PREMISE for everything below: a REAL evacuation still rewrites.
+///
+/// Tightening a forwarding walk is only a fix if the legitimate walk survives
+/// it. `rewrite_raw_addr`'s own doc records the opposite mistake — gating on
+/// `self.ptrs.classify()` left genuine from-space `shapes.entries` keys
+/// un-rekeyed and turned the verifier red. So this case runs first and asserts
+/// both that the rewrite happens and that neither refusal counter moved.
+#[test]
+fn a_real_forwarding_pointer_is_still_followed() {
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let nursery_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    let valid_ptrs = build_valid_pointer_set();
+    let old_user = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT);
+    let hdr = unsafe { header_from_user_ptr(nursery_user) as *mut GcHeader };
+
+    let sources = refused_forwarding_source_count();
+    let targets = refused_forwarding_target_count();
+    unsafe {
+        set_forwarding_address(hdr, old_user);
+    }
+
+    let mut key = nursery_user as usize;
+    let rewrote = RuntimeRootVisitor::for_rewrite(&valid_ptrs).visit_metadata_usize_slot(&mut key);
+
+    unsafe {
+        (*hdr).gc_flags &= !GC_FLAG_FORWARDED;
+    }
+
+    assert!(rewrote, "a genuinely evacuated key must still be rekeyed");
+    assert_eq!(key, old_user as usize);
+    assert_eq!(
+        refused_forwarding_source_count(),
+        sources,
+        "a real arena object header must not be refused as a walk source"
+    );
+    assert_eq!(
+        refused_forwarding_target_count(),
+        targets,
+        "a real to-space object must not be refused as a walk target"
+    );
+}
+
+/// SABOTAGE: the forwarding word is a NaN-boxed value, not an address.
+///
+/// Before #8174 the walk returned it and the caller masked it to 48 bits. Now
+/// the whole rewrite is refused, so the slot keeps the only value that is not a
+/// lie about where the object is.
+#[test]
+fn a_nan_boxed_forwarding_target_is_refused() {
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let nursery_user = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    let valid_ptrs = build_valid_pointer_set();
+    let hdr = unsafe { header_from_user_ptr(nursery_user) as *mut GcHeader };
+
+    // PREMISE: 48-bit masking would have produced a plausible heap address, so
+    // the old code's silent acceptance was not obviously wrong at the call site.
+    let masked = (NAN_BOXED_NON_ADDRESS & crate::value::POINTER_MASK) as usize;
+    assert!(
+        crate::value::addr_class::is_plausible_heap_addr(masked) || masked < 0x0001_0000_0000_0000,
+        "premise: the masked word looks like an address"
+    );
+
+    let before = refused_forwarding_target_count();
+    unsafe {
+        set_forwarding_address(hdr, NAN_BOXED_NON_ADDRESS as *mut u8);
+    }
+
+    let mut key = nursery_user as usize;
+    let rewrote = RuntimeRootVisitor::for_rewrite(&valid_ptrs).visit_metadata_usize_slot(&mut key);
+
+    unsafe {
+        (*hdr).gc_flags &= !GC_FLAG_FORWARDED;
+    }
+
+    assert!(!rewrote, "a non-address forwarding target must not rewrite");
+    assert_eq!(
+        key, nursery_user as usize,
+        "the key must be left alone, not bound to a masked NaN-boxed word"
+    );
+    assert_eq!(
+        refused_forwarding_target_count(),
+        before + 1,
+        "the refusal must be counted, or a production run cannot report it"
+    );
+}
+
+/// SABOTAGE: the recycled bytes at a dead key, read as a `GcHeader`.
+///
+/// This is #8040 one step earlier than the case above — the walk should never
+/// have reached the forwarding word at all. The planted bytes are the ones the
+/// #8168 investigation observed (`gc_flags = 0x86`, `obj_type = 104`), and the
+/// forwarding word planted behind them names a genuinely live object, which is
+/// what made the old behaviour corrupt rather than merely useless.
+#[test]
+fn recycled_bytes_are_not_read_as_a_forwarding_stub() {
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    // A live allocation whose payload interior is a legitimate arena address
+    // that is NOT an object start — exactly what a recycled key names.
+    let owner = crate::arena::arena_alloc_gc(128, 8, GC_TYPE_OBJECT);
+    let stale_key = owner as usize + 64;
+    let fake_header = (stale_key - GC_HEADER_SIZE) as *mut GcHeader;
+    unsafe {
+        (*fake_header).obj_type = 104;
+        (*fake_header).gc_flags = 0x86;
+        (*fake_header)._reserved = 0;
+        (*fake_header).size = 48;
+        *(stale_key as *mut u64) = owner as u64;
+    }
+
+    // PREMISE, in two parts, both of which the pre-#8174 gate consulted and
+    // nothing else: the address is in a known heap region, and the byte at the
+    // `gc_flags` offset carries `GC_FLAG_FORWARDED`. A walk gated only on those
+    // two follows this.
+    assert_ne!(
+        crate::arena::classify_heap_space(stale_key - GC_HEADER_SIZE),
+        crate::arena::HeapSpace::Unknown,
+        "premise: the recycled address classifies as heap"
+    );
+    assert_ne!(
+        unsafe { (*fake_header).gc_flags } & GC_FLAG_FORWARDED,
+        0,
+        "premise: the recycled bytes present as forwarded"
+    );
+    assert!(
+        gc_type_info(104).is_none(),
+        "premise: 104 is not a registered GC type, which is what makes these \
+         bytes distinguishable from an object"
+    );
+
+    let before = refused_forwarding_source_count();
+    assert!(
+        forwarding_walk_header(stale_key).is_none(),
+        "a header with an unregistered obj_type must not be walked"
+    );
+    assert_eq!(refused_forwarding_source_count(), before + 1);
+}
+
+/// The target predicate on its own, over the three shapes a bogus word takes.
+#[test]
+fn a_forwarding_target_must_be_an_object_start() {
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let live = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_OBJECT);
+    assert!(
+        forwarding_target_is_object_start(live as usize),
+        "a real arena allocation is a valid forwarding target"
+    );
+    assert!(
+        !forwarding_target_is_object_start(NAN_BOXED_NON_ADDRESS as usize),
+        "a NaN-boxed word is above HEAP_MAX and is not an address"
+    );
+    assert!(
+        !forwarding_target_is_object_start(7),
+        "a handle-band id is not an address"
+    );
+    assert!(
+        !forwarding_target_is_object_start(0),
+        "null is not an address"
+    );
+}
+
+/// The #8174 registry itself: `gc::dead_owner::fan_out` iterates this array
+/// instead of naming its prunes inline, and `scripts/gc_rekeyed_key_tables.py`
+/// reads it to adjudicate every `dead_owner:` verdict. A prune silently dropped
+/// from it would take a rekeyed table's death story with it — which is exactly
+/// how #8040 happened — so assert the shape the gate depends on.
+#[test]
+fn the_dead_key_prune_registry_keeps_its_shape() {
+    use crate::gc::dead_owner::{DeadKeyOwner, DEAD_KEY_PRUNES};
+
+    assert!(
+        DEAD_KEY_PRUNES.len() >= 15,
+        "DEAD_KEY_PRUNES shrank to {} entries; a prune was removed from the \
+         fan-out, and every `dead_owner:` verdict in \
+         scripts/gc_rekeyed_key_tables.json that named it is now a lie",
+        DEAD_KEY_PRUNES.len()
+    );
+
+    let mut labels: Vec<&str> = DEAD_KEY_PRUNES.iter().map(|entry| entry.table).collect();
+    let total = labels.len();
+    labels.sort_unstable();
+    labels.dedup();
+    assert_eq!(
+        labels.len(),
+        total,
+        "DEAD_KEY_PRUNES table labels must be unique — the registry is an \
+         inventory, and two entries with one label hide a table"
+    );
+
+    // #8168's table, narrowed to closures. Its absence from the fan-out IS
+    // #8040; if a refactor ever drops it again, fail here rather than in a
+    // `TypeError: value is not a function` several collections later.
+    assert!(
+        DEAD_KEY_PRUNES.iter().any(
+            |entry| entry.table == "FUNCTION_CLASS_IDS" && entry.owner == DeadKeyOwner::Closure
+        ),
+        "FUNCTION_CLASS_IDS must stay registered with the GC_TYPE_CLOSURE \
+         predicate (#8168)"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/forwarding_target_validation.rs
+++ b/crates/perry-runtime/src/gc/tests/forwarding_target_validation.rs
@@ -198,7 +198,7 @@ fn the_dead_key_prune_registry_keeps_its_shape() {
     use crate::gc::dead_owner::{DeadKeyOwner, DEAD_KEY_PRUNES};
 
     assert!(
-        DEAD_KEY_PRUNES.len() >= 15,
+        DEAD_KEY_PRUNES.len() >= 19,
         "DEAD_KEY_PRUNES shrank to {} entries; a prune was removed from the \
          fan-out, and every `dead_owner:` verdict in \
          scripts/gc_rekeyed_key_tables.json that named it is now a lie",

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -17,6 +17,7 @@ mod dirty_page_cache;
 mod env_knob_parse;
 mod error_side_tables;
 mod evacuation;
+mod forwarding_target_validation;
 mod fromspace_protect;
 mod fromspace_scan;
 mod global_bootstrap;

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -1307,7 +1307,6 @@ fn test_gc_init_mutable_scanner_families_rewrite_runtime_slots() {
     assert_eq!(promise.current_microtask_next_ptr, fixture.old_addr());
     assert_eq!(promise.inline_trap_next_ptr, fixture.old_addr());
     assert_eq!(promise.inline_trap_step_ptr, fixture.old_addr());
-    assert_eq!(promise.async_step_guard_last_closure, fixture.old_addr());
     assert_eq!(promise.inline_callback_ptr, fixture.old_addr());
     assert_eq!(promise.inline_next_ptr, fixture.old_addr());
     assert_eq!(promise.inline_value_bits, fixture.old_bits);

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -23,6 +23,18 @@ pub(super) fn try_rewrite_nanboxed_value(bits: u64, valid_ptrs: &ValidPointerSet
     Some(tag | (new_user as u64 & POINTER_MASK))
 }
 
+/// #8174: refuses a forwarding target that is not a heap object start, in
+/// lockstep with [`CopyingNurseryCollector::rewrite_raw_addr`](super::copying).
+///
+/// The lockstep is the point. This function is what the VERIFY pass runs
+/// (`RuntimeRootVisitMode::Verify`), and it panics whenever it can rewrite a
+/// slot the rewrite pass left alone. Tightening only the rewrite pass would
+/// therefore have turned a silently-corrupt rewrite into a `PERRY_GC_VERIFY_
+/// EVACUATION` abort blaming an innocent scanner — the two walkers must reach
+/// the same verdict or the verifier is measuring the difference between them
+/// instead of the heap. Its own gate (`valid_ptrs`, a live census) is strictly
+/// stronger than the copier's heap-region test, so this only changes the case
+/// where a genuinely LIVE forwarded object's target word is corrupt.
 pub(super) fn try_rewrite_raw_addr(ptr_addr: usize, valid_ptrs: &ValidPointerSet) -> Option<usize> {
     if ptr_addr == 0 {
         return None;
@@ -41,6 +53,9 @@ pub(super) fn try_rewrite_raw_addr(ptr_addr: usize, valid_ptrs: &ValidPointerSet
             let next = forwarding_address(header) as usize;
             if next == 0 || next == current {
                 return rewrote.then_some(current);
+            }
+            if !accept_forwarding_target(next) {
+                return None;
             }
             current = next;
             rewrote = true;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1019,6 +1019,64 @@ pub fn scan_transition_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
     });
 }
 
+/// #8192: death pruning for the transition cache.
+///
+/// Two of an entry's three pointers are metadata-only and therefore weak:
+/// `prev_keys` (the pre-transition keys `ArrayHeader`) and `key_ptr` (the
+/// interned `StringHeader` of the property name). Only `next_keys` is a strong
+/// root. Both weak halves are **rekeyed** by `scan_transition_cache_roots_mut`
+/// when their object moves, which is what makes a dead one dangerous rather
+/// than merely stale: the arena recycles the address and the next rewrite pass
+/// reads the recycled bytes as a `GcHeader` (#8040, and see `gc::dead_owner`).
+///
+/// The entry is a pure cache, so the repair is to drop it. `next_keys == 0` is
+/// the empty-slot sentinel and `prev_keys == 0` is the "object had no keys
+/// array" sentinel; neither is an address, so neither is probed.
+pub(crate) fn prune_dead_transition_cache_entries(is_dead_owner: &dyn Fn(usize) -> bool) {
+    with_transition_cache(|table| unsafe {
+        for i in 0..TRANSITION_CACHE_SIZE {
+            let entry = &mut (*table)[i];
+            if entry.next_keys == 0 {
+                continue;
+            }
+            let dead = (entry.prev_keys != 0 && is_dead_owner(entry.prev_keys))
+                || (entry.key_ptr != 0 && is_dead_owner(entry.key_ptr));
+            if dead {
+                *entry = TransitionEntry {
+                    prev_keys: 0,
+                    key_ptr: 0,
+                    next_keys: 0,
+                    slot_idx: 0,
+                    target_len: 0,
+                };
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_transition_cache_occupancy() -> usize {
+    with_transition_cache(|table| unsafe {
+        (0..TRANSITION_CACHE_SIZE)
+            .filter(|&i| (*table)[i].next_keys != 0)
+            .count()
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_transition_cache_entry(prev_keys: usize, key_ptr: usize, next_keys: usize) {
+    let slot = transition_cache_slot(prev_keys, key_ptr);
+    with_transition_cache(|table| unsafe {
+        (*table)[slot] = TransitionEntry {
+            prev_keys,
+            key_ptr,
+            next_keys,
+            slot_idx: 0,
+            target_len: 1,
+        };
+    });
+}
+
 /// GC root scanner: mark all cached shape keys arrays so they're not freed.
 /// The inline cache + overflow map both hold the raw `*mut ArrayHeader`
 /// pointers; without this scanner, GC would free those arrays, leaving

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -721,7 +721,6 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                         if new_count > ASYNC_STEP_REENTRY_BOUND {
                             ASYNC_STEP_GUARD.with(|c| {
                                 c.set(AsyncStepGuard {
-                                    last_closure: 0,
                                     consecutive_error_count: 0,
                                 })
                             });
@@ -746,14 +745,12 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                         }
                         ASYNC_STEP_GUARD.with(|c| {
                             c.set(AsyncStepGuard {
-                                last_closure: step_closure as usize,
                                 consecutive_error_count: new_count,
                             })
                         });
                     } else {
                         ASYNC_STEP_GUARD.with(|c| {
                             c.set(AsyncStepGuard {
-                                last_closure: 0,
                                 consecutive_error_count: 0,
                             })
                         });

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -648,13 +648,21 @@ pub(crate) static TASK_QUEUE: RefCell<std::collections::VecDeque<Task>>
     /// the step dispatch. This bounds the worst-case loop at
     /// `ASYNC_STEP_REENTRY_BOUND` iterations instead of unbounded.
     pub(crate) static ASYNC_STEP_GUARD: std::cell::Cell<AsyncStepGuard>
-        = const { std::cell::Cell::new(AsyncStepGuard { last_closure: 0, consecutive_error_count: 0 }) };
+        = const { std::cell::Cell::new(AsyncStepGuard { consecutive_error_count: 0 }) };
 }
 
 /// Defensive guard state for the async step driver. See `ASYNC_STEP_GUARD`.
+///
+/// #8193: this used to carry a `last_closure: usize` — the address of the
+/// closure that took the last erroring step. The same-closure check that read
+/// it was deleted when #712/#921/#922 showed a runaway loop ALTERNATES between
+/// two closures, so the field became write-only. It was not inert, though: it
+/// was a raw heap address that `scan_promise_roots_mut` REKEYED without
+/// marking, and nothing pruned it when the closure died — the #8040 shape (see
+/// `gc::dead_owner`). The fix for state nobody reads is to delete it, not to
+/// maintain it correctly.
 #[derive(Copy, Clone)]
 pub(crate) struct AsyncStepGuard {
-    pub last_closure: usize,
     pub consecutive_error_count: u32,
 }
 

--- a/crates/perry-runtime/src/promise/scanners.rs
+++ b/crates/perry-runtime/src/promise/scanners.rs
@@ -84,13 +84,6 @@ pub fn scan_promise_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
         }
     });
 
-    ASYNC_STEP_GUARD.with(|c| {
-        let mut guard = c.get();
-        if visitor.visit_metadata_usize_slot(&mut guard.last_closure) {
-            c.set(guard);
-        }
-    });
-
     PROMISE_CONTEXTS.with(|contexts| {
         let mut contexts = contexts.borrow_mut();
         let mut moved = Vec::new();
@@ -136,14 +129,17 @@ const PROMISE_SCAN_CURRENT_MICROTASK_CALLBACK: u8 = 2;
 const PROMISE_SCAN_CURRENT_MICROTASK_VALUE: u8 = 3;
 const PROMISE_SCAN_CURRENT_MICROTASK_NEXT: u8 = 4;
 const PROMISE_SCAN_INLINE_TRAP: u8 = 5;
-const PROMISE_SCAN_ASYNC_STEP_GUARD: u8 = 6;
-const PROMISE_SCAN_CONTEXTS: u8 = 7;
-const PROMISE_SCAN_ALL_STATES: u8 = 8;
-const PROMISE_SCAN_SETTLE_LISTENERS: u8 = 9;
-const PROMISE_SCAN_OVERFLOW_REACTIONS: u8 = 10;
-const PROMISE_SCAN_PREV_CONTEXTS: u8 = 11;
-const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 12;
-const PROMISE_SCAN_DONE: u8 = 13;
+// #8193 removed PROMISE_SCAN_ASYNC_STEP_GUARD: the only slot it visited was
+// `AsyncStepGuard::last_closure`, a write-only raw closure address that this
+// pass rekeyed and nothing pruned. The field is gone, so the phase has nothing
+// left to scan and the ordinals close up behind it.
+const PROMISE_SCAN_CONTEXTS: u8 = 6;
+const PROMISE_SCAN_ALL_STATES: u8 = 7;
+const PROMISE_SCAN_SETTLE_LISTENERS: u8 = 8;
+const PROMISE_SCAN_OVERFLOW_REACTIONS: u8 = 9;
+const PROMISE_SCAN_PREV_CONTEXTS: u8 = 10;
+const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 11;
+const PROMISE_SCAN_DONE: u8 = 12;
 
 #[derive(Default)]
 pub(crate) struct PromiseRootScanState {
@@ -199,7 +195,6 @@ pub(crate) fn scan_promise_roots_mut_step(
                 scan_current_microtask_next_step(visitor, remaining)
             }
             PROMISE_SCAN_INLINE_TRAP => scan_inline_trap_step(visitor, state, remaining),
-            PROMISE_SCAN_ASYNC_STEP_GUARD => scan_async_step_guard_step(visitor, remaining),
             PROMISE_SCAN_CONTEXTS => scan_promise_contexts_step(visitor, state, remaining),
             PROMISE_SCAN_ALL_STATES => scan_promise_all_states_step(visitor, state, remaining),
             PROMISE_SCAN_SETTLE_LISTENERS => {
@@ -488,22 +483,6 @@ fn scan_inline_trap_step(
     })
 }
 
-fn scan_async_step_guard_step(
-    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
-    remaining: &mut usize,
-) -> bool {
-    if !consume_root_work(remaining) {
-        return false;
-    }
-    ASYNC_STEP_GUARD.with(|c| {
-        let mut guard = c.get();
-        if visitor.visit_metadata_usize_slot(&mut guard.last_closure) {
-            c.set(guard);
-        }
-    });
-    true
-}
-
 fn scan_promise_contexts_step(
     visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
     state: &mut PromiseRootScanState,
@@ -751,7 +730,6 @@ pub(crate) struct TestPromiseScannerSnapshot {
     pub current_microtask_next_ptr: usize,
     pub inline_trap_next_ptr: usize,
     pub inline_trap_step_ptr: usize,
-    pub async_step_guard_last_closure: usize,
     pub inline_callback_ptr: usize,
     pub inline_next_ptr: usize,
     pub inline_value_bits: u64,
@@ -815,7 +793,6 @@ pub(crate) fn test_seed_promise_scanner_roots(
     });
     ASYNC_STEP_GUARD.with(|c| {
         c.set(AsyncStepGuard {
-            last_closure: callback_ptr as usize,
             consecutive_error_count: 1,
         })
     });
@@ -898,9 +875,6 @@ pub(crate) fn test_promise_scanner_snapshot() -> TestPromiseScannerSnapshot {
         snapshot.inline_trap_next_ptr = trap.trap_next as usize;
         snapshot.inline_trap_step_ptr = trap.current_step;
     });
-    ASYNC_STEP_GUARD.with(|c| {
-        snapshot.async_step_guard_last_closure = c.get().last_closure;
-    });
     PROMISE_CONTEXTS.with(|contexts| {
         let contexts = contexts.borrow();
         if let Some((key, context)) = contexts.first() {
@@ -941,7 +915,6 @@ pub(crate) fn test_clear_promise_scanner_roots() {
     INLINE_TRAP.with(|c| c.set(InlineTrap::empty()));
     ASYNC_STEP_GUARD.with(|c| {
         c.set(AsyncStepGuard {
-            last_closure: 0,
             consecutive_error_count: 0,
         })
     });

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1961,6 +1961,48 @@ static KEEP_REFLECT_OWN_KEYS: extern "C" fn(f64) -> f64 = js_reflect_own_keys;
 #[used]
 static KEEP_REFLECT_APPLY: extern "C" fn(f64, f64, f64) -> f64 = js_reflect_apply;
 
+/// #8194: death pruning for `REFLECT_METADATA`.
+///
+/// The key carries the decorator target's NaN-boxed bits, and
+/// `rewrite_metadata_target_bits` **rekeys** them when the target moves.
+/// Entries were removed only by `Reflect.deleteMetadata`, so a target that
+/// simply became unreachable left its address in the key — the #8040 shape,
+/// because the next rewrite pass reads whatever the arena put there.
+///
+/// Non-`POINTER_TAG` keys (class refs, primitives) and handle-band ids are
+/// left alone: they are not heap addresses, and the `gc::dead_owner` probes
+/// decline to attribute them anyway.
+pub(crate) fn prune_dead_reflect_metadata_targets(is_dead_owner: &dyn Fn(usize) -> bool) {
+    REFLECT_METADATA.with(|store| {
+        store.borrow_mut().retain(|key, _| {
+            if (key.target_bits & !POINTER_MASK) != POINTER_TAG {
+                return true;
+            }
+            let addr = (key.target_bits & POINTER_MASK) as usize;
+            addr == 0 || !is_dead_owner(addr)
+        });
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_reflect_metadata_len() -> usize {
+    REFLECT_METADATA.with(|store| store.borrow().len())
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_reflect_metadata(target_bits: u64, key: &str) {
+    REFLECT_METADATA.with(|store| {
+        store.borrow_mut().insert(
+            MetadataKey {
+                target_bits,
+                key: key.to_string(),
+                property_key: None,
+            },
+            f64::from_bits(TAG_UNDEFINED),
+        );
+    });
+}
+
 /// Rewrite a `REFLECT_METADATA` key's POINTER-tagged target bits during the
 /// GC metadata-rewrite phase; non-pointer targets (class refs, primitives)
 /// pass through untouched.

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -20,6 +20,10 @@
 //! functions in this module.
 
 mod accessors;
+#[cfg(test)]
+pub(crate) use accessors::{
+    test_seed_symbol_accessor_property, test_symbol_accessor_property_count,
+};
 mod constructors;
 mod gc_roots;
 mod get;
@@ -527,6 +531,21 @@ per_test_global! {
 /// are never pruned).
 pub(crate) fn prune_dead_symbol_property_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
     let mut verdicts: HashMap<usize, bool> = HashMap::new();
+    // #8195: the accessor table is keyed by the SAME owner address and was the
+    // one of the three not pruned here. Take its verdicts first, into the same
+    // memo, so all three tables agree about every owner within one pass.
+    {
+        let verdicts = std::cell::RefCell::new(&mut verdicts);
+        accessors::prune_dead_symbol_accessor_owners(&|owner| {
+            let mut verdicts = verdicts.borrow_mut();
+            if let Some(&known) = verdicts.get(&owner) {
+                return known;
+            }
+            let dead = is_dead_owner(owner);
+            verdicts.insert(owner, dead);
+            dead
+        });
+    }
     {
         let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
         if let Some(map) = guard.as_mut() {

--- a/crates/perry-runtime/src/symbol/accessors.rs
+++ b/crates/perry-runtime/src/symbol/accessors.rs
@@ -35,6 +35,43 @@ pub(super) fn clear_all_symbol_accessor_properties_for_object(obj_key: usize) {
     }
 }
 
+/// #8195: death pruning for `SYMBOL_ACCESSOR_PROPERTIES`, called from
+/// `symbol::prune_dead_symbol_property_owners` so all three symbol tables
+/// share one deadness verdict per owner.
+///
+/// The `sym_key` half of the key is a strong root
+/// (`scan_symbol_accessor_roots_mut`'s `visit_usize_slot`); the OWNER half is
+/// metadata-only and rekeyed, so it can go stale. Until now the only bulk
+/// removal was `clear_all_symbol_accessor_properties_for_object`, reached
+/// solely from the handle-recycle path — never for a plain heap object. Two
+/// consequences, both closed here: the accessor closures held in the
+/// descriptor were immortal, and the dead owner address survived into the next
+/// cycle's rewrite pass (#8040's shape; see `gc::dead_owner`).
+pub(super) fn prune_dead_symbol_accessor_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    if let Some(map) = guard.as_mut() {
+        map.retain(|(owner, _), _| !is_dead_owner(*owner));
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_symbol_accessor_property_count() -> usize {
+    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard.as_ref().map_or(0, |map| map.len())
+}
+
+#[cfg(test)]
+pub(crate) fn test_seed_symbol_accessor_property(obj_key: usize, sym_key: usize, get_bits: u64) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard.get_or_insert_with(HashMap::new).insert(
+        (obj_key, sym_key),
+        SymbolAccessorDescriptor {
+            get: get_bits,
+            set: TAG_UNDEFINED,
+        },
+    );
+}
+
 pub(crate) unsafe fn set_symbol_accessor_property(
     obj_f64: f64,
     sym_f64: f64,

--- a/scripts/gc_pin_sites.py
+++ b/scripts/gc_pin_sites.py
@@ -120,6 +120,15 @@ ALLOWLIST: list[tuple[str, str, str]] = [
         "arming the latch, to prove the dynamic move_young guard catches an "
         "incomplete latch. It must stay a raw write or it tests nothing.",
     ),
+    (
+        "crates/perry-runtime/src/gc/tests/forwarding_target_validation.rs",
+        "(*fake_header).gc_flags = 0x86;",
+        "#8174 plants the RECYCLED BYTES #8040 observed at a dead side-table "
+        "key, verbatim, and reads them as a GcHeader. 0x86 happens to carry "
+        "bit 2, but nothing here is pinning anything: the address is payload "
+        "interior of a live allocation and there is no object at it. Writing "
+        "the bytes as named flags would be a lie about what was measured.",
+    ),
 ]
 
 # Floor: the tree currently carries ~80 `GC_FLAG_PINNED` tokens. A regex that

--- a/scripts/gc_rekeyed_key_tables.json
+++ b/scripts/gc_rekeyed_key_tables.json
@@ -22,14 +22,14 @@
     {
       "site": "crates/perry-runtime/src/builtins/console.rs::scan_console_log_singleton_roots_mut",
       "table": "CONSOLE_INSTANCES",
-      "death": "open_gap:#8190",
-      "why": "No prune anywhere: absent from DEAD_KEY_PRUNES and from gc_type_clear_dead_payload_side_tables; the key is a plain js_object_alloc address (console.rs:1037-1049)."
+      "death": "dead_owner:prune_dead_console_instance_owners",
+      "why": "#8190: registered prune retains on !is_dead_owner over the console instance object address (builtins/console.rs)."
     },
     {
       "site": "crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs::scan_boxed_primitive_payload_roots_mut",
       "table": "BOXED_PRIMITIVE_PAYLOADS",
-      "death": "open_gap:#8191",
-      "why": "No prune anywhere: the file holds only the declaration, two reads and this scanner; the key is an ObjectHeader address (boxed_primitives.rs:98)."
+      "death": "dead_owner:prune_dead_boxed_primitive_payload_owners",
+      "why": "#8191: registered prune retains on !is_dead_owner over the wrapper ObjectHeader address (builtins/formatting/boxed_primitives.rs)."
     },
     {
       "site": "crates/perry-runtime/src/closure/dynamic_props.rs::scan_closure_dynamic_props_roots_mut",
@@ -86,16 +86,16 @@
       "why": "Registered prune retains both maps on !is_dead_owner (object/descriptor_state.rs:1035-1055); handle-band ids in the same maps are skipped by the probe as unattributable."
     },
     {
-      "site": "crates/perry-runtime/src/object/mod.rs::scan_transition_cache_roots_mut",
-      "table": "TRANSITION_CACHE_GLOBAL",
-      "death": "open_gap:#8192",
-      "why": "Neither entry.prev_keys nor entry.key_ptr is marked or pruned; only entry.next_keys is a strong root (object/mod.rs:1005-1007). A rewrite does invalidate the entry, but only after rewrite_raw_addr has already read the recycled header."
-    },
-    {
       "site": "crates/perry-runtime/src/object/mod.rs::scan_overflow_fields_roots_mut",
       "table": "state().object_hot.overflow_fields",
       "death": "self_pruned:clear_overflow_for_ptr",
       "why": "Cleared per dead object by gc_type_clear_dead_payload_side_tables (gc/types.rs:799) from the sweep (gc/oldgen.rs:700, 924, 1573), outside the dead_owner fan-out."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/mod.rs::scan_transition_cache_roots_mut",
+      "table": "TRANSITION_CACHE_GLOBAL",
+      "death": "dead_owner:prune_dead_transition_cache_entries",
+      "why": "#8192: registered prune drops the whole cache entry when either weak half (prev_keys keys-array, key_ptr interned string) is dead; next_keys is a strong root and cannot be."
     },
     {
       "site": "crates/perry-runtime/src/object/shapes.rs::scan_shape_table_rekey_mut",
@@ -122,34 +122,16 @@
       "why": "Sweep path via the PromiseCleanup finalize hook (gc/types.rs:835-838 -> promise/mod.rs:1024); copying path via cleanup_copied_minor_all_states_for_gc (promise/mod.rs:1087), which validates obj_type == GC_TYPE_PROMISE before trusting FORWARDED."
     },
     {
-      "site": "crates/perry-runtime/src/promise/reactions.rs::scan_promise_settle_listeners_mut",
-      "table": "PROMISE_SETTLE_LISTENERS",
-      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
-      "why": "Sweep path from promise/mod.rs:1022 and copying path via cleanup_copied_minor_settle_listeners_for_gc (promise/mod.rs:1085), both keyed on a validated promise header."
-    },
-    {
       "site": "crates/perry-runtime/src/promise/reactions.rs::scan_promise_overflow_reactions_mut",
       "table": "PROMISE_OVERFLOW_REACTIONS",
       "death": "self_pruned:remove_overflow_reactions_for_dead_promise",
       "why": "Sweep path from promise/mod.rs:1023 and copying path via cleanup_copied_minor_overflow_reactions_for_gc (promise/mod.rs:1086), both keyed on a validated promise header."
     },
     {
-      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_roots_mut",
-      "table": "ASYNC_STEP_GUARD.last_closure (+ PROMISE_CONTEXTS)",
-      "death": "open_gap:#8193",
-      "why": "PROMISE_CONTEXTS in this same function is self-pruned by clear_promise_context, but ASYNC_STEP_GUARD.last_closure (scanners.rs:89) is written at microtasks.rs:749 and never marked or pruned; the verdict takes the weaker of the two keys."
-    },
-    {
-      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_async_step_guard_step",
-      "table": "ASYNC_STEP_GUARD.last_closure",
-      "death": "open_gap:#8193",
-      "why": "Budgeted twin of the scanners.rs:89 site on the identical Cell, with the identical missing prune."
-    },
-    {
-      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_contexts_step",
-      "table": "PROMISE_CONTEXTS",
-      "death": "self_pruned:clear_promise_context",
-      "why": "Budgeted twin of the scanners.rs:100 site on the same store; sweep path promise/mod.rs:1005-1012, copying path promise/mod.rs:1069-1084."
+      "site": "crates/perry-runtime/src/promise/reactions.rs::scan_promise_settle_listeners_mut",
+      "table": "PROMISE_SETTLE_LISTENERS",
+      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
+      "why": "Sweep path from promise/mod.rs:1022 and copying path via cleanup_copied_minor_settle_listeners_for_gc (promise/mod.rs:1085), both keyed on a validated promise header."
     },
     {
       "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_all_states_step",
@@ -158,10 +140,10 @@
       "why": "Budgeted twin of scan_promise_all_states_mut on the same PromiseKeyedTable, with the same two prune paths."
     },
     {
-      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_settle_listeners_step",
-      "table": "PROMISE_SETTLE_LISTENERS",
-      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
-      "why": "Budgeted twin of scan_promise_settle_listeners_mut on the same PromiseKeyedTable, with the same two prune paths."
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_contexts_step",
+      "table": "PROMISE_CONTEXTS",
+      "death": "self_pruned:clear_promise_context",
+      "why": "Budgeted twin of the scanners.rs:100 site on the same store; sweep path promise/mod.rs:1005-1012, copying path promise/mod.rs:1069-1084."
     },
     {
       "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_overflow_reactions_step",
@@ -170,10 +152,22 @@
       "why": "Budgeted twin of scan_promise_overflow_reactions_mut on the same PromiseKeyedTable, with the same two prune paths."
     },
     {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_roots_mut",
+      "table": "PROMISE_CONTEXTS",
+      "death": "self_pruned:clear_promise_context",
+      "why": "Sweep path via the PromiseCleanup finalize hook (gc/types.rs -> promise/mod.rs clear_promise_context) and copying path via cleanup_copied_minor_promise_contexts_for_gc. #8193 deleted this function's other metadata key, ASYNC_STEP_GUARD.last_closure, which nothing read."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_settle_listeners_step",
+      "table": "PROMISE_SETTLE_LISTENERS",
+      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
+      "why": "Budgeted twin of scan_promise_settle_listeners_mut on the same PromiseKeyedTable, with the same two prune paths."
+    },
+    {
       "site": "crates/perry-runtime/src/proxy.rs::rewrite_metadata_target_bits",
       "table": "REFLECT_METADATA (MetadataKey.target_bits)",
-      "death": "open_gap:#8194",
-      "why": "Entries are removed only by Reflect.deleteMetadata (proxy/metadata.rs:95); only the value is marked (proxy.rs:2009), and the scanner's own doc concedes keys go stale on a target move."
+      "death": "dead_owner:prune_dead_reflect_metadata_targets",
+      "why": "#8194: registered prune retains entries whose POINTER_TAG'd target is not dead; non-pointer keys and handle ids are left alone."
     },
     {
       "site": "crates/perry-runtime/src/set.rs::scan_set_iterator_array_roots_mut",
@@ -182,40 +176,22 @@
       "why": "Registered prune retains on !is_dead_owner over the iterator array address (set.rs:51)."
     },
     {
-      "site": "crates/perry-runtime/src/symbol/accessors.rs::scan_symbol_accessor_roots_mut",
-      "table": "SYMBOL_ACCESSOR_PROPERTIES (owner half)",
-      "death": "open_gap:#8195",
-      "why": "prune_dead_symbol_property_owners covers only SYMBOL_PROPERTIES and SYMBOL_PROPERTY_ATTRS (symbol.rs:528-550); the accessor table's only bulk removal is on the handle-recycle path (symbol/properties.rs:163). The sym_key half IS rooted (accessors.rs:149)."
-    },
-    {
       "site": "crates/perry-runtime/src/symbol/accessors.rs::scan_symbol_accessor_root_slot",
       "table": "SYMBOL_ACCESSOR_PROPERTIES (owner half)",
-      "death": "open_gap:#8195",
-      "why": "Budgeted twin of scan_symbol_accessor_roots_mut on the same table, with the identical missing prune."
-    },
-    {
-      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_roots_mut",
-      "table": "SYMBOL_PROPERTIES",
       "death": "dead_owner:prune_dead_symbol_property_owners",
-      "why": "Registered prune retains on !is_dead_owner over the property owner (symbol.rs:530-539)."
+      "why": "#8195: budgeted twin of scan_symbol_accessor_roots_mut on the same table, covered by the same prune."
     },
     {
-      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_attrs_mut",
-      "table": "SYMBOL_PROPERTY_ATTRS",
+      "site": "crates/perry-runtime/src/symbol/accessors.rs::scan_symbol_accessor_roots_mut",
+      "table": "SYMBOL_ACCESSOR_PROPERTIES (owner half)",
       "death": "dead_owner:prune_dead_symbol_property_owners",
-      "why": "Same registered prune retains the attrs map on the owner half of its tuple key (symbol.rs:540-549)."
+      "why": "#8195: the accessor table now shares that prune with SYMBOL_PROPERTIES and SYMBOL_PROPERTY_ATTRS, through one memoized owner verdict per pass (symbol/accessors.rs prune_dead_symbol_accessor_owners)."
     },
     {
-      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_pointer_metadata_roots_mut",
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_pointer_metadata_if_forwarded",
       "table": "SYMBOL_POINTERS",
       "death": "dead_owner:prune_dead_symbol_pointers",
-      "why": "Registered prune retains on the GC_TYPE_STRING-narrowed predicate (symbol.rs:563-568), which is correct because symbols are gc_malloc'd with GC_TYPE_STRING (symbol.rs:646-649)."
-    },
-    {
-      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_property_owner_if_forwarded",
-      "table": "SYMBOL_PROPERTIES",
-      "death": "dead_owner:prune_dead_symbol_property_owners",
-      "why": "Budgeted per-slot twin of scan_symbol_property_roots_mut on the same table and prune (symbol.rs:530)."
+      "why": "Budgeted per-slot twin of scan_symbol_pointer_metadata_roots_mut on the same table and prune (symbol.rs:563)."
     },
     {
       "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_property_attrs_if_forwarded",
@@ -224,10 +200,28 @@
       "why": "Budgeted per-slot twin of scan_symbol_property_attrs_mut on the same table and prune (symbol.rs:540)."
     },
     {
-      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_pointer_metadata_if_forwarded",
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_property_owner_if_forwarded",
+      "table": "SYMBOL_PROPERTIES",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Budgeted per-slot twin of scan_symbol_property_roots_mut on the same table and prune (symbol.rs:530)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_pointer_metadata_roots_mut",
       "table": "SYMBOL_POINTERS",
       "death": "dead_owner:prune_dead_symbol_pointers",
-      "why": "Budgeted per-slot twin of scan_symbol_pointer_metadata_roots_mut on the same table and prune (symbol.rs:563)."
+      "why": "Registered prune retains on the GC_TYPE_STRING-narrowed predicate (symbol.rs:563-568), which is correct because symbols are gc_malloc'd with GC_TYPE_STRING (symbol.rs:646-649)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_attrs_mut",
+      "table": "SYMBOL_PROPERTY_ATTRS",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Same registered prune retains the attrs map on the owner half of its tuple key (symbol.rs:540-549)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_roots_mut",
+      "table": "SYMBOL_PROPERTIES",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Registered prune retains on !is_dead_owner over the property owner (symbol.rs:530-539)."
     },
     {
       "site": "crates/perry-runtime/src/weakref.rs::rewritten_holder_addr",

--- a/scripts/gc_rekeyed_key_tables.json
+++ b/scripts/gc_rekeyed_key_tables.json
@@ -1,0 +1,239 @@
+{
+  "_comment": [
+    "Custody manifest for REKEYED address-keyed side tables (#8174).",
+    "One entry per `visit_metadata_*` call site, keyed `<file>::<enclosing fn>`.",
+    "Enforced by scripts/gc_rekeyed_key_tables.py: an unclassified site FAILS, and",
+    "so does an entry that matches no site -- a fix must delete its own exemption.",
+    "`open_gap` verdicts are capped by MAX_OPEN_GAPS in that script and may only go down."
+  ],
+  "sites": [
+    {
+      "site": "crates/perry-runtime/src/array/header.rs::scan_array_named_property_roots_mut",
+      "table": "ARRAY_NAMED_PROPS",
+      "death": "dead_owner:prune_dead_array_named_property_owners",
+      "why": "Registered prune retains on !is_dead_owner over the array owner address (array/header.rs:352)."
+    },
+    {
+      "site": "crates/perry-runtime/src/buffer/own_props.rs::scan_buffer_own_props_roots_mut",
+      "table": "buffer_props()",
+      "death": "self_pruned:clear_buffer_own_props",
+      "why": "Dropped by finalize_collected_dead_buffer (buffer/header.rs:772) off collect_dead_registered_buffers_post_trace; buffers are arena_alloc_gc_old + TENURED (buffer/header.rs:593-600), so a copying minor never forwards one."
+    },
+    {
+      "site": "crates/perry-runtime/src/builtins/console.rs::scan_console_log_singleton_roots_mut",
+      "table": "CONSOLE_INSTANCES",
+      "death": "open_gap:#8190",
+      "why": "No prune anywhere: absent from DEAD_KEY_PRUNES and from gc_type_clear_dead_payload_side_tables; the key is a plain js_object_alloc address (console.rs:1037-1049)."
+    },
+    {
+      "site": "crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs::scan_boxed_primitive_payload_roots_mut",
+      "table": "BOXED_PRIMITIVE_PAYLOADS",
+      "death": "open_gap:#8191",
+      "why": "No prune anywhere: the file holds only the declaration, two reads and this scanner; the key is an ObjectHeader address (boxed_primitives.rs:98)."
+    },
+    {
+      "site": "crates/perry-runtime/src/closure/dynamic_props.rs::scan_closure_dynamic_props_roots_mut",
+      "table": "CLOSURE_PROPS / CLOSURE_STATIC_PROTOTYPES / CLOSURE_DELETED_KEYS",
+      "death": "dead_owner:prune_dead_closure_side_table_owners",
+      "why": "All three tables are retained on the GC_TYPE_CLOSURE-narrowed predicate in one prune (closure/dynamic_props.rs:206-214)."
+    },
+    {
+      "site": "crates/perry-runtime/src/fs/mod.rs::scan_filehandle_object_fd_metadata_roots_mut",
+      "table": "FILEHANDLE_OBJECT_FDS",
+      "death": "dead_owner:prune_dead_filehandle_fd_entries",
+      "why": "Registered prune retains on the FileHandle object owner (fs/mod.rs:131); the id-keyed DIR_REGISTRY is deliberately excluded and is not an address key."
+    },
+    {
+      "site": "crates/perry-runtime/src/json/mod.rs::scan_parse_roots_mut",
+      "table": "PARSE_KEY_RING",
+      "death": "key_is_rooted",
+      "why": "The same scanner marks the identical StringHeader addresses eight lines earlier through PARSE_KEY_CACHE (visit_tagged_raw_const_ptr_slot with STRING_TAG, json/mod.rs:554-557); the ring is a strict subset, and every cache clear is paired with clear_parse_key_ring."
+    },
+    {
+      "site": "crates/perry-runtime/src/map.rs::scan_map_iterator_array_roots_mut",
+      "table": "MAP_ITERATOR_ARRAYS",
+      "death": "dead_owner:prune_dead_map_iterator_array_owners",
+      "why": "Registered prune retains on !is_dead_owner over the iterator array address (map.rs:54)."
+    },
+    {
+      "site": "crates/perry-runtime/src/node_submodules/diagnostics.rs::scan_diagnostics_channel_key_roots_mut",
+      "table": "DIAG_CHANNEL_BY_KEY",
+      "death": "key_is_rooted",
+      "why": "The Symbol arm's bits are marked as state.name by visit_nanbox_f64_slot (node_submodules/mod.rs:1509); every DIAG_CHANNEL_BY_KEY insert is paired with a DIAG_CHANNELS insert and eviction removes both (diagnostics.rs:924-996)."
+    },
+    {
+      "site": "crates/perry-runtime/src/node_vm.rs::scan_vm_roots_mut",
+      "table": "VM_CONTEXTS / VM_SCRIPTS / VM_FUNCTIONS",
+      "death": "dead_owner:prune_dead_vm_owner_entries",
+      "why": "One registered prune retains all three tables on !is_dead_owner (node_vm.rs:1420-1434)."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/arguments.rs::scan_arguments_object_roots_mut",
+      "table": "ARGUMENTS_OBJECTS",
+      "death": "dead_owner:prune_dead_arguments_object_entries",
+      "why": "Registered prune retains on !is_dead_owner over the arguments-object owner (object/arguments.rs:79-86)."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/class_registry/gc_roots.rs::visit_metadata_nanbox_key",
+      "table": "FUNCTION_CLASS_IDS",
+      "death": "dead_owner:prune_dead_function_class_id_keys",
+      "why": "The #8168 fix: retains on the GC_TYPE_CLOSURE-narrowed predicate over the POINTER_TAG'd closure address (class_registry/gc_roots.rs:530). This helper is the rekey path for both scan_function_class_id_keys_mut and its budgeted twin."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/descriptor_state.rs::rewrite_descriptor_owner",
+      "table": "state().descriptors.property_descriptors + .accessor_descriptors",
+      "death": "dead_owner:prune_dead_descriptor_owner_entries",
+      "why": "Registered prune retains both maps on !is_dead_owner (object/descriptor_state.rs:1035-1055); handle-band ids in the same maps are skipped by the probe as unattributable."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/mod.rs::scan_transition_cache_roots_mut",
+      "table": "TRANSITION_CACHE_GLOBAL",
+      "death": "open_gap:#8192",
+      "why": "Neither entry.prev_keys nor entry.key_ptr is marked or pruned; only entry.next_keys is a strong root (object/mod.rs:1005-1007). A rewrite does invalidate the entry, but only after rewrite_raw_addr has already read the recycled header."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/mod.rs::scan_overflow_fields_roots_mut",
+      "table": "state().object_hot.overflow_fields",
+      "death": "self_pruned:clear_overflow_for_ptr",
+      "why": "Cleared per dead object by gc_type_clear_dead_payload_side_tables (gc/types.rs:799) from the sweep (gc/oldgen.rs:700, 924, 1573), outside the dead_owner fan-out."
+    },
+    {
+      "site": "crates/perry-runtime/src/object/shapes.rs::scan_shape_table_rekey_mut",
+      "table": "state().shapes.inner (descriptors + indices)",
+      "death": "dead_owner:prune_dead_shape_keys",
+      "why": "Registered prune drops descriptors whose keys_array is dead and retains inner.indices on the same predicate, then rebuilds the reverse indices (object/shapes.rs:966-985)."
+    },
+    {
+      "site": "crates/perry-runtime/src/perf_hooks.rs::scan_perf_entries_roots_mut",
+      "table": "PERF_ENTRY_KEYS_ARRAY",
+      "death": "key_is_rooted",
+      "why": "The recorded address is the shared shape keys_array that scan_shape_cache_roots_mut strongly marks with visit_raw_mut_ptr_slot (object/mod.rs:1041); it is also allocated longlived (object/alloc.rs:753) so it never sits in a copying from-space."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/async_step.rs::scan_async_step_thunk_cache_mut",
+      "table": "LAST_ASYNC_STEP_THUNKS",
+      "death": "key_is_rooted",
+      "why": "The same scanner strongly marks the fulfill/reject thunks (visit_raw_mut_ptr_slot, async_step.rs:850-851) whose capture slot 0 IS the key closure (async_step.rs:881-884), and closure captures are traced and rewritten by trace_closure."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/combinators.rs::scan_promise_all_states_mut",
+      "table": "PROMISE_ALL_STATES",
+      "death": "self_pruned:remove_all_states_for_dead_promise",
+      "why": "Sweep path via the PromiseCleanup finalize hook (gc/types.rs:835-838 -> promise/mod.rs:1024); copying path via cleanup_copied_minor_all_states_for_gc (promise/mod.rs:1087), which validates obj_type == GC_TYPE_PROMISE before trusting FORWARDED."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/reactions.rs::scan_promise_settle_listeners_mut",
+      "table": "PROMISE_SETTLE_LISTENERS",
+      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
+      "why": "Sweep path from promise/mod.rs:1022 and copying path via cleanup_copied_minor_settle_listeners_for_gc (promise/mod.rs:1085), both keyed on a validated promise header."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/reactions.rs::scan_promise_overflow_reactions_mut",
+      "table": "PROMISE_OVERFLOW_REACTIONS",
+      "death": "self_pruned:remove_overflow_reactions_for_dead_promise",
+      "why": "Sweep path from promise/mod.rs:1023 and copying path via cleanup_copied_minor_overflow_reactions_for_gc (promise/mod.rs:1086), both keyed on a validated promise header."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_roots_mut",
+      "table": "ASYNC_STEP_GUARD.last_closure (+ PROMISE_CONTEXTS)",
+      "death": "open_gap:#8193",
+      "why": "PROMISE_CONTEXTS in this same function is self-pruned by clear_promise_context, but ASYNC_STEP_GUARD.last_closure (scanners.rs:89) is written at microtasks.rs:749 and never marked or pruned; the verdict takes the weaker of the two keys."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_async_step_guard_step",
+      "table": "ASYNC_STEP_GUARD.last_closure",
+      "death": "open_gap:#8193",
+      "why": "Budgeted twin of the scanners.rs:89 site on the identical Cell, with the identical missing prune."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_contexts_step",
+      "table": "PROMISE_CONTEXTS",
+      "death": "self_pruned:clear_promise_context",
+      "why": "Budgeted twin of the scanners.rs:100 site on the same store; sweep path promise/mod.rs:1005-1012, copying path promise/mod.rs:1069-1084."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_all_states_step",
+      "table": "PROMISE_ALL_STATES",
+      "death": "self_pruned:remove_all_states_for_dead_promise",
+      "why": "Budgeted twin of scan_promise_all_states_mut on the same PromiseKeyedTable, with the same two prune paths."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_settle_listeners_step",
+      "table": "PROMISE_SETTLE_LISTENERS",
+      "death": "self_pruned:remove_settle_listeners_for_dead_promise",
+      "why": "Budgeted twin of scan_promise_settle_listeners_mut on the same PromiseKeyedTable, with the same two prune paths."
+    },
+    {
+      "site": "crates/perry-runtime/src/promise/scanners.rs::scan_promise_overflow_reactions_step",
+      "table": "PROMISE_OVERFLOW_REACTIONS",
+      "death": "self_pruned:remove_overflow_reactions_for_dead_promise",
+      "why": "Budgeted twin of scan_promise_overflow_reactions_mut on the same PromiseKeyedTable, with the same two prune paths."
+    },
+    {
+      "site": "crates/perry-runtime/src/proxy.rs::rewrite_metadata_target_bits",
+      "table": "REFLECT_METADATA (MetadataKey.target_bits)",
+      "death": "open_gap:#8194",
+      "why": "Entries are removed only by Reflect.deleteMetadata (proxy/metadata.rs:95); only the value is marked (proxy.rs:2009), and the scanner's own doc concedes keys go stale on a target move."
+    },
+    {
+      "site": "crates/perry-runtime/src/set.rs::scan_set_iterator_array_roots_mut",
+      "table": "SET_ITERATOR_ARRAYS",
+      "death": "dead_owner:prune_dead_set_iterator_array_owners",
+      "why": "Registered prune retains on !is_dead_owner over the iterator array address (set.rs:51)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/accessors.rs::scan_symbol_accessor_roots_mut",
+      "table": "SYMBOL_ACCESSOR_PROPERTIES (owner half)",
+      "death": "open_gap:#8195",
+      "why": "prune_dead_symbol_property_owners covers only SYMBOL_PROPERTIES and SYMBOL_PROPERTY_ATTRS (symbol.rs:528-550); the accessor table's only bulk removal is on the handle-recycle path (symbol/properties.rs:163). The sym_key half IS rooted (accessors.rs:149)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/accessors.rs::scan_symbol_accessor_root_slot",
+      "table": "SYMBOL_ACCESSOR_PROPERTIES (owner half)",
+      "death": "open_gap:#8195",
+      "why": "Budgeted twin of scan_symbol_accessor_roots_mut on the same table, with the identical missing prune."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_roots_mut",
+      "table": "SYMBOL_PROPERTIES",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Registered prune retains on !is_dead_owner over the property owner (symbol.rs:530-539)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_property_attrs_mut",
+      "table": "SYMBOL_PROPERTY_ATTRS",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Same registered prune retains the attrs map on the owner half of its tuple key (symbol.rs:540-549)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_pointer_metadata_roots_mut",
+      "table": "SYMBOL_POINTERS",
+      "death": "dead_owner:prune_dead_symbol_pointers",
+      "why": "Registered prune retains on the GC_TYPE_STRING-narrowed predicate (symbol.rs:563-568), which is correct because symbols are gc_malloc'd with GC_TYPE_STRING (symbol.rs:646-649)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_property_owner_if_forwarded",
+      "table": "SYMBOL_PROPERTIES",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Budgeted per-slot twin of scan_symbol_property_roots_mut on the same table and prune (symbol.rs:530)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_property_attrs_if_forwarded",
+      "table": "SYMBOL_PROPERTY_ATTRS",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "Budgeted per-slot twin of scan_symbol_property_attrs_mut on the same table and prune (symbol.rs:540)."
+    },
+    {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::rewrite_symbol_pointer_metadata_if_forwarded",
+      "table": "SYMBOL_POINTERS",
+      "death": "dead_owner:prune_dead_symbol_pointers",
+      "why": "Budgeted per-slot twin of scan_symbol_pointer_metadata_roots_mut on the same table and prune (symbol.rs:563)."
+    },
+    {
+      "site": "crates/perry-runtime/src/weakref.rs::rewritten_holder_addr",
+      "table": "WEAK_HOLDERS",
+      "death": "self_pruned:prune_dead_weak_holders",
+      "why": "Called directly from prune_dead_owner_side_tables_post_trace (gc/dead_owner.rs), not from fan_out; the copying path prunes inline via HolderDisposition::Drop in process_weak_targets_from_registry (weakref.rs:960-966)."
+    }
+  ]
+}

--- a/scripts/gc_rekeyed_key_tables.py
+++ b/scripts/gc_rekeyed_key_tables.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Custody gate for REKEYED address-keyed side tables (#8174).
+
+WHY THIS EXISTS
+---------------
+
+`RuntimeRootVisitor::visit_metadata_usize_slot` (and its `i64` / raw-pointer
+siblings) rewrite a recorded raw heap address if a moving collection forwarded
+it, and deliberately do NOT mark it. That is the whole point: the address is a
+side table's KEY, not a reference the program can reach, so keeping it alive
+would leak. The cost of that choice is that the key's object CAN die, and the
+arena can then recycle the address under it.
+
+When that happens the copying minor's rewrite pass reads the recycled bytes as
+a `GcHeader`. #8040 is what that looks like: recycled payload bytes with
+`gc_flags = 0x86` — `GC_FLAG_FORWARDED` set by coincidence — `obj_type = 104`,
+and a "forwarding pointer" that was really a NaN-boxed value. The walk followed
+it, the caller masked it to 48 bits, and a synthetic class's id was bound to an
+interned string. The program died several collections later in an unrelated
+function with `TypeError: value is not a function`, and tracing it back took
+days.
+
+`gc::dead_owner` is the fix for that class: it drops entries whose key object is
+provably dead, so no dead key survives to be walked. #8168 wired up the one
+table that had been missed. Nothing was checking, and nothing would catch the
+next one — the invariant was maintained by a hand-written list happening to be
+complete. This script is that check.
+
+WHAT IT DOES
+------------
+
+1. **Enumerate** every `visit_metadata_*` call site in `perry-runtime` /
+   `perry-stdlib`, attributed to its enclosing `fn`. That set IS the population
+   of rekeyed keys — a slot rewritten without being marked.
+
+2. **Read the runtime registry**: `DEAD_KEY_PRUNES` in
+   `crates/perry-runtime/src/gc/dead_owner.rs`, the array `fan_out()` iterates.
+   A `death: "dead_owner:<fn>"` verdict must name a prune that is actually in
+   it, so deleting a prune from the registry fails here rather than silently
+   reopening #8040.
+
+3. **Require a written verdict** for every site, in
+   `scripts/gc_rekeyed_key_tables.json`. A new site with no entry fails; an
+   entry that matches no site fails (a stale exemption is how these gates rot —
+   same rule as `scripts/gc_root_dominance_allowlist.json` and
+   `scripts/gc_runtime_root_holders.json`).
+
+VERDICTS
+--------
+
+* `dead_owner:<fn>`   — pruned by a registered `DEAD_KEY_PRUNES` entry.
+* `self_pruned:<fn>`  — pruned by the table's own GC pass, not via
+                        `dead_owner`. `<fn>` must exist in the tree.
+* `key_is_rooted`     — some scanner strongly MARKS the same address, so the
+                        key cannot die while the entry lives. `why` must name
+                        the marking site.
+* `not_a_gc_address`  — the key is a handle id, an fd, or a `Box::leak`'d
+                        pseudo-object with no `GcHeader`, so it is never
+                        forwardable. `why` must say which.
+* `open_gap:#<issue>` — no prune and no rooting, tracked. Permitted, CAPPED,
+                        and never allowed to grow: `MAX_OPEN_GAPS` is the count
+                        at landing time.
+
+HOW IT FAILS
+------------
+
+* a rekey site with no manifest entry               -> exit 1
+* a manifest entry matching no rekey site           -> exit 1
+* `dead_owner:<fn>` not in the runtime registry     -> exit 1
+* `self_pruned:<fn>` not defined anywhere           -> exit 1
+* a verdict with no `why`                           -> exit 1
+* more `open_gap` entries than `MAX_OPEN_GAPS`      -> exit 1
+* fewer than `MIN_SITES` sites matched              -> exit 2 (regex rot: a
+  scan that stopped matching would otherwise report a clean, empty, green run)
+* fewer than `MIN_REGISTRY_PRUNES` registry entries -> exit 2, same reason
+
+WHAT THIS GATE CANNOT SEE
+-------------------------
+
+Named, because an unstated limit is how a gate gets trusted past its subject.
+
+* **Whether a prune is CORRECT.** It reads the wiring, not the predicate. A
+  prune that narrows on the wrong `obj_type` reads as covered here.
+* **A key rekeyed by hand**, outside `visit_metadata_*` — e.g. a table walked
+  by a per-object move hook (`gc_type_after_payload_move`). Those are not in
+  the population and need no entry; three registry prunes
+  (`ELEMENT_SHAPES`, `OBJECT_PROTOTYPES`, `exotic_expando`) are exactly that
+  shape, which is why registry entries are NOT required to have a site.
+* **Timing.** On the copying minor the rewrite pass runs BEFORE the prune
+  (`copying.rs`: rewrite, then `finalize_dead_copied_minor_from_space_side_
+  allocations`). A prune therefore protects the NEXT cycle, which is sound only
+  because the address is not recycled until the later from-space flip. This
+  gate does not check that ordering.
+
+Usage:
+    python3 scripts/gc_rekeyed_key_tables.py             # check the repo
+    python3 scripts/gc_rekeyed_key_tables.py --list      # print the population
+    python3 scripts/gc_rekeyed_key_tables.py --self-test # check the checker
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_NAME = "scripts/gc_rekeyed_key_tables.json"
+REGISTRY_PATH = "crates/perry-runtime/src/gc/dead_owner.rs"
+CRATES = ("crates/perry-runtime/src", "crates/perry-stdlib/src")
+
+# `gc/roots.rs` DEFINES the three methods; its own bodies are not call sites.
+EXCLUDED_FILES = ("crates/perry-runtime/src/gc/roots.rs",)
+
+# Floors. A regex that stops matching must fail loudly, not report a clean run.
+MIN_SITES = 30
+MIN_REGISTRY_PRUNES = 12
+# The number of declared, tracked `open_gap` verdicts at landing time. This
+# number may go DOWN. Raising it is a decision, not a fix.
+MAX_OPEN_GAPS = 8
+
+REKEY_CALL = re.compile(
+    r"\.visit_metadata_(?:usize_slot|i64_slot|usize_raw_slot)\s*\("
+)
+FN_DECL = re.compile(
+    r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?(?:default\s+)?(?:const\s+)?"
+    r"(?:async\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]*\"\s+)?fn\s+([A-Za-z0-9_]+)"
+)
+REGISTRY_PRUNE = re.compile(r"prune:\s*crate::(?:[A-Za-z0-9_]+::)*([A-Za-z0-9_]+)\s*,")
+ANY_FN_DEF = re.compile(r"\bfn\s+([A-Za-z0-9_]+)")
+
+VERDICT_KINDS = (
+    "dead_owner",
+    "self_pruned",
+    "key_is_rooted",
+    "not_a_gc_address",
+    "open_gap",
+)
+
+
+def is_test_path(rel: str) -> bool:
+    return (
+        "/tests/" in rel
+        or rel.endswith("/tests.rs")
+        or rel.endswith("_tests.rs")
+        or "/benches/" in rel
+    )
+
+
+def collect_sites(root: Path) -> list[tuple[str, str, int]]:
+    """Every rekey call site as (repo-relative file, enclosing fn, line)."""
+    sites: list[tuple[str, str, int]] = []
+    for crate in CRATES:
+        base = root / crate
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.rs")):
+            rel = path.relative_to(root).as_posix()
+            if is_test_path(rel) or rel in EXCLUDED_FILES:
+                continue
+            enclosing = "<file scope>"
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                decl = FN_DECL.match(line)
+                if decl:
+                    enclosing = decl.group(1)
+                stripped = line.lstrip()
+                # A doc comment showing the call is documentation, not a site.
+                if stripped.startswith("//"):
+                    continue
+                if REKEY_CALL.search(line):
+                    sites.append((rel, enclosing, lineno))
+    return sites
+
+
+def registry_prunes(root: Path) -> set[str]:
+    path = root / REGISTRY_PATH
+    if not path.is_file():
+        return set()
+    text = path.read_text()
+    start = text.find("DEAD_KEY_PRUNES")
+    if start < 0:
+        return set()
+    return set(REGISTRY_PRUNE.findall(text[start:]))
+
+
+def defined_fns(root: Path) -> set[str]:
+    names: set[str] = set()
+    for crate in CRATES:
+        base = root / crate
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.rs"):
+            names.update(ANY_FN_DEF.findall(path.read_text()))
+    return names
+
+
+def load_manifest(root: Path) -> list[dict]:
+    path = root / MANIFEST_NAME
+    if not path.is_file():
+        return []
+    data = json.loads(path.read_text())
+    return data.get("sites", data) if isinstance(data, dict) else data
+
+
+def check(root: Path, *, min_sites: int = MIN_SITES,
+          min_registry: int = MIN_REGISTRY_PRUNES,
+          max_open_gaps: int = MAX_OPEN_GAPS) -> tuple[int, list[str]]:
+    out: list[str] = []
+    sites = collect_sites(root)
+    keys = {f"{rel}::{fn}" for rel, fn, _ in sites}
+    prunes = registry_prunes(root)
+
+    if len(keys) < min_sites:
+        return 2, [
+            f"only {len(keys)} rekey sites matched (floor {min_sites}). The scan "
+            "regex or the crate list is broken; an empty scan reads as a clean "
+            "run, so this is a hard failure rather than a pass.",
+        ]
+    if len(prunes) < min_registry:
+        return 2, [
+            f"only {len(prunes)} entries parsed out of DEAD_KEY_PRUNES in "
+            f"{REGISTRY_PATH} (floor {min_registry}). Every `dead_owner:` "
+            "verdict would read as unregistered; refusing to adjudicate.",
+        ]
+
+    manifest = load_manifest(root)
+    by_site: dict[str, dict] = {}
+    for entry in manifest:
+        site = entry.get("site", "")
+        if site in by_site:
+            out.append(f"duplicate manifest entry for {site}")
+        by_site[site] = entry
+
+    open_gaps = 0
+    for site in sorted(keys):
+        entry = by_site.get(site)
+        if entry is None:
+            out.append(
+                f"UNCLASSIFIED rekey site {site}: a metadata key is rewritten "
+                "here without being marked, so its object can die and the "
+                "recycled address can be walked as a forwarding header "
+                f"(#8174). Add an entry to {MANIFEST_NAME}."
+            )
+            continue
+        death = str(entry.get("death", ""))
+        why = str(entry.get("why", "")).strip()
+        kind, _, arg = death.partition(":")
+        if kind not in VERDICT_KINDS:
+            out.append(f"{site}: unknown death verdict {death!r}")
+            continue
+        if len(why) < 20:
+            out.append(f"{site}: verdict {death!r} needs a `why` that says how")
+        if kind == "dead_owner":
+            if arg not in prunes:
+                out.append(
+                    f"{site}: death names `{arg}`, which is not in "
+                    f"DEAD_KEY_PRUNES ({REGISTRY_PATH}). Either the prune was "
+                    "removed from the registry or the verdict is wrong."
+                )
+        elif kind == "self_pruned":
+            if arg not in defined_fns(root):
+                out.append(f"{site}: self_pruned names `{arg}`, which is not defined")
+        elif kind == "open_gap":
+            open_gaps += 1
+            if not re.fullmatch(r"#\d+", arg):
+                out.append(f"{site}: open_gap must name an issue, got {arg!r}")
+
+    for site in sorted(by_site):
+        if site not in keys:
+            out.append(
+                f"STALE manifest entry {site}: no rekey site matches it any "
+                "more. A fix must delete its own exemption."
+            )
+
+    if open_gaps > max_open_gaps:
+        out.append(
+            f"{open_gaps} open_gap verdicts, cap is {max_open_gaps}. A new "
+            "rekeyed table without a prune is #8040 again; wire it into "
+            "DEAD_KEY_PRUNES instead of raising the cap."
+        )
+
+    if out:
+        return 1, out
+    return 0, [
+        f"{len(keys)} rekey sites, {len(prunes)} registered prunes, "
+        f"{open_gaps}/{max_open_gaps} declared gaps — all classified."
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Self-test: plant each failure shape and require the checker to reject it.
+# A gate nobody has watched fail is a gate nobody has tested.
+# ---------------------------------------------------------------------------
+GOOD_REGISTRY = """
+pub(super) const DEAD_KEY_PRUNES: &[DeadKeyPrune] = &[
+    DeadKeyPrune { table: "T1", owner: DeadKeyOwner::Any, prune: crate::a::prune_one, },
+    DeadKeyPrune { table: "T2", owner: DeadKeyOwner::Closure, prune: crate::b::c::prune_two, },
+];
+"""
+
+GOOD_SOURCE = """
+fn scan_one_mut(visitor: &mut RuntimeRootVisitor<'_>) {
+    visitor.visit_metadata_usize_slot(&mut owner);
+}
+fn scan_two_mut(visitor: &mut RuntimeRootVisitor<'_>) {
+    visitor.visit_metadata_i64_slot(&mut key);
+}
+fn prune_one(_d: &dyn Fn(usize) -> bool) {}
+fn prune_two(_d: &dyn Fn(usize) -> bool) {}
+fn its_own_pass(_d: &dyn Fn(usize) -> bool) {}
+"""
+
+GOOD_MANIFEST = {
+    "sites": [
+        {
+            "site": "crates/perry-runtime/src/one.rs::scan_one_mut",
+            "table": "T1",
+            "death": "dead_owner:prune_one",
+            "why": "pruned by the registered T1 prune in the fan-out",
+        },
+        {
+            "site": "crates/perry-runtime/src/one.rs::scan_two_mut",
+            "table": "T2",
+            "death": "self_pruned:its_own_pass",
+            "why": "pruned by its own registry pass at collection time",
+        },
+    ]
+}
+
+SELF_TEST_KWARGS = {"min_sites": 2, "min_registry": 2, "max_open_gaps": 0}
+
+
+def _plant(root: Path, registry: str, source: str, manifest: dict) -> None:
+    (root / "crates/perry-runtime/src/gc").mkdir(parents=True, exist_ok=True)
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    (root / REGISTRY_PATH).write_text(registry)
+    (root / "crates/perry-runtime/src/one.rs").write_text(source)
+    (root / MANIFEST_NAME).write_text(json.dumps(manifest))
+
+
+def _run(registry: str, source: str, manifest: dict, **kw) -> tuple[int, list[str]]:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _plant(root, registry, source, manifest)
+        return check(root, **{**SELF_TEST_KWARGS, **kw})
+
+
+def self_test() -> int:
+    import copy
+
+    failures: list[str] = []
+
+    def expect(label: str, want: int, got: tuple[int, list[str]]) -> None:
+        if got[0] != want:
+            failures.append(f"{label}: wanted exit {want}, got {got[0]} {got[1]}")
+
+    expect("a correctly classified tree passes", 0,
+           _run(GOOD_REGISTRY, GOOD_SOURCE, GOOD_MANIFEST))
+
+    # 1. A NEW rekey site with no verdict.
+    expect("new unclassified rekey site", 1, _run(
+        GOOD_REGISTRY,
+        GOOD_SOURCE + "\nfn scan_three_mut(v: &mut V) { v.visit_metadata_usize_slot(&mut k); }\n",
+        GOOD_MANIFEST))
+
+    # 2. A stale entry that matches nothing.
+    stale = copy.deepcopy(GOOD_MANIFEST)
+    stale["sites"].append({
+        "site": "crates/perry-runtime/src/one.rs::scan_gone_mut",
+        "table": "T9", "death": "dead_owner:prune_one",
+        "why": "a table that was deleted, whose exemption was not",
+    })
+    expect("stale manifest entry", 1, _run(GOOD_REGISTRY, GOOD_SOURCE, stale))
+
+    # 3. The prune is dropped from the runtime registry.
+    expect("prune removed from DEAD_KEY_PRUNES", 1, _run(
+        GOOD_REGISTRY.replace(
+            'DeadKeyPrune { table: "T1", owner: DeadKeyOwner::Any, prune: crate::a::prune_one, },',
+            'DeadKeyPrune { table: "T1", owner: DeadKeyOwner::Any, prune: crate::a::prune_other, },'),
+        GOOD_SOURCE, GOOD_MANIFEST))
+
+    # 4. `self_pruned` naming a function that does not exist.
+    ghost = copy.deepcopy(GOOD_MANIFEST)
+    ghost["sites"][1]["death"] = "self_pruned:no_such_pass"
+    expect("self_pruned names a missing fn", 1, _run(GOOD_REGISTRY, GOOD_SOURCE, ghost))
+
+    # 5. A verdict with no reasoning.
+    bare = copy.deepcopy(GOOD_MANIFEST)
+    bare["sites"][0]["why"] = "because"
+    expect("verdict without a why", 1, _run(GOOD_REGISTRY, GOOD_SOURCE, bare))
+
+    # 6. An open_gap over the cap.
+    gap = copy.deepcopy(GOOD_MANIFEST)
+    gap["sites"][1]["death"] = "open_gap:#8174"
+    expect("open_gap over the cap", 1, _run(GOOD_REGISTRY, GOOD_SOURCE, gap))
+    expect("open_gap under the cap passes", 0,
+           _run(GOOD_REGISTRY, GOOD_SOURCE, gap, max_open_gaps=1))
+    nonum = copy.deepcopy(gap)
+    nonum["sites"][1]["death"] = "open_gap:soon"
+    expect("open_gap without an issue number", 1,
+           _run(GOOD_REGISTRY, GOOD_SOURCE, nonum, max_open_gaps=1))
+
+    # 7. Floor rot: the scan finds nothing / the registry parse finds nothing.
+    expect("scan regex rot", 2, _run(GOOD_REGISTRY, "fn nothing() {}\n", {"sites": []}))
+    expect("registry parse rot", 2,
+           _run("pub(super) const DEAD_KEY_PRUNES: &[DeadKeyPrune] = &[];\n",
+                GOOD_SOURCE, GOOD_MANIFEST))
+
+    # 8. A doc comment showing the call is not a site.
+    expect("a doc comment is not a call site", 0, _run(
+        GOOD_REGISTRY,
+        GOOD_SOURCE + "\n//! see `visitor.visit_metadata_usize_slot(&mut key)`\n",
+        GOOD_MANIFEST))
+
+    for line in failures:
+        print(f"self-test FAIL: {line}")
+    if failures:
+        return 1
+    print("self-test: 12 planted shapes, all adjudicated as expected")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--list", action="store_true", help="print the population")
+    ap.add_argument("--self-test", action="store_true", help="check the checker")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.list:
+        manifest = {e.get("site"): e for e in load_manifest(REPO_ROOT)}
+        for rel, fn, lineno in collect_sites(REPO_ROOT):
+            entry = manifest.get(f"{rel}::{fn}", {})
+            print(f"{rel}:{lineno}\t{fn}\t{entry.get('table', '?')}\t"
+                  f"{entry.get('death', 'UNCLASSIFIED')}")
+        return 0
+
+    code, messages = check(REPO_ROOT)
+    for line in messages:
+        print(("gc_rekeyed_key_tables: " if code else "") + line)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gc_rekeyed_key_tables.py
+++ b/scripts/gc_rekeyed_key_tables.py
@@ -117,10 +117,13 @@ EXCLUDED_FILES = ("crates/perry-runtime/src/gc/roots.rs",)
 
 # Floors. A regex that stops matching must fail loudly, not report a clean run.
 MIN_SITES = 30
-MIN_REGISTRY_PRUNES = 12
-# The number of declared, tracked `open_gap` verdicts at landing time. This
-# number may go DOWN. Raising it is a decision, not a fix.
-MAX_OPEN_GAPS = 8
+MIN_REGISTRY_PRUNES = 16
+# Declared, tracked `open_gap` verdicts allowed. ZERO, and it stays zero: the
+# audit that came with this gate found six rekeyed tables with no death story
+# (#8190-#8195) and all six were fixed rather than exempted, so there is no
+# precedent here for declaring one. Raising this is a decision to ship a known
+# #8040 exposure, not a fix.
+MAX_OPEN_GAPS = 0
 
 REKEY_CALL = re.compile(
     r"\.visit_metadata_(?:usize_slot|i64_slot|usize_raw_slot)\s*\("


### PR DESCRIPTION
Closes #8174, #8190, #8191, #8192, #8193, #8194, #8195.

## What was wrong

`GC_FLAG_FORWARDED` means "the first payload word is where this object moved to". Both forwarding walkers — `CopyingNurseryCollector::rewrite_raw_addr` and `gc::verify::try_rewrite_raw_addr` — trusted that byte for **any** address in a known heap region, and trusted whatever word they found behind it.

For a slot the collector already proved is a live reference, both are safe. For a **metadata key** neither is. `RuntimeRootVisitor::visit_metadata_usize_slot` and its siblings rewrite a recorded raw heap address if a moving collection forwarded it, and deliberately do **not** mark it — the key is a side table's key, not a reference the program can reach, so rooting it would leak. The price is that the key's object can die and the arena can recycle the address under it.

#8040 is what that looks like, instrumented: recycled payload bytes at a dead `FUNCTION_CLASS_IDS` key presenting `gc_flags = 0x86` (`GC_FLAG_FORWARDED` set by coincidence), `obj_type = 104` — a type id no `GcTypeInfo` entry exists for — and a "forwarding pointer" that was really a NaN-boxed value (`0x7FFF…`). The walk followed it, could not classify the next hop, **stopped and returned it**, and `visit_metadata_nanbox_key` masked it to 48 bits into a live, unrelated survivor. #8168 removed that one dead key. This closes the following, and then removes the remaining dead keys.

## 1. Two discriminators, one at each end of the hop (`gc/forwarding.rs`, new)

* **`forwarding_walk_header`** refuses to read a forwarding pointer out of an address that does not read back as a real arena object header (`plausible_gc_header`: registered `obj_type`, sane size, `GC_FLAG_ARENA`). #8040's bytes fail on `obj_type = 104`. Every real forwarding source passes — `set_forwarding_address` overwrites one payload word and ORs one flag bit, and all four production installers (`copying::move_young`, promotion, `gc::oldgen` defrag, `array::push_pop`'s growth stub) operate on arena objects.

  This is **not** the `self.ptrs.classify()` gate that `rewrite_raw_addr`'s own doc records as having un-rekeyed legitimate `shapes.entries` keys and turned the verifier red. That one additionally narrows on SPACE and resolves the survivor thread-locals; the header test carries none of that. `plausible_gc_header` is already the acceptance test `CopyingPointerSet::classify_arena` applies to every arena pointer the collector classifies, so nothing it rejects was ever an object the collector could have moved.
* **`accept_forwarding_target`** refuses a target that is not the start of a heap object, so a bogus word can no longer become the answer by virtue of the walk merely stopping at it. Off-arena it still accepts a malloc'd array-growth target, but only above the handle band and below `HEAP_MAX` — which is what the `0x7FFF…` word fails.

Both are applied to the verifier too. `try_rewrite_raw_addr` is what `RuntimeRootVisitMode::Verify` runs, and it panics whenever it can rewrite a slot the rewrite pass left alone; tightening one walker alone would have converted a silent corruption into a `PERRY_GC_VERIFY_EVACUATION` abort blaming an innocent scanner.

Refusals are counted and, under `PERRY_GC_DIAG=1`, reported **only when non-zero** as

```
[gc-forwarding] copying_minor refused_sources=3 refused_targets=0 total_sources=8 total_targets=0 by_walk=[crate::object::shapes::scan_shape_table_rekey_mut=3]
```

The `by_walk` breakdown comes from `pin::CopyingWalkPhaseGuard`, which already names the scanner around every rewrite-pass walk. The aggregate says a stale key reached a rewrite walk; the breakdown says *whose*, which is the whole distance between "there is a bug of the #8040 shape somewhere" and a fix — #8040 itself took days to attribute.

## 2. The structural half

`gc::dead_owner` is the real fix for this class: drop the entry before its dead key can be walked. Its fan-out covered a dozen tables, #8168 made it thirteen, and nothing checked the list was complete.

* **`DEAD_KEY_PRUNES`** (`gc/dead_owner.rs`) is now the registry `fan_out` iterates: 19 entries, each naming the tables it prunes and which of the pass's three deadness predicates it takes.
* **`scripts/gc_rekeyed_key_tables.py`**, wired into `lint` (a required context), enumerates all 37 `visit_metadata_*` sites in `perry-runtime`/`perry-stdlib` and requires a written verdict for each in `scripts/gc_rekeyed_key_tables.json`.

### What the gate rejects

| shape | result |
|---|---|
| a new rekey site with no verdict | exit 1 |
| a manifest entry matching no site (stale exemption) | exit 1 |
| `dead_owner:<fn>` naming a prune not in `DEAD_KEY_PRUNES` | exit 1 |
| `self_pruned:<fn>` naming a function that does not exist | exit 1 |
| a verdict with no reasoning | exit 1 |
| any `open_gap` verdict at all (`MAX_OPEN_GAPS = 0`) | exit 1 |
| the site scan or the registry parse matching too little | exit **2** — a broken regex must not read as a clean, empty, green run |

`--self-test` plants twelve shapes (every row above, plus an `open_gap` without an issue number, plus a doc comment that must **not** count as a site, plus a correctly-classified tree that must pass) and requires the checker to adjudicate each. It runs in the same `lint` step, before the real scan.

## 3. What the audit found — all six fixed, not exempted

The gate's first run turned up six more rekeyed tables with no death story. Rather than declare them, they are fixed, so the manifest lands with **zero** gaps and `MAX_OPEN_GAPS = 0`.

| table | fix | issue |
|---|---|---|
| `CONSOLE_INSTANCES` | `prune_dead_console_instance_owners` | #8190 |
| `BOXED_PRIMITIVE_PAYLOADS` | `prune_dead_boxed_primitive_payload_owners` | #8191 |
| `TRANSITION_CACHE_GLOBAL` (`prev_keys`, `key_ptr`) | `prune_dead_transition_cache_entries` | #8192 |
| `ASYNC_STEP_GUARD.last_closure` | **field deleted** | #8193 |
| `REFLECT_METADATA.target_bits` | `prune_dead_reflect_metadata_targets` | #8194 |
| `SYMBOL_ACCESSOR_PROPERTIES` (owner half) | folded into `prune_dead_symbol_property_owners` | #8195 |

**#8193 is not a prune.** `AsyncStepGuard::last_closure` held the address of the closure that took the last erroring async step, for a same-closure check that was **deleted** when #712/#921/#922 showed a runaway loop alternates between two closures. Nothing has read it since. It was not inert, though — it was a raw heap address the promise scanner rekeyed without marking, and nothing pruned it. Writing a prune to maintain state nobody reads is its own dead code, so the field goes, and with it the `PROMISE_SCAN_ASYNC_STEP_GUARD` budgeted phase whose only slot it was.

**#8195 is not a new prune either.** The accessor table shares its owner key with `SYMBOL_PROPERTIES` and `SYMBOL_PROPERTY_ATTRS`, both pruned since the 2026-07-09 audit, and was simply left out. It now takes the same pass's memoized owner verdict, so all three agree about every owner. That also closes a leak — a dead owner's accessor closures were immortal.

## Tests

**`gc/tests/forwarding_target_validation.rs`, 5 cases.** The two sabotage cases plant #8040's shape verbatim and **assert the premise first** — the address classifies as heap, the byte carries `GC_FLAG_FORWARDED`, and `104` is not a registered type — so a green run says the discriminator works rather than that nothing was tried. The premise case asserts the opposite direction: a genuine evacuation still rewrites and **neither refusal counter moves**, which is the property the rejected `classify()`-based tightening broke. The registry case asserts `DEAD_KEY_PRUNES` has not shrunk, its labels are unique, and #8168's `FUNCTION_CLASS_IDS` entry is still present with its `GC_TYPE_CLOSURE` narrowing.

**`gc/tests/dead_owner_side_tables.rs`, 10 new cases.** Each new prune gets a pair: the prune **fires** (dead owner, one collection, the table observably shrinks) and its inverse (a rooted owner's entry survives — a prune that drops live entries is worse than the stale key it removes). The transition-cache case allocates its rooted `next_keys` in OLD-GEN on purpose: a reachable neighbour in the dead array's own nursery block would force-mark it (#7975) and the prune would correctly decline, which would have read as a failure of the prune.

## Local validation

**End-to-end, under the moving collector.** A churn fixture (60 rounds × 120 objects, dropping all but a 3-round window) that exercises exactly the surfaces this touches — varied shapes, symbol-keyed properties, accessor descriptors, `Map`/`Set` + iterators, synthetic classes via plain-function prototypes, closure dynamic props, proxies with a `get` trap, `Reflect.get`, promises — run under

```
PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED=<8174|8040|1> PERRY_GC_FORCE_EVACUATE=1 \
PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=64 PERRY_GC_DIAG=1
```

| seed | copying minors | copied_objects | `retired_set` | verify panics | `[gc-forwarding]` | oracle |
|---|---|---|---|---|---|---|
| 8174 | 3,605 | 296,537 | `#3604` | 0 | 0 | byte-identical to node |
| 8040 | 5,060 | 411,522 | `#5319` | 0 | 0 | byte-identical to node |
| 1 | 3,605 | 296,537 | `#3604` | 0 | 0 | byte-identical to node |

`scripts/gc_evacuation_liveness_assert.py` passes on all three, so the subject was live rather than "nothing threw". **Zero `[gc-forwarding]` lines** is the load-bearing number: on a healthy workload that hammers every rekeyed surface, the new discriminators refuse nothing, i.e. no legitimate rewrite was lost.

**Suites** (against `bfb0707be`):

- `cargo test -p perry-runtime --lib` — **2514 passed / 0 failed / 4 ignored**
- `cargo test -p perry --bin perry` — **987 passed / 0 failed**
- `cargo test -p perry-codegen --no-fail-fast` — **1483 passed / 9 failed**, the same 9 by name as `main` (this crate does not depend on `perry-runtime`)

**Gates**: `cargo fmt --all -- --check`, `check_file_size.sh`, `gc_runtime_root_holders.py`, `gc_store_site_inventory.py`, `gc_pin_sites.py` (+ `--self-test`), `gc_gate_wiring_check.py`, `raw_handle_debt.py` (990, unchanged), `shape_descriptor_census.py`, `addr_class_inventory.py`, `check_gc_env_knobs.py`, `check_test_registration.py`, `class_id_collisions.py`, `workspace_architecture.py --check`, `check_gc_doc_claims.py`, `check_locale_independent_io.py`, and the new `gc_rekeyed_key_tables.py` (+ `--self-test`) — all clean. `check_thread_locals.py` is red on `main` for three files this branch does not touch (`dyn_eval/interp.rs`, `module_require.rs`, `node_vm.rs`); the new counters use `crate::perry_thread_local!` and add no fourth.

`scripts/gc_pin_sites.py` gains one allowlist entry: the planted `gc_flags = 0x86` carries bit 2, but nothing is being pinned — the address is payload interior of a live allocation with no object at it, and rewriting the byte as named flags would misreport what #8040 actually observed.

## Not fixed here

**#8163 is unaffected and stays open.** Retested on `53e8a21e3` before this branch: the production Next App Route fixture's forced-evacuation arm still fails with `TypeError: value is not a function` (243 copying minors, 117,579 objects copied, 0 verify panics, normal arm green) — [details on the issue](https://github.com/PerryTS/perry/issues/8163#issuecomment-5306500848). This branch narrows what a stale key can be *followed* into; the holder losing that closure is a different defect.

https://claude.ai/code/session_01AHvBYz7E6wWKv8kmvLLGpj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection safety by rejecting invalid forwarding pointers and targets.
  * Removed stale entries from runtime metadata tables when their owning objects are collected.
  * Preserved valid rooted entries during cleanup.
  * Simplified asynchronous error handling by removing obsolete closure tracking.

* **Tests**
  * Added comprehensive coverage for forwarding validation and stale metadata cleanup.

* **Chores**
  * Added automated audits to verify garbage-collection cleanup coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->