### PR TITLE
test(gap): make the gap gate capable of passing (10 of 15 snapshot entries recorded an unreachable status)

### DIFF
--- a/changelog.d/8196-gap-gate-unreachable-node-fail.md
+++ b/changelog.d/8196-gap-gate-unreachable-node-fail.md
@@ -1,0 +1,65 @@
+### Fixed — the gap gate could never be green
+
+`run_parity_tests.sh` can only record `node_fail` via `perry_abnormal_exit`, which
+matches **signals and timeout only** (124, 132/134/136/138/139, >128). Node's real
+failures in this suite are a plain `exit 1` — `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`
+for the enum and parameter-property tests (strip-only mode cannot run them, and
+Node 26 dropped `--experimental-transform-types`), and `MODULE_NOT_FOUND` for the
+npm ones. Those fall through to a normal comparison and come out `parity_fail`.
+
+**Ten of the fifteen `gap_snapshot.json` entries recorded `node_fail`, a status the
+harness is structurally incapable of emitting.** `gap_snapshot.py diff()` therefore
+returned `changed` for every one, and any diff makes it exit 1 — so the gate could
+never pass, on any tree. It survived because `parity` is tag-gated and invisible
+per-PR; `conformance-smoke` (which runs `run_gap_tests.sh --shard N/8`, the same
+suite) is what surfaced it as 8/8 red shards in #8117.
+
+This is the mirror of CLAUDE.md's "four ways a gate can be unable to **fail**": a
+gate that cannot **pass** is equally uninformative, and rots the same way.
+
+Resolved by category rather than by editing statuses — the schema says "do not
+hand-edit", and hand-editing is how ten impossible statuses got there:
+
+* **3 TypeScript-syntax tests** (`test_gap_4510_enum_forward_ref`,
+  `test_gap_derived_param_props`, `test_gap_enum_in_function_body`) get
+  `test-parity/expected/*.txt` fixtures — the channel the `test_decorators_*` tests
+  already use for exactly this reason. Node can never run them, so the oracle was
+  built with `esbuild` → node and cross-checked against the expectations written in
+  each test's own header; Perry is byte-identical to all three. Note
+  `test_gap_derived_param_props` already said *"this is a perry-only expected-output
+  test"* — the fixture was simply never created, so it had verified nothing since May.
+* **6 npm tests** (`backoff_options`, `cron_cronjob`, `dayjs_factory_arg`,
+  `moment_methods`, `ratelimiter_memory`, `slugify_options`) had their packages
+  declared as devDependencies. They were never in `package.json`, so the oracle could
+  not run **in any environment, CI included** — `npm ci` would not install them
+  either. `.npmrc` says the root npm install exists precisely to "materialize the
+  parity-test fixture deps". All six now run under node with exit 0 and all six match
+  Perry: live parity, which is stronger than a frozen fixture.
+* **1 remaining, re-triaged as a real Perry bug** rather than a snapshot artifact.
+  `test_gap_prop_plan_cache_invalidation` is written for sloppy mode but runs as ESM,
+  which is strict, so its frozen-object writes throw. Node and Perry both correctly
+  throw and differ only in the message: node names the constructor (`'#<H>'`), Perry
+  hardcodes `'#<Object>'` at `error.rs:1726`, because
+  `js_throw_type_error_immutable_write` takes `(kind, key_ptr, key_len)` and no
+  receiver. Recorded with that root cause; the fix is a receiver-aware variant behind
+  the existing `throw_immutable_write` wrapper (14 callers, no codegen ABI change).
+
+The snapshot was then **regenerated from a full 562-test run** (`UPDATE_SNAPSHOT=1`),
+not hand-edited: **99.1% parity, 5 non-passing entries, 0 crashes**, and
+`gap_snapshot.py check` exits 0. `test_gap_iterator_helpers_2874`, which had been
+listed while passing, is gone.
+
+Also fixed: `scripts/gc_gate_wiring_check.py` did not list `check_gc_env_knobs.py`
+in `GATES`, so the gate-integrity checker could not see one of the gates it exists to
+audit. Now 8 gates, self-test green.
+
+Two things deliberately not done. `SKIP_TESTS` in `run_parity_tests.sh` is exact-match
+and holds only legacy `test_*` names, so it can never match a `test_gap_*` test — left
+alone because every current case is better served by the expected-output channel.
+And `test_gap_webcrypto_async_threadpool` failed once during an unsharded verification
+run at load ~64 and was **not** recorded: it asserts that an async digest crosses a
+macrotask boundary, node printed `false`, and 5/5 re-runs at load ~45 print `true`,
+matching Perry. The oracle flaked, and parking it would have converted a load artifact
+into a permanently accepted failure.
+
+Refs #8117.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "perry",
+  "name": "wt-gapfix",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +9,13 @@
         "node-cron": "^4.2.1"
       },
       "devDependencies": {
+        "cron": "^4.4.0",
+        "dayjs": "^1.11.21",
+        "exponential-backoff": "^3.1.3",
+        "moment": "^2.30.1",
         "mongodb": "^7.0.0",
+        "rate-limiter-flexible": "^11.2.0",
+        "slugify": "^1.6.9",
         "zod": "^4.3.5"
       }
     },
@@ -53,6 +59,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.4.tgz",
+      "integrity": "sha512-V536ZAd6ZJztrrBlLcDFaaZrXNAL2E5uGmssWf/dpSiLkmkLScXUYhUBnWPmtW+cIqnNHzf6//TCMpIc9SCRRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -95,6 +108,31 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ethers": {
       "version": "6.17.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
@@ -123,12 +161,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/mongodb": {
       "version": "7.0.0",
@@ -208,6 +273,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-11.2.0.tgz",
+      "integrity": "sha512-L0eIK+BmFMi6NcvmtEg7RSswOFKi9MMD5RhBIypFfOve+G6Jl1Xbb8qEHgK3uRzNtkOFYF0L9f7P4rSf2PnUVw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slugify": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sparse-bitfield": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "test:scripts": "node --test scripts/soak/*.test.mts"
   },
   "devDependencies": {
+    "cron": "^4.4.0",
+    "dayjs": "^1.11.21",
+    "exponential-backoff": "^3.1.3",
+    "moment": "^2.30.1",
     "mongodb": "^7.0.0",
+    "rate-limiter-flexible": "^11.2.0",
+    "slugify": "^1.6.9",
     "zod": "^4.3.5"
   },
   "dependencies": {

--- a/scripts/gc_gate_wiring_check.py
+++ b/scripts/gc_gate_wiring_check.py
@@ -103,6 +103,16 @@ GATES = [
         "unit tests structurally cannot cover: a NEW materialiser path that "
         "forgets to finalize at all",
     ),
+    (
+        ".github/workflows/test.yml",
+        "lint",
+        "scripts/check_gc_env_knobs.py (--self-test, then the gate itself) — "
+        "the only CI execution of the GC env-knob kill-policy check, which "
+        "caught #8131's inverted PERRY_LL_RS4GC_STACKMAP_TRACE polarity. It is "
+        "a STEP inside `lint` rather than a job of its own, so the job-level "
+        "reachability question this script asks is the only wiring hazard it "
+        "can have — and #8166 was filed believing it ran nowhere at all",
+    ),
 ]
 
 MAIN_LINE_EVENTS = ("push", "schedule")

--- a/test-parity/expected/test_gap_4510_enum_forward_ref.txt
+++ b/test-parity/expected/test_gap_4510_enum_forward_ref.txt
@@ -1,0 +1,6 @@
+fwd: B
+num: 2
+auto: 2
+before: green
+dispatch: isB
+back: off

--- a/test-parity/expected/test_gap_derived_param_props.txt
+++ b/test-parity/expected/test_gap_derived_param_props.txt
@@ -1,0 +1,4 @@
+base: 1 def
+mid: 2 mid true [9]
+leaf: 3 mid false [1,2] leaf
+withBody: 5 T init-T

--- a/test-parity/expected/test_gap_enum_in_function_body.txt
+++ b/test-parity/expected/test_gap_enum_in_function_body.txt
@@ -1,0 +1,5 @@
+parse: gem:GEM,gem:foo
+levels: 0,1,2,HIGH
+classify: missing ok other
+nested: ab
+mixed: one/two

--- a/test-parity/gap_snapshot.json
+++ b/test-parity/gap_snapshot.json
@@ -24,62 +24,6 @@
       "category": "bug-open",
       "reason": "process SIGINT trace hook gap; standing per #5917 diff."
     },
-    "test_gap_4510_enum_forward_ref": {
-      "status": "node_fail",
-      "issue": null,
-      "added": "2026-07-22",
-      "category": "gap-categorical",
-      "reason": "node --experimental-strip-types refuses this file: ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX, 'TypeScript enum is not supported in strip-only mode'. The oracle CANNOT execute the very feature under test, so this has never verified anything. Fix by giving it a test-parity/expected/<name>.txt fixture (expected-output mode), not by editing the test."
-    },
-    "test_gap_backoff_options": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'exponential-backoff' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
-    },
-    "test_gap_cron_cronjob": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'cron' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
-    },
-    "test_gap_dayjs_factory_arg": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'dayjs' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
-    },
-    "test_gap_derived_param_props": {
-      "status": "node_fail",
-      "issue": null,
-      "added": "2026-07-22",
-      "category": "gap-categorical",
-      "reason": "node --experimental-strip-types refuses this file: ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX, 'TypeScript parameter property is not supported in strip-only mode'. The oracle CANNOT execute the very feature under test, so this has never verified anything. Fix by giving it a test-parity/expected/<name>.txt fixture (expected-output mode), not by editing the test."
-    },
-    "test_gap_enum_in_function_body": {
-      "status": "node_fail",
-      "issue": null,
-      "added": "2026-07-30",
-      "category": "gap-categorical",
-      "reason": "node --experimental-strip-types refuses a function-body enum with ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX. The oracle cannot execute the TypeScript syntax under test; add an expected-output fixture to restore coverage."
-    },
-    "test_gap_iterator_helpers_2874": {
-      "status": "parity_fail",
-      "issue": "2874",
-      "added": "2026-07-04",
-      "category": "bug-open",
-      "reason": "iterator helpers (#2874); standing per #5917."
-    },
-    "test_gap_moment_methods": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'moment' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
-    },
     "test_gap_perfhooks_3088_3008_3010_3011": {
       "status": "parity_fail",
       "issue": "3088",
@@ -88,25 +32,11 @@
       "reason": "perf_hooks cluster (#3088/#3008/#3010/#3011); standing per #5917."
     },
     "test_gap_prop_plan_cache_invalidation": {
-      "status": "node_fail",
+      "status": "parity_fail",
       "issue": null,
       "added": "2026-07-22",
-      "category": "gap-bisect",
-      "reason": "node exits non-zero with TypeError: Cannot assign to read only property 'q' of object '#<H>' (ESM is strict mode). Either the fixture needs to expect the throw or the assignment is wrong; needs triage. Surfaced by the snapshot recording node_fail."
-    },
-    "test_gap_ratelimiter_memory": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'rate-limiter-flexible' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
-    },
-    "test_gap_slugify_options": {
-      "status": "node_fail",
-      "issue": "1634",
-      "added": "2026-07-22",
-      "category": "ci-env",
-      "reason": "node exits non-zero: cannot resolve the 'slugify' npm import without node_modules, so the oracle never runs and the test verifies nothing. Same class as test_ramda_sum. Was invisible under the old gate, which dropped node_fail from the denominator; needs a CI-side fixture (#1634)."
+      "category": "bug-open",
+      "reason": "Root-caused 2026-08-16, no longer 'needs triage'. The test is written for SLOPPY mode (its own comments say \"writes must be dropped\" / \"silent no-op\") but runs as ESM, which is strict, so cases 3 and 4 throw instead. Node AND Perry both correctly throw; they differ only in the message. Node names the constructor -- \"of object '#<H>'\" -- while Perry hardcodes \"'#<Object>'\" at error.rs:1726, because js_throw_type_error_immutable_write takes (kind, key_ptr, key_len) and no receiver. normalize_failure_output keeps the full error line, so the messages diverge. Real Perry parity bug, not a snapshot artifact: 14 callers, all behind the throw_immutable_write wrapper, so a receiver-aware variant fixes it without a codegen ABI change."
     },
     "test_gap_v8_2_3680plus": {
       "status": "parity_fail",


### PR DESCRIPTION
### Fixed — the gap gate could never be green

`run_parity_tests.sh` can only record `node_fail` via `perry_abnormal_exit`, which
matches **signals and timeout only** (124, 132/134/136/138/139, >128). Node's real
failures in this suite are a plain `exit 1` — `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`
for the enum and parameter-property tests (strip-only mode cannot run them, and
Node 26 dropped `--experimental-transform-types`), and `MODULE_NOT_FOUND` for the
npm ones. Those fall through to a normal comparison and come out `parity_fail`.

**Ten of the fifteen `gap_snapshot.json` entries recorded `node_fail`, a status the
harness is structurally incapable of emitting.** `gap_snapshot.py diff()` therefore
returned `changed` for every one, and any diff makes it exit 1 — so the gate could
never pass, on any tree. It survived because `parity` is tag-gated and invisible
per-PR; `conformance-smoke` (which runs `run_gap_tests.sh --shard N/8`, the same
suite) is what surfaced it as 8/8 red shards in #8117.

This is the mirror of CLAUDE.md's "four ways a gate can be unable to **fail**": a
gate that cannot **pass** is equally uninformative, and rots the same way.

Resolved by category rather than by editing statuses — the schema says "do not
hand-edit", and hand-editing is how ten impossible statuses got there:

* **3 TypeScript-syntax tests** (`test_gap_4510_enum_forward_ref`,
  `test_gap_derived_param_props`, `test_gap_enum_in_function_body`) get
  `test-parity/expected/*.txt` fixtures — the channel the `test_decorators_*` tests
  already use for exactly this reason. Node can never run them, so the oracle was
  built with `esbuild` → node and cross-checked against the expectations written in
  each test's own header; Perry is byte-identical to all three. Note
  `test_gap_derived_param_props` already said *"this is a perry-only expected-output
  test"* — the fixture was simply never created, so it had verified nothing since May.
* **6 npm tests** (`backoff_options`, `cron_cronjob`, `dayjs_factory_arg`,
  `moment_methods`, `ratelimiter_memory`, `slugify_options`) had their packages
  declared as devDependencies. They were never in `package.json`, so the oracle could
  not run **in any environment, CI included** — `npm ci` would not install them
  either. `.npmrc` says the root npm install exists precisely to "materialize the
  parity-test fixture deps". All six now run under node with exit 0 and all six match
  Perry: live parity, which is stronger than a frozen fixture.
* **1 remaining, re-triaged as a real Perry bug** rather than a snapshot artifact.
  `test_gap_prop_plan_cache_invalidation` is written for sloppy mode but runs as ESM,
  which is strict, so its frozen-object writes throw. Node and Perry both correctly
  throw and differ only in the message: node names the constructor (`'#<H>'`), Perry
  hardcodes `'#<Object>'` at `error.rs:1726`, because
  `js_throw_type_error_immutable_write` takes `(kind, key_ptr, key_len)` and no
  receiver. Recorded with that root cause; the fix is a receiver-aware variant behind
  the existing `throw_immutable_write` wrapper (14 callers, no codegen ABI change).

The snapshot was then **regenerated from a full 562-test run** (`UPDATE_SNAPSHOT=1`),
not hand-edited: **99.1% parity, 5 non-passing entries, 0 crashes**, and
`gap_snapshot.py check` exits 0. `test_gap_iterator_helpers_2874`, which had been
listed while passing, is gone.

Also fixed: `scripts/gc_gate_wiring_check.py` did not list `check_gc_env_knobs.py`
in `GATES`, so the gate-integrity checker could not see one of the gates it exists to
audit. Now 8 gates, self-test green.

Two things deliberately not done. `SKIP_TESTS` in `run_parity_tests.sh` is exact-match
and holds only legacy `test_*` names, so it can never match a `test_gap_*` test — left
alone because every current case is better served by the expected-output channel.
And `test_gap_webcrypto_async_threadpool` failed once during an unsharded verification
run at load ~64 and was **not** recorded: it asserts that an async digest crosses a
macrotask boundary, node printed `false`, and 5/5 re-runs at load ~45 print `true`,
matching Perry. The oracle flaked, and parking it would have converted a load artifact
into a permanently accepted failure.

Refs #8117.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parity reporting so Node execution failures are distinguished from genuine parity mismatches.
  * Reclassified an immutable-write discrepancy for clearer tracking and follow-up.
* **Tests**
  * Updated expected results for enum handling, derived parameter properties, and nested parsing scenarios.
  * Refreshed parity snapshots to reflect current test outcomes and remove obsolete entries.
* **Chores**
  * Improved validation of test-gate wiring and environment settings.
  * Added development tooling to support scheduling, retries, date handling, rate limiting, and slug generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->