### PR TITLE
fix(gc): unify the Map/Set entry tripwires on the canonical heap-address classifier

### DIFF
--- a/crates/perry-runtime/src/gc/layout_slot_visit.rs
+++ b/crates/perry-runtime/src/gc/layout_slot_visit.rs
@@ -203,17 +203,22 @@ pub(super) unsafe fn visit_gc_rewrite_slot_descriptors(
             }
             // Defensive tripwire (# fabricated-Map): if a fabricated Map
             // header ever slips past `plausible_gc_header`, the `entries`
-            // field would be a NaN-boxed JSValue (top bits 0x7FFD…) read
-            // from the original object's payload — an impossible pointer
-            // on x86-64 where user-space addresses stay below bit 47.
-            // Reject it rather than dereference a derived slot range from
-            // a garbage base. This is a backstop; the primary fix is the
-            // fixed-layout size check in `plausible_gc_header`.
-            if ((*map).entries as usize) >> 47 != 0 {
+            // field would be a NaN-boxed JSValue (top bits 0x7FFD…) or some
+            // other non-pointer word read from the original object's
+            // payload. Reject it rather than dereference a derived slot
+            // range from a garbage base. This is a backstop; the primary
+            // fix is the fixed-layout size check in `plausible_gc_header`.
+            // Use the shared heap-address classifier so the bound is
+            // platform-correct (a fixed `>> 47` cutoff would false-reject
+            // genuine entries on aarch64 Linux, where user space reaches
+            // bit 48) and so low / handle-band garbage is rejected too,
+            // not only the NaN-box signature.
+            let entries_addr = (*map).entries as usize;
+            if !crate::value::addr_class::is_plausible_heap_addr(entries_addr) {
                 if crate::gc::gc_diag_enabled() {
                     eprintln!(
-                        "[gc-tripwire] Map entries has implausible top bits: {:#x} (fabricated Map?)",
-                        (*map).entries as usize
+                        "[gc-tripwire] Map entries is not a plausible heap address: {:#x} (fabricated Map?)",
+                        entries_addr
                     );
                 }
                 return;

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -557,12 +557,18 @@ pub(crate) unsafe fn gc_element_slot_range(
     }
     // Defensive tripwire (cf. Map's entries check in layout_slot_visit):
     // a NaN-boxed JSValue read as `elements` carries 0x7FFD in the top
-    // bits — an impossible x86-64 user-space pointer.
-    if ((*set).elements as usize) >> 47 != 0 {
+    // bits, and other non-pointer payload words can land below the heap
+    // range or in the handle band. Reject any `elements` that is not a
+    // plausible heap address rather than dereference a derived slot range
+    // from a garbage base. Uses the shared platform-correct classifier
+    // (a fixed `>> 47` cutoff would false-reject genuine elements on
+    // aarch64 Linux, where user space reaches bit 48).
+    let elements_addr = (*set).elements as usize;
+    if !crate::value::addr_class::is_plausible_heap_addr(elements_addr) {
         if crate::gc::gc_diag_enabled() {
             eprintln!(
-                "[gc-tripwire] Set elements has implausible top bits: {:#x} (fabricated Set?)",
-                (*set).elements as usize
+                "[gc-tripwire] Set elements is not a plausible heap address: {:#x} (fabricated Set?)",
+                elements_addr
             );
         }
         return None;
@@ -2445,5 +2451,52 @@ mod tests {
             jsvalue_eq(val1, val2),
             "cross-tag strings with same content should be equal"
         );
+    }
+
+    /// `gc_element_slot_range`'s defensive tripwire must reject an
+    /// `elements` word that is not a plausible heap address — a NaN-boxed
+    /// JSValue (top bits 0x7FFD), a low garbage address below the handle
+    /// band, and a handle-band id — while still accepting a genuine
+    /// system-allocator `elements` pointer. The previous `>> 47` cutoff
+    /// only caught the NaN-box signature and accepted low / handle-band
+    /// garbage; the unified `is_plausible_heap_addr` classifier closes
+    /// both gaps and is platform-correct.
+    #[test]
+    fn test_gc_element_slot_range_rejects_implausible_elements() {
+        // Genuine Set: elements is a real system-allocator pointer.
+        let set = js_set_alloc(4);
+        js_set_add(set, 1.0);
+        assert!(
+            unsafe { gc_element_slot_range(set) }.is_some(),
+            "genuine Set elements must yield a slot range"
+        );
+
+        // Build a stack SetHeader so we can control `elements` directly.
+        let mut header = SetHeader {
+            size: 1,
+            capacity: 4,
+            elements: std::ptr::null_mut(),
+        };
+
+        let cases: &[(&str, *mut f64)] = &[
+            // NaN-boxed JSValue (POINTER_TAG 0x7FFD) — the fabricated-Map
+            // signature that crashes on dereference.
+            ("nan-box", 0x7FFD_0000_0000_1000u64 as *mut f64),
+            // Low address below the handle band — the old `>> 47` check
+            // accepted this (0 >> 47 == 0), letting the collector derive a
+            // slot range from an unmapped / unrelated low address.
+            ("low-addr", 0x4000u64 as *mut f64),
+            // Handle-band id (just below HANDLE_BAND_MAX = 0x100000).
+            ("handle-band", 0x80000u64 as *mut f64),
+        ];
+
+        for &(label, fake_elements) in cases {
+            header.elements = fake_elements;
+            let got = unsafe { gc_element_slot_range(&mut header as *mut SetHeader) };
+            assert!(
+                got.is_none(),
+                "elements={label} must be rejected by the tripwire, got {got:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Follow-up to the Major CodeRabbit finding on [#8251](https://github.com/PerryTS/perry/pull/8251): the Map and Set descriptor arms each carried their own `(addr >> 47) != 0` tripwire with subtly different logic, and both were wrong in two ways.

**The bug in the tripwires.** `>> 47 != 0` is true for *any* address with a bit set at or above bit 47. That catches the NaN-boxed `0x7ffd…` fault signature it was written for — but it also accepts low garbage and the handle band, and it is platform-wrong on aarch64 Linux, where user space reaches bit 48. A value in that band would read as "plausible" and the tripwire would not fire.

**The fix.** Both arms now use `crate::value::addr_class::is_plausible_heap_addr`, the canonical predicate already used across the gc module. This is safe and strictly more conservative: Map/Set `entries`/`elements` are always `std::alloc::alloc` pointers, which live above the handle band in the heap range, so every genuine entry still passes while the malformed band is now rejected.

**Verification.** Added `test_gc_element_slot_range_rejects_implausible_elements` covering NaN-box, low-address, and handle-band rejection plus a genuine Set. `cargo test -p perry-runtime --lib`: 2556 passed, 0 failed (failing set identical to parent). The four `fabricated_map_rejection` tests from #8251 still pass. Registry arm unaffected by construction — the tripwire only fires on non-plausible entries/elements, which never occur for genuine objects (proven by the genuine-Set assertion).

Thread: https://github.com/PerryTS/perry/pull/8251#discussion_r3792628101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime memory management reliability across supported platforms.
  * Added safeguards to reject invalid memory references during garbage collection, helping prevent crashes and memory-access errors.
  * Corrected handling of valid allocator-managed pointers while continuing to reject malformed or unsupported addresses.

* **Tests**
  * Added regression coverage for valid and invalid pointer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->