### PR TITLE
fix(gtk4): initialize GTK before creating Canvas

### DIFF
--- a/changelog.d/8262-gtk-canvas-init.md
+++ b/changelog.d/8262-gtk-canvas-init.md
@@ -1,6 +1,11 @@
 ### fix(gtk4): initialize GTK before creating Canvas
 
-`Canvas()` now initializes GTK before constructing its `DrawingArea`, matching
-the other GTK widget constructors. GTK4 apps can therefore create a canvas
-before calling `App()` without aborting with “GTK has not been initialized.”
-Fixes #7995.
+Perry applications commonly construct their widget tree before calling
+`App()`. Unlike the other GTK widget constructors,
+`crates/perry-ui-gtk4/src/widgets/canvas.rs` previously called
+`DrawingArea::new()` without first invoking the shared GTK initializer, so that
+normal ordering aborted with “GTK has not been initialized.”
+
+`Canvas()` now calls `ensure_gtk_init()` before `DrawingArea::new()`. A
+source-order regression test covers the fixed ordering and proves that the
+pre-fix sequence is rejected. Fixes #7995.

--- a/changelog.d/8262-gtk-canvas-init.md
+++ b/changelog.d/8262-gtk-canvas-init.md
@@ -1,0 +1,6 @@
+### fix(gtk4): initialize GTK before creating Canvas
+
+`Canvas()` now initializes GTK before constructing its `DrawingArea`, matching
+the other GTK widget constructors. GTK4 apps can therefore create a canvas
+before calling `App()` without aborting with “GTK has not been initialized.”
+Fixes #7995.

--- a/crates/perry-ui-gtk4/src/widgets/canvas.rs
+++ b/crates/perry-ui-gtk4/src/widgets/canvas.rs
@@ -135,6 +135,7 @@ fn image_handle_from_arg(image: i64) -> i64 {
 
 /// Create a Canvas widget with given dimensions.
 pub fn create(width: f64, height: f64) -> i64 {
+    crate::app::ensure_gtk_init();
     let area = DrawingArea::new();
     area.set_content_width(width as i32);
     area.set_content_height(height as i32);
@@ -315,6 +316,43 @@ pub fn create(width: f64, height: f64) -> i64 {
     });
 
     handle
+}
+
+#[cfg(test)]
+mod tests {
+    fn init_precedes_drawing_area(source: &str) -> bool {
+        let start = source
+            .find("pub fn create(width: f64, height: f64) -> i64")
+            .expect("Canvas create function must exist");
+        let body = &source[start..];
+        let end = body
+            .find("\n/// Clear all drawing commands.")
+            .expect("Canvas create function terminator must exist");
+        let body = &body[..end];
+
+        let init = body.find("crate::app::ensure_gtk_init();");
+        let constructor = body.find("DrawingArea::new();");
+        matches!((init, constructor), (Some(init), Some(constructor)) if init < constructor)
+    }
+
+    #[test]
+    fn canvas_initializes_gtk_before_constructing_drawing_area() {
+        assert!(
+            init_precedes_drawing_area(include_str!("canvas.rs")),
+            "Canvas must initialize GTK before DrawingArea::new() (#7995)"
+        );
+        assert!(
+            !init_precedes_drawing_area(
+                "pub fn create(width: f64, height: f64) -> i64 {\n\
+                 let area = DrawingArea::new();\n\
+                 crate::app::ensure_gtk_init();\n\
+                 area\n\
+                 }\n\
+                 /// Clear all drawing commands."
+            ),
+            "the ordering check must reject the pre-fix constructor order"
+        );
+    }
 }
 
 /// Clear all drawing commands.


### PR DESCRIPTION
## Summary
- initialize GTK before constructing a GTK4 `Canvas` drawing area
- add a source-invariant regression test for initialization ordering

Fixes #7995

## Testing
- `cargo fmt -p perry-ui-gtk4 -- --check`
- `rustfmt --edition 2021 --check crates/perry-ui-gtk4/src/widgets/canvas.rs`
- `cargo check -p perry-ui-gtk4` (Windows cfg smoke check)
- `python scripts/check_test_registration.py`
- `git diff --check`

The Linux-only GTK build and unit test will run in the scoped PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canvas creation now initializes GTK before constructing its drawing area.
  * GTK4 applications can create a canvas before calling `App()`, avoiding initialization failures.
* **Tests**
  * Added regression coverage to verify the required initialization order and prevent the issue from recurring.
* **Documentation**
  * Added a changelog entry describing the canvas initialization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->