### PR TITLE
gc: extend the root-holder census across perry-ffi/ext/ui and fix the five unrooted holders it exposed

### DIFF
--- a/changelog.d/8216-gc-root-holder-census-ffi-coverage.md
+++ b/changelog.d/8216-gc-root-holder-census-ffi-coverage.md
@@ -1,0 +1,102 @@
+fix(gc): extend the root-holder census across perry-ffi/ext/ui, and fix the five unrooted holders it exposed
+
+#8211 made `scripts/gc_runtime_root_holders.py` parse what it was already
+pointed at. This PR closes the census's remaining WHOLE-CRATE blind spot:
+its crate list was `perry-runtime` + `perry-stdlib`, while every
+`perry-ext-*` crate parks user closures in handle side tables as NaN-boxed
+`i64`/`f64` — shapes its type-name/allocator-context rules could not match
+even when pointed at them. `gc_root_dominance_check.py` reads emitted LLVM
+IR and is structurally blind to Rust-side tables, so this census is the
+ONLY detector for the class; a crate outside its scope is not less checked,
+it is unchecked.
+
+The census now has three glob-discovered crate tiers (a new crate is in
+scope the day it is created):
+
+* **core** (runtime/stdlib): rules A/B unchanged on top of #8211's parser,
+  plus a multi-line declaration join — `static X: T` with the `=` on a later
+  line was invisible to any single-line regex; it recovers four more real
+  holders (`ACCESSOR_RECEIVER_OVERRIDE`, `PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER`,
+  `CURRENT_MICROTASK_VALUE`, `SET_INDEX`), now verdicted.
+* **ffi-side, gated** (`perry-ffi` + every `perry-ext-*`): type-SHAPE rules,
+  because JS values cross the C ABI as integers — value-position primitives
+  in containers (`Vec<i64>` listeners, `HashMap<K, f64>` callback maps; map
+  KEYS are exempt handle ids), recursive crate-local struct/enum resolution
+  (enum struct-variants like `ClientClose { callback: i64 }` included),
+  `dyn`-erased payloads, and bare scalars in closure-handling files.
+  Uncovered holders need a written verdict, same as core.
+* **frontier** (`perry-ui*`): 461 real unregistered callback tables across
+  eight platform crates (three not buildable on the gate host), pinned BY
+  IDENTITY as a ratchet — a new UI holder fails lint, a fixed one must
+  delete its entry. Named debt, not verdicts; the green run prints them as
+  UNVERIFIED.
+
+Two coverage-soundness fixes keep the wider walk honest: registration
+arguments seed the call graph as BARE PATHS only (harvesting every
+identifier out of `SOURCE.as_ptr()`-style C-ABI calls seeds `as_ptr`/`len`/
+`state` — names that ARE `fn`s in these crates — and falsely covers
+holders), and deep-hop attribution is fenced to crates that register at
+least one scanner (the platform-ported UI crates define whole files of
+same-named functions, which read 27 frontier holders as covered by name
+collision). `--self-test` plants every new shape — fn-body `OnceLock` i64
+table, `lazy_static!` `static ref`, multi-line decl, struct/enum payload,
+`dyn` payload, closure-context scalar positive AND negative, C-ABI
+trampoline coverage, the fence case, and both frontier-ratchet red paths —
+and requires detection.
+
+The widened census found five real unrooted holders, each fixed with a
+seeded fail-before/pass-after fixture (registered in
+`test-parity/gc_repsel_corpus.txt`; all four byte-match Node under
+`PERRY_GC_SCHEDULE_SEED=7` with the fromspace-protect instrument armed and
+1697–2543 copying minors per run):
+
+* `perry-ext-http` `H2_PENDING_EVENTS`: `session.close/settings/ping(cb)`
+  park the callback as raw NaN-box bits across a pump tick (the
+  settings/ping callbacks have NO other holder). Pre-fix repro is a literal
+  `TypeError: value is not a function`. Fixed with a scanner over the queue
+  PLUS a drain custody chain — the drain used to snapshot into a bare local
+  `Vec`, unrooting every not-yet-fired callback again while earlier events
+  ran JS, so drained events now sit in a scanned thread-local and each arm
+  parks its callback in a scanned stack across its allocating prep, reading
+  the possibly-rewritten value back at call time (also un-breaks the
+  stale retain-by-value removal in `close_callbacks`).
+* `perry-ext-net` `once_flags()`: once-listener membership keyed by the
+  closure's ADDRESS BITS; evacuation rewrote the scanned `listeners()` copy
+  but a `HashSet` element cannot be rewritten in place, so once-listeners
+  fired forever after a move (fixture: pre-fix `once fired: 2 of 2`,
+  post-fix `1 of 2`). `scan_net_roots` now drains/forwards/reinserts the
+  set in the same pass.
+* `perry-ext-fetch` `REQUEST_HANDLES[*].signal`: a NaN-boxed AbortSignal
+  whose only holder is the table, in a crate that registered no scanner at
+  all. New `gc.rs` scanner (via `perry_ffi`'s named wrapper, i.e. the same
+  C-ABI route as every ext provider), armed at `store_request`.
+
+Because that scanner takes `REQUEST_HANDLES` during a collection on the
+mutator thread, every reader holding the guard across a GC allocation
+became a self-deadlock (and under panic=abort + invoke-EH an unwind does
+not run `Drop`, so the failure is a permanent hang, not a panic). All
+ext-fetch sites are hoisted (clone out, drop the guard, then allocate) and
+two unit tests keep the invariant the same way #8211's stdlib tests do: a
+`try_lock` probe after every reader — a re-introduced held guard FAILS
+instead of hanging — and a source scan for allocation-through-a-live-borrow
+that asserts against its own planted sample. The scan promptly caught three
+MORE sites beyond the request getters (`js_fetch_response_status_text/type/url`,
+borrowing `FETCH_RESPONSES`): latent rather than live, since no scanner
+takes that lock today, but hoisted anyway so the invariant is file-wide and
+any future response scanner is born safe — which is why the test exists
+rather than a one-off fix.
+
+Inventory: 13 new verdicts on top of #8211's 51 (the eight ext queue/
+registry tables — all handle-id or Rust-owned payloads, with the JS values
+living in already-scanned holders — plus backoff's `NEXT_ID`, ext-fetch's
+`REQUEST_HANDLES` now covered from its `gc.rs`, and the three multi-line
+core holders above), and the `frontier` list. Census totals on this tree:
+621 declarations scanned across the three tiers, 92 reached by a
+registered scanner, 64 classified, 461 ratcheted.
+
+Known pre-existing failure, NOT absorbed here: `perry-ext-net --lib`'s
+`gc_mutable_scanner_rewrites_listener_roots` fails on the current base even
+with origin/main's `lib.rs` swapped into the same tree (A/B verified);
+#8204 touched zero perry-ext-net files and no workflow runs that suite, so
+nothing ever watched it. The once-flags fixture above covers this PR's
+`scan_net_roots` change independently.

--- a/crates/perry-ext-fetch/src/gc.rs
+++ b/crates/perry-ext-fetch/src/gc.rs
@@ -1,0 +1,39 @@
+//! GC registration for perry-ext-fetch's request registry (split out of
+//! `lib.rs` for the 2,000-line lint gate; a child module reaches the
+//! crate-private tables via `use super::*`).
+
+use super::*;
+
+static FETCH_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Called from `store_request`, so the scanner is installed before the
+/// first signal is ever parked. Registers through `perry_ffi`'s named
+/// wrapper, which is itself the stable C-ABI
+/// `perry_ffi_gc_register_mutable_root_scanner_named` — the route every
+/// ext staticlib provider uses, so a trimmed image still installs into the
+/// process-wide runtime.
+pub(crate) fn ensure_gc_scanner_registered() {
+    FETCH_GC_REGISTERED.call_once(|| {
+        perry_ffi::gc_register_mutable_root_scanner_named("perry-ext-fetch", scan_fetch_roots);
+    });
+}
+
+/// GC root scanner: every stored `Request`'s `signal` is a NaN-boxed
+/// AbortSignal OBJECT (user-passed, or freshly built by
+/// `default_abort_signal_value()` — in which case this table is its ONLY
+/// holder). It lives from `new Request(...)` until the last
+/// `request.signal` read, across arbitrary user JS; without this scanner a
+/// full collection frees it and a copying minor leaves the table pointing
+/// at the old address.
+///
+/// Locking contract: this runs DURING a collection on the mutator thread
+/// and takes `REQUEST_HANDLES`, so no reader may hold that guard across a
+/// GC allocation (`alloc_string` et al.) — see the try_lock probe and
+/// source-scan tests in `tests.rs`.
+fn scan_fetch_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    if let Ok(mut requests) = REQUEST_HANDLES.lock() {
+        for request in requests.values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.signal);
+        }
+    }
+}

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -19,6 +19,7 @@ use std::sync::Mutex;
 
 // Web Fetch constructor validation helpers (#2640 / #2643) — split out to
 // keep lib.rs under the 2,000-line lint gate.
+mod gc;
 mod validation;
 use validation::{
     is_forbidden_method, is_null_body_status, is_redirect_status, is_valid_status_text,
@@ -183,7 +184,8 @@ lazy_static! {
     static ref BLOB_HANDLES: Mutex<HashMap<usize, BlobData>> = Mutex::new(HashMap::new());
     static ref NEXT_BLOB_ID: Mutex<usize> = Mutex::new(1);
 
-    static ref REQUEST_HANDLES: Mutex<HashMap<usize, RequestData>> = Mutex::new(HashMap::new());
+    pub(crate) static ref REQUEST_HANDLES: Mutex<HashMap<usize, RequestData>> =
+        Mutex::new(HashMap::new());
     static ref NEXT_REQUEST_ID: Mutex<usize> = Mutex::new(1);
 
     static ref FORM_DATA_HANDLES: Mutex<HashMap<usize, FormDataStore>> =
@@ -392,6 +394,7 @@ fn store_blob(data: BlobData) -> usize {
 }
 
 fn store_request(data: RequestData) -> usize {
+    gc::ensure_gc_scanner_registered();
     let mut id_guard = NEXT_REQUEST_ID.lock().unwrap();
     let id = *id_guard;
     *id_guard += 1;
@@ -687,9 +690,18 @@ pub extern "C" fn js_fetch_response_status(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_fetch_response_status_text(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = FETCH_RESPONSES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => alloc_string(&r.status_text).as_raw(),
+    // Clone out, drop the guard, THEN allocate — same discipline as the
+    // REQUEST_HANDLES readers: a GC allocation under a registry guard hangs
+    // any scanner that takes the same lock on this thread.
+    let text = {
+        FETCH_RESPONSES
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|r| r.status_text.clone())
+    };
+    match text {
+        Some(text) => alloc_string(&text).as_raw(),
         None => std::ptr::null_mut(),
     }
 }
@@ -707,9 +719,15 @@ pub extern "C" fn js_fetch_response_ok(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_fetch_response_type(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = FETCH_RESPONSES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => alloc_string(&r.type_name).as_raw(),
+    let type_name = {
+        FETCH_RESPONSES
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|r| r.type_name.clone())
+    };
+    match type_name {
+        Some(type_name) => alloc_string(&type_name).as_raw(),
         None => alloc_string("").as_raw(),
     }
 }
@@ -717,9 +735,15 @@ pub extern "C" fn js_fetch_response_type(handle: f64) -> *mut StringHeader {
 #[no_mangle]
 pub extern "C" fn js_fetch_response_url(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = FETCH_RESPONSES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => alloc_string(&r.url).as_raw(),
+    let url = {
+        FETCH_RESPONSES
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|r| r.url.clone())
+    };
+    match url {
+        Some(url) => alloc_string(&url).as_raw(),
         None => alloc_string("").as_raw(),
     }
 }
@@ -1641,9 +1665,18 @@ pub unsafe extern "C" fn js_request_new(
 #[no_mangle]
 pub extern "C" fn js_request_get_url(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = REQUEST_HANDLES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => alloc_string(&r.url).as_raw(),
+    // Clone out, drop the guard, THEN allocate: `alloc_string` can trigger a
+    // collection, and `scan_fetch_roots` takes this same lock on this same
+    // thread — allocating under the guard is a self-deadlock.
+    let url = {
+        REQUEST_HANDLES
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|r| r.url.clone())
+    };
+    match url {
+        Some(url) => alloc_string(&url).as_raw(),
         None => alloc_string("").as_raw(),
     }
 }
@@ -1651,21 +1684,27 @@ pub extern "C" fn js_request_get_url(handle: f64) -> *mut StringHeader {
 #[no_mangle]
 pub extern "C" fn js_request_get_method(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = REQUEST_HANDLES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => alloc_string(&r.method).as_raw(),
+    let method = {
+        REQUEST_HANDLES
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|r| r.method.clone())
+    };
+    match method {
+        Some(method) => alloc_string(&method).as_raw(),
         None => alloc_string("GET").as_raw(),
     }
 }
 
 fn request_string_field(handle: f64, f: impl FnOnce(&RequestData) -> &str) -> *mut StringHeader {
     let id = handle_id(handle);
-    let g = REQUEST_HANDLES.lock().unwrap();
-    match g.get(&id) {
-        Some(r) => {
-            let s = f(r);
-            alloc_string(s).as_raw()
-        }
+    let value = {
+        let g = REQUEST_HANDLES.lock().unwrap();
+        g.get(&id).map(|r| f(r).to_string())
+    };
+    match value {
+        Some(value) => alloc_string(&value).as_raw(),
         None => alloc_string("").as_raw(),
     }
 }
@@ -1746,10 +1785,13 @@ pub extern "C" fn js_request_get_headers(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_request_get_body(handle: f64) -> f64 {
     let id = handle_id(handle);
-    let g = REQUEST_HANDLES.lock().unwrap();
-    match g.get(&id).and_then(|r| r.body.as_ref()) {
+    let body = {
+        let g = REQUEST_HANDLES.lock().unwrap();
+        g.get(&id).and_then(|r| r.body.clone())
+    };
+    match body {
         Some(b) => {
-            let ptr = alloc_string(&String::from_utf8_lossy(b)).as_raw();
+            let ptr = alloc_string(&String::from_utf8_lossy(&b)).as_raw();
             f64::from_bits(STRING_TAG | (ptr as u64 & 0x0000_FFFF_FFFF_FFFF))
         }
         None => f64::from_bits(TAG_UNDEFINED),

--- a/crates/perry-ext-fetch/src/tests.rs
+++ b/crates/perry-ext-fetch/src/tests.rs
@@ -326,3 +326,107 @@ fn request_binary_body_round_trips_byte_exact() {
         "arrayBuffer()/bytes() must be byte-exact"
     );
 }
+
+/// The fetch root scanner (`scan_fetch_roots`) takes `REQUEST_HANDLES`
+/// during a collection ON THE MUTATOR THREAD, so no reader may still hold
+/// (or leak) that guard when it performs a GC allocation. The failure mode
+/// is not a panic: under this repo's panic=abort + invoke-EH transport an
+/// unwind does not run `Drop`, so a guard alive at the wrong moment means
+/// the mutex is NEVER released and the next scan or reader BLOCKS — a hang,
+/// which a hanging test cannot report. This probes with `try_lock` after
+/// every reader instead, so a re-introduced held guard turns into a
+/// FAILURE.
+#[test]
+fn request_reads_release_the_registry_guard() {
+    let id = store_request(RequestData {
+        url: "https://guard.test/x".to_string(),
+        method: "GET".to_string(),
+        body: Some(b"guard-body".to_vec()),
+        headers: HeadersStore::default(),
+        destination: "document".to_string(),
+        referrer: "about:client".to_string(),
+        referrer_policy: String::new(),
+        mode: "cors".to_string(),
+        credentials: "same-origin".to_string(),
+        cache: "default".to_string(),
+        redirect: "follow".to_string(),
+        integrity: String::new(),
+        keepalive: false,
+        duplex: "half".to_string(),
+        signal: f64::from_bits(TAG_UNDEFINED),
+    });
+    let handle = id as f64;
+
+    let probe = |label: &str| {
+        let free = REQUEST_HANDLES.try_lock().is_ok();
+        assert!(
+            free,
+            "{label} left REQUEST_HANDLES locked — the fetch root scanner would hang"
+        );
+    };
+
+    let url = js_request_get_url(handle);
+    assert!(!url.is_null());
+    probe("js_request_get_url");
+    let method = js_request_get_method(handle);
+    assert!(!method.is_null());
+    probe("js_request_get_method");
+    let destination = js_request_get_destination(handle);
+    assert!(!destination.is_null());
+    probe("js_request_get_destination (request_string_field)");
+    let body = js_request_get_body(handle);
+    assert_ne!(body.to_bits(), 0);
+    probe("js_request_get_body");
+    let _signal = js_request_get_signal(handle);
+    probe("js_request_get_signal");
+
+    REQUEST_HANDLES.lock().unwrap().remove(&id);
+}
+
+/// Companion source invariant for the test above: the pre-fix bug shape was
+/// `alloc_string(&r.url)` with `r` borrowed out of the live
+/// `REQUEST_HANDLES` guard — a GC allocation whose argument keeps the guard
+/// alive across the collection the allocation can trigger. Scan the source
+/// for that shape, and prove the scanner can still FIRE with a planted
+/// sample (a matcher that silently stopped matching would hold this gate
+/// green forever).
+#[test]
+fn no_allocation_is_taken_off_a_live_registry_borrow() {
+    let source = include_str!("lib.rs");
+    let forbidden = regex_lite_scan(source);
+    assert!(
+        forbidden.is_empty(),
+        "GC allocation reaches through a live REQUEST_HANDLES borrow — hoist the \
+         clone out of the guard first (self-deadlock with scan_fetch_roots): {forbidden:?}"
+    );
+    let planted =
+        "let g = REQUEST_HANDLES.lock().unwrap();\n    Some(r) => alloc_string(&r.url).as_raw(),";
+    assert!(
+        !regex_lite_scan(planted).is_empty(),
+        "the forbidden-pattern scan no longer matches its own planted sample"
+    );
+}
+
+/// Textual matcher for `no_allocation_is_taken_off_a_live_registry_borrow`:
+/// an `alloc_string` whose argument reaches through the registry-borrow
+/// convention names (`r`, `req`) used by every reader in this file.
+fn regex_lite_scan(source: &str) -> Vec<String> {
+    source
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                return false;
+            }
+            [
+                "alloc_string(&r.",
+                "alloc_string(r.",
+                "alloc_string(&req.",
+                "alloc_string(req.",
+            ]
+            .iter()
+            .any(|pattern| line.contains(pattern))
+        })
+        .map(|line| line.trim().to_string())
+        .collect()
+}

--- a/crates/perry-ext-http/src/server/http2_server.rs
+++ b/crates/perry-ext-http/src/server/http2_server.rs
@@ -81,6 +81,67 @@ lazy_static! {
     pub(crate) static ref H2_PENDING_EVENTS: Mutex<Vec<Http2PendingEvent>> = Mutex::new(Vec::new());
 }
 
+thread_local! {
+    /// Events drained out of [`H2_PENDING_EVENTS`] but not yet dispatched.
+    /// The drain used to snapshot into a bare local `Vec`, so every
+    /// not-yet-fired callback was unrooted again while earlier events ran
+    /// arbitrary JS (`call1` + microtasks). Parked here instead, one event
+    /// popped at a time, so the scanner below keeps custody until dispatch.
+    pub(crate) static H2_DRAINED_EVENTS: std::cell::RefCell<std::collections::VecDeque<Http2PendingEvent>> =
+        const { std::cell::RefCell::new(std::collections::VecDeque::new()) };
+    /// Callback(s) of the event(s) currently being dispatched — a stack so a
+    /// re-entrant pump cannot clobber an outer frame's slot. An arm pushes
+    /// its callback BEFORE any allocating prep (`settings_value`,
+    /// `buffer_value_from_bytes`, listener fan-out) and pops the — possibly
+    /// rewritten — value right before the call.
+    pub(crate) static H2_ACTIVE_CALLBACKS: std::cell::RefCell<Vec<i64>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// GC root scanner hook — visit every user closure parked in
+/// [`H2_PENDING_EVENTS`], the drained-but-undelivered events in
+/// [`H2_DRAINED_EVENTS`], and the in-dispatch [`H2_ACTIVE_CALLBACKS`] stack.
+///
+/// `session.close(cb)` / `session.settings(obj, cb)` / `session.ping(cb)`
+/// queue their callback as raw NaN-box bits in an event that crosses at
+/// least one pump tick before `call0`/`call2`/`call3` fires it. A collection
+/// in that window moves (copying minor) or frees (full sweep — the settings
+/// and ping callbacks have NO other holder) the closure, and the drain then
+/// calls through a stale pointer. Wired into
+/// `super::scan_http_server_roots`, the scanner this crate registers.
+pub(crate) fn scan_h2_pending_event_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    fn visit_event_callbacks(
+        events: &mut dyn Iterator<Item = &mut Http2PendingEvent>,
+        visitor: &mut perry_ffi::GcRootVisitor<'_>,
+    ) {
+        for event in events {
+            match event {
+                Http2PendingEvent::ClientClose { callback, .. }
+                | Http2PendingEvent::SessionSettingsCallback { callback, .. }
+                | Http2PendingEvent::SessionPingCallback { callback, .. } => {
+                    if *callback != 0 {
+                        visitor.visit_i64_slot(callback);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    if let Ok(mut queue) = H2_PENDING_EVENTS.lock() {
+        visit_event_callbacks(&mut queue.iter_mut(), visitor);
+    }
+    H2_DRAINED_EVENTS.with(|drained| {
+        visit_event_callbacks(&mut drained.borrow_mut().iter_mut(), visitor);
+    });
+    H2_ACTIVE_CALLBACKS.with(|active| {
+        for callback in active.borrow_mut().iter_mut() {
+            if *callback != 0 {
+                visitor.visit_i64_slot(callback);
+            }
+        }
+    });
+}
+
 static NEXT_H2_STREAM_ID: AtomicI64 = AtomicI64::new(1);
 
 pub(crate) fn next_stream_id() -> i64 {

--- a/crates/perry-ext-http/src/server/http2_server/pump.rs
+++ b/crates/perry-ext-http/src/server/http2_server/pump.rs
@@ -274,12 +274,20 @@ pub(crate) fn has_active_h2_clients() -> bool {
 }
 
 pub(crate) fn process_pending_h2_events() -> i32 {
-    let events: Vec<Http2PendingEvent> = match H2_PENDING_EVENTS.lock() {
-        Ok(mut q) => q.drain(..).collect(),
-        Err(_) => return 0,
+    // Drain into the SCANNED thread-local (super::H2_DRAINED_EVENTS), not a
+    // bare local: every event dispatched below can run arbitrary JS and
+    // collect, and the callbacks of the not-yet-dispatched events must stay
+    // visible to scan_h2_pending_event_roots until their turn.
+    let count = {
+        let drained: Vec<Http2PendingEvent> = match H2_PENDING_EVENTS.lock() {
+            Ok(mut q) => q.drain(..).collect(),
+            Err(_) => return 0,
+        };
+        let n = drained.len() as i32;
+        super::H2_DRAINED_EVENTS.with(|d| d.borrow_mut().extend(drained));
+        n
     };
-    let count = events.len() as i32;
-    for event in events {
+    while let Some(event) = super::H2_DRAINED_EVENTS.with(|d| d.borrow_mut().pop_front()) {
         match event {
             Http2PendingEvent::Session {
                 server_handle,
@@ -388,6 +396,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 session_handle,
                 callback,
             } => {
+                // Park the callback in the scanned stack across the
+                // listener fan-out (arbitrary JS + GC), and read the
+                // possibly-rewritten value back right before the call — a
+                // bare `callback` local would go stale on evacuation, and
+                // the retain-by-value below would then compare the STALE
+                // bits against the rewritten close_callbacks entries and
+                // remove nothing.
+                super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().push(callback));
                 let listeners = get_handle::<Http2SessionHandle>(session_handle)
                     .and_then(|s| s.listeners.get("close").cloned())
                     .unwrap_or_default();
@@ -397,6 +413,8 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                         js_promise_run_microtasks();
                     }
                 }
+                let callback =
+                    super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().pop().unwrap_or(0));
                 call0(callback);
                 if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
                     session.close_callbacks.retain(|cb| *cb != callback);
@@ -423,7 +441,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 callback,
                 settings,
             } => {
-                call2(callback, null_value(), settings_value(&settings));
+                // `settings_value` allocates the JS settings object and can
+                // collect; keep the callback in the scanned stack across it.
+                super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().push(callback));
+                let err = null_value();
+                let settings_arg = settings_value(&settings);
+                let callback =
+                    super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().pop().unwrap_or(0));
+                call2(callback, err, settings_arg);
                 if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
                     session.pending_callbacks.retain(|cb| *cb != callback);
                     session.pending_settings_ack = false;
@@ -437,12 +462,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 callback,
                 payload,
             } => {
-                call3(
-                    callback,
-                    null_value(),
-                    0.0,
-                    buffer_value_from_bytes(&payload),
-                );
+                // `buffer_value_from_bytes` allocates; same custody dance as
+                // the settings callback above.
+                super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().push(callback));
+                let err = null_value();
+                let payload_arg = buffer_value_from_bytes(&payload);
+                let callback =
+                    super::H2_ACTIVE_CALLBACKS.with(|a| a.borrow_mut().pop().unwrap_or(0));
+                call3(callback, err, 0.0, payload_arg);
                 if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
                     session.pending_callbacks.retain(|cb| *cb != callback);
                 }

--- a/crates/perry-ext-http/src/server/mod.rs
+++ b/crates/perry-ext-http/src/server/mod.rs
@@ -178,6 +178,10 @@ fn scan_http_server_roots(visitor: &mut GcRootVisitor<'_>) {
     iter_handles_of_mut::<Http2StreamHandle, _>(|stream| {
         scan_listener_roots(&mut stream.listeners, visitor);
     });
+
+    // Closures parked in the HTTP/2 pending-event queue between a JS-side
+    // `session.close/settings/ping(cb)` and the main-thread drain.
+    http2_server::scan_h2_pending_event_roots(visitor);
 }
 
 #[cfg(test)]

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -239,6 +239,25 @@ fn scan_net_roots(visitor: &mut GcRootVisitor<'_>) {
             }
         }
     }
+    // `once_flags()` keys membership by the closure's ADDRESS BITS. The
+    // canonical copy in `listeners()` above keeps the closure alive and is
+    // rewritten when the copying GC moves it — but a `HashSet<i64>` element
+    // cannot be rewritten in place, so without this rebuild the set still
+    // holds the OLD address after evacuation: the once-membership test in
+    // `lifecycle.rs` then misses, the listener is never auto-removed, and a
+    // "once" callback fires on every subsequent event. Drain, forward each
+    // element through the visitor, and reinsert under the new identity.
+    if let Ok(mut once) = statics::once_flags().lock() {
+        for per_handle in once.values_mut() {
+            for set in per_handle.values_mut() {
+                let old: Vec<i64> = set.drain().collect();
+                for mut cb in old {
+                    visitor.visit_i64_slot(&mut cb);
+                    set.insert(cb);
+                }
+            }
+        }
+    }
 }
 
 pub(crate) struct SocketState {

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -1,347 +1,2275 @@
 {
-  "_README": [
-    "Verdicts for every runtime GC-pointer holder that scripts/gc_runtime_root_holders.py",
-    "enumerates and finds NOT reached by a registered root scanner in its own file (#7231).",
-    "",
-    "An entry that matches no such holder FAILS the gate. That is deliberate: it is what",
-    "makes a fix delete its own entry, and it is why 'covered_elsewhere' is a verdict rather",
-    "than a suppression \u2014 if the scanner that covers it is ever deleted, the holder stays",
-    "uncovered, the entry stays matched, and nothing tells you. Read the named scanner if you",
-    "touch it.",
-    "",
-    "Verdicts:",
-    "  covered_elsewhere  - a REGISTERED scanner visits it, but from a different file, so the",
-    "                       same-file rule cannot see it. `scanner` names it. These are the",
-    "                       gate's known false positives, recorded rather than silenced.",
-    "  not_a_gc_pointer   - the stored value is an id, a counter, an epoch, a code address, a",
-    "                       .rodata object, or Rust-owned state. Nothing for the collector.",
-    "  test_only          - #[cfg(test)] storage; never live in a shipped binary.",
-    "  open_gap           - a real unrooted GC pointer. `issue` says where it is tracked; this",
-    "                       verdict FAILS while old-page relocation ships enabled.",
-    "  unverified         - enumerated, verdict NOT established. This also FAILS: an unknown",
-    "                       movable-address contract cannot be a production exemption."
-  ],
-  "holders": [
-    {
-      "file": "crates/perry-runtime/src/async_hooks.rs",
-      "name": "ASYNC_RESOURCE_HANDLES",
-      "verdict": "not_a_gc_pointer",
-      "why": "HashSet of async resource IDs (async_hooks' asyncId space), not heap addresses. The resource OBJECTS live in RESOURCES, which scan_async_hooks_roots_mut visits."
-    },
-    {
-      "file": "crates/perry-runtime/src/async_hooks.rs",
-      "name": "ASYNC_RESOURCE_HANDLE_COUNT",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic counter of live async-resource handles. Holds no address at all; the resource objects live in RESOURCES, which scan_async_hooks_roots_mut visits."
-    },
-    {
-      "file": "crates/perry-runtime/src/child_process/reactor.rs",
-      "name": "CP_NEXT_LIVE_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic id counter for CP_LIVE keys. CP_LIVE itself is covered by cp_reactor_scan_roots_mut."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/blob.rs",
-      "name": "FILE_BLOB_STREAMS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by stream id; FileBlobStreamState is Rust-owned (byte buffers + offsets), no JS values."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/blob.rs",
-      "name": "NEXT_FILE_BLOB_STREAM_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic id counter."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
-      "name": "DIAG_CHANNELS",
-      "verdict": "covered_elsewhere",
-      "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1505)",
-      "why": "Visited from the sibling module, so the same-file rule misses it."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
-      "name": "ERROR_USER_PROPS",
-      "verdict": "covered_elsewhere",
-      "scanner": "node_submodules::diagnostics_gc::scan_error_user_props_roots_mut (diagnostics_gc.rs:46/72/134)",
-      "why": "The whole GC half of diagnostics lives in diagnostics_gc.rs, including the ErrorHeader-address rekey."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
-      "name": "DIAG_NOOP_CLOSURE",
-      "verdict": "covered_elsewhere",
-      "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1499)",
-      "why": "Visited from the sibling module."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_vm.rs",
-      "name": "VM_INTRINSIC_GLOBAL",
-      "verdict": "covered_elsewhere",
-      "scanner": "gc::roots::visit_global_root_slots, reached by js_gc_register_global_root (gc/roots.rs:325 pushes the slot into GLOBAL_ROOTS; gc/roots.rs:1433 hands it to the mutable-root walk)",
-      "why": "Caches the shared VM intrinsic realm's globalThis as NaN-boxed bits. The single site that writes the cell \u2014 fresh_intrinsic_global, node_vm.rs:1080 \u2014 calls js_gc_register_global_root(slot.as_ptr()) in the same `with` closure, immediately after the store and with no allocation in between; the early return on a non-zero cell means that store happens at most once per thread, so there is no path that populates the cell without registering it. GLOBAL_ROOTS is thread_local, exactly like the cell, and visit_mutable_root_slots feeds it to BOTH the marker and the post-evacuation rewrite (gc/tests/copying.rs:1272, test_copying_minor_rewrites_shadow_and_global_roots), so the cached pointer is marked and forwarded rather than left stale."
-    },
-    {
-      "file": "crates/perry-runtime/src/object/class_registry/state.rs",
-      "name": "CLASS_OBJECT_VALUES",
-      "verdict": "covered_elsewhere",
-      "scanner": "object::scan_class_side_table_roots_mut and its budgeted step twin (class_registry/gc_roots.rs:138 and :256)",
-      "why": "The class side tables are declared in state.rs and scanned from gc_roots.rs. Both twins visit it \u2014 #7239 diffed all eight budgeted (FULL, STEP) pairs and found no drift."
-    },
-    {
-      "file": "crates/perry-runtime/src/process.rs",
-      "name": "MODULE_LOADER_NEXT_RESOLVE",
-      "verdict": "covered_elsewhere",
-      "scanner": "process::scan_process_module_loader_roots_mut (process/node_module.rs:17)",
-      "why": "Declared in process.rs, scanned from the process/node_module.rs submodule."
-    },
-    {
-      "file": "crates/perry-runtime/src/process.rs",
-      "name": "MODULE_LOADER_NEXT_LOAD",
-      "verdict": "covered_elsewhere",
-      "scanner": "process::scan_process_module_loader_roots_mut (process/node_module.rs:17)",
-      "why": "Same scanner, same file split."
-    },
-    {
-      "file": "crates/perry-runtime/src/pty/mod.rs",
-      "name": "EXIT_SINK",
-      "verdict": "test_only",
-      "why": "#[cfg(test)] sink for the pty exit callback's two JSValues. Never compiled into a shipped binary."
-    },
-    {
-      "file": "crates/perry-runtime/src/string/format.rs",
-      "name": "POW10",
-      "verdict": "not_a_gc_pointer",
-      "why": "A [u64; 7] constant table of powers of ten."
-    },
-    {
-      "file": "crates/perry-runtime/src/string/mod.rs",
-      "name": "PERRY_EMPTY_STRING",
-      "verdict": "not_a_gc_pointer",
-      "why": "A StringHeader living in .rodata, not in the arena. It has no GcHeader, is never allocated and never moves; the collector's heap-attribution predicates reject its address."
-    },
-    {
-      "file": "crates/perry-runtime/src/symbol/properties.rs",
-      "name": "CACHED",
-      "verdict": "not_a_gc_pointer",
-      "why": "Memoizes the sym_key of the Symbol.for('NextInternalRequestMeta') REGISTERED symbol. Registered / well-known symbols are Box::leak'd (symbol.rs's SYMBOL_REGISTRY / WELL_KNOWN_SYMBOLS), so they live outside the GC arena and their addresses are stable for the process. A FRESH Symbol() would not be \u2014 see #7246."
-    },
-    {
-      "file": "crates/perry-runtime/src/thread.rs",
-      "name": "ACTIVE_THREAD_JOBS",
-      "verdict": "not_a_gc_pointer",
-      "why": "In-flight job counter for perry/thread."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams.rs",
-      "name": "N",
-      "verdict": "not_a_gc_pointer",
-      "why": "Five identically-named per-function AtomicUsize call counters inside streams.rs (one entry covers all five: this inventory keys on file+name). Telemetry, no JS values."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/transform.rs",
-      "name": "TRANSFORM_CALLS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Telemetry call counter for the transform path. Holds a count, never an address; no JS value ever reaches it."
-    },
-    {
-      "file": "crates/perry-runtime/src/object/native_module.rs",
-      "name": "TEST_BOUND_METHOD_MOVE",
-      "verdict": "test_only",
-      "why": "#[cfg(test)] diagnostic trace for the bound-method moving-GC regression: records the (before, after) addresses a test-forced minor produced so the test can assert the relocation happened. The addresses are compared as integers, never dereferenced, and the cell is dead in a shipped binary."
-    },
-    {
-      "file": "crates/perry-runtime/src/closure/alloc.rs",
-      "name": "CAPTURED_MISS_STREAK",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by the closure's func_ptr \u2014 a CODE address, which the collector neither moves nor traces; the value is a miss-streak count."
-    },
-    {
-      "file": "crates/perry-runtime/src/closure/alloc.rs",
-      "name": "CLOSURE_ALLOC_COUNT",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic allocation counter (telemetry). Holds no address."
-    },
-    {
-      "file": "crates/perry-runtime/src/closure/alloc.rs",
-      "name": "CLOSURE_CAP_SINGLETON_HIT",
-      "verdict": "not_a_gc_pointer",
-      "why": "Cache hit counter (telemetry). Holds no address."
-    },
-    {
-      "file": "crates/perry-runtime/src/closure/alloc.rs",
-      "name": "CLOSURE_CAP_SINGLETON_MISS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Cache miss counter (telemetry). Holds no address."
-    },
-    {
-      "file": "crates/perry-runtime/src/fs/filehandle.rs",
-      "name": "NEXT_READ_LINES_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic id counter for READ_LINES_REGISTRY keys. The registry's own heap values are visited by scan_filehandle_roots_mut (fs/filehandle.rs:65), reached from scan_fs_handle_roots_mut."
-    },
-    {
-      "file": "crates/perry-runtime/src/net.rs",
-      "name": "TCP_SERVERS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by handle id; TcpListenerWrapper is Rust-owned (tokio listener + SocketAddr), no JS values."
-    },
-    {
-      "file": "crates/perry-runtime/src/net.rs",
-      "name": "TCP_SOCKETS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by handle id; TcpStreamWrapper is Rust-owned (tokio stream + SocketAddr), no JS values."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
-      "name": "DIAG_TRACES",
-      "verdict": "covered_elsewhere",
-      "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1528, visit_raw_mut_ptr_slot on DiagTracingState.obj)",
-      "why": "Visited from the sibling module, so the same-file rule misses it. The `events: [i64; 5]` are DIAG_CHANNELS ids, not addresses."
-    },
-    {
-      "file": "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs",
-      "name": "DIAG_STORE_SCOPES",
-      "verdict": "not_a_gc_pointer",
-      "why": "DiagStoreScopeState.handles are store KEYS produced by store_handle() (diagnostics_tail.rs:72), which admits only an INT32-tagged value, a POINTER_TAG value inside the handle band (raw < 0x10000), or a finite float \u2014 a real heap pointer returns None, so one cannot be stored here by construction. The store CONTEXT objects live in DIAG_CHANNELS[*].stores, which scan_node_submodule_singleton_roots_mut visits."
-    },
-    {
-      "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
-      "name": "THREAD_GLOBAL_THIS",
-      "verdict": "covered_elsewhere",
-      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_get_global_this) and marked+rewritten as a mutable global root",
-      "why": "A raw-pointer cache slot registered as a global root at first population; the registration is a call, not a scanner body, so the walk cannot see it."
-    },
-    {
-      "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
-      "name": "THREAD_MODULE_TOP_THIS",
-      "verdict": "covered_elsewhere",
-      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_module_top_this)",
-      "why": "Same shape as THREAD_GLOBAL_THIS: a NaN-boxed cache slot registered as a mutable global root at first population."
-    },
-    {
-      "file": "crates/perry-runtime/src/regex.rs",
-      "name": "REGEX_POINTERS",
-      "verdict": "covered_elsewhere",
-      "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs), the RegExp move/death hooks the copying minor and sweep invoke",
-      "why": "Address-KEYED owner set, not a root: the key is rekeyed when the RegExpHeader moves and removed when it dies; it never keeps the header alive. Reached from GC hooks, not from a registered scanner, so the walk misses it."
-    },
-    {
-      "file": "crates/perry-runtime/src/regex.rs",
-      "name": "REGEX_SOURCE_TABLE",
-      "verdict": "covered_elsewhere",
-      "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs)",
-      "why": "Address-KEYED owner table (owned String copies of pattern/flags); rekeyed on move, cleared on death, same hooks as REGEX_POINTERS."
-    },
-    {
-      "file": "crates/perry-runtime/src/text.rs",
-      "name": "DECODER_REGISTRY",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by decoder handle id; DecoderState is Rust-owned (encoding enum, label, flags), no JS values."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch/body_metadata.rs",
-      "name": "FORM_DATA_REGISTRY",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by fetch handle id; FormDataStore is Rust-owned (Vec<(String, String)>). The bound-method closures for FormData live in FORM_DATA_METHOD_VALUE_CACHE, which fetch::gc::scan_fetch_roots_with visits."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch/mod.rs",
-      "name": "BLOB_REGISTRY",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by fetch handle id; BlobData is Rust-owned (bytes, content type, file name, last-modified). No JS values."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch/mod.rs",
-      "name": "FETCH_RESPONSES",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by fetch handle id; FetchResponse is Rust-owned (status, HeadersStore, body bytes, cached HANDLE IDS for headers/body stream). No JS values."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch/mod.rs",
-      "name": "REQUEST_REGISTRY",
-      "verdict": "covered_elsewhere",
-      "scanner": "fetch::gc::scan_fetch_roots_with (fetch/gc.rs, visit_nanbox_f64_slot on RequestRecord.signal), registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:fetch\"",
-      "why": "RequestRecord.signal is the AbortSignal object behind request.signal (#8163). Visited from the child module, so the same-file rule misses it; everything else in the record is Rust-owned."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch/mod.rs",
-      "name": "STREAM_HANDLES",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by stream id; StreamState is Rust-owned (status, buffered lines, error String)."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch_blob.rs",
-      "name": "NEXT_OBJECT_URL_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic id counter."
-    },
-    {
-      "file": "crates/perry-stdlib/src/fetch_blob.rs",
-      "name": "OBJECT_URL_REGISTRY",
-      "verdict": "not_a_gc_pointer",
-      "why": "blob: URL string -> Blob HANDLE ID (a fetch-band small integer), not an address."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams.rs",
-      "name": "READABLE_STREAMS",
-      "verdict": "covered_elsewhere",
-      "scanner": "streams::gc::scan_stream_roots_with (streams/gc.rs, registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:streams\")",
-      "why": "Chunks, callbacks, pending-read promises and error values are all visited from the child module, so the same-file rule misses it."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/tee.rs",
-      "name": "TEE_PULLING",
-      "verdict": "not_a_gc_pointer",
-      "why": "HashSet of tee SOURCE stream ids (READABLE_STREAMS keys), not addresses."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/tee.rs",
-      "name": "TEE_STARTED",
-      "verdict": "not_a_gc_pointer",
-      "why": "HashSet of tee source stream ids, not addresses."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/transform.rs",
-      "name": "TRANSFORM_BACKPRESSURED_JOBS",
-      "verdict": "covered_elsewhere",
-      "scanner": "streams::gc::scan_transform_deferred_roots (streams/gc.rs, visit_raw_mut_ptr_slot on each job closure)",
-      "why": "The values are ClosureHeader addresses of parked write jobs; visited from streams/gc.rs, so the same-file rule misses it."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/transform.rs",
-      "name": "TRANSFORM_PAIRS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Transform readable id -> writable id: both are stream HANDLE IDS."
-    },
-    {
-      "file": "crates/perry-stdlib/src/streams/transform.rs",
-      "name": "TRANSFORM_PENDING_WRITES",
-      "verdict": "not_a_gc_pointer",
-      "why": "Transform writable id -> COUNT of queued write jobs (#6607). No address."
-    },
-    {
-      "file": "crates/perry-stdlib/src/worker_threads.rs",
-      "name": "NEXT_PORT_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic MessagePort id counter."
-    },
-    {
-      "file": "crates/perry-stdlib/src/ws.rs",
-      "name": "NEXT_WS_ID",
-      "verdict": "not_a_gc_pointer",
-      "why": "Monotonic ws id counter."
-    },
-    {
-      "file": "crates/perry-stdlib/src/ws.rs",
-      "name": "WS_CLIENT_PARENT_SERVER",
-      "verdict": "not_a_gc_pointer",
-      "why": "Client ws id -> parent server HANDLE id. No address."
-    },
-    {
-      "file": "crates/perry-stdlib/src/ws.rs",
-      "name": "WS_CONNECTIONS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Keyed by ws id; WsConnection is Rust-owned (command sender, buffered message Strings, state flags). Listener closures live in WS_CLIENT_LISTENERS, which scan_ws_roots_mut visits."
-    }
-  ]
+ "_README": [
+  "Verdicts for every runtime GC-pointer holder that scripts/gc_runtime_root_holders.py",
+  "enumerates and finds NOT reached by a registered root scanner in its own file (#7231).",
+  "",
+  "An entry that matches no such holder FAILS the gate. That is deliberate: it is what",
+  "makes a fix delete its own entry, and it is why 'covered_elsewhere' is a verdict rather",
+  "than a suppression — if the scanner that covers it is ever deleted, the holder stays",
+  "uncovered, the entry stays matched, and nothing tells you. Read the named scanner if you",
+  "touch it.",
+  "",
+  "Verdicts:",
+  "  covered_elsewhere  - a REGISTERED scanner visits it, but from a different file, so the",
+  "                       same-file rule cannot see it. `scanner` names it. These are the",
+  "                       gate's known false positives, recorded rather than silenced.",
+  "  not_a_gc_pointer   - the stored value is an id, a counter, an epoch, a code address, a",
+  "                       .rodata object, or Rust-owned state. Nothing for the collector.",
+  "  test_only          - #[cfg(test)] storage; never live in a shipped binary.",
+  "  open_gap           - a real unrooted GC pointer. `issue` says where it is tracked; this",
+  "                       verdict FAILS while old-page relocation ships enabled.",
+  "  unverified         - enumerated, verdict NOT established. This also FAILS: an unknown",
+  "                       movable-address contract cannot be a production exemption."
+ ],
+ "holders": [
+  {
+   "file": "crates/perry-runtime/src/async_hooks.rs",
+   "name": "ASYNC_RESOURCE_HANDLES",
+   "verdict": "not_a_gc_pointer",
+   "why": "HashSet of async resource IDs (async_hooks' asyncId space), not heap addresses. The resource OBJECTS live in RESOURCES, which scan_async_hooks_roots_mut visits."
+  },
+  {
+   "file": "crates/perry-runtime/src/async_hooks.rs",
+   "name": "ASYNC_RESOURCE_HANDLE_COUNT",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic counter of live async-resource handles. Holds no address at all; the resource objects live in RESOURCES, which scan_async_hooks_roots_mut visits."
+  },
+  {
+   "file": "crates/perry-runtime/src/child_process/reactor.rs",
+   "name": "CP_NEXT_LIVE_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic id counter for CP_LIVE keys. CP_LIVE itself is covered by cp_reactor_scan_roots_mut."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/blob.rs",
+   "name": "FILE_BLOB_STREAMS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by stream id; FileBlobStreamState is Rust-owned (byte buffers + offsets), no JS values."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/blob.rs",
+   "name": "NEXT_FILE_BLOB_STREAM_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic id counter."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
+   "name": "DIAG_CHANNELS",
+   "verdict": "covered_elsewhere",
+   "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1505)",
+   "why": "Visited from the sibling module, so the same-file rule misses it."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
+   "name": "ERROR_USER_PROPS",
+   "verdict": "covered_elsewhere",
+   "scanner": "node_submodules::diagnostics_gc::scan_error_user_props_roots_mut (diagnostics_gc.rs:46/72/134)",
+   "why": "The whole GC half of diagnostics lives in diagnostics_gc.rs, including the ErrorHeader-address rekey."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
+   "name": "DIAG_NOOP_CLOSURE",
+   "verdict": "covered_elsewhere",
+   "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1499)",
+   "why": "Visited from the sibling module."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_vm.rs",
+   "name": "VM_INTRINSIC_GLOBAL",
+   "verdict": "covered_elsewhere",
+   "scanner": "gc::roots::visit_global_root_slots, reached by js_gc_register_global_root (gc/roots.rs:325 pushes the slot into GLOBAL_ROOTS; gc/roots.rs:1433 hands it to the mutable-root walk)",
+   "why": "Caches the shared VM intrinsic realm's globalThis as NaN-boxed bits. The single site that writes the cell — fresh_intrinsic_global, node_vm.rs:1080 — calls js_gc_register_global_root(slot.as_ptr()) in the same `with` closure, immediately after the store and with no allocation in between; the early return on a non-zero cell means that store happens at most once per thread, so there is no path that populates the cell without registering it. GLOBAL_ROOTS is thread_local, exactly like the cell, and visit_mutable_root_slots feeds it to BOTH the marker and the post-evacuation rewrite (gc/tests/copying.rs:1272, test_copying_minor_rewrites_shadow_and_global_roots), so the cached pointer is marked and forwarded rather than left stale."
+  },
+  {
+   "file": "crates/perry-runtime/src/object/class_registry/state.rs",
+   "name": "CLASS_OBJECT_VALUES",
+   "verdict": "covered_elsewhere",
+   "scanner": "object::scan_class_side_table_roots_mut and its budgeted step twin (class_registry/gc_roots.rs:138 and :256)",
+   "why": "The class side tables are declared in state.rs and scanned from gc_roots.rs. Both twins visit it — #7239 diffed all eight budgeted (FULL, STEP) pairs and found no drift."
+  },
+  {
+   "file": "crates/perry-runtime/src/process.rs",
+   "name": "MODULE_LOADER_NEXT_RESOLVE",
+   "verdict": "covered_elsewhere",
+   "scanner": "process::scan_process_module_loader_roots_mut (process/node_module.rs:17)",
+   "why": "Declared in process.rs, scanned from the process/node_module.rs submodule."
+  },
+  {
+   "file": "crates/perry-runtime/src/process.rs",
+   "name": "MODULE_LOADER_NEXT_LOAD",
+   "verdict": "covered_elsewhere",
+   "scanner": "process::scan_process_module_loader_roots_mut (process/node_module.rs:17)",
+   "why": "Same scanner, same file split."
+  },
+  {
+   "file": "crates/perry-runtime/src/pty/mod.rs",
+   "name": "EXIT_SINK",
+   "verdict": "test_only",
+   "why": "#[cfg(test)] sink for the pty exit callback's two JSValues. Never compiled into a shipped binary."
+  },
+  {
+   "file": "crates/perry-runtime/src/string/format.rs",
+   "name": "POW10",
+   "verdict": "not_a_gc_pointer",
+   "why": "A [u64; 7] constant table of powers of ten."
+  },
+  {
+   "file": "crates/perry-runtime/src/string/mod.rs",
+   "name": "PERRY_EMPTY_STRING",
+   "verdict": "not_a_gc_pointer",
+   "why": "A StringHeader living in .rodata, not in the arena. It has no GcHeader, is never allocated and never moves; the collector's heap-attribution predicates reject its address."
+  },
+  {
+   "file": "crates/perry-runtime/src/symbol/properties.rs",
+   "name": "CACHED",
+   "verdict": "not_a_gc_pointer",
+   "why": "Memoizes the sym_key of the Symbol.for('NextInternalRequestMeta') REGISTERED symbol. Registered / well-known symbols are Box::leak'd (symbol.rs's SYMBOL_REGISTRY / WELL_KNOWN_SYMBOLS), so they live outside the GC arena and their addresses are stable for the process. A FRESH Symbol() would not be — see #7246."
+  },
+  {
+   "file": "crates/perry-runtime/src/thread.rs",
+   "name": "ACTIVE_THREAD_JOBS",
+   "verdict": "not_a_gc_pointer",
+   "why": "In-flight job counter for perry/thread."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams.rs",
+   "name": "N",
+   "verdict": "not_a_gc_pointer",
+   "why": "Five identically-named per-function AtomicUsize call counters inside streams.rs (one entry covers all five: this inventory keys on file+name). Telemetry, no JS values."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/transform.rs",
+   "name": "TRANSFORM_CALLS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Telemetry call counter for the transform path. Holds a count, never an address; no JS value ever reaches it."
+  },
+  {
+   "file": "crates/perry-runtime/src/object/native_module.rs",
+   "name": "TEST_BOUND_METHOD_MOVE",
+   "verdict": "test_only",
+   "why": "#[cfg(test)] diagnostic trace for the bound-method moving-GC regression: records the (before, after) addresses a test-forced minor produced so the test can assert the relocation happened. The addresses are compared as integers, never dereferenced, and the cell is dead in a shipped binary."
+  },
+  {
+   "file": "crates/perry-runtime/src/closure/alloc.rs",
+   "name": "CAPTURED_MISS_STREAK",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by the closure's func_ptr — a CODE address, which the collector neither moves nor traces; the value is a miss-streak count."
+  },
+  {
+   "file": "crates/perry-runtime/src/closure/alloc.rs",
+   "name": "CLOSURE_ALLOC_COUNT",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic allocation counter (telemetry). Holds no address."
+  },
+  {
+   "file": "crates/perry-runtime/src/closure/alloc.rs",
+   "name": "CLOSURE_CAP_SINGLETON_HIT",
+   "verdict": "not_a_gc_pointer",
+   "why": "Cache hit counter (telemetry). Holds no address."
+  },
+  {
+   "file": "crates/perry-runtime/src/closure/alloc.rs",
+   "name": "CLOSURE_CAP_SINGLETON_MISS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Cache miss counter (telemetry). Holds no address."
+  },
+  {
+   "file": "crates/perry-runtime/src/fs/filehandle.rs",
+   "name": "NEXT_READ_LINES_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic id counter for READ_LINES_REGISTRY keys. The registry's own heap values are visited by scan_filehandle_roots_mut (fs/filehandle.rs:65), reached from scan_fs_handle_roots_mut."
+  },
+  {
+   "file": "crates/perry-runtime/src/net.rs",
+   "name": "TCP_SERVERS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by handle id; TcpListenerWrapper is Rust-owned (tokio listener + SocketAddr), no JS values."
+  },
+  {
+   "file": "crates/perry-runtime/src/net.rs",
+   "name": "TCP_SOCKETS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by handle id; TcpStreamWrapper is Rust-owned (tokio stream + SocketAddr), no JS values."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/diagnostics.rs",
+   "name": "DIAG_TRACES",
+   "verdict": "covered_elsewhere",
+   "scanner": "node_submodules::scan_node_submodule_singleton_roots_mut (node_submodules/mod.rs:1528, visit_raw_mut_ptr_slot on DiagTracingState.obj)",
+   "why": "Visited from the sibling module, so the same-file rule misses it. The `events: [i64; 5]` are DIAG_CHANNELS ids, not addresses."
+  },
+  {
+   "file": "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs",
+   "name": "DIAG_STORE_SCOPES",
+   "verdict": "not_a_gc_pointer",
+   "why": "DiagStoreScopeState.handles are store KEYS produced by store_handle() (diagnostics_tail.rs:72), which admits only an INT32-tagged value, a POINTER_TAG value inside the handle band (raw < 0x10000), or a finite float — a real heap pointer returns None, so one cannot be stored here by construction. The store CONTEXT objects live in DIAG_CHANNELS[*].stores, which scan_node_submodule_singleton_roots_mut visits."
+  },
+  {
+   "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
+   "name": "THREAD_GLOBAL_THIS",
+   "verdict": "covered_elsewhere",
+   "scanner": "gc::roots GLOBAL_ROOTS — the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_get_global_this) and marked+rewritten as a mutable global root",
+   "why": "A raw-pointer cache slot registered as a global root at first population; the registration is a call, not a scanner body, so the walk cannot see it."
+  },
+  {
+   "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
+   "name": "THREAD_MODULE_TOP_THIS",
+   "verdict": "covered_elsewhere",
+   "scanner": "gc::roots GLOBAL_ROOTS — the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_module_top_this)",
+   "why": "Same shape as THREAD_GLOBAL_THIS: a NaN-boxed cache slot registered as a mutable global root at first population."
+  },
+  {
+   "file": "crates/perry-runtime/src/regex.rs",
+   "name": "REGEX_POINTERS",
+   "verdict": "covered_elsewhere",
+   "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs), the RegExp move/death hooks the copying minor and sweep invoke",
+   "why": "Address-KEYED owner set, not a root: the key is rekeyed when the RegExpHeader moves and removed when it dies; it never keeps the header alive. Reached from GC hooks, not from a registered scanner, so the walk misses it."
+  },
+  {
+   "file": "crates/perry-runtime/src/regex.rs",
+   "name": "REGEX_SOURCE_TABLE",
+   "verdict": "covered_elsewhere",
+   "scanner": "regex::regex_header_moved_for_gc / regex_header_clear_dead_for_gc (regex.rs)",
+   "why": "Address-KEYED owner table (owned String copies of pattern/flags); rekeyed on move, cleared on death, same hooks as REGEX_POINTERS."
+  },
+  {
+   "file": "crates/perry-runtime/src/text.rs",
+   "name": "DECODER_REGISTRY",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by decoder handle id; DecoderState is Rust-owned (encoding enum, label, flags), no JS values."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch/body_metadata.rs",
+   "name": "FORM_DATA_REGISTRY",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by fetch handle id; FormDataStore is Rust-owned (Vec<(String, String)>). The bound-method closures for FormData live in FORM_DATA_METHOD_VALUE_CACHE, which fetch::gc::scan_fetch_roots_with visits."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch/mod.rs",
+   "name": "BLOB_REGISTRY",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by fetch handle id; BlobData is Rust-owned (bytes, content type, file name, last-modified). No JS values."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch/mod.rs",
+   "name": "FETCH_RESPONSES",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by fetch handle id; FetchResponse is Rust-owned (status, HeadersStore, body bytes, cached HANDLE IDS for headers/body stream). No JS values."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch/mod.rs",
+   "name": "REQUEST_REGISTRY",
+   "verdict": "covered_elsewhere",
+   "scanner": "fetch::gc::scan_fetch_roots_with (fetch/gc.rs, visit_nanbox_f64_slot on RequestRecord.signal), registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:fetch\"",
+   "why": "RequestRecord.signal is the AbortSignal object behind request.signal (#8163). Visited from the child module, so the same-file rule misses it; everything else in the record is Rust-owned."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch/mod.rs",
+   "name": "STREAM_HANDLES",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by stream id; StreamState is Rust-owned (status, buffered lines, error String)."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch_blob.rs",
+   "name": "NEXT_OBJECT_URL_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic id counter."
+  },
+  {
+   "file": "crates/perry-stdlib/src/fetch_blob.rs",
+   "name": "OBJECT_URL_REGISTRY",
+   "verdict": "not_a_gc_pointer",
+   "why": "blob: URL string -> Blob HANDLE ID (a fetch-band small integer), not an address."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams.rs",
+   "name": "READABLE_STREAMS",
+   "verdict": "covered_elsewhere",
+   "scanner": "streams::gc::scan_stream_roots_with (streams/gc.rs, registered through perry_ffi_gc_register_mutable_root_scanner_named as \"stdlib:streams\")",
+   "why": "Chunks, callbacks, pending-read promises and error values are all visited from the child module, so the same-file rule misses it."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/tee.rs",
+   "name": "TEE_PULLING",
+   "verdict": "not_a_gc_pointer",
+   "why": "HashSet of tee SOURCE stream ids (READABLE_STREAMS keys), not addresses."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/tee.rs",
+   "name": "TEE_STARTED",
+   "verdict": "not_a_gc_pointer",
+   "why": "HashSet of tee source stream ids, not addresses."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/transform.rs",
+   "name": "TRANSFORM_BACKPRESSURED_JOBS",
+   "verdict": "covered_elsewhere",
+   "scanner": "streams::gc::scan_transform_deferred_roots (streams/gc.rs, visit_raw_mut_ptr_slot on each job closure)",
+   "why": "The values are ClosureHeader addresses of parked write jobs; visited from streams/gc.rs, so the same-file rule misses it."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/transform.rs",
+   "name": "TRANSFORM_PAIRS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Transform readable id -> writable id: both are stream HANDLE IDS."
+  },
+  {
+   "file": "crates/perry-stdlib/src/streams/transform.rs",
+   "name": "TRANSFORM_PENDING_WRITES",
+   "verdict": "not_a_gc_pointer",
+   "why": "Transform writable id -> COUNT of queued write jobs (#6607). No address."
+  },
+  {
+   "file": "crates/perry-stdlib/src/worker_threads.rs",
+   "name": "NEXT_PORT_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic MessagePort id counter."
+  },
+  {
+   "file": "crates/perry-stdlib/src/ws.rs",
+   "name": "NEXT_WS_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic ws id counter."
+  },
+  {
+   "file": "crates/perry-stdlib/src/ws.rs",
+   "name": "WS_CLIENT_PARENT_SERVER",
+   "verdict": "not_a_gc_pointer",
+   "why": "Client ws id -> parent server HANDLE id. No address."
+  },
+  {
+   "file": "crates/perry-stdlib/src/ws.rs",
+   "name": "WS_CONNECTIONS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Keyed by ws id; WsConnection is Rust-owned (command sender, buffered message Strings, state flags). Listener closures live in WS_CLIENT_LISTENERS, which scan_ws_roots_mut visits."
+  },
+  {
+   "file": "crates/perry-ext-http/src/lib.rs",
+   "name": "HTTP_PENDING_EVENTS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Client-side pending-event queue. Every variant carries a perry-ffi registry Handle, strings, Bytes, or an errno i64 (rule S fired on TransportError.errno) — no NaN-boxed value. The closures the drain fires live in ClientRequestHandle (response_callback/end_callback/pending_write_callbacks/listeners), which scan_http_roots visits."
+  },
+  {
+   "file": "crates/perry-ext-http/src/server/server.rs",
+   "name": "CONNECTIONS",
+   "verdict": "not_a_gc_pointer",
+   "why": "TrackedConnection = {server_handle: ffi registry id, close: Notify, busy/read_active: atomics}. No JS values; server closures live in the HttpServer handle, scanned by scan_http_server_roots."
+  },
+  {
+   "file": "crates/perry-ext-http/src/server/server.rs",
+   "name": "PENDING_CONNECTION_EVENTS",
+   "verdict": "not_a_gc_pointer",
+   "why": "Vec of server-handle registry ids drained by js_node_http_server_process_pending to fire 'connection' listeners; the listeners themselves are in HttpServer.listeners, scanned by scan_http_server_roots."
+  },
+  {
+   "file": "crates/perry-ext-http/src/server/server/in_flight.rs",
+   "name": "IN_FLIGHT",
+   "verdict": "not_a_gc_pointer",
+   "why": "InFlightRequest = three perry-ffi registry handle ids + a deadline Instant. The JS-value-bearing objects behind the ids (IncomingMessage/ServerResponse) are registered handles scanned by scan_http_server_roots via iter_handles_of_mut."
+  },
+  {
+   "file": "crates/perry-ext-net/src/lib.rs",
+   "name": "P",
+   "verdict": "not_a_gc_pointer",
+   "why": "pending_events(): Vec<PendingNetEvent>; every variant carries socket/server ids, Bytes, String, bool, or DropInfo (SocketAddrs) — no closures or NaN-boxed values. Listener closures live in listeners(), visited by scan_net_roots."
+  },
+  {
+   "file": "crates/perry-ext-net/src/lib.rs",
+   "name": "SCRATCH",
+   "verdict": "not_a_gc_pointer",
+   "why": "Drain-side reusable Vec<PendingNetEvent> inside js_ext_net_drain_pending; same payload as P (ids/Bytes/strings), emptied within the drain call. No JS values."
+  },
+  {
+   "file": "crates/perry-ext-net/src/server_state.rs",
+   "name": "STATE",
+   "verdict": "not_a_gc_pointer",
+   "why": "ConnectionOrderState = socket-id VecDeques, per-server usize credits, and buffered Bytes chunks keyed by socket id. Pure ids and bytes; no NaN-boxed values."
+  },
+  {
+   "file": "crates/perry-ext-pdf/src/lib.rs",
+   "name": "WARNED",
+   "verdict": "not_a_gc_pointer",
+   "why": "HashSet of perry-ffi registry handle ids already found stale, kept only to log each once. Registry ids are indices into the ffi DashMap, not heap addresses."
+  },
+  {
+   "file": "crates/perry-runtime/src/process.rs",
+   "name": "PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER",
+   "verdict": "covered_elsewhere",
+   "scanner": "process::scan_process_finalization_roots_mut (process/finalization.rs:171; visits the cell at :184-189 via visit_raw_const_ptr_slot; reg_scanner! at gc/mod.rs:1008)",
+   "why": "Declared in process.rs, scanned from the process/finalization.rs submodule — same file split as the MODULE_LOADER_* siblings."
+  },
+  {
+   "file": "crates/perry-runtime/src/promise/microtasks.rs",
+   "name": "CURRENT_MICROTASK_VALUE",
+   "verdict": "covered_elsewhere",
+   "scanner": "promise::scan_promise_roots_mut (promise/scanners.rs:66, visit_cell_f64_slot) plus its budgeted step twin scan_current_microtask_value_step (scanners.rs:420); registered via reg_budgeted_scanner! at gc/mod.rs:833-838",
+   "why": "Declared in promise/microtasks.rs, scanned from promise/scanners.rs. The scanners.rs:786/913 sites are the mutator-side save/clear the scanner exists to protect, not the coverage mechanism."
+  },
+  {
+   "file": "crates/perry-runtime/src/set.rs",
+   "name": "SET_INDEX",
+   "verdict": "not_a_gc_pointer",
+   "why": "Derived cache of the Set's own elements array, which is the canonical scanned storage (GcRewriteDescriptorKind::Set element-slot walk). Not root-scanner-shaped: the outer address key is rekeyed on relocation by GcMoveHookKind::SetSideTables -> set_header_moved_for_gc (set.rs:352), the JSValueKey inner keys are rebuilt post-rewrite by GcRewriteHookKind::SetIndex -> rebuild_set_index_for_gc (set.rs:315, fired from gc/copying.rs:669/798, gc/barrier/mod.rs:195, gc/verify.rs:114), and finalize_set_side_allocation_for_gc (set.rs:374) prunes dead owners — the same three-hook design as MAP_INDEX."
+  },
+  {
+   "file": "crates/perry-ext-exponential-backoff/src/lib.rs",
+   "name": "NEXT_ID",
+   "verdict": "not_a_gc_pointer",
+   "why": "Monotonic backoff-state id counter (lib.rs:378). The closures live in STATES (BackoffState.task/outer/retry_cb), which scan_backoff_roots visits."
+  },
+  {
+   "file": "crates/perry-ext-fetch/src/lib.rs",
+   "name": "REQUEST_HANDLES",
+   "verdict": "covered_elsewhere",
+   "scanner": "gc::scan_fetch_roots (crates/perry-ext-fetch/src/gc.rs), registered via perry_ffi::gc_register_mutable_root_scanner_named from gc::ensure_gc_scanner_registered, armed at store_request before the first insert",
+   "why": "Declared in lib.rs, scanned from the gc.rs submodule (split out for the 2,000-line gate): every RequestRecord.signal slot is visited and rewritten."
+  }
+ ],
+ "_FRONTIER_README": "Identity-pinned ratchet over the perry-ui* crates (see the census docstring, 'The frontier tier'). Each entry is a static/thread_local that CAN hold a NaN-boxed JS callback and that no registered scanner reaches. These are not verdicts: most of these tables really do park user closures (BUTTON_CALLBACKS et al) and registering per-crate scanners is the fix. The list may only shrink: a new UI holder fails lint until pinned deliberately, and a fixed (covered) holder fails until its entry is deleted. Covered frontier holders must NOT be pinned.",
+ "frontier": [
+  {
+   "file": "crates/perry-ui-android/src/app.rs",
+   "name": "ON_ACTIVATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-android/src/app.rs",
+   "name": "ON_TERMINATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-android/src/app.rs",
+   "name": "PENDING_CONFIG"
+  },
+  {
+   "file": "crates/perry-ui-android/src/callback.rs",
+   "name": "CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/callback.rs",
+   "name": "NEXT_KEY"
+  },
+  {
+   "file": "crates/perry-ui-android/src/drag_drop.rs",
+   "name": "DRAG_KEYS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/menu.rs",
+   "name": "CONTEXT_MENUS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/menu.rs",
+   "name": "MENUS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/pointer.rs",
+   "name": "KEYS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/sheet.rs",
+   "name": "SHEETS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "ON_CHANGE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/system.rs",
+   "name": "NOTIFICATION_REMOTE_TOKEN_KEY"
+  },
+  {
+   "file": "crates/perry-ui-android/src/system.rs",
+   "name": "NOTIFICATION_TAP_KEY"
+  },
+  {
+   "file": "crates/perry-ui-android/src/toolbar.rs",
+   "name": "TOOLBARS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/bloomview.rs",
+   "name": "BLOOM_WINDOWS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/bottom_nav.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGE_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+   "name": "CANVAS_STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/image_gallery.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/lazyvstack.rs",
+   "name": "LAZY_STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/navstack.rs",
+   "name": "NAV_STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/picker.rs",
+   "name": "PICKER_STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/scrollview.rs",
+   "name": "REFRESH_LAYOUTS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/tabbar.rs",
+   "name": "TABBAR_STATE"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
+   "name": "TREE_NODES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
+   "name": "TREE_VIEWS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/webview.rs",
+   "name": "EVAL_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-android/src/window.rs",
+   "name": "WINDOWS"
+  },
+  {
+   "file": "crates/perry-ui-android/src/ws.rs",
+   "name": "PENDING_RESOLVES"
+  },
+  {
+   "file": "crates/perry-ui-geisterhand/src/chaos.rs",
+   "name": "EVENTS_FIRED"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "APPS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "ON_ACTIVATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "ON_TERMINATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "PENDING_SHORTCUTS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "SHORTCUT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/app.rs",
+   "name": "TIMER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/audio.rs",
+   "name": "AUDIO_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/camera.rs",
+   "name": "CAMERA_VIEWS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
+   "name": "DRAG_FILE"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
+   "name": "DRAG_TEXT"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
+   "name": "DRAG_URL"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
+   "name": "DROP_CB"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs",
+   "name": "RESIZE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/media_playback.rs",
+   "name": "CMD_RX"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/media_playback.rs",
+   "name": "CMD_TX"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/menu.rs",
+   "name": "MENUBARS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/menu.rs",
+   "name": "MENUS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/menu.rs",
+   "name": "MENU_ITEM_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "ON_CHANGE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/toolbar.rs",
+   "name": "TOOLBAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/tray.rs",
+   "name": "TRAYS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/bottom_nav.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/button.rs",
+   "name": "BUTTON_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+   "name": "CANVAS_COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+   "name": "CANVAS_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/chart.rs",
+   "name": "CHARTS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/command_palette.rs",
+   "name": "STATE"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/image_gallery.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/lazyvstack.rs",
+   "name": "LAZY_VSTACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/mod.rs",
+   "name": "BORDER_STATE"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/picker.rs",
+   "name": "PICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/rich_tooltip.rs",
+   "name": "BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/scrollview.rs",
+   "name": "SCROLL_END_STATES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/securefield.rs",
+   "name": "SECUREFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/slider.rs",
+   "name": "SLIDER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/text_registry.rs",
+   "name": "TEXT_REGISTRY"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/textarea.rs",
+   "name": "TEXTAREA_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/textfield.rs",
+   "name": "REGISTERED_ENTRIES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/toggle.rs",
+   "name": "TOGGLE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/tree_view.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-gtk4/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/app.rs",
+   "name": "PENDING_CONFIG"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/app.rs",
+   "name": "TIMER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/audio_playback.rs",
+   "name": "BUSES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/audio_playback.rs",
+   "name": "FADES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/audio_playback.rs",
+   "name": "SOUNDS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/audio_playback.rs",
+   "name": "VOICES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/background.rs",
+   "name": "HANDLERS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/background.rs",
+   "name": "REGISTERED_BLOCKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/camera.rs",
+   "name": "TAP_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/deeplinks.rs",
+   "name": "HANDLER"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/drag_drop.rs",
+   "name": "DRAG_FILE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/drag_drop.rs",
+   "name": "DRAG_TEXT"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/drag_drop.rs",
+   "name": "DRAG_URL"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/drag_drop.rs",
+   "name": "DROP_CB"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/geolocation.rs",
+   "name": "PENDING_ONE_SHOTS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/geolocation.rs",
+   "name": "PERMISSION_REQUESTS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/geolocation.rs",
+   "name": "WATCHES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/location.rs",
+   "name": "LOCATION_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/menu.rs",
+   "name": "ACTION_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/menu.rs",
+   "name": "MENUBARS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/menu.rs",
+   "name": "MENUS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/network.rs",
+   "name": "LISTENERS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/network.rs",
+   "name": "MONITOR_BLOCK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "NEXT_COMPLETION_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "ON_BACKGROUND_RECEIVE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "ON_REMOTE_RECEIVE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "ON_REMOTE_TOKEN_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "ON_TAP_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/notifications.rs",
+   "name": "PENDING_COMPLETIONS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/pointer.rs",
+   "name": "INSTALLED"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/pointer.rs",
+   "name": "MOUSE_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/pointer.rs",
+   "name": "MOUSE_MOVE_CB"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/pointer.rs",
+   "name": "MOUSE_UP_CB"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/pointer.rs",
+   "name": "RECOG_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "DEFERRED_REBUILDS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "ON_CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/bottom_nav.rs",
+   "name": "DELEGATE_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/bottom_nav.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/button.rs",
+   "name": "BUTTON_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/button.rs",
+   "name": "TAP_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/calendar.rs",
+   "name": "CALENDAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+   "name": "CANVAS_COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+   "name": "CANVAS_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/chart.rs",
+   "name": "CHARTS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/combobox.rs",
+   "name": "COMBOBOX_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/date_picker.rs",
+   "name": "DATEPICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/image_gallery.rs",
+   "name": "DELEGATE_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/image_gallery.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/mod.rs",
+   "name": "DOUBLE_CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/navstack.rs",
+   "name": "NAV_STACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/picker.rs",
+   "name": "PICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/picker.rs",
+   "name": "PICKER_SELECTED"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/rich_text.rs",
+   "name": "CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/rich_tooltip.rs",
+   "name": "BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
+   "name": "REFRESH_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
+   "name": "SCROLL_DELEGATE_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
+   "name": "SCROLL_END_STATES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/securefield.rs",
+   "name": "SECUREFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/slider.rs",
+   "name": "SLIDER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/tabbar.rs",
+   "name": "DELEGATE_MAP"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/tabbar.rs",
+   "name": "TABBAR_STATE"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/textarea.rs",
+   "name": "TEXTAREA_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/textfield.rs",
+   "name": "SUBMIT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/toggle.rs",
+   "name": "TOGGLE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/tree_view.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/tree_view.rs",
+   "name": "TREES"
+  },
+  {
+   "file": "crates/perry-ui-ios/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "APPS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "ON_ACTIVATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "ON_TERMINATE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "PENDING_SHORTCUTS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "SHORTCUT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "TIMER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/app.rs",
+   "name": "WINDOW_FOCUS_LOST_CBS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/audio_playback.rs",
+   "name": "BUSES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/audio_playback.rs",
+   "name": "FADES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/audio_playback.rs",
+   "name": "SOUNDS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/audio_playback.rs",
+   "name": "VOICES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/background.rs",
+   "name": "HANDLERS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/background.rs",
+   "name": "REGISTERED_BLOCKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/deeplinks.rs",
+   "name": "HANDLER"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/drag_drop.rs",
+   "name": "DRAG_FILE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/drag_drop.rs",
+   "name": "DRAG_TEXT"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/drag_drop.rs",
+   "name": "DRAG_URL"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/drag_drop.rs",
+   "name": "DROP_CB"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/geolocation.rs",
+   "name": "PENDING_ONE_SHOTS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/geolocation.rs",
+   "name": "PERMISSION_REQUESTS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/geolocation.rs",
+   "name": "WATCHES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/location.rs",
+   "name": "LOCATION_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/menu.rs",
+   "name": "MENU_ITEM_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/network.rs",
+   "name": "LISTENERS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/network.rs",
+   "name": "MONITOR_BLOCK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/notifications.rs",
+   "name": "ON_REMOTE_RECEIVE_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/notifications.rs",
+   "name": "ON_REMOTE_TOKEN_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/notifications.rs",
+   "name": "ON_TAP_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/pointer.rs",
+   "name": "HOVER_CB"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/pointer.rs",
+   "name": "MOUSE_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/pointer.rs",
+   "name": "MOUSE_MOVE_CB"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/pointer.rs",
+   "name": "MOUSE_UP_CB"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/pointer.rs",
+   "name": "MOVE_DEDUP"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "ON_CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "TEXTFIELD_TO_BINDING"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/tray.rs",
+   "name": "TRAY_CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/bottom_nav.rs",
+   "name": "BOTTOM_NAVS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/bottom_nav.rs",
+   "name": "TARGET_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/button.rs",
+   "name": "BUTTON_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/calendar.rs",
+   "name": "CALENDAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+   "name": "CANVAS_COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+   "name": "CANVAS_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/chart.rs",
+   "name": "CHARTS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/combobox.rs",
+   "name": "COMBOBOX_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/command_palette.rs",
+   "name": "COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/date_picker.rs",
+   "name": "DATEPICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/image_gallery.rs",
+   "name": "GALLERIES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/image_gallery.rs",
+   "name": "OBSERVER_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
+   "name": "LAZY_VSTACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
+   "name": "SCROLL_END_OBSERVER_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
+   "name": "SCROLL_END_STATES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+   "name": "BG_COLOR_MAP"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+   "name": "CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+   "name": "DOUBLE_CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+   "name": "HOVER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+   "name": "PARENT_MAP"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/navstack.rs",
+   "name": "NAV_STACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/picker.rs",
+   "name": "PICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/rich_text.rs",
+   "name": "CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/rich_tooltip.rs",
+   "name": "BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/scrollview.rs",
+   "name": "SCROLL_END_OBSERVER_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/scrollview.rs",
+   "name": "SCROLL_END_STATES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/securefield.rs",
+   "name": "SECUREFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/slider.rs",
+   "name": "SLIDER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/table.rs",
+   "name": "TABLES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/textarea.rs",
+   "name": "TEXTAREA_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_FOCUS_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_SUBMIT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/toggle.rs",
+   "name": "TOGGLE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/toolbar.rs",
+   "name": "TOOLBARS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/toolbar.rs",
+   "name": "TOOLBAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/tree_view.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/tree_view.rs",
+   "name": "TREES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-macos/src/widgets/zstack.rs",
+   "name": "ZSTACK_HANDLES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/app.rs",
+   "name": "PENDING_CONFIG"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/app.rs",
+   "name": "TIMER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+   "name": "BUSES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+   "name": "FADES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+   "name": "SOUNDS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+   "name": "VOICES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/background.rs",
+   "name": "HANDLERS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/background.rs",
+   "name": "REGISTERED_BLOCKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/location.rs",
+   "name": "LOCATION_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/menu.rs",
+   "name": "ACTION_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/menu.rs",
+   "name": "MENUBARS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/menu.rs",
+   "name": "MENUS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/pointer.rs",
+   "name": "INSTALLED"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/pointer.rs",
+   "name": "MOUSE_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/pointer.rs",
+   "name": "MOUSE_MOVE_CB"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/pointer.rs",
+   "name": "MOUSE_UP_CB"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/pointer.rs",
+   "name": "RECOG_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "ON_CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/bottom_nav.rs",
+   "name": "DELEGATE_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/bottom_nav.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/button.rs",
+   "name": "BUTTON_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/button.rs",
+   "name": "TAP_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+   "name": "CANVAS_COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+   "name": "CANVAS_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/mod.rs",
+   "name": "DOUBLE_CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/navstack.rs",
+   "name": "NAV_STACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/picker.rs",
+   "name": "PICKER_SELECTED"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/scrollview.rs",
+   "name": "REFRESH_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/securefield.rs",
+   "name": "SECUREFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/slider.rs",
+   "name": "SLIDER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/tabbar.rs",
+   "name": "DELEGATE_MAP"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/tabbar.rs",
+   "name": "TABBAR_STATE"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/textarea.rs",
+   "name": "TEXTAREA_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/textfield.rs",
+   "name": "SUBMIT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-tvos/src/widgets/toggle.rs",
+   "name": "TOGGLE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/app.rs",
+   "name": "PENDING_CONFIG"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/app.rs",
+   "name": "TIMER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+   "name": "BUSES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+   "name": "FADES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+   "name": "SOUNDS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+   "name": "VOICES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/background.rs",
+   "name": "HANDLERS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/background.rs",
+   "name": "REGISTERED_BLOCKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/camera.rs",
+   "name": "TAP_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/drag_drop.rs",
+   "name": "DRAG_FILE"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/drag_drop.rs",
+   "name": "DRAG_TEXT"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/drag_drop.rs",
+   "name": "DRAG_URL"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/drag_drop.rs",
+   "name": "DROP_CB"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/location.rs",
+   "name": "LOCATION_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/menu.rs",
+   "name": "ACTION_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/menu.rs",
+   "name": "MENUBARS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/menu.rs",
+   "name": "MENUS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/pointer.rs",
+   "name": "INSTALLED"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/pointer.rs",
+   "name": "MOUSE_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/pointer.rs",
+   "name": "MOUSE_MOVE_CB"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/pointer.rs",
+   "name": "MOUSE_UP_CB"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/pointer.rs",
+   "name": "RECOG_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "ON_CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/bottom_nav.rs",
+   "name": "DELEGATE_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/bottom_nav.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/button.rs",
+   "name": "BUTTON_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/button.rs",
+   "name": "TAP_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/calendar.rs",
+   "name": "CALENDAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+   "name": "CANVAS_COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+   "name": "CANVAS_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+   "name": "IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/chart.rs",
+   "name": "CHARTS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/combobox.rs",
+   "name": "COMBOBOX_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/date_picker.rs",
+   "name": "DATEPICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/mod.rs",
+   "name": "DOUBLE_CLICK_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/navstack.rs",
+   "name": "NAV_STACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/picker.rs",
+   "name": "PICKER_SELECTED"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/rich_text.rs",
+   "name": "CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/rich_tooltip.rs",
+   "name": "BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/scrollview.rs",
+   "name": "REFRESH_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/securefield.rs",
+   "name": "SECUREFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/slider.rs",
+   "name": "SLIDER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/tabbar.rs",
+   "name": "DELEGATE_MAP"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/tabbar.rs",
+   "name": "TABBAR_STATE"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/textarea.rs",
+   "name": "TEXTAREA_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/textfield.rs",
+   "name": "SUBMIT_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/textfield.rs",
+   "name": "TEXTFIELD_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/tree_view.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/tree_view.rs",
+   "name": "TREES"
+  },
+  {
+   "file": "crates/perry-ui-visionos/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+   "name": "BUSES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+   "name": "FADES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+   "name": "SOUNDS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+   "name": "VOICES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/background.rs",
+   "name": "HANDLERS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/notifications.rs",
+   "name": "ON_TAP_CALLBACK"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "ON_CHANGE_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/tree.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-watchos/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/app.rs",
+   "name": "APPS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/app.rs",
+   "name": "PENDING_SHORTCUTS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/drag_drop.rs",
+   "name": "DRAG_FILE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/drag_drop.rs",
+   "name": "DRAG_TEXT"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/drag_drop.rs",
+   "name": "DRAG_URL"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/drag_drop.rs",
+   "name": "DROP_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/media_playback.rs",
+   "name": "PLAYERS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/media_playback.rs",
+   "name": "Q"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/menu.rs",
+   "name": "CONTEXT_MENU_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/pointer.rs",
+   "name": "CLICK_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/pointer.rs",
+   "name": "HOVER_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/pointer.rs",
+   "name": "MOUSE_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/pointer.rs",
+   "name": "MOUSE_MOVE_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/pointer.rs",
+   "name": "MOUSE_UP_CB"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "FOR_EACH_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "MULTI_TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "SLIDER_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "STATES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "TEXTFIELD_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "TEXT_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "TOGGLE_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/state.rs",
+   "name": "VISIBILITY_BINDINGS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/toolbar.rs",
+   "name": "TOOLBARS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/tray.rs",
+   "name": "TRAYS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/bottom_nav.rs",
+   "name": "ITEM_LOOKUP"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/bottom_nav.rs",
+   "name": "NAVS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/button.rs",
+   "name": "BTN_HWND_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/button.rs",
+   "name": "BUTTON_CONTENT"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/calendar.rs",
+   "name": "CALENDAR_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+   "name": "CANVAS_CMDS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGE_CACHE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+   "name": "CANVAS_IMAGE_SIZES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+   "name": "CANVAS_LAST_FRAME"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/chart.rs",
+   "name": "CHARTS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/combobox.rs",
+   "name": "CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/command_palette.rs",
+   "name": "COMMANDS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/date_picker.rs",
+   "name": "DATEPICKER_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/image_gallery.rs",
+   "name": "GALLERIES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/lazyvstack.rs",
+   "name": "LAZYVSTACK_STATES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/map_view.rs",
+   "name": "MAPS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "BORDER_STATE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "BORDER_SUBCLASSED"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "CORNER_RADII"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "HWND_MAP"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "OPACITY_VALUES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "PARENT_SHADOW_REGISTRY"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "SHADOW_PARAMS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+   "name": "WIDGETS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/navstack.rs",
+   "name": "NAV_STACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/pdf_view.rs",
+   "name": "PDFS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/rich_text.rs",
+   "name": "CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/rich_tooltip.rs",
+   "name": "TOOLTIPS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/scrollview.rs",
+   "name": "SCROLL_END_STATES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/scrollview.rs",
+   "name": "SCROLL_STATES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/slider.rs",
+   "name": "SLIDER_INFO"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/table.rs",
+   "name": "TABLES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/text.rs",
+   "name": "DECORATION_VALUES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/text.rs",
+   "name": "HWND_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/text_registry.rs",
+   "name": "TEXT_IDS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/tree_view.rs",
+   "name": "CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/tree_view.rs",
+   "name": "NODES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/webview.rs",
+   "name": "HWND_TO_HANDLE"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/widgets/webview.rs",
+   "name": "WEBVIEW_STATES"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/window.rs",
+   "name": "FOCUS_LOST_CALLBACKS"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/window.rs",
+   "name": "HWND_TO_WINDOW"
+  },
+  {
+   "file": "crates/perry-ui-windows/src/window.rs",
+   "name": "WINDOW_ROOTS"
+  },
+  {
+   "file": "crates/perry-ui/src/key_dispatch.rs",
+   "name": "KEY_DOWN_CB"
+  },
+  {
+   "file": "crates/perry-ui/src/key_dispatch.rs",
+   "name": "KEY_UP_CB"
+  }
+ ]
 }

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Runtime-side GC-pointer holder custody gate (#7231).
+"""Runtime-side GC-pointer holder custody gate (#7231; ffi/ext/ui coverage 2026-08).
 
-A `thread_local!` or `static` in `perry-runtime` / `perry-stdlib` that stores a
-pointer into the GC heap **is a GC root**, and the collector only knows that if
-something registers it via `gc_register_*root_scanner*`. An unregistered holder
-is not an intermittent bug: it goes bad at collection #0 and stays bad, so the
-symptom is a *perfectly reproducible* use-after-free — the opposite tell from
-the #7154 stale-register class.
+A `thread_local!` or `static` that stores a pointer into the GC heap **is a GC
+root**, and the collector only knows that if something registers it via
+`gc_register_*root_scanner*`. An unregistered holder is not an intermittent
+bug: it goes bad at collection #0 and stays bad, so the symptom is a
+*perfectly reproducible* use-after-free — the opposite tell from the #7154
+stale-register class.
 
 Nothing static could find this class before. `scripts/gc_root_dominance_check.py`
 reads emitted LLVM IR, and a runtime table is not in it — that is not a gap in
@@ -14,19 +14,52 @@ that tool, it is outside its subject. #7226, #7239, #7268 and #7274 were all
 found by hand. This script is the enumeration those fixes kept re-deriving,
 turned into something that can fail.
 
+That asymmetry is also why the CRATE SET below must be complete. The static
+checker is structurally blind to every Rust-side table, in every crate, so
+this census is the ONLY detector for the whole class — and a crate outside
+its scope is not "less checked", it is UNCHECKED. The `perry-ext-*` crates
+park user closures in handle side tables (a `WsClientListeners.listeners`
+value, a `BackoffState.task`); those closures cross the C ABI as NaN-boxed
+`i64`/`f64`, so nothing in their declared types says "heap pointer" — which
+is exactly how this census reported clean over them for months: its two
+original rules could not parse the shape, and its crate list did not include
+the crates. A gate whose subject never ran. If you widen the crate set again,
+extend the RULES to the new crates' value-representation first, or you are
+adding green paint, not coverage.
+
 What it does
 ------------
 
-1. **Enumerate** every `static` / `thread_local!` declaration in the two crates
-   whose stored type can hold a GC heap pointer (rule A: the type names a heap
-   header type or `JSValue`; rule B: the type is an integer/`f64` cell that
-   some function in its own file both names and allocates in, which is how
-   `CACHED_ENV: Cell<f64>` — the highest-impact holder in #7231's original
-   report — has to be caught).
+1. **Enumerate** every `static` / `thread_local!` / `lazy_static!` declaration
+   whose stored type can hold a GC heap pointer. Three crate tiers:
+
+   * **core** (`perry-runtime`, `perry-stdlib`): rule A (the type names a heap
+     header type or `JSValue`) and rule B (an integer/`f64` cell that some
+     function in its own file both names and allocates in, which is how
+     `CACHED_ENV: Cell<f64>` — the highest-impact holder in #7231's original
+     report — has to be caught).
+   * **ffi-side, gated** (`perry-ffi`, every `crates/perry-ext-*` — discovered
+     by GLOB, so a new ext crate is in scope the day it is created): JS values
+     cross the C ABI as NaN-boxed `i64`/`f64`, so the rules read the TYPE
+     SHAPE instead of type names — rule V (an `i64`/`u64`/`f64` in a container
+     VALUE position: `Vec<i64>` listener lists, `HashMap<K, f64>` callback
+     maps; map KEYS are exempt, they are handle ids), rule S (a container of a
+     crate-local struct/enum whose fields can hold such a value —
+     `HashMap<u64, BackoffState>` where `BackoffState.task` is NaN-box bits;
+     resolved recursively through crate-local types), rule E (a type-erased
+     `dyn` payload in value position — `DashMap<Handle, Box<dyn Any>>` can
+     hold anything, including a struct full of closures), and rule F (a BARE
+     integer/`f64` scalar in a file where some function both names it and
+     touches closure/NaN-box machinery). Declarations inside function bodies
+     (`static T: OnceLock<..> = ..` in an accessor fn) and `lazy_static!`'s
+     `static ref` are parsed; multi-line declarations are joined.
+   * **frontier** (`crates/perry-ui*` — also by glob): same rules, but tracked
+     by an identity-pinned ratchet instead of per-holder verdicts. See
+     "The frontier tier" below.
 
 2. **Compute coverage** rather than trusting names. The registered scanner set
    is read from every `gc_register_*root_scanner*(...)` call site; a call graph
-   over all `fn` bodies in both crates is walked from those roots to
+   over all `fn` bodies in every scanned crate is walked from those roots to
    `MAX_SCANNER_DEPTH`, and a holder counts as covered when its identifier
    appears in a reachable function **defined in the same file as the
    declaration**. The same-file requirement is not incidental: `REGISTRY`,
@@ -36,19 +69,47 @@ What it does
    an accessor (`cp_live_lock()`, `get_closure_props()`, `buffer_props()`)
    rather than by name.
 
-3. **Require a verdict** for everything left over. Each uncovered holder must
-   appear in `scripts/gc_runtime_root_holders.json` with a `verdict` and a
+3. **Require a verdict** for everything left over. Each uncovered gated holder
+   must appear in `scripts/gc_runtime_root_holders.json` with a `verdict` and a
    `why`. A holder with no entry fails; an entry that matches no holder fails
    (a stale exemption is how these gates rot — same rule as
    `scripts/gc_root_dominance_allowlist.json`).
 
+The frontier tier
+-----------------
+
+The `perry-ui*` crates hold hundreds of NaN-boxed callback tables
+(`BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>>` × every widget × eight
+platform crates), none of them registered with the GC. Several of those crates
+cannot even be BUILT on the host that runs this gate (windows/android/gtk4),
+so "fix them all in the commit that widens the census" would mean shipping
+unverifiable edits — the exact sin this repo's gate history warns about. The
+honest alternative is neither exempting them (a `not_a_gc_pointer` verdict for
+a real callback table would be a lie) nor ignoring them (the blind spot this
+extension closes):
+
+* every frontier holder is ENUMERATED by the same rules,
+* the population is pinned BY IDENTITY (`file` + `name`) in the inventory's
+  `frontier` list,
+* a NEW frontier holder fails this gate immediately — growth is loud, the
+  original blind spot cannot re-open,
+* a frontier entry matching nothing also fails — the list can only shrink,
+  and fixing a holder (registering a scanner that reaches it) forces its
+  entry to be deleted.
+
+A frontier entry is a precisely-named piece of debt, not a verdict. When a UI
+crate gains real scanner coverage, its holders read as covered, their entries
+go stale, and the deletion is the receipt.
+
 How it fails
 ------------
 
-* a new uncovered holder with no inventory entry -> exit 1
+* a new uncovered gated holder with no inventory entry -> exit 1
 * an inventory entry that no longer matches a declaration -> exit 1
 * an `open_gap` or `unverified` verdict -> exit 1; old-page relocation ships
   enabled, so a known or unevaluated movable-address holder cannot be exempted
+* a frontier holder not in the pinned `frontier` list -> exit 1 (ratchet up)
+* a `frontier` entry matching no holder -> exit 1 (ratchet down / stale)
 * fewer than MIN_HOLDERS declarations matched -> exit 2, because a regex that
   stopped matching would otherwise report a clean, empty, green run
 * fewer than MIN_REGISTERED registered scanners found -> exit 2, same reason:
@@ -74,10 +135,16 @@ Named, because an unstated limit is how a gate gets trusted past its subject.
   `scan_exotic_expando_roots_mut`. A new field added there is invisible here.
   `STATE_FIELD_FLOOR` below asserts the struct has not grown past the field
   count this was checked at, so growth is at least *loud*.
-* **An integer-typed holder whose own file never calls an allocator.** Rule B
-  needs a function that both names the holder and allocates; a cell written
-  purely from a value handed in across a module boundary has neither, and is
-  invisible.
+* **An integer-typed holder whose own file never calls an allocator, in a CORE
+  crate.** Rule B needs a function that both names the holder and allocates; a
+  cell written purely from a value handed in across a module boundary has
+  neither, and is invisible. The ffi-side shape rules (V/S/E/F) close exactly
+  this hole for the ffi/ext/ui crates — where it is the NORM, every value
+  arrives across the ABI — but they are deliberately NOT applied to
+  `perry-runtime`/`perry-stdlib`: measured 2026-08, they would add ~150 new
+  core candidates, each needing a researched verdict, which is a separate
+  tightening campaign. Until someone runs it, a core `Mutex<Vec<i64>>` table
+  in a non-allocating file is still invisible here.
 * **A holder reached by a scanner in a DIFFERENT file.** It reads as uncovered
   and needs an inventory entry saying so; `verdict: "covered_elsewhere"` is that
   entry, and it records which scanner.
@@ -88,13 +155,6 @@ Named, because an unstated limit is how a gate gets trusted past its subject.
   holders. Deeper hops are matched on the bare name, because nothing in the text
   says which module a call resolved to; that direction over-approximates
   coverage, and an inventory entry is the correction.
-* **Anything outside `perry-runtime` / `perry-stdlib`.** The `perry-ext-*`
-  crates park user closures in handle-struct FIELDS (`ServerResponse.listeners`
-  / `once_listeners`, `IncomingMessage.signal`, ...) and register their scanners
-  by hand through `perry_ffi`; nothing here checks that a scanner reaches every
-  such field. #8163's second holder was exactly that — ext-http scanned
-  `listeners` and never `once_listeners`. That is a struct-field census over
-  registered handle types, a different instrument from this declaration scan.
 * **Whether a "covered" holder is covered CORRECTLY.** The scanner may visit
   three of a table's four slots — the shape #7239 found in
   `scan_parent_port_event_roots_mut`. Reading the body is the only way, and this
@@ -113,7 +173,27 @@ from pathlib import Path, PurePath, PureWindowsPath
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INVENTORY_PATH = REPO_ROOT / "scripts" / "gc_runtime_root_holders.json"
 
-CRATES = ("crates/perry-runtime/src", "crates/perry-stdlib/src")
+# Crate tiers. Core keeps the original name-and-allocator rules; ffi-side
+# crates get the shape rules (their JS values are NaN-boxed integers); ui
+# crates are enumerated but ratcheted rather than verdict-gated (docstring:
+# "The frontier tier"). ffi/ext/ui membership is discovered by GLOB so that a
+# new crate is inside the census the day it is created — the original
+# whole-crate blind spot must not be reproducible by `cargo new`.
+CORE_CRATES = ("crates/perry-runtime/src", "crates/perry-stdlib/src")
+
+
+def gated_ffi_crates(root: Path) -> tuple[str, ...]:
+    found = ["crates/perry-ffi/src"]
+    for crate_dir in sorted((root / "crates").glob("perry-ext-*")):
+        found.append(f"crates/{crate_dir.name}/src")
+    return tuple(c for c in found if (root / c).is_dir())
+
+
+def frontier_ui_crates(root: Path) -> tuple[str, ...]:
+    found = []
+    for crate_dir in sorted((root / "crates").glob("perry-ui*")):
+        found.append(f"crates/{crate_dir.name}/src")
+    return tuple(c for c in found if (root / c).is_dir())
 
 
 def repo_relative(path: PurePath, root: PurePath) -> str:
@@ -135,6 +215,56 @@ HEAP_TYPE_TOKENS = (
 # `CACHED_ENV: Cell<f64>` (#7231's headline holder) has exactly this shape, and
 # so do `ERROR_CONSTRUCTOR_PTR: Cell<usize>` and `INPUT_HANDLER: AtomicI64`.
 INT_TYPE_TOKENS = ("f64", "usize", "u64", "i64", "AtomicI64", "AtomicUsize", "AtomicU64")
+
+# ffi-side rule A adds the perry-ffi spellings. `Promise` is here because a
+# `*mut Promise` parked in a pending-event struct is a movable GC object
+# (ext-events' `pending_once_promises` really does this, and really scans it).
+FFI_HEAP_TYPE_TOKENS = HEAP_TYPE_TOKENS + ("JsValue", "JsClosure", "Promise")
+
+# Rule V/S value primitives: what a NaN-boxed JS value (or raw ClosureHeader
+# address) is stored AS on the ffi side of the C ABI. `usize` is deliberately
+# absent — in the ffi/ui crates it is an ObjC object address, a slab index or
+# a map key, and including it triples the population with zero known true
+# positives (measured 2026-08).
+FFI_VALUE_PRIMITIVES = frozenset({"f64", "i64", "u64"})
+
+# Containers whose FIRST generic argument is a KEY (exempt from rule V: keys
+# are handle ids / addresses, not owned JS values).
+KEYED_CONTAINERS = frozenset({"HashMap", "BTreeMap", "DashMap", "IndexMap", "PtrHashMap", "StdHashMap", "FxHashMap"})
+
+# Transparent wrappers/containers whose arguments are all VALUE positions.
+WALK_CONTAINERS = frozenset(
+    {
+        "Vec", "VecDeque", "HashSet", "BTreeSet", "LinkedList", "BinaryHeap",
+        "Slab", "SmallVec", "Option", "Box", "Arc", "Rc", "Weak",
+        "RefCell", "Cell", "UnsafeCell", "SyncUnsafeCell", "MaybeUninit", "ManuallyDrop",
+        "Mutex", "RwLock", "StdMutex", "OnceLock", "OnceCell", "LazyLock", "Lazy",
+        "AtomicRefCell",
+    }
+)
+
+# Collection names whose presence distinguishes rule V (a table OF values)
+# from rule F (a bare scalar cell, which needs closure-machinery context).
+COLLECTION_NAMES = frozenset(
+    {
+        "Vec", "VecDeque", "HashSet", "BTreeSet", "LinkedList", "BinaryHeap",
+        "Slab", "SmallVec", "HashMap", "BTreeMap", "DashMap", "IndexMap",
+        "PtrHashMap", "StdHashMap", "FxHashMap",
+    }
+)
+
+# Rule F's qualifier, at function granularity like rule B's: some function in
+# the declaring file both names the bare-scalar holder and visibly handles
+# closures / NaN-boxed values. Chosen narrow: `from_bits`/`to_bits` alone
+# would match every bit-fiddling counter in the tree.
+FFI_CLOSURE_CONTEXT_TOKENS = (
+    "Closure",
+    "closure",
+    "nanbox",
+    "visit_i64_slot",
+    "visit_nanbox_f64_slot",
+    "JsValue",
+)
 
 # A function POINTER is not data — `KEEP_*` dead-strip anchors and vtable slots
 # hold code addresses, which the collector neither moves nor traces.
@@ -169,38 +299,37 @@ ALLOCATOR_TOKENS = (
 # holder reached only from `gc_init` reads as uncovered — which is exactly what
 # happened when they were introduced, and the MIN_REGISTERED floor below is
 # what caught it.
-#
-# The argument list may itself contain ONE level of calls — the provider-safe
-# C-ABI registration `perry_ffi_gc_register_mutable_root_scanner_named(
-# SOURCE.as_ptr(), SOURCE.len(), 0, scan_stream_roots_ffi)` (`streams/gc.rs`,
-# `fetch/gc.rs`) is the shape. A `[^;()]*` argument body stopped at the first
-# `(` of `as_ptr(` and dropped the scanner name, so every FFI-registered
-# stdlib scanner was invisible to the walk and its tables read as uncovered
-# (#8163 exposed this the moment `lazy_static!` tables entered the census).
+# The argument text may contain one level of nested calls:
+# `perry_ffi_gc_register_mutable_root_scanner_named(SOURCE.as_ptr(),
+# SOURCE.len(), 0, scan_events_roots_trampoline)` is the dependency-free
+# C-ABI registration the ext crates use, and a `[^()]*` argument body
+# silently missed it — every holder that trampoline covers then read as
+# uncovered.
 REGISTER_CALL = re.compile(
     r"(?:gc_register_\w*root_scanner\w*|reg_scanner!|reg_budgeted_scanner!)"
-    r"\s*\((?P<args>(?:[^;()]|\([^;()]*\))*)\)",
+    r"\s*\((?P<args>(?:[^;()]|\([^()]*\))*)\)",
     re.S,
 )
-# `strip_comments` blanks string literals before this runs, so `extern "C" fn`
-# reaches the matcher as `extern "" fn` — the ABI string must be matched as
-# ANY (possibly empty) literal, or no `extern "C"` function in either crate has
-# a body in the walk. That is what kept the C-ABI scanner trampolines
-# (`scan_stream_roots_ffi`, `scan_fetch_roots_ffi`) unreachable (#8163).
+# `function_bodies` runs over strip_comments output, where every string
+# literal — including the `"C"` in `extern "C" fn` — has been replaced with
+# `""`. The original `extern\s+"C"` alternative therefore never matched, and
+# every `extern "C" fn` body (each C-ABI scanner TRAMPOLINE) was invisible to
+# the call graph: coverage that flowed through one silently read as
+# uncovered. Accept the stripped form.
 FN_DEF = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|extern\s+\"[^\"]*\"\s+)*fn\s+(\w+)"
 )
 IDENT = re.compile(r"\b[A-Za-z_]\w*\b")
 
 # A declaration: `static NAME: TYPE =` — covers `pub(crate) static`, the bodies
-# of `thread_local!` blocks (which use the same syntax), `static NAME:
-# Lazy<...>`, and — since #8163 — `lazy_static!`'s `static ref NAME: TYPE =`.
-# The `ref` keyword was invisible to the first version of this regex, which
-# left every `lazy_static!` table in both crates out of the census; that is
-# how `HEADERS_METHOD_VALUE_CACHE` (a `Mutex<HashMap<_, u64>>` of NaN-boxed
-# closure pointers) went unaudited and unrooted, and became #8163's holder.
+# of `thread_local!` blocks (which use the same syntax), `lazy_static!`'s
+# `static ref NAME:`, `static mut`, function-body statics (`static T:
+# OnceLock<..>` inside an accessor fn — the dominant ext-crate shape), and
+# `static NAME: Lazy<...>`. The `=` may be on a later line; `declarations`
+# joins continuation lines, so the type is NOT captured here.
 DECL = re.compile(
-    r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?static\s+(?:ref\s+)?(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*(?P<type>[^=]+?)\s*="
+    r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?static\s+(?:ref\s+)?(?:mut\s+)?"
+    r"(?P<name>[A-Z][A-Z0-9_]*)\s*:\s*(?P<type>.*)$"
 )
 
 MAX_SCANNER_DEPTH = 3
@@ -216,9 +345,9 @@ STATE_STRUCT = "struct RuntimeState"
 STATE_FIELD_FLOOR = 5
 
 
-def source_files(root: Path) -> list[Path]:
+def crate_source_files(root: Path, crates: tuple[str, ...]) -> list[Path]:
     files: list[Path] = []
-    for crate in CRATES:
+    for crate in crates:
         base = root / crate
         if not base.is_dir():
             continue
@@ -234,6 +363,18 @@ def source_files(root: Path) -> list[Path]:
                 continue
             files.append(path)
     return files
+
+
+def tiered_source_files(root: Path) -> list[tuple[Path, str]]:
+    """Every scanned file with its tier: core / ffi / frontier."""
+    out: list[tuple[Path, str]] = []
+    for path in crate_source_files(root, CORE_CRATES):
+        out.append((path, "core"))
+    for path in crate_source_files(root, gated_ffi_crates(root)):
+        out.append((path, "ffi"))
+    for path in crate_source_files(root, frontier_ui_crates(root)):
+        out.append((path, "frontier"))
+    return out
 
 
 STRING_LITERAL = re.compile(r'"(?:[^"\\\n]|\\.)*"')
@@ -283,11 +424,12 @@ def function_bodies(text: str) -> dict[str, str]:
         while index < len(lines):
             line = lines[index]
             # A body-less declaration — `fn f(...);` inside an `extern "C" {}`
-            # block or a trait — has no body to count. Before this check the
-            # counter ran on into the NEXT item's braces and swallowed every
-            # function up to wherever the depth happened to balance; in
-            # `streams/gc.rs` and `fetch/gc.rs` that hid the FFI-registered
-            # scanner entry point itself, so the walk never started (#8163).
+            # block or a trait — has no body to count. Before this check
+            # (#8211) the counter ran on into the NEXT item's braces and
+            # swallowed every function up to wherever the depth happened to
+            # balance; in `streams/gc.rs` and `fetch/gc.rs` that hid the
+            # FFI-registered scanner entry point itself, so the walk never
+            # started.
             if not started and line.rstrip().endswith(";") and "{" not in line:
                 declaration_only = True
                 index += 1
@@ -306,19 +448,61 @@ def function_bodies(text: str) -> dict[str, str]:
     return bodies
 
 
+MAX_DECL_CONTINUATION_LINES = 6
+
+
+def _top_level_eq(text: str) -> int:
+    """Index of the first `=` outside any `<...>` nesting, or -1."""
+    depth = 0
+    for index, char in enumerate(text):
+        prev = text[index - 1] if index else ""
+        if char == "<":
+            depth += 1
+        elif char == ">" and prev != "-":  # `->` in a fn-pointer type is not a close
+            depth -= 1
+        elif char == "=" and depth == 0 and prev not in "<>=!":
+            return index
+    return -1
+
+
 def declarations(rel: str, text: str) -> list[tuple[str, int, str]]:
-    """(name, line, type) for every static-shaped declaration in the file."""
+    """(name, line, type) for every static-shaped declaration in the file.
+
+    The type may continue past the declaration line (`static DEFERRED:\n
+    RefCell<VecDeque<(Handle, FastifyPendingRequest)>> =` is real code);
+    continuation lines are joined until the initializer's `=` appears at
+    generic-depth 0. A declaration with no `=` within the join window (an
+    `extern` block static, defined and therefore scanned in its home crate)
+    is skipped, matching the original single-line behavior.
+    """
     out: list[tuple[str, int, str]] = []
-    for lineno, line in enumerate(strip_comments(text).splitlines(), start=1):
-        match = DECL.match(line)
+    lines = strip_comments(text).splitlines()
+    index = 0
+    while index < len(lines):
+        match = DECL.match(lines[index])
         if not match:
+            index += 1
             continue
-        out.append((match.group("name"), lineno, " ".join(match.group("type").split())))
+        first_line = index + 1  # 1-based
+        joined = match.group("type")
+        stop = index
+        while (
+            _top_level_eq(joined) < 0
+            and stop + 1 < len(lines)
+            and stop - index < MAX_DECL_CONTINUATION_LINES
+        ):
+            stop += 1
+            joined += " " + lines[stop].strip()
+        cut = _top_level_eq(joined)
+        index = stop + 1
+        if cut < 0:
+            continue
+        out.append((match.group("name"), first_line, " ".join(joined[:cut].split())))
     return out
 
 
 def holder_is_candidate(name: str, type_text: str, allocating_context: str) -> str | None:
-    """Return the rule that makes this a candidate, or None.
+    """Return the rule that makes this a candidate, or None (CORE crates).
 
     `allocating_context` is the concatenated text of every function in the
     declaring file that calls a GC allocator.
@@ -334,14 +518,265 @@ def holder_is_candidate(name: str, type_text: str, allocating_context: str) -> s
     return None
 
 
+# --- ffi-side type-shape rules --------------------------------------------
+
+
+def _split_generic_args(text: str) -> list[str]:
+    args: list[str] = []
+    depth = 0
+    current = ""
+    for char in text:
+        if char in "<(":
+            depth += 1
+        elif char in ">)":
+            depth -= 1
+        if char == "," and depth == 0:
+            args.append(current.strip())
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        args.append(current.strip())
+    return args
+
+
+_OUTER_GENERIC = re.compile(r"^(?:[\w:]*::)?(\w+)\s*<(.*)>$", re.S)
+_BARE_NAME = re.compile(r"^(?:[\w:]*::)?(\w+)$")
+
+
+def _outer_type(type_text: str) -> tuple[str, str | None]:
+    """('Vec', 'i64') for `Vec<i64>`, ('tuple', inner) for `(A, B)`, else (text, None)."""
+    text = type_text.strip().rstrip(";").strip()
+    while text.startswith("&"):
+        text = text.lstrip("&").replace("'static", "", 1).strip()
+    if text.startswith("(") and text.endswith(")"):
+        return ("tuple", text[1:-1])
+    match = _OUTER_GENERIC.match(text)
+    if match:
+        return (match.group(1), match.group(2))
+    match = _BARE_NAME.match(text)
+    if match:
+        return (match.group(1), None)
+    return (text, None)
+
+
+def value_position_leaves(type_text: str, key_position: bool = False):
+    """Yield (leaf_name, in_key_position) over a type's shape.
+
+    Map KEYS are marked so rule V can exempt them: a `HashMap<i64, _>` key is
+    a handle id, while a `Vec<i64>` ELEMENT is (in the ffi crates) very often
+    a parked closure. Unknown generic wrappers contribute their own name as a
+    leaf AND have their arguments walked as values — erring toward candidacy,
+    which the inventory can correct; the reverse error is silent.
+    """
+    name, args = _outer_type(type_text)
+    if name == "tuple":
+        for arg in _split_generic_args(args or ""):
+            yield from value_position_leaves(arg, key_position)
+        return
+    # An atomic integer cell IS its integer: `AtomicI64` parks NaN-box bits
+    # exactly like a `Cell<i64>` (INPUT_HANDLER was the runtime's precedent).
+    name = {"AtomicI64": "i64", "AtomicU64": "u64", "AtomicUsize": "usize"}.get(name, name)
+    if args is None:
+        yield (name, key_position)
+        return
+    arg_list = _split_generic_args(args)
+    if name in KEYED_CONTAINERS:
+        if arg_list:
+            yield from value_position_leaves(arg_list[0], True)
+        for arg in arg_list[1:]:
+            yield from value_position_leaves(arg, key_position)
+        return
+    if name in WALK_CONTAINERS:
+        for arg in arg_list:
+            yield from value_position_leaves(arg, key_position)
+        return
+    yield (name, key_position)
+    for arg in arg_list:
+        yield from value_position_leaves(arg, key_position)
+
+
+STRUCT_OR_ENUM_DEF = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:struct|enum)\s+(\w+)")
+_FIELD_PIECE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:r#)?\w+\s*:\s*(.+)$", re.S)
+_VARIANT_PIECE = re.compile(r"^\s*(?:r#)?\w+\s*\((.*)\)\s*$", re.S)
+MAX_STRUCT_RESOLUTION_DEPTH = 3
+
+
+def _split_body_pieces(text: str) -> list[str]:
+    """Split a struct/enum body on top-level commas ({}, <>, () all nest)."""
+    pieces: list[str] = []
+    depth = 0
+    current = ""
+    for char in text:
+        if char in "<({":
+            depth += 1
+        elif char in ">)}":
+            depth -= 1
+        if char == "," and depth == 0:
+            pieces.append(current.strip())
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        pieces.append(current.strip())
+    return pieces
+
+
+def crate_type_index(texts_by_file: list[str]) -> dict[str, list[str]]:
+    """struct/enum name -> the field/variant-argument types it contains.
+
+    Brace-counted over comment-stripped text, like `function_bodies`. Enum
+    tuple variants count (`Retry(u64, i64)` can park a closure exactly like a
+    named field can), and so do single-line bodies (`struct P { cb: i64 }`) —
+    a line-anchored field regex silently dropped those, which un-resolved
+    every type the self-test plants compactly.
+    """
+    index: dict[str, list[str]] = {}
+    for text in texts_by_file:
+        lines = strip_comments(text).splitlines()
+        for start, line in enumerate(lines):
+            match = STRUCT_OR_ENUM_DEF.match(line)
+            if not match:
+                continue
+            depth = 0
+            started = False
+            body: list[str] = []
+            for body_line in lines[start:]:
+                body.append(body_line)
+                depth += body_line.count("{") - body_line.count("}")
+                if "{" in body_line:
+                    started = True
+                if started and depth <= 0:
+                    break
+                if not started and ";" in body_line:
+                    break  # unit or tuple struct `struct X(A, B);`
+            body_text = "\n".join(body)
+            open_brace = body_text.find("{")
+            if open_brace >= 0:
+                inner = body_text[open_brace + 1 : body_text.rfind("}")]
+            else:
+                # tuple struct: `struct X(A, B);`
+                open_paren = body_text.find("(")
+                if open_paren < 0:
+                    continue
+                inner = body_text[open_paren + 1 : body_text.rfind(")")]
+                index.setdefault(match.group(1), []).extend(_split_body_pieces(inner))
+                continue
+            field_types: list[str] = []
+
+            def collect_pieces(chunk: str, depth: int = 0) -> None:
+                for piece in _split_body_pieces(chunk):
+                    if "{" in piece and depth < 2:
+                        # enum STRUCT variant: `ClientClose { callback: i64 }`
+                        # — the exact shape ext-http parks closures in.
+                        collect_pieces(
+                            piece[piece.find("{") + 1 : piece.rfind("}")], depth + 1
+                        )
+                        continue
+                    field = _FIELD_PIECE.match(piece)
+                    if field:
+                        field_types.append(field.group(1).strip())
+                        continue
+                    variant = _VARIANT_PIECE.match(piece)
+                    if variant:
+                        field_types.extend(_split_generic_args(variant.group(1)))
+
+            collect_pieces(inner)
+            index.setdefault(match.group(1), []).extend(field_types)
+    return index
+
+
+def type_can_hold_js_value(
+    type_text: str,
+    type_index: dict[str, list[str]],
+    depth: int = 0,
+    seen: frozenset = frozenset(),
+) -> bool:
+    """Can this type's VALUE positions hold a NaN-boxed JS value / GC address?
+
+    Resolves crate-local struct/enum names recursively (bounded, cycle-safe).
+    """
+    if any(token in type_text for token in FFI_HEAP_TYPE_TOKENS):
+        return True
+    for leaf, key_position in value_position_leaves(type_text):
+        if key_position:
+            continue
+        if leaf in FFI_VALUE_PRIMITIVES:
+            return True
+        if "dyn" in leaf.split():
+            return True
+        if depth < MAX_STRUCT_RESOLUTION_DEPTH and leaf in type_index and leaf not in seen:
+            for field_type in type_index[leaf]:
+                if type_can_hold_js_value(
+                    field_type, type_index, depth + 1, seen | {leaf}
+                ):
+                    return True
+    return False
+
+
+def ffi_holder_is_candidate(
+    name: str,
+    type_text: str,
+    type_index: dict[str, list[str]],
+    closure_context: str,
+) -> str | None:
+    """Return the rule that makes this ffi/ui-crate declaration a candidate.
+
+    `closure_context` is the concatenated text of every function in the
+    declaring file that touches closure/NaN-box machinery (rule F's
+    qualifier).
+    """
+    if FN_POINTER.search(type_text):
+        return None
+    if any(token in type_text for token in FFI_HEAP_TYPE_TOKENS):
+        return "A"
+    leaves = list(value_position_leaves(type_text))
+    has_collection = any(
+        re.search(r"\b%s\s*<" % re.escape(container), type_text)
+        for container in COLLECTION_NAMES
+    )
+    prim_in_value_position = any(
+        leaf in FFI_VALUE_PRIMITIVES and not key for leaf, key in leaves
+    )
+    erased_in_value_position = any(
+        "dyn" in leaf.split() and not key for leaf, key in leaves
+    )
+    if erased_in_value_position:
+        return "E"
+    if prim_in_value_position and has_collection:
+        return "V"
+    for leaf, key in leaves:
+        if key or leaf in FFI_VALUE_PRIMITIVES:
+            continue
+        if leaf in type_index and type_can_hold_js_value(leaf, type_index):
+            return "S"
+    if prim_in_value_position and re.search(r"\b%s\b" % re.escape(name), closure_context):
+        return "F"
+    return None
+
+
 def scan(root: Path) -> tuple[list[dict], int]:
-    files = source_files(root)
+    tiered = tiered_source_files(root)
+    tier_of: dict[Path, str] = {path: tier for path, tier in tiered}
     texts: dict[Path, str] = {}
-    for path in files:
+    for path, _tier in tiered:
         try:
             texts[path] = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
+
+    # Per-crate struct/enum field index for the ffi-side rule S. Keyed by the
+    # crate directory so `SocketState` in perry-ext-net cannot certify (or
+    # condemn) a same-named type in another crate.
+    crate_texts: dict[str, list[str]] = {}
+    for path, text in texts.items():
+        if tier_of[path] == "core":
+            continue
+        crate_key = repo_relative(path, root).split("/src/", 1)[0]
+        crate_texts.setdefault(crate_key, []).append(text)
+    type_index_by_crate = {
+        crate: crate_type_index(crate_files) for crate, crate_files in crate_texts.items()
+    }
 
     # 1. registered scanner entry points, WITH the module path they were
     #    registered under.
@@ -355,18 +790,49 @@ def scan(root: Path) -> tuple[list[dict], int]:
     # siblings. The registration text carries the path
     # (`crate::json::raw_json::scan_raw_json_key_root_mut`), so the ROOT set can
     # be resolved to a file even though later hops cannot.
+    # Only BARE-PATH arguments seed the walk. The C-ABI registration form
+    # (`..._named(SOURCE.as_ptr(), SOURCE.len(), 0, trampoline)`) puts method
+    # calls in argument position, and harvesting every identifier out of them
+    # seeds `as_ptr`/`len`/`state` — names that ARE `fn`s somewhere in these
+    # crates (impl methods), which makes half the tree "reachable" and
+    # certifies holders nothing scans. False coverage is the one direction the
+    # inventory cannot correct, so the filter errs the other way: an argument
+    # containing `.`/`!`/`$`/digits is not a scanner path and contributes
+    # nothing.
     registered_paths: list[tuple[str, list[str]]] = []
+    bare_path = re.compile(r"(?:\w+::)*[A-Za-z_]\w*")
     for text in texts.values():
         for match in REGISTER_CALL.finditer(strip_comments(text)):
-            for ident in re.findall(r"[A-Za-z_][\w:]*", match.group("args")):
-                segments = ident.split("::")
+            for arg in _split_generic_args(match.group("args")):
+                if not bare_path.fullmatch(arg.strip()):
+                    continue
+                segments = arg.strip().split("::")
                 registered_paths.append((segments[-1], segments[:-1]))
 
-    # 2. call graph over every fn in both crates
+    # 2. call graph over every fn in the scanned crates
     bodies: dict[str, list[tuple[Path, str]]] = {}
     for path, text in texts.items():
         for name, body in function_bodies(text).items():
             bodies.setdefault(name, []).append((path, body))
+
+    # Deep hops are matched on the BARE name, and the platform-ported crates
+    # define whole files of same-named functions (every perry-ui* crate has a
+    # `media_playback.rs` mirroring perry-runtime's). Without a fence, a
+    # runtime scanner's helper name drags the UI twin's body into the
+    # reachable set and 27 real frontier debt items read as covered. The
+    # fence: a crate in which NOTHING registers a scanner cannot host
+    # genuinely reachable scanner code — no registered scanner can call into
+    # it (scanners only call within their own crate or into perry-ffi, both
+    # of which register). Depth-0 seeds stay exempt: a registration that
+    # NAMES a function in such a crate pins it explicitly, which is exactly
+    # what fixing a UI crate will look like.
+    registering_crates: set[str] = set()
+    for path, text in texts.items():
+        if REGISTER_CALL.search(strip_comments(text)):
+            registering_crates.add(repo_relative(path, root).split("/src/", 1)[0])
+
+    def crate_hosts_reachable_code(path: Path) -> bool:
+        return repo_relative(path, root).split("/src/", 1)[0] in registering_crates
 
     def path_matches(defining: Path, segments: list[str]) -> bool:
         """Does `defining` plausibly hold the item named by `segments`?
@@ -420,6 +886,8 @@ def scan(root: Path) -> tuple[list[dict], int]:
             for path, body in bodies.get(name, []):
                 if allowed is not None and path not in allowed:
                     continue
+                if allowed is None and not crate_hosts_reachable_code(path):
+                    continue
                 nxt.update(IDENT.findall(body))
         frontier = {n for n in nxt if n in bodies and n not in reachable}
         if not frontier:
@@ -432,20 +900,36 @@ def scan(root: Path) -> tuple[list[dict], int]:
         for path, body in bodies.get(name, []):
             if allowed is not None and path not in allowed:
                 continue
+            if allowed is None and not crate_hosts_reachable_code(path):
+                continue
             reachable_text_by_file[path] = reachable_text_by_file.get(path, "") + "\n" + body
 
     # 3. classify declarations
     holders: list[dict] = []
     for path, text in texts.items():
         rel = repo_relative(path, root)
-        allocating_context = "\n".join(
-            body
-            for _name, body in function_bodies(text).items()
-            if any(token in body for token in ALLOCATOR_TOKENS)
-        )
+        tier = tier_of[path]
+        bodies_here = function_bodies(text)
         covered_text = reachable_text_by_file.get(path, "")
+        if tier == "core":
+            allocating_context = "\n".join(
+                body
+                for _name, body in bodies_here.items()
+                if any(token in body for token in ALLOCATOR_TOKENS)
+            )
+        else:
+            crate_key = rel.split("/src/", 1)[0]
+            type_index = type_index_by_crate.get(crate_key, {})
+            closure_context = "\n".join(
+                body
+                for _name, body in bodies_here.items()
+                if any(token in body for token in FFI_CLOSURE_CONTEXT_TOKENS)
+            )
         for name, lineno, type_text in declarations(rel, text):
-            rule = holder_is_candidate(name, type_text, allocating_context)
+            if tier == "core":
+                rule = holder_is_candidate(name, type_text, allocating_context)
+            else:
+                rule = ffi_holder_is_candidate(name, type_text, type_index, closure_context)
             if rule is None:
                 continue
             covered = re.search(r"\b%s\b" % re.escape(name), covered_text) is not None
@@ -456,6 +940,7 @@ def scan(root: Path) -> tuple[list[dict], int]:
                     "name": name,
                     "type": type_text[:160],
                     "rule": rule,
+                    "tier": tier,
                     "covered": covered,
                 }
             )
@@ -484,6 +969,36 @@ def load_inventory(path: Path) -> list[dict]:
     if not path.exists():
         return []
     return json.loads(path.read_text(encoding="utf-8"))["holders"]
+
+
+def load_frontier(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return json.loads(path.read_text(encoding="utf-8")).get("frontier", [])
+
+
+def apply_frontier(holders: list[dict], frontier: list[dict]) -> tuple[list[dict], list[dict]]:
+    """(new_unpinned, stale_entries) for the frontier ratchet.
+
+    A COVERED frontier holder must not be pinned either — coverage is the fix,
+    and the deletion of its entry is the receipt (same rule as the gated
+    inventory).
+    """
+    pinned = {(entry["file"], entry["name"]) for entry in frontier}
+    used: set[tuple[str, str]] = set()
+    unpinned: list[dict] = []
+    for holder in holders:
+        if holder["tier"] != "frontier":
+            continue
+        key = (holder["file"], holder["name"])
+        if holder["covered"]:
+            continue
+        if key in pinned:
+            used.add(key)
+        else:
+            unpinned.append(holder)
+    stale = [e for e in frontier if (e["file"], e["name"]) not in used]
+    return unpinned, stale
 
 
 def inventory_problems(inventory: list[dict]) -> list[str]:
@@ -543,6 +1058,8 @@ def apply_inventory(
     used: set[tuple[str, str]] = set()
     unclassified: list[dict] = []
     for holder in holders:
+        if holder.get("tier", "core") == "frontier":
+            continue  # ratcheted by apply_frontier, not verdict-gated
         if holder["covered"]:
             continue
         key = (holder["file"], holder["name"])
@@ -600,8 +1117,38 @@ def report(root: Path, quiet: bool = False) -> int:
     inventory = load_inventory(INVENTORY_PATH)
     unclassified, stale = apply_inventory(holders, inventory)
     malformed = inventory_problems(inventory)
+    frontier = load_frontier(INVENTORY_PATH)
+    frontier_new, frontier_stale = apply_frontier(holders, frontier)
 
     status = 0
+    if frontier_new:
+        status = 1
+        print(
+            "\ngc_runtime_root_holders: NEW frontier (perry-ui*) holders not pinned in\n"
+            "the inventory's `frontier` list. The UI callback-table debt is ratcheted:\n"
+            "it may only shrink. Either register a scanner that reaches the new holder\n"
+            "(see the ext crates' `gc_register_mutable_root_scanner_named` pattern) or,\n"
+            "if this really is new platform surface, pin it deliberately — with the\n"
+            "understanding that a NaN-boxed callback parked there is invisible to the\n"
+            "collector until a scanner exists.\n",
+            file=sys.stderr,
+        )
+        for holder in frontier_new:
+            print(
+                f"  {holder['file']}:{holder['line']}: {holder['name']}: "
+                f"{holder['type']}  [rule {holder['rule']}]",
+                file=sys.stderr,
+            )
+    if frontier_stale:
+        status = 1
+        print(
+            "\ngc_runtime_root_holders: these `frontier` entries no longer match an\n"
+            "uncovered holder — delete them. (Going stale is what FIXING one looks\n"
+            "like: the deletion is the receipt.)\n",
+            file=sys.stderr,
+        )
+        for entry in frontier_stale:
+            print(f"  {entry['file']} | {entry['name']}", file=sys.stderr)
     if malformed:
         status = 1
         print(
@@ -645,11 +1192,24 @@ def report(root: Path, quiet: bool = False) -> int:
 
     if status == 0 and not quiet:
         covered = sum(1 for h in holders if h["covered"])
+        frontier_count = sum(1 for h in holders if h["tier"] == "frontier")
         print(
             f"gc_runtime_root_holders: OK — {len(holders)} holder declarations "
-            f"scanned, {covered} reached by a registered scanner, "
-            f"{len(inventory)} classified in the inventory "
+            f"scanned ({frontier_count} frontier), {covered} reached by a registered "
+            f"scanner, {len(inventory)} classified in the inventory, "
+            f"{len(frontier)} pinned on the frontier ratchet "
             f"({registered_count} registered scanners)."
+        )
+        # State the blind spots on every green run rather than letting
+        # silence imply coverage (the #8206 pattern; details in the module
+        # docstring under "What this gate CANNOT see").
+        print(
+            "  UNVERIFIED by this gate: RuntimeState struct fields "
+            "(growth-floor only); core-crate integer tables in files that "
+            f"never call an allocator (rule B's limit); and the "
+            f"{len(frontier)} pinned frontier holders, which are ENUMERATED "
+            "and RATCHETED but scanned by nothing — a callback parked there "
+            "is invisible to the collector."
         )
     return status
 
@@ -659,7 +1219,10 @@ def print_list(root: Path) -> int:
     print(f"# {len(holders)} candidate holders, {registered_count} registered scanners")
     for holder in holders:
         flag = "COVERED  " if holder["covered"] else "UNCOVERED"
-        print(f"{flag} {holder['file']}:{holder['line']} {holder['name']}: {holder['type']}")
+        print(
+            f"{flag} [{holder['tier']}/{holder['rule']}] "
+            f"{holder['file']}:{holder['line']} {holder['name']}: {holder['type']}"
+        )
     return 0
 
 
@@ -716,6 +1279,86 @@ pub fn scan_dup_roots_mut(v: &mut V) { for p in DUP_A_TABLE.borrow_mut().iter_mu
 static DUP_B_TABLE: RefCell<Vec<*mut ObjectHeader>> = RefCell::new(Vec::new());
 pub fn scan_dup_roots_mut(v: &mut V) { for p in DUP_B_TABLE.borrow_mut().iter_mut() { v.visit(p); } }
 """,
+    # An ffi-side crate registering through the C-ABI trampoline. Exercises:
+    # nested parens in the registration args (`SOURCE.as_ptr()`), an
+    # `extern "C" fn` seed body (invisible to FN_DEF before the stripped-
+    # literal fix), a function-body `static _: OnceLock<..>` reached through
+    # its accessor, a multi-line rule-V declaration, rule E (`dyn` payload),
+    # and rule F both ways (a scalar in closure context vs a plain counter).
+    "crates/perry-ext-fake/src/lib.rs": """
+struct FakeParked { cb: i64, name: String }
+fn parked() -> &'static Mutex<HashMap<u64, FakeParked>> {
+    static PARKED: OnceLock<Mutex<HashMap<u64, FakeParked>>> = OnceLock::new();
+    PARKED.get_or_init(|| Mutex::new(HashMap::new()))
+}
+static EXT_LISTENERS: Mutex<HashMap<usize,
+    Vec<i64>>> =
+    Mutex::new(HashMap::new());
+static EXT_ERASED: Lazy<DashMap<Handle, Box<dyn Any + Send + Sync>>> = Lazy::new(DashMap::new);
+static EXT_LAST_CB: AtomicI64 = AtomicI64::new(0);
+static EXT_COUNTER: AtomicI64 = AtomicI64::new(0);
+static EXT_IDS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+fn stash_cb(value: f64) {
+    let closure = value.to_bits() as i64;
+    EXT_LAST_CB.store(closure, Ordering::SeqCst);
+}
+fn bump() { EXT_COUNTER.fetch_add(1, Ordering::SeqCst); }
+fn ensure_registered() {
+    const SOURCE: &str = "perry-ext-fake";
+    unsafe {
+        perry_ffi_gc_register_mutable_root_scanner_named(
+            SOURCE.as_ptr(),
+            SOURCE.len(),
+            0,
+            scan_fake_trampoline,
+        );
+    }
+}
+extern "C" fn scan_fake_trampoline(_id: usize, visit: Visit, ctx: Ctx) {
+    scan_fake_roots(visit, ctx);
+}
+fn scan_fake_roots(visit: Visit, ctx: Ctx) {
+    for entry in parked().lock().unwrap().values_mut() { visit(&mut entry.cb, ctx); }
+    for cb_vec in EXT_LISTENERS.lock().unwrap().values_mut() {
+        for cb in cb_vec.iter_mut() { visit(cb, ctx); }
+    }
+}
+""",
+    # An ffi-side crate that registers NOTHING: the planted catches. `TABLE`
+    # is the exact shape the census could not see before this extension —
+    # `static … OnceLock<…>` inside a function body whose value type is a
+    # bare `i64` carrying a NaN-boxed JS value.
+    "crates/perry-ext-leaky/src/lib.rs": """
+struct LeakyListeners { cbs: Vec<i64> }
+lazy_static! {
+    static ref LEAKY_LISTENERS: Mutex<HashMap<usize, LeakyListeners>> = Mutex::new(HashMap::new());
+}
+fn table() -> &'static Mutex<HashMap<u64, i64>> {
+    static TABLE: OnceLock<Mutex<HashMap<u64, i64>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+static LEAKY_DEFERRED: Mutex<VecDeque<(u64,
+    LeakyListeners)>> =
+    Mutex::new(VecDeque::new());
+""",
+    # Frontier (perry-ui*) crate: enumerated + ratcheted, never verdict-gated.
+    "crates/perry-ui-fake/src/widgets/button.rs": """
+thread_local! {
+    static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+pub fn set_callback(key: usize, callback: f64) {
+    BUTTON_CALLBACKS.with(|c| c.borrow_mut().insert(key, callback));
+}
+""",
+    # The fence case: `accessor` is ALSO the name of a genuinely reachable
+    # helper in thing.rs. perry-ui-fake registers nothing, so its same-named
+    # body must NOT be attributed — without the fence NAV_TABLE reads
+    # covered, which is exactly the 27-holder false-coverage bug this
+    # extension hit on the real tree.
+    "crates/perry-ui-fake/src/media.rs": """
+static NAV_TABLE: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
+fn accessor() -> u32 { let _ = NAV_TABLE.borrow(); 0 }
+""",
 }
 
 
@@ -766,7 +1409,9 @@ def self_test() -> int:
     holders = _scan_tree()
     by_key = {(h["file"], h["name"]): h for h in holders}
 
-    def expect(rel: str, name: str, covered: bool, why: str) -> None:
+    def expect(
+        rel: str, name: str, covered: bool, why: str, tier: str | None = None
+    ) -> None:
         key = (rel, name)
         if key not in by_key:
             failures.append(f"scanner MISSED the declaration {rel}:{name} ({why})")
@@ -776,6 +1421,15 @@ def self_test() -> int:
                 f"{rel}:{name} read as covered={by_key[key]['covered']}, "
                 f"expected {covered} ({why})"
             )
+        if tier is not None and by_key[key]["tier"] != tier:
+            failures.append(
+                f"{rel}:{name} classified in tier {by_key[key]['tier']!r}, "
+                f"expected {tier!r} ({why})"
+            )
+
+    def expect_absent(rel: str, name: str, why: str) -> None:
+        if (rel, name) in by_key:
+            failures.append(f"{rel}:{name} should NOT be a candidate ({why})")
 
     expect(
         "crates/perry-runtime/src/thing.rs",
@@ -823,10 +1477,122 @@ def self_test() -> int:
         "dup_b's holder",
     )
 
+    # --- ffi-side shapes: the 2026-08 blind spot, planted -------------------
+    expect(
+        "crates/perry-ext-fake/src/lib.rs",
+        "PARKED",
+        True,
+        "function-body OnceLock table, covered through accessor + C-ABI "
+        "trampoline registration (nested parens + extern-C seed body)",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ext-fake/src/lib.rs",
+        "EXT_LISTENERS",
+        True,
+        "multi-line rule-V declaration named directly in the scanner",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ext-fake/src/lib.rs",
+        "EXT_ERASED",
+        False,
+        "rule E: dyn-erased payload in value position, nothing scans it",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ext-fake/src/lib.rs",
+        "EXT_LAST_CB",
+        False,
+        "rule F: bare scalar named by a closure-handling function",
+        tier="ffi",
+    )
+    expect_absent(
+        "crates/perry-ext-fake/src/lib.rs",
+        "EXT_COUNTER",
+        "a bare counter with no closure-machinery context must not be a "
+        "candidate — rule F's qualifier is what keeps this census readable",
+    )
+    expect_absent(
+        "crates/perry-ext-fake/src/lib.rs",
+        "EXT_IDS",
+        "Vec<usize> is an id list; usize is deliberately not a value primitive",
+    )
+    expect(
+        "crates/perry-ext-leaky/src/lib.rs",
+        "TABLE",
+        False,
+        "THE previously-invisible shape: static OnceLock<Mutex<HashMap<u64, "
+        "i64>>> inside a function body, i64 value position, no scanner",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ext-leaky/src/lib.rs",
+        "LEAKY_LISTENERS",
+        False,
+        "lazy_static `static ref` + rule S through a crate-local struct's "
+        "Vec<i64> field",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ext-leaky/src/lib.rs",
+        "LEAKY_DEFERRED",
+        False,
+        "multi-line declaration + rule S through a tuple payload",
+        tier="ffi",
+    )
+    expect(
+        "crates/perry-ui-fake/src/widgets/button.rs",
+        "BUTTON_CALLBACKS",
+        False,
+        "the canonical UI callback table lands in the frontier tier",
+        tier="frontier",
+    )
+    expect(
+        "crates/perry-ui-fake/src/media.rs",
+        "NAV_TABLE",
+        False,
+        "fence: `accessor` is also a reachable helper name in thing.rs, but "
+        "perry-ui-fake registers nothing, so its body must not be attributed "
+        "— without the fence this reads covered",
+        tier="frontier",
+    )
+
+    # --- frontier ratchet red paths ----------------------------------------
+    planted_frontier = [h for h in holders if h["tier"] == "frontier"]
+    if len(planted_frontier) < 2:
+        failures.append("expected at least two planted frontier holders")
+    unpinned, _stale = apply_frontier(holders, [])
+    if len(unpinned) != len(planted_frontier):
+        failures.append(
+            f"apply_frontier with an EMPTY baseline reported {len(unpinned)} "
+            f"unpinned of {len(planted_frontier)} frontier holders — a new UI "
+            f"holder could land silently"
+        )
+    exact_baseline = [
+        {"file": h["file"], "name": h["name"]} for h in planted_frontier
+    ]
+    unpinned, stale = apply_frontier(holders, exact_baseline)
+    if unpinned or stale:
+        failures.append(
+            "an exact frontier baseline still reported "
+            f"{len(unpinned)} unpinned / {len(stale)} stale"
+        )
+    _unpinned, stale = apply_frontier(
+        holders,
+        exact_baseline + [{"file": "crates/perry-ui-fake/src/gone.rs", "name": "GONE"}],
+    )
+    if not stale:
+        failures.append(
+            "a frontier entry matching no holder was NOT reported stale — "
+            "the ratchet could not shrink"
+        )
+
     # Classification is only half of it — the VERDICT machinery has to go red.
-    # An empty inventory must leave every uncovered holder unclassified…
+    # An empty inventory must leave every uncovered GATED holder unclassified
+    # (frontier holders are the ratchet's subject, not the inventory's)…
     unclassified, _stale = apply_inventory(holders, [])
-    uncovered = [h for h in holders if not h["covered"]]
+    uncovered = [h for h in holders if not h["covered"] and h["tier"] != "frontier"]
     if len(unclassified) != len(uncovered) or not uncovered:
         failures.append(
             f"apply_inventory with an EMPTY inventory reported {len(unclassified)} "
@@ -878,6 +1644,15 @@ def self_test() -> int:
         failures.append(
             "inventory has %d stale entr(y|ies): %s"
             % (len(stale), ", ".join(f"{e['file']}:{e['name']}" for e in stale))
+        )
+    _unpinned, frontier_stale = apply_frontier(real_holders, load_frontier(INVENTORY_PATH))
+    if frontier_stale:
+        failures.append(
+            "frontier list has %d stale entr(y|ies): %s"
+            % (
+                len(frontier_stale),
+                ", ".join(f"{e['file']}:{e['name']}" for e in frontier_stale[:5]),
+            )
         )
     failures.extend(inventory_problems(inventory))
     # …and the structural checker must itself be able to fail.

--- a/test-files/test_gap_gc_fetch_method_value_cache_rooting.ts
+++ b/test-files/test_gap_gc_fetch_method_value_cache_rooting.ts
@@ -1,0 +1,58 @@
+// Census follow-up (gc_runtime_root_holders ffi/ext coverage): the fetch
+// bound-method value caches — HEADERS_METHOD_VALUE_CACHE
+// (crates/perry-stdlib/src/fetch/headers_method_value.rs) and
+// FORM_DATA_METHOD_VALUE_CACHE (fetch/dispatch.rs) — park a NaN-boxed
+// bound-method ClosureHeader per (handle, method) pair so
+// `h.entries === h.entries` holds. Before fetch/gc.rs existed, that cache
+// was the closure's ONLY holder once the first property read's transient
+// died: the one-shot js_write_barrier_root_nanbox at the insert site only
+// shades a mark cycle already in flight, so a later full sweep freed the
+// closure and a copying minor moved it while the cache kept the OLD bits.
+// The second property read then returned a dangling function value.
+//
+// The reads below go through the cache twice per object, with an
+// allocating loop between them so a seeded schedule has back-edge polls to
+// fire on. Run as
+//
+//   PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED=7 \
+//   PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_VERIFY_EVACUATION=1 \
+//   PERRY_GC_DIAG=1 ./out
+//
+// (`PERRY_GC_SCHEDULE_SEED` implies forced evacuation.) A green run only
+// counts if a `[gc-fromspace-protect] retired_set=#N` line appeared and the
+// exit verdict reports copying_minors/moved_objects above zero. Pre-fix the
+// second `typeof` dereferences the poisoned from-space copy and dies;
+// post-fix the cache slot is a registered root, rewritten on evacuation.
+
+function churn(): number {
+  let keep: Array<{ i: number; s: string }> = [];
+  for (let i = 0; i < 30000; i++) {
+    keep.push({ i, s: "pad-" + i });
+    if (keep.length > 64) keep = [];
+  }
+  return keep.length;
+}
+
+const h = new Headers();
+h.set("a", "1");
+h.append("b", "2");
+
+// First reads populate the cache; their transient results die immediately.
+console.log("headers first:", typeof h.get, typeof h.entries);
+churn();
+// Second reads are CACHE HITS — pre-fix these bits dangle.
+console.log("headers second:", typeof h.get, typeof h.entries);
+const collected: string[] = [];
+for (const [k, v] of h.entries()) {
+  collected.push(k + "=" + v);
+}
+console.log("headers entries:", collected.join(","));
+console.log("headers has:", h.has("a"), h.get("b"));
+
+const fd = new FormData();
+fd.append("k", "v");
+fd.append("k2", "v2");
+console.log("formdata first:", typeof fd.get, typeof fd.has);
+churn();
+console.log("formdata second:", typeof fd.get, typeof fd.has);
+console.log("formdata get:", fd.get("k"), fd.get("k2"), fd.has("nope"));

--- a/test-files/test_gap_gc_http2_pending_event_callback_rooting.ts
+++ b/test-files/test_gap_gc_http2_pending_event_callback_rooting.ts
@@ -1,0 +1,41 @@
+// Census follow-up (gc_runtime_root_holders ffi/ext coverage): perry-ext-http
+// parks the user callbacks of `session.close(cb)` / `session.settings(obj,
+// cb)` / `session.ping(cb)` as raw NaN-box bits inside H2_PENDING_EVENTS
+// (server/http2_server.rs) between the JS-side dispatch and the main-thread
+// drain. The settings/ping callbacks have NO other holder in that window,
+// so before scan_h2_pending_event_roots existed a full collection freed
+// them and a copying minor left the queue pointing into from-space — the
+// drain then called through a dangling closure. The churn between each
+// dispatch and the pump tick is what gives a seeded schedule a window. Run
+// under the seeded instrument env (see
+// test_gap_gc_fetch_method_value_cache_rooting.ts); a green run needs the
+// retired_set line and nonzero copying_minors.
+import http2 from "node:http2";
+
+function churn(): number {
+  let keep: Array<{ i: number; s: string }> = [];
+  for (let i = 0; i < 30000; i++) {
+    keep.push({ i, s: "pad-" + i });
+    if (keep.length > 64) keep = [];
+  }
+  return keep.length;
+}
+
+const server = http2.createServer();
+server.listen(0, () => {
+  const port = (server.address() as any).port;
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  client.on("error", (e: any) => console.log("client error:", e && e.message));
+  client.settings({ enablePush: false }, () => {
+    console.log("settings cb fired");
+    client.ping(() => {
+      console.log("ping cb fired");
+      client.close(() => {
+        console.log("close cb fired");
+        server.close();
+      });
+    });
+    churn();
+  });
+  churn();
+});

--- a/test-files/test_gap_gc_net_once_flags_rekey.ts
+++ b/test-files/test_gap_gc_net_once_flags_rekey.ts
@@ -1,0 +1,60 @@
+// Census follow-up (gc_runtime_root_holders ffi/ext coverage): perry-ext-net's
+// `once_flags()` side table keys once-listener membership by the closure's
+// ADDRESS BITS (statics::once_flags(), lib.rs). The canonical copy in
+// `listeners()` is scanned — the closure stays alive and its Vec slot is
+// REWRITTEN when the copying GC moves it — but a HashSet element cannot be
+// rewritten in place, so before scan_net_roots learned to drain/forward/
+// reinsert the set, an evacuation between `.once(...)` and the event left
+// the set holding the OLD address: the fire-time membership test missed,
+// the listener was never auto-removed, and the "once" callback ran again on
+// the next event. Two 'data' events are separated CAUSALLY (client acks the
+// first before the server sends the second) so GC pauses cannot coalesce
+// them, and the once-handler churns the heap so the seeded schedule moves
+// the parked closure between registration and each fire. Node (and fixed
+// Perry) count 1. Run under the seeded instrument env (see
+// test_gap_gc_fetch_method_value_cache_rooting.ts); a green run needs the
+// retired_set line and nonzero copying_minors.
+import * as net from "node:net";
+
+function churn(): number {
+  let keep: Array<{ i: number; s: string }> = [];
+  for (let i = 0; i < 30000; i++) {
+    keep.push({ i, s: "pad-" + i });
+    if (keep.length > 64) keep = [];
+  }
+  return keep.length;
+}
+
+let onceFires = 0;
+let dataEvents = 0;
+
+const server = net.createServer((sock) => {
+  let responded = false;
+  sock.write("first");
+  sock.on("data", () => {
+    if (responded) return;
+    responded = true;
+    sock.write("second");
+    setTimeout(() => {
+      sock.end();
+    }, 30);
+  });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const addr = server.address() as net.AddressInfo;
+  const client = net.connect(addr.port, "127.0.0.1");
+  client.once("data", () => {
+    onceFires++;
+    churn();
+    client.write("go");
+  });
+  client.on("data", () => {
+    dataEvents++;
+  });
+  client.on("close", () => {
+    console.log("once fired:", onceFires, "of", dataEvents, "events");
+    server.close();
+  });
+  churn();
+});

--- a/test-files/test_gap_gc_request_signal_rooting.ts
+++ b/test-files/test_gap_gc_request_signal_rooting.ts
@@ -1,0 +1,38 @@
+// Census follow-up (gc_runtime_root_holders ffi/ext coverage):
+// REQUEST_REGISTRY's RequestRecord.signal (crates/perry-stdlib/src/fetch/
+// mod.rs) holds a NaN-boxed AbortSignal OBJECT. For `new Request(url)` with
+// no caller-supplied signal, signal_or_default() builds a fresh
+// AbortController and this registry slot is the signal's ONLY holder — no
+// scanner visited it before scan_request_registry_roots was wired into
+// fetch/gc.rs, so a full collection freed the object and a copying minor
+// left the slot pointing into from-space. `request.clone()` copies the same
+// stale bits into a second entry. The reads below cross an allocating loop
+// so the seeded schedule can collect between construction and the `.signal`
+// reads. Run under the seeded instrument env (see the sibling
+// test_gap_gc_fetch_method_value_cache_rooting.ts header); a green run
+// needs the retired_set line and nonzero copying_minors.
+
+function churn(): number {
+  let keep: Array<{ i: number; s: string }> = [];
+  for (let i = 0; i < 30000; i++) {
+    keep.push({ i, s: "pad-" + i });
+    if (keep.length > 64) keep = [];
+  }
+  return keep.length;
+}
+
+const req = new Request("https://example.test/x", { method: "POST", body: "b" });
+churn();
+// Pre-fix: req.signal returns the registry's stale bits; property reads on
+// it dereference the dead/moved object.
+console.log("signal:", typeof req.signal, req.signal.aborted);
+const clone = req.clone();
+churn();
+console.log("clone signal:", typeof clone.signal, clone.signal.aborted);
+console.log("same object:", req.signal === req.signal);
+
+const ctl = new AbortController();
+const req2 = new Request("https://example.test/y", { signal: ctl.signal });
+churn();
+ctl.abort();
+console.log("user signal:", req2.signal.aborted);

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -795,3 +795,13 @@ test_gap_gc_define_property_descriptor_rooting
 # purpose — a back-edge poll is the only safepoint reachable from user JS, so an
 # allocation-free callback makes the whole file pass vacuously.
 test_gap_gc_uint8_buffer_callback_rooting
+
+# Census follow-up (gc_runtime_root_holders ffi/ext coverage): runtime-side
+# side-table holders. Each parks a NaN-boxed value in a Rust static across a
+# GC window; the fixture drives the owning subsystem (fetch caches, Request
+# signal registry, ext-net once-flags, ext-http H2 pending-event queue) with
+# allocating churn between park and use.
+test_gap_gc_fetch_method_value_cache_rooting
+test_gap_gc_request_signal_rooting
+test_gap_gc_net_once_flags_rekey
+test_gap_gc_http2_pending_event_callback_rooting


### PR DESCRIPTION
Closes the whole-crate blind spot in `scripts/gc_runtime_root_holders.py` — the census that answers *"which statics and thread-locals can hold a GC heap pointer, and does a registered scanner reach them?"* — and fixes the five real unrooted holders the widened census exposed. Builds directly on #8211, which made the parser see the shapes it was already pointed at; this PR points it at the crates it never scanned.

## Why this is the right instrument

`gc_root_dominance_check.py` reads emitted LLVM IR and is structurally blind to Rust-side tables, and the live-heap sweeps (`PERRY_GC_PROTECT_FROMSPACE_HOLDERS`) cannot see a holder that is a Rust `HashMap` outside the GC heap. This census is the only detector for the class — and its crate list was `perry-runtime` + `perry-stdlib`, while every `perry-ext-*` crate parks **user closures** in handle side tables as NaN-boxed `i64`/`f64`. A crate outside the census's scope is not less checked; it is unchecked.

## The census extension

Three glob-discovered crate tiers (a new crate is in scope the day `cargo new` runs):

- **core** (runtime/stdlib): #8211's rules unchanged, plus a **multi-line declaration join** — `static X: T` with `=` on a later line was invisible to any single-line regex. Recovers four real holders (`ACCESSOR_RECEIVER_OVERRIDE`, `PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER`, `CURRENT_MICROTASK_VALUE`, `SET_INDEX`), all now verdicted with mechanisms.
- **ffi-side, gated** (`perry-ffi` + every `perry-ext-*`): type-**shape** rules, because JS values cross the C ABI as integers — value-position primitives in containers (map keys exempt: they are handle ids), recursive crate-local struct/enum resolution (enum struct-variants like `ClientClose { callback: i64 }` included), `dyn`-erased payloads, bare scalars in closure-handling files. Uncovered holders need written verdicts, same as core.
- **frontier** (`perry-ui*`): **461 real unregistered callback tables** across eight platform crates (three not buildable on the gate host), pinned **by identity** as a ratchet — a new UI holder fails `lint`, a fixed holder must delete its entry. Named debt, not verdicts; every green run prints them as UNVERIFIED.

Two soundness fixes keep the wider call-graph walk honest: registration arguments seed as **bare paths only** (harvesting every identifier out of `SOURCE.as_ptr()`-style C-ABI calls seeds `as_ptr`/`len`/`state` — names that ARE `fn`s in these crates — and falsely certifies holders), and deep-hop attribution is **fenced to crates that register at least one scanner** (the platform-ported UI crates define whole files of same-named functions; without the fence, 27 frontier holders read covered by pure name collision). `--self-test` plants every new shape — fn-body `OnceLock` i64 table, `lazy_static!` `static ref`, multi-line decl, struct/enum payload, `dyn` payload, closure-context scalar positive AND negative, C-ABI trampoline coverage, the fence case, both frontier-ratchet red paths — and requires detection.

## The five real holders, each with a seeded fail-before/pass-after fixture

All four fixtures byte-match Node under `PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_SEED=7 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_DIAG=1`, with the `[gc-fromspace-protect] retired_set=#N` line present and 1697–2543 copying minors / 124k–178k moved objects per run; registered in `test-parity/gc_repsel_corpus.txt` so the gc-stress matrix runs them.

| holder | pre-fix under the same seed | fix |
|---|---|---|
| `perry-ext-http` `H2_PENDING_EVENTS` (`session.close/settings/ping(cb)` parked as raw NaN-box bits across a pump tick; settings/ping have NO other holder) | literal `TypeError: value is not a function`, exit 1 | scanner over the queue **plus a drain custody chain**: the drain used to snapshot into a bare local `Vec`, unrooting every not-yet-fired callback while earlier events ran JS — drained events now sit in a scanned thread-local, and each arm parks its callback in a scanned stack across its allocating prep, reading the possibly-rewritten value back at call time (also un-breaks the stale retain-by-value removal in `close_callbacks`) |
| `perry-ext-net` `once_flags()` (once-membership keyed by the closure's address bits; the scanned `listeners()` copy is rewritten on evacuation, a `HashSet` element cannot be) | `once fired: 2 of 2 events` (oracle: 1) | `scan_net_roots` drains/forwards/reinserts the set in the same pass |
| `perry-ext-fetch` `REQUEST_HANDLES[*].signal` (NaN-boxed AbortSignal whose only holder is the table; the crate registered no scanner at all) | `signal: object undefined`, `user signal: undefined` (registry pointed at the stale copy while `abort()` flagged the moved one) | new `src/gc.rs` scanner via `perry_ffi`'s named wrapper (the same C-ABI route as every ext provider), armed at `store_request` |
| stdlib `HEADERS_METHOD_VALUE_CACHE` / `FORM_DATA_METHOD_VALUE_CACHE` / `REQUEST_REGISTRY.signal` | `headers second: object object` (oracle: `function function`) | fixed by #8211 — the two fetch fixtures here now serve as its end-to-end seeded regression tests |

## The ext-fetch locking invariant, and why it is a test rather than a one-off fix

The new ext-fetch scanner takes `REQUEST_HANDLES` during a collection **on the mutator thread**, so a reader holding that guard across a GC allocation is a self-deadlock — and under panic=abort + invoke-EH an unwind does not run `Drop`, so the failure mode is a **permanent hang**, not a panic. All request readers are hoisted (clone out, drop the guard, then allocate), and two unit tests keep the invariant in the shape #8211 established for stdlib: `request_reads_release_the_registry_guard` (`try_lock` probe after every reader — a re-introduced held guard fails instead of hanging) and `no_allocation_is_taken_off_a_live_registry_borrow` (source scan that asserts against its own planted sample). **The scan immediately caught three more sites beyond the request getters** — `js_fetch_response_status_text/type/url`, borrowing `FETCH_RESPONSES`. Latent rather than live (no scanner takes that lock today), hoisted anyway so the invariant is file-wide and any future response scanner is born safe. That catch is the argument for the test.

## Inventory and totals

13 new verdicts on top of #8211's 51 (the eight ext queue/registry tables — all handle-id or Rust-owned payloads with the JS values in already-scanned holders — plus backoff's `NEXT_ID`, ext-fetch's `REQUEST_HANDLES` now `covered_elsewhere` from its `gc.rs`, and the three multi-line core holders), plus the 461-entry `frontier` list. Census on this tree: **621 declarations scanned, 92 reached by a registered scanner, 64 classified, 461 ratcheted (136 registered scanners)**. `perry-ext-fetch/src/lib.rs` was split (`src/gc.rs`) to stay under the 2000-line gate.

## Validation

- Census gate + `--self-test` green; sabotage direction proven by the planted shapes.
- Fixtures: all four fail-before (captured under the same seed against a reverted build) / pass-after with instruments armed; plain runs byte-match Node.
- `cargo test -p perry-runtime --lib` **2522 / 0 / 4**; `-p perry --bin perry` **987 / 0**; `-p perry-stdlib --lib` 119 / 0; `-p perry-ext-fetch --lib` 15 / 0; `-p perry-ext-http --lib` 68 / 0; `-p perry-codegen --no-fail-fast` **1495 / 9** with the failure-name set byte-identical to a pre-branch run (all typed-proof/artifact tests; this PR touches no codegen files).
- Every scripted gate green: fmt, file-size, rekeyed-tables (+self-test), thread-locals, store-site, pin-sites, raw-handle, shape-census, addr-class, env-knobs, gate-wiring, test-registration, dominance `--audit-poll-reach`, workspace-architecture.

## Known pre-existing failure (not absorbed here)

`perry-ext-net --lib`'s `gc_mutable_scanner_rewrites_listener_roots` fails on the current base **even with origin/main's `lib.rs` swapped into the same tree** (A/B verified). #8204 touched zero perry-ext-net files and no workflow runs that suite, so nothing has ever watched it. This PR's `scan_net_roots` change is covered independently by the seeded once-flags fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of Fetch request signals, cached methods, and request-body access during memory cleanup.
  - Prevented HTTP/2 callbacks from becoming stale or being lost during allocation-heavy activity.
  - Fixed one-time network event handlers so they continue to fire correctly after garbage collection.
  - Prevented potential fetch request hangs and lock-related deadlocks during callback or response processing.

- **Tests**
  - Added regression and stress coverage for Fetch, HTTP/2, and network event handling under forced garbage collection.
  - Expanded automated checks for runtime memory-root coverage across supported components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->