### PR TITLE
fix(gc): root the two holders outside the GC heap behind the forced-evacuation App Route arm (#8163)

### DIFF
--- a/changelog.d/8211-gc-8163-forced-evac-holders.md
+++ b/changelog.d/8211-gc-8163-forced-evac-holders.md
@@ -1,0 +1,63 @@
+### Fixed — forced-evacuation App Route arm: two holders outside the GC heap (#8163)
+
+The production Next 16.3.0 App Route fixture's forced-evacuation arm died with
+`TypeError: value is not a function` around copying minor #238. Both holders were
+Rust tables outside the GC heap that no root scanner marked or rewrote — the class
+`PERRY_GC_VERIFY_EVACUATION` cannot see (no scanner to verify) and
+`PERRY_GC_PROTECT_FROMSPACE_HOLDERS` cannot see (not in the heap). Found by running
+the host under `PERRY_GC_PROTECT_FROMSPACE=1 …_DEPTH=800` and instrumenting the two
+suspects until each printed the exact address the fault reporter named.
+
+* **`HEADERS_METHOD_VALUE_CACHE`** (perry-stdlib `fetch`) — the bound-method closure
+  behind `headers.get` / `.entries` / …, cached per `(handle, method)` in a
+  `lazy_static!` `HashMap<_, u64>`. Its only "rooting" was
+  `js_write_barrier_root_nanbox`, which is the incremental-marking shade, not a root.
+  Next's route reads `(await headers()).get(...)` twice per request with awaits
+  between; the closure allocated by the first read was retired by a later minor and
+  the second read handed the pre-move address to `typeof` inside Next's
+  `ReflectAdapter.get`. `FORM_DATA_METHOD_VALUE_CACHE` and `RequestRecord::signal`
+  (the `AbortSignal` behind `request.signal`) had the same shape. A new
+  `fetch/gc.rs` registers a scanner through the C ABI (like `streams/gc.rs`, so a
+  trimmed stdlib provider installs it in the runtime image) that marks and rewrites
+  all three; `js_request_new` now builds its record before taking the registry lock,
+  since the default-signal allocation could otherwise collect under the guard the
+  scanner needs.
+* **`ServerResponse.once_listeners`** (perry-ext-http) — `res.once(event, cb)` stores
+  into a second table that `take_event_listeners` merges into every emit, and
+  `scan_http_server_roots` visited only `listeners`. Next's `pipeToNodeResponse`
+  registers `res.once('close', …)`; the closure was retired at #211 and reached
+  `emit_no_arg_to_listeners` from the `res.end()` tail as a from-space address. The
+  scanner now visits it. While there, the `res.end()` tail (`js_node_http_res_end`,
+  `_full`, `_with_cb`, `standalone_end`) took listener/callback snapshots OUT of the
+  handle and then ran JS before using them — rooting inside
+  `emit_no_arg_to_listeners` roots what it is *handed*, so a stale snapshot stayed
+  stale. `EndTail` (new `server/response_end.rs`, split out because `response.rs`
+  sat at the 2,000-line cap) parks every snapshot in the transient-root stack before
+  the first JS call. `js_node_http_im_resume`'s `'end'` snapshot and
+  `js_node_https_server_close`'s callback get the same treatment.
+
+**Why the audit missed it.** `scripts/gc_runtime_root_holders.py` could not see any
+of this: its `DECL` regex did not match `lazy_static!`'s `static ref`, so 93 tables
+across runtime+stdlib were outside the census; `strip_comments` blanks string
+literals so `extern "C" fn` reached `FN_DEF` as `extern "" fn` and no C-ABI function
+had a body in the walk (the FFI scanner trampolines included); a body-less
+`fn f(...);` inside an `extern "C" {}` block started a brace count that swallowed
+the following functions; and the registration regex stopped at the first `(` of
+`SOURCE.as_ptr()`, dropping the scanner name from every C-ABI registration. All four
+are fixed. The census grows from 78 to 129 declarations (74 reached by a scanner,
+was 53); the 31 newly visible uncovered holders each carry a written verdict in
+`gc_runtime_root_holders.json`, and one stale entry is deleted.
+
+**Validation.** Same app dylib, same seed (8036), providers from the same tree:
+main → 59 `TypeError`s / 0 `PASS`, from-space fault at minor #218; fixed → 2×
+`PASS: 21`, 446 copying minors, 0 errors, and clean under
+`PERRY_GC_PROTECT_FROMSPACE=1 …_DEPTH=800` on seeds 8036, 8174, 1, 8040, 4242. The
+fixture's forced arm (`PERRY_NEXT_ROUTE_FORCED_GC`) is back ON by default. Unit
+tests: the fetch scanner emits and rewrites all three slots; the ext-http rewrite
+test gains `once_listeners` and `pending_write_callbacks`.
+
+Follow-up (not fixed here): perry-ext-net's `once_flags` keys `HashSet<i64>` by
+closure ADDRESS to decide which listener to drop after a `once` fires — a rekeyed
+table of the #8174 family (a moved closure fires twice, a recycled address drops the
+wrong listener); and the ext crates' handle-struct fields are still outside any
+census (`once_listeners` was one).

--- a/changelog.d/8211-gc-8163-forced-evac-holders.md
+++ b/changelog.d/8211-gc-8163-forced-evac-holders.md
@@ -36,6 +36,24 @@ suspects until each printed the exact address the fault reporter named.
   the first JS call. `js_node_http_im_resume`'s `'end'` snapshot and
   `js_node_https_server_close`'s callback get the same treatment.
 
+**Registering a scanner over a table makes every "allocate under its guard" site a
+deadlock, so those were hoisted in the same change.** `std::sync::Mutex` is not
+reentrant: the scanner takes `REQUEST_REGISTRY` during a collection on the mutator
+thread, so any site holding that guard across a GC allocation self-deadlocks the
+first time the allocation collects. Twelve string arms in `dispatch_request_property`
+plus `js_request_get_url` / `_method` / `_body`, `js_request_input_to_url` and
+`request_string_field` now snapshot the field bytes under the guard and allocate
+after dropping it. Worse, `js_request_clone` **threw** under the guard — the
+exception transport unwinds through the frame without running `Drop` (it is written
+for `panic=abort`), so the registry mutex would stay locked for the life of the
+process; it now decides "unusable" under the guard and throws outside it. Two tests
+hold this line, because the failure mode is a hang and a test that hangs is worse
+than one that fails: `request_reads_release_the_registry_guard` `try_lock`s after
+every reader, and `no_allocation_is_taken_off_a_live_registry_borrow` scans for the
+`js_string_from_bytes(req.…)` shape (with a planted sample proving the scan can
+still match it). Found in review by a parallel session — credit to them; the
+contract that caught it is the one this module's own docs state.
+
 **Why the audit missed it.** `scripts/gc_runtime_root_holders.py` could not see any
 of this: its `DECL` regex did not match `lazy_static!`'s `static ref`, so 93 tables
 across runtime+stdlib were outside the census; `strip_comments` blanks string
@@ -45,8 +63,16 @@ had a body in the walk (the FFI scanner trampolines included); a body-less
 the following functions; and the registration regex stopped at the first `(` of
 `SOURCE.as_ptr()`, dropping the scanner name from every C-ABI registration. All four
 are fixed. The census grows from 78 to 129 declarations (74 reached by a scanner,
-was 53); the 31 newly visible uncovered holders each carry a written verdict in
-`gc_runtime_root_holders.json`, and one stale entry is deleted.
+was 53) — the gate was green because the narrow regex hid the candidates, not
+because they were classified. The 31 newly visible uncovered holders each carry a
+written verdict in `gc_runtime_root_holders.json` naming the mechanism (the
+address-keyed `REGEX_POINTERS` / `REGEX_SOURCE_TABLE` are rekeyed on move and
+pruned on death by `regex_header_moved_for_gc` / `_clear_dead_for_gc`, dispatched
+from `gc/types.rs`; `THREAD_GLOBAL_THIS` / `THREAD_MODULE_TOP_THIS` register their
+own cell address with `js_gc_register_global_root`; `DIAG_STORE_SCOPES` cannot hold
+a heap pointer because `store_handle` rejects one), and one stale entry
+(`EXT_BLOCKING_TASKS_INFLIGHT`, now reached through the newly visible C-ABI scanner
+chain) is deleted.
 
 **Validation.** Same app dylib, same seed (8036), providers from the same tree:
 main → 59 `TypeError`s / 0 `PASS`, from-space fault at minor #218; fixed → 2×

--- a/crates/perry-ext-http/src/server/handle_dispatch.rs
+++ b/crates/perry-ext-http/src/server/handle_dispatch.rs
@@ -731,7 +731,7 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_method(
                     .unwrap_or(0);
                 (first, cb)
             };
-            crate::server::response::js_node_http_res_end_with_cb(handle, chunk, cb);
+            crate::server::response_end::js_node_http_res_end_with_cb(handle, chunk, cb);
             self_ref
         }
         "flushHeaders" => {

--- a/crates/perry-ext-http/src/server/https_server.rs
+++ b/crates/perry-ext-http/src/server/https_server.rs
@@ -578,7 +578,12 @@ pub unsafe extern "C" fn js_node_https_server_close(handle: i64, callback: i64) 
     // Node 19+: `server.close()` destroys idle keep-alive connections
     // (active requests are allowed to finish) (#4905/#4971).
     signal_connections_close(handle, true);
+    // #8082/#8163: `callback` crosses the close-listener emits, which run JS —
+    // same rooting as the `http.Server.close` twin in `server.rs`.
+    let scope = perry_ffi::TransientRootScope::enter();
+    let callback_rooted = scope.root_addr(callback);
     emit_no_arg_to_listeners(&close_listeners);
+    let callback = callback_rooted.get();
     if callback != 0 {
         let raw = callback as *const RawClosureHeader;
         let closure = JsClosure::from_raw(raw);

--- a/crates/perry-ext-http/src/server/mod.rs
+++ b/crates/perry-ext-http/src/server/mod.rs
@@ -63,6 +63,7 @@ mod https_server;
 mod raw_upgrade;
 mod request;
 mod response;
+mod response_end;
 mod response_fast;
 mod server;
 mod tls;
@@ -151,6 +152,14 @@ fn scan_http_server_roots(visitor: &mut GcRootVisitor<'_>) {
     });
     iter_handles_of_mut::<ServerResponse, _>(|sr| {
         scan_listener_roots(&mut sr.listeners, visitor);
+        // #8163: `res.once(event, cb)` stores into a SECOND table that
+        // `take_event_listeners` merges into every emit. It was never scanned,
+        // so a `once('close')` closure that a moving minor relocated (or, with
+        // no other referent, freed) reached `emit_no_arg_to_listeners` as a
+        // pre-move address — Next's `pipeToNodeResponse` registers exactly
+        // that, and the production App Route fixture faulted on it under
+        // forced evacuation.
+        scan_listener_roots(&mut sr.once_listeners, visitor);
         visitor.visit_nanbox_f64_slot(&mut sr.standalone_socket);
         for cb in sr.pending_write_callbacks.iter_mut() {
             visitor.visit_i64_slot(cb);
@@ -395,9 +404,15 @@ mod tests {
         let incoming_handle = register_handle(incoming);
 
         let response_listener = young_gc_root();
+        let response_once_listener = young_gc_root();
+        let response_write_cb = young_gc_root();
         let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
         let mut response = ServerResponse::new(response_tx);
         response.listeners = listener_map("finish", response_listener);
+        // #8163: the `once` table is a distinct holder — it must be rewritten
+        // too, or `res.once('close', cb)` hands a pre-move closure to the emit.
+        response.once_listeners = listener_map("close", response_once_listener);
+        response.pending_write_callbacks = vec![response_write_cb];
         let response_handle = register_handle(response);
 
         let _ = perry_runtime::gc::gc_collect_minor();
@@ -424,6 +439,8 @@ mod tests {
 
             let response = get_handle::<ServerResponse>(response_handle).expect("response");
             assert_rewritten(response_listener, response.listeners["finish"][0]);
+            assert_rewritten(response_once_listener, response.once_listeners["close"][0]);
+            assert_rewritten(response_write_cb, response.pending_write_callbacks[0]);
         }
 
         drop_handle(http_handle);

--- a/crates/perry-ext-http/src/server/request.rs
+++ b/crates/perry-ext-http/src/server/request.rs
@@ -558,10 +558,16 @@ pub extern "C" fn js_node_http_im_resume(handle: i64) {
     } else {
         return;
     }
+    // #8163: the `'end'` snapshot crosses the `'data'` emits, which run JS and
+    // can trigger a moving collection — root it and re-read at use.
+    // (`emit_data_to_listeners` roots its own snapshot internally.)
+    let scope = perry_ffi::TransientRootScope::enter();
+    let end_rooted = scope.root_addrs(&end_listeners);
     if should_emit_data {
         emit_data_to_listeners(&data_listeners, &body_bytes, encoding.as_deref());
     }
     if should_emit_end {
+        let end_listeners: Vec<i64> = end_rooted.iter().map(|cb| cb.get()).collect();
         emit_end_to_listeners(&end_listeners);
     }
 }

--- a/crates/perry-ext-http/src/server/response.rs
+++ b/crates/perry-ext-http/src/server/response.rs
@@ -19,7 +19,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::oneshot;
 
-use crate::server::request::{emit_no_arg_to_listeners, handle_to_pointer_f64};
+use crate::server::request::handle_to_pointer_f64;
+use crate::server::response_end::call_closure0;
 use crate::server::types::{
     js_json_stringify, js_node_setheaders_entries_json, js_value_is_closure, jsvalue_to_body_bytes,
     jsvalue_to_owned_string, read_string_header, PTR_MASK, STRING_TAG, TAG_FALSE, TAG_NULL,
@@ -471,7 +472,7 @@ impl ServerResponse {
     }
 
     /// Auto-fill `Content-Length` if unset and we know the full body.
-    fn ensure_content_length(&mut self) {
+    pub(crate) fn ensure_content_length(&mut self) {
         // A response with trailers must not declare a fixed Content-Length:
         // the body length alone doesn't bound the response (trailing headers
         // still follow), and some clients/proxies treat a present
@@ -1159,7 +1160,7 @@ pub extern "C" fn js_node_http_res_write(handle: i64, chunk: f64) -> i32 {
 /// Return the closure pointer carried by `value_bits` if it is a real callable
 /// (POINTER_TAG + CLOSURE_MAGIC), else 0. Uses `js_value_is_closure` so a
 /// `Buffer`/object chunk — also POINTER_TAG — is never mistaken for a callback.
-fn callback_from_bits(value_bits: i64) -> i64 {
+pub(crate) fn callback_from_bits(value_bits: i64) -> i64 {
     if unsafe { js_value_is_closure(value_bits) } != 0 {
         (value_bits as u64 & PTR_MASK) as i64
     } else {
@@ -1170,7 +1171,7 @@ fn callback_from_bits(value_bits: i64) -> i64 {
 /// Pick the callback from a `(encoding?, callback?)` trailing arg pair, the
 /// later slot first — mirroring Node's `(chunk, encoding, callback)` rule. A
 /// string encoding is not callable, so it is skipped.
-fn pick_trailing_callback(arg2: i64, arg3: i64) -> i64 {
+pub(crate) fn pick_trailing_callback(arg2: i64, arg3: i64) -> i64 {
     let c3 = callback_from_bits(arg3);
     if c3 != 0 {
         c3
@@ -1228,53 +1229,6 @@ pub extern "C" fn js_node_http_res_write_full(
     f64::from_bits(if below_hwm { TAG_TRUE } else { TAG_FALSE })
 }
 
-/// `res.end([chunk][, encoding][, callback])` — the full Node surface routed
-/// from the static native dispatch table. Handles the `end(cb)` form (callback
-/// in the first slot) as well as `end(chunk[, encoding][, callback])`. Queued
-/// write callbacks fire first (in order), then the end callback, then the
-/// `'finish'`/`'close'` listeners — Node's ordering where `'finish'` never
-/// precedes the end callback (#4909).
-///
-/// # Safety
-/// FFI entry; `handle` must be a live `ServerResponse` handle (or absent).
-#[no_mangle]
-pub unsafe extern "C" fn js_node_http_res_end_full(handle: i64, chunk: f64, arg2: i64, arg3: i64) {
-    // `end(cb)` passes the callback as the first arg; otherwise it trails.
-    let first_cb = callback_from_bits(chunk.to_bits() as i64);
-    let (real_chunk, callback) = if first_cb != 0 {
-        (f64::from_bits(TAG_UNDEFINED), first_cb)
-    } else {
-        (chunk, pick_trailing_callback(arg2, arg3))
-    };
-
-    let is_standalone = get_handle::<ServerResponse>(handle)
-        .map(|sr| sr.standalone)
-        .unwrap_or(false);
-    if is_standalone {
-        // standalone_end already runs write cbs → end cb → listeners in order.
-        standalone_end(handle, real_chunk, callback);
-        return;
-    }
-
-    let listeners = finalize_buffered_end(handle, real_chunk);
-    let write_cbs = get_handle_mut::<ServerResponse>(handle)
-        .map(|sr| std::mem::take(&mut sr.pending_write_callbacks))
-        .unwrap_or_default();
-    for cb in write_cbs {
-        call_closure0(cb);
-    }
-    // Node order: queued write callbacks flush, then `'finish'` listeners, then
-    // the end callback, then `'close'`. The end cb fires *after* `'finish'` so
-    // a `res.on('finish')` handler that inspects end-callback state sees the
-    // same interleaving as Node.
-    let (finish_listeners, close_listeners) = listeners.unwrap_or_default();
-    emit_no_arg_to_listeners(&finish_listeners);
-    if callback != 0 {
-        call_closure0(callback);
-    }
-    emit_no_arg_to_listeners(&close_listeners);
-}
-
 /// `res.addTrailers(headers)` — store HTTP trailers emitted after the
 /// response body, per Node's `ServerResponse.addTrailers`. Trailers carry
 /// metadata that isn't known until the body has been produced.
@@ -1317,7 +1271,7 @@ pub extern "C" fn js_node_http_res_add_trailers(handle: i64, headers_value: f64)
 /// that `res.end(cb)` can run write/end callbacks before `'finish'` (Node's
 /// contract, where `'finish'` never precedes the end callback). Returns
 /// `None` if the response was already ended or the handle is gone.
-fn finalize_buffered_end(handle: i64, chunk: f64) -> Option<(Vec<i64>, Vec<i64>)> {
+pub(crate) fn finalize_buffered_end(handle: i64, chunk: f64) -> Option<(Vec<i64>, Vec<i64>)> {
     let v = JsValue::from_bits(chunk.to_bits());
     let final_chunk = if v.is_undefined() || v.is_null() {
         None
@@ -1384,17 +1338,6 @@ fn finalize_buffered_end(handle: i64, chunk: f64) -> Option<(Vec<i64>, Vec<i64>)
     }
     sr.writable_finished = true;
     Some((finish_listeners, close_listeners))
-}
-
-/// `res.end(chunk?)` — append final chunk + flush the response back
-/// to hyper through the oneshot channel + fire `'finish'` and
-/// `'close'` listeners.
-#[no_mangle]
-pub extern "C" fn js_node_http_res_end(handle: i64, chunk: f64) {
-    if let Some((finish_listeners, close_listeners)) = finalize_buffered_end(handle, chunk) {
-        emit_no_arg_to_listeners(&finish_listeners);
-        emit_no_arg_to_listeners(&close_listeners);
-    }
 }
 
 /// Flush the response head to the wire now and switch the response into
@@ -1819,123 +1762,9 @@ pub extern "C" fn js_node_http_res_write_with_cb(handle: i64, chunk: f64, callba
     }
 }
 
-/// `res.end([chunk][, callback])` — callback-aware variant. Standalone
-/// responses flush through the assigned socket; everything else takes the
-/// existing hyper-oneshot path. Queued write callbacks run first, in
-/// order, then the end callback (#4904).
-#[no_mangle]
-pub unsafe extern "C" fn js_node_http_res_end_with_cb(handle: i64, chunk: f64, callback: i64) {
-    let is_standalone = get_handle::<ServerResponse>(handle)
-        .map(|sr| sr.standalone)
-        .unwrap_or(false);
-    if is_standalone {
-        standalone_end(handle, chunk, callback);
-        return;
-    }
-    // #4909 — Node's flush ordering, matching `js_node_http_res_end_full`:
-    // queued write callbacks → `'finish'` → end callback → `'close'`. The
-    // previous code fired `'finish'`/`'close'` (via `js_node_http_res_end`)
-    // before any callback ran.
-    let listeners = finalize_buffered_end(handle, chunk);
-    let write_cbs = get_handle_mut::<ServerResponse>(handle)
-        .map(|sr| std::mem::take(&mut sr.pending_write_callbacks))
-        .unwrap_or_default();
-    for cb in write_cbs {
-        call_closure0(cb);
-    }
-    let (finish_listeners, close_listeners) = listeners.unwrap_or_default();
-    emit_no_arg_to_listeners(&finish_listeners);
-    if callback != 0 {
-        call_closure0(callback);
-    }
-    emit_no_arg_to_listeners(&close_listeners);
-}
-
-/// Flush a standalone response: serialize the head + buffered body and
-/// write them through the assigned socket's JS `write` method — one write
-/// for head+body, then the zero-length finish chunk Node's corked flush
-/// emits. The body is suppressed for HEAD requests.
-unsafe fn standalone_end(handle: i64, chunk: f64, callback: i64) {
-    let v = JsValue::from_bits(chunk.to_bits());
-    let final_chunk = if v.is_undefined() || v.is_null() {
-        None
-    } else {
-        jsvalue_to_body_bytes(chunk)
-    };
-
-    let (socket, payload, write_cbs, finish_listeners, close_listeners);
-    {
-        let sr = match get_handle_mut::<ServerResponse>(handle) {
-            Some(s) => s,
-            None => return,
-        };
-        if sr.writable_ended {
-            return;
-        }
-        if let Some(c) = final_chunk {
-            sr.buffered_body.extend_from_slice(&c);
-        }
-        sr.headers_sent = true;
-        sr.writable_ended = true;
-        sr.ensure_content_length();
-        let body = std::mem::take(&mut sr.buffered_body);
-        // Fast path: with no custom `statusMessage`, a common status code has a
-        // precomputed `HTTP/1.1 <code> <canonical reason>\r\n` status line,
-        // skipping the per-response `format!`. The interned bytes equal exactly
-        // what the `format!` produced for `(code, canonical reason)`. A custom
-        // message, or an uncommon code, falls back so its reason still reaches
-        // the wire byte-for-byte.
-        let mut head = match sr.status_message.as_deref() {
-            None => {
-                crate::server::response_fast::status_line_bytes(sr.status_code).map(str::to_string)
-            }
-            Some(_) => None,
-        }
-        .unwrap_or_else(|| {
-            let reason = sr.status_message.clone().unwrap_or_else(|| {
-                StatusCode::from_u16(sr.status_code)
-                    .ok()
-                    .and_then(|s| s.canonical_reason())
-                    .unwrap_or("")
-                    .to_string()
-            });
-            format!("HTTP/1.1 {} {}\r\n", sr.status_code, reason)
-        });
-        for (k, v) in sr.snapshot_headers() {
-            head.push_str(&k);
-            head.push_str(": ");
-            head.push_str(&v);
-            head.push_str("\r\n");
-        }
-        head.push_str("\r\n");
-        let mut bytes = head.into_bytes();
-        if sr.standalone_req_method.as_deref() != Some("HEAD") {
-            bytes.extend_from_slice(&body);
-        }
-        payload = bytes;
-        socket = sr.standalone_socket;
-        write_cbs = std::mem::take(&mut sr.pending_write_callbacks);
-        finish_listeners = take_event_listeners(sr, "finish");
-        close_listeners = take_event_listeners(sr, "close");
-        sr.writable_finished = true;
-    }
-    if !JsValue::from_bits(socket.to_bits()).is_undefined() {
-        socket_write_str(socket, &String::from_utf8_lossy(&payload));
-        socket_write_str(socket, "");
-    }
-    for cb in write_cbs {
-        call_closure0(cb);
-    }
-    if callback != 0 {
-        call_closure0(callback);
-    }
-    emit_no_arg_to_listeners(&finish_listeners);
-    emit_no_arg_to_listeners(&close_listeners);
-}
-
 /// Invoke `socket.write(chunk)` on an arbitrary JS value through the
 /// runtime's dynamic method-call path.
-unsafe fn socket_write_str(socket: f64, chunk: &str) {
+pub(crate) unsafe fn socket_write_str(socket: f64, chunk: &str) {
     extern "C" {
         fn js_native_call_method_str_key(
             object: f64,
@@ -1948,19 +1777,6 @@ unsafe fn socket_write_str(socket: f64, chunk: &str) {
     let chunk_val = f64::from_bits(JsValue::from_string_ptr(alloc_string(chunk).as_raw()).bits());
     let args = [chunk_val];
     let _ = js_native_call_method_str_key(socket, name.as_raw() as i64, args.as_ptr(), 1);
-}
-
-/// Call a closure pointer with no args, ignoring the result.
-fn call_closure0(callback: i64) {
-    if callback == 0 {
-        return;
-    }
-    unsafe {
-        let closure = JsClosure::from_raw(callback as *const RawClosureHeader);
-        if !closure.is_null() {
-            let _ = closure.call0();
-        }
-    }
 }
 
 pub(crate) fn alloc_server_response_for_request(

--- a/crates/perry-ext-http/src/server/response_end.rs
+++ b/crates/perry-ext-http/src/server/response_end.rs
@@ -1,0 +1,294 @@
+//! `res.end()` — the tail of a server response: flush, then run the queued
+//! write callbacks, the end callback and the `'finish'` / `'close'` listeners
+//! in Node's order.
+//!
+//! Split out of `response.rs` (which sits at the 2,000-line lint gate) when
+//! #8163 gave this family its rooting discipline. The four entry points share
+//! `EndTail`, which parks every snapshot the sequence consumes in the
+//! runtime's transient-root stack before any of it crosses a JS call.
+
+use hyper::StatusCode;
+use perry_ffi::{get_handle, get_handle_mut, JsClosure, JsValue, RawClosureHeader};
+
+use crate::server::request::emit_no_arg_to_listeners;
+use crate::server::response::{
+    callback_from_bits, finalize_buffered_end, pick_trailing_callback, socket_write_str,
+    take_event_listeners, ServerResponse,
+};
+use crate::server::types::{jsvalue_to_body_bytes, TAG_UNDEFINED};
+
+/// `res.end([chunk][, encoding][, callback])` — the full Node surface routed
+/// from the static native dispatch table. Handles the `end(cb)` form (callback
+/// in the first slot) as well as `end(chunk[, encoding][, callback])`. Queued
+/// write callbacks fire first (in order), then the end callback, then the
+/// `'finish'`/`'close'` listeners — Node's ordering where `'finish'` never
+/// precedes the end callback (#4909).
+///
+/// # Safety
+/// FFI entry; `handle` must be a live `ServerResponse` handle (or absent).
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_res_end_full(handle: i64, chunk: f64, arg2: i64, arg3: i64) {
+    // `end(cb)` passes the callback as the first arg; otherwise it trails.
+    let first_cb = callback_from_bits(chunk.to_bits() as i64);
+    let (real_chunk, callback) = if first_cb != 0 {
+        (f64::from_bits(TAG_UNDEFINED), first_cb)
+    } else {
+        (chunk, pick_trailing_callback(arg2, arg3))
+    };
+
+    let is_standalone = get_handle::<ServerResponse>(handle)
+        .map(|sr| sr.standalone)
+        .unwrap_or(false);
+    if is_standalone {
+        // standalone_end already runs write cbs → end cb → listeners in order.
+        standalone_end(handle, real_chunk, callback);
+        return;
+    }
+
+    let (finish_listeners, close_listeners) =
+        finalize_buffered_end(handle, real_chunk).unwrap_or_default();
+    let write_cbs = get_handle_mut::<ServerResponse>(handle)
+        .map(|sr| std::mem::take(&mut sr.pending_write_callbacks))
+        .unwrap_or_default();
+    // #8163: every snapshot crosses the JS calls below — root them all first.
+    let scope = perry_ffi::TransientRootScope::enter();
+    let tail = EndTail::root(
+        &scope,
+        &write_cbs,
+        callback,
+        &finish_listeners,
+        &close_listeners,
+    );
+    // Node order: queued write callbacks flush, then `'finish'` listeners, then
+    // the end callback, then `'close'`. The end cb fires *after* `'finish'` so
+    // a `res.on('finish')` handler that inspects end-callback state sees the
+    // same interleaving as Node.
+    tail.run_write_callbacks();
+    tail.emit_finish();
+    tail.run_end_callback();
+    tail.emit_close();
+}
+
+/// `res.end(chunk?)` — append final chunk + flush the response back
+/// to hyper through the oneshot channel + fire `'finish'` and
+/// `'close'` listeners.
+#[no_mangle]
+pub extern "C" fn js_node_http_res_end(handle: i64, chunk: f64) {
+    if let Some((finish_listeners, close_listeners)) = finalize_buffered_end(handle, chunk) {
+        // #8163: the `'close'` snapshot crosses the `'finish'` emits.
+        let scope = perry_ffi::TransientRootScope::enter();
+        let tail = EndTail::root(&scope, &[], 0, &finish_listeners, &close_listeners);
+        tail.emit_finish();
+        tail.emit_close();
+    }
+}
+
+/// `res.end([chunk][, callback])` — callback-aware variant. Standalone
+/// responses flush through the assigned socket; everything else takes the
+/// existing hyper-oneshot path. Queued write callbacks run first, in
+/// order, then the end callback (#4904).
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_res_end_with_cb(handle: i64, chunk: f64, callback: i64) {
+    let is_standalone = get_handle::<ServerResponse>(handle)
+        .map(|sr| sr.standalone)
+        .unwrap_or(false);
+    if is_standalone {
+        standalone_end(handle, chunk, callback);
+        return;
+    }
+    // #4909 — Node's flush ordering, matching `js_node_http_res_end_full`:
+    // queued write callbacks → `'finish'` → end callback → `'close'`. The
+    // previous code fired `'finish'`/`'close'` (via `js_node_http_res_end`)
+    // before any callback ran.
+    let (finish_listeners, close_listeners) =
+        finalize_buffered_end(handle, chunk).unwrap_or_default();
+    let write_cbs = get_handle_mut::<ServerResponse>(handle)
+        .map(|sr| std::mem::take(&mut sr.pending_write_callbacks))
+        .unwrap_or_default();
+    // #8163: every snapshot crosses the JS calls below — root them all first.
+    let scope = perry_ffi::TransientRootScope::enter();
+    let tail = EndTail::root(
+        &scope,
+        &write_cbs,
+        callback,
+        &finish_listeners,
+        &close_listeners,
+    );
+    tail.run_write_callbacks();
+    tail.emit_finish();
+    tail.run_end_callback();
+    tail.emit_close();
+}
+
+/// Flush a standalone response: serialize the head + buffered body and
+/// write them through the assigned socket's JS `write` method — one write
+/// for head+body, then the zero-length finish chunk Node's corked flush
+/// emits. The body is suppressed for HEAD requests.
+unsafe fn standalone_end(handle: i64, chunk: f64, callback: i64) {
+    let v = JsValue::from_bits(chunk.to_bits());
+    let final_chunk = if v.is_undefined() || v.is_null() {
+        None
+    } else {
+        jsvalue_to_body_bytes(chunk)
+    };
+
+    let (socket, payload, write_cbs, finish_listeners, close_listeners);
+    {
+        let sr = match get_handle_mut::<ServerResponse>(handle) {
+            Some(s) => s,
+            None => return,
+        };
+        if sr.writable_ended {
+            return;
+        }
+        if let Some(c) = final_chunk {
+            sr.buffered_body.extend_from_slice(&c);
+        }
+        sr.headers_sent = true;
+        sr.writable_ended = true;
+        sr.ensure_content_length();
+        let body = std::mem::take(&mut sr.buffered_body);
+        // Fast path: with no custom `statusMessage`, a common status code has a
+        // precomputed `HTTP/1.1 <code> <canonical reason>\r\n` status line,
+        // skipping the per-response `format!`. The interned bytes equal exactly
+        // what the `format!` produced for `(code, canonical reason)`. A custom
+        // message, or an uncommon code, falls back so its reason still reaches
+        // the wire byte-for-byte.
+        let mut head = match sr.status_message.as_deref() {
+            None => {
+                crate::server::response_fast::status_line_bytes(sr.status_code).map(str::to_string)
+            }
+            Some(_) => None,
+        }
+        .unwrap_or_else(|| {
+            let reason = sr.status_message.clone().unwrap_or_else(|| {
+                StatusCode::from_u16(sr.status_code)
+                    .ok()
+                    .and_then(|s| s.canonical_reason())
+                    .unwrap_or("")
+                    .to_string()
+            });
+            format!("HTTP/1.1 {} {}\r\n", sr.status_code, reason)
+        });
+        for (k, v) in sr.snapshot_headers() {
+            head.push_str(&k);
+            head.push_str(": ");
+            head.push_str(&v);
+            head.push_str("\r\n");
+        }
+        head.push_str("\r\n");
+        let mut bytes = head.into_bytes();
+        if sr.standalone_req_method.as_deref() != Some("HEAD") {
+            bytes.extend_from_slice(&body);
+        }
+        payload = bytes;
+        socket = sr.standalone_socket;
+        write_cbs = std::mem::take(&mut sr.pending_write_callbacks);
+        finish_listeners = take_event_listeners(sr, "finish");
+        close_listeners = take_event_listeners(sr, "close");
+        sr.writable_finished = true;
+    }
+    // #8163: `socket_write_str` calls the socket's JS `write`, so every
+    // snapshot taken above is already crossing JS from here on — root first.
+    let scope = perry_ffi::TransientRootScope::enter();
+    let tail = EndTail::root(
+        &scope,
+        &write_cbs,
+        callback,
+        &finish_listeners,
+        &close_listeners,
+    );
+    if !JsValue::from_bits(socket.to_bits()).is_undefined() {
+        socket_write_str(socket, &String::from_utf8_lossy(&payload));
+        socket_write_str(socket, "");
+    }
+    tail.run_write_callbacks();
+    tail.run_end_callback();
+    tail.emit_finish();
+    tail.emit_close();
+}
+
+/// The `res.end()` tail — queued write callbacks, the end callback, and the
+/// `'finish'` / `'close'` listeners — with every snapshot ROOTED for the whole
+/// sequence (#8163).
+///
+/// The listener vectors are taken OUT of the `ServerResponse` handle
+/// (`take_event_listeners`), the write callbacks are `mem::take`n, and the end
+/// callback is a raw argument: from that moment the registered mutable-root
+/// scanner (`scan_http_server_roots`) no longer sees any of them. Each of the
+/// four steps runs JS and can therefore trigger a moving collection, so a plain
+/// `Vec<i64>` snapshot used AFTER an earlier step is a pre-move address — the
+/// production Next App Route fixture faulted on exactly this: `'finish'`
+/// listeners ran, a copying minor moved the `'close'` listener closure, and
+/// `emit_no_arg_to_listeners(&close_listeners)` dereferenced the retired
+/// from-space copy. Rooting inside `emit_no_arg_to_listeners` alone is not
+/// enough — it roots what it is *handed*, and it was handed a stale snapshot.
+///
+/// Every address lives in the runtime's transient-root stack (marked AND
+/// rewritten on evacuation) and is re-read at each use. The caller decides the
+/// order — the buffered path fires the end callback *after* `'finish'` (Node
+/// registers `end(cb)` as a `'finish'` listener behind the existing ones,
+/// #4909), the standalone path fires it before.
+struct EndTail<'a> {
+    _scope: &'a perry_ffi::TransientRootScope,
+    write_cbs: Vec<perry_ffi::TransientRootedAddr>,
+    callback: perry_ffi::TransientRootedAddr,
+    finish: Vec<perry_ffi::TransientRootedAddr>,
+    close: Vec<perry_ffi::TransientRootedAddr>,
+}
+
+impl<'a> EndTail<'a> {
+    /// Root every snapshot. Must be called before ANY of them crosses a JS
+    /// call — i.e. immediately after they are taken out of the handle.
+    fn root(
+        scope: &'a perry_ffi::TransientRootScope,
+        write_cbs: &[i64],
+        callback: i64,
+        finish: &[i64],
+        close: &[i64],
+    ) -> Self {
+        Self {
+            _scope: scope,
+            write_cbs: scope.root_addrs(write_cbs),
+            callback: scope.root_addr(callback),
+            finish: scope.root_addrs(finish),
+            close: scope.root_addrs(close),
+        }
+    }
+
+    fn run_write_callbacks(&self) {
+        for cb in &self.write_cbs {
+            call_closure0(cb.get());
+        }
+    }
+
+    fn run_end_callback(&self) {
+        call_closure0(self.callback.get());
+    }
+
+    fn emit_finish(&self) {
+        emit_no_arg_to_listeners(&Self::current(&self.finish));
+    }
+
+    fn emit_close(&self) {
+        emit_no_arg_to_listeners(&Self::current(&self.close));
+    }
+
+    /// The post-collection addresses, read at the moment of use.
+    fn current(rooted: &[perry_ffi::TransientRootedAddr]) -> Vec<i64> {
+        rooted.iter().map(|cb| cb.get()).collect()
+    }
+}
+
+/// Call a closure pointer with no args, ignoring the result.
+pub(crate) fn call_closure0(callback: i64) {
+    if callback == 0 {
+        return;
+    }
+    unsafe {
+        let closure = JsClosure::from_raw(callback as *const RawClosureHeader);
+        if !closure.is_null() {
+            let _ = closure.call0();
+        }
+    }
+}

--- a/crates/perry-stdlib/src/fetch/body_metadata.rs
+++ b/crates/perry-stdlib/src/fetch/body_metadata.rs
@@ -259,14 +259,17 @@ pub unsafe extern "C" fn js_response_form_data(handle: f64) -> *mut perry_runtim
 
 fn request_string_field(handle: f64, f: impl FnOnce(&RequestRecord) -> &str) -> *mut StringHeader {
     let id = handle_id(handle);
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    match guard.get(&id) {
-        Some(req) => {
-            let value = f(req);
-            js_string_from_bytes(value.as_ptr(), value.len() as u32)
-        }
-        None => js_string_from_bytes("".as_ptr(), 0),
-    }
+    // #8163: snapshot under the guard, allocate after it is dropped — the Fetch
+    // root scanner takes this same lock during a collection on this thread, so
+    // allocating inside the guard's scope self-deadlocks whenever that
+    // allocation triggers one. See `fetch::gc` and `js_request_get_url`.
+    let value = REQUEST_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|req| f(req).to_owned())
+        .unwrap_or_default();
+    js_string_from_bytes(value.as_ptr(), value.len() as u32)
 }
 
 #[no_mangle]

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -371,73 +371,53 @@ pub fn dispatch_request_property(req_id: usize, prop: &str) -> Option<f64> {
             js_class_method_bind(handle_to_f64(req_id), name.as_ptr(), name.len())
         });
     }
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    let req = guard.get(&req_id)?;
-    let bits = match prop {
-        "url" => {
-            let p = js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);
-            JSValue::string_ptr(p).bits()
+    // #8163: every string arm here used to call `js_string_from_bytes` WHILE
+    // holding the `REQUEST_REGISTRY` guard. The Fetch root scanner takes that
+    // same lock during a collection on this thread, so any `request.url` read
+    // whose allocation triggered one would self-deadlock. Snapshot the bytes
+    // under the guard, release it, and allocate after. Arms that answer
+    // without allocating (`bodyUsed`, `keepalive`, `signal`) still return
+    // directly. See `fetch::gc`.
+    enum RequestProp {
+        /// Bytes to turn into a JS string once the registry lock is released.
+        Bytes(Vec<u8>),
+        /// An answer that needed no allocation.
+        Ready(f64),
+    }
+    let snapshot = {
+        let guard = REQUEST_REGISTRY.lock().unwrap();
+        let req = guard.get(&req_id)?;
+        match prop {
+            "url" => RequestProp::Bytes(req.url.as_bytes().to_vec()),
+            "method" => RequestProp::Bytes(req.method.as_bytes().to_vec()),
+            "destination" => RequestProp::Bytes(req.destination.as_bytes().to_vec()),
+            "referrer" => RequestProp::Bytes(req.referrer.as_bytes().to_vec()),
+            "referrerPolicy" => RequestProp::Bytes(req.referrer_policy.as_bytes().to_vec()),
+            "mode" => RequestProp::Bytes(req.mode.as_bytes().to_vec()),
+            "credentials" => RequestProp::Bytes(req.credentials.as_bytes().to_vec()),
+            "cache" => RequestProp::Bytes(req.cache.as_bytes().to_vec()),
+            "redirect" => RequestProp::Bytes(req.redirect.as_bytes().to_vec()),
+            "integrity" => RequestProp::Bytes(req.integrity.as_bytes().to_vec()),
+            "duplex" => RequestProp::Bytes(req.duplex.as_bytes().to_vec()),
+            "body" => match &req.body {
+                Some(b) => RequestProp::Bytes(b.clone()),
+                None => RequestProp::Ready(f64::from_bits(TAG_NULL)),
+            },
+            "bodyUsed" => RequestProp::Ready(tagged_bool(req.body_used)),
+            "keepalive" => RequestProp::Ready(tagged_bool(req.keepalive)),
+            "signal" => RequestProp::Ready(req.signal),
+            // Other Request properties not yet wired — fall through so other
+            // dispatchers (or the final undefined fallback) can answer.
+            _ => return None,
         }
-        "method" => {
-            let p = js_string_from_bytes(req.method.as_ptr(), req.method.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "destination" => {
-            let p = js_string_from_bytes(req.destination.as_ptr(), req.destination.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "referrer" => {
-            let p = js_string_from_bytes(req.referrer.as_ptr(), req.referrer.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "referrerPolicy" => {
-            let p = js_string_from_bytes(
-                req.referrer_policy.as_ptr(),
-                req.referrer_policy.len() as u32,
-            );
-            JSValue::string_ptr(p).bits()
-        }
-        "mode" => {
-            let p = js_string_from_bytes(req.mode.as_ptr(), req.mode.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "credentials" => {
-            let p = js_string_from_bytes(req.credentials.as_ptr(), req.credentials.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "cache" => {
-            let p = js_string_from_bytes(req.cache.as_ptr(), req.cache.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "redirect" => {
-            let p = js_string_from_bytes(req.redirect.as_ptr(), req.redirect.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "integrity" => {
-            let p = js_string_from_bytes(req.integrity.as_ptr(), req.integrity.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "duplex" => {
-            let p = js_string_from_bytes(req.duplex.as_ptr(), req.duplex.len() as u32);
-            JSValue::string_ptr(p).bits()
-        }
-        "body" => match &req.body {
-            Some(b) => {
-                let p = js_string_from_bytes(b.as_ptr(), b.len() as u32);
-                JSValue::string_ptr(p).bits()
-            }
-            None => TAG_NULL,
-        },
-        "bodyUsed" => {
-            return Some(tagged_bool(req.body_used));
-        }
-        "keepalive" => return Some(tagged_bool(req.keepalive)),
-        "signal" => return Some(req.signal),
-        // Other Request properties not yet wired — fall through so other
-        // dispatchers (or the final undefined fallback) can answer.
-        _ => return None,
     };
-    Some(f64::from_bits(bits))
+    match snapshot {
+        RequestProp::Ready(value) => Some(value),
+        RequestProp::Bytes(bytes) => {
+            let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+            Some(f64::from_bits(JSValue::string_ptr(p).bits()))
+        }
+    }
 }
 
 /// #1698: try to dispatch a method call on a Request handle by registry id.

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -239,8 +239,20 @@ pub(crate) unsafe fn fetch_request_body_bytes(body_ptr: *const StringHeader) -> 
 }
 
 lazy_static::lazy_static! {
-    static ref FORM_DATA_METHOD_VALUE_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
+    /// Bound-method closures behind `formData.get` / `.entries` / … — the
+    /// `FormData` twin of `HEADERS_METHOD_VALUE_CACHE`, and a GC root for the
+    /// same reason (#8163): the values are heap closures held outside the heap.
+    pub(super) static ref FORM_DATA_METHOD_VALUE_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
         Mutex::new(HashMap::new());
+}
+
+/// Visit every cached `FormData` bound-method closure (see `super::gc`).
+pub(super) fn visit_form_data_method_value_roots<V: super::gc::FetchRootVisitor>(visitor: &mut V) {
+    if let Ok(mut cache) = FORM_DATA_METHOD_VALUE_CACHE.lock() {
+        for bits in cache.values_mut() {
+            visitor.visit_nanbox_u64_slot(bits);
+        }
+    }
 }
 
 fn form_data_bound_method_value(form_id: usize, method_name: &'static str) -> f64 {
@@ -257,6 +269,8 @@ fn form_data_bound_method_value(form_id: usize, method_name: &'static str) -> f6
         fn js_write_barrier_root_nanbox(value_bits: u64);
     }
 
+    // Register before allocating — see `headers_bound_method_value`.
+    super::gc::ensure_gc_registered();
     let closure =
         perry_runtime::closure::js_closure_alloc(perry_runtime::closure::BOUND_METHOD_FUNC_PTR, 3);
     perry_runtime::closure::js_closure_set_capture_f64(closure, 0, handle_to_f64(form_id));

--- a/crates/perry-stdlib/src/fetch/gc.rs
+++ b/crates/perry-stdlib/src/fetch/gc.rs
@@ -28,11 +28,31 @@
 //! process-wide runtime image rather than into any runtime glue that happens to
 //! be linked into the stdlib image.
 //!
-//! Locking contract: the scanner runs *during* a collection on the mutator
-//! thread and takes each table's mutex, so no site may hold one of these guards
-//! across a GC allocation. `js_request_new` builds its `RequestRecord`
-//! (including the default `AbortSignal` allocation) *before* taking the
-//! `REQUEST_REGISTRY` lock for that reason.
+//! **Locking contract (load-bearing).** The scanner runs *during* a collection
+//! on the mutator thread and takes each table's mutex, so **no site may hold one
+//! of these guards across a GC allocation, or across a throw**. `std::sync::Mutex`
+//! is not reentrant: an allocation under the guard that triggers a collection
+//! deadlocks against this scanner on the same thread, and a throw under the
+//! guard unwinds through the frame without running `Drop` (the `eh.rs` transport
+//! is written for `panic=abort` semantics), leaving the registry locked for the
+//! life of the process.
+//!
+//! Registering this scanner is therefore what turned a dozen pre-existing
+//! "allocate under the guard" sites into real deadlocks, and they were hoisted
+//! in the same change: `js_request_new` builds its whole `RequestRecord`
+//! (default `AbortSignal` allocation included) before taking the lock;
+//! `js_request_get_url` / `_method` / `_body`, `js_request_input_to_url`,
+//! `request_string_field` and `dispatch_request_property`'s twelve string arms
+//! snapshot the field bytes under the guard and allocate after dropping it; and
+//! `js_request_clone` decides "unusable" under the guard but throws outside it.
+//! Two tests hold the line, because the failure mode is a HANG and a test that
+//! hangs is worse than one that fails:
+//! `fetch::tests::request_reads_release_the_registry_guard` exercises every
+//! reader and asserts the mutex is free afterwards (a guard leaked by a throw
+//! shows up here), and
+//! `fetch::tests::no_allocation_is_taken_off_a_live_registry_borrow` is a
+//! source scan for the shape that caused it — `js_string_from_bytes(req.…)`,
+//! i.e. allocating straight out of a borrow that only the guard keeps alive.
 
 use super::*;
 use std::ffi::c_void;

--- a/crates/perry-stdlib/src/fetch/gc.rs
+++ b/crates/perry-stdlib/src/fetch/gc.rs
@@ -1,0 +1,138 @@
+//! Provider-safe GC registration for the Web Fetch registries' heap values.
+//!
+//! The Fetch handle registries are process-global `lazy_static!` tables keyed
+//! by small handle ids, and three of them hold *heap values*, not just Rust
+//! data:
+//!
+//! * `HEADERS_METHOD_VALUE_CACHE` — the bound-method closure behind
+//!   `headers.get` / `headers.entries` / … (one per `(handle, method)`),
+//! * `FORM_DATA_METHOD_VALUE_CACHE` — the same for `FormData`,
+//! * `RequestRecord::signal` — the `AbortSignal` object behind `request.signal`.
+//!
+//! Until #8163 nothing marked or rewrote those slots. `js_write_barrier_root_nanbox`
+//! at the store site is only the incremental-marking shade — it does not
+//! register a root — so under a moving collector the cached closure either
+//! died (nothing else referenced it once the caller dropped the bound copy) or
+//! moved, and the next `headers.get` read handed the pre-move address to
+//! `typeof`. That is precisely the shape the production Next App Route fixture
+//! hit under forced evacuation: `(await headers()).get(...)` twice per request
+//! with collections between, and the second read faulting on a retired
+//! from-space closure. `PERRY_GC_VERIFY_EVACUATION` cannot see it (no scanner
+//! to verify), `PERRY_GC_PROTECT_FROMSPACE_HOLDERS` cannot see it (the holder is
+//! a Rust `HashMap` outside the GC heap), and `scripts/gc_runtime_root_holders.py`
+//! could not see it either — its declaration regex did not match
+//! `lazy_static!`'s `static ref` (fixed alongside this module).
+//!
+//! Registration goes through the stable C ABI, exactly like `streams::gc`, so a
+//! separately packaged stdlib provider installs its scanner into the
+//! process-wide runtime image rather than into any runtime glue that happens to
+//! be linked into the stdlib image.
+//!
+//! Locking contract: the scanner runs *during* a collection on the mutator
+//! thread and takes each table's mutex, so no site may hold one of these guards
+//! across a GC allocation. `js_request_new` builds its `RequestRecord`
+//! (including the default `AbortSignal` allocation) *before* taking the
+//! `REQUEST_REGISTRY` lock for that reason.
+
+use super::*;
+use std::ffi::c_void;
+
+const FFI_SLOT_NANBOX_F64: u32 = 4;
+const FFI_SLOT_NANBOX_U64: u32 = 5;
+
+type FfiMutableRootVisitor = extern "C" fn(kind: u32, slot: *mut c_void, ctx: *mut c_void) -> bool;
+type FfiNamedMutableRootScanner =
+    extern "C" fn(scanner_id: usize, visit: FfiMutableRootVisitor, ctx: *mut c_void);
+
+extern "C" {
+    fn perry_ffi_gc_register_mutable_root_scanner_named(
+        source_ptr: *const u8,
+        source_len: usize,
+        scanner_id: usize,
+        scanner: FfiNamedMutableRootScanner,
+    );
+}
+
+/// The two slot shapes the Fetch registries hold. Both are NaN-boxed values;
+/// the visitor marks the referent and rewrites the slot when it moved.
+pub(super) trait FetchRootVisitor {
+    fn visit_nanbox_f64_slot(&mut self, slot: &mut f64);
+    fn visit_nanbox_u64_slot(&mut self, slot: &mut u64);
+}
+
+impl FetchRootVisitor for perry_runtime::gc::RuntimeRootVisitor<'_> {
+    fn visit_nanbox_f64_slot(&mut self, slot: &mut f64) {
+        perry_runtime::gc::RuntimeRootVisitor::visit_nanbox_f64_slot(self, slot);
+    }
+
+    fn visit_nanbox_u64_slot(&mut self, slot: &mut u64) {
+        perry_runtime::gc::RuntimeRootVisitor::visit_nanbox_u64_slot(self, slot);
+    }
+}
+
+struct FfiFetchRootVisitor {
+    visit: FfiMutableRootVisitor,
+    ctx: *mut c_void,
+}
+
+impl FetchRootVisitor for FfiFetchRootVisitor {
+    fn visit_nanbox_f64_slot(&mut self, slot: &mut f64) {
+        (self.visit)(
+            FFI_SLOT_NANBOX_F64,
+            slot as *mut f64 as *mut c_void,
+            self.ctx,
+        );
+    }
+
+    fn visit_nanbox_u64_slot(&mut self, slot: &mut u64) {
+        (self.visit)(
+            FFI_SLOT_NANBOX_U64,
+            slot as *mut u64 as *mut c_void,
+            self.ctx,
+        );
+    }
+}
+
+static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Register the Fetch root scanner exactly once. Called from every site that
+/// stores a heap value into one of the registries, before the store, so the
+/// value is reachable from the first collection after it lands.
+pub(super) fn ensure_gc_registered() {
+    GC_REGISTERED.call_once(|| {
+        const SOURCE: &[u8] = b"stdlib:fetch";
+        unsafe {
+            perry_ffi_gc_register_mutable_root_scanner_named(
+                SOURCE.as_ptr(),
+                SOURCE.len(),
+                0,
+                scan_fetch_roots_ffi,
+            );
+        }
+    });
+}
+
+extern "C" fn scan_fetch_roots_ffi(
+    _scanner_id: usize,
+    visit: FfiMutableRootVisitor,
+    ctx: *mut c_void,
+) {
+    scan_fetch_roots_with(&mut FfiFetchRootVisitor { visit, ctx });
+}
+
+#[cfg(test)]
+pub(super) fn scan_fetch_roots(mark: &mut dyn FnMut(f64)) {
+    let mut visitor = perry_runtime::gc::RuntimeRootVisitor::for_copy(mark);
+    scan_fetch_roots_with(&mut visitor);
+}
+
+/// Visit every heap-value slot the Fetch registries own.
+pub(super) fn scan_fetch_roots_with<V: FetchRootVisitor>(visitor: &mut V) {
+    headers_method_value::visit_roots(visitor);
+    dispatch::visit_form_data_method_value_roots(visitor);
+    if let Ok(mut requests) = REQUEST_REGISTRY.lock() {
+        for request in requests.values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.signal);
+        }
+    }
+}

--- a/crates/perry-stdlib/src/fetch/headers_method_value.rs
+++ b/crates/perry-stdlib/src/fetch/headers_method_value.rs
@@ -6,6 +6,12 @@
 //! caches) the bound-method closure that backs those reads. Split out of
 //! `mod.rs` to keep that file under the 2,000-line lint gate. The child module
 //! sees `mod.rs`'s private items via `use super::*`.
+//!
+//! The cache is a GC root (#8163). Its values are NaN-boxed closure pointers
+//! living in a Rust `HashMap` outside the GC heap, so it is invisible to every
+//! heap-side instrument; `super::gc` registers the scanner that marks them and
+//! rewrites the slots when the closure moves. Every read that misses here
+//! allocates, so registration happens before the first insert.
 
 use super::*;
 
@@ -32,8 +38,20 @@ extern "C" {
 }
 
 lazy_static::lazy_static! {
-    static ref HEADERS_METHOD_VALUE_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
+    pub(super) static ref HEADERS_METHOD_VALUE_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
         Mutex::new(HashMap::new());
+}
+
+/// Visit every cached bound-method closure. Called from `super::gc`'s
+/// registered scanner; the guard is never held across an allocation on the
+/// mutator side (`headers_bound_method_value` drops it before allocating), so
+/// taking it during a collection cannot deadlock.
+pub(super) fn visit_roots<V: super::gc::FetchRootVisitor>(visitor: &mut V) {
+    if let Ok(mut cache) = HEADERS_METHOD_VALUE_CACHE.lock() {
+        for bits in cache.values_mut() {
+            visitor.visit_nanbox_u64_slot(bits);
+        }
+    }
 }
 
 pub(crate) fn headers_bound_method_value(headers_id: usize, method_name: &'static str) -> f64 {
@@ -50,6 +68,10 @@ pub(crate) fn headers_bound_method_value(headers_id: usize, method_name: &'stati
         fn js_write_barrier_root_nanbox(value_bits: u64);
     }
 
+    // Register before the allocation below: the closure is unreferenced from
+    // JS the moment the caller drops its bound copy, so the cache slot must be
+    // a live root by the first collection that can run after the insert.
+    super::gc::ensure_gc_registered();
     let closure =
         unsafe { provider_js_closure_alloc(perry_runtime::closure::BOUND_METHOD_FUNC_PTR, 3) };
     unsafe {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -1734,11 +1734,15 @@ pub extern "C" fn js_request_get_headers(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_request_get_url(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    match guard.get(&id) {
-        Some(req) => js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32),
-        None => std::ptr::null_mut(),
-    }
+    // #8163: snapshot under the guard, allocate after it is dropped. The Fetch
+    // root scanner takes this same lock during a collection on this thread, so
+    // a `js_string_from_bytes` inside the guard's scope self-deadlocks the
+    // moment that allocation triggers one. See `fetch::gc`.
+    let url = match REQUEST_REGISTRY.lock().unwrap().get(&id) {
+        Some(req) => req.url.clone(),
+        None => return std::ptr::null_mut(),
+    };
+    js_string_from_bytes(url.as_ptr(), url.len() as u32)
 }
 
 /// Coerce the first argument of `new Request(input, init)` to its URL string.
@@ -1752,8 +1756,14 @@ pub extern "C" fn js_request_get_url(handle: f64) -> *mut StringHeader {
 #[no_mangle]
 pub extern "C" fn js_request_input_to_url(value: f64) -> *mut StringHeader {
     let id = handle_id(value);
-    if let Some(req) = REQUEST_REGISTRY.lock().unwrap().get(&id) {
-        return js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);
+    // #8163: snapshot under the guard, allocate after (see `js_request_get_url`).
+    let url = REQUEST_REGISTRY
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|req| req.url.clone());
+    if let Some(url) = url {
+        return js_string_from_bytes(url.as_ptr(), url.len() as u32);
     }
     perry_runtime::value::js_jsvalue_to_string(value) as *mut StringHeader
 }
@@ -1761,28 +1771,28 @@ pub extern "C" fn js_request_input_to_url(value: f64) -> *mut StringHeader {
 #[no_mangle]
 pub extern "C" fn js_request_get_method(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    match guard.get(&id) {
-        Some(req) => js_string_from_bytes(req.method.as_ptr(), req.method.len() as u32),
-        None => std::ptr::null_mut(),
-    }
+    // #8163: snapshot under the guard, allocate after (see `js_request_get_url`).
+    let method = match REQUEST_REGISTRY.lock().unwrap().get(&id) {
+        Some(req) => req.method.clone(),
+        None => return std::ptr::null_mut(),
+    };
+    js_string_from_bytes(method.as_ptr(), method.len() as u32)
 }
 
 /// req.body — returns a string body or null. NaN-boxed return.
 #[no_mangle]
 pub extern "C" fn js_request_get_body(handle: f64) -> f64 {
     let id = handle_id(handle);
-    let guard = REQUEST_REGISTRY.lock().unwrap();
-    match guard.get(&id) {
+    // #8163: snapshot under the guard, allocate after (see `js_request_get_url`).
+    let body = match REQUEST_REGISTRY.lock().unwrap().get(&id) {
         Some(req) => match &req.body {
-            Some(b) => {
-                let s = js_string_from_bytes(b.as_ptr(), b.len() as u32);
-                f64::from_bits(JSValue::string_ptr(s).bits())
-            }
-            None => f64::from_bits(TAG_NULL),
+            Some(b) => b.clone(),
+            None => return f64::from_bits(TAG_NULL),
         },
-        None => f64::from_bits(TAG_NULL),
-    }
+        None => return f64::from_bits(TAG_NULL),
+    };
+    let s = js_string_from_bytes(body.as_ptr(), body.len() as u32);
+    f64::from_bits(JSValue::string_ptr(s).bits())
 }
 
 /// request.bodyUsed -> boolean
@@ -1797,13 +1807,19 @@ pub extern "C" fn js_request_body_used(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_request_clone(handle: f64) -> f64 {
     let id = handle_id(handle);
-    let cloned = {
+    // #8163: the `unusable` throw MUST NOT happen under the guard. It allocates
+    // an Error (a collection point, and the scanner takes this same lock) and
+    // then unwinds through this frame without running `Drop`, so the registry
+    // mutex would stay locked for the life of the process. Decide under the
+    // guard, throw after it is dropped. `Err(())` is "unusable".
+    #[allow(clippy::result_unit_err)]
+    let cloned: Option<Result<RequestRecord, ()>> = {
         let guard = REQUEST_REGISTRY.lock().unwrap();
         guard.get(&id).map(|req| {
             if req.body.is_some() && req.body_used {
-                unsafe { throw_fetch_type_error("unusable") };
+                return Err(());
             }
-            RequestRecord {
+            Ok(RequestRecord {
                 url: req.url.clone(),
                 method: req.method.clone(),
                 body: req.body.clone(),
@@ -1821,16 +1837,19 @@ pub extern "C" fn js_request_clone(handle: f64) -> f64 {
                 duplex: req.duplex.clone(),
                 signal: req.signal,
                 cached_headers_id: None,
-            }
+            })
         })
     };
-    if let Some(new_req) = cloned {
-        let new_id = alloc_fetch_handle_id();
-        gc::ensure_gc_registered();
-        REQUEST_REGISTRY.lock().unwrap().insert(new_id, new_req);
-        return handle_to_f64(new_id);
+    match cloned {
+        Some(Err(())) => unsafe { throw_fetch_type_error("unusable") },
+        Some(Ok(new_req)) => {
+            let new_id = alloc_fetch_handle_id();
+            gc::ensure_gc_registered();
+            REQUEST_REGISTRY.lock().unwrap().insert(new_id, new_req);
+            handle_to_f64(new_id)
+        }
+        None => f64::from_bits(TAG_UNDEFINED),
     }
-    f64::from_bits(TAG_UNDEFINED)
 }
 
 /// Read and consume a request's stored body. Bodiless requests are reusable and

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -38,6 +38,11 @@ pub use dispatch::*;
 mod body_metadata;
 pub use body_metadata::*;
 
+// GC root scanner for the heap values the Fetch registries hold (#8163):
+// the two bound-method caches and `RequestRecord::signal`. Same
+// child-module/`use super::*` contract as `headers`.
+mod gc;
+
 // Web Fetch `Request` constructors (`js_request_new` /
 // `js_request_new_from_init`) — split out to keep this file under the
 // 2,000-line lint gate (#5458). Same child-module/`use super::*` contract as
@@ -1821,6 +1826,7 @@ pub extern "C" fn js_request_clone(handle: f64) -> f64 {
     };
     if let Some(new_req) = cloned {
         let new_id = alloc_fetch_handle_id();
+        gc::ensure_gc_registered();
         REQUEST_REGISTRY.lock().unwrap().insert(new_id, new_req);
         return handle_to_f64(new_id);
     }

--- a/crates/perry-stdlib/src/fetch/request_ctor.rs
+++ b/crates/perry-stdlib/src/fetch/request_ctor.rs
@@ -93,31 +93,36 @@ pub unsafe extern "C" fn js_request_new(
     } else {
         HeadersStore::default()
     };
+    // `signal` is a heap value the registry keeps (and the GC scanner in
+    // `super::gc` roots), and defaulting it ALLOCATES an `AbortController` —
+    // so resolve it, and build the whole record, before taking the registry
+    // lock: the scanner takes that same lock during a collection on this
+    // thread, and a collection triggered by the allocation under the guard
+    // would deadlock.
+    let signal = body_metadata::signal_or_default(signal);
     let id = alloc_fetch_handle_id();
-    REQUEST_REGISTRY.lock().unwrap().insert(
-        id,
-        RequestRecord {
-            url,
-            method,
-            body,
-            body_used: false,
-            headers,
-            destination: String::new(),
-            referrer: string_from_header(referrer_ptr)
-                .unwrap_or_else(|| "about:client".to_string()),
-            referrer_policy: string_from_header(referrer_policy_ptr).unwrap_or_default(),
-            mode: string_from_header(mode_ptr).unwrap_or_else(|| "cors".to_string()),
-            credentials: string_from_header(credentials_ptr)
-                .unwrap_or_else(|| "same-origin".to_string()),
-            cache: string_from_header(cache_ptr).unwrap_or_else(|| "default".to_string()),
-            redirect: string_from_header(redirect_ptr).unwrap_or_else(|| "follow".to_string()),
-            integrity: string_from_header(integrity_ptr).unwrap_or_default(),
-            keepalive: body_metadata::bool_from_js(keepalive),
-            duplex: string_from_header(duplex_ptr).unwrap_or_else(|| "half".to_string()),
-            signal: body_metadata::signal_or_default(signal),
-            cached_headers_id: None,
-        },
-    );
+    let record = RequestRecord {
+        url,
+        method,
+        body,
+        body_used: false,
+        headers,
+        destination: String::new(),
+        referrer: string_from_header(referrer_ptr).unwrap_or_else(|| "about:client".to_string()),
+        referrer_policy: string_from_header(referrer_policy_ptr).unwrap_or_default(),
+        mode: string_from_header(mode_ptr).unwrap_or_else(|| "cors".to_string()),
+        credentials: string_from_header(credentials_ptr)
+            .unwrap_or_else(|| "same-origin".to_string()),
+        cache: string_from_header(cache_ptr).unwrap_or_else(|| "default".to_string()),
+        redirect: string_from_header(redirect_ptr).unwrap_or_else(|| "follow".to_string()),
+        integrity: string_from_header(integrity_ptr).unwrap_or_default(),
+        keepalive: body_metadata::bool_from_js(keepalive),
+        duplex: string_from_header(duplex_ptr).unwrap_or_else(|| "half".to_string()),
+        signal,
+        cached_headers_id: None,
+    };
+    super::gc::ensure_gc_registered();
+    REQUEST_REGISTRY.lock().unwrap().insert(id, record);
     handle_to_f64(id)
 }
 

--- a/crates/perry-stdlib/src/fetch/tests.rs
+++ b/crates/perry-stdlib/src/fetch/tests.rs
@@ -230,3 +230,146 @@ fn fetch_root_scanner_rewrites_relocated_slots_in_place() {
         .remove(&(headers_id, "entries"));
     REQUEST_REGISTRY.lock().unwrap().remove(&handle_id(request));
 }
+
+/// #8163: every `Request` reader must RELEASE the `REQUEST_REGISTRY` guard
+/// before it returns. The Fetch root scanner takes that same lock during a
+/// collection on this thread, so a leaked guard — which is what a throw under
+/// the guard produces, since the exception transport unwinds through the frame
+/// without running `Drop` — silently disables the scanner and reintroduces
+/// #8163's root cause. `try_lock` is the cheap witness: it fails if the guard
+/// is still held, and unlike calling a reader while holding the lock it FAILS
+/// rather than hangs.
+#[test]
+fn request_reads_release_the_registry_guard() {
+    let request = unsafe {
+        js_request_new(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0.0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            f64::from_bits(TAG_FALSE),
+            std::ptr::null(),
+            f64::from_bits(TAG_UNDEFINED),
+        )
+    };
+    let id = handle_id(request);
+    assert!(
+        REQUEST_REGISTRY.try_lock().is_ok(),
+        "js_request_new leaked the registry guard"
+    );
+
+    let readers: &[(&str, &dyn Fn())] = &[
+        ("js_request_get_url", &|| {
+            js_request_get_url(request);
+        }),
+        ("js_request_get_method", &|| {
+            js_request_get_method(request);
+        }),
+        ("js_request_get_body", &|| {
+            js_request_get_body(request);
+        }),
+        ("js_request_input_to_url", &|| {
+            js_request_input_to_url(request);
+        }),
+        ("js_request_get_signal", &|| {
+            js_request_get_signal(request);
+        }),
+        ("js_request_get_destination", &|| {
+            js_request_get_destination(request);
+        }),
+        ("js_request_clone", &|| {
+            js_request_clone(request);
+        }),
+    ];
+    for (name, run) in readers {
+        run();
+        assert!(
+            REQUEST_REGISTRY.try_lock().is_ok(),
+            "{name} left the registry guard held"
+        );
+    }
+
+    // The untyped dispatcher's string arms are the twelve sites that used to
+    // allocate under the guard; walk every one.
+    for prop in [
+        "url",
+        "method",
+        "destination",
+        "referrer",
+        "referrerPolicy",
+        "mode",
+        "credentials",
+        "cache",
+        "redirect",
+        "integrity",
+        "duplex",
+        "body",
+        "bodyUsed",
+        "keepalive",
+        "signal",
+    ] {
+        dispatch::dispatch_request_property(id, prop);
+        assert!(
+            REQUEST_REGISTRY.try_lock().is_ok(),
+            "dispatch_request_property({prop:?}) left the registry guard held"
+        );
+    }
+
+    REQUEST_REGISTRY.lock().unwrap().remove(&id);
+}
+
+/// #8163, the half `try_lock` cannot see: a reader that allocates *while* the
+/// guard is live deadlocks against the root scanner instead of leaking, and a
+/// test that reproduces it would hang rather than fail. The shape is
+/// syntactic — `js_string_from_bytes(req.<field>.as_ptr(), …)` allocates
+/// straight out of a borrow that only the `REQUEST_REGISTRY` guard keeps
+/// alive — so scan for it. Post-fix every site snapshots the bytes into an
+/// owned local first and allocates after dropping the guard.
+#[test]
+fn no_allocation_is_taken_off_a_live_registry_borrow() {
+    const SOURCES: &[(&str, &str)] = &[
+        ("fetch/mod.rs", include_str!("mod.rs")),
+        ("fetch/dispatch.rs", include_str!("dispatch.rs")),
+        ("fetch/body_metadata.rs", include_str!("body_metadata.rs")),
+        ("fetch/request_ctor.rs", include_str!("request_ctor.rs")),
+    ];
+    // `req` is the universal binding for a borrowed `RequestRecord` in these
+    // files; `b` is the one used for its `body`. `f(req)` is
+    // `request_string_field`'s accessor form.
+    const FORBIDDEN: &[&str] = &[
+        "js_string_from_bytes(req.",
+        "js_string_from_bytes(b.",
+        "js_string_from_bytes(f(req)",
+    ];
+    let mut offenders = Vec::new();
+    for (name, text) in SOURCES {
+        for (lineno, line) in text.lines().enumerate() {
+            let code = line.split("//").next().unwrap_or(line);
+            for pattern in FORBIDDEN {
+                if code.contains(pattern) {
+                    offenders.push(format!("{name}:{}: {}", lineno + 1, line.trim()));
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "allocation taken directly off a REQUEST_REGISTRY borrow (#8163 — snapshot \
+         the bytes, drop the guard, then allocate):\n  {}",
+        offenders.join("\n  ")
+    );
+
+    // The scan must be able to see the shape it forbids, or it is decoration.
+    let planted = "        let p = js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);";
+    assert!(
+        FORBIDDEN.iter().any(|pattern| planted.contains(pattern)),
+        "the forbidden-pattern list no longer matches the shape it exists to catch"
+    );
+}

--- a/crates/perry-stdlib/src/fetch/tests.rs
+++ b/crates/perry-stdlib/src/fetch/tests.rs
@@ -104,3 +104,129 @@ fn response_constructor_copies_headers_initializer() {
         .unwrap()
         .remove(&response_headers_id);
 }
+
+/// #8163: the Headers / FormData bound-method caches and `RequestRecord::signal`
+/// are heap values held in Rust tables outside the GC heap. The registered
+/// scanner must EMIT them (mark) — a value it does not emit dies on the next
+/// collection and the cache hands out a dangling closure.
+#[test]
+fn fetch_root_scanner_emits_method_caches_and_request_signal() {
+    let headers_id = alloc_headers(HeadersStore::default());
+    let headers_get = headers_bound_method_value(headers_id, "get");
+    let form_id = alloc_fetch_handle_id();
+    let form_bits: u64 = 0x7FFD_0000_0000_1230;
+    dispatch::FORM_DATA_METHOD_VALUE_CACHE
+        .lock()
+        .unwrap()
+        .insert((form_id, "get"), form_bits);
+    let request = unsafe {
+        js_request_new(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0.0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            f64::from_bits(TAG_FALSE),
+            std::ptr::null(),
+            f64::from_bits(TAG_UNDEFINED),
+        )
+    };
+    let signal = js_request_get_signal(request);
+    assert_ne!(
+        signal.to_bits(),
+        TAG_UNDEFINED,
+        "a default AbortSignal is allocated"
+    );
+
+    let mut emitted = Vec::new();
+    gc::scan_fetch_roots(&mut |value| emitted.push(value.to_bits()));
+
+    assert!(
+        emitted.contains(&headers_get.to_bits()),
+        "cached Headers bound-method closure must be a root"
+    );
+    assert!(
+        emitted.contains(&form_bits),
+        "cached FormData bound-method closure must be a root"
+    );
+    assert!(
+        emitted.contains(&signal.to_bits()),
+        "request.signal must be a root"
+    );
+
+    dispatch::FORM_DATA_METHOD_VALUE_CACHE
+        .lock()
+        .unwrap()
+        .remove(&(form_id, "get"));
+}
+
+/// #8163: marking alone is not enough under a moving collector — the cache
+/// slot must be REWRITTEN, or the next `headers.get` read returns the
+/// pre-move address (exactly what Next's `ReflectAdapter.get` hit). The
+/// visitor here relocates only the slots this test planted, so parallel tests
+/// sharing the process-global tables are untouched.
+#[test]
+fn fetch_root_scanner_rewrites_relocated_slots_in_place() {
+    struct Relocate {
+        targets: Vec<u64>,
+    }
+    impl gc::FetchRootVisitor for Relocate {
+        fn visit_nanbox_f64_slot(&mut self, slot: &mut f64) {
+            if self.targets.contains(&slot.to_bits()) {
+                *slot = f64::from_bits(slot.to_bits() + 0x1000);
+            }
+        }
+        fn visit_nanbox_u64_slot(&mut self, slot: &mut u64) {
+            if self.targets.contains(slot) {
+                *slot += 0x1000;
+            }
+        }
+    }
+
+    let headers_id = alloc_headers(HeadersStore::default());
+    let before = headers_bound_method_value(headers_id, "entries");
+    let request = unsafe {
+        js_request_new(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0.0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            f64::from_bits(TAG_FALSE),
+            std::ptr::null(),
+            f64::from_bits(TAG_UNDEFINED),
+        )
+    };
+    let signal_before = js_request_get_signal(request);
+
+    gc::scan_fetch_roots_with(&mut Relocate {
+        targets: vec![before.to_bits(), signal_before.to_bits()],
+    });
+
+    // The cache HIT path must hand back the relocated value, not the planted one.
+    let after = headers_bound_method_value(headers_id, "entries");
+    assert_eq!(after.to_bits(), before.to_bits() + 0x1000);
+    assert_eq!(
+        js_request_get_signal(request).to_bits(),
+        signal_before.to_bits() + 0x1000
+    );
+
+    // Leave no bogus (relocated) pointers behind for other tests.
+    headers_method_value::HEADERS_METHOD_VALUE_CACHE
+        .lock()
+        .unwrap()
+        .remove(&(headers_id, "entries"));
+    REQUEST_REGISTRY.lock().unwrap().remove(&handle_id(request));
+}

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -177,7 +177,7 @@
       "file": "crates/perry-runtime/src/fs/filehandle.rs",
       "name": "NEXT_READ_LINES_ID",
       "verdict": "not_a_gc_pointer",
-      "why": "Monotonic id counter for READ_LINES_REGISTRY keys."
+      "why": "Monotonic id counter for READ_LINES_REGISTRY keys. The registry's own heap values are visited by scan_filehandle_roots_mut (fs/filehandle.rs:65), reached from scan_fs_handle_roots_mut."
     },
     {
       "file": "crates/perry-runtime/src/net.rs",
@@ -202,7 +202,7 @@
       "file": "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs",
       "name": "DIAG_STORE_SCOPES",
       "verdict": "not_a_gc_pointer",
-      "why": "DiagStoreScopeState.handles are DIAG_CHANNELS/DIAG_STORE ids (i64 keys), not heap addresses; `disposed` is a flag. The store objects live in DIAG_CHANNELS, which scan_node_submodule_singleton_roots_mut visits."
+      "why": "DiagStoreScopeState.handles are store KEYS produced by store_handle() (diagnostics_tail.rs:72), which admits only an INT32-tagged value, a POINTER_TAG value inside the handle band (raw < 0x10000), or a finite float \u2014 a real heap pointer returns None, so one cannot be stored here by construction. The store CONTEXT objects live in DIAG_CHANNELS[*].stores, which scan_node_submodule_singleton_roots_mut visits."
     },
     {
       "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -132,12 +132,6 @@
       "why": "In-flight job counter for perry/thread."
     },
     {
-      "file": "crates/perry-stdlib/src/common/async_bridge.rs",
-      "name": "EXT_BLOCKING_TASKS_INFLIGHT",
-      "verdict": "not_a_gc_pointer",
-      "why": "In-flight blocking-task counter. The JS values are in PENDING_RESOLUTIONS / PENDING_DEFERRED, both covered by scan_pending_native_async_resolution_roots_mut."
-    },
-    {
       "file": "crates/perry-stdlib/src/streams.rs",
       "name": "N",
       "verdict": "not_a_gc_pointer",
@@ -154,6 +148,200 @@
       "name": "TEST_BOUND_METHOD_MOVE",
       "verdict": "test_only",
       "why": "#[cfg(test)] diagnostic trace for the bound-method moving-GC regression: records the (before, after) addresses a test-forced minor produced so the test can assert the relocation happened. The addresses are compared as integers, never dereferenced, and the cell is dead in a shipped binary."
+    },
+    {
+      "file": "crates/perry-runtime/src/closure/alloc.rs",
+      "name": "CAPTURED_MISS_STREAK",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by the closure's func_ptr \u2014 a CODE address, which the collector neither moves nor traces; the value is a miss-streak count."
+    },
+    {
+      "file": "crates/perry-runtime/src/closure/alloc.rs",
+      "name": "CLOSURE_ALLOC_COUNT",
+      "verdict": "not_a_gc_pointer",
+      "why": "Monotonic allocation counter (telemetry). Holds no address."
+    },
+    {
+      "file": "crates/perry-runtime/src/closure/alloc.rs",
+      "name": "CLOSURE_CAP_SINGLETON_HIT",
+      "verdict": "not_a_gc_pointer",
+      "why": "Cache hit counter (telemetry). Holds no address."
+    },
+    {
+      "file": "crates/perry-runtime/src/closure/alloc.rs",
+      "name": "CLOSURE_CAP_SINGLETON_MISS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Cache miss counter (telemetry). Holds no address."
+    },
+    {
+      "file": "crates/perry-runtime/src/fs/filehandle.rs",
+      "name": "NEXT_READ_LINES_ID",
+      "verdict": "not_a_gc_pointer",
+      "why": "Monotonic id counter for READ_LINES_REGISTRY keys."
+    },
+    {
+      "file": "crates/perry-runtime/src/net.rs",
+      "name": "TCP_SERVERS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by handle id; TcpListenerWrapper is Rust-owned (tokio listener + SocketAddr), no JS values."
+    },
+    {
+      "file": "crates/perry-runtime/src/net.rs",
+      "name": "TCP_SOCKETS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by handle id; TcpStreamWrapper is Rust-owned (tokio stream + SocketAddr), no JS values."
+    },
+    {
+      "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
+      "name": "DIAG_TRACES",
+      "verdict": "covered_elsewhere",
+      "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1528, visit_raw_mut_ptr_slot on DiagTracingState.obj)",
+      "why": "Visited from the sibling module, so the same-file rule misses it. The `events: [i64; 5]` are DIAG_CHANNELS ids, not addresses."
+    },
+    {
+      "file": "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs",
+      "name": "DIAG_STORE_SCOPES",
+      "verdict": "not_a_gc_pointer",
+      "why": "DiagStoreScopeState.handles are DIAG_CHANNELS/DIAG_STORE ids (i64 keys), not heap addresses; `disposed` is a flag. The store objects live in DIAG_CHANNELS, which scan_node_submodule_singleton_roots_mut visits."
+    },
+    {
+      "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
+      "name": "THREAD_GLOBAL_THIS",
+      "verdict": "covered_elsewhere",
+      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_get_global_this) and marked+rewritten as a mutable global root",
+      "why": "A raw-pointer cache slot registered as a global root at first population; the registration is a call, not a scanner body, so the walk cannot see it."
+    },
+    {
+      "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
+      "name": "THREAD_MODULE_TOP_THIS",
+      "verdict": "covered_elsewhere",
+      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_module_top_this)",
+      "why": "Same shape as THREAD_GLOBAL_THIS: a NaN-boxed cache slot registered as a mutable global root at first population."
+    },
+    {
+      "file": "crates/perry-runtime/src/regex.rs",
+      "name": "REGEX_POINTERS",
+      "verdict": "covered_elsewhere",
+      "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs), the RegExp move/death hooks the copying minor and sweep invoke",
+      "why": "Address-KEYED owner set, not a root: the key is rekeyed when the RegExpHeader moves and removed when it dies; it never keeps the header alive. Reached from GC hooks, not from a registered scanner, so the walk misses it."
+    },
+    {
+      "file": "crates/perry-runtime/src/regex.rs",
+      "name": "REGEX_SOURCE_TABLE",
+      "verdict": "covered_elsewhere",
+      "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs)",
+      "why": "Address-KEYED owner table (owned String copies of pattern/flags); rekeyed on move, cleared on death, same hooks as REGEX_POINTERS."
+    },
+    {
+      "file": "crates/perry-runtime/src/text.rs",
+      "name": "DECODER_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by decoder handle id; DecoderState is Rust-owned (encoding enum, label, flags), no JS values."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch/body_metadata.rs",
+      "name": "FORM_DATA_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by fetch handle id; FormDataStore is Rust-owned (Vec<(String, String)>). The bound-method closures for FormData live in FORM_DATA_METHOD_VALUE_CACHE, which fetch::gc::scan_fetch_roots_with visits."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch/mod.rs",
+      "name": "BLOB_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by fetch handle id; BlobData is Rust-owned (bytes, content type, file name, last-modified). No JS values."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch/mod.rs",
+      "name": "FETCH_RESPONSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by fetch handle id; FetchResponse is Rust-owned (status, HeadersStore, body bytes, cached HANDLE IDS for headers/body stream). No JS values."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch/mod.rs",
+      "name": "REQUEST_REGISTRY",
+      "verdict": "covered_elsewhere",
+      "scanner": "fetch::gc::scan_fetch_roots_with (fetch/gc.rs, visit_nanbox_f64_slot on RequestRecord.signal), registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:fetch\"",
+      "why": "RequestRecord.signal is the AbortSignal object behind request.signal (#8163). Visited from the child module, so the same-file rule misses it; everything else in the record is Rust-owned."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch/mod.rs",
+      "name": "STREAM_HANDLES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by stream id; StreamState is Rust-owned (status, buffered lines, error String)."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch_blob.rs",
+      "name": "NEXT_OBJECT_URL_ID",
+      "verdict": "not_a_gc_pointer",
+      "why": "Monotonic id counter."
+    },
+    {
+      "file": "crates/perry-stdlib/src/fetch_blob.rs",
+      "name": "OBJECT_URL_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "blob: URL string -> Blob HANDLE ID (a fetch-band small integer), not an address."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams.rs",
+      "name": "READABLE_STREAMS",
+      "verdict": "covered_elsewhere",
+      "scanner": "streams::gc::scan_stream_roots_with (streams/gc.rs, registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:streams\")",
+      "why": "Chunks, callbacks, pending-read promises and error values are all visited from the child module, so the same-file rule misses it."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams/tee.rs",
+      "name": "TEE_PULLING",
+      "verdict": "not_a_gc_pointer",
+      "why": "HashSet of tee SOURCE stream ids (READABLE_STREAMS keys), not addresses."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams/tee.rs",
+      "name": "TEE_STARTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "HashSet of tee source stream ids, not addresses."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams/transform.rs",
+      "name": "TRANSFORM_BACKPRESSURED_JOBS",
+      "verdict": "covered_elsewhere",
+      "scanner": "streams::gc::scan_transform_deferred_roots (streams/gc.rs, visit_raw_mut_ptr_slot on each job closure)",
+      "why": "The values are ClosureHeader addresses of parked write jobs; visited from streams/gc.rs, so the same-file rule misses it."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams/transform.rs",
+      "name": "TRANSFORM_PAIRS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Transform readable id -> writable id: both are stream HANDLE IDS."
+    },
+    {
+      "file": "crates/perry-stdlib/src/streams/transform.rs",
+      "name": "TRANSFORM_PENDING_WRITES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Transform writable id -> COUNT of queued write jobs (#6607). No address."
+    },
+    {
+      "file": "crates/perry-stdlib/src/worker_threads.rs",
+      "name": "NEXT_PORT_ID",
+      "verdict": "not_a_gc_pointer",
+      "why": "Monotonic MessagePort id counter."
+    },
+    {
+      "file": "crates/perry-stdlib/src/ws.rs",
+      "name": "NEXT_WS_ID",
+      "verdict": "not_a_gc_pointer",
+      "why": "Monotonic ws id counter."
+    },
+    {
+      "file": "crates/perry-stdlib/src/ws.rs",
+      "name": "WS_CLIENT_PARENT_SERVER",
+      "verdict": "not_a_gc_pointer",
+      "why": "Client ws id -> parent server HANDLE id. No address."
+    },
+    {
+      "file": "crates/perry-stdlib/src/ws.rs",
+      "name": "WS_CONNECTIONS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Keyed by ws id; WsConnection is Rust-owned (command sender, buffered message Strings, state flags). Listener closures live in WS_CLIENT_LISTENERS, which scan_ws_roots_mut visits."
     }
   ]
 }

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -88,6 +88,13 @@ Named, because an unstated limit is how a gate gets trusted past its subject.
   holders. Deeper hops are matched on the bare name, because nothing in the text
   says which module a call resolved to; that direction over-approximates
   coverage, and an inventory entry is the correction.
+* **Anything outside `perry-runtime` / `perry-stdlib`.** The `perry-ext-*`
+  crates park user closures in handle-struct FIELDS (`ServerResponse.listeners`
+  / `once_listeners`, `IncomingMessage.signal`, ...) and register their scanners
+  by hand through `perry_ffi`; nothing here checks that a scanner reaches every
+  such field. #8163's second holder was exactly that — ext-http scanned
+  `listeners` and never `once_listeners`. That is a struct-field census over
+  registered handle types, a different instrument from this declaration scan.
 * **Whether a "covered" holder is covered CORRECTLY.** The scanner may visit
   three of a table's four slots — the shape #7239 found in
   `scan_parent_port_event_roots_mut`. Reading the body is the only way, and this
@@ -162,19 +169,38 @@ ALLOCATOR_TOKENS = (
 # holder reached only from `gc_init` reads as uncovered — which is exactly what
 # happened when they were introduced, and the MIN_REGISTERED floor below is
 # what caught it.
+#
+# The argument list may itself contain ONE level of calls — the provider-safe
+# C-ABI registration `perry_ffi_gc_register_mutable_root_scanner_named(
+# SOURCE.as_ptr(), SOURCE.len(), 0, scan_stream_roots_ffi)` (`streams/gc.rs`,
+# `fetch/gc.rs`) is the shape. A `[^;()]*` argument body stopped at the first
+# `(` of `as_ptr(` and dropped the scanner name, so every FFI-registered
+# stdlib scanner was invisible to the walk and its tables read as uncovered
+# (#8163 exposed this the moment `lazy_static!` tables entered the census).
 REGISTER_CALL = re.compile(
     r"(?:gc_register_\w*root_scanner\w*|reg_scanner!|reg_budgeted_scanner!)"
-    r"\s*\((?P<args>[^;()]*)\)",
+    r"\s*\((?P<args>(?:[^;()]|\([^;()]*\))*)\)",
     re.S,
 )
-FN_DEF = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|extern\s+\"C\"\s+)*fn\s+(\w+)")
+# `strip_comments` blanks string literals before this runs, so `extern "C" fn`
+# reaches the matcher as `extern "" fn` — the ABI string must be matched as
+# ANY (possibly empty) literal, or no `extern "C"` function in either crate has
+# a body in the walk. That is what kept the C-ABI scanner trampolines
+# (`scan_stream_roots_ffi`, `scan_fetch_roots_ffi`) unreachable (#8163).
+FN_DEF = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|extern\s+\"[^\"]*\"\s+)*fn\s+(\w+)"
+)
 IDENT = re.compile(r"\b[A-Za-z_]\w*\b")
 
 # A declaration: `static NAME: TYPE =` — covers `pub(crate) static`, the bodies
-# of `thread_local!` blocks (which use the same syntax), and `static NAME:
-# Lazy<...>`.
+# of `thread_local!` blocks (which use the same syntax), `static NAME:
+# Lazy<...>`, and — since #8163 — `lazy_static!`'s `static ref NAME: TYPE =`.
+# The `ref` keyword was invisible to the first version of this regex, which
+# left every `lazy_static!` table in both crates out of the census; that is
+# how `HEADERS_METHOD_VALUE_CACHE` (a `Mutex<HashMap<_, u64>>` of NaN-boxed
+# closure pointers) went unaudited and unrooted, and became #8163's holder.
 DECL = re.compile(
-    r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?static\s+(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*(?P<type>[^=]+?)\s*="
+    r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?static\s+(?:ref\s+)?(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*(?P<type>[^=]+?)\s*="
 )
 
 MAX_SCANNER_DEPTH = 3
@@ -253,8 +279,19 @@ def function_bodies(text: str) -> dict[str, str]:
         depth = 0
         started = False
         chunk: list[str] = []
+        declaration_only = False
         while index < len(lines):
             line = lines[index]
+            # A body-less declaration — `fn f(...);` inside an `extern "C" {}`
+            # block or a trait — has no body to count. Before this check the
+            # counter ran on into the NEXT item's braces and swallowed every
+            # function up to wherever the depth happened to balance; in
+            # `streams/gc.rs` and `fetch/gc.rs` that hid the FFI-registered
+            # scanner entry point itself, so the walk never started (#8163).
+            if not started and line.rstrip().endswith(";") and "{" not in line:
+                declaration_only = True
+                index += 1
+                break
             chunk.append(line)
             depth += line.count("{") - line.count("}")
             if "{" in line:
@@ -262,6 +299,8 @@ def function_bodies(text: str) -> dict[str, str]:
             index += 1
             if started and depth <= 0:
                 break
+        if declaration_only:
+            continue
         bodies.setdefault(name, "")
         bodies[name] += "\n".join(chunk)
     return bodies

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -7,9 +7,9 @@
 # production oracle byte-for-byte across 10 cold starts of two 21-request
 # verifier passes each.
 #
-# What it does NOT assert by default: behaviour under forced evacuation. That
-# arm is opt-in behind `PERRY_NEXT_ROUTE_FORCED_GC=1` and is currently red —
-# see the block above the cold-start loop and #8163.
+# Odd cold starts run under FORCED evacuation with a seeded GC schedule and the
+# moving-GC liveness assert (#8163 — fixed; `PERRY_NEXT_ROUTE_FORCED_GC=0`
+# turns that arm off for a normal-only run).
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -187,26 +187,19 @@ run_cold_start() {
   cleanup_server
 }
 
-# The forced-evacuation arm is OPT-IN, and deliberately not a skip.
-#
-# It currently FAILS — a stale closure reaches Next's `Reflect.get` adapter
-# from a holder that is outside the GC heap and unregistered with any root
-# scanner (#8163 has the full elimination trail and a seconds-long
-# reproducer). Shipping it on would make this fixture red for everyone; making
-# it a `SKIP` would let it read as covered when it is not; wrapping it in
-# `continue-on-error` would make it documentation rather than a gate. So it is
-# a knob that is OFF here and FAILS LOUDLY when set — the one arrangement that
-# neither blocks the production-parity coverage below nor overstates it.
-#
-# `PERRY_NEXT_ROUTE_FORCED_GC=1` restores the original alternation (odd cold
-# starts run under forced evacuation with the moving-GC liveness assert) and is
-# how #8163 should be worked and, once fixed, how this default flips back.
-FORCED_GC="${PERRY_NEXT_ROUTE_FORCED_GC:-0}"
+# The forced-evacuation arm is ON by default: odd cold starts run under forced
+# evacuation with the moving-GC liveness assert. It was opt-in (and red) while
+# #8163 was open — a stale closure reached Next's `Reflect.get` adapter from
+# `HEADERS_METHOD_VALUE_CACHE`, and a second one reached the `res.end()` tail
+# from `ServerResponse.once_listeners`; both were holders outside the GC heap
+# that no root scanner marked or rewrote. `PERRY_NEXT_ROUTE_FORCED_GC=0` runs
+# the normal arm only; it is a knob, not a skip, and never `continue-on-error`.
+FORCED_GC="${PERRY_NEXT_ROUTE_FORCED_GC:-1}"
 if [[ "$FORCED_GC" == "1" ]]; then
   echo "  [6/7] $COLD_STARTS cold processes (alternating normal / FORCED-evacuation), two 21-request verifier runs each"
 else
   echo "  [6/7] $COLD_STARTS cold processes, two 21-request verifier runs each"
-  echo "        forced-evacuation arm OFF (#8163) — set PERRY_NEXT_ROUTE_FORCED_GC=1 to run it"
+  echo "        forced-evacuation arm OFF (PERRY_NEXT_ROUTE_FORCED_GC=0)"
 fi
 for index in $(seq 0 $((COLD_STARTS - 1))); do
   if [[ "$FORCED_GC" == "1" ]] && (( index % 2 == 1 )); then mode="forced"; else mode="normal"; fi
@@ -217,5 +210,5 @@ echo "  [7/7] production AppRouteRouteModule.handle parity complete"
 if [[ "$FORCED_GC" == "1" ]]; then
   echo "PASS $NAME (with forced-evacuation arm)"
 else
-  echo "PASS $NAME (forced-evacuation arm not run — #8163)"
+  echo "PASS $NAME (forced-evacuation arm not run — PERRY_NEXT_ROUTE_FORCED_GC=0)"
 fi


### PR DESCRIPTION
Refs #8163 — **does not close it.** This fixes the forced-evacuation arm the issue is titled for, and a parallel session's independent 500-batch measurement shows at least one *more* unregistered holder remains on the DEFAULT-GC path with the identical signature. See "Residual" below.

## What was wrong

The production Next 16.3.0 App Route fixture's forced-evacuation arm failed with `TypeError: value is not a function` around copying minor #238. The issue's elimination trail was right: the stale closure was held by something **outside the GC heap and unregistered with any root scanner**. There were two of them, one behind the other, and neither is visible to any existing instrument — `PERRY_GC_VERIFY_EVACUATION` (no scanner to verify), `PERRY_GC_PROTECT_FROMSPACE_HOLDERS` (not in the heap), or `scripts/gc_runtime_root_holders.py` (see below).

Both were **measured, not inferred**: the host ran under `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` and each suspect was instrumented until it printed the exact address the fault reporter named.

### 1. `HEADERS_METHOD_VALUE_CACHE` (perry-stdlib `fetch`)

`headers.get` / `.entries` / … are bound-method closures cached per `(handle, method)` in a `lazy_static!` `Mutex<HashMap<_, u64>>`. The store site called `js_write_barrier_root_nanbox`, which is the incremental-marking **shade**, not a root registration — nothing marked or rewrote the cache. The route reads `(await headers()).get("x-request-id")` twice per request with awaits between; the closure allocated by the first read (cache *miss*, `id=262149 name=get bits=0x7ffd044c5059f980`) was retired by a later minor, and the second read (cache *hit*, same bits) handed it to `typeof` inside Next's `ReflectAdapter.get` — fault at `0x44c5059f978`, the header of that 48-byte closure.

`FORM_DATA_METHOD_VALUE_CACHE` and `RequestRecord::signal` (the `AbortSignal` behind `request.signal`) have the same shape. New `fetch/gc.rs` registers one scanner through the C ABI (`perry_ffi_gc_register_mutable_root_scanner_named`, like `streams/gc.rs`, so a trimmed stdlib provider installs it in the runtime image) that marks and rewrites all three. `js_request_new` now builds its `RequestRecord` — including the default-`AbortSignal` allocation — *before* taking the registry lock, because the scanner takes that lock during a collection on the same thread.

### 2. `ServerResponse.once_listeners` (perry-ext-http)

`res.once(event, cb)` stores into a **second** table that `take_event_listeners` merges into every emit; `scan_http_server_roots` visited only `listeners`. Next's `pipeToNodeResponse` registers `res.once('close', …)`. Instrumented: the `close` snapshot taken at the top of `res.end()` already contained `0x3f4dc628190` (retired at minor #211) — stale *at snapshot time*, i.e. the table itself was never rewritten. The scanner now visits it.

While there, the whole `res.end()` tail (`js_node_http_res_end`, `_full`, `_with_cb`, `standalone_end`) took listener/callback snapshots **out** of the handle and then ran JS (write callbacks, `'finish'`, the end callback) before using them. `emit_no_arg_to_listeners` roots what it is *handed* (#8082), so a stale snapshot stayed stale. `EndTail` (new `server/response_end.rs` — split out because `response.rs` sat at the 2,000-line cap at 1993 lines) parks every snapshot in the transient-root stack before the first JS call and re-reads per use; the two Node orderings (buffered: finish → end cb → close; standalone: end cb → finish → close) are preserved. `js_node_http_im_resume`'s `'end'` snapshot (crosses the `'data'` emits) and `js_node_https_server_close`'s callback (the https twin of the #8082 http fix) get the same treatment.

## Registering the scanner made a dozen latent sites into deadlocks

`std::sync::Mutex` is not reentrant, and the scanner takes `REQUEST_REGISTRY` during a collection **on the mutator thread** — so once this scanner exists, any site holding that guard across a GC allocation self-deadlocks the first time the allocation collects. `dispatch_request_property`'s twelve string arms, `js_request_get_url` / `_method` / `_body`, `js_request_input_to_url` and `request_string_field` all did exactly that; they now snapshot the field bytes under the guard and allocate after dropping it.

`js_request_clone` was worse: it **threw** while holding the guard. The exception transport is written for `panic=abort` and steps through the frame without running `Drop`, so the mutex is not poisoned — it stays *locked for the life of the process*, and the scanner's `if let Ok(...)` would then block rather than skip. It now decides "unusable" under the guard and throws outside it.

Two tests hold this, because the failure mode is a **hang** and a hanging test is worse than a failing one:

* `request_reads_release_the_registry_guard` — `try_lock`s after every reader and after all fifteen dispatcher props; catches a leaked guard (the clone case) deterministically.
* `no_allocation_is_taken_off_a_live_registry_borrow` — source-scans for `js_string_from_bytes(req.…)`, the syntactic signature of allocating out of a borrow only the guard keeps alive, and asserts against a planted sample that the scan can still match the shape it forbids.

The `fetch/gc.rs` module doc now states the contract and names every hoisted site. Reported in review by a parallel session working adjacent GC issues; verified here against the code before acting. (`perry-ext-fetch` has its own `REQUEST_HANDLES` registry which this scanner does not touch, so its twins are out of scope for this PR.)

## Why the audit missed it — four blind spots in `scripts/gc_runtime_root_holders.py`, all fixed

| blind spot | effect |
|---|---|
| `DECL` did not match `lazy_static!`'s `static ref` | 93 tables across runtime+stdlib were outside the census, `HEADERS_METHOD_VALUE_CACHE` among them |
| `strip_comments` blanks string literals, so `extern "C" fn` reached `FN_DEF` as `extern "" fn` | no C-ABI function had a body in the walk — including the FFI scanner trampolines (`scan_stream_roots_ffi`, `scan_fetch_roots_ffi`) |
| a body-less `fn f(...);` in an `extern "C" {}` block started a brace count | swallowed the functions after it, hiding the same trampolines a second way |
| the registration regex stopped at the first `(` of `SOURCE.as_ptr()` | every C-ABI registration lost its scanner name |

Census: **78 → 129** declarations, **53 → 74** reached by a registered scanner — i.e. the gate was green because the narrow regex hid the candidates, not because they were classified. The 31 newly visible uncovered holders each carry a written verdict in `gc_runtime_root_holders.json` (counters, handle-id maps, Rust-owned registries, or `covered_elsewhere` naming the scanner/rekey hook — e.g. `REQUEST_REGISTRY` → `fetch::gc`, `READABLE_STREAMS`/`TRANSFORM_BACKPRESSURED_JOBS` → `streams::gc`, `DIAG_TRACES` → `scan_node_submodule_singleton_roots_mut`, `THREAD_GLOBAL_THIS` → `js_gc_register_global_root`); one stale entry (`EXT_BLOCKING_TASKS_INFLIGHT`, now reached) is deleted. `--self-test` passes.

## Validation

Same app dylib, same seed (8036), providers built from the same tree, A/B by swapping only the provider images:

| arm | plain forced run | + `PROTECT_FROMSPACE` depth 800 |
|---|---|---|
| main | **59** `TypeError`s, 0 `PASS`, 455 copying minors | fault at minor #218 (`obj_type=4 size=48`) |
| fix | **0** errors, **2× `PASS: 21`**, 446 copying minors, 0 verify panics | clean; also clean on seeds 8174, 1, 8040, 4242 |

Full `tests/release/packages/next-app-route/fixture.sh` with the forced arm ON (now the default) and a fresh release compiler: see the run summary in the last comment. `PERRY_NEXT_ROUTE_FORCED_GC` flips from opt-in to on-by-default; `=0` still runs the normal arm only.

Tests: `fetch::tests::fetch_root_scanner_emits_method_caches_and_request_signal` and `…rewrites_relocated_slots_in_place` (the cache HIT path must return the *rewritten* value); the ext-http `root scanner rewrites` test gains `once_listeners` and `pending_write_callbacks`. `cargo test --release -p perry-stdlib --lib fetch::` and `-p perry-ext-http --lib` green; `check_file_size.sh`, `cargo fmt --check`, `gc_runtime_root_holders.py` (+ `--self-test`) clean.

## Residual — #8163 stays open

Independently measured on the quiet bench mini (same host, same hour, 500 warm batches per arm, no GC knobs), by the session that owns the #8040 batch instrument — numbers theirs, [full comment](https://github.com/PerryTS/perry/issues/8163#issuecomment-5307890158):

| arm | default-GC warm batches | forced+seeded |
|---|---|---|
| main `3c95020f8` | 4 failures / 100 | dies at copying minor ~#238 |
| this branch | 5 failures / **500** | survives to copying minor **~#2696**, 3712 minors, Σcopied ≈1.04M, 0 verify panics |

So the forced arm is genuinely fixed (~10× longer survival, and the shipped fixture passes 10/10 with liveness asserted), and the default-path failure rate drops — but it is **not eliminated**: 5 batches still fail with an empty body plus `TypeError: value is not a function` landing immediately after a default-mode `[gc-copy-minor] ran … in_place=false`. Their own caveat is worth keeping: against yesterday's 8/500 main figure the improvement overlaps Poisson noise, so treat the rate reduction as suggestive and the residual as certain.

**The shipped fixture is structurally blind to this** — it runs 2 verifier passes per process, and the residual needs ~100 passes against one warm process to surface. That instrument (`~/mini-batch-8163.sh`) lives with them, and by agreement they are taking the residual hunt, scoped out of every file this PR touches. This PR therefore uses `Refs`, not `Closes`.

## Not fixed here (follow-ups)

* perry-ext-net's `once_flags` keys a `HashSet<i64>` by closure **address** to decide which listener to drop after a `once` fires — a rekeyed table of the #8174 family: a closure the collector moves fires again, and a recycled address drops the wrong listener. Semantic, not memory-unsafe.
* Handle-struct fields in the ext crates (`once_listeners` was one) are still outside any census; `gc_runtime_root_holders.py` audits `static` declarations only.

No version bump (maintainer bumps at merge).

https://claude.ai/code/session_01YAif84burv8q6QngSN6wU8
