### PR TITLE
fix(test): pointer identity for a 'static name is not assertable on MSVC

### DIFF
--- a/changelog.d/8239-windows-static-literal-identity.md
+++ b/changelog.d/8239-windows-static-literal-identity.md
@@ -1,0 +1,16 @@
+`windows-build` is green again, restoring the whole `test.yml` run that
+`release-packages`' `await-tests` requires before it will cut a tag.
+
+Two tests from #8177 failed on Windows and only there, asserting that a bound
+method's closure captures the `'static` method-name literal by comparing
+pointers. Both failing pairs differed by the same constant offset (0x161F90) —
+two copies of the same read-only data, not a heap pointer. ELF
+(`SHF_MERGE|SHF_STRINGS`) and Mach-O (`__TEXT,__cstring`) merge identical
+read-only strings, so the copy the closure captures and the copy the lookup
+returns land at one address; MSVC does not pool identical literals across
+codegen units, so they stay distinct. Both are `'static`.
+
+The address comparison is now gated on a linker that merges. The property the
+test exists for — the captured name must not be the movable key string's
+interior — is asserted unconditionally, as are the captured length and bytes, so
+Windows keeps the coverage and loses only the proxy it cannot evaluate.

--- a/crates/perry-runtime/src/gc/tests/handle_bound_method_name.rs
+++ b/crates/perry-runtime/src/gc/tests/handle_bound_method_name.rs
@@ -84,6 +84,20 @@ unsafe fn assert_names_the_literal(
     what: &str,
 ) {
     let (name_ptr, name_len) = captured_name(bound);
+    // Pointer identity is only assertable where the linker merges identical
+    // read-only strings. ELF (`SHF_MERGE|SHF_STRINGS`) and Mach-O
+    // (`__TEXT,__cstring`) do; MSVC does not pool identical literals across
+    // codegen units, so the copy the closure captures and the copy the lookup
+    // returns can be two distinct `&'static [u8]` at different addresses.
+    // Measured on the Windows runner: both failing pairs differed by the SAME
+    // constant offset (0x161F90), i.e. two whole copies of the same read-only
+    // data, not a heap pointer.
+    //
+    // Both are `'static`, which is the property this test exists for: the name
+    // must not be the MOVABLE key string's interior. That invariant is asserted
+    // unconditionally below, together with the length and the bytes, so Windows
+    // keeps real coverage — it just cannot use address equality as the proxy.
+    #[cfg(not(windows))]
     assert_eq!(
         name_ptr,
         expected.as_ptr(),


### PR DESCRIPTION
`windows-build` is **red on main** (green 08-14 and 08-15, red 08-16). It fails the whole `test.yml` run — and a successful `test.yml` on the tip SHA is exactly what `release-packages`' `await-tests` requires before it will cut a tag. So this blocks the release.

## The failure

Two tests from #8177 fail on Windows and only on Windows:

```
a_bound_text_decoder_decode_never_captures_the_key_strings_interior
a_bound_text_encoder_method_never_captures_the_key_strings_interior

assertion `left == right` failed: the closure must capture the 'static literal
  left: 0x7ff6e735e903   right: 0x7ff6e71fc973
```

## Why it is not a runtime bug

Both failing pairs differ by the **same constant offset** (`0x161F90`) — two whole copies of the same read-only data, not a heap pointer.

ELF (`SHF_MERGE|SHF_STRINGS`) and Mach-O (`__TEXT,__cstring`) merge identical read-only strings, so the copy the closure captures and the copy the lookup returns land at one address and identity holds. **MSVC does not pool identical literals across codegen units**, so they stay distinct. Both are `'static`.

The test's own doc comment already names this hazard for locally-written literals and requires `expected` to come from the lookup under test — and these call sites do exactly that. The remaining difference is between two `'static` copies, which no sourcing discipline can collapse on a linker that does not merge them.

## Fix

Gate the **address** assertion on a linker that merges. Everything substantive stays unconditional:

- the captured name is **not** the movable key string's interior — the invariant the test exists for
- the captured length matches
- the captured bytes match

Windows keeps that coverage; it just cannot use address equality as the proxy.

## Validation

- **Windows arm simulated**: compiled with the assertion excluded — builds warning clean, no unused `expected` (the crate is built `-D warnings`).
- **Non-Windows**: all 6 tests in the module pass on macOS.
- Confirmed this is a fresh regression, not chronic: `windows-build` succeeded on the 08-14 and 08-15 main runs and the test file arrived in that window via #8177.