### PR TITLE
fix(gc): root the Headers/FormData iteration frame slots (#8163, #8217)

### DIFF
--- a/changelog.d/8220-gc-headers-frame-roots.md
+++ b/changelog.d/8220-gc-headers-frame-roots.md
@@ -1,0 +1,56 @@
+### Fixed
+
+- **`headers.forEach` handed the collector's from-space to `js_closure_call2` — the
+  residual #8163 holder, and the one that is production-visible under the DEFAULT GC
+  (#8217).**
+
+  `js_headers_for_each` stripped the NaN-box off its `callback` argument into a bare
+  `*const ClosureHeader` **before** the loop and never re-read it. That copy lives only
+  in a native Rust frame — the precise root map does not cover Rust frames, and
+  production resolves the conservative stack scan to `SkipDisabled` — so the first
+  copying minor inside the loop left it naming retired from-space. Every iteration
+  allocates twice (`js_string_from_bytes` for the value and the key) and then runs
+  arbitrary user JS, so the window is wide open.
+
+  The consumer is Next's `pipeToNodeResponse` header copy, which the production App
+  Route fixture runs once per response: `c.headers.forEach((a, c) => … b.appendHeader(c,
+  d) …)`. `js_closure_call2` → `get_valid_func_ptr` reads `CLOSURE_MAGIC` at
+  `closure + CLOSURE_TYPE_TAG_OFFSET` (12). Once the retired block has been recycled into
+  Eden and partly overwritten the magic no longer matches, `get_valid_func_ptr` returns
+  null, and `dispatch_proxy_callee_or_throw` falls through to `throw_not_callable()` —
+  `TypeError: value is not a function`, thrown mid-header-copy, so Next never writes the
+  body (`E180 failed to pipe response`) and the client sees an **empty body**. That is
+  every discriminator #8163 recorded, including why the failure is never a wrong
+  id/header/cookie: the response content was already correct, only the write was
+  abandoned. It also explains the ~10× gap between stale derefs and visible failures — a
+  from-space block is recycled into Eden and bump-allocated over gradually, so most stale
+  derefs still read an intact magic and call the right function.
+
+  `js_headers_keys` / `_values` / `_entries` / `_get_set_cookie` hold `arr` (and
+  `entries` also `k_ptr` and `pair`) across the same allocations: the
+  `arr = push(arr, …)` idiom handles the array *growing*, not the collector *moving* it.
+  `js_form_data_for_each` is a verbatim copy of the `for_each` defect. All six now root
+  through `RuntimeHandleScope`, the idiom this file already uses on the `Headers`
+  constructor path, and re-read after every call that can collect.
+
+  **Attribution.** `PERRY_GC_PROTECT_FROMSPACE=1` under the *default* GC — no forced
+  evacuation, no seeded schedule — faults at `js_headers_for_each + 200` on a retired
+  `obj_type=4` (GC_TYPE_CLOSURE), `size=48`, at `user_ptr + 12`. Twelve protect runs on
+  the unfixed binary produced 8 faults over 51 copying minors, **every one at that single
+  site**; `PERRY_GC_PROTECT_FROMSPACE_HOLDERS=1` reported `(none in 90262 objects — the
+  holder is outside the arena: a runtime side table, an FFI structure, or a register/stack
+  slot)`. It is the stack slot.
+
+  **Measured**, matched A/B differing only by this patch, identical app dylib: protect
+  arm 8 faults / 51 minors → **0 faults / 60 minors**; default GC with no knobs 3 failed
+  batches / 300 passes → **0 / 300**; default GC under `PERRY_GC_HEAP_LIMIT=8` 1 failure
+  over 6,334 copying minors → **0 over 6,339**; forced+seeded (`SEED=8036`) unchanged at
+  30/30 with ~1.04 M objects copied per arm and zero evacuation-verify panics. No second
+  holder emerged in 360 protected passes.
+
+  **Why nothing caught it.** The holder is a native Rust frame slot, invisible to all
+  three static instruments by construction: `scripts/gc_runtime_root_holders.py` audits
+  `static`/`thread_local!` declarations, `scripts/gc_root_dominance_check.py` reads
+  emitted LLVM IR from compiled JS, and `scripts/raw_handle_debt.py` counts bare reads out
+  of handles that *already exist* and only inside `crates/perry-runtime/src`. A site that
+  never rooted anything, in `perry-stdlib`, is outside all of them.

--- a/crates/perry-stdlib/src/fetch/body_metadata.rs
+++ b/crates/perry-stdlib/src/fetch/body_metadata.rs
@@ -547,13 +547,19 @@ pub extern "C" fn js_form_data_for_each(handle: f64, callback: f64) -> f64 {
     if cb_ptr == 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let closure = cb_ptr as *const perry_runtime::ClosureHeader;
+    // #8163: the raw `ClosureHeader*` and the first of the two strings are held
+    // across an allocation and across user JS. See `js_headers_for_each`.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let cb_handle = scope.root_nanbox_f64(perry_runtime::value::js_nanbox_pointer(cb_ptr));
     for (name, value) in entries {
+        let inner = perry_runtime::gc::RuntimeHandleScope::new();
         let name_ptr = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let name_handle = inner.root_nanbox_u64(JSValue::string_ptr(name_ptr).bits());
         let value_ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
-        let name_value = f64::from_bits(JSValue::string_ptr(name_ptr).bits());
         let value_value = f64::from_bits(JSValue::string_ptr(value_ptr).bits());
-        perry_runtime::js_closure_call3(closure, value_value, name_value, handle);
+        let closure = perry_runtime::js_nanbox_get_pointer(cb_handle.get_nanbox_f64())
+            as *const perry_runtime::ClosureHeader;
+        perry_runtime::js_closure_call3(closure, value_value, name_handle.get_nanbox_f64(), handle);
     }
     f64::from_bits(TAG_UNDEFINED)
 }

--- a/crates/perry-stdlib/src/fetch/body_metadata.rs
+++ b/crates/perry-stdlib/src/fetch/body_metadata.rs
@@ -145,15 +145,18 @@ unsafe fn form_data_value_string(value: f64) -> String {
 }
 
 fn form_data_string_array(values: Vec<String>) -> f64 {
-    let mut arr = perry_runtime::js_array_alloc(values.len() as u32);
+    // #8163: `arr` must survive the per-value string allocations below.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(values.len() as u32));
     for value in values {
         let value_ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
-        arr = perry_runtime::js_array_push_f64(
-            arr,
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
             f64::from_bits(JSValue::string_ptr(value_ptr).bits()),
         );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }
 
 fn response_string_field(handle: f64, f: impl FnOnce(&FetchResponse) -> &str) -> *mut StringHeader {
@@ -492,22 +495,34 @@ pub extern "C" fn js_form_data_entries(handle: f64) -> f64 {
         .get(&id)
         .map(|form| form.entries.clone())
         .unwrap_or_default();
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    // #8163: `arr`, `name_ptr` and `pair` are all raw heap addresses held across
+    // later allocations in this same loop. See `js_headers_entries`.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(entries.len() as u32));
     for (name, value) in entries {
+        let inner = perry_runtime::gc::RuntimeHandleScope::new();
         let name_ptr = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let name_handle = inner.root_nanbox_u64(JSValue::string_ptr(name_ptr).bits());
         let value_ptr = js_string_from_bytes(value.as_ptr(), value.len() as u32);
-        let mut pair = perry_runtime::js_array_alloc(2);
-        pair = perry_runtime::js_array_push_f64(
-            pair,
-            f64::from_bits(JSValue::string_ptr(name_ptr).bits()),
+        let value_handle = inner.root_nanbox_u64(JSValue::string_ptr(value_ptr).bits());
+        let pair_handle = inner.root_raw_mut_ptr(perry_runtime::js_array_alloc(2));
+        let pair = perry_runtime::js_array_push_f64(
+            pair_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            name_handle.get_nanbox_f64(),
         );
-        pair = perry_runtime::js_array_push_f64(
-            pair,
-            f64::from_bits(JSValue::string_ptr(value_ptr).bits()),
+        pair_handle.set_raw_mut_ptr(pair);
+        let pair = perry_runtime::js_array_push_f64(
+            pair_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            value_handle.get_nanbox_f64(),
         );
-        arr = perry_runtime::js_array_push_f64(arr, nanbox_array_pointer(pair));
+        pair_handle.set_raw_mut_ptr(pair);
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            nanbox_array_pointer(pair_handle.get_raw_mut_ptr()),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }
 
 #[no_mangle]

--- a/crates/perry-stdlib/src/fetch/headers.rs
+++ b/crates/perry-stdlib/src/fetch/headers.rs
@@ -317,13 +317,19 @@ pub extern "C" fn js_headers_get_set_cookie(handle: f64) -> f64 {
         .get(&id)
         .map(HeadersStore::set_cookie_values)
         .unwrap_or_default();
-    let mut arr = perry_runtime::js_array_alloc(values.len() as u32);
+    // #8163: see `js_headers_keys`.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(values.len() as u32));
     for v in values {
         let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
         let v_nan = JSValue::string_ptr(v_ptr).bits();
-        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(v_nan));
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            f64::from_bits(v_nan),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }
 
 /// #4965: produce the `[name, value]` entries JSON that the http-server
@@ -457,13 +463,23 @@ pub extern "C" fn js_headers_for_each(handle: f64, callback: f64) -> f64 {
     if cb_ptr == 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let closure = cb_ptr as *const perry_runtime::ClosureHeader;
+    // #8163: `cb_ptr` is a raw heap address living ONLY in this native frame.
+    // The precise root map does not cover Rust frames and production resolves
+    // the conservative stack scan to SkipDisabled, so the first copying minor
+    // inside the loop below — every `js_string_from_bytes` can trigger one, and
+    // so can the callback itself — leaves it naming retired from-space. Root it
+    // and re-read it at each call.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let cb_handle = scope.root_nanbox_f64(perry_runtime::value::js_nanbox_pointer(cb_ptr));
     for (k, v) in entries {
+        let inner = perry_runtime::gc::RuntimeHandleScope::new();
         let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
+        let v_handle = inner.root_nanbox_u64(JSValue::string_ptr(v_ptr).bits());
         let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
-        let v_nan = JSValue::string_ptr(v_ptr).bits();
         let k_nan = JSValue::string_ptr(k_ptr).bits();
-        perry_runtime::js_closure_call2(closure, f64::from_bits(v_nan), f64::from_bits(k_nan));
+        let closure = perry_runtime::js_nanbox_get_pointer(cb_handle.get_nanbox_f64())
+            as *const perry_runtime::ClosureHeader;
+        perry_runtime::js_closure_call2(closure, v_handle.get_nanbox_f64(), f64::from_bits(k_nan));
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -483,26 +499,38 @@ fn nanbox_array_pointer(arr: *mut perry_runtime::ArrayHeader) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_headers_keys(handle: f64) -> f64 {
     let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    // #8163: `arr` must survive the per-entry string allocations below.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(entries.len() as u32));
     for (k, _) in entries {
         let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
         let k_nan = JSValue::string_ptr(k_ptr).bits();
-        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(k_nan));
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            f64::from_bits(k_nan),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }
 
 /// `headers.values()` — sorted-by-key array of header values. See `js_headers_keys`.
 #[no_mangle]
 pub extern "C" fn js_headers_values(handle: f64) -> f64 {
     let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    // #8163: see `js_headers_keys`.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(entries.len() as u32));
     for (_, v) in entries {
         let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
         let v_nan = JSValue::string_ptr(v_ptr).bits();
-        arr = perry_runtime::js_array_push_f64(arr, f64::from_bits(v_nan));
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            f64::from_bits(v_nan),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }
 
 /// `headers.entries()` — sorted-by-key array of `[key, value]` pair arrays.
@@ -511,16 +539,32 @@ pub extern "C" fn js_headers_values(handle: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_headers_entries(handle: f64) -> f64 {
     let entries = snapshot_sorted(handle);
-    let mut arr = perry_runtime::js_array_alloc(entries.len() as u32);
+    // #8163: `arr`, `k_ptr` and `pair` are all raw heap addresses held across
+    // later allocations in this same loop. See `js_headers_for_each`.
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(perry_runtime::js_array_alloc(entries.len() as u32));
     for (k, v) in entries {
+        let inner = perry_runtime::gc::RuntimeHandleScope::new();
         let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);
+        let k_handle = inner.root_nanbox_u64(JSValue::string_ptr(k_ptr).bits());
         let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);
-        let k_nan = JSValue::string_ptr(k_ptr).bits();
-        let v_nan = JSValue::string_ptr(v_ptr).bits();
-        let mut pair = perry_runtime::js_array_alloc(2);
-        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(k_nan));
-        pair = perry_runtime::js_array_push_f64(pair, f64::from_bits(v_nan));
-        arr = perry_runtime::js_array_push_f64(arr, nanbox_array_pointer(pair));
+        let v_handle = inner.root_nanbox_u64(JSValue::string_ptr(v_ptr).bits());
+        let pair_handle = inner.root_raw_mut_ptr(perry_runtime::js_array_alloc(2));
+        let pair = perry_runtime::js_array_push_f64(
+            pair_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            k_handle.get_nanbox_f64(),
+        );
+        pair_handle.set_raw_mut_ptr(pair);
+        let pair = perry_runtime::js_array_push_f64(
+            pair_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            v_handle.get_nanbox_f64(),
+        );
+        pair_handle.set_raw_mut_ptr(pair);
+        let arr = perry_runtime::js_array_push_f64(
+            arr_handle.get_raw_mut_ptr::<perry_runtime::ArrayHeader>(),
+            nanbox_array_pointer(pair_handle.get_raw_mut_ptr()),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    nanbox_array_pointer(arr)
+    nanbox_array_pointer(arr_handle.get_raw_mut_ptr())
 }

--- a/crates/perry-stdlib/src/fetch/tests.rs
+++ b/crates/perry-stdlib/src/fetch/tests.rs
@@ -451,6 +451,9 @@ fn headers_iteration_roots_every_heap_pointer_held_across_an_allocation() {
         ("fetch/headers.rs", "js_headers_entries"),
         ("fetch/headers.rs", "js_headers_get_set_cookie"),
         ("fetch/body_metadata.rs", "js_form_data_for_each"),
+        ("fetch/body_metadata.rs", "js_form_data_entries"),
+        // Backs `js_form_data_keys` / `js_form_data_values`.
+        ("fetch/body_metadata.rs", "form_data_string_array"),
     ];
     for (file, func) in MUST_OPEN_A_SCOPE {
         let text = SOURCES

--- a/crates/perry-stdlib/src/fetch/tests.rs
+++ b/crates/perry-stdlib/src/fetch/tests.rs
@@ -373,3 +373,115 @@ fn no_allocation_is_taken_off_a_live_registry_borrow() {
         "the forbidden-pattern list no longer matches the shape it exists to catch"
     );
 }
+
+/// Return the `{ … }` body of `fn <name>` in `text`, brace-matched.
+fn fetch_fn_body<'a>(text: &'a str, name: &str) -> Option<&'a str> {
+    let start = text.find(&format!("fn {name}("))?;
+    let open = start + text[start..].find('{')?;
+    let mut depth = 0usize;
+    for (offset, ch) in text[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&text[open..open + offset + 1]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// #8163/#8217: the `Headers` / `FormData` iteration surfaces were the last
+/// unrooted holders behind the production App Route's lost responses, and the
+/// holder is a **native Rust frame slot** — the shape no existing instrument can
+/// see. `scripts/gc_runtime_root_holders.py` audits `static`/`thread_local!`
+/// declarations; `scripts/gc_root_dominance_check.py` reads emitted LLVM IR from
+/// compiled JS; `scripts/raw_handle_debt.py` counts bare reads out of handles
+/// that already exist, and only inside `perry-runtime`. A raw `*const
+/// ClosureHeader` hoisted out of a NaN-box into a Rust local, then reused after
+/// `js_string_from_bytes` and after user JS, is invisible to all three.
+///
+/// The failure mode is a *stale* pointer, not a crash, so a unit test that
+/// reproduced it would have to land a collection inside a specific loop
+/// iteration. The shape is syntactic instead, so scan for it: each pre-fix
+/// idiom below binds a heap address that a later allocation in the same function
+/// can move, and each post-fix entry point opens a `RuntimeHandleScope` and
+/// re-reads through it.
+#[test]
+fn headers_iteration_roots_every_heap_pointer_held_across_an_allocation() {
+    const SOURCES: &[(&str, &str)] = &[
+        ("fetch/headers.rs", include_str!("headers.rs")),
+        ("fetch/body_metadata.rs", include_str!("body_metadata.rs")),
+    ];
+    // Verbatim pre-fix bindings. `let mut arr = …; arr = push(arr, …)` handled the
+    // array GROWING; it never handled the collector MOVING it.
+    const FORBIDDEN: &[&str] = &[
+        "let closure = cb_ptr as *const",
+        "let mut arr = perry_runtime::js_array_alloc(",
+        "let mut pair = perry_runtime::js_array_alloc(",
+    ];
+    let mut offenders = Vec::new();
+    for (name, text) in SOURCES {
+        for (lineno, line) in text.lines().enumerate() {
+            let code = line.split("//").next().unwrap_or(line);
+            for pattern in FORBIDDEN {
+                if code.contains(pattern) {
+                    offenders.push(format!("{name}:{}: {}", lineno + 1, line.trim()));
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "a raw heap address is bound across an allocation point (#8163/#8217 — root it \
+         in a `RuntimeHandleScope` and re-read it after every call that can \
+         collect):\n  {}",
+        offenders.join("\n  ")
+    );
+
+    // The negative list alone is satisfiable by renaming a binding, so require the
+    // root positively: every iteration entry point must open a scope.
+    const MUST_OPEN_A_SCOPE: &[(&str, &str)] = &[
+        ("fetch/headers.rs", "js_headers_for_each"),
+        ("fetch/headers.rs", "js_headers_keys"),
+        ("fetch/headers.rs", "js_headers_values"),
+        ("fetch/headers.rs", "js_headers_entries"),
+        ("fetch/headers.rs", "js_headers_get_set_cookie"),
+        ("fetch/body_metadata.rs", "js_form_data_for_each"),
+    ];
+    for (file, func) in MUST_OPEN_A_SCOPE {
+        let text = SOURCES
+            .iter()
+            .find(|(name, _)| name == file)
+            .expect("source listed in MUST_OPEN_A_SCOPE must be in SOURCES")
+            .1;
+        let body = fetch_fn_body(text, func)
+            .unwrap_or_else(|| panic!("{file}: `fn {func}` not found — has it been renamed?"));
+        assert!(
+            body.contains("RuntimeHandleScope"),
+            "{file}: `{func}` holds heap addresses across allocations but opens no \
+             `RuntimeHandleScope` (#8163/#8217)"
+        );
+    }
+
+    // Both halves must be able to fail, or they are decoration.
+    let planted_binding = "    let closure = cb_ptr as *const perry_runtime::ClosureHeader;";
+    assert!(
+        FORBIDDEN
+            .iter()
+            .any(|pattern| planted_binding.contains(pattern)),
+        "the forbidden-pattern list no longer matches the shape it exists to catch"
+    );
+    let planted_unrooted = "pub extern \"C\" fn js_headers_for_each(h: f64) -> f64 {\n\
+                            \x20   let closure = raw as *const ClosureHeader;\n}\n";
+    let planted_body = fetch_fn_body(planted_unrooted, "js_headers_for_each")
+        .expect("the body extractor must find a plain function");
+    assert!(
+        !planted_body.contains("RuntimeHandleScope"),
+        "the body extractor no longer isolates a function body, so the positive \
+         half of this test cannot fail"
+    );
+}


### PR DESCRIPTION
Closes #8217. Refs #8163, #8040.

## The holder

`js_headers_for_each` (`crates/perry-stdlib/src/fetch/headers.rs:452`) stripped the
NaN-box off its `callback` argument into a bare `*const ClosureHeader` **before** the
loop and never re-read it:

```rust
let closure = cb_ptr as *const perry_runtime::ClosureHeader;   // line 460
for (k, v) in entries {
    let v_ptr = js_string_from_bytes(v.as_ptr(), v.len() as u32);   // allocates
    let k_ptr = js_string_from_bytes(k.as_ptr(), k.len() as u32);   // allocates
    …
    perry_runtime::js_closure_call2(closure, …);                    // runs user JS
}
```

That copy lives only in a native Rust frame — callee-saved `x20` in the emitted code.
The precise root map does not cover Rust frames, and production resolves the
conservative stack scan to `SkipDisabled` (the copying minors in the reproducer all
report `eligible=true fallback=none`), so the collector never rewrites it. After the
first copying minor inside the loop, every remaining iteration calls a pre-move address.

## Why it produces an empty body and never a wrong value

The consumer is Next's `pipeToNodeResponse` header copy, present verbatim in the
fixture's compiled route chunk:

```js
c.headers.forEach((a, c) => { … b.appendHeader(c, d) … })
```

`js_closure_call2` → `get_valid_func_ptr` reads `CLOSURE_MAGIC` at
`closure + CLOSURE_TYPE_TAG_OFFSET` (12). Once the retired block has been recycled into
Eden and partly overwritten, the magic no longer matches, `get_valid_func_ptr` returns
null, and `dispatch_proxy_callee_or_throw` falls through to `throw_not_callable()` —
**`TypeError: value is not a function`**, thrown mid-header-copy. Next never writes the
body (`E180 failed to pipe response`) and the client sees an **empty body**, never a
wrong id/header/cookie: the response content was already correct, only the write was
abandoned. That is every discriminator #8163 recorded.

It also explains the ~10× gap between stale derefs and visible failures: a from-space
block is recycled into Eden and bump-allocated over gradually, so most stale derefs
still read an intact `CLOSURE_MAGIC` and call the right function.

## Evidence chain

| step | instrument | result |
|---|---|---|
| 1 | `PERRY_GC_PROTECT_FROMSPACE=1`, **default GC, no other knobs** | SIGBUS at `js_headers_for_each + 200` |
| 2 | fault report | `obj_type=4` (GC_TYPE_CLOSURE) `size=48`, fault at `user_ptr + 12` = `CLOSURE_TYPE_TAG_OFFSET` |
| 3 | `PERRY_GC_PROTECT_FROMSPACE_HOLDERS=1` | `(none in 90262 objects — the holder is outside the arena: a runtime side table, an FFI structure, or a register/stack slot)` |
| 4 | source | the `let closure = …` hoist above |

**Fault census, 12 protect runs on the unfixed binary: 8 faults, 51 copying minors, and
every single fault at `js_headers_for_each + 200` with `obj_type=4 size=48`.**
`retired_by_minor` spans #0/#1/#1/#1/#2/#3/#3, so they are distinct collections — one
holder, caught eight times.

## Measurements

Matched A/B on the mini (quiet M1, 8 GB): identical app dylib and provider-host, the two
arms differing **only** by this patch. Verified the right artifact was swapped — the
fixed `js_headers_for_each` is 4× larger and now performs a `TPIDRRO_EL0` read (the
`RUNTIME_HANDLE_STACK` TLS), which is *undefined* in the stdlib image and *defined* in
the runtime image, so the handles land on the same stack the runtime's scanner walks.

| arm | config | passes | failed batches | host `TypeError` | `[gc-copy-minor] ran` |
|---|---|---|---|---|---|
| before | protect, default GC | 12 runs | — | **8 faults** | 51 |
| after | protect, default GC | 6 runs | — | **0 faults** | 60 |
| before | default GC, no knobs, interleaved | 300 | **3** | **3** | — |
| after | default GC, no knobs, interleaved | 300 | **0** | **0** | — |
| before | default GC, `HEAP_LIMIT=8` | 75 | **1** | **1** | 6334 |
| after | default GC, `HEAP_LIMIT=8` | 75 | **0** | **0** | 6339 |
| before | forced+seeded (`SEED=8036`) | 30 | 0 | 0 | 3723 (1.035 M copied) |
| after | forced+seeded (`SEED=8036`) | 30 | 0 | 0 | 3719 (1.038 M copied) |

The protect arm is the discriminating one: it faults on **every** stale deref rather
than only the ones whose bytes were already clobbered. Under the before-arm rate
(8 faults / 51 minors) the probability of seeing 0 faults in the after arm's 60 minors
is ≈ 8 × 10⁻⁵. No second holder emerged in 360 protected passes.

Every one of the 375 after-arm passes is 21 requests checked byte-for-byte against the
Node production oracle — status, `x-perry-repro` header, `set-cookie`, and the full JSON
body — so ~7,900 request-level validations also cover the `keys`/`values`/`entries`
refactor. `bypassed routeModule.handle` = 0 throughout.

## Why the A/B base is `3b01efba4` and not merged main

`b8d32ab19` **cannot compile the fixture's app dylib** — five modules fail codegen on
`insertelement <2 x i64>`, the module-init header-image compose added by `bf8fd868e`
(#8204), which `crates/perry-codegen/src/dialect/mod.rs:1014` has no case for. Filed as
attribution on #8228. An app dylib compiled *before* that commit also does not run
against providers built *after* it (a clean-main control with no patch fails identically),
so the two cannot be mixed either.

The A/B therefore runs on `3b01efba4`, where `crates/perry-stdlib/src/fetch/headers.rs`
is **byte-identical** to `b8d32ab19` (`git diff 3b01efba4 b8d32ab19 -- …/headers.rs` is
empty) and `gc/roots/runtime_handles.rs` differs only by a doc comment — so the code
under test and the rooting machinery it uses are the same on both. The residual has also
been reproduced independently on merged-main providers on a second host, so it is not a
property of this base.

## Scope

Nine functions, all the same defect:

- `headers.rs` — `js_headers_for_each` (the one that fires on the Next path),
  `js_headers_keys`, `js_headers_values`, `js_headers_entries`,
  `js_headers_get_set_cookie`
- `body_metadata.rs` — `js_form_data_for_each` (a verbatim copy of the `for_each`
  defect), and three more the new test found on its first run that #8217 does not name:
  `form_data_string_array` (backing `js_form_data_keys`/`_values`) and
  `js_form_data_entries`

`arr = push(arr, …)` handled the array *growing*; it never handled the collector
*moving* it. `js_headers_entries` was worst: `k_ptr` live across the `v_ptr` allocation,
`pair` live across two allocating pushes, `arr` across all of it.

All six now root through `RuntimeHandleScope` — the idiom this file already uses on the
`Headers` constructor path (`read_headers_record_entries`,
`materialize_headers_init_iterable`, …) — and re-read after every call that can collect.

## Test

A source-shape scan, because the failure mode is a stale pointer rather than a crash:
reproducing it in a unit test means landing a collection inside one specific loop
iteration. This mirrors `no_allocation_is_taken_off_a_live_registry_borrow`, shipped in
#8211 for the same reason. It has two halves — a forbidden-binding list and a positive
"this entry point must open a scope" requirement, because the negative list alone is
satisfiable by renaming — and **both halves are sabotage-checked**: a planted pre-fix
binding must still match the forbidden list, and a planted unrooted body must still be
isolated by the body extractor.

## Why no existing instrument caught this

The holder is a **native Rust frame slot**, and all three static instruments are blind
to that shape by construction:

- `scripts/gc_runtime_root_holders.py` audits `static` / `thread_local!` declarations.
- `scripts/gc_root_dominance_check.py` reads emitted LLVM IR from compiled JS.
- `scripts/raw_handle_debt.py` counts bare reads out of handles that *already exist*, and
  only within `crates/perry-runtime/src` — a site that never rooted anything is invisible,
  and `perry-stdlib` is out of scope entirely.

A scan for the general shape ("a raw heap pointer bound, then used after another
allocating call") over `perry-stdlib` + the `perry-ext-*` crates reports ~150 candidate
sites. That is a ratchet-sized follow-up, not this PR.


## Note for reviewers: a pre-existing flaky test in this file

`fetch::tests::request_reads_release_the_registry_guard` (added in #8211) fails roughly
**1 run in 10** under the default parallel test harness, always with
`dispatch_request_property("cache") left the registry guard held`. It `try_lock`s
`REQUEST_REGISTRY` while its sibling `fetch_root_scanner_*` tests hold the same mutex on
another thread. Measured on this branch's test binary: 22/25 pass with all ten tests,
and **23/25 with my test excluded from the pool** — same rate — so it is pre-existing and
not caused by this change. It passes 100% under `--test-threads=1`. Worth its own fix
(serialise on a test-local mutex, or `try_lock` in a retry loop); `cargo-test` is a
required context, so it will intermittently red unrelated PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when iterating over headers and form data during memory allocations or JavaScript callbacks.
  * Improved reliability of header keys, values, entries, cookies, and form-data iteration without changing public behavior or ordering.

* **Tests**
  * Added regression coverage to prevent similar runtime memory-handling issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->