### PR TITLE
fix(gc): root the operands of three native-method lowerings

### DIFF
--- a/changelog.d/8266-operand-rooting-misc-methods.md
+++ b/changelog.d/8266-operand-rooting-misc-methods.md
@@ -1,0 +1,17 @@
+**GC: root the operands of three native-method lowerings.**
+
+`expr/misc_methods.rs` lowered the operands of `ProcessOn`, `ProcessOnce` and
+`ObjectDefineProperty` with sequential `lower_expr` calls and no rooting — the
+first operand was live across the lowering of the second and third, either of
+which can collect. All three now go through `with_operands_rooted`.
+
+This is not observable as a wrong answer unless a collection lands in the
+window, which is why it survived: an unrooted register only goes bad when a GC
+lands inside its live range.
+
+Extracted from #8260 by @jdalton, whose two other hunks are deliberately not
+taken — see that PR for the reasoning (box pointers are outside the GC heap, so
+binding a shadow slot for them roots nothing and would restore the live-set
+population #8143 removed to fix #8132; and rooting closure captures across
+`js_closure_alloc` regresses
+`shadow_slot_hygiene::closure_body_write_to_captured_outer_local_is_visible_to_shadow_analysis`).

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -9,6 +9,7 @@ use perry_hir::{Expr, UnaryOp};
 
 use crate::nanbox::double_literal;
 use crate::native_value::{ExpectedNativeRep, LoweredValue, MaterializationReason, NativeRep};
+use crate::rooting;
 use crate::type_analysis::{is_numeric_expr, is_provably_not_bigint};
 use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
 
@@ -190,17 +191,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
 
         // -------- Object.defineProperty --------
+        // #8258: root all three operands across each other's lowering.
+        // `key` and `value` are arbitrary expressions that can allocate
+        // (ToString, accessor descriptors, closure creation), leaving `obj`
+        // and `key` stale in bare SSA registers across the collection point.
         Expr::ObjectDefineProperty(obj, key, value) => {
-            let o = lower_expr(ctx, obj)?;
-            let k = lower_expr(ctx, key)?;
-            let v = lower_expr(ctx, value)?;
-            let blk = ctx.block();
-            blk.call(
-                DOUBLE,
-                "js_object_define_property",
-                &[(DOUBLE, &o), (DOUBLE, &k), (DOUBLE, &v)],
-            );
-            Ok(o)
+            rooting::with_operands_rooted(ctx, &[obj, key, value], |ctx, vals| {
+                let blk = ctx.block();
+                blk.call(
+                    DOUBLE,
+                    "js_object_define_property",
+                    &[(DOUBLE, &vals[0]), (DOUBLE, &vals[1]), (DOUBLE, &vals[2])],
+                );
+                Ok(vals[0].clone())
+            })
         }
 
         // -------- path.isAbsolute(p) -> boolean --------
@@ -675,32 +679,50 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- process.on(event, handler) — EventEmitter listener
         // registration on the process singleton.
+        // #8258: root `event` across `handler`'s lowering (closure creation
+        // allocates) and across `unbox_str_handle` (SSO materialization
+        // allocates). Root `handler` across `unbox_str_handle` for the same
+        // reason. Without rooting, the event string held in a bare register
+        // across the closure allocation becomes stale after a copying minor,
+        // and the stale NaN-box is read as undefined/null by the runtime.
         Expr::ProcessOn { event, handler } => {
-            let event_box = lower_expr(ctx, event)?;
-            let handler_box = lower_expr(ctx, handler)?;
-            let blk = ctx.block();
-            let event_handle = unbox_str_handle(blk, &event_box);
-            let handler_handle = unbox_to_i64(blk, &handler_box);
-            Ok(blk.call(
+            let mut group = rooting::open_rooted_group(2);
+            let event_idx = group.lower(ctx, event, true)?;
+            let _handler_idx = group.lower(ctx, handler, true)?;
+            // Re-read event after handler's lowering (closure creation).
+            let event_box = group.reread(ctx, event_idx)?;
+            // unbox_str_handle can allocate (SSO materialization).
+            let event_handle = unbox_str_handle(ctx.block(), &event_box);
+            // Re-read handler after unbox_str_handle's potential allocation.
+            let handler_box = group.reread(ctx, _handler_idx)?;
+            let handler_handle = unbox_to_i64(ctx.block(), &handler_box);
+            let result = ctx.block().call(
                 DOUBLE,
                 "js_process_on",
                 &[(I64, &event_handle), (I64, &handler_handle)],
-            ))
+            );
+            group.release(ctx);
+            Ok(result)
         }
 
         // -------- process.once(event, handler) — one-shot listener;
         // the handler is removed after its first invocation (Node parity).
+        // #8258: same rooting as ProcessOn — see above.
         Expr::ProcessOnce { event, handler } => {
-            let event_box = lower_expr(ctx, event)?;
-            let handler_box = lower_expr(ctx, handler)?;
-            let blk = ctx.block();
-            let event_handle = unbox_str_handle(blk, &event_box);
-            let handler_handle = unbox_to_i64(blk, &handler_box);
-            Ok(blk.call(
+            let mut group = rooting::open_rooted_group(2);
+            let event_idx = group.lower(ctx, event, true)?;
+            let _handler_idx = group.lower(ctx, handler, true)?;
+            let event_box = group.reread(ctx, event_idx)?;
+            let event_handle = unbox_str_handle(ctx.block(), &event_box);
+            let handler_box = group.reread(ctx, _handler_idx)?;
+            let handler_handle = unbox_to_i64(ctx.block(), &handler_box);
+            let result = ctx.block().call(
                 DOUBLE,
                 "js_process_once",
                 &[(I64, &event_handle), (I64, &handler_handle)],
-            ))
+            );
+            group.release(ctx);
+            Ok(result)
         }
 
         // -------- process.stdin.setRawMode(enabled) — toggle raw-mode


### PR DESCRIPTION
Extracts the one sound hunk of #8260 by @jdalton. The other two are deliberately not taken; the reasoning is in that PR and summarised in the changelog fragment.

## What this is

`expr/misc_methods.rs` lowered the operands of `ProcessOn`, `ProcessOnce` and `ObjectDefineProperty` with sequential `lower_expr` calls and no rooting:

```rust
let o = lower_expr(ctx, obj)?;
let k = lower_expr(ctx, key)?;   // can collect — `o` is live across this
let v = lower_expr(ctx, value)?; // and this
```

`o` is held live across two more lowerings, either of which can allocate. Replaced with the repo's standard `with_operands_rooted`. Not observable as a wrong answer unless a collection lands in that window, which is why it survived.

## Why the other two hunks are excluded

**Box pointer alloca shadow-slot bind** rests on a false premise. Its comment describes "a GC that moves the box", but box pointers are `std::alloc`'d and outside the GC heap — `box.rs:40`, and `gc_root_dominance_check.py:2713` classifies `js_box_alloc*` as an `IMMOVABLE_SOURCE` — and `BOX_REGISTRY` is monotonic so they are never freed either. The slot would root nothing, and it would restore the per-box population that #8143 removed from the live set to fix #8132's 21× RS4GC blowup (63 of the ~300 values live at ~90% of statepoints were `js_box_alloc_bits` slots; unbinding them cut relocations 65%).

**Closure capture rooting across `js_closure_alloc`** regresses a codegen test. A/B on that single file:

| `expr/closure.rs` | `shadow_slot_hygiene::closure_body_write_to_captured_outer_local_is_visible_to_shadow_analysis` |
|---|---|
| at `main` | **ok** |
| with the hunk | **FAILED** — "captured Any local written to a pointer inside a closure must keep its outer slot" |

It removes a root rather than adding one.

## Verification

Both suites on top of current `main`:

- `cargo test -p perry-codegen --no-fail-fast` — **27 suites, 1504 passed, 9 failed**, and all nine are in the known baseline set. With the closure hunk present it was 10 failures, the extra one being the test above.
- `cargo test -p perry-runtime --lib` — **2557 passed, 0 failed, 4 ignored**
- `cargo fmt --all --check` clean

Credit to @jdalton for finding this and for the fault-site diagnosis in #8260.
