### PR TITLE
fix(runtime): convert four raw thread_local! blocks so lint can pass on main

### DIFF
--- a/changelog.d/8199-thread-locals-lint-red.md
+++ b/changelog.d/8199-thread-locals-lint-red.md
@@ -1,0 +1,40 @@
+### Fixed — `lint` was red on `main`
+
+`scripts/check_thread_locals.py` is wired into the `lint` job and **exits 1 on
+clean `main`**, so the job has been failing for every commit since the two PRs
+that introduced the violations landed earlier today (#7312 and #7382). Per
+CLAUDE.md's own gate taxonomy this is the worst variety: a required context that
+is red for a pre-existing reason trains everyone to bypass it, and the next
+genuine failure arrives indistinguishable from the standing one.
+
+Four raw `thread_local!` blocks, all added today:
+
+* `crates/perry-runtime/src/dyn_eval/interp.rs` — **two** blocks against one
+  recorded, and the top-level one is explicitly hot by its own comment:
+  *"Nested function/arrow expressions evaluate many times (ajv validators run
+  per request)"*. On Darwin each read is a `_tlv_get_addr` **call** (#7469), so
+  this is the exact shape the policy exists to prevent.
+* `crates/perry-runtime/src/module_require.rs` — `PENDING_REQUIRE_PARENT`, on
+  the `require()` path.
+* `crates/perry-runtime/src/node_vm.rs` — `VM_INTRINSIC_GLOBAL`, `VM_CONTEXTS`.
+* `crates/perry-runtime/src/process/node_module/source_map.rs` —
+  `SOURCE_MAP_PROTOTYPE`, `SOURCE_MAP_CACHE`.
+
+All four converted to `crate::perry_thread_local!` rather than recorded as cold.
+The macro takes both the `= const { … }` and `= expr` forms and keeps `.with()`
+at every call site, so each is a one-line change; `cargo check -p perry-runtime`
+is clean with zero warnings. Conversion is the right default here — the script's
+own documentation says recording a declaration that is not cold "would be
+recording the wrong fact … and would spend the allowlist's credibility on
+entries no one can justify", and at least one of these is demonstrably hot.
+
+Re-recording the allowlist also drops the now-stale `interp.rs` entry (the file
+has no raw blocks left, and the checker fails on a stale entry as well as a new
+one — an entry nobody has to justify any more).
+
+**`_hot_declarations` moves 174 → 225, and 43 of that was already wrong.**
+Recomputing the field on pristine `main` yields 217, not the committed 174, so
+the counter had drifted through earlier PRs that converted declarations without
+re-running `--update`. The field is informational — only `--self-test` asserts
+it — so nothing was gated on the stale value, but the number in the file was not
+the number in the tree. It now is.

--- a/crates/perry-runtime/src/dyn_eval/interp.rs
+++ b/crates/perry-runtime/src/dyn_eval/interp.rs
@@ -50,7 +50,7 @@ pub(crate) enum Flow {
 
 // ── nested-function registration cache ────────────────────────────────────
 
-thread_local! {
+crate::perry_thread_local! {
     /// AST-node address → registered fn id. Nested function/arrow expressions
     /// evaluate many times (ajv validators run per request); registering the
     /// node once keeps the registry bounded by the number of syntactic
@@ -266,7 +266,7 @@ pub(crate) fn alloc_interp_closure(
 }
 
 fn ensure_thunk_registered() {
-    thread_local! {
+    crate::perry_thread_local! {
         static REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     }
     REGISTERED.with(|registered| {

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -802,7 +802,7 @@ mod path_registry;
 
 use path_registry::{PathModuleRequireError, MODULE_PATH_REGISTRY};
 
-thread_local! {
+crate::perry_thread_local! {
     static PENDING_REQUIRE_PARENT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 

--- a/crates/perry-runtime/src/node_vm.rs
+++ b/crates/perry-runtime/src/node_vm.rs
@@ -175,7 +175,7 @@ struct ScriptMetadata {
 
 static VM_COMPILED_FUNCTION_SOURCES: OnceLock<Mutex<HashMap<usize, String>>> = OnceLock::new();
 
-thread_local! {
+crate::perry_thread_local! {
     static VM_INTRINSIC_GLOBAL: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static VM_CONTEXTS: std::cell::RefCell<HashMap<usize, ContextState>> =
         std::cell::RefCell::new(HashMap::new());

--- a/crates/perry-runtime/src/process/node_module/source_map.rs
+++ b/crates/perry-runtime/src/process/node_module/source_map.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, RefCell};
 
 const SOURCE_MAP_CLASS_ID: u32 = 0xFFFF_04D0;
 
-thread_local! {
+crate::perry_thread_local! {
     static SOURCE_MAP_PROTOTYPE: Cell<u64> = const { Cell::new(0) };
     static SOURCE_MAP_CACHE: RefCell<std::collections::HashMap<String, u64>> =
         RefCell::new(std::collections::HashMap::new());

--- a/scripts/thread_local_cold_allowlist.json
+++ b/scripts/thread_local_cold_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Files still declaring raw `thread_local!`. Every entry is a declaration that pays `_tlv_get_addr` on Darwin; the count is a ratchet, so adding one to an already-listed file fails too. New code should use `crate::perry_thread_local!` \u2014 see crates/perry-runtime/src/tls_hot.rs. Regenerate with scripts/check_thread_locals.py --update.",
-  "_hot_declarations": 174,
+  "_hot_declarations": 225,
   "files": {
     "crates/perry-runtime/src/agent.rs": 1,
     "crates/perry-runtime/src/arena/block.rs": 2,
@@ -19,7 +19,6 @@
     "crates/perry-runtime/src/cluster.rs": 2,
     "crates/perry-runtime/src/dyn_eval/bridge.rs": 1,
     "crates/perry-runtime/src/dyn_eval/env.rs": 1,
-    "crates/perry-runtime/src/dyn_eval/interp.rs": 1,
     "crates/perry-runtime/src/dyn_eval/mod.rs": 1,
     "crates/perry-runtime/src/eh.rs": 1,
     "crates/perry-runtime/src/eh_walker.rs": 1,


### PR DESCRIPTION
### Fixed — `lint` was red on `main`

`scripts/check_thread_locals.py` is wired into the `lint` job and **exits 1 on
clean `main`**, so the job has been failing for every commit since the two PRs
that introduced the violations landed earlier today (#7312 and #7382). Per
CLAUDE.md's own gate taxonomy this is the worst variety: a required context that
is red for a pre-existing reason trains everyone to bypass it, and the next
genuine failure arrives indistinguishable from the standing one.

Four raw `thread_local!` blocks, all added today:

* `crates/perry-runtime/src/dyn_eval/interp.rs` — **two** blocks against one
  recorded, and the top-level one is explicitly hot by its own comment:
  *"Nested function/arrow expressions evaluate many times (ajv validators run
  per request)"*. On Darwin each read is a `_tlv_get_addr` **call** (#7469), so
  this is the exact shape the policy exists to prevent.
* `crates/perry-runtime/src/module_require.rs` — `PENDING_REQUIRE_PARENT`, on
  the `require()` path.
* `crates/perry-runtime/src/node_vm.rs` — `VM_INTRINSIC_GLOBAL`, `VM_CONTEXTS`.
* `crates/perry-runtime/src/process/node_module/source_map.rs` —
  `SOURCE_MAP_PROTOTYPE`, `SOURCE_MAP_CACHE`.

All four converted to `crate::perry_thread_local!` rather than recorded as cold.
The macro takes both the `= const { … }` and `= expr` forms and keeps `.with()`
at every call site, so each is a one-line change; `cargo check -p perry-runtime`
is clean with zero warnings. Conversion is the right default here — the script's
own documentation says recording a declaration that is not cold "would be
recording the wrong fact … and would spend the allowlist's credibility on
entries no one can justify", and at least one of these is demonstrably hot.

Re-recording the allowlist also drops the now-stale `interp.rs` entry (the file
has no raw blocks left, and the checker fails on a stale entry as well as a new
one — an entry nobody has to justify any more).

**`_hot_declarations` moves 174 → 225, and 43 of that was already wrong.**
Recomputing the field on pristine `main` yields 217, not the committed 174, so
the counter had drifted through earlier PRs that converted declarations without
re-running `--update`. The field is informational — only `--self-test` asserts
it — so nothing was gated on the stale value, but the number in the file was not
the number in the tree. It now is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved lint failures related to thread-local state declarations.
  * Updated thread-local validation counts and removed an outdated exception.
* **Chores**
  * Standardized internal thread-local storage usage across runtime components.
  * Updated the changelog with details of the maintenance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->