### PR TITLE
fix(codegen): teach the in-process IR reader the vector instructions codegen emits (#8228)

### DIFF
--- a/changelog.d/8241-dialect-vector-instructions.md
+++ b/changelog.d/8241-dialect-vector-instructions.md
@@ -1,0 +1,28 @@
+Fixed the in-process LLVM backend failing every module large enough to split
+across native codegen units (#8228). Perry's dialect reader — the hand-written
+parser the native path round-trips its own textual IR through — had no
+`insertelement` case, so the `<2 x i64>` object-header image that #8204 began
+composing at module init fell through to the binary-op arm and reported
+``bad binary op `insertelement` operands``. The native path is the default for
+split modules only, so this surfaced on exactly the biggest modules of a large
+app: the pinned production Next.js App Route fixture could not build its app
+dylib at all, five modules deep including the route runtime itself.
+
+The reader now accepts the closed set of vector forms perry-codegen actually
+emits: `insertelement`, `extractelement`, `shufflevector`, vector-typed `add`
+and `mul`, constant vector literals, and `poison`/`undef`/`zeroinitializer` of
+vector type. That also covers `expr/channel.rs`'s `<4 x i32>` SIMD byte-channel
+reduction, which was the same latent bug and had simply never appeared in a
+module big enough to split. `insertvalue`/`extractvalue` are deliberately still
+rejected — codegen emits neither, and an unreachable arm is untested code.
+
+The reason this could ship green is that the reader's only gate was a set of
+frozen `.ll` snapshots under `experiments/`, which by construction cannot see a
+form the emitters started producing later; and no per-PR job compiles anything
+large enough to take the native path. Replaced with a live emit → re-parse test
+that compiles a real module through the real emitters and feeds every function
+it produced back through the reader, so the next new emission form fails in
+`cargo-test` instead of in a user build.
+
+Interim workaround for anyone on a released build: `PERRY_LLVM_INPROCESS=off`
+selects the text transport, which is unaffected.

--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -28,6 +28,7 @@ use inkwell::{AddressSpace, FloatPredicate, IntPredicate};
 
 mod eh;
 mod types;
+mod vector;
 
 use types::{basic_type, constant, fn_type_of, indirect_fn_type, strip_label, ty_and_val};
 #[cfg(test)]
@@ -529,6 +530,15 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
                     .build_select(cond.into_int_value(), a, bv, dst.trim_start_matches('%'))
                     .map_err(be)?
             }
+            // Vector forms (#8228). These MUST be dispatched by name: the
+            // fallthrough below is the binary-op arm, which sees a
+            // three-operand `insertelement` as a malformed `add` and reports
+            // "bad binary op `insertelement` operands" — the failure that
+            // blocked every multi-unit module once #8204 started emitting the
+            // header-image compose.
+            "insertelement" => self.insert_element(dst, rest)?,
+            "extractelement" => self.extract_element(dst, rest)?,
+            "shufflevector" => self.shuffle_vector(dst, rest)?,
             _ => self.binary_or_cast(dst, op, rest)?,
         };
         self.def(dst, v)?;
@@ -1018,6 +1028,14 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
         let a = self.val(ty, atok)?;
         let b2 = self.val(ty, parts[1].trim())?;
         let nm = name;
+        if let (BasicValueEnum::VectorValue(av), BasicValueEnum::VectorValue(bv)) = (a, b2) {
+            // `expr/channel.rs` emits `mul`/`add` over `<4 x i32>`. The scalar
+            // arms below reach their operands through `into_int_value()`,
+            // which panics on a vector instead of erroring, so split first.
+            let out = self.vector_binary(op_base, nm, av, bv)?;
+            apply_flags(out.as_instruction_value(), &flag_tokens);
+            return Ok(out);
+        }
         let out: BasicValueEnum = match op_base {
             "add" => self
                 .builder

--- a/crates/perry-codegen/src/dialect/tests.rs
+++ b/crates/perry-codegen/src/dialect/tests.rs
@@ -27,6 +27,27 @@ fn split_corpus(text: &str) -> (String, Vec<String>) {
     (skeleton, fns)
 }
 
+/// Build every `define` in `text` through the reader and verify the module.
+/// Returns the instruction count so callers can assert the corpus was real.
+fn roundtrip_ir(text: &str, module_name: &str) -> usize {
+    let (skeleton, fns) = split_corpus(text);
+    let ctx = Context::create();
+    let module =
+        crate::inprocess::parse_ir_text(&ctx, &skeleton, module_name).expect("skeleton parses");
+    for f in &fns {
+        predeclare_function_from_text(&ctx, &module, f)
+            .unwrap_or_else(|e| panic!("predeclare: {e:#}"));
+    }
+    let mut n = 0usize;
+    for f in &fns {
+        n += add_function_from_text(&ctx, &module, f).unwrap_or_else(|e| panic!("{e:#}"));
+    }
+    module
+        .verify()
+        .unwrap_or_else(|e| panic!("verifier rejected native module:\n{}", e.to_string()));
+    n
+}
+
 /// Every function in a real perry-emitted corpus file must construct
 /// natively and pass the LLVM verifier. This is the reader's primary
 /// gate: a form it cannot express fails here, not in a user build.
@@ -37,25 +58,11 @@ fn corpus_roundtrip(path: &str) {
     // failure mode the Linux bring-up had to rule out by hand.
     let text = std::fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("corpus file {path} is not readable: {e}"));
-    let (skeleton, fns) = split_corpus(&text);
-    let ctx = Context::create();
-    let module =
-        crate::inprocess::parse_ir_text(&ctx, &skeleton, "corpus_skel").expect("skeleton parses");
-    for f in &fns {
-        predeclare_function_from_text(&ctx, &module, f)
-            .unwrap_or_else(|e| panic!("predeclare: {e:#}"));
-    }
-    let mut n = 0usize;
-    for f in &fns {
-        n += add_function_from_text(&ctx, &module, f).unwrap_or_else(|e| panic!("{e:#}"));
-    }
+    let n = roundtrip_ir(&text, "corpus_skel");
     assert!(
         n > 1000,
         "expected a real corpus, built only {n} instructions"
     );
-    module
-        .verify()
-        .unwrap_or_else(|e| panic!("verifier rejected native module:\n{}", e.to_string()));
 }
 
 #[test]
@@ -98,4 +105,204 @@ fn corpus_batch_kernel() {
         env!("CARGO_MANIFEST_DIR"),
         "/../../experiments/llvm-inprocess-spike/batch_kernel.ll"
     ));
+}
+
+// ---------------------------------------------------------------------------
+// #8228: LIVE emit -> re-parse, not a frozen corpus
+// ---------------------------------------------------------------------------
+//
+// The three `corpus_*` tests above are the reader's primary gate, and they are
+// all **snapshots**: `.ll` files checked in under `experiments/`. A form the
+// emitters started producing *after* those files were captured is invisible to
+// them, and the reader is only the DEFAULT for split (multi-unit) modules
+// (`native_emit::native_units_mode`) — every gap/parity fixture is a single
+// unit and keeps the text path. So a new emission form could ship, be silently
+// untested by every per-PR job, and first fail in a user build of a large app.
+//
+// That is exactly what #8204 did: it added the `<2 x i64>` object-header-image
+// compose, the reader had no `insertelement` case, and the fall-through
+// binary-op arm reported `bad binary op \`insertelement\` operands` on the five
+// biggest modules of the Next App Route fixture — the only build big enough to
+// split, and one that is tag-gated.
+//
+// `compiled_module_ir_round_trips_through_the_reader` closes the class rather
+// than the instance: it compiles a real module through the real emitters and
+// re-parses every function it produced, so the NEXT new form fails here.
+
+use crate::{compile_module, CompileOptions};
+use perry_hir::types::Type;
+use perry_hir::{Class, ClassField, Expr, Module, ModuleInitKind, Stmt};
+
+/// The header-image compose the reader must accept. Asserted present before
+/// the round-trip so a fixture that stopped exercising the inline allocator
+/// fails loudly instead of passing vacuously (CLAUDE.md: a gate must assert
+/// its subject was live).
+const HEADER_IMAGE_COMPOSE: &str = "insertelement <2 x i64> <i64 ";
+
+fn cell_class() -> Class {
+    Class {
+        id: 3,
+        name: "Cell".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: vec![ClassField {
+            name: "v".to_string(),
+            key_expr: None,
+            ty: Type::Number,
+            init: None,
+            is_private: false,
+            is_readonly: false,
+            decorators: Vec::new(),
+        }],
+        constructor: None,
+        methods: Vec::new(),
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        computed_members: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        aliases: Vec::new(),
+        is_nested: false,
+        alloc_width_hint: 0,
+        specialized_from: None,
+    }
+}
+
+/// `while (…) { const c = new Cell(1) }` — a `new` in a loop, which is what
+/// admits the inline bump allocator and therefore the per-class header image.
+/// The result is bound rather than discarded: a discarded value takes a
+/// different lowering path (#7590).
+fn cell_loop_module() -> Module {
+    let mut m = Module::new("dialect_roundtrip.ts");
+    m.classes = vec![cell_class()];
+    m.init = vec![Stmt::While {
+        condition: Expr::Bool(false),
+        body: vec![Stmt::Let {
+            id: 4001,
+            name: "c".to_string(),
+            ty: Type::Named("Cell".to_string()),
+            mutable: false,
+            init: Some(Expr::New {
+                class_name: "Cell".to_string(),
+                args: vec![Expr::Number(1.0)],
+                type_args: Vec::new(),
+                byte_offset: 0,
+                cap_args_appended: 0,
+            }),
+        }],
+    }];
+    m.init_kind = ModuleInitKind::Eager;
+    m
+}
+
+#[test]
+fn compiled_module_ir_round_trips_through_the_reader() {
+    let opts = CompileOptions {
+        emit_ir_only: true,
+        is_entry_module: true,
+        ..Default::default()
+    };
+    let ir = String::from_utf8(compile_module(&cell_loop_module(), opts).expect("module compiles"))
+        .expect("LLVM IR is UTF-8");
+    assert!(
+        ir.contains(HEADER_IMAGE_COMPOSE),
+        "fixture no longer emits the inline-allocator header image, so this \
+         test would round-trip nothing relevant:\n{ir}"
+    );
+    let n = roundtrip_ir(&ir, "emit_roundtrip");
+    assert!(n > 0, "round-tripped an empty module");
+}
+
+/// The `format!` templates `expr/channel.rs` emits for its `<4 x i32>` SIMD
+/// byte-channel reduction, in emission order. The fixture below is BUILT from
+/// these strings rather than duplicating them, and each is asserted to still
+/// be present verbatim in that file's source — so if the emitter's text
+/// changes, this test's fixture changes with it or the test fails, and it can
+/// never quietly test a shape codegen stopped producing.
+const CHANNEL_TEMPLATES: &[&str] = &[
+    "{} = insertelement <4 x i32> {}, i32 {}, i32 {}",
+    "{} = insertelement <4 x i32> poison, i32 {}, i32 0",
+    "{} = shufflevector <4 x i32> {}, <4 x i32> poison, <4 x i32> zeroinitializer",
+    "{} = mul <4 x i32> {}, {}",
+    "{} = add <4 x i32> {}, {}",
+    "{} = extractelement <4 x i32> {}, i32 {}",
+];
+
+/// Substitute `args` into a `format!`-style template's `{}` holes.
+fn instantiate(template: &str, args: &[&str]) -> String {
+    let mut parts = template.split("{}");
+    let mut out = parts.next().unwrap_or_default().to_string();
+    for (i, tail) in parts.enumerate() {
+        out.push_str(args.get(i).unwrap_or_else(|| {
+            panic!("template `{template}` needs more than {} args", args.len())
+        }));
+        out.push_str(tail);
+    }
+    out
+}
+
+#[test]
+fn channel_reduction_vector_forms_round_trip() {
+    let src = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/expr/channel.rs"))
+        .expect("channel.rs is readable");
+    for t in CHANNEL_TEMPLATES {
+        assert!(
+            src.contains(&format!("\"{t}\"")),
+            "expr/channel.rs no longer emits `{t}` — update CHANNEL_TEMPLATES \
+             so this fixture keeps matching the emitter"
+        );
+    }
+    let zeros = "<i32 0, i32 0, i32 0, i32 0>";
+    let mut body = vec![
+        "  %b0 = load i8, ptr %acc".to_string(),
+        "  %z0 = zext i8 %b0 to i32".to_string(),
+        // Lane 0 seeded from the constant zero vector, lane 1 chained off a
+        // register — both operand shapes the emitter produces.
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[0], &["%v0", zeros, "%z0", "0"])
+        ),
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[0], &["%v1", "%v0", "%z0", "1"])
+        ),
+        format!("  {}", instantiate(CHANNEL_TEMPLATES[1], &["%k0", "3"])),
+        format!("  {}", instantiate(CHANNEL_TEMPLATES[2], &["%ks", "%k0"])),
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[3], &["%mv", "%v1", "%ks"])
+        ),
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[0], &["%a0", zeros, "%z0", "0"])
+        ),
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[4], &["%na", "%a0", "%mv"])
+        ),
+        format!(
+            "  {}",
+            instantiate(CHANNEL_TEMPLATES[5], &["%l0", "%na", "0"])
+        ),
+        "  store i32 %l0, ptr %acc".to_string(),
+        "  ret void".to_string(),
+    ];
+    body.insert(0, "entry:".to_string());
+    let ir = format!(
+        "define void @channel_probe(ptr %acc) {{\n{}\n}}\n",
+        body.join("\n")
+    );
+    let n = roundtrip_ir(&ir, "channel_roundtrip");
+    assert!(
+        n >= body.len() - 1,
+        "built only {n} instructions from:\n{ir}"
+    );
 }

--- a/crates/perry-codegen/src/dialect/types.rs
+++ b/crates/perry-codegen/src/dialect/types.rs
@@ -9,7 +9,7 @@
 use anyhow::{anyhow, bail, Result};
 use inkwell::context::Context;
 use inkwell::module::Module;
-use inkwell::types::{BasicType, BasicTypeEnum, FunctionType};
+use inkwell::types::{BasicType, BasicTypeEnum, FunctionType, VectorType};
 use inkwell::values::BasicValueEnum;
 use inkwell::AddressSpace;
 
@@ -257,12 +257,16 @@ pub(super) fn constant<'ctx>(
             BasicTypeEnum::FloatType(t) => t.get_undef().into(),
             BasicTypeEnum::IntType(t) => t.get_undef().into(),
             BasicTypeEnum::PointerType(t) => t.get_undef().into(),
+            BasicTypeEnum::VectorType(t) => t.get_undef().into(),
             other => bail!("undef of unsupported type {other:?}"),
         },
+        // `insertelement <4 x i32> poison, ...` seeds `expr/channel.rs`'s
+        // lane-0 splat, so a vector poison is an emitted form, not a corner.
         "poison" => match ty {
             BasicTypeEnum::FloatType(t) => t.get_poison().into(),
             BasicTypeEnum::IntType(t) => t.get_poison().into(),
             BasicTypeEnum::PointerType(t) => t.get_poison().into(),
+            BasicTypeEnum::VectorType(t) => t.get_poison().into(),
             other => bail!("poison of unsupported type {other:?}"),
         },
         "true" => ctx.bool_type().const_int(1, false).into(),
@@ -272,6 +276,8 @@ pub(super) fn constant<'ctx>(
             BasicTypeEnum::IntType(t) => t.const_zero().into(),
             BasicTypeEnum::ArrayType(t) => t.const_zero().into(),
             BasicTypeEnum::PointerType(t) => t.const_null().into(),
+            // The all-zero `shufflevector` mask (`channel.rs`'s splat).
+            BasicTypeEnum::VectorType(t) => t.const_zero().into(),
             other => bail!("zeroinitializer of unsupported type {other:?}"),
         },
         _ => match ty {
@@ -294,7 +300,47 @@ pub(super) fn constant<'ctx>(
                 let v: i128 = tok.parse().map_err(|_| anyhow!("bad integer `{tok}`"))?;
                 t.const_int(v as u64, v < 0).into()
             }
+            BasicTypeEnum::VectorType(t) => return vector_constant(ctx, module, t, tok),
             other => bail!("cannot materialize `{tok}` as {other:?}"),
         },
     })
+}
+
+/// `<i64 207232172546, i64 0>` — an LLVM constant vector literal.
+///
+/// Perry emits one as the seed operand of the #8122/#8204 header-image
+/// `insertelement` (`function.rs`, `codegen/string_pool.rs`) and another as
+/// `channel.rs`'s all-zero `<4 x i32>` accumulator seed. Every element of a
+/// vector literal is itself a constant, so this recurses through `constant`
+/// with the vector's element type and cross-checks the per-element type token
+/// — a `<2 x i64>` whose elements claim `i32` is a codegen bug worth a loud
+/// error, not a silent truncation.
+fn vector_constant<'ctx>(
+    ctx: &'ctx Context,
+    module: &Module<'ctx>,
+    ty: VectorType<'ctx>,
+    tok: &str,
+) -> Result<BasicValueEnum<'ctx>> {
+    let body = tok
+        .strip_prefix('<')
+        .and_then(|t| t.strip_suffix('>'))
+        .ok_or_else(|| anyhow!("cannot materialize `{tok}` as a vector constant"))?;
+    let elem_ty = ty.get_element_type();
+    let mut elems: Vec<BasicValueEnum<'ctx>> = Vec::new();
+    for part in split_top_level(body) {
+        let (part_ty_tok, val_tok) = ty_and_val(&part)?;
+        let part_ty = basic_type(ctx, part_ty_tok)?;
+        if part_ty != elem_ty {
+            bail!("vector constant `{tok}` element type `{part_ty_tok}` is not the element type");
+        }
+        elems.push(constant(ctx, module, part_ty, val_tok)?);
+    }
+    if elems.len() as u32 != ty.get_size() {
+        bail!(
+            "vector constant `{tok}` has {} elements, type has {}",
+            elems.len(),
+            ty.get_size()
+        );
+    }
+    Ok(VectorType::const_vector(&elems).into())
 }

--- a/crates/perry-codegen/src/dialect/vector.rs
+++ b/crates/perry-codegen/src/dialect/vector.rs
@@ -1,0 +1,142 @@
+//! Vector-instruction construction for the in-process LLVM reader (#8228):
+//! `insertelement`, `extractelement`, `shufflevector`, and vector-typed
+//! arithmetic.
+//!
+//! Split out of `dialect/mod.rs` to keep that file under the 2000-line cap,
+//! following `eh.rs`; these share the parent reader's state (value map,
+//! builder) exactly as the EH forms do.
+//!
+//! **The closed set this file accepts is the set perry-codegen emits.** Two
+//! emitters produce vectors, and both reach this reader as `Raw` text:
+//!
+//! * the #8122/#8204 object-header image — `insertelement <2 x i64>
+//!   <i64 PACKED, i64 0>, i64 %header_word, i32 1` from
+//!   `function.rs::entry_init_object_header_image` and
+//!   `codegen/string_pool.rs`, whose result is stored as one `<2 x i64>`
+//!   per inline `new`;
+//! * `expr/channel.rs`'s byte-channel reduction — `insertelement` /
+//!   `shufflevector` / `extractelement` over `<4 x i32>`, plus vector `mul`
+//!   and `add`.
+//!
+//! Nothing else emits a vector or aggregate instruction: `insertvalue` never
+//! appears, and the tree's only `extractvalue` is an *input* fixture to a
+//! landing-pad text transform, not emitted IR. Implementing those anyway
+//! would add arms no test can reach, which is the opposite of this reader's
+//! contract — it accepts a closed set precisely so a NEW emission form fails
+//! loudly here instead of diverging silently.
+
+use anyhow::{bail, Result};
+use inkwell::types::BasicTypeEnum;
+use inkwell::values::{BasicValueEnum, IntValue, VectorValue};
+
+use super::{basic_type, be, split_top_level, ty_and_val, FnReader};
+
+impl<'ctx, 'm> FnReader<'ctx, 'm> {
+    /// `insertelement <N x T> VEC, T ELEM, i32 IDX`
+    ///
+    /// `VEC` is a register, a constant vector literal (`<i64 W, i64 0>`), or
+    /// `poison` — `channel.rs` seeds its splat from the last of those and the
+    /// header image from the middle one, so all three arrive here.
+    pub(super) fn insert_element(&mut self, dst: &str, rest: &str) -> Result<BasicValueEnum<'ctx>> {
+        let parts = split_top_level(rest);
+        if parts.len() != 3 {
+            bail!("bad insertelement operands: {rest}");
+        }
+        let vector = self.vector_operand("insertelement", &parts[0])?;
+        let (elem_ty, elem_tok) = ty_and_val(&parts[1])?;
+        let elem = self.val(basic_type(self.ctx, elem_ty)?, elem_tok)?;
+        let index = self.vector_index("insertelement", &parts[2])?;
+        Ok(self
+            .builder
+            .build_insert_element(vector, elem, index, dst.trim_start_matches('%'))
+            .map_err(be)?
+            .into())
+    }
+
+    /// `extractelement <N x T> VEC, i32 IDX`
+    pub(super) fn extract_element(
+        &mut self,
+        dst: &str,
+        rest: &str,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        let parts = split_top_level(rest);
+        if parts.len() != 2 {
+            bail!("bad extractelement operands: {rest}");
+        }
+        let vector = self.vector_operand("extractelement", &parts[0])?;
+        let index = self.vector_index("extractelement", &parts[1])?;
+        self.builder
+            .build_extract_element(vector, index, dst.trim_start_matches('%'))
+            .map_err(be)
+    }
+
+    /// `shufflevector <N x T> A, <N x T> B, <M x i32> MASK`
+    ///
+    /// The mask is an ordinary constant vector operand in the text form, so
+    /// it parses like the other two; `zeroinitializer` (the lane-0 splat
+    /// `channel.rs` emits) is handled by the constant reader.
+    pub(super) fn shuffle_vector(&mut self, dst: &str, rest: &str) -> Result<BasicValueEnum<'ctx>> {
+        let parts = split_top_level(rest);
+        if parts.len() != 3 {
+            bail!("bad shufflevector operands: {rest}");
+        }
+        let a = self.vector_operand("shufflevector", &parts[0])?;
+        let b = self.vector_operand("shufflevector", &parts[1])?;
+        let mask = self.vector_operand("shufflevector", &parts[2])?;
+        Ok(self
+            .builder
+            .build_shuffle_vector(a, b, mask, dst.trim_start_matches('%'))
+            .map_err(be)?
+            .into())
+    }
+
+    /// Vector-typed arithmetic, split off the scalar binary-op arm.
+    ///
+    /// inkwell's integer builders are generic over `IntMathValue`, which
+    /// `VectorValue` implements — but the scalar arm reaches its operands via
+    /// `into_int_value()`, which *panics* on a vector rather than returning an
+    /// error. Only the two ops `channel.rs` emits are accepted.
+    pub(super) fn vector_binary(
+        &mut self,
+        op: &str,
+        name: &str,
+        a: VectorValue<'ctx>,
+        b: VectorValue<'ctx>,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        Ok(match op {
+            "add" => self.builder.build_int_add(a, b, name).map_err(be)?.into(),
+            "mul" => self.builder.build_int_mul(a, b, name).map_err(be)?.into(),
+            other => bail!(
+                "vector binary op `{other}` is not emitted by perry-codegen — \
+                 add it here and to the emitter's test if that changed"
+            ),
+        })
+    }
+
+    /// Parse one `<N x T> VALUE` operand and require it to be a vector.
+    fn vector_operand(&mut self, op: &str, part: &str) -> Result<VectorValue<'ctx>> {
+        let (ty_tok, tok) = ty_and_val(part)?;
+        let ty = basic_type(self.ctx, ty_tok)?;
+        if !matches!(ty, BasicTypeEnum::VectorType(_)) {
+            bail!("{op} operand `{part}` is not a vector type");
+        }
+        let v = self.val(ty, tok)?;
+        match v {
+            BasicValueEnum::VectorValue(v) => Ok(v),
+            other => bail!("{op} operand `{part}` resolved to a non-vector {other:?}"),
+        }
+    }
+
+    /// Parse a lane index operand (`i32 1`).
+    fn vector_index(&mut self, op: &str, part: &str) -> Result<IntValue<'ctx>> {
+        let (ty_tok, tok) = ty_and_val(part)?;
+        let ty = basic_type(self.ctx, ty_tok)?;
+        if !matches!(ty, BasicTypeEnum::IntType(_)) {
+            bail!("{op} index `{part}` is not an integer");
+        }
+        match self.val(ty, tok)? {
+            BasicValueEnum::IntValue(v) => Ok(v),
+            other => bail!("{op} index `{part}` resolved to a non-integer {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8228.

## What was broken

Perry's in-process LLVM backend round-trips its own textual IR through a
hand-written dialect reader (`crates/perry-codegen/src/dialect/`). That reader
accepts a *closed* set of instruction forms by design — anything else is
supposed to fail loudly rather than diverge silently.

`#8204` (the #8122 header-shrink instruction-cost recovery) started emitting the
per-class object-header image as a `<2 x i64>` composed at module init:

```
%r7 = insertelement <2 x i64> <i64 207232172546, i64 0>, i64 %r6, i32 1
```

The reader has no `insertelement` case, so the line fell through to the
binary-op arm, which sees three operands where it wants two:

```
native codegen unit 2/3 failed: unit 1: in line:
  %r7 = insertelement <2 x i64> <i64 207232172546, i64 0>, i64 %r6, i32 1:
  bad binary op `insertelement` operands: <2 x i64> <i64 207232172546, i64 0>, i64 %r6, i32 1
```

The reader is only the default for **split** (multi-unit) modules
(`native_emit::native_units_mode`), so this hit exactly the modules big enough to
split — the five biggest of the Next App Route fixture, including
`next-server/app-route.runtime.prod.js` itself.

## What this covers, and what it deliberately does not

`git grep` over `crates/perry-codegen/src` for every vector/aggregate form gives
two emitters, and both reach the reader as `Raw` text:

| form | emitter |
|---|---|
| `insertelement <2 x i64> <i64 W, i64 0>, i64 %hdr, i32 1` | `function.rs:586`, `codegen/string_pool.rs:514` |
| `insertelement <4 x i32> {<i32 0,…>\|%reg\|poison}, i32 %v, i32 N` | `expr/channel.rs:401,410,440` |
| `shufflevector <4 x i32> %a, <4 x i32> poison, <4 x i32> zeroinitializer` | `expr/channel.rs:415` |
| `extractelement <4 x i32> %v, i32 N` | `expr/channel.rs:469` |
| `mul` / `add` over `<4 x i32>` | `expr/channel.rs:421,449` |

All of it is now accepted:

- **`dialect/vector.rs`** (new; split out for the 2000-line cap, following
  `eh.rs`/`types.rs`) — `insertelement`, `extractelement`, `shufflevector`, and
  the vector arm of binary arithmetic. The last one is not cosmetic: inkwell's
  integer builders *are* generic over `VectorValue`, but the scalar arm reaches
  its operands through `into_int_value()`, which **panics** on a vector instead
  of returning an error, so `mul <4 x i32>` would have aborted the compiler
  rather than reported anything.
- **`dialect/types.rs`** — constant vector literals (`<i64 W, i64 0>`,
  `<i32 0, i32 0, i32 0, i32 0>`) plus `poison` / `undef` / `zeroinitializer`
  of vector type. `channel.rs` seeds a splat from `poison` and its shuffle mask
  is `zeroinitializer`, so those are emitted forms, not corners.

**`channel.rs`'s `<4 x i32>` family was the same latent bug** — it has simply
never been reached, because a byte-channel reduction has not yet shown up in a
module large enough to split. It is covered by this fix.

Deliberately **not** implemented: `insertvalue` and `extractvalue`. Perry emits
neither — the tree's only `extractvalue` is an *input* fixture to
`retype_landing_pads_for_statepoints`, not emitted IR. Adding them would be arms
no test can reach, which is the opposite of what a closed reader is for. Vector
binary ops other than `add`/`mul` bail with a message naming the emitter, for
the same reason.

## Why did this reach `main`?

**Because the reader's only gate is a set of frozen snapshots.** All three
`dialect::tests::corpus_*` tests round-trip `.ll` files checked in under
`experiments/llvm-inprocess-spike/`. A form the emitters started producing
*after* those files were captured is invisible to them by construction.

Nothing else covered it either:

- the reader is the default only on the **multi-unit** path, and every
  gap/parity fixture is small enough to be a single unit, which keeps the
  mature text transport;
- `PERRY_LLVM_INPROCESS=0` (external clang/opt) compiles all 104 modules clean
  at the same commit, and that is the configuration
  `tests/test_next_app_route_dylib.sh` pins;
- the one build big enough to split is the release-tier App Route fixture,
  which is tag-gated.

So the failure needed a large in-process build to appear, and no per-PR job
performs one.

### The test added

`dialect::tests::compiled_module_ir_round_trips_through_the_reader` replaces the
snapshot with a **live emit → re-parse**: it compiles a real HIR module (a class
`new`'d in a loop, which admits the inline bump allocator and therefore the
header image) through the real emitters, then feeds every function of the
resulting IR back through the reader and verifies the module. It asserts the
`insertelement <2 x i64> <i64 ` compose is present *before* round-tripping, so a
fixture that stopped exercising the allocator fails loudly instead of passing
vacuously. This closes the class, not the instance: the next new emission form
goes red in `cargo-test`.

`dialect::tests::channel_reduction_vector_forms_round_trip` covers the
`<4 x i32>` family, which no HIR fixture reaches cheaply. Its IR is **built from
the emitter's own `format!` templates** rather than from duplicated literals, and
each template is asserted to still be present verbatim in `expr/channel.rs` — so
if the emitter's text changes, this fixture changes with it or the test fails.

## Validation

All on the bench mini (M1, macOS 26.5.1 arm64, LLVM 22.1.8), `perry-dev` profile.

### Sabotage A/B — the new tests are the detector

Reverting **only the fix** (`dialect/{mod,types}.rs` back to `main`,
`dialect/vector.rs` removed) while keeping the new tests, on the same tree:

```
running 5 tests
test dialect::tests::channel_reduction_vector_forms_round_trip ... FAILED
test dialect::tests::compiled_module_ir_round_trips_through_the_reader ... FAILED
test dialect::tests::corpus_exception_handling ... ok
test dialect::tests::corpus_spike ... ok
test dialect::tests::corpus_batch_kernel ... ok

---- dialect::tests::compiled_module_ir_round_trips_through_the_reader stdout ----
in line: %r10 = insertelement <2 x i64> <i64 207232172546, i64 0>, i64 %r9, i32 1:
  bad binary op `insertelement` operands: <2 x i64> <i64 207232172546, i64 0>, i64 %r9, i32 1
```

`207232172546` is the **same packed header word the production failure reports**, so
the unit test reproduces the field failure exactly. And the three frozen-corpus tests
pass in *both* arms — the demonstration that they could never have caught this.

### Test counts

- `cargo build --profile perry-dev -p perry` — clean, no new warnings.
- `cargo test --profile perry-dev -p perry-codegen --lib` — **1057 passed, 0 failed**
  (1055 before; the two new tests are the delta).
- `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/addr_class_inventory.py` — clean.

`crates/perry-codegen/tests/*.rs` were not run: this change touches only
`src/dialect/`, which no integration suite covers.

### Acceptance: the App Route fixture's app dylib

Same tree, same fixture, same runtime archives (the diff is codegen-only, so both
arms share one `PERRY_RUNTIME_DIR`); only the compiler binary differs.
`PERRY_MODULE_JOBS=2 PERRY_CODEGEN_UNIT_JOBS=2`, in-process backend (default),
`perry compile perry-host.js --output-type dylib --no-auto-optimize --no-cache`.

**Before** — exit 1 after 14m19s, all five modules from #8228, one signature:

```
Error compiling module '.next/server/chunks/2.js' … with --backend llvm:
  native codegen unit 2/3 failed: unit 1: in line:
  %r7 = insertelement <2 x i64> <i64 207232172546, i64 0>, i64 %r6, i32 1:
  bad binary op `insertelement` operands: <2 x i64> <i64 207232172546, i64 0>, i64 %r6, i32 1
… chunks/430.js            native codegen unit 4/6 failed: unit 3
… jsonwebtoken/index.js    native codegen unit 2/2 failed: unit 1
… app-page.runtime.prod.js native codegen unit 8/10 failed: unit 7
… app-route.runtime.prod.js native codegen unit 3/4 failed: unit 2

✗ 5 module(s) failed to compile — REFUSING TO LINK
```

**After** — exit 0 after 15m24s, `Error compiling module` count **0**, all 104
modules compiled, `Wrote shared library: next-app-after.dylib` (87,490,488 bytes),
and `nm -u` still shows `js_gc_init` undefined (the fixture's own check that the app
dylib does not embed the Perry ABI).

### Third arm: the defect is isolated to the native path

Same unfixed `main` compiler, same fixture, only `PERRY_LLVM_INPROCESS=off` added
(that selects the mature text transport, `native_emit::native_units_mode`):
**exit 0 in 9m15s, `Error compiling module` count 0, dylib written.** So the three
arms are

| arm | compiler | backend | result |
|---|---|---|---|
| 1 | `main` | in-process (default) | **exit 1** — 5 modules, `bad binary op \`insertelement\`` |
| 2 | `main` | `PERRY_LLVM_INPROCESS=off` | exit 0, dylib written |
| 3 | `main` + this fix | in-process (default) | exit 0, dylib written |

Arm 2 is a usable interim workaround and is now noted on #8228, but it is not free:
the text path materialized 222.6 MB of IR for one module and produced a **206 MB**
dylib against the native path's **87 MB** (the giant modules drop to `-O0` there).
It is a way to keep moving, not a reason to leave the native default broken.

Running the App Route end to end is out of scope here and owned separately; this PR
is done when the dylib links.
