### PR TITLE
fix(gc): reclaim unreachable proxy registry entries

### DIFF
--- a/changelog.d/8245-proxy-registry-gc.md
+++ b/changelog.d/8245-proxy-registry-gc.md
@@ -1,0 +1,18 @@
+**GC: unreachable Proxies no longer retain their target graphs for the life of the thread.**
+
+Proxy values are id-band handles rather than heap objects, so the collector previously had no
+death signal for them: `PROXIES` grew append-only and its root scanner kept every target and
+handler strongly alive. Full traces now observe proxy-band payloads through mutable roots,
+registered runtime roots, heap fields (including pointer-free layout ranges), and incremental
+mark barriers. Observed proxies recursively retain their target and handler; once a complete
+full trace reaches sweep, unobserved registry entries become collected tombstones. Minor
+collections keep the registry strong because they do not enumerate the whole heap.
+
+Native proxy operations pin their receiver with a `RuntimeHandleScope` across trap calls that
+can run user code and collect. Using a tombstoned handle raises a named collected-proxy
+`TypeError` instead of silently losing proxy semantics or handing its payload to object code.
+With `PERRY_GC_DIAG=1`, every completed full trace reports live entries, tombstones, entries
+reclaimed in the pass, and a monotone reclaimed total. Five focused GC fixtures cover full
+reclamation, minor strength, exact shadow roots, pointer-free heap ranges, and nested proxies.
+
+Closes #8230.

--- a/crates/perry-runtime/src/gc/barrier/mod.rs
+++ b/crates/perry-runtime/src/gc/barrier/mod.rs
@@ -130,7 +130,7 @@ impl DirtyHeaderSlotScan {
                     }));
                 }
             }
-            GcMutableSlotDescriptor::PointerFreeRange => {}
+            GcMutableSlotDescriptor::PointerFreeRange(_) => {}
         });
 
         Some(Self {
@@ -612,7 +612,7 @@ pub(super) unsafe fn scan_dirty_object_slots(
                     }
                 }
             }
-            GcMutableSlotDescriptor::PointerFreeRange => {}
+            GcMutableSlotDescriptor::PointerFreeRange(_) => {}
         }
     });
 }
@@ -964,6 +964,11 @@ fn incremental_mark_barrier_value_with_valid_ptrs(
     value_bits: u64,
     valid_ptrs: &ValidPointerSet,
 ) -> bool {
+    if crate::proxy::gc_full_trace_active()
+        && crate::proxy::gc_observe_traced_value(value_bits, valid_ptrs)
+    {
+        return false;
+    }
     let Some((addr, header)) = current_heap_header_for_heap_word(value_bits, Some(valid_ptrs))
     else {
         return false;

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1165,6 +1165,9 @@ impl GcCycleState {
             .take()
             .expect("valid-pointer builder exists");
         self.valid_ptrs = Some(builder.finish());
+        if self.minor.is_none() {
+            crate::proxy::gc_begin_full_trace();
+        }
         trace_phase_record(&mut self.trace, "build_valid_pointer_set", phase_start);
         // Enable the incremental mark barrier for BOTH kinds. A budgeted
         // MINOR cycle sliced across mutator turns has the same lost-store
@@ -1688,6 +1691,9 @@ impl GcCycleState {
                 while !gap_drain.step(valid_ptrs, usize::MAX) {}
                 incremental_mark_barrier_disable();
             }
+            if full_trace {
+                crate::proxy::gc_finish_full_trace();
+            }
 
             let (do_age_bump, reclaim_dead_old_blocks, targeted_old_blocks, sweep_malloc) =
                 if let Some(minor) = self.minor.as_ref() {
@@ -1972,6 +1978,9 @@ impl Drop for GcCycleState {
         // Both kinds enable the barrier now (minor cycles too); never let the
         // raw valid-ptrs pointer dangle past the cycle that owns the set.
         if self.phase != GcCyclePhase::Complete {
+            if self.minor.is_none() {
+                crate::proxy::gc_abort_full_trace();
+            }
             incremental_mark_barrier_disable();
             super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(0));
             clear_mark_seeds();

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -1680,7 +1680,7 @@ pub(super) enum GcMutableSlotDescriptor {
         range: HeapSlotRange,
         layout_kind: Option<HeapChildSlotReadKind>,
     },
-    PointerFreeRange,
+    PointerFreeRange(HeapSlotRange),
 }
 
 impl GcMutableSlotDescriptor {
@@ -1692,7 +1692,7 @@ impl GcMutableSlotDescriptor {
                     visit(GcMutableSlot::new(range.slot(i), layout_kind));
                 }
             }
-            GcMutableSlotDescriptor::PointerFreeRange => {}
+            GcMutableSlotDescriptor::PointerFreeRange(_) => {}
         }
     }
 }

--- a/crates/perry-runtime/src/gc/layout_slot_visit.rs
+++ b/crates/perry-runtime/src/gc/layout_slot_visit.rs
@@ -76,7 +76,7 @@ pub(super) unsafe fn visit_gc_layout_slot_descriptors(
             if raw_numeric_object_slots != 0 {
                 record_layout_raw_numeric_object_field_range_skipped(raw_numeric_object_slots);
             }
-            visit(GcMutableSlotDescriptor::PointerFreeRange);
+            visit(GcMutableSlotDescriptor::PointerFreeRange(range));
         }
         HeapPayloadSlotScan::AllPointers {
             raw_numeric_object_slots,

--- a/crates/perry-runtime/src/gc/root_words.rs
+++ b/crates/perry-runtime/src/gc/root_words.rs
@@ -154,6 +154,11 @@ pub(super) fn decode_root_word(bits: u64) -> Option<RootWord> {
 /// covers them.
 #[inline]
 pub(super) fn mark_mutable_root_bits(bits: u64, valid_ptrs: &ValidPointerSet) {
+    if crate::proxy::gc_full_trace_active()
+        && crate::proxy::gc_observe_traced_value(bits, valid_ptrs)
+    {
+        return;
+    }
     let Some(word) = decode_root_word(bits) else {
         return;
     };

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -621,7 +621,7 @@ pub(super) fn try_mark_conservative_word(
     true
 }
 
-pub(super) fn try_mark_value_or_raw(word: u64, valid_ptrs: &ValidPointerSet) -> bool {
+pub(crate) fn try_mark_value_or_raw(word: u64, valid_ptrs: &ValidPointerSet) -> bool {
     // First try NaN-boxed interpretation (POINTER_TAG / STRING_TAG / BIGINT_TAG)
     if try_mark_value(word, valid_ptrs) {
         return true;
@@ -919,11 +919,21 @@ impl<'a> RuntimeRootVisitor<'a> {
 
     #[inline]
     pub(super) fn record_source_scan_bits(&mut self, bits: u64) {
+        if crate::proxy::gc_full_trace_active() {
+            if let RuntimeRootVisitMode::Mark { valid_ptrs } = &self.mode {
+                crate::proxy::gc_observe_traced_value(bits, valid_ptrs);
+            }
+        }
         if let Some(stats) = self.root_source_stats {
             unsafe {
                 (*stats).record_scan(bits != 0, root_slot_pointer_candidate(bits));
             }
         }
+    }
+
+    #[inline]
+    pub(crate) fn is_mark_phase(&self) -> bool {
+        matches!(self.mode, RuntimeRootVisitMode::Mark { .. })
     }
 
     #[inline]

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -36,6 +36,7 @@ mod lazy_tape_side_alloc;
 mod oldgen;
 mod os_tag;
 mod promote_in_place;
+mod proxy_registry;
 mod root_words;
 mod rooted_container_values;
 mod rooted_define_property;

--- a/crates/perry-runtime/src/gc/tests/proxy_registry.rs
+++ b/crates/perry-runtime/src/gc/tests/proxy_registry.rs
@@ -1,0 +1,130 @@
+use super::super::*;
+use super::support::*;
+
+fn full_collect() {
+    let trigger = GcTriggerSnapshot {
+        kind: GcTriggerKind::Manual,
+        steps_before: Some(GcStepSnapshot::current()),
+    };
+    let _ = GcCycleState::new_full(trigger).run_to_completion();
+}
+
+fn alloc_proxy_endpoint() -> (*mut u8, f64) {
+    let ptr = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(ptr);
+    }
+    (ptr, f64::from_bits(ptr_bits(ptr as usize)))
+}
+
+#[test]
+fn full_trace_prunes_an_unobserved_proxy_and_its_registry_only_graph() {
+    let _guard = GcTestIsolationGuard::new();
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let reclaimed_before = crate::proxy::test_proxy_gc_reclaimed_total();
+    let (target_ptr, target) = alloc_proxy_endpoint();
+    let (handler_ptr, handler) = alloc_proxy_endpoint();
+    let proxy = crate::proxy::js_proxy_new(target, handler);
+
+    full_collect();
+
+    assert!(!crate::proxy::test_proxy_slot_is_live(proxy));
+    assert_eq!(
+        crate::proxy::test_proxy_gc_reclaimed_total(),
+        reclaimed_before + 1,
+        "the prune counter proves the full-trace reclamation path ran"
+    );
+    assert!(!malloc_user_ptr_tracked(target_ptr));
+    assert!(!malloc_user_ptr_tracked(handler_ptr));
+}
+
+#[test]
+fn a_minor_trace_keeps_the_registry_strong_and_never_prunes_proxy_ids() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    gc_register_mutable_root_scanner(crate::proxy::scan_proxy_roots_mut);
+    let (target_ptr, target) = alloc_proxy_endpoint();
+    let (handler_ptr, handler) = alloc_proxy_endpoint();
+    let proxy = crate::proxy::js_proxy_new(target, handler);
+
+    let _ = gc_collect_minor();
+
+    assert!(crate::proxy::test_proxy_slot_is_live(proxy));
+    assert!(malloc_user_ptr_tracked(target_ptr));
+    assert!(malloc_user_ptr_tracked(handler_ptr));
+
+    full_collect();
+    assert!(!crate::proxy::test_proxy_slot_is_live(proxy));
+}
+
+#[test]
+fn a_shadow_root_keeps_a_proxy_and_its_graph_until_the_next_full_trace() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let (target_ptr, target) = alloc_proxy_endpoint();
+    let (handler_ptr, handler) = alloc_proxy_endpoint();
+    let proxy = crate::proxy::js_proxy_new(target, handler);
+    js_shadow_slot_set(0, proxy.to_bits());
+
+    full_collect();
+
+    assert!(crate::proxy::test_proxy_slot_is_live(proxy));
+    assert!(malloc_user_ptr_tracked(target_ptr));
+    assert!(malloc_user_ptr_tracked(handler_ptr));
+
+    js_shadow_slot_set(0, crate::value::TAG_UNDEFINED);
+    full_collect();
+    assert!(!crate::proxy::test_proxy_slot_is_live(proxy));
+    assert!(!malloc_user_ptr_tracked(target_ptr));
+    assert!(!malloc_user_ptr_tracked(handler_ptr));
+}
+
+#[test]
+fn a_proxy_in_a_pointer_free_heap_range_is_still_observed() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let (_target_ptr, target) = alloc_proxy_endpoint();
+    let (_handler_ptr, handler) = alloc_proxy_endpoint();
+    let proxy = crate::proxy::js_proxy_new(target, handler);
+    let (owner, fields) = unsafe { alloc_old_test_object(1) };
+    unsafe {
+        *fields = proxy.to_bits();
+        layout_init_pointer_free(owner as *mut u8);
+    }
+    js_shadow_slot_set(0, ptr_bits(owner as usize));
+
+    full_collect();
+
+    assert!(
+        crate::proxy::test_proxy_slot_is_live(proxy),
+        "the full trace must inspect proxy-band values even in a range whose heap layout is pointer-free"
+    );
+
+    js_shadow_slot_set(0, crate::value::TAG_UNDEFINED);
+    full_collect();
+    assert!(!crate::proxy::test_proxy_slot_is_live(proxy));
+}
+
+#[test]
+fn observing_an_outer_proxy_recursively_keeps_its_proxy_target_live() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let (_inner_target_ptr, inner_target) = alloc_proxy_endpoint();
+    let (_handler_ptr, handler) = alloc_proxy_endpoint();
+    let inner = crate::proxy::js_proxy_new(inner_target, handler);
+    let outer = crate::proxy::js_proxy_new(inner, handler);
+    js_shadow_slot_set(0, outer.to_bits());
+
+    full_collect();
+
+    assert!(crate::proxy::test_proxy_slot_is_live(outer));
+    assert!(crate::proxy::test_proxy_slot_is_live(inner));
+
+    js_shadow_slot_set(0, crate::value::TAG_UNDEFINED);
+    full_collect();
+    assert!(!crate::proxy::test_proxy_slot_is_live(outer));
+    assert!(!crate::proxy::test_proxy_slot_is_live(inner));
+}

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -551,7 +551,7 @@ pub(super) fn clear_mark_seeds() {
 }
 
 #[inline]
-pub(super) fn try_mark_value(value_bits: u64, valid_ptrs: &ValidPointerSet) -> bool {
+pub(crate) fn try_mark_value(value_bits: u64, valid_ptrs: &ValidPointerSet) -> bool {
     let tag = value_bits & TAG_MASK;
     // Hot-path tag rejection. POINTER_TAG / STRING_TAG / BIGINT_TAG are
     // the only NaN-tags that wrap a heap pointer; everything else
@@ -564,6 +564,12 @@ pub(super) fn try_mark_value(value_bits: u64, valid_ptrs: &ValidPointerSet) -> b
     }
     let ptr_val = (value_bits & POINTER_MASK) as usize;
     if ptr_val == 0 {
+        return false;
+    }
+
+    if crate::proxy::gc_full_trace_active()
+        && crate::proxy::gc_observe_traced_value(value_bits, valid_ptrs)
+    {
         return false;
     }
 
@@ -630,6 +636,11 @@ pub(super) unsafe fn mark_field_into_worklist(
     valid_ptrs: &ValidPointerSet,
     worklist: &mut Vec<*mut GcHeader>,
 ) -> bool {
+    if crate::proxy::gc_full_trace_active()
+        && crate::proxy::gc_observe_traced_value(val_bits, valid_ptrs)
+    {
+        return false;
+    }
     let tag = val_bits & TAG_MASK;
     let ptr_val: usize = if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
         let p = (val_bits & POINTER_MASK) as usize;
@@ -997,15 +1008,25 @@ pub(super) unsafe fn trace_heap_rewrite_slots(
     valid_ptrs: &ValidPointerSet,
     worklist: &mut Vec<*mut GcHeader>,
 ) {
-    visit_gc_rewrite_slots(header, |slot| unsafe {
-        if crate::weakref::is_weak_target_trace_slot(header, slot.slot) {
+    visit_gc_rewrite_slot_descriptors(header, |descriptor| unsafe {
+        if let GcMutableSlotDescriptor::PointerFreeRange(range) = descriptor {
+            if crate::proxy::gc_full_trace_active() {
+                for i in 0..range.slot_count() {
+                    crate::proxy::gc_observe_traced_value(*range.slot(i), valid_ptrs);
+                }
+            }
             return;
         }
-        slot.record_layout_read();
-        if slot.layout_kind.is_some() {
-            record_trace_slot_read();
-        }
-        mark_field_into_worklist(*slot.slot, valid_ptrs, worklist);
+        descriptor.visit_slots(&mut |slot| {
+            if crate::weakref::is_weak_target_trace_slot(header, slot.slot) {
+                return;
+            }
+            slot.record_layout_read();
+            if slot.layout_kind.is_some() {
+                record_trace_slot_read();
+            }
+            mark_field_into_worklist(*slot.slot, valid_ptrs, worklist);
+        });
     });
 }
 

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -17,7 +17,7 @@
 //! codegen rewrites known Proxy locals to ProxyGet/ProxySet/etc. variants at
 //! HIR lowering time, which route through the entry points here.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
@@ -63,9 +63,10 @@ pub use reflect::{
 ///
 /// Revocation detaches: `js_proxy_revoke` stores 0 bits into `target` and
 /// `handler` (spec: [[ProxyTarget]]/[[ProxyHandler]] become null) so the
-/// wrapped graphs can die — `scan_proxy_roots_mut` otherwise strongly roots
-/// them for the life of the registry slot (2026-07-09 GC audit). No valid
-/// proxy target/handler is ever the all-zero-bits number `0.0` (both must be
+/// wrapped graphs can die. Minor collections strongly scan live entries;
+/// full collections instead discover proxy handles through traced slots and
+/// prune entries whose handles were not observed. No valid proxy
+/// target/handler is ever the all-zero-bits number `0.0` (both must be
 /// objects), so 0 bits is an unambiguous detached sentinel. Every trap path
 /// checks `revoked` before touching `target`/`handler`.
 #[repr(C)]
@@ -96,6 +97,14 @@ thread_local! {
     /// a scanner that rewrites `target_bits` during GC fixup (similar to the
     /// 9 existing scanners in gc.rs).
     static REFLECT_METADATA: RefCell<HashMap<MetadataKey, f64>> = RefCell::new(HashMap::new());
+    /// Live proxy ids observed by the current full GC trace. `None` outside a
+    /// full trace; minors continue to root every registry entry strongly.
+    static PROXY_FULL_TRACE_LIVE: RefCell<Option<Vec<bool>>> = const { RefCell::new(None) };
+    /// Hot reject-path gate: collector funnels test this before decoding a
+    /// proxy-band payload, so ordinary marking pays one TLS boolean branch.
+    static PROXY_FULL_TRACE_ACTIVE: Cell<bool> = const { Cell::new(false) };
+    /// Monotone liveness counter for diagnostics and non-vacuous tests.
+    static PROXY_GC_RECLAIMED_TOTAL: Cell<u64> = const { Cell::new(0) };
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -233,15 +242,138 @@ fn lookup(proxy_boxed: f64) -> Option<u64> {
         return None;
     }
     let id = decode_proxy_id(lower48 as i64)?;
-    // Only a real entry in the registry counts as a proxy.
-    PROXIES.with(|p| {
+    // A collected slot remains a tombstone. Treating it as a non-proxy would
+    // hand the small id-band payload to generic object code, which may
+    // dereference it; fail loudly if the collector ever under-approximates.
+    let status = PROXIES.with(|p| {
         let v = p.borrow();
-        if (id as usize) < v.len() && v[id as usize].is_some() {
-            Some(id)
-        } else {
-            None
+        match v.get(id as usize) {
+            Some(Some(_)) => 1,
+            Some(None) => 2,
+            None => 0,
         }
-    })
+    });
+    match status {
+        1 => Some(id),
+        2 => collected_return(),
+        _ => None,
+    }
+}
+
+/// Keep a proxy id visible to any full collection that starts while a native
+/// proxy operation is running. The returned scope owns the slot; the handle
+/// itself need not be retained because slots live until the scope is dropped.
+fn pin_proxy_for_native_call(proxy_boxed: f64) -> crate::gc::RuntimeHandleScope {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let _ = scope.root_nanbox_f64(proxy_boxed);
+    scope
+}
+
+/// Arm proxy-id observation for a full trace. The registry becomes weak for
+/// the mark phase until [`gc_finish_full_trace`] prunes unobserved entries.
+pub(crate) fn gc_begin_full_trace() {
+    let (len, has_live_entries) = PROXIES.with(|p| {
+        let proxies = p.borrow();
+        (proxies.len(), proxies.iter().any(Option::is_some))
+    });
+    PROXY_FULL_TRACE_LIVE.with(|live| {
+        assert!(live.borrow().is_none(), "proxy full trace already active");
+        *live.borrow_mut() = Some(vec![false; len]);
+    });
+    PROXY_FULL_TRACE_ACTIVE.with(|active| active.set(has_live_entries));
+}
+
+#[inline(always)]
+pub(crate) fn gc_full_trace_active() -> bool {
+    PROXY_FULL_TRACE_ACTIVE.with(Cell::get)
+}
+
+/// Observe one bits value from a collector-owned tracing funnel. Returns true
+/// when it names an existing proxy slot (live or a collected tombstone).
+/// First observation marks the live entry's target/handler immediately; this
+/// closes the cycle without making the whole registry a strong root.
+pub(crate) fn gc_observe_traced_value(bits: u64, valid_ptrs: &crate::gc::ValidPointerSet) -> bool {
+    if !gc_full_trace_active() || (bits & !POINTER_MASK) != POINTER_TAG {
+        return false;
+    }
+    let payload = (bits & POINTER_MASK) as usize;
+    if !crate::value::addr_class::is_proxy_id_band(payload) {
+        return false;
+    }
+    let Some(id) = decode_proxy_id(payload as i64) else {
+        return false;
+    };
+    let entry = PROXIES.with(|proxies| {
+        let proxies = proxies.borrow();
+        proxies.get(id as usize).map(|slot| {
+            slot.as_ref()
+                .map(|entry| (entry.target.to_bits(), entry.handler.to_bits()))
+        })
+    });
+    let Some(entry) = entry else {
+        return false;
+    };
+    let first_observation = PROXY_FULL_TRACE_LIVE.with(|live| {
+        let mut live = live.borrow_mut();
+        let live = live.as_mut().expect("proxy observation outside full trace");
+        if id as usize >= live.len() {
+            live.resize(id as usize + 1, false);
+        }
+        let first = !live[id as usize];
+        live[id as usize] = true;
+        first
+    });
+    if first_observation {
+        if let Some((target, handler)) = entry {
+            crate::gc::try_mark_value_or_raw(target, valid_ptrs);
+            crate::gc::try_mark_value_or_raw(handler, valid_ptrs);
+        }
+    }
+    true
+}
+
+/// End a full proxy trace and tombstone every registry entry whose handle was
+/// not observed. Returns the number reclaimed in this pass.
+pub(crate) fn gc_finish_full_trace() -> usize {
+    PROXY_FULL_TRACE_ACTIVE.with(|active| active.set(false));
+    let live = PROXY_FULL_TRACE_LIVE.with(|state| {
+        state
+            .borrow_mut()
+            .take()
+            .expect("proxy full trace was not active")
+    });
+    let (reclaimed, remaining, slots) = PROXIES.with(|proxies| {
+        let mut proxies = proxies.borrow_mut();
+        let mut reclaimed = 0usize;
+        for (id, slot) in proxies.iter_mut().enumerate().skip(1) {
+            if slot.is_some() && !live.get(id).copied().unwrap_or(false) {
+                slot.take();
+                reclaimed += 1;
+            }
+        }
+        let remaining = proxies.iter().flatten().count();
+        (reclaimed, remaining, proxies.len().saturating_sub(1))
+    });
+    let total = PROXY_GC_RECLAIMED_TOTAL.with(|counter| {
+        let total = counter.get().saturating_add(reclaimed as u64);
+        counter.set(total);
+        total
+    });
+    if crate::gc::gc_diag_enabled() {
+        eprintln!(
+            "[gc-proxy-registry] live={remaining} tombstones={} slots={slots} reclaimed={reclaimed} reclaimed_total={total}",
+            slots.saturating_sub(remaining),
+        );
+    }
+    reclaimed
+}
+
+/// Cancel observation when an in-progress GC cycle is dropped.
+pub(crate) fn gc_abort_full_trace() {
+    PROXY_FULL_TRACE_ACTIVE.with(|active| active.set(false));
+    PROXY_FULL_TRACE_LIVE.with(|live| {
+        live.borrow_mut().take();
+    });
 }
 
 /// Allocate a new proxy. Returns the NaN-boxed POINTER_TAG value holding the
@@ -329,6 +461,12 @@ pub extern "C" fn js_proxy_new(target: f64, handler: f64) -> f64 {
             revoked: false,
             callable,
         })));
+        // A proxy born during a sliced full trace was absent from the begin
+        // snapshot. Arm observation before its handle can be published into a
+        // root/heap slot; the incremental write barrier will record it.
+        if PROXY_FULL_TRACE_LIVE.with(|live| live.borrow().is_some()) {
+            PROXY_FULL_TRACE_ACTIVE.with(|active| active.set(true));
+        }
         let encoded = encode_proxy_id(id) as u64;
         f64::from_bits(POINTER_TAG | (encoded & POINTER_MASK))
     })
@@ -465,6 +603,13 @@ fn handler_trap(handler: f64, trap_name: &str) -> f64 {
 /// Raise a "proxy revoked" TypeError via `js_throw`. Does not return.
 fn revoked_return() -> f64 {
     revoked_return_with_message("Cannot perform operation on a proxy that has been revoked")
+}
+
+fn collected_return() -> ! {
+    let _ = revoked_return_with_message(
+        "Cannot perform operation on a proxy that has been garbage collected",
+    );
+    unreachable!("js_throw returned from collected proxy TypeError")
 }
 
 fn revoked_return_with_message(msg: &str) -> f64 {
@@ -721,6 +866,7 @@ fn call_with_this_and_args(f: f64, this_arg: f64, args: &[f64]) -> f64 {
 /// otherwise fetch the field from the target directly via the generic path.
 #[no_mangle]
 pub extern "C" fn js_proxy_get(proxy_boxed: f64, key: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_UNDEFINED),
@@ -2121,19 +2267,24 @@ fn rewrite_metadata_target_bits(
     }
 }
 
-/// GC scanner for the proxy registry + reflect-metadata store (2026-07-02
-/// audit P0; ported from the stranded be73b4f8d). A proxy's target/handler
-/// are commonly reachable ONLY through `PROXIES` — without visiting them a
-/// minor GC collects (or moves) them and every subsequent trap derefs freed
-/// or stale memory. `REFLECT_METADATA`'s own doc admits its keys go stale on
-/// a target move; rekey them during the metadata-rewrite phase.
+/// GC scanner for the proxy registry + reflect-metadata store. A minor trace
+/// must visit every live entry because it does not scan the whole heap. A full
+/// mark trace skips those strong edges and observes proxy handles from roots
+/// and heap slots instead; rewrite/verify phases still visit surviving entry
+/// slots. `REFLECT_METADATA`'s keys are rekeyed during metadata rewrite.
 pub(crate) fn scan_proxy_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    PROXIES.with(|proxies| {
-        for entry in proxies.borrow_mut().iter_mut().flatten() {
-            visitor.visit_nanbox_f64_slot(&mut entry.target);
-            visitor.visit_nanbox_f64_slot(&mut entry.handler);
-        }
-    });
+    // A full mark trace discovers liveness from proxy-band handles instead of
+    // making the registry itself a root. Minors cannot make that inference
+    // because they do not scan the whole heap, and rewrite/verify phases must
+    // still update the live entries after evacuation.
+    if !(gc_full_trace_active() && visitor.is_mark_phase()) {
+        PROXIES.with(|proxies| {
+            for entry in proxies.borrow_mut().iter_mut().flatten() {
+                visitor.visit_nanbox_f64_slot(&mut entry.target);
+                visitor.visit_nanbox_f64_slot(&mut entry.handler);
+            }
+        });
+    }
 
     REFLECT_METADATA.with(|store| {
         let mut store = store.borrow_mut();
@@ -2153,6 +2304,25 @@ pub(crate) fn scan_proxy_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
             }
         }
     });
+}
+
+#[cfg(test)]
+pub(crate) fn test_proxy_slot_is_live(proxy_boxed: f64) -> bool {
+    let bits = proxy_boxed.to_bits();
+    let Some(id) = decode_proxy_id((bits & POINTER_MASK) as i64) else {
+        return false;
+    };
+    PROXIES.with(|proxies| {
+        proxies
+            .borrow()
+            .get(id as usize)
+            .is_some_and(Option::is_some)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn test_proxy_gc_reclaimed_total() -> u64 {
+    PROXY_GC_RECLAIMED_TOTAL.with(Cell::get)
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/proxy/apply_construct.rs
+++ b/crates/perry-runtime/src/proxy/apply_construct.rs
@@ -5,9 +5,9 @@
 //! (split-large-files recipe). Pure relocation; behavior is unchanged.
 
 use super::{
-    closure_from, create_list_from_array_like, handler_trap, lookup, reflect_value_is_object,
-    revoked_return, throw_type_error, value_display_string, POINTER_MASK, POINTER_TAG, PROXIES,
-    TAG_NULL, TAG_UNDEFINED,
+    closure_from, create_list_from_array_like, handler_trap, lookup, pin_proxy_for_native_call,
+    reflect_value_is_object, revoked_return, throw_type_error, value_display_string, POINTER_MASK,
+    POINTER_TAG, PROXIES, TAG_NULL, TAG_UNDEFINED,
 };
 use crate::closure::js_closure_call3;
 
@@ -139,6 +139,7 @@ pub fn call_proxy_value_with_this(proxy: f64, this_arg: f64, args: &[f64]) -> f6
 /// `args_array` is an already-constructed Array JSValue (NaN-boxed).
 #[no_mangle]
 pub extern "C" fn js_proxy_apply(proxy_boxed: f64, this_arg: f64, args_array: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_UNDEFINED),
@@ -216,6 +217,7 @@ fn forward_construct(target: f64, args_array: f64, new_target: f64) -> f64 {
 /// `undefined` (the `new Proxy(...)` path).
 #[no_mangle]
 pub extern "C" fn js_proxy_construct(proxy_boxed: f64, args_array: f64, new_target: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_UNDEFINED),

--- a/crates/perry-runtime/src/proxy/has_delete.rs
+++ b/crates/perry-runtime/src/proxy/has_delete.rs
@@ -5,13 +5,14 @@
 
 use super::{
     call_trap, handler_trap, invariants, is_callable, is_non_configurable_exotic_own, lookup,
-    nanbox_bool, revoked_return, PROXIES, TAG_FALSE, TAG_UNDEFINED,
+    nanbox_bool, pin_proxy_for_native_call, revoked_return, PROXIES, TAG_FALSE, TAG_UNDEFINED,
 };
 
 /// `key in proxy` — if `handler.has` exists, call it; else forward to the
 /// target's `[[HasProperty]]` (recursing through a proxy target).
 #[no_mangle]
 pub extern "C" fn js_proxy_has(proxy_boxed: f64, key: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_FALSE),
@@ -64,6 +65,7 @@ pub extern "C" fn js_proxy_has(proxy_boxed: f64, key: f64) -> f64 {
 /// delegate to `js_object_delete_field` on the target.
 #[no_mangle]
 pub extern "C" fn js_proxy_delete(proxy_boxed: f64, key: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_FALSE),

--- a/crates/perry-runtime/src/proxy/json.rs
+++ b/crates/perry-runtime/src/proxy/json.rs
@@ -1,6 +1,6 @@
 use super::{
-    closure_from, handler_trap, is_callable, lookup, revoked_return, revoked_return_with_message,
-    POINTER_MASK, POINTER_TAG, PROXIES, TAG_UNDEFINED,
+    closure_from, handler_trap, is_callable, lookup, pin_proxy_for_native_call, revoked_return,
+    revoked_return_with_message, POINTER_MASK, POINTER_TAG, PROXIES, TAG_UNDEFINED,
 };
 
 /// Return the proxy target for internal-operation callers that must throw on a
@@ -43,6 +43,7 @@ fn js_proxy_checked_target_with_revoked_message(
 /// abrupt completions are visible to callers that implement
 /// `EnumerableOwnProperties`.
 pub(crate) fn js_proxy_own_keys_for_json(proxy_boxed: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_UNDEFINED),

--- a/crates/perry-runtime/src/proxy/own_keys.rs
+++ b/crates/perry-runtime/src/proxy/own_keys.rs
@@ -7,7 +7,8 @@
 
 use super::{
     call_trap, create_list_from_array_like, handler_trap, is_callable_function, lookup,
-    revoked_return, throw_type_error, POINTER_MASK, POINTER_TAG, PROXIES, TAG_NULL, TAG_UNDEFINED,
+    pin_proxy_for_native_call, revoked_return, throw_type_error, POINTER_MASK, POINTER_TAG,
+    PROXIES, TAG_NULL, TAG_UNDEFINED,
 };
 
 /// #7949: root the caller's key list before touching the heap.
@@ -122,6 +123,7 @@ fn target_key_is_configurable(target: f64, key: f64) -> bool {
 /// forwards to the target when no trap is present.
 #[no_mangle]
 pub extern "C" fn js_proxy_own_keys(proxy_boxed: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return alloc_key_array(&[]),

--- a/crates/perry-runtime/src/proxy/prototype.rs
+++ b/crates/perry-runtime/src/proxy/prototype.rs
@@ -3,8 +3,8 @@
 
 use super::{
     call_trap, handler_trap, is_callable_function, js_reflect_is_extensible, lookup, nanbox_bool,
-    reflect_non_object_typeerror, reflect_target_get_prototype_of, reflect_value_is_object,
-    revoked_return, throw_type_error, PROXIES, TAG_NULL, TAG_UNDEFINED,
+    pin_proxy_for_native_call, reflect_non_object_typeerror, reflect_target_get_prototype_of,
+    reflect_value_is_object, revoked_return, throw_type_error, PROXIES, TAG_NULL, TAG_UNDEFINED,
 };
 
 /// `Reflect.setPrototypeOf(target, proto)` (#2761).
@@ -56,6 +56,7 @@ pub extern "C" fn js_reflect_set_prototype_of(target: f64, proto: f64) -> f64 {
 /// non-extensible-target invariant: a `true` result requires the new proto to
 /// SameValue the target's current proto.
 fn proxy_set_prototype_of(proxy_boxed: f64, proto: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return nanbox_bool(false),

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -54,6 +54,7 @@ pub(crate) fn proxy_set_with_receiver(
     value: f64,
     receiver: f64,
 ) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(proxy_boxed);
     let id = match lookup(proxy_boxed) {
         Some(id) => id,
         None => return f64::from_bits(TAG_FALSE),

--- a/crates/perry-runtime/src/proxy/reflect_misc.rs
+++ b/crates/perry-runtime/src/proxy/reflect_misc.rs
@@ -118,6 +118,7 @@ pub extern "C" fn js_reflect_apply(f: f64, this_arg: f64, args_array: f64) -> f6
 #[no_mangle]
 pub extern "C" fn js_reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f64 {
     if lookup(obj).is_some() {
+        let _proxy_pin = pin_proxy_for_native_call(obj);
         let id = lookup(obj).unwrap();
         let (target, handler, revoked) = PROXIES.with(|p| {
             p.borrow()
@@ -195,6 +196,7 @@ pub(crate) fn js_proxy_get_prototype_of(obj: f64) -> f64 {
 /// target's actual prototype. Used by both `Object.getPrototypeOf(proxy)` and
 /// `Reflect.getPrototypeOf(proxy)` so they validate identically.
 pub(super) fn proxy_get_prototype_of_impl(obj: f64) -> f64 {
+    let _proxy_pin = pin_proxy_for_native_call(obj);
     let Some(id) = lookup(obj) else {
         return crate::object::js_object_get_prototype_of(obj);
     };
@@ -261,6 +263,7 @@ pub extern "C" fn js_reflect_get_prototype_of(obj: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_reflect_is_extensible(target: f64) -> f64 {
     if let Some(id) = lookup(target) {
+        let _proxy_pin = pin_proxy_for_native_call(target);
         let (inner, handler, revoked) = PROXIES.with(|p| {
             p.borrow()
                 .get(id as usize)
@@ -308,6 +311,7 @@ pub extern "C" fn js_reflect_is_extensible(target: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_reflect_prevent_extensions(target: f64) -> f64 {
     if let Some(id) = lookup(target) {
+        let _proxy_pin = pin_proxy_for_native_call(target);
         let (inner, handler, revoked) = PROXIES.with(|p| {
             p.borrow()
                 .get(id as usize)


### PR DESCRIPTION
## Summary

Make the id-band Proxy registry weak during full GC traces so unreachable proxies no longer retain their target and handler graphs for the lifetime of the thread.

## Changes

- Observe proxy-band payloads through mutable roots, registered runtime roots, heap fields, pointer-free heap ranges, and the incremental mark barrier.
- Keep the registry strong for minor collections, but tombstone entries not observed by a completed full trace.
- Recursively retain target/handler graphs for observed proxies, including nested proxies.
- Pin proxy IDs with `RuntimeHandleScope` across native proxy trap entry points.
- Fail loudly with a collected-proxy `TypeError` if a tombstoned handle is used.
- Emit `PERRY_GC_DIAG=1` proxy-registry live/tombstone/reclaimed counters and add focused full/minor/root/layout regressions.

## Related issue

Closes #8230.

## Test plan

- [ ] `cargo build --release` clean (not run)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run in full)
- [x] `cargo test -p perry-runtime --lib -- --test-threads=4` — 2,532 passed, 4 ignored before rebasing onto current `main`
- [x] `cargo test -p perry-runtime --lib gc::tests::proxy_registry -- --test-threads=1` — 5 passed after rebase
- [x] `cargo test -p perry-runtime --lib proxy::tests -- --test-threads=1` — 14 passed after rebase
- [x] `cargo fmt --all -- --check`
- [x] `scripts/check_file_size.sh`
- [x] `python3 scripts/gc_runtime_root_holders.py`
- [x] `python3 scripts/check_gc_env_knobs.py`
- [x] Added focused tests in the affected crate
- [ ] Docs update (not needed; internal GC behavior)
- [ ] Platform UI backend build (not applicable)

## Screenshots / output

With `PERRY_GC_DIAG=1`, completed full traces now report:

```text
[gc-proxy-registry] live=<n> tombstones=<n> slots=<n> reclaimed=<n> reclaimed_total=<n>
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct