### PR TITLE
test(next): arm the routeModule.handle guard and make verifier passes per cold start a knob (default 10) in the release App Route fixture

### DIFF
--- a/changelog.d/8210-release-next-fixture-guard-knob.md
+++ b/changelog.d/8210-release-next-fixture-guard-knob.md
@@ -8,7 +8,9 @@
 - The two hard-coded verifier passes per cold start became
   `PERRY_NEXT_ROUTE_VERIFIERS_PER_START` (default 10), so the default run is
   10 cold starts × 10 passes = 100 batches, matching
-  `tests/test_next_app_route_dylib.sh` and #8040's 100-iteration bullet. With
-  the default this fixture is red on today's `main` because of #8163 (~2% of
-  warm batches lose one response after a default-mode copying minor); `=2`
+  `tests/test_next_app_route_dylib.sh` and #8040's 100-iteration bullet. Each
+  10-pass process runs ~2-3 copying minors, so the default is sensitive to
+  per-collection bugs and intermittently red on today's `main` (#8163: ~2% of
+  post-minor batches lose one response); collection depth in one warm process
+  is `PERRY_NEXT_ROUTE_WARM_PASSES` (#8215), a complementary knob. `=2`
   restores the previous coverage. The forced-evacuation arm is unchanged.

--- a/changelog.d/8210-release-next-fixture-guard-knob.md
+++ b/changelog.d/8210-release-next-fixture-guard-knob.md
@@ -1,0 +1,14 @@
+### Testing
+
+- `tests/release/packages/next-app-route/fixture.sh` now runs the armed
+  `routeModule.handle` bypass guard (its `perry-host.js` is byte-identical to
+  `tests/fixtures/next-app-route/perry-host.js`) and greps every cold-start log
+  for `generated handler bypassed` as a hard failure — the guard's only signal is
+  the host log; `verify.mjs` exits 0 when it fires (#8161).
+- The two hard-coded verifier passes per cold start became
+  `PERRY_NEXT_ROUTE_VERIFIERS_PER_START` (default 10), so the default run is
+  10 cold starts × 10 passes = 100 batches, matching
+  `tests/test_next_app_route_dylib.sh` and #8040's 100-iteration bullet. With
+  the default this fixture is red on today's `main` because of #8163 (~2% of
+  warm batches lose one response after a default-mode copying minor); `=2`
+  restores the previous coverage. The forced-evacuation arm is unchanged.

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -203,8 +203,10 @@ run_cold_start() {
   local verifier label
   for verifier in $(seq 1 "$VERIFIERS_PER_START"); do
     if (( verifier == 1 )); then label="cold"; else label="warm"; fi
-    BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1 \
-      || fail "$mode cold start $index: $label verifier $verifier/$VERIFIERS_PER_START failed"
+    BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1 || {
+      tail -40 "$log" | sed 's/^/    /'
+      fail "$mode cold start $index: $label verifier $verifier/$VERIFIERS_PER_START failed"
+    }
   done
   if [[ "$mode" == "forced" ]]; then
     python3 "$REPO_ROOT/scripts/gc_evacuation_liveness_assert.py" \

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -15,19 +15,21 @@
 # throws inside a `.then()` after the response is already sent, so
 # `verify.mjs` still exits 0 when it fires (#8161).
 #
-# Known state (#8163): with the default 10 verifier passes per process this
-# fixture is intermittently RED on today's `main` — a default-mode copying
-# minor occasionally strands a stale closure, and ~2% of the batches that
-# follow one lose a response (`TypeError: value is not a function` in the host
-# log right after a `[gc-copy-minor] ran` line, then an empty body in
-# `verify.mjs`). Two passes per process finished before the first copying
-# minor (~pass 3), which is how the fixture read green while #8040's
-# 100-iteration bullet was red. Set `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2`
-# to recover the old coverage.
+# Known state (#8163, reopened): #8211 rooted the two holders behind the
+# forced-evacuation arm, but a default-GC residual remains — a default-mode
+# copying minor occasionally strands a stale closure, and ~1-2% of the batches
+# that follow one lose a response (`TypeError: value is not a function` in the
+# host log right after a `[gc-copy-minor] ran` line, then an empty body in
+# `verify.mjs`). With the default 10 verifier passes per process this fixture
+# is therefore intermittently RED until that residual lands. Two passes per
+# process finished before the first copying minor (~pass 3), which is how the
+# fixture read green while #8040's 100-iteration bullet was red; set
+# `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2` to recover exactly the old
+# coverage.
 #
-# Odd cold starts run under FORCED evacuation with a seeded GC schedule and the
-# moving-GC liveness assert (#8163 — fixed; `PERRY_NEXT_ROUTE_FORCED_GC=0`
-# turns that arm off for a normal-only run).
+# Odd cold starts run under FORCED evacuation with a seeded GC schedule and
+# the moving-GC liveness assert (its two #8163 holders were fixed in #8211;
+# `PERRY_NEXT_ROUTE_FORCED_GC=0` turns that arm off for a normal-only run).
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -4,8 +4,25 @@
 # What this asserts, on every run: Next 16.3.0's UNTOUCHED production webpack
 # output compiles to an app-only dylib against separately loaded runtime and
 # stdlib provider images, serves through a `dlopen` host, and matches the Node
-# production oracle byte-for-byte across 10 cold starts of two 21-request
-# verifier passes each.
+# production oracle byte-for-byte across 10 cold starts of
+# `PERRY_NEXT_ROUTE_VERIFIERS_PER_START` (default 10) 21-request verifier
+# passes each — 100 batches by default, #8040's "100-iteration run of the
+# 20-way concurrent request batch". Every request must also enter the generated
+# `AppRouteRouteModule.handle`: `perry-host.js` wraps it and logs
+# `generated handler bypassed routeModule.handle` for any request that reached
+# the userland handler another way, and each cold-start log is grepped for that
+# line as a hard failure. That signal lives ONLY in the host log — the guard
+# throws inside a `.then()` after the response is already sent, so
+# `verify.mjs` still exits 0 when it fires (#8161).
+#
+# Known state (#8163): with the default 10 verifier passes per process this
+# fixture is RED on today's `main` — a default-mode copying minor occasionally
+# strands a stale closure, and ~2% of warm batches then lose one response
+# (`TypeError: value is not a function` in the host log right after a
+# `[gc-copy-minor] ran` line, then an empty body in `verify.mjs`). Two passes
+# per process never reached a copying minor, which is how the fixture read
+# green while #8040's 100-iteration bullet was red. Set
+# `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2` to recover the old coverage.
 #
 # Odd cold starts run under FORCED evacuation with a seeded GC schedule and the
 # moving-GC liveness assert (#8163 — fixed; `PERRY_NEXT_ROUTE_FORCED_GC=0`
@@ -18,6 +35,7 @@ REPO_ROOT="$(cd ../../../.. && pwd)"
 PERRY_BIN="${PERRY_BIN:-$REPO_ROOT/target/release/perry}"
 PORT_BASE="${PERRY_NEXT_ROUTE_PORT:-31836}"
 COLD_STARTS="${PERRY_NEXT_ROUTE_COLD_STARTS:-10}"
+VERIFIERS_PER_START="${PERRY_NEXT_ROUTE_VERIFIERS_PER_START:-10}"
 if [[ -n "${PERRY_NEXT_ROUTE_BUILD_DIR:-}" ]]; then
   BUILD_DIR="$PERRY_NEXT_ROUTE_BUILD_DIR"
   BUILD_DIR_OWNED=0
@@ -60,6 +78,14 @@ fail() {
 for tool in npm node cargo cc ar nm python3; do
   command -v "$tool" >/dev/null 2>&1 || fail "$tool is not on PATH"
 done
+for value in "$COLD_STARTS" "$VERIFIERS_PER_START"; do
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "cold starts and verifiers per start must be positive integers (got '$value')"
+done
+TOTAL_BATCHES=$((COLD_STARTS * VERIFIERS_PER_START))
+# `generated handler bypassed` is the routeModule.handle guard in perry-host.js.
+# It is a log line, not an exit code: verify.mjs passes even when it fires, so
+# the per-cold-start grep below is the only place the guard can fail the run.
+FORBIDDEN_DIAGNOSTICS='generated handler bypassed|\[perry-gc\].*SKIPPED|unsettled-await|unimplemented|compatibility[- ]fallback'
 [[ -x "$PERRY_BIN" ]] || fail "perry not found at $PERRY_BIN"
 
 case "$(uname -s)" in
@@ -174,14 +200,19 @@ run_cold_start() {
   done
   [[ "$ready" == "1" ]] || fail "$mode cold start $index did not become ready"
 
-  BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1 || fail "$mode cold verifier 1 failed"
-  BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1 || fail "$mode warm verifier 2 failed"
+  local verifier label
+  for verifier in $(seq 1 "$VERIFIERS_PER_START"); do
+    if (( verifier == 1 )); then label="cold"; else label="warm"; fi
+    BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1 \
+      || fail "$mode cold start $index: $label verifier $verifier/$VERIFIERS_PER_START failed"
+  done
   if [[ "$mode" == "forced" ]]; then
     python3 "$REPO_ROOT/scripts/gc_evacuation_liveness_assert.py" \
       "$log" --probe "$NAME-$mode-$index" \
       || fail "$mode cold start $index did not prove moving-GC liveness"
   fi
-  if grep -Eiq '\[perry-gc\].*SKIPPED|unsettled-await|unimplemented|compatibility[- ]fallback' "$log"; then
+  if grep -Eiq "$FORBIDDEN_DIAGNOSTICS" "$log"; then
+    grep -Ein "$FORBIDDEN_DIAGNOSTICS" "$log" | head -20 | sed 's/^/    /'
     fail "$mode cold start $index emitted a forbidden fallback diagnostic"
   fi
   cleanup_server
@@ -196,9 +227,9 @@ run_cold_start() {
 # the normal arm only; it is a knob, not a skip, and never `continue-on-error`.
 FORCED_GC="${PERRY_NEXT_ROUTE_FORCED_GC:-1}"
 if [[ "$FORCED_GC" == "1" ]]; then
-  echo "  [6/7] $COLD_STARTS cold processes (alternating normal / FORCED-evacuation), two 21-request verifier runs each"
+  echo "  [6/7] $COLD_STARTS cold processes (alternating normal / FORCED-evacuation), $VERIFIERS_PER_START 21-request verifier runs each ($TOTAL_BATCHES batches)"
 else
-  echo "  [6/7] $COLD_STARTS cold processes, two 21-request verifier runs each"
+  echo "  [6/7] $COLD_STARTS cold processes, $VERIFIERS_PER_START 21-request verifier runs each ($TOTAL_BATCHES batches)"
   echo "        forced-evacuation arm OFF (PERRY_NEXT_ROUTE_FORCED_GC=0)"
 fi
 for index in $(seq 0 $((COLD_STARTS - 1))); do
@@ -206,9 +237,9 @@ for index in $(seq 0 $((COLD_STARTS - 1))); do
   run_cold_start "$index" "$mode"
 done
 
-echo "  [7/7] production AppRouteRouteModule.handle parity complete"
+echo "  [7/7] production AppRouteRouteModule.handle parity complete: $TOTAL_BATCHES verifier batches over $COLD_STARTS cold starts, 0 bypass-guard fires"
 if [[ "$FORCED_GC" == "1" ]]; then
-  echo "PASS $NAME (with forced-evacuation arm)"
+  echo "PASS $NAME ($TOTAL_BATCHES batches, with forced-evacuation arm)"
 else
-  echo "PASS $NAME (forced-evacuation arm not run — PERRY_NEXT_ROUTE_FORCED_GC=0)"
+  echo "PASS $NAME ($TOTAL_BATCHES batches, forced-evacuation arm not run — PERRY_NEXT_ROUTE_FORCED_GC=0)"
 fi

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -16,13 +16,14 @@
 # `verify.mjs` still exits 0 when it fires (#8161).
 #
 # Known state (#8163): with the default 10 verifier passes per process this
-# fixture is RED on today's `main` — a default-mode copying minor occasionally
-# strands a stale closure, and ~2% of warm batches then lose one response
-# (`TypeError: value is not a function` in the host log right after a
-# `[gc-copy-minor] ran` line, then an empty body in `verify.mjs`). Two passes
-# per process never reached a copying minor, which is how the fixture read
-# green while #8040's 100-iteration bullet was red. Set
-# `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2` to recover the old coverage.
+# fixture is intermittently RED on today's `main` — a default-mode copying
+# minor occasionally strands a stale closure, and ~2% of the batches that
+# follow one lose a response (`TypeError: value is not a function` in the host
+# log right after a `[gc-copy-minor] ran` line, then an empty body in
+# `verify.mjs`). Two passes per process finished before the first copying
+# minor (~pass 3), which is how the fixture read green while #8040's
+# 100-iteration bullet was red. Set `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2`
+# to recover the old coverage.
 #
 # Odd cold starts run under FORCED evacuation with a seeded GC schedule and the
 # moving-GC liveness assert (#8163 — fixed; `PERRY_NEXT_ROUTE_FORCED_GC=0`
@@ -35,6 +36,13 @@ REPO_ROOT="$(cd ../../../.. && pwd)"
 PERRY_BIN="${PERRY_BIN:-$REPO_ROOT/target/release/perry}"
 PORT_BASE="${PERRY_NEXT_ROUTE_PORT:-31836}"
 COLD_STARTS="${PERRY_NEXT_ROUTE_COLD_STARTS:-10}"
+# Verifier passes per cold start: restart/ABI/parity/bypass-guard coverage
+# across N fresh processes. Each 10-pass process runs ~2-3 copying minors
+# (the first lands around pass 3), so this arm is sensitive to per-collection
+# bugs — but a fresh process lives permanently in the early/small-heap regime
+# and never reaches the grown heap where collections accelerate. Collection
+# DEPTH in one process is a different knob (`PERRY_NEXT_ROUTE_WARM_PASSES`,
+# #8215); neither substitutes for the other.
 VERIFIERS_PER_START="${PERRY_NEXT_ROUTE_VERIFIERS_PER_START:-10}"
 if [[ -n "${PERRY_NEXT_ROUTE_BUILD_DIR:-}" ]]; then
   BUILD_DIR="$PERRY_NEXT_ROUTE_BUILD_DIR"

--- a/tests/release/packages/next-app-route/perry-host.js
+++ b/tests/release/packages/next-app-route/perry-host.js
@@ -8,6 +8,13 @@ if (typeof routeModule.handle !== "function" || typeof handler !== "function") {
   throw new Error("production App Route handler exports are missing");
 }
 
+const enteredRequestIds = new Set();
+const routeModuleHandle = routeModule.handle.bind(routeModule);
+routeModule.handle = async (request, context) => {
+  enteredRequestIds.add(request.nextUrl.searchParams.get("id") ?? "missing");
+  return routeModuleHandle(request, context);
+};
+
 const pending = new Set();
 const port = Number(process.env.PORT ?? "3100");
 const hostname = process.env.HOSTNAME ?? "127.0.0.1";
@@ -19,11 +26,18 @@ const server = createServer((request, response) => {
       promise.finally(() => pending.delete(promise));
     },
   });
-  work.catch((error) => {
-    console.error(error);
-    if (!response.headersSent) response.statusCode = 500;
-    response.end();
-  });
+  work
+    .then(() => {
+      const id = new URL(request.url, `http://${hostname}:${port}`).searchParams.get("id") ?? "missing";
+      if (!enteredRequestIds.delete(id)) {
+        throw new Error(`${id}: generated handler bypassed routeModule.handle`);
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+      if (!response.headersSent) response.statusCode = 500;
+      response.end();
+    });
 });
 
 server.listen(port, hostname, () => {


### PR DESCRIPTION
Part of #8040 (DoD audit, 2026-08-16). Test-only, `tests/release/packages/next-app-route/` only.

## (a) The `routeModule.handle` bypass guard, armed and gated

`perry-host.js` is now byte-identical to `tests/fixtures/next-app-route/perry-host.js` (#8161): it wraps `routeModule.handle`, records the request id that passes through it, and logs `<id>: generated handler bypassed routeModule.handle` for any request whose response was produced without entering the generated `AppRouteRouteModule.handle`. That was already run against this fixture on `main` `3c95020f8` (10 cold × 2 verifiers PASS, 0 guard fires in 520 batches — #8040 comment).

The guard's signal lives **only in the host log**: it throws inside a `.then()` after the response is already sent, so `verify.mjs` still exits 0 when it fires (measured in #8161: 22 log hits, exit 0, with the wrapper removed). `fixture.sh` therefore greps every cold-start log for `generated handler bypassed` as a hard failure, in the existing forbidden-diagnostic check (now one `FORBIDDEN_DIAGNOSTICS` regex, with the matching lines echoed before `fail`). Sabotage-checked without a rebuild: a log with a planted `Error: 7: generated handler bypassed routeModule.handle` line matches the regex (would fail), a clean `READY` + `PASS: 21 …` log does not.

## (b) `PERRY_NEXT_ROUTE_VERIFIERS_PER_START`, default 10

The two hard-coded `verify.mjs` runs per cold start (`cold verifier 1` / `warm verifier 2`) become a loop over `PERRY_NEXT_ROUTE_VERIFIERS_PER_START` (positive integer, **default 10**), labelled `cold verifier 1/N` / `warm verifier k/N`. The default is now 10 cold starts × 10 passes = **100 batches**, the same shape as `tests/test_next_app_route_dylib.sh` and #8040's "100-iteration run of the 20-way concurrent request batch" bullet. The `[6/7]`, `[7/7]` and `PASS` lines print the totals.

The forced-evacuation arm (`PERRY_NEXT_ROUTE_FORCED_GC=1`, off by default, #8163) is untouched apart from inheriting the loop; the header comment describes the new default, the guard, and the state below.

## Plainly: with the default 10 this fixture is intermittently RED on today's `main`

That is the knob doing its job. #8163's last comment ("Reproduces under DEFAULT GC") measured 8 of 500 batches losing one response against a warm process with no GC knobs at all — every failure right after a `[gc-copy-minor] ran … in_place=false` line, `TypeError: value is not a function` in the host log, empty body in `verify.mjs`. Two passes per process finished before the first copying minor (~pass 3 in a fresh process), which is exactly why this fixture read green while #8040's 100-iteration bullet was red. `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2` recovers the previous coverage and passes.

So this is expected to merge **after** #8163's fix (or with the release harness pinning `=2` until then) — owner's call on the order.

## Two regimes, two knobs (coordination with #8215)

This knob and #8215's `PERRY_NEXT_ROUTE_WARM_PASSES` cover different regimes, and neither substitutes for the other:

- **`PERRY_NEXT_ROUTE_VERIFIERS_PER_START` (this PR)** — restart / ABI / parity / bypass-guard coverage across N fresh processes. Each 10-pass process runs ~2–3 copying minors (the first lands around pass 3; measured directly in this PR's validation: every 10-pass cold start logged 3 `[gc-copy-minor] ran` lines under `PERRY_GC_DIAG=1`), so the default is genuinely sensitive to per-collection bugs — a fresh process just lives permanently in the early/small-heap regime.
- **`PERRY_NEXT_ROUTE_WARM_PASSES` (#8215)** — collection *depth* in ONE process, where the heap grows and the minor cadence accelerates (8–9 passes between minors early, tightening to 2–3 by pass ~99). Only a warm process reaches that regime.

#8215 touches the same `[6/7]` region of `fixture.sh`; this PR's diff there is deliberately small, and I will rebase in whichever direction the owner decides. **Whichever of #8210/#8215 lands second must not drop the other's knob** — they are complementary, not alternatives.

## Validation (bench mini, macOS arm64, `perry` from a `perry-dev` build of `main`-equivalent `07c8040bf`, `PERRY_MODULE_JOBS=2`, `PERRY_GC_DIAG=1` on the serving arms)

All three arms ran the full `fixture.sh` end to end (npm ci + `next build` + oracle + provider archives + app dylib + serving) at branch commit `0c65f41b4`; the one later commit is comment-only (verified: zero non-comment diff lines in `fixture.sh`). `PERRY_LLVM_INPROCESS=0` was set for the app compile — see "not this PR's bug" below.

| arm | result | copy-minors / TypeErrors / bypass fires (per failing or first process) |
|---|---|---|
| `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2` | **PASS** — `PASS next-app-route (20 batches, forced-evacuation arm not run — #8163)`, 10 cold starts x 2, 0 guard fires | 0 minors in a 2-pass process (the pre-knob blind spot, directly reconfirmed) |
| default (10) | **FAIL (expected, #8163)** — `normal cold start 0: warm verifier 3/10 failed`, `verify.mjs` `Unexpected end of JSON input` | 1 `[gc-copy-minor] ran` → 2 `TypeError: value is not a function`, 0 bypass fires |
| default (10), repeat | **FAIL (expected, #8163)** — same batch (cold start 0, verifier 3/10), same signature | 1 minor → 2 `TypeError`s, 0 bypass fires |

Verifier pass 3 is exactly where the first copying minor of a fresh process lands, so the failing batch matches #8163's cadence data precisely. The `=2` arm passing plus the default arm failing **on the first collection** is the knob's whole point: the old hard-coded 2 passes ended before the collector ever moved an object.

Guard sabotage check (no rebuild): the fixture's `FORBIDDEN_DIAGNOSTICS` regex was run against a log with a planted `Error: 7: generated handler bypassed routeModule.handle` line (matches → run fails) and against a clean `READY` + `PASS: 21 …` log (no match). The armed-host + this grep combination also has live evidence from the sibling gate: 0 guard fires across all serving runs.

Mini log paths: `~/perry-bench.noindex/tmp-8040-knob/ext-v2.log`, `ext-v10.log`, `ext-v10-b.log`, per-cold-start host logs under `~/perry-bench.noindex/tmp-8040-knob/logs-ext-v10*/perry-normal-0.log`, fixture build logs in `~/perry-bench.noindex/build-knob/`.

### Re-validated after rebasing onto `main` with #8211 (forced arm now ON by default)

#8211 flipped `PERRY_NEXT_ROUTE_FORCED_GC` to default 1, so the forced arms now run *through* this PR's new verifier loop. Rebased onto `c926cf142`, rebuilt `perry` from the rebased tree, and re-ran at `PERRY_NEXT_ROUTE_VERIFIERS_PER_START=2`:

```
[6/7] 10 cold processes (alternating normal / FORCED-evacuation), 2 21-request verifier runs each (20 batches)
next-app-route-forced-1: evacuation live — 440 copying minor(s), 197840 objects copied
next-app-route-forced-3: evacuation live — 440 copying minor(s), 198319 objects copied
next-app-route-forced-5: evacuation live — 440 copying minor(s), 197006 objects copied
next-app-route-forced-7: evacuation live — 440 copying minor(s), 197883 objects copied
next-app-route-forced-9: evacuation live — 440 copying minor(s), 197877 objects copied
[7/7] production AppRouteRouteModule.handle parity complete: 20 verifier batches over 10 cold starts, 0 bypass-guard fires
PASS next-app-route (20 batches, with forced-evacuation arm)
```

**exit 0.** All five forced cold starts passed `scripts/gc_evacuation_liveness_assert.py` through the new loop — the subject was live (440 copying minors, ~198k objects copied each), not merely "nothing threw". Log: `~/perry-bench.noindex/tmp-8040-knob/rebased-v2.log`, per-cold-start logs in `logs-rebased-v2/`. Rebase conflict resolution kept #8211's post-fix wording and this PR's `$VERIFIERS_PER_START` / `$TOTAL_BATCHES` parameterization; the header now describes #8163 as reopened on the default-GC residual rather than fixed.

The default-10 arms above were measured *before* #8211 landed. #8211 fixed the two forced-arm holders; the default-GC residual it left is now named and has a fix in flight (**#8220**, `js_headers_for_each`'s hoisted closure pointer in `crates/perry-stdlib/src/fetch/headers.rs:460` plus eight sibling sites — 8 from-space faults → 0, 3 failures/300 warm passes → 0). So the expected merge order is: #8220 first, then this PR's default-10 goes green. I did not re-measure the default-10 arms on top of #8220.

## Not this PR's bug: `fixture.sh`'s default in-process LLVM backend fails 5 modules on current `main`

On this box, the untouched fixture's app compile (in-process LLVM 22 backend, the default when `PERRY_LLVM_INPROCESS` is unset) fails deterministically on current `main`-equivalent (`07c8040bf`): `5 module(s) failed to compile — REFUSING TO LINK` — `.next/server/chunks/2.js`, `chunks/430.js`, `next/dist/compiled/jsonwebtoken/index.js`, `app-page.runtime.prod.js`, `app-route.runtime.prod.js` (the app's 5 biggest modules), with **no per-module error text at all** (the summary says to search for `Error compiling module`; no such line is emitted). The same app compiles clean with `PERRY_LLVM_INPROCESS=0` (the dylib gate's configuration), and the untouched fixture compiled clean in-process on `3c95020f8` on this same box earlier today (#8163's validation runs) — so the window is `3c95020f8..07c8040bf` (candidates touching codegen: #8201, #8204, #8206). Repro + log: `~/perry-bench.noindex/tmp-8040-knob/probe-inprocess.log`. Filed separately; this PR does not work around it beyond validating with the external backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved release validation for Next.js route handling by detecting requests that bypass the expected processing path.
  - Added configurable verification passes for cold and warm process testing, with clearer progress and failure reporting.
  - Preserved forced garbage-collection and liveness checks while expanding repeated verification coverage.
  - Documented available verification settings and the default test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->