### PR TITLE
fix(ext-fetch): let the crate's own test binary link, restoring the ext-link gate

### DIFF
--- a/changelog.d/8197-ext-fetch-test-link.md
+++ b/changelog.d/8197-ext-fetch-test-link.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- `perry-ext-fetch` can build its own test binary again (#8155). `perry-runtime`
+  is compiled here with `external-fetch-symbols`, so it declares `js_blob_new`,
+  `js_file_new`, `js_headers_init_from_value` and `js_fetch_notify_signal_aborted`
+  as `extern` and calls them, on the promise that the final link supplies them —
+  which `perry-stdlib` does in a real binary but nothing does in this crate's
+  test link. `cargo test --no-run` therefore failed to link, which kept the
+  `ext-link` gate red on every PR; since `cargo-test`'s scope deliberately keeps
+  `perry-ext-*` out of its fan-out (#7656), that left the whole ext family
+  ungated, and this crate's own 13 tests had never run.
+
+  The four symbols are now defined in a `#[cfg(test)]` module rather than for
+  real: this crate is a `staticlib` whose objects win the final link ahead of
+  perry-stdlib, so shipping them would silently replace perry-stdlib's
+  Blob/File/Headers constructors and abort bridge everywhere. `cfg(test)` code
+  never reaches `libperry_ext_fetch.a`, and perry-stdlib is absent from the test
+  link, so no duplicate symbol can arise. A guard test asserts no shipped file
+  in the crate defines any of the four, so moving them out from behind
+  `cfg(test)` fails there rather than at a customer's link.

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -29,6 +29,12 @@ use validation::{throw_range_error, throw_type_error};
 #[cfg(test)]
 mod test_async_shims;
 
+// Definitions for the four fetch symbols perry-runtime CALLS under
+// `external-fetch-symbols` but perry-stdlib OWNS, so this crate's own test
+// binary links (#8155). Test-only on purpose — see the module docs.
+#[cfg(test)]
+mod test_link_stubs;
+
 const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;

--- a/crates/perry-ext-fetch/src/test_link_stubs.rs
+++ b/crates/perry-ext-fetch/src/test_link_stubs.rs
@@ -1,0 +1,153 @@
+//! Test-binary definitions for the fetch symbols `perry-runtime` CALLS but
+//! this crate does not own (#8155).
+//!
+//! # Why this exists
+//!
+//! `perry-runtime` is built here with `external-fetch-symbols`, which is
+//! correct for every shipped configuration: it declares
+//! `js_blob_new` / `js_file_new` / `js_headers_init_from_value` /
+//! `js_fetch_notify_signal_aborted` as `extern` and *calls* them
+//! (`object/global_fetch.rs`, `url/abort.rs`), on the promise that someone
+//! else in the final link defines them. In a real binary that someone is
+//! `perry-stdlib` (`fetch_blob.rs`, `fetch/abort_bridge.rs`).
+//!
+//! This crate's own test binary links `perry-runtime` and nothing else, so
+//! those calls have no definition and `cargo test --no-run` fails to link —
+//! which is what kept the `ext-link` gate red on every PR while
+//! `cargo-test`'s scope deliberately keeps `perry-ext-*` out of its fan-out
+//! (#7656). The gate for the whole ext family was therefore dark.
+//!
+//! # Why `#[cfg(test)]` rather than a real implementation
+//!
+//! This crate is a `staticlib` whose objects WIN the final link ahead of
+//! perry-stdlib (`prefer_well_known_before_stdlib`). Defining these four for
+//! real here would therefore *replace* perry-stdlib's Blob/File/Headers
+//! constructors and abort bridge in every shipped binary — a behaviour change
+//! smuggled in under a CI fix, and one that would have to reimplement
+//! `FETCH_ABORT_WATCHERS` and the blob registry to be equivalent. This crate
+//! implements 39 fetch symbols; these four are deliberately not among them.
+//!
+//! `#[cfg(test)]` is compiled only into the test harness, never into
+//! `libperry_ext_fetch.a`, so the shipped surface is byte-identical and no
+//! duplicate symbol can reach a real link. The
+//! `shipped_staticlib_does_not_define_stdlib_owned_fetch_symbols` test below
+//! is the standing proof of that.
+//!
+//! Semantics match `perry-runtime`'s own `stdlib_stubs.rs`: warn once, return
+//! `undefined`. A test that needs real Blob/File behaviour needs perry-stdlib
+//! in its link, and should say so rather than silently getting a no-op.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+fn warn_once(name: &str) {
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        eprintln!(
+            "perry-ext-fetch: test-only stub `{name}` called — perry-stdlib owns \
+             the real implementation and is not in this test binary's link (#8155)"
+        );
+    }
+}
+
+/// `undefined`, NaN-boxed. Spelled out rather than imported so this module
+/// depends on nothing that could drift it away from the runtime's ABI.
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+#[no_mangle]
+pub extern "C" fn js_blob_new(_parts: f64, _type_value: f64) -> f64 {
+    warn_once("js_blob_new");
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub extern "C" fn js_file_new(
+    _parts: f64,
+    _name: f64,
+    _type_value: f64,
+    _last_modified: f64,
+) -> f64 {
+    warn_once("js_file_new");
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub extern "C" fn js_headers_init_from_value(_handle: f64, _init: f64) -> f64 {
+    warn_once("js_headers_init_from_value");
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+#[no_mangle]
+pub extern "C" fn js_fetch_notify_signal_aborted(_signal_ptr: i64) {
+    warn_once("js_fetch_notify_signal_aborted");
+}
+
+#[cfg(test)]
+mod tests {
+    /// The four symbols above must never reach the shipped archive.
+    ///
+    /// They are `#[cfg(test)]`, so this asserts a property of the build
+    /// configuration rather than of the source: if someone later moves this
+    /// module out from behind `cfg(test)` — or the crate starts exporting a
+    /// real one of these — `libperry_ext_fetch.a` would begin overriding
+    /// perry-stdlib's constructors at the final link, silently, because ext
+    /// archives are linked first. Reading the crate's own source for a
+    /// non-`cfg(test)` definition is the check that survives that move.
+    #[test]
+    fn shipped_staticlib_does_not_define_stdlib_owned_fetch_symbols() {
+        let source = include_str!("test_link_stubs.rs");
+        let cfg_test_position = source
+            .find("#[cfg(test)]")
+            .expect("this module is gated behind #[cfg(test)] in lib.rs");
+        assert!(
+            cfg_test_position > 0,
+            "test_link_stubs must stay behind #[cfg(test)]"
+        );
+
+        for symbol in [
+            "js_blob_new",
+            "js_file_new",
+            "js_headers_init_from_value",
+            "js_fetch_notify_signal_aborted",
+        ] {
+            let defined_outside_this_module = crate_sources_defining(symbol);
+            assert!(
+                defined_outside_this_module.is_empty(),
+                "{symbol} is defined in the shipped surface ({defined_outside_this_module:?}); \
+                 that overrides perry-stdlib's implementation at the final link, because ext \
+                 archives are linked before stdlib"
+            );
+        }
+    }
+
+    /// Files of this crate (excluding this test-only module) that define
+    /// `symbol` as a `#[no_mangle]` export.
+    fn crate_sources_defining(symbol: &str) -> Vec<String> {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let needle = format!("fn {symbol}(");
+        let mut hits = Vec::new();
+        let mut stack = vec![root];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_none_or(|ext| ext != "rs")
+                    || path.file_name().is_some_and(|n| n == "test_link_stubs.rs")
+                {
+                    continue;
+                }
+                if std::fs::read_to_string(&path)
+                    .is_ok_and(|text| text.contains(&needle) && text.contains("no_mangle"))
+                {
+                    hits.push(path.display().to_string());
+                }
+            }
+        }
+        hits
+    }
+}

--- a/crates/perry-ext-fetch/src/test_link_stubs.rs
+++ b/crates/perry-ext-fetch/src/test_link_stubs.rs
@@ -94,13 +94,22 @@ mod tests {
     /// non-`cfg(test)` definition is the check that survives that move.
     #[test]
     fn shipped_staticlib_does_not_define_stdlib_owned_fetch_symbols() {
-        let source = include_str!("test_link_stubs.rs");
-        let cfg_test_position = source
-            .find("#[cfg(test)]")
-            .expect("this module is gated behind #[cfg(test)] in lib.rs");
+        // Read the GATE, not this file. An earlier version scanned
+        // `test_link_stubs.rs` for `#[cfg(test)]` and found the annotation on
+        // the inner `mod tests` below — so deleting the gate in `lib.rs`, the
+        // one thing that keeps these four symbols out of the shipped archive,
+        // left the assertion passing. The fact under test lives in lib.rs.
+        let lib_rs = include_str!("lib.rs");
+        let declaration = lib_rs
+            .find("mod test_link_stubs;")
+            .expect("lib.rs must declare the test_link_stubs module");
+        let preceding = &lib_rs[..declaration];
         assert!(
-            cfg_test_position > 0,
-            "test_link_stubs must stay behind #[cfg(test)]"
+            preceding.trim_end().ends_with("#[cfg(test)]"),
+            "`mod test_link_stubs;` in lib.rs must be immediately preceded by \
+             #[cfg(test)] — without it these four symbols land in \
+             libperry_ext_fetch.a and override perry-stdlib's implementations \
+             at the final link, because ext archives are linked first"
         );
 
         for symbol in [


### PR DESCRIPTION
Closes #8155.

## The failure

`cargo test --no-run -p perry-ext-fetch` cannot link:

```
Undefined symbols for architecture arm64:
  "_js_blob_new",                    referenced from: perry_runtime::object::global_fetch::call_global_blob_new
  "_js_fetch_notify_signal_aborted", referenced from: perry_runtime::url::abort::notify_fetch_abort
  "_js_file_new",                    referenced from: perry_runtime::object::global_fetch::call_global_file_new
  "_js_headers_init_from_value",     referenced from: perry_runtime::object::global_fetch::call_global_headers_init_from_value
```

`perry-runtime` is built here with `external-fetch-symbols`, which is correct for every shipped configuration: it declares those four `extern` and *calls* them, on the promise that the final link provides them. In a real binary `perry-stdlib` does (`fetch_blob.rs`, `fetch/abort_bridge.rs`). This crate's test binary links `perry-runtime` and nothing else.

**The cost was not one crate.** `ext-link` is the only gate covering `perry-ext-*`, because `cargo-test`'s scope deliberately keeps that family out of its fan-out (#7656). While it was red on every PR, the whole family was ungated — and `perry-ext-fetch`'s own **13 tests had never run**, because the binary could not be produced. They pass.

## The fix, and what it deliberately is not

Four definitions in a `#[cfg(test)]` module.

**Not real implementations.** This crate is a `staticlib` whose objects win the final link ahead of perry-stdlib (`prefer_well_known_before_stdlib`), so defining them for real would *replace* perry-stdlib's Blob/File/Headers constructors and abort bridge in every shipped binary — a behaviour change smuggled in under a CI fix, and one that would have to reimplement `FETCH_ABORT_WATCHERS` and the blob registry to be equivalent. This crate implements 39 fetch symbols; these four are deliberately not among them.

`#[cfg(test)]` never reaches `libperry_ext_fetch.a`, and perry-stdlib is absent from the test link, so no duplicate symbol can arise. Semantics match the runtime's own `stdlib_stubs.rs`: warn once, return `undefined`.

**Also not the dev-dependency route**, which #8155's analysis had already tried and rejected: adding `perry-stdlib` plus `extern crate` to force its objects in does make the link succeed, but produces `duplicate symbol` diagnostics that macOS `ld` downgrades to warnings — link-order-dependent binding in a test binary, which is precisely the failure shape of #8156.

A guard test asserts that no non-`cfg(test)` file in this crate defines any of the four, so a later move out from behind `cfg(test)` fails here rather than silently overriding stdlib at link time. **Sabotage-verified**: defining `js_blob_new` in a shipped module fails it with the offending path named.

## One thing in the issue's analysis that is a false premise

The issue notes that `stdlib_stubs.rs` has no `js_file_new` stub (nor `js_fetch_notify_signal_aborted`) and reads that as an independent gap. It isn't: both call sites are `cfg`'d on `external-fetch-symbols`, and the non-external arms use the `GLOBAL_FETCH_*` function-pointer registry and a no-op respectively. Nothing references them in the stub configuration, so no stub is owed. Recorded so nobody "fixes" it.

## Relationship to #8187

#8187 makes `ext-link` opt-in on PRs (label `run-extended-tests`) and adds nightly/tag arms, citing this issue as the reason. That stops the noise; it does not make the link work, so the nightly arm would still have been red. The two are complementary — this PR touches only Rust and no workflow file, so they cannot conflict.

## Validation

- `cargo test --release --no-run -p perry-ext-fetch` — the gate's exact command — **links**.
- `cargo check --release -p perry-ext-fetch` (the gate's per-package feature-graph step) clean.
- `cargo test -p perry-ext-fetch`: **13 passed**, up from a crate that could not build a test binary.
- `cargo fmt --check`, `check_file_size.sh` clean; no new clippy warnings (the 4 on this crate are pre-existing).

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored successful test-binary builds for the external fetch component.
  * Added safeguards to ensure test-only compatibility code is excluded from shipped builds.
  * Prevented fetch functionality from being unintentionally overridden in production.
  * Improved build reliability and verification for fetch-related functionality without changing the behavior of released applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->