### PR TITLE
fix(gc): root box pointer allocas and unrooted call operands (#8258)

### DIFF
--- a/crates/perry-codegen/src/expr/closure.rs
+++ b/crates/perry-codegen/src/expr/closure.rs
@@ -7,6 +7,8 @@
 use anyhow::Result;
 use perry_hir::Expr;
 
+use crate::rooting;
+use crate::rooting::Repr;
 use crate::type_analysis::compute_auto_captures;
 use crate::types::{DOUBLE, I32, I64, PTR};
 
@@ -120,6 +122,32 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     captured_value_bits.push(v_bits);
                 }
             }
+
+            // #8258: Root captured values across js_closure_alloc, which can
+            // trigger a copying minor. Box pointers (raw i64) and NaN-boxed
+            // values held in bare SSA registers are invisible to the collector;
+            // without rooting, a GC during the allocation moves the underlying
+            // objects, the registers hold stale addresses, and
+            // js_closure_set_capture_bits stores stale pointers into the
+            // closure's capture slots. Later, js_box_get_bits on a stale box
+            // pointer reads garbage, surfacing as "TypeError: Cannot convert
+            // undefined or null to object" when the closure body calls
+            // js_require_object_coercible on the captured value.
+            //
+            // The captured-singleton path (js_closure_alloc_with_captures_singleton)
+            // roots captures inside the runtime helper, so this group is only
+            // re-read on the non-singleton path below.
+            let mut capture_handles: Vec<rooting::EmittedValue> = Vec::new();
+            let capture_group = if !captured_value_bits.is_empty() {
+                let mut g = rooting::open_rooted_group(captured_value_bits.len());
+                for v_bits in &captured_value_bits {
+                    let h = g.adopt_emitted(ctx, Repr::Ptr, v_bits, true);
+                    capture_handles.push(h);
+                }
+                Some(g)
+            } else {
+                None
+            };
 
             // Compute the closure function name BEFORE taking the
             // mutable block borrow.
@@ -350,8 +378,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // (so the cached layout matches a fresh allocation). The
             // other paths still need explicit per-slot writes.
             if !captured_singleton {
+                // #8258: Re-read captured values after js_closure_alloc
+                // (which may have triggered a copying minor that moved the
+                // boxed objects). The captured-singleton path roots captures
+                // inside the runtime helper; this path does not, so the
+                // re-read is mandatory.
+                let re_read_bits: Vec<String> = if let Some(ref g) = capture_group {
+                    capture_handles.iter()
+                        .map(|h| g.reread_emitted(ctx, *h))
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                let bits_to_set: &[String] = if re_read_bits.is_empty() {
+                    &captured_value_bits
+                } else {
+                    &re_read_bits
+                };
                 let blk = ctx.block();
-                for (idx, val_bits) in captured_value_bits.iter().enumerate() {
+                for (idx, val_bits) in bits_to_set.iter().enumerate() {
                     let idx_str = idx.to_string();
                     blk.call_void(
                         "js_closure_set_capture_bits",
@@ -417,6 +462,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         (I64, &new_target_bits),
                     ],
                 );
+            }
+            // #8258: Release the capture root group after all capture slots
+            // are written. The `this` and `new.target` captures are loaded
+            // from the frame's this/new_target stack or IMPLICIT_THIS, which
+            // are runtime singletons not at risk from a copying minor.
+            if let Some(g) = capture_group {
+                g.release(ctx);
             }
             Ok(nanbox_pointer_inline(ctx.block(), &closure_handle))
         }

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -9,6 +9,7 @@ use perry_hir::{Expr, UnaryOp};
 
 use crate::nanbox::double_literal;
 use crate::native_value::{ExpectedNativeRep, LoweredValue, MaterializationReason, NativeRep};
+use crate::rooting;
 use crate::type_analysis::{is_numeric_expr, is_provably_not_bigint};
 use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
 
@@ -190,17 +191,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // -------- Object.defineProperty --------
+        // #8258: root all three operands across each other's lowering.
+        // `key` and `value` are arbitrary expressions that can allocate
+        // (ToString, accessor descriptors, closure creation), leaving `obj`
+        // and `key` stale in bare SSA registers across the collection point.
         Expr::ObjectDefineProperty(obj, key, value) => {
-            let o = lower_expr(ctx, obj)?;
-            let k = lower_expr(ctx, key)?;
-            let v = lower_expr(ctx, value)?;
-            let blk = ctx.block();
-            blk.call(
-                DOUBLE,
-                "js_object_define_property",
-                &[(DOUBLE, &o), (DOUBLE, &k), (DOUBLE, &v)],
-            );
-            Ok(o)
+            rooting::with_operands_rooted(ctx, &[obj, key, value], |ctx, vals| {
+                let blk = ctx.block();
+                blk.call(
+                    DOUBLE,
+                    "js_object_define_property",
+                    &[(DOUBLE, &vals[0]), (DOUBLE, &vals[1]), (DOUBLE, &vals[2])],
+                );
+                Ok(vals[0].clone())
+            })
         }
 
         // -------- path.isAbsolute(p) -> boolean --------
@@ -675,32 +679,50 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- process.on(event, handler) — EventEmitter listener
         // registration on the process singleton.
+        // #8258: root `event` across `handler`'s lowering (closure creation
+        // allocates) and across `unbox_str_handle` (SSO materialization
+        // allocates). Root `handler` across `unbox_str_handle` for the same
+        // reason. Without rooting, the event string held in a bare register
+        // across the closure allocation becomes stale after a copying minor,
+        // and the stale NaN-box is read as undefined/null by the runtime.
         Expr::ProcessOn { event, handler } => {
-            let event_box = lower_expr(ctx, event)?;
-            let handler_box = lower_expr(ctx, handler)?;
-            let blk = ctx.block();
-            let event_handle = unbox_str_handle(blk, &event_box);
-            let handler_handle = unbox_to_i64(blk, &handler_box);
-            Ok(blk.call(
+            let mut group = rooting::open_rooted_group(2);
+            let event_idx = group.lower(ctx, event, true)?;
+            let _handler_idx = group.lower(ctx, handler, true)?;
+            // Re-read event after handler's lowering (closure creation).
+            let event_box = group.reread(ctx, event_idx)?;
+            // unbox_str_handle can allocate (SSO materialization).
+            let event_handle = unbox_str_handle(ctx.block(), &event_box);
+            // Re-read handler after unbox_str_handle's potential allocation.
+            let handler_box = group.reread(ctx, _handler_idx)?;
+            let handler_handle = unbox_to_i64(ctx.block(), &handler_box);
+            let result = ctx.block().call(
                 DOUBLE,
                 "js_process_on",
                 &[(I64, &event_handle), (I64, &handler_handle)],
-            ))
+            );
+            group.release(ctx);
+            Ok(result)
         }
 
         // -------- process.once(event, handler) — one-shot listener;
         // the handler is removed after its first invocation (Node parity).
+        // #8258: same rooting as ProcessOn — see above.
         Expr::ProcessOnce { event, handler } => {
-            let event_box = lower_expr(ctx, event)?;
-            let handler_box = lower_expr(ctx, handler)?;
-            let blk = ctx.block();
-            let event_handle = unbox_str_handle(blk, &event_box);
-            let handler_handle = unbox_to_i64(blk, &handler_box);
-            Ok(blk.call(
+            let mut group = rooting::open_rooted_group(2);
+            let event_idx = group.lower(ctx, event, true)?;
+            let _handler_idx = group.lower(ctx, handler, true)?;
+            let event_box = group.reread(ctx, event_idx)?;
+            let event_handle = unbox_str_handle(ctx.block(), &event_box);
+            let handler_box = group.reread(ctx, _handler_idx)?;
+            let handler_handle = unbox_to_i64(ctx.block(), &handler_box);
+            let result = ctx.block().call(
                 DOUBLE,
                 "js_process_once",
                 &[(I64, &event_handle), (I64, &handler_handle)],
-            ))
+            );
+            group.release(ctx);
+            Ok(result)
         }
 
         // -------- process.stdin.setRawMode(enabled) — toggle raw-mode

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -698,6 +698,19 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
         ctx.func
             .entry_allocas_push_store(crate::types::I64, &undef_bits, &slot);
         ctx.block().store(crate::types::I64, &box_ptr, &slot);
+        // #8258: Bind a shadow slot for the box-pointer alloca so the
+        // precise-roots pass retypes it to `ptr addrspace(1)`, making the
+        // RS4GC pass relocate the box pointer during a copying minor.
+        // Without this, the alloca stays `i64` — invisible to the collector
+        // — and a GC that moves the box leaves the slot holding a stale
+        // from-space pointer. Subsequent `js_box_set_bits` writes go to the
+        // old (freed) box location while the moved box retains its sentinel
+        // (`TAG_UNDEFINED | 1`), surfacing later as
+        // "TypeError: Cannot convert undefined or null to object" when a
+        // closure reads the stale box.
+        if let Some(slot_idx) = ctx.func.reserve_shadow_slot() {
+            crate::expr::shadow_slot::emit_shadow_slot_bind_ptr(ctx, slot_idx, &slot);
+        }
         record_boxed_slot_js_value_bits(ctx, *id, &box_ptr, "preallocate_boxes.box_ptr_slot");
         if cell_note != "jsvalue_box_cell" {
             let lowered = LoweredValue::js_value_bits(&box_ptr);


### PR DESCRIPTION
Work toward #8258 (the seeded rooting `TypeError: Cannot convert undefined or null to object`). Three codegen rooting improvements, applied and verified in IR — **but the seeded failure survives**, so this is a partial fix and the PR is opened as progress + diagnosis, not a resolution.

## The fault site (diagnosed)

The throw is from `Object.getPrototypeOf` in `crates/perry-runtime/src/object/object_ops/prototype.rs:161`, called with value bits `0x7ffc000000000001` (`TAG_UNDEFINED | 1` — the box sentinel from `js_box_alloc_bits`). The value originates from a box capture slot read via `js_closure_get_capture_bits(closure, 1)` inside the node-machine-id webpack bundle (`perry_closure_node_modules_node_machine_id_dist_index_js__283`). The box retains its initial sentinel — the captured variable's value was never written to the moved box.

The safepoint fires in `src_lib_util_graceful_exit_ts__init_body` (the first imported module's for-of over SIGNALS) with `total_slots=0` in the scanner profile — zero GC stack slots available. The GC moves ~6,548 objects.

## The three fixes (verified in emitted IR)

1. **Box pointer alloca shadow-slot bind** (`stmt/mod.rs`) — `PreallocateBoxes` created box pointer slots as `alloca i64`, invisible to the RS4GC pass. Added `emit_shadow_slot_bind_ptr` so the precise-roots pass retypes them to `ptr addrspace(1)`.
2. **Closure capture rooting across `js_closure_alloc`** (`closure.rs`) — `captured_value_bits` were loaded before the allocation and used after it without rooting. Added `RootedGroup` with `adopt_emitted` and re-reads on the non-singleton path.
3. **`ProcessOn`/`ProcessOnce`/`ObjectDefineProperty` operand rooting** (`misc_methods.rs`) — sequential `lower_expr` calls without `with_operands_rooted`; fixed with `open_rooted_group`.

## Results

- Seeds 8, 11, 22: FAIL before, FAIL after — **not resolved**.
- Seeds 1, 5, 15, 20: PASS before, PASS after — no regression.
- `cargo test -p perry-runtime`: all pass. `-p perry-codegen`: same failure set as parent.

## What remains

The alloca retyping is confirmed in IR but the crash persists, and the box still holds the sentinel — so the captured variable's value never reaches the moved box. This points deeper than codegen alloca tracking: either the assignment writes to a stale box pointer from a different frame, or `scan_box_roots_mut` (`crates/perry-runtime/src/box.rs:212`) / the remember-set has a gap for closures created in the node-machine-id webpack bundle. `crates/perry-runtime/src/closure/alloc.rs:323` (`js_closure_alloc_with_captures_singleton`) is the runtime-side capture rooting to inspect next.

Opened as progress + a complete diagnosis for the next pass, not a claim of resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stability when closures capture values during memory cleanup.
  * Fixed potential issues affecting event processing and property updates under memory pressure.
  * Improved reliability for boxed values when memory is relocated by automatic cleanup.
  * Reduced the risk of intermittent crashes or incorrect behavior during garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->