### PR TITLE
fix(perf_hooks): implement class prototype machinery

### DIFF
--- a/changelog.d/8254-perf-hooks-class-prototypes.md
+++ b/changelog.d/8254-perf-hooks-class-prototypes.md
@@ -1,0 +1,15 @@
+### fix(perf_hooks): give public classes Node-compatible prototypes and constructors
+
+The public `node:perf_hooks` classes now expose their real prototype chains,
+property descriptors, accessors, methods, and `Symbol.toStringTag` values.
+Performance entries, observers, the global `performance` object, and observer
+entry lists are linked to the same canonical prototypes, so reflection,
+`instanceof`, extracted prototype calls, and receiver validation agree with
+Node.
+
+`new PerformanceMark(name, options)` now creates a detached mark with cloned
+detail data without adding it to the performance timeline. The other
+non-publicly-constructible perf classes throw `ERR_ILLEGAL_CONSTRUCTOR`, while
+`PerformanceObserver` retains its supported constructor. Entry-list filters
+also report Node-compatible missing-argument, Symbol-coercion, and invalid-this
+errors across both generic and typed dispatch paths. Fixes #8231.

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -515,6 +515,35 @@ pub(super) fn lower_builtin_new<'a>(
                 &[(DOUBLE, &cb)],
             )))
         }
+        "PerformanceMark" => {
+            let (name, options) = adopt_two_leading_args_discard_rest(ctx, args, group)?;
+            ctx.pending_declares.push((
+                "js_perf_mark_constructor".to_string(),
+                DOUBLE,
+                vec![DOUBLE, DOUBLE],
+            ));
+            Ok(Some(ctx.block().call(
+                DOUBLE,
+                "js_perf_mark_constructor",
+                &[(DOUBLE, &name), (DOUBLE, &options)],
+            )))
+        }
+        "Performance"
+        | "PerformanceEntry"
+        | "PerformanceMeasure"
+        | "PerformanceObserverEntryList"
+        | "PerformanceResourceTiming" => {
+            for arg in args {
+                let _ = lower_expr(ctx, arg)?;
+            }
+            ctx.pending_declares
+                .push(("js_perf_illegal_constructor".to_string(), DOUBLE, vec![]));
+            Ok(Some(ctx.block().call(
+                DOUBLE,
+                "js_perf_illegal_constructor",
+                &[],
+            )))
+        }
         // string_decoder.StringDecoder — issue #848. `new StringDecoder("utf8")`
         // pre-fix fell through to the generic `js_object_alloc(0, 0)` placeholder,
         // so `dec.write` / `dec.end` were `undefined`. Allocate a real handle

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -453,6 +453,20 @@ pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
 
+    // `PerformanceObserver.supportedEntryTypes` is a built-in static accessor:
+    // reflection reads its descriptor below, while ordinary property reads
+    // must invoke it and receive a fresh frozen array. Native-module class
+    // exports otherwise store only ordinary dynamic data properties, so keep
+    // this constructor-specific accessor at the common closure read seam.
+    if prop == "supportedEntryTypes" {
+        let value = crate::value::js_nanbox_pointer(ptr as i64);
+        if unsafe { crate::object::bound_native_callable_module_and_method(value) }.is_some_and(
+            |(module, method)| module == "perf_hooks" && method == "PerformanceObserver",
+        ) {
+            return crate::perf_hooks::perf_supported_entry_types_value();
+        }
+    }
+
     if let Some(acc) = crate::object::get_accessor_descriptor(ptr, prop) {
         if acc.get == 0 {
             return f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -313,6 +313,13 @@ pub unsafe extern "C" fn js_new_function_construct(
         super::super::object_ops::throw_object_type_error(b"is not a constructor");
     }
     if let Some((module, method)) = bound_native_callable_module_and_method(func_value) {
+        if module == "perf_hooks" {
+            if let Some(result) =
+                crate::perf_hooks::construct_perf_hooks_class(&method, args_ptr, args_len)
+            {
+                return result;
+            }
+        }
         if module == "sqlite"
             && matches!(
                 method.as_str(),

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1051,6 +1051,26 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    // PerformanceObserverEntryList is a native namespace receiver, and typed
+    // feedback can dispatch its methods before the generic prototype/native-
+    // module tower below. Validate the WebIDL-required filter argument at this
+    // common entry so direct calls and extracted prototype calls agree.
+    if method_name_len == 16
+        && !method_name_ptr.is_null()
+        && crate::perf_hooks::is_perf_observer_list_value(object)
+    {
+        let name = std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
+        let arg0 = if args_len > 0 && !args_ptr.is_null() {
+            *args_ptr
+        } else {
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        };
+        if name == b"getEntriesByName" {
+            crate::perf_hooks::validate_perf_list_filter_arg(arg0, "name", args_len == 0);
+        } else if name == b"getEntriesByType" {
+            crate::perf_hooks::validate_perf_list_filter_arg(arg0, "type", args_len == 0);
+        }
+    }
     // #7769: the tower's own previously-computed answer for this
     // (class_id, method_name) pair, when the receiver still satisfies every
     // per-object precondition. See `try_class_vtable_fast_dispatch`.

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -96,7 +96,19 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     // module's handler is registered by its `js_nm_install_<module>()`, and
     // this path is only reachable through that module's namespace — so a
     // binary links exactly the attach machinery of the modules it imports.
-    if export_module_name == "module" && property_name == "SourceMap" {
+    if export_module_name == "perf_hooks" {
+        // These constructors are also installed as globals during realm
+        // bootstrap, before an explicit perf_hooks import necessarily arms the
+        // optional module hook. Their prototypes are intrinsic constructor
+        // state, so install them at this common callable-creation seam.
+        unsafe {
+            crate::perf_hooks::attach_perf_hooks_constructor(
+                property_name,
+                value.get_nanbox_f64(),
+                crate::value::js_nanbox_get_pointer(value.get_nanbox_f64()) as usize,
+            );
+        }
+    } else if export_module_name == "module" && property_name == "SourceMap" {
         // A named import can materialize this callable without first lowering
         // a namespace expression (and therefore before `js_nm_install_module`
         // registers the optional attach handler). SourceMap's prototype is
@@ -1623,18 +1635,10 @@ pub(crate) unsafe fn nm_attach_crypto(
 
 #[allow(unused_mut)]
 pub(crate) unsafe fn nm_attach_perf_hooks(
-    property_name: &str,
-    mut value: f64,
-    closure_addr: usize,
+    _property_name: &str,
+    value: f64,
+    _closure_addr: usize,
 ) -> f64 {
-    // `PerformanceObserver.supportedEntryTypes` is a static array on the
-    // constructor. `PerformanceObserver` is a function value (a bound-method
-    // closure), so hang the array off it as a dynamic property — keeps
-    // `typeof PerformanceObserver === "function"` while the static read works.
-    if property_name == "PerformanceObserver" {
-        let arr = crate::perf_hooks::js_perf_supported_entry_types();
-        crate::closure::closure_set_dynamic_prop(closure_addr, "supportedEntryTypes", arr);
-    }
     value
 }
 

--- a/crates/perry-runtime/src/object/native_module_dispatch/dispatch_m_p.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch/dispatch_m_p.rs
@@ -599,9 +599,11 @@ pub(crate) unsafe fn nm_dispatch_perf(ctx: &NmCtx, module_name: &str, method_nam
         // ── PerformanceObserverEntryList (the callback `list` arg) ──
         ("perf_observer_list", "getEntries") => crate::perf_hooks::current_list_get_entries(),
         ("perf_observer_list", "getEntriesByType") => {
+            crate::perf_hooks::validate_perf_list_filter_arg(arg(0), "type", args_len == 0);
             crate::perf_hooks::current_list_get_by_type(arg(0))
         }
         ("perf_observer_list", "getEntriesByName") => {
+            crate::perf_hooks::validate_perf_list_filter_arg(arg(0), "name", args_len == 0);
             crate::perf_hooks::current_list_get_by_name(arg(0))
         }
 

--- a/crates/perry-runtime/src/perf_hooks.rs
+++ b/crates/perry-runtime/src/perf_hooks.rs
@@ -33,6 +33,11 @@ use std::cell::{Cell, RefCell};
 use std::sync::{Once, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+mod prototypes;
+
+pub(crate) use prototypes::{attach_perf_hooks_constructor, perf_supported_entry_types_value};
+use prototypes::{is_perf_constructor_name, link_perf_prototype};
+
 const ENTRY_TYPE_MARK: u8 = 0;
 const ENTRY_TYPE_MEASURE: u8 = 1;
 const ENTRY_TYPE_RESOURCE: u8 = 2;
@@ -327,6 +332,7 @@ pub fn performance_namespace() -> f64 {
     }
     let module = b"perf_hooks";
     let ns = crate::object::js_create_native_module_namespace(module.as_ptr(), module.len());
+    let ns = link_perf_prototype(ns, "Performance");
     PERFORMANCE_NS.with(|c| c.set(ns.to_bits()));
     ns
 }
@@ -549,7 +555,13 @@ unsafe fn entry_to_object(e: &PerfEntry) -> f64 {
     if let Some(initiator_type) = &e.initiator_type {
         set_named_field(obj, "initiatorType", str_value(initiator_type));
     }
-    crate::value::js_nanbox_pointer(obj as i64)
+    let class_name = match e.entry_type {
+        ENTRY_TYPE_MARK => "PerformanceMark",
+        ENTRY_TYPE_MEASURE => "PerformanceMeasure",
+        ENTRY_TYPE_RESOURCE => "PerformanceResourceTiming",
+        _ => "PerformanceEntry",
+    };
+    link_perf_prototype(crate::value::js_nanbox_pointer(obj as i64), class_name)
 }
 
 /// `performance.now()` reading used for default mark startTimes / measure
@@ -744,6 +756,75 @@ pub extern "C" fn js_perf_mark(name_val: f64, options_val: f64) -> f64 {
         PERF_ENTRIES.with(|store| store.borrow_mut().push(entry));
         obj
     }
+}
+
+/// `new PerformanceMark(name, options?)` creates a detached mark. Node clones
+/// `detail` exactly like `performance.mark`, but does not append the result to
+/// the global performance timeline or notify observers.
+#[no_mangle]
+pub extern "C" fn js_perf_mark_constructor(name_val: f64, options_val: f64) -> f64 {
+    unsafe {
+        if crate::symbol::js_is_symbol(name_val) != 0 {
+            throw_type_error("Cannot convert a Symbol value to a string");
+        }
+        let name = coerce_to_string(name_val);
+        let mut start_time = perf_now();
+        let mut detail_bits = JSValue::null().bits();
+        if let Some(opts) = as_object_ptr(options_val) {
+            if option_present(opts, "startTime") {
+                match option_number(opts, "startTime") {
+                    Some(st) => {
+                        validate_user_timing_timestamp(st);
+                        start_time = st;
+                    }
+                    None => throw_type_error_with_code(
+                        "The \"startTime\" option must be of type number",
+                        "ERR_INVALID_ARG_TYPE",
+                    ),
+                }
+            }
+            detail_bits = option_detail_bits(opts);
+        }
+        let entry = PerfEntry {
+            name,
+            entry_type: ENTRY_TYPE_MARK,
+            start_time,
+            duration: 0.0,
+            detail_bits,
+            object_bits: 0,
+            initiator_type: None,
+        };
+        entry_to_object(&entry)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_perf_illegal_constructor() -> f64 {
+    throw_type_error_with_code("Illegal constructor", "ERR_ILLEGAL_CONSTRUCTOR")
+}
+
+pub(crate) unsafe fn construct_perf_hooks_class(
+    class_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if !is_perf_constructor_name(class_name) {
+        return None;
+    }
+    let args = if args_ptr.is_null() {
+        &[][..]
+    } else {
+        std::slice::from_raw_parts(args_ptr, args_len)
+    };
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    Some(match class_name {
+        "PerformanceMark" => js_perf_mark_constructor(
+            args.first().copied().unwrap_or(undefined),
+            args.get(1).copied().unwrap_or(undefined),
+        ),
+        "PerformanceObserver" => js_perf_observer_new(args.first().copied().unwrap_or(undefined)),
+        _ => js_perf_illegal_constructor(),
+    })
 }
 
 // ── performance.measure(name, startOrOptions?, end?) ─────────────────────────
@@ -1366,7 +1447,19 @@ unsafe fn make_observer_object(id: usize) -> f64 {
         keys = crate::array::js_array_push(keys, JSValue::string_ptr(kp));
     }
     crate::object::js_object_set_keys(obj, keys);
-    crate::value::js_nanbox_pointer(obj as i64)
+    link_perf_prototype(
+        crate::value::js_nanbox_pointer(obj as i64),
+        "PerformanceObserver",
+    )
+}
+
+fn is_perf_observer_value(value: f64) -> bool {
+    unsafe {
+        let Some(obj) = as_object_ptr(value) else {
+            return false;
+        };
+        string_of(js_object_get_field(obj, 0)).as_deref() == Some("perf_observer")
+    }
 }
 
 /// True if `v` is callable (matches `typeof v === "function"`) — covers
@@ -1675,6 +1768,7 @@ pub extern "C" fn js_perf_observer_flush_all(
             let module = b"perf_observer_list";
             let list =
                 crate::object::js_create_native_module_namespace(module.as_ptr(), module.len());
+            let list = link_perf_prototype(list, "PerformanceObserverEntryList");
             let cb_jv = JSValue::from_bits(cb_bits);
             if cb_jv.is_pointer() {
                 // Node invokes the callback as `(list, observer)` with `this`
@@ -1712,6 +1806,18 @@ pub(crate) unsafe fn current_list_to_array(filter: impl Fn(&PerfEntry) -> bool) 
 
 pub unsafe fn current_list_get_entries() -> f64 {
     current_list_to_array(|_| true)
+}
+
+pub(crate) fn validate_perf_list_filter_arg(value: f64, name: &str, missing: bool) {
+    if missing || JSValue::from_bits(value.to_bits()).is_undefined() {
+        throw_type_error_with_code(
+            &format!("The \"{name}\" argument must be specified"),
+            "ERR_MISSING_ARGS",
+        );
+    }
+    if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+        throw_type_error("Cannot convert a Symbol value to a string");
+    }
 }
 
 pub unsafe fn current_list_get_by_type(type_val: f64) -> f64 {

--- a/crates/perry-runtime/src/perf_hooks/prototypes.rs
+++ b/crates/perry-runtime/src/perf_hooks/prototypes.rs
@@ -1,0 +1,423 @@
+use super::*;
+
+const PERF_CONSTRUCTOR_NAMES: &[&str] = &[
+    "Performance",
+    "PerformanceEntry",
+    "PerformanceMark",
+    "PerformanceMeasure",
+    "PerformanceObserver",
+    "PerformanceObserverEntryList",
+    "PerformanceResourceTiming",
+];
+
+pub(super) fn is_perf_constructor_name(class_name: &str) -> bool {
+    PERF_CONSTRUCTOR_NAMES.contains(&class_name)
+}
+
+fn invalid_perf_receiver(class_name: &str) -> ! {
+    throw_type_error_with_code(
+        &format!("The \"this\" argument must be an instance of {class_name}"),
+        "ERR_INVALID_THIS",
+    )
+}
+
+extern "C" fn perf_entry_field_getter_thunk(closure: *const crate::closure::ClosureHeader) -> f64 {
+    unsafe {
+        let this = crate::object::js_implicit_this_get();
+        let Some(obj) = as_object_ptr(this) else {
+            invalid_perf_receiver("PerformanceEntry");
+        };
+        if !is_perf_entry_object(obj) {
+            invalid_perf_receiver("PerformanceEntry");
+        }
+        let name_ptr = crate::closure::js_closure_get_capture_ptr(closure, 0) as *const u8;
+        let name_len = crate::closure::js_closure_get_capture_ptr(closure, 1) as usize;
+        if name_ptr.is_null() {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        let name = std::slice::from_raw_parts(name_ptr, name_len);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let receiver = scope.root_nanbox_f64(this);
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let obj = JSValue::from_bits(receiver.get_nanbox_u64())
+            .as_pointer::<crate::object::ObjectHeader>();
+        f64::from_bits(js_object_get_field_by_name(obj, key).bits())
+    }
+}
+
+extern "C" fn perf_entry_to_json_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    unsafe {
+        let this = crate::object::js_implicit_this_get();
+        let Some(obj) = as_object_ptr(this) else {
+            invalid_perf_receiver("PerformanceEntry");
+        };
+        if !is_perf_entry_object(obj) {
+            invalid_perf_receiver("PerformanceEntry");
+        }
+        perf_entry_to_json(this)
+    }
+}
+
+extern "C" fn perf_time_origin_getter_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    time_origin_ms()
+}
+
+extern "C" fn perf_supported_entry_types_getter_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    perf_supported_entry_types_value()
+}
+
+pub(crate) fn perf_supported_entry_types_value() -> f64 {
+    let _no_move = crate::gc::GcSuppressScope::new();
+    let value = js_perf_supported_entry_types();
+    crate::object::js_object_freeze(value)
+}
+
+extern "C" fn perf_observer_observe_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    options: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_value(this) {
+        invalid_perf_receiver("PerformanceObserver");
+    }
+    js_perf_observer_observe(this, options)
+}
+
+extern "C" fn perf_observer_disconnect_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_value(this) {
+        invalid_perf_receiver("PerformanceObserver");
+    }
+    js_perf_observer_disconnect(this)
+}
+
+extern "C" fn perf_observer_take_records_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_value(this) {
+        invalid_perf_receiver("PerformanceObserver");
+    }
+    js_perf_observer_take_records(this)
+}
+
+extern "C" fn perf_list_get_entries_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_list_value(this) {
+        invalid_perf_receiver("PerformanceObserverEntryList");
+    }
+    unsafe { current_list_get_entries() }
+}
+
+extern "C" fn perf_list_get_by_type_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    entry_type: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_list_value(this) {
+        invalid_perf_receiver("PerformanceObserverEntryList");
+    }
+    unsafe { current_list_get_by_type(entry_type) }
+}
+
+extern "C" fn perf_list_get_by_name_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    name: f64,
+) -> f64 {
+    let this = crate::object::js_implicit_this_get();
+    if !is_perf_observer_list_value(this) {
+        invalid_perf_receiver("PerformanceObserverEntryList");
+    }
+    unsafe { current_list_get_by_name(name) }
+}
+
+fn perf_method_value(func_ptr: *const u8, name: &str, arity: u32) -> f64 {
+    crate::closure::js_register_closure_arity(func_ptr, arity);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    crate::object::set_bound_native_closure_name(closure, name);
+    crate::object::set_builtin_closure_length(closure as usize, arity);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+unsafe fn install_perf_method(
+    proto: *mut crate::object::ObjectHeader,
+    name: &str,
+    value: f64,
+    enumerable: bool,
+) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(proto, key, value);
+    crate::object::set_builtin_property_attrs(
+        proto as usize,
+        name.to_string(),
+        crate::object::PropertyAttrs::new(true, enumerable, true),
+    );
+}
+
+unsafe fn install_perf_getter(
+    proto: *mut crate::object::ObjectHeader,
+    name: &str,
+    getter: f64,
+    enumerable: bool,
+) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    js_object_set_field_by_name(proto, key, f64::from_bits(crate::value::TAG_UNDEFINED));
+    crate::object::set_builtin_accessor_descriptor(
+        proto as usize,
+        name.to_string(),
+        crate::object::AccessorDescriptor {
+            get: getter.to_bits(),
+            set: 0,
+        },
+        crate::object::PropertyAttrs::new(true, enumerable, true),
+    );
+}
+
+unsafe fn install_perf_to_string_tag(proto: *mut crate::object::ObjectHeader, tag: &str) {
+    let symbol = crate::symbol::well_known_symbol("toStringTag");
+    if symbol.is_null() {
+        return;
+    }
+    let value = str_value(tag);
+    crate::symbol::js_object_set_symbol_property(
+        crate::value::js_nanbox_pointer(proto as i64),
+        crate::value::js_nanbox_pointer(symbol as i64),
+        f64::from_bits(value.bits()),
+    );
+    crate::symbol::set_symbol_property_attrs(
+        proto as usize,
+        symbol as usize,
+        crate::object::PropertyAttrs::new(false, false, true),
+    );
+}
+
+unsafe fn perf_field_getter(name: &str) -> f64 {
+    let leaked: &'static [u8] = name.as_bytes().to_vec().leak();
+    let func_ptr = perf_entry_field_getter_thunk as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 0);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 2);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, leaked.as_ptr() as i64);
+    crate::closure::js_closure_set_capture_ptr(closure, 1, leaked.len() as i64);
+    crate::object::set_bound_native_closure_name(closure, &format!("get {name}"));
+    crate::object::set_builtin_closure_length(closure as usize, 0);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+fn perf_constructor_prototype(class_name: &str) -> f64 {
+    let ctor = crate::object::bound_native_callable_export_value("perf_hooks", class_name);
+    let ptr = crate::value::js_nanbox_get_pointer(ctor) as usize;
+    crate::closure::closure_get_dynamic_prop(ptr, "prototype")
+}
+
+pub(super) fn link_perf_prototype(value: f64, class_name: &str) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value = scope.root_nanbox_f64(value);
+    let prototype = scope.root_nanbox_f64(perf_constructor_prototype(class_name));
+    let obj = crate::value::js_nanbox_get_pointer(value.get_nanbox_f64()) as usize;
+    crate::object::prototype_chain::object_set_static_prototype(
+        obj,
+        prototype.get_nanbox_f64().to_bits(),
+    );
+    value.get_nanbox_f64()
+}
+
+pub(crate) unsafe fn attach_perf_hooks_constructor(
+    class_name: &str,
+    constructor_value: f64,
+    closure_addr: usize,
+) {
+    if !PERF_CONSTRUCTOR_NAMES.contains(&class_name) {
+        return;
+    }
+    let _no_move = crate::gc::GcSuppressScope::new();
+    let proto = crate::object::js_object_alloc(0, 0);
+    if proto.is_null() {
+        return;
+    }
+
+    let constructor_key = crate::string::js_string_from_bytes(b"constructor".as_ptr(), 11);
+    js_object_set_field_by_name(proto, constructor_key, constructor_value);
+    crate::object::set_builtin_property_attrs(
+        proto as usize,
+        "constructor".to_string(),
+        crate::object::PropertyAttrs::new(true, false, true),
+    );
+
+    match class_name {
+        "Performance" => {
+            for method in [
+                "clearMarks",
+                "clearMeasures",
+                "clearResourceTimings",
+                "getEntries",
+                "getEntriesByName",
+                "getEntriesByType",
+                "mark",
+                "measure",
+                "now",
+                "setResourceTimingBufferSize",
+                "toJSON",
+            ] {
+                let value = crate::object::bound_native_callable_export_value("perf_hooks", method);
+                install_perf_method(proto, method, value, true);
+            }
+            for method in ["eventLoopUtilization", "markResourceTiming", "timerify"] {
+                let value = crate::object::bound_native_callable_export_value("perf_hooks", method);
+                install_perf_method(proto, method, value, false);
+            }
+            let getter = perf_method_value(
+                perf_time_origin_getter_thunk as *const u8,
+                "get timeOrigin",
+                0,
+            );
+            install_perf_getter(proto, "timeOrigin", getter, true);
+            install_perf_to_string_tag(proto, "Performance");
+        }
+        "PerformanceEntry" => {
+            for field in ["name", "entryType", "startTime", "duration"] {
+                let getter = perf_field_getter(field);
+                install_perf_getter(proto, field, getter, true);
+            }
+            let to_json = perf_method_value(perf_entry_to_json_thunk as *const u8, "toJSON", 0);
+            install_perf_method(proto, "toJSON", to_json, true);
+        }
+        "PerformanceMark" | "PerformanceMeasure" => {
+            let base = perf_constructor_prototype("PerformanceEntry");
+            crate::object::prototype_chain::object_set_static_prototype(
+                proto as usize,
+                base.to_bits(),
+            );
+            let getter = perf_field_getter("detail");
+            install_perf_getter(proto, "detail", getter, true);
+            let to_json = perf_method_value(perf_entry_to_json_thunk as *const u8, "toJSON", 0);
+            install_perf_method(proto, "toJSON", to_json, false);
+            install_perf_to_string_tag(proto, class_name);
+        }
+        "PerformanceObserver" => {
+            install_perf_method(
+                proto,
+                "observe",
+                perf_method_value(perf_observer_observe_thunk as *const u8, "observe", 1),
+                true,
+            );
+            install_perf_method(
+                proto,
+                "disconnect",
+                perf_method_value(perf_observer_disconnect_thunk as *const u8, "disconnect", 0),
+                true,
+            );
+            install_perf_method(
+                proto,
+                "takeRecords",
+                perf_method_value(
+                    perf_observer_take_records_thunk as *const u8,
+                    "takeRecords",
+                    0,
+                ),
+                true,
+            );
+            install_perf_to_string_tag(proto, class_name);
+        }
+        "PerformanceObserverEntryList" => {
+            install_perf_method(
+                proto,
+                "getEntries",
+                perf_method_value(perf_list_get_entries_thunk as *const u8, "getEntries", 0),
+                true,
+            );
+            install_perf_method(
+                proto,
+                "getEntriesByType",
+                perf_method_value(
+                    perf_list_get_by_type_thunk as *const u8,
+                    "getEntriesByType",
+                    1,
+                ),
+                true,
+            );
+            install_perf_method(
+                proto,
+                "getEntriesByName",
+                perf_method_value(
+                    perf_list_get_by_name_thunk as *const u8,
+                    "getEntriesByName",
+                    1,
+                ),
+                true,
+            );
+            install_perf_to_string_tag(proto, class_name);
+        }
+        "PerformanceResourceTiming" => {
+            let base = perf_constructor_prototype("PerformanceEntry");
+            crate::object::prototype_chain::object_set_static_prototype(
+                proto as usize,
+                base.to_bits(),
+            );
+            for field in [
+                "initiatorType",
+                "workerStart",
+                "redirectStart",
+                "redirectEnd",
+                "fetchStart",
+                "domainLookupStart",
+                "domainLookupEnd",
+                "connectStart",
+                "connectEnd",
+                "secureConnectionStart",
+                "nextHopProtocol",
+                "requestStart",
+                "responseStart",
+                "responseEnd",
+                "encodedBodySize",
+                "decodedBodySize",
+                "transferSize",
+                "deliveryType",
+                "responseStatus",
+            ] {
+                let getter = perf_field_getter(field);
+                install_perf_getter(proto, field, getter, true);
+            }
+            let to_json = perf_method_value(perf_entry_to_json_thunk as *const u8, "toJSON", 0);
+            install_perf_method(proto, "toJSON", to_json, true);
+            install_perf_to_string_tag(proto, class_name);
+        }
+        _ => {}
+    }
+
+    let proto_value = crate::value::js_nanbox_pointer(proto as i64);
+    crate::closure::closure_set_dynamic_prop(closure_addr, "prototype", proto_value);
+    crate::object::set_builtin_property_attrs(
+        closure_addr,
+        "prototype".to_string(),
+        crate::object::PropertyAttrs::new(false, false, false),
+    );
+
+    if class_name == "PerformanceObserver" {
+        let getter = perf_method_value(
+            perf_supported_entry_types_getter_thunk as *const u8,
+            "get supportedEntryTypes",
+            0,
+        );
+        crate::closure::closure_set_dynamic_prop(
+            closure_addr,
+            "supportedEntryTypes",
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+        );
+        crate::object::set_builtin_accessor_descriptor(
+            closure_addr,
+            "supportedEntryTypes".to_string(),
+            crate::object::AccessorDescriptor {
+                get: getter.to_bits(),
+                set: 0,
+            },
+            crate::object::PropertyAttrs::new(true, false, true),
+        );
+    }
+}


### PR DESCRIPTION
Closes #8231.

## Summary

- install real `perf_hooks` constructor prototypes, inheritance, descriptors, getters, methods, and `Symbol.toStringTag` metadata
- implement direct `PerformanceMark` construction while preserving detached-timeline behavior and enforce illegal constructors for the remaining classes
- link performance entries, observers, and observer entry lists to their canonical prototypes and validate entry-list receivers/arguments across typed dispatch

## Validation

- `cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static`
- all six parity fixtures listed in #8231 pass
- adjacent `global/class-constructors` and `observer/supported-entry-types-exact` parity fixtures pass
- `./scripts/test_affected_crates.sh --base origin/main` scoped tests completed (runtime 2546, Perry 987, codegen 1062, FFI 26; zero failures)
- `./scripts/pre-tag-check.sh --quick`

No version bump included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Node-compatible `node:perf_hooks` class prototypes, inheritance, methods, accessors, and descriptors.
  - Added `PerformanceMark` construction with support for names and options.
  - Added `PerformanceObserver.supportedEntryTypes`.
  - Added performance entry list filtering by name and type.

- **Bug Fixes**
  - Added validation for invalid constructors and entry-list filter arguments.
  - Improved compatibility for performance object behavior and string tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->