### PR TITLE
fix(gc): address bot review followups from #7291, #7281, #7284

### DIFF
--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -2471,8 +2471,8 @@ pub fn gc_check_trigger() {
             // non-moving in-place minor runs and nothing relocates.
             //
             // ★ #7148 disposition: **keep as the bounded valve, now counted.**
-            // The deferral above is the primary path and is sound by
-            // construction; reaching here means the slack expired without the
+            // The deferral above is the primary path and makes the collection
+            // point precise; reaching here means the slack expired without the
             // program touching a single loop back-edge poll or microtask-pump
             // boundary — a mega-expression, or a synchronous recursion, that
             // allocated `gc_moving_defer_slack_dyn_bytes()` past the deferral

--- a/docs/src/cli/app-updates.md
+++ b/docs/src/cli/app-updates.md
@@ -160,7 +160,7 @@ The startup notice reports what a *previous* run recorded. To make a run actuall
 ask, call the check from your own code — Perry gives you everything except the
 request itself, which uses your app's own `fetch()`:
 
-```typescript
+```typescript,no-test
 import {
   embeddedCheckHeaders,
   embeddedCheckUrl,

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -66,7 +66,7 @@ perry compile server.ts --embed "./dist/**" -o myapp
 
 Embedded files are reachable at runtime three ways:
 
-```ts
+```typescript,no-test
 import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "perry";
 import { readFileSync } from "fs";
 

--- a/docs/src/container/determinism.md
+++ b/docs/src/container/determinism.md
@@ -63,7 +63,7 @@ Both are unacceptable for production.
 
 The four mechanisms compose. The most common production pattern combines (4) and (3):
 
-```typescript
+```typescript,no-test
 import { selectBackendFor, setBackend, up } from 'perry/container';
 
 const best = JSON.parse(selectBackendFor(JSON.stringify(spec))) as string;
@@ -89,7 +89,7 @@ sensible default. `AcceptPartial` is for dev / "just make it run."
 
 **Companion APIs:**
 
-```typescript
+```typescript,no-test
 // "What backend is currently active?"
 console.log(getBackend());                                // "docker"
 

--- a/docs/src/container/overview.md
+++ b/docs/src/container/overview.md
@@ -57,7 +57,7 @@ so a single program can use multiple.
 | 3 | Programmatic pin | TS-runtime pin before first op | `await setBackend('podman')` |
 | 4 | Capability-aware | pick the best backend **for the spec** | `JSON.parse(selectBackendFor(JSON.stringify(spec)))` |
 
-```typescript
+```typescript,no-test
 import {
   setBackend, setBackends, getBackend, getBackendPriority,
   getAvailableBackends, selectBackendFor, up,

--- a/docs/src/internals/explicit-memory.md
+++ b/docs/src/internals/explicit-memory.md
@@ -15,7 +15,7 @@ views over it report length 0, and any further `transfer`/`slice`/view
 construction on it throws a `TypeError`. This is standard ECMAScript — the same
 code runs under Node and Bun unchanged.
 
-```ts
+```typescript,no-test
 let scratch = new ArrayBuffer(64 * 1024 * 1024);
 // ... use it ...
 scratch = scratch.transfer(0); // detach: the 64 MB backing is released
@@ -35,7 +35,7 @@ A Perry-native module in the spirit of `perry/thread`: it compiles to direct
 runtime calls and does not resolve under Node/Bun, so guard the import if the
 source must also run there.
 
-```ts
+```typescript,no-test
 import { collect, minor, idleHint } from "perry/gc";
 
 collect();  // full collection now — same as the global gc()
@@ -50,7 +50,7 @@ after presenting. When allocation pressure has made a collection imminent, it
 runs at your chosen boundary instead of landing mid-frame at whatever
 allocation happens to trip the threshold:
 
-```ts
+```typescript,no-test
 function frame() {
   update();
   render();

--- a/docs/src/internals/gc-rooting-invariant.md
+++ b/docs/src/internals/gc-rooting-invariant.md
@@ -109,8 +109,9 @@ collection point** instead of caching the load.
 
 A thread-local or static cell holding a GC pointer that no registered scanner
 rewrites. Unlike the register-class bugs above (which go bad intermittently when a
-collection lands in a narrow window), a runtime cache goes bad at collection #0
-and stays bad.
+collection lands in a narrow window), an unregistered runtime cache becomes
+stale at the first moving collection after it is populated and stays stale
+until rewritten.
 
 Real instances: `js_value_typeof` interned its eight result strings in
 thread-local `Cell<*mut StringHeader>`s with no registered scanner (#7226);

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -26,7 +26,7 @@ that is only known at runtime. A *constant* code string is the exception —
 real native functions (#1679). Only a body built from runtime data hits this
 limit:
 
-```ts
+```typescript,no-test
 // Constant body → compiled natively (works)
 const add = new Function("a", "b", "return a + b");
 
@@ -68,7 +68,7 @@ Resolvable specifiers are unaffected and still compile + load: string literals
 `const` locals (`` import(`./${KIND}.js`) ``), finite string-literal-union
 parameters, and directory globs.
 
-```ts
+```typescript,no-test
 // Resolvable → compiled + loaded as today.
 const real = await import("./real.js");
 
@@ -169,7 +169,7 @@ but user-written modules should use static `import` declarations.
 
 Dynamic prototype manipulation is supported for the common patterns:
 
-```ts
+```typescript,no-test
 // Supported
 MyClass.prototype.newMethod = function () {};   // prototype method assignment
 Object.setPrototypeOf(obj, proto);              // incl. chains of any length

--- a/docs/src/language/native-values.md
+++ b/docs/src/language/native-values.md
@@ -5,7 +5,7 @@ JavaScript number semantics, and normal objects and arrays remain managed
 values. At boundaries where byte width and C-compatible layout are part of
 correctness, `perry/native` provides an explicit, opt-in contract.
 
-```typescript
+```typescript,no-test
 import {
   type u32,
   type u64,

--- a/docs/src/plugins/native-extensions.md
+++ b/docs/src/plugins/native-extensions.md
@@ -151,7 +151,7 @@ export async function requestReview(): Promise<void> {
 
 For manifest symbols that follow the `js_<pkg>_<snake_case>` convention (where `<pkg>` is the sanitized last segment of the package name), Perry derives an **ergonomic camelCase alias** so consumers can import a spec-faithful name without you writing any wrapper (issue #5621). For `@perryts/webgpu` a manifest symbol `js_webgpu_request_adapter` is importable as `requestAdapter`:
 
-```ts
+```typescript,no-test
 // The package's src/index.ts only ambient-declares the raw symbols…
 export declare function js_webgpu_request_adapter(): Promise<number>;
 
@@ -161,7 +161,7 @@ import { requestAdapter } from "@perryts/webgpu"; // → js_webgpu_request_adapt
 
 The alias is a convenience **for packages that only export ambient `declare` signatures**. A *genuine* implemented export always wins over a derived alias (issue #6715): if your `src/index.ts` also exports a real wrapper whose name equals a manifest symbol's derived alias, the import binds to **your wrapper**, not the FFI symbol — your wrapper code runs, and it can call the raw symbol internally:
 
-```ts
+```typescript,no-test
 export declare function js_speech_speak(
   text: string, rate: number, pitch: number, locale: string, voiceId: string): Promise<number>;
 

--- a/docs/src/testing/node-compat-matrix.md
+++ b/docs/src/testing/node-compat-matrix.md
@@ -82,7 +82,7 @@ node-suite oracle; the compat matrix carries its own "latest stable" pin.
 
 For a module `M` and a form, the probe does:
 
-```ts
+```typescript,no-test
 import * as ns from "M"          // or "node:M"
 // sorted list of `<exportName>:<typeof export[name]>` over Object.keys(ns),
 // plus `default:<typeof ns.default>`, wrapped in a __FP__...__FP__ sentinel.


### PR DESCRIPTION
fix(gc): address bot review followups from #7291, #7281, #7284

Three verified bot findings folded into one commit:

1. policy.rs "sound by construction" overclaim (#7291 thread): the
   #7280 correction at line 2379 explicitly says the deferral is NOT
   "sound by construction" because runtime Rust frames need explicit
   rooting, but the comment at line 2474 still called the same deferral
   "sound by construction." Aligned it to "makes the collection point
   precise," matching the corrected framing.

2. gc-rooting-invariant.md "collection #0" imprecision (#7281 thread):
   a runtime cache populated after earlier collections goes bad at the
   first moving collection after population, not at collection #0.
   Reworded to state that precisely.

3. 15 untagged TypeScript doc fences (#7281 thread): perry-doc-tests
   --lint reported untagged ts/typescript fences across docs/src. Tagged
   each as typescript,no-test. Linter now reports "docs/src ok."

Refuted (no change needed):
- #7284 thread claimed docs overclaim --audit-poll-capable CI wiring,
  but the workflow step was included in the PR squashed commit and is
  present on main; the docs are accurate.
- #7281 thread 3 claimed the static-checker scope was unlimited, but
  the doc already says "Scope: emitted-LLVM rooting hazards only."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified garbage-collection guidance, including when unregistered runtime caches may become stale.
  * Updated TypeScript examples with consistent language annotations.
  * Excluded illustrative code snippets from automated documentation tests where appropriate.

* **Chores**
  * Improved internal garbage-collection commentary to more precisely describe nursery deferral behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->