### PR TITLE
fix(gc): the root-dominance symbol scan must accept the C-unwind ABI

### DIFF
--- a/changelog.d/8207-root-dominance-c-unwind-abi.md
+++ b/changelog.d/8207-root-dominance-c-unwind-abi.md
@@ -1,0 +1,22 @@
+The GC root-dominance symbol scan accepts the `C-unwind` ABI, restoring the
+`gc-root-dominance` and `gc-root-dominance-statepoints` gates. Both were red on
+main with `POLL_CAPABLE_RUNTIME entries that name no runtime symbol:
+js_closure_call2`.
+
+The entry was correct. `js_closure_call2` is a real, exported runtime symbol;
+what the scan could not see was its ABI string, because `runtime_symbols`
+matched `extern "C" fn js_*` and the function is declared `extern "C-unwind"`.
+The audit's own message warns against the wrong repair ("do not just delete it,
+or the audit goes green and the hole stays"), which is exactly the trap: the
+name was never wrong.
+
+`"C-unwind"` is a distinct ABI string but the same exported C symbol, and the
+runtime uses it for every entry point a JS exception may unwind through — today
+18 symbols, including `js_throw`, the whole `js_native_call_method*` dispatch
+family, the `js_typed_feedback_native_call_*` paths, and `js_closure_call2`.
+Those are the allocating, poll-capable calls the analysis exists to reason
+about, so every consumer of `runtime_symbols` had been under-counting them; the
+phantom entry was the symptom that made a wider blindness visible.
+
+The scan now accepts both spellings, taking `runtime_symbols` from 3803 to 3821
+exported symbols.

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -660,7 +660,15 @@ ALLOC_RE = re.compile(
 # Deleting a dead alternative changes NOTHING about what the checker matches --
 # that is what "matches no symbol" means -- so this is not a narrowing.
 
-_EXTERN_C_FN_RE = re.compile(r'extern\s+"C"\s+fn\s+(js_\w+)')
+# `"C-unwind"` counts too. It is a distinct ABI string but the SAME exported
+# C symbol, and the runtime uses it for every entry point a JS exception may
+# unwind through -- `js_throw`, the whole `js_native_call_method*` dispatch
+# family, `js_closure_call2`. Matching only `"C"` made those 18 symbols
+# invisible to every consumer of `runtime_symbols`: `--audit-poll-capable`
+# reported `js_closure_call2` as naming nothing (it names a real, exported
+# symbol), and the alloc/poll classifications silently under-counted the
+# calls most likely to allocate. The name was never wrong; the scanner was.
+_EXTERN_C_FN_RE = re.compile(r'extern\s+"C(?:-unwind)?"\s+fn\s+(js_\w+)')
 
 # The runtime crates that export the C-ABI surface perry-codegen calls.
 SYMBOL_ROOTS = ("crates/perry-runtime/src", "crates/perry-stdlib/src")


### PR DESCRIPTION
`gc-root-dominance` and `gc-root-dominance-statepoints` are **red on main**:

```
error: POLL_CAPABLE_RUNTIME entries that name no runtime symbol:
  js_closure_call2
```

## The entry is right; the scanner is blind

`js_closure_call2` is a real, exported runtime symbol. What changed is its ABI string — it is declared `extern "C-unwind"`, and `runtime_symbols` scans for `extern "C" fn js_*` only. So the audit concluded the entry named nothing.

The audit's own message warns against the wrong repair — *"do not just delete it, or the audit goes green and the hole stays"* — and that is exactly the trap here.

## Why this is more than one phantom

`"C-unwind"` is a distinct ABI string but the **same exported C symbol**, and the runtime uses it for every entry point a JS exception may unwind through. Today that is **18 symbols**, and they are not incidental:

- `js_throw`, `js_throw_type_error_not_a_function`
- the entire `js_native_call_method*` dispatch family (8 of them)
- `js_typed_feedback_native_call_method*` (4)
- `js_closure_call2`, `js_fs_read_file*`

Those are precisely the allocating, poll-capable calls this analysis exists to reason about. **Every** consumer of `runtime_symbols` was under-counting them, so the blindness was never limited to the one phantom that happened to make it visible.

## Fix

Accept both spellings. `runtime_symbols` goes 3803 → **3821** exported symbols and the phantom clears.

## Validation

All five audits the workflow runs, on this branch:

| audit | result |
|---|---|
| `--self-test` | OK |
| `--audit-alloc-re` | 71 alternatives, every one matched |
| `--audit-poll-capable` | 137 entries, every one matched |
| `--audit-immovable-sources` | 1 probe, 0 failing |
| `--audit-poll-reach` | 1622 symbols with an intra-runtime call edge, 386 matched by ALLOC_RE, none unlisted |

Reproduced the failure on a clean `origin/main` checkout first, so this is confirmed to be a main breakage and not an artifact of my tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime symbol analysis to recognize both standard C and C-unwind functions.
  * Restored related validation checks and expanded detection of exported runtime symbols, including JavaScript exception-unwind entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->