### PR TITLE
fix(runtime): convert four hot thread_locals, unbreaking self-test-checkers on main

### DIFF
--- a/changelog.d/8199-hot-thread-locals.md
+++ b/changelog.d/8199-hot-thread-locals.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Convert four hot `thread_local!` declarations to `crate::perry_thread_local!`,
+  which `self-test-checkers` was failing on across `main`
+  (`node_module/source_map.rs`, `node_vm.rs`, `dyn_eval/interp.rs`,
+  `module_require.rs`). All four are hot by #7469's own criterion: the first two
+  hold GC roots that `scan_roots` / `scan_vm_roots_mut` walk on every
+  collection, `interp.rs`'s is the AST-node → fn-id registry that re-evaluates
+  per request, and `module_require.rs`'s is per-`require()` state. Converting
+  rather than recording them cold is what the access pattern justifies.
+
+  `interp.rs`'s second block stays raw on purpose — a one-shot `REGISTERED`
+  flag, genuinely cold, and the one the allowlist already records for that file;
+  converting it too would leave a stale entry, which the checker also rejects.

--- a/crates/perry-runtime/src/dyn_eval/interp.rs
+++ b/crates/perry-runtime/src/dyn_eval/interp.rs
@@ -50,7 +50,7 @@ pub(crate) enum Flow {
 
 // ── nested-function registration cache ────────────────────────────────────
 
-thread_local! {
+crate::perry_thread_local! {
     /// AST-node address → registered fn id. Nested function/arrow expressions
     /// evaluate many times (ajv validators run per request); registering the
     /// node once keeps the registry bounded by the number of syntactic

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -802,7 +802,7 @@ mod path_registry;
 
 use path_registry::{PathModuleRequireError, MODULE_PATH_REGISTRY};
 
-thread_local! {
+crate::perry_thread_local! {
     static PENDING_REQUIRE_PARENT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 

--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -175,7 +175,7 @@ struct ScriptMetadata {
 
 static VM_COMPILED_FUNCTION_SOURCES: OnceLock<Mutex<HashMap<usize, String>>> = OnceLock::new();
 
-thread_local! {
+crate::perry_thread_local! {
     static VM_INTRINSIC_GLOBAL: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static VM_CONTEXTS: std::cell::RefCell<HashMap<usize, ContextState>> =
         std::cell::RefCell::new(HashMap::new());

--- a/crates/perry-runtime/src/process/node_module/source_map.rs
+++ b/crates/perry-runtime/src/process/node_module/source_map.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, RefCell};
 
 const SOURCE_MAP_CLASS_ID: u32 = 0xFFFF_04D0;
 
-thread_local! {
+crate::perry_thread_local! {
     static SOURCE_MAP_PROTOTYPE: Cell<u64> = const { Cell::new(0) };
     static SOURCE_MAP_CACHE: RefCell<std::collections::HashMap<String, u64>> =
         RefCell::new(std::collections::HashMap::new());


### PR DESCRIPTION
`self-test-checkers` is red on `main`, and has been for anyone who looks: four files declare raw `thread_local!` blocks that #7469's policy requires be `crate::perry_thread_local!` unless deliberately recorded as cold.

```
crates/perry-runtime/src/process/node_module/source_map.rs: 1 raw block(s), none allowed.
crates/perry-runtime/src/dyn_eval/interp.rs: gained raw blocks (1 recorded, 2 found).
crates/perry-runtime/src/module_require.rs: 1 raw block(s), none allowed.
crates/perry-runtime/src/node_vm.rs: 1 raw block(s), none allowed.
```

I hit it because it fails on my own unrelated PR (#8197); it is not caused by either.

## Converted, not recorded cold — and why that is the right side of the choice

The checker offers two resolutions, and picking the wrong one records a false fact. All four are hot by the policy's own criterion:

- **`source_map.rs`** and **`node_vm.rs`** hold **GC roots**: `scan_roots` and `scan_vm_roots_mut` walk them on *every* collection. `node_vm.rs` has 11 further `.with()` sites.
- **`dyn_eval/interp.rs`**'s top-level block is the AST-node → fn-id registry, and its own comment says it evaluates many times per request ("ajv validators run per request").
- **`module_require.rs`**'s `PENDING_REQUIRE_PARENT` is per-`require()` resolution state.

## One block deliberately left raw

`interp.rs` has a **second** block at line 269 — a one-shot `REGISTERED: Cell<bool>` guard inside a function. That one is genuinely cold, and it is the one `thread_local_cold_allowlist.json` already records for that file. Converting it too would drop the file's raw count to 0 and make the recorded entry stale, which the checker also fails on ("a stale allowlist entry is an entry nobody has to justify any more"). So the count stays 1 and the entry stays justified.

## Validation

- `scripts/check_thread_locals.py`: **FAILED → `OK: 224 hot declarations, 130 raw blocks in 91 recorded cold files, capacity 768`**
- `cargo test -p perry-runtime --lib`: **2514 passed**
- `cargo fmt --check` clean

Four one-line changes; no behaviour change — `perry_thread_local!` is documented as same syntax, same `.with()` at every call site.

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved management of frequently accessed runtime-local state.
  * Reduced overhead for thread-local access across evaluation, module loading, VM state, and source-map handling.

* **Documentation**
  * Added a changelog entry describing the runtime-local storage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->