### PR TITLE
perf(runtime): remove the expired implicit-this diagnostic from the hot path

### DIFF
--- a/changelog.d/8252-remove-this-set-diagnostic.md
+++ b/changelog.d/8252-remove-this-set-diagnostic.md
@@ -1,0 +1,21 @@
+### Performance
+
+**The default-off `PERRY_GC_THIS_SET_CHECK` diagnostic no longer taxes every
+dynamic call.** `js_implicit_this_set` is the save/restore boundary for the
+implicit receiver around dynamically-dispatched calls. The diagnostic added
+for the `#7803` investigation wrapped each TLS replacement with two
+`OnceLock::get_or_init` mode checks, so an unset environment variable still
+paid two atomic fast paths and branches per setter invocation. On the
+closure-heavy `pipeline` workload that setter runs about 2.9 million times.
+
+The investigation in `#8243` isolates this as the entire previously
+unattributed `#8084` regression: with one compiler and per-arm runtime/stdlib
+archives, `PERRY_NO_AUTO_OPTIMIZE=1`, and min-of-5 instructions retired,
+`pipeline` falls from 3,868,625,816 to 3,718,178,431 instructions (**-3.89%**).
+All ten runs produce byte-identical output, and the fixed arm spans only 0.08%
+around its minimum. This accounts for the reported +3.95% regression; neither
+the callee-rooting hunk nor the stack-map walker caused it.
+
+The expired diagnostic and its now-unused GC header-coherence wrapper are
+removed, restoring `js_implicit_this_set` to one TLS replacement. The setter's
+contract now records that default-off diagnostics must stay off this hot path.

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -121,17 +121,6 @@ use barrier_arming::*;
 /// eligibility preflight is skipped on. Every write of the bit goes through
 /// `pin::pin_object`; `scripts/gc_pin_sites.py` enforces that in `lint`.
 mod pin;
-
-/// #7803 diagnostics: expose the pin-latch's header-coherence verdict to
-/// runtime-side producer traps (e.g. `object::this_binding::this_set_check`)
-/// so every instrument grades headers with the same rules.
-pub(crate) fn header_incoherence_for_diagnostics(
-    obj_type: u8,
-    size: u32,
-    flags: u8,
-) -> Option<String> {
-    pin::header_incoherence(obj_type, size, flags)
-}
 #[cfg(test)]
 pub(crate) use pin::test_reset_young_pin_latch;
 pub use pin::{

--- a/crates/perry-runtime/src/object/this_binding.rs
+++ b/crates/perry-runtime/src/object/this_binding.rs
@@ -153,82 +153,16 @@ pub extern "C" fn js_implicit_this_get_sloppy() -> f64 {
     value
 }
 
-/// #7803 producer trap (diagnostic, default-off, parsed by value):
-/// `PERRY_GC_THIS_SET_CHECK=1` prints — `=abort` aborts with — a backtrace
-/// the moment a POINTER_TAG value whose header-at-minus-8 is incoherent
-/// enters the implicit-this cell. The seed-3 latch shows the cell (and its
-/// frame saves) holding `boxed(array + interior_offset)`; every walk
-/// downstream then misreads array element bytes as a GcHeader. The abort at
-/// the STORE names the producer, which the collector-side latch cannot.
-#[inline]
-fn this_set_check(value: f64, side: &str) {
-    use std::sync::OnceLock;
-    static MODE: OnceLock<u8> = OnceLock::new();
-    let mode =
-        *MODE.get_or_init(
-            || match std::env::var("PERRY_GC_THIS_SET_CHECK").ok().as_deref() {
-                Some("abort") => 2,
-                Some("1") | Some("on") | Some("true") => 1,
-                _ => 0,
-            },
-        );
-    if mode == 0 {
-        return;
-    }
-    let bits = value.to_bits();
-    if bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
-        return;
-    }
-    let addr = (bits & crate::value::POINTER_MASK) as usize;
-    if addr < crate::gc::GC_HEADER_SIZE
-        || !crate::value::addr_class::is_plausible_heap_addr(addr)
-        || !crate::arena::pointer_in_nursery(addr)
-    {
-        // Only young-arena candidates: the observed interiors are nursery
-        // arrays, and old/malloc objects have differently-managed headers.
-        return;
-    }
-    // Read the header through the centralized probe rather than re-typing the
-    // `addr - GC_HEADER_SIZE` cast: it repeats the band guard and additionally
-    // rejects the headerless small-buffer slab range, so no reachable input can
-    // turn this diagnostic into a wild read (`scripts/addr_class_inventory.py`).
-    let Some(header) = (unsafe { crate::value::addr_class::try_read_gc_header(addr) }) else {
-        return;
-    };
-    let (obj_type, size, flags) = (header.obj_type, header.size, header.gc_flags);
-    if crate::gc::header_incoherence_for_diagnostics(obj_type, size, flags).is_some() {
-        eprintln!(
-            "[gc-this-set-check] {side} value {bits:#018x} — target header \
-             obj_type={obj_type} size={size} flags={flags:#04x} is INCOHERENT \
-             (an interior or stale pointer entering the this cell).\n\
-             --- setter backtrace ---\n{}",
-            std::backtrace::Backtrace::force_capture()
-        );
-        if mode == 2 {
-            std::process::abort();
-        }
-    }
-}
-
 /// Set the implicit `this` and return the previous value.
 /// Callers must restore the previous value to scope the binding to the
 /// duration of a single method-style call.
+///
+/// This is part of every dynamically-dispatched call's save/restore path.
+/// Keep the shipped path to one TLS replacement; default-off diagnostics here
+/// still impose their mode checks millions of times on closure-heavy programs.
 #[no_mangle]
 pub extern "C" fn js_implicit_this_set(value: f64) -> f64 {
-    this_set_check(
-        value,
-        "INCOMING (read from a frame save slot — the WALKER corrupted the slot)",
-    );
-    let previous = IMPLICIT_THIS.with(|c| f64::from_bits(c.replace(value.to_bits())));
-    // Under the trap, grade the OUTGOING value too: an incoherent incoming
-    // value was read from a frame save slot (the walker corrupted the SLOT),
-    // an incoherent outgoing one was sitting in the cell (the scanner
-    // corrupted the CELL). Which side fires first is the decisive bit.
-    this_set_check(
-        previous,
-        "OUTGOING (was sitting in the cell — the SCANNER corrupted the cell)",
-    );
-    previous
+    IMPLICIT_THIS.with(|c| f64::from_bits(c.replace(value.to_bits())))
 }
 
 /// Read the current `new.target` value for ordinary function bodies.


### PR DESCRIPTION
Closes #8243.

## Root cause

#8084 added two calls to `this_set_check` around every `js_implicit_this_set` TLS replacement. Even with `PERRY_GC_THIS_SET_CHECK` unset, each check paid a `OnceLock::get_or_init` fast path and branch. `pipeline` invokes the setter about 2.9 million times per run while saving and restoring implicit `this` around its closure calls, so the default-off diagnostic alone accounts for the previously unattributed regression.

This removes the expired diagnostic and its now-unused GC coherence wrapper, restoring `js_implicit_this_set` to one TLS replacement. The nearby comment records the hot-path invariant so another diagnostic does not silently reintroduce per-call work.

## Measurement

Current `main` at `09bbf032f`, same compiler for both arms, per-arm runtime and stdlib archives, `PERRY_NO_AUTO_OPTIMIZE=1`, `PERRY_DISABLE_BUILD_CACHE=1`, `/usr/bin/time -l`, min-of-5:

| arm | instructions retired |
|---|---:|
| baseline | 3,868,625,816 |
| this PR | 3,718,178,431 |
| delta | **-3.89%** |

All ten runs printed `55626000 3 3` with the same SHA-256. The five fixed runs span 0.08% around their minimum, so the recovered 3.89% is well outside the noise floor and accounts for the reported +3.95% regression.

## Validation

- `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime --lib object::tests -- --test-threads=1` (38 passed)
- `cargo check --release -p perry-runtime`
- `cargo fmt --all --check`
- `scripts/check_file_size.sh`
- `python3 scripts/check_thread_locals.py`
- `python3 scripts/addr_class_inventory.py`

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime performance for implicit `this` assignments by removing unnecessary diagnostic checks.
  * Benchmarking showed a 3.89% reduction in executed instructions for the pipeline workload.
* **Behavior**
  * Preserved existing output while simplifying thread-local value updates.
  * Removed optional pointer-validation and garbage-collection diagnostic reporting that was disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->