### PR TITLE
perf(codegen): compute the callee-rooting window instead of hardcoding it (#8159)

### DIFF
--- a/changelog.d/8240-narrow-callee-rooting-window.md
+++ b/changelog.d/8240-narrow-callee-rooting-window.md
@@ -1,0 +1,72 @@
+### Performance
+
+**The callee-rooting window at a call site is computed, not hardcoded — and the
+measurement says it is not what `#8159` attributed it to.**
+
+`#8084` closed a real moving-GC defect: five call arms lowered the CALLEE into a
+bare register, lowered the arguments below it — each of which can allocate — and
+handed the original register to the consuming call. Under the shipping
+statepoint lowering that register is in no live bundle, so nothing marks it and
+nothing relocates it. The fix asked `rooting/`'s existing machinery for
+protection and paid for it with a hardcoded `collects = true` at every site.
+
+`collects` is not a strategy, it is a **window**: "can anything between this
+operand and its consumer collect?" Hardcoding it `true` buys a slot store, a
+re-read and a release at every call site whether or not the window contains a
+collection point. `operand_protection` has always been able to answer this — its
+`Reuse` arm emits no push, no re-read and no truncate, keeping the pre-`#8084`
+IR byte for byte. It needed the truthful window, which `any_operand_may_collect`
+computes and `with_operands_rooted_window` has passed all along.
+
+- `lower_call/early_branches.rs` (closure-typed local call) — the window is the
+  argument lowering. The re-read sits above the unmask because that is where the
+  value leaves the tracked domain; a collection point *below* the unmask is a
+  separate exposure that rooting the box cannot repair either way.
+- `expr/new_dynamic.rs`, both `js_new_function_construct` arms — the callee's
+  window is every argument, argument `i`'s is the arguments after it. Neither
+  reaches a collection point of its own: `lower_js_args_array` is an entry
+  alloca plus stores, and `emit_call_location_at` emits nothing at all in a
+  default build. `new C(a, b)` over plain locals is back to emitting no rooting,
+  which is the shape `operand_needs_root`'s own doc already claims for it.
+- `expr/new_dynamic.rs`'s `NewDynamicSpread` and `expr/call_spread.rs` keep
+  `true`, and now say why: `bundle_args_rooted` opens with `js_array_alloc`, and
+  a spread call reaches `js_array_like_to_array` unconditionally, so those
+  windows allocate in every instance of the arm. Nothing to narrow, as opposed
+  to nothing narrowed.
+
+Each flag is computed **below** the operand it protects, as
+`with_operands_rooted_window` computes it: the predicate reads `ctx`, so asking
+before the lowering asks about a different state.
+
+**The measurement is negative, and that is the finding.** `#8159` attributed
+`pipeline`'s +3.95% to this rooting sequence. `pipeline` never reaches these
+arms: its `rec = stage(rec)` lowers through `lower_dynamic_closure_call`
+(`js_closure_unbox_callee_checked`), already fully rooted before `#8084`, and
+the emitted IR for `gc-handoff/apps/pipeline.ts` is BYTE-IDENTICAL across this
+change. Instructions retired, min-of-5, identical runtime archives on both arms,
+stdout sha-identical: `pipeline` +0.02%, `interp` −0.04%, `iso_miss` −0.05%,
+`asyncpipe` +0.11%, `shapes` −0.18% — all inside noise. What it does move is the
+population that has these shapes: zod's dep-native live bundles 36611 → 36598,
+relocates 432545 → 432338. So `#8159`'s attribution to the commit stands and its
+attribution to that hunk does not; the cost is elsewhere in `#8084`'s other
+~2500 lines.
+
+**Soundness, both corpora, base versus this change on the same build:**
+dep-native `unrooted 2` (budget 3), `stale 0`, seeded 40/40 — identical;
+curated-native `unrooted 0`, `stale 1`, seeded 39/40 — identical, and both
+halves of that verdict are pre-existing on clean `07c8040bf` (invisible until
+`#8207`, because the job aborted earlier at `--audit-poll-capable`). `#7803`'s
+own shape keeps its root by construction: its arguments are freshly-allocated
+object literals.
+
+`temp_root_coverage/call_callee.rs` states the contract from both sides — two
+differential pairs whose fixtures differ in exactly one thing, the argument's
+kind — and lives in `src/`, so it runs in the per-PR `cargo-test` gate rather
+than the nightly tier. Sabotage-checked against `#8084`'s hardcoded `true`: both
+NEGATIVES go red there and both positives stay green. The callee local's
+object-literal initializer is load-bearing and commented as such —
+`expr_is_known_non_pointer_shadow_value` suppresses rooting for a `LocalGet`
+with no reserved shadow slot whose type proof is not pointer-bearing, so a first
+draft using `Expr::Undefined` had both POSITIVES failing against a correct
+compiler and both negatives passing for that reason rather than the one they
+claim.

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -474,6 +474,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `open_rooted_group` rather than `with_rooted_group`: the release
             // has to sit below the consuming call, which is past the end of the
             // spread/regs marshalling block rather than inside it.
+            //
+            // #8159: `true` stays, and for the reason `NewDynamicSpread` gives
+            // — a spread call reaches `js_array_like_to_array` on its spread
+            // source unconditionally, so the window allocates in every
+            // instance of this arm. Nothing to narrow, as opposed to nothing
+            // narrowed.
             let mut callee_group = crate::rooting::open_rooted_group(1);
             let cb_box = lower_expr(ctx, callee)?;
             let cb_root = callee_group.adopt(ctx, callee, &cb_box, true);

--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -100,6 +100,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // The CALLEE has the §18/#7803 defect too: this spread arm was not
             // among the three `8842a0be4` fixed. A root and not a reload — JS
             // resolves the callee before the arguments.
+            //
+            // #8159: `true`, and not a computed window, on purpose.
+            // `bundle_args_rooted` opens with `js_array_alloc` and emits a
+            // `js_array_push_f64` / `js_array_concat` per argument, so this
+            // window allocates for EVERY spread construction — `new F(...[])`
+            // included. There is no narrowing to make here, which is worth
+            // stating: the two non-spread arms below take their window from
+            // `any_operand_may_collect` precisely because theirs can be empty.
             let mut callee_group = crate::rooting::open_rooted_group(1);
             let func_double = lower_expr(ctx, callee)?;
             let callee_root = callee_group.adopt(ctx, callee, &func_double, true);
@@ -715,12 +723,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // miscompile in place of a rooting bug. That is exactly why
                 // `operand_is_reloadable` refuses module globals, and the
                 // group's `operand_protection` answers it the same way here.
+                //
+                // #8159: the window is COMPUTED, not assumed. #8084 hardcoded
+                // `true`, which buys a slot, a re-read and a release at every
+                // call site whether or not anything between an operand and its
+                // consumer can collect — 3.9% of `pipeline`'s instructions,
+                // enough to swallow another PR's entire win on that row.
+                // `operand_protection` already answers "root, re-derive or
+                // reuse?", and its `Reuse` arm keeps the pre-#8084 IR byte for
+                // byte; all it was missing was the truthful window.
+                //
+                // The callee's window is every argument; argument `i`'s is the
+                // arguments after it. Neither reaches a collection point of its
+                // own: `lower_js_args_array` is an entry alloca plus stores,
+                // and `emit_call_location_at` emits nothing at all in a default
+                // build. So `new C(a, b)` over plain locals is back to emitting
+                // no rooting — the shape `operand_needs_root`'s doc already
+                // claims for it — while `new C(mk(), x)` still roots.
+                //
+                // Each flag is computed BELOW the operand it protects, exactly
+                // as `with_operands_rooted_window` computes it: the predicate
+                // reads `ctx`, so asking before the lowering asks about a
+                // different state.
                 let result = crate::rooting::with_rooted_group(ctx, args.len() + 1, |ctx, g| {
                     let func_double = lower_expr(ctx, callee)?;
-                    let callee_root = g.adopt(ctx, callee, &func_double, true);
+                    let callee_collects = crate::rooting::any_operand_may_collect(ctx, args.iter());
+                    let callee_root = g.adopt(ctx, callee, &func_double, callee_collects);
                     let mut arg_ids = Vec::with_capacity(args.len());
-                    for a in args {
-                        arg_ids.push(g.lower(ctx, a, true)?);
+                    for (i, a) in args.iter().enumerate() {
+                        let value = lower_expr(ctx, a)?;
+                        let collects =
+                            crate::rooting::any_operand_may_collect(ctx, args[i + 1..].iter());
+                        arg_ids.push(g.adopt(ctx, a, &value, collects));
                     }
                     let lowered_args: Vec<String> = arg_ids
                         .iter()
@@ -759,13 +793,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     MaterializationReason::UnknownCallEscape,
                 );
             }
-            // #7803: same callee-outlives-arguments fix as the arm above.
+            // #7803: same callee-outlives-arguments fix as the arm above,
+            // and #8159's same computed window — see there for both.
             crate::rooting::with_rooted_group(ctx, args.len() + 1, |ctx, g| {
                 let func_double = lower_expr(ctx, callee)?;
-                let callee_root = g.adopt(ctx, callee, &func_double, true);
+                let callee_collects = crate::rooting::any_operand_may_collect(ctx, args.iter());
+                let callee_root = g.adopt(ctx, callee, &func_double, callee_collects);
                 let mut arg_ids = Vec::with_capacity(args.len());
-                for a in args {
-                    arg_ids.push(g.lower(ctx, a, true)?);
+                for (i, a) in args.iter().enumerate() {
+                    let value = lower_expr(ctx, a)?;
+                    let collects =
+                        crate::rooting::any_operand_may_collect(ctx, args[i + 1..].iter());
+                    arg_ids.push(g.adopt(ctx, a, &value, collects));
                 }
                 let lowered_args: Vec<String> = arg_ids
                     .iter()

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -396,9 +396,20 @@ pub fn try_lower_closure_typed_local_call(
             // arms: re-lowering `LocalGet` below the arguments re-reads the box
             // and would observe an assignment an argument made, when JS
             // resolved the callee before them.
+            //
+            // #8159: the window is EXACTLY the argument lowering below. The
+            // re-read sits above the unmask because that is where the value
+            // leaves the tracked domain — a collection point BELOW the unmask
+            // is a different exposure, which rooting the box cannot repair
+            // either way. So the flag is the same question every other
+            // combinator in `rooting/` asks its caller, and answering it
+            // truthfully puts `stage(rec)` — `pipeline`'s inner loop, three of
+            // these per record — back on the IR it had before #8084, while
+            // `stage(mk())` still roots.
             let mut callee_group = crate::rooting::open_rooted_group(1);
             let recv_box = lower_expr(ctx, callee)?;
-            let callee_root = callee_group.adopt(ctx, callee, &recv_box, true);
+            let collects = crate::rooting::any_operand_may_collect(ctx, args.iter());
+            let callee_root = callee_group.adopt(ctx, callee, &recv_box, collects);
             let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
             for a in args {
                 lowered_args.push(lower_expr(ctx, a)?);

--- a/crates/perry-codegen/src/temp_root_coverage/call_callee.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/call_callee.rs
@@ -1,0 +1,252 @@
+//! #8159: the callee's rooting window at a call site is COMPUTED, not assumed.
+//!
+//! #8084 fixed a real defect — three call arms lowered the CALLEE into a bare
+//! register, lowered the arguments below it, and handed the original register
+//! to the consuming call, so under the shipping statepoint lowering nothing
+//! marked it and nothing relocated it. It paid for the fix with a hardcoded
+//! `collects = true` at every one of those sites, which buys a slot, a re-read
+//! and a release per call whether or not anything in the window can collect.
+//! On `pipeline` — three closure-typed local calls per record, all with
+//! `LocalGet` arguments — that cost 3.9% of the program's instructions, enough
+//! to consume another PR's entire measured win on that row.
+//!
+//! `operand_protection` has always been able to answer this: its `Reuse` arm
+//! emits no push, no re-read and no truncate, keeping the pre-#8084 IR byte for
+//! byte. What it needed was the truthful window, which is what these tests pin
+//! — from BOTH sides, because either half alone passes for nothing. A compiler
+//! that roots nothing fails the allocating-argument tests; one that roots
+//! unconditionally (#8084's shape) fails the inert-argument tests. The two
+//! fixtures in each pair differ in exactly one thing: the argument's kind.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{allocating, main_ir_for, under_both_lowerings};
+use crate::testing::temp_slots::{call_operands, slot_traffic, temp_root_slots, SlotEvent};
+use perry_hir::types::{FunctionType, Type};
+use perry_hir::{Expr, Stmt};
+
+/// `%reg -> <def>` for every definition in `fn_ir`.
+fn defs(fn_ir: &str) -> BTreeMap<String, String> {
+    fn_ir
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.split_once(" = "))
+        .map(|(dst, def)| (dst.trim().to_string(), def.trim().to_string()))
+        .collect()
+}
+
+/// Does operand `n` of the first call to `consumer` come out of a **pooled
+/// temp-root** slot?
+///
+/// `temp_slots::derives_from_slot_load` cannot answer this one. `slot_traffic`
+/// sees every alloca, and the callee here is a `LocalGet` — always a load out
+/// of the local's OWN slot — so that helper answers `true` on both sides of
+/// this differential and the negative would be vacuous. [`temp_root_slots`] is
+/// the filter that separates a pooled temporary from a named local's slot; the
+/// def-chain walk below is the one `derives_from_slot_load` performs, because
+/// the pooled load is an `i64` while the call wants a NaN-boxed `double` (one
+/// `bitcast`) or a masked handle (a `bitcast` and an `and`).
+fn operand_comes_from_a_temp_root(fn_ir: &str, consumer: &str, n: usize) -> bool {
+    let temps: BTreeSet<String> = temp_root_slots(fn_ir).into_iter().collect();
+    let loaded: BTreeSet<String> = slot_traffic(fn_ir)
+        .into_iter()
+        .filter(|(slot, _)| temps.contains(slot))
+        .flat_map(|(_, events)| events)
+        .filter_map(|event| match event {
+            SlotEvent::Load { into, .. } => Some(into),
+            _ => None,
+        })
+        .collect();
+    let defs = defs(fn_ir);
+    let Some(mut reg) = call_operands(fn_ir, consumer).and_then(|ops| ops.get(n).cloned()) else {
+        return false;
+    };
+    for _ in 0..6 {
+        if loaded.contains(&reg) {
+            return true;
+        }
+        let Some(def) = defs.get(&reg) else {
+            return false;
+        };
+        let Some(next) = def
+            .split(|c: char| !(c.is_alphanumeric() || c == '%' || c == '.' || c == '_'))
+            .find(|word| word.starts_with('%'))
+        else {
+            return false;
+        };
+        reg = next.to_string();
+    }
+    false
+}
+
+/// An `any` local initialized to `undefined` — inert to LOWER (a load), so it
+/// is the argument that puts nothing in the callee's window.
+fn any_local(id: u32, name: &str) -> Stmt {
+    Stmt::Let {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::Undefined),
+    }
+}
+
+/// A CALLEE local, initialized to an object literal.
+///
+/// The initializer is load-bearing and cost a first draft of this file its
+/// meaning. `expr_is_known_non_pointer_shadow_value` suppresses rooting for a
+/// `LocalGet` with no reserved shadow slot whose type proof is not
+/// pointer-bearing — so a callee local initialized to `Expr::Undefined` is
+/// never rooted no matter what the window says. Both POSITIVE tests failed
+/// against a correct compiler, and, worse, both NEGATIVES were passing for
+/// that reason rather than for the one they claim. A heap initializer reserves
+/// the slot and makes the rooting question apply at all.
+fn callee_local(id: u32, name: &str, ty: Type) -> Stmt {
+    Stmt::Let {
+        id,
+        name: name.to_string(),
+        ty,
+        mutable: false,
+        init: Some(Expr::Object(Vec::new())),
+    }
+}
+
+/// The `(r: any) => any` annotation, which is the whole gate on
+/// `try_lower_closure_typed_local_call`'s guarded dispatch.
+fn stage_type() -> Type {
+    Type::Function(FunctionType {
+        params: vec![("r".to_string(), Type::Any, false)],
+        return_type: Box::new(Type::Any),
+        is_async: false,
+        is_generator: false,
+    })
+}
+
+/// `const out = stage(<arg>)` — `pipeline`'s inner loop, once.
+///
+/// The result is BOUND rather than discarded: a discarded expression statement
+/// goes through a different tail (#7590), and this contract is about the call
+/// that a real program's value flows out of.
+fn closure_call_ir(name: &str, arg: Expr) -> String {
+    main_ir_for(
+        name,
+        vec![
+            callee_local(0, "stage", stage_type()),
+            any_local(1, "rec"),
+            Stmt::Let {
+                id: 2,
+                name: "out".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::LocalGet(0)),
+                    args: vec![arg],
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                }),
+            },
+        ],
+    )
+}
+
+/// `const inst = new ctor(<arg>)` on an `any`-typed callee — the shape that
+/// routes to `js_new_function_construct`.
+fn dynamic_new_ir(name: &str, arg: Expr) -> String {
+    main_ir_for(
+        name,
+        vec![
+            callee_local(0, "ctor", Type::Any),
+            any_local(1, "x"),
+            Stmt::Let {
+                id: 2,
+                name: "inst".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::NewDynamic {
+                    callee: Box::new(Expr::LocalGet(0)),
+                    args: vec![arg],
+                    byte_offset: 0,
+                }),
+            },
+        ],
+    )
+}
+
+/// `stage(rec)` — nothing between the callee's lowering and the unmask can
+/// collect, so the callee must reach `js_closure_call1` in the register it was
+/// lowered into.
+#[test]
+fn a_closure_typed_local_call_with_an_inert_argument_roots_no_callee() {
+    under_both_lowerings(|lowering| {
+        let ir = closure_call_ir("closure_call_inert_arg.ts", Expr::LocalGet(1));
+        assert!(
+            ir.contains("@js_closure_call1("),
+            "{lowering}: the fixture must reach the closure-typed local call \
+             arm, or this proves nothing:\n{ir}"
+        );
+        assert!(
+            !operand_comes_from_a_temp_root(&ir, "js_closure_call1", 0),
+            "{lowering}: a `LocalGet` argument reaches no collection point, so \
+             the callee's window is empty and rooting it is pure cost — a \
+             store, a re-read and a clear on every call (#8159):\n{ir}"
+        );
+    });
+}
+
+/// …and the same call with an ALLOCATING argument must root it: the object
+/// literal is a collection point, and the register the callee was lowered into
+/// is in no live bundle (#7803/#8084).
+#[test]
+fn a_closure_typed_local_call_roots_the_callee_across_an_allocating_argument() {
+    under_both_lowerings(|lowering| {
+        let ir = closure_call_ir("closure_call_allocating_arg.ts", allocating());
+        assert!(
+            ir.contains("@js_closure_call1("),
+            "{lowering}: the fixture must reach the closure-typed local call \
+             arm, or this proves nothing:\n{ir}"
+        );
+        assert!(
+            operand_comes_from_a_temp_root(&ir, "js_closure_call1", 0),
+            "{lowering}: the callee outlives an allocating argument, so it must \
+             be re-read from a rooted slot — a bare register is in no live \
+             bundle and nothing relocates it (#7803):\n{ir}"
+        );
+    });
+}
+
+/// `new ctor(x)` — same claim on the `js_new_function_construct` arm, whose
+/// window is the arguments plus `lower_js_args_array` (an entry alloca and
+/// stores, which collect nothing).
+#[test]
+fn a_dynamic_construction_with_an_inert_argument_roots_neither_callee_nor_argument() {
+    under_both_lowerings(|lowering| {
+        let ir = dynamic_new_ir("new_dynamic_inert_arg.ts", Expr::LocalGet(1));
+        assert!(
+            ir.contains("@js_new_function_construct("),
+            "{lowering}: the fixture must reach the dynamic-construct arm, or \
+             this proves nothing:\n{ir}"
+        );
+        // Stronger than the closure pair's negative, and available here because
+        // this arm saves no implicit `this`: NOTHING in the lowering is rooted.
+        crate::testing::temp_slots::assert_no_temp_rooting(&ir, lowering);
+    });
+}
+
+/// …and the allocating-argument twin, which must still root the callee across
+/// it — the 21-hazard population #8084 measured in zod's `schemas.ts`.
+#[test]
+fn a_dynamic_construction_roots_the_callee_across_an_allocating_argument() {
+    under_both_lowerings(|lowering| {
+        let ir = dynamic_new_ir("new_dynamic_allocating_arg.ts", allocating());
+        assert!(
+            ir.contains("@js_new_function_construct("),
+            "{lowering}: the fixture must reach the dynamic-construct arm, or \
+             this proves nothing:\n{ir}"
+        );
+        assert!(
+            operand_comes_from_a_temp_root(&ir, "js_new_function_construct", 0),
+            "{lowering}: the constructor outlives an allocating argument and \
+             must be re-read from a rooted slot (#7803):\n{ir}"
+        );
+    });
+}

--- a/crates/perry-codegen/src/temp_root_coverage/mod.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/mod.rs
@@ -44,6 +44,7 @@ use crate::{compile_module, AppMetadata, CompileOptions};
 use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
 
 mod builtin_ctor;
+mod call_callee;
 mod operands;
 
 fn entry_opts() -> CompileOptions {


### PR DESCRIPTION
Closes #8159 — but not in the direction the issue expected, so the headline first.

## The narrowing works, and it does not recover pipeline's 3.9%

#8159 asked whether #8084's per-call-site rooting sequence can be narrowed "e.g. skipping the reread when nothing between adopt and use can allocate". It can, this PR does it, and **it recovers none of the cost on `pipeline`** — because `pipeline` never reaches the arms #8084 touched.

`pipeline`'s inner loop is `rec = stage(rec)`, which lowers through `lower_dynamic_closure_call` (`js_closure_unbox_callee_checked`) — the #7154 lowering, already fully rooted before #8084. The emitted IR for `gc-handoff/apps/pipeline.ts` is **byte-identical** across this change, and `grep` finds no call to `js_new_function_construct` or `js_closure_call_apply_with_spread` in it at all. That rules the mechanism out structurally rather than failing to detect it.

So the issue's attribution to the *commit* stands; its attribution to that *hunk* does not. The +3.95% is somewhere in #8084's other ~2,500 lines — `gc_map.rs` (+355), `gc/roots/stack_maps*` (~1,660), `gc/copying.rs` + `copying_pointer_set.rs`, `pin.rs`, `tenuring.rs`, `object/this_binding.rs`. See the issue comment for the sharpest suspect.

## What the change is

`collects` is not a strategy, it is a **window**: "can anything between this operand and its consumer collect?" #8084 hardcoded it `true` at five arms, which buys a slot store, a re-read and a release at every call site whether or not the window contains a collection point. `operand_protection` has always been able to answer this — its `Reuse` arm emits no push, no re-read and no truncate, keeping the pre-#8084 IR byte for byte. It just needed the truthful window, which `any_operand_may_collect` computes and `with_operands_rooted_window` has passed all along.

Three arms now compute it; **two deliberately keep `true` and say why** — `bundle_args_rooted` opens with `js_array_alloc`, and a spread call reaches `js_array_like_to_array` unconditionally, so those windows allocate in every instance of the arm. Nothing to narrow, as opposed to nothing narrowed.

Each flag is computed **below** the operand it protects, as `with_operands_rooted_window` computes it: the predicate reads `ctx`, so asking before the lowering asks about a different state.

## Measurements

Both arms are the same tree at `07c8040bf` differing only in these three files; **identical `libperry_runtime.a` / `libperry_stdlib.a`** (codegen-only change, `cmp`-verified untouched across the second build), per-arm `PERRY_CACHE_DIR`, `PERRY_NO_AUTO_OPTIMIZE=1`, `/usr/bin/time -l`, min-of-5, stdout sha256 identical on every row.

| row | base | this PR | Δ |
|---|--:|--:|--:|
| `pipeline` | 3,952,488,683 | 3,953,452,078 | +0.02% |
| `interp` | 13,815,893,339 | 13,810,291,395 | −0.04% |
| `iso_miss` | 16,498,233,755 | 16,489,972,804 | −0.05% |
| `asyncpipe` | 1,304,733,639 | 1,306,205,988 | +0.11% |
| `shapes` | 1,325,703,306 | 1,323,270,162 | −0.18% |

All inside noise. Where it *does* move something is zod, which is the population that has these shapes: dep-native live bundles 36,611 → 36,598, relocates 432,545 → 432,338.

## Soundness

`gc_root_dominance_check.py`, base vs this PR on the same build, both corpora — **identical verdicts**:

| corpus | unrooted | stale | seeded |
|---|--:|--:|--:|
| dep-native (zod, 81 modules, 12,957 fns) | 2 (budget 3) | 0 | 40/40 caught |
| curated-native (145 sources, 172 modules) | 0 | 1 | 39/40 caught |

`--self-test` passes, so a green here means "examined and clean" rather than "declined to examine". #7803's own shape keeps its root by construction — its arguments are freshly-allocated object literals.

Two observations about **clean `main`**, neither caused by this PR (both arms report them identically), recorded so they aren't rediscovered:

- **curated-native is red at `07c8040bf`**: one `stale` hazard (`test_gap_class_forward_capture_6523::__closure_7`, `unmasked->js_box_set`, moving via `js_object_get_field_by_name_f64`) against `--max-stale 0`, plus **39/40** seeded violations caught where CI requires 40. It was invisible until #8207, because the job aborted earlier at `--audit-poll-capable`.
- **dep-native reads 2, not the 3 the workflow budgets.** Slack nobody knows about is where the next regression lands green. Not tightened here on purpose: the number is LLVM-version dependent and I measured it with homebrew `opt`, not CI's — lowering a budget I cannot verify in CI is how the gate goes red for the next person. Worth CI measuring and tightening.

## Tests

`temp_root_coverage/call_callee.rs` — two differential pairs, in `src/` so they run in the per-PR `cargo-test` gate rather than the nightly tier. The two fixtures in each pair differ in exactly one thing, the argument's kind.

**Sabotage-checked**: against #8084's hardcoded `true`, both NEGATIVES go red and both positives stay green. Neither half passes for nothing.

The callee local's object-literal initializer is load-bearing and is commented as such: `expr_is_known_non_pointer_shadow_value` suppresses rooting for a `LocalGet` with no reserved shadow slot whose type proof is not pointer-bearing, so a first draft using `Expr::Undefined` had both POSITIVES failing against a correct compiler and — worse — both negatives passing for that reason rather than the one they claim.

Local: `cargo test -p perry-codegen --lib temp_root_coverage` 17/17 under both lowerings, `cargo fmt --all --check` clean.
