### PR TITLE
style(runtime): rustfmt param_type_guard test call sites

### DIFF
--- a/crates/perry-runtime/src/param_type_guard.rs
+++ b/crates/perry-runtime/src/param_type_guard.rs
@@ -923,13 +923,19 @@ mod tests {
         );
 
         assert_eq!(
-            guard(node, &descriptor(0, &[&tracked_single_field_node(true, b"next", 0)])),
+            guard(
+                node,
+                &descriptor(0, &[&tracked_single_field_node(true, b"next", 0)])
+            ),
             1
         );
         // Without it the walk runs out of depth and the caller conservatively
         // takes the generic function — never a hang, never a false accept.
         assert_eq!(
-            guard(node, &descriptor(0, &[&tracked_single_field_node(false, b"next", 0)])),
+            guard(
+                node,
+                &descriptor(0, &[&tracked_single_field_node(false, b"next", 0)])
+            ),
             0
         );
     }


### PR DESCRIPTION
Pure `cargo fmt` over two test call sites in `param_type_guard.rs` that exceeded the width limit after a helper rename in #8238. No behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted cyclic-value test guard calls for improved readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->