### PR TITLE
fix(async): publish released boxes when activation quiesces

### DIFF
--- a/changelog.d/8208-async-box-release-reuse.md
+++ b/changelog.d/8208-async-box-release-reuse.md
@@ -6,58 +6,33 @@ The release is now real, with pooled reuse:
 
 - New HIR `Stmt::ReleaseBoxes(ids)` (a reclamation hint — safe to drop, but must be remapped like a `LocalSet` target by id-substitution passes) replaces the per-cell `LocalSet(id, undefined)` release, and the terminal release set now covers the whole activation frame including `__gen_state`/`__gen_done`/`__gen_executing` and the pending-completion record.
 - Codegen lowers it to `js_box_release` / `js_i32_box_release` / `js_bool_box_release`, mirroring `emit_preallocate_boxes`' kind selection, through local slots or closure-capture slots.
-- The runtime release clears the cell, de-registers it, evicts the positive-cache slot, and parks the address in a per-kind quarantine that drains into a free pool at the outermost microtask-pump exit once the task queue is empty; `js_*box_alloc*` reuses pooled cells before calling `std::alloc`. Cell memory is never handed back to the allocator, so "was a box" can never become "is another object" — perry#4898 and #7906 survive unchanged. A stray duplicate resume of a terminal activation observes parked terminal values (`__gen_done`=true, `__gen_state`=-1) and takes byte-for-byte the pre-release short-circuit path; by the time the pool is eligible for reuse the task queue has drained, so no such resume can exist.
+- The runtime release clears the cell, de-registers it, evicts the positive-cache slot, and parks the address in the current async-step invocation's release scope. After that invocation returns, its cells move to the free pool when no resume for the same activation remains queued. A queued duplicate resume falls back to the original outermost empty-queue quarantine. `js_*box_alloc*` reuses pooled cells before calling `std::alloc`. Cell memory is never handed back to the allocator, so "was a box" can never become "is another object" — perry#4898 and #7906 survive unchanged. A stray duplicate resume still observes the parked terminal values (`__gen_done`=true, `__gen_state`=-1) and takes the pre-release short-circuit path.
 
-**Measured on `b8d32ab19`** with both arms rebuilt at that commit (the earlier run on `07c8040bf` reproduced within 0.3 MB on every row, so #8204's header shrink and GC pacing change, #8196's side-table prunes, and #8211/#8212/#8162 none of them move this residue). `asyncpipe` at BATCHES=120/600/1200, `PERRY_GC_DIAG=1` `[box-stats]`:
+### Per-activation publication removes both the slope and the small-workload floor
 
-| BATCHES | allocs | releases | resident cells | peak RSS before | peak RSS after |
+`asyncpipe`, current head, peak RSS best-of-5 via `/usr/bin/time -l`; every run at every size produced byte-identical stdout and identical box counters:
+
+| BATCHES | allocs / releases | resident cells | base RSS | #8208 global-boundary RSS | final RSS |
 |--:|--:|--:|--:|--:|--:|
-| 120 | 192,868 | 192,868 | **65,915** | 41.0 MB | 41.8 MB |
-| 600 | 964,228 | 964,228 | **65,915** | 83.3 MB | 58.8 MB |
-| 1200 | 1,928,428 | 1,928,428 | **65,915** | 149.0 MB | **79.9 MB** |
+| 30 | 48,238 / 48,238 | **1,635** | 21.92 MiB | 22.44 MiB | **20.84 MiB** |
+| 60 | 96,448 / 96,448 | **1,635** | 28.41 MiB | 29.20 MiB | **27.22 MiB** |
+| 1200 | 1,928,428 / 1,928,428 | **1,635** | 138.02 MiB | 79.08 MiB | **79.30 MiB** |
 
-Allocations grow exactly linearly (1,607 cells/batch) and `releases == allocs` at every size, while the malloc-side residue `allocs - pool_reuses` is a **constant 65,915** across a 10× range — one inter-`tick()` cascade's working set, slope zero. Both registries are empty at exit. Baseline peak RSS grows ~100 KB/batch; `vmmap` Memory Tag 240 (mimalloc) resident falls 141.1 MB → 71.6 MB at BATCHES=1200 (dirty 104.5 → 57.2 MB), which is the whole of the RSS delta. Program stdout is byte-identical at all three sizes.
+The malloc-side residue is now a constant 1,635 cells across a 40x workload range, down from #8208's 65,915-cell inter-pump working set. The strict small-workload bar is met: the 30- and 60-batch rows are 1.08 MiB and 1.19 MiB below the no-release base rather than 0.52 MiB and 0.80 MiB above it. At 1,200 batches the 58.72 MiB saving is retained (the 0.22 MiB difference from #8208 alone is inside the observed RSS floor while the cell counter improves 40x).
 
-### Peak RSS across workload size, and the floor that is left
+The publication rule does not add a counter update to every await:
 
-`asyncpipe`, both arms rebuilt at `923342925`, peak RSS best-of-5, stdout byte-identical at every point:
-
-| BATCHES | 30 | 60 | 90 | 120 | 300 | 600 | 1200 |
-|---|--:|--:|--:|--:|--:|--:|--:|
-| base MB | 21.92 | 28.41 | 36.59 | 41.33 | 57.02 | 85.59 | 138.02 |
-| fix MB | 22.44 | 29.20 | 35.72 | 40.48 | 49.06 | 57.97 | 79.08 |
-| **delta** | **+0.52** | **+0.80** | −0.88 | −0.84 | −7.95 | −27.62 | **−58.94** |
-
-**This does not yet meet "strictly not worse on every row": below ~75 batches the change still costs ~0.9 MB.** Threading the free list through the cells moved the crossover from ~200 batches to between 60 and 90, but it did not remove the floor. (The 1200-row saving reads smaller than the −69.7 MB measured at `b8d32ab19` only because main's own param-guard work, #8238/#8242, cut the BASE arm's peak from 149.0 to 138.0 MB in the meantime.)
-
-The residue is **not** the reuse pool, which now costs zero bytes, and it is not a pool-sizing policy question. Measured mechanism:
-
-- The quarantine is published only at an outermost microtask-pump exit with an empty task queue, and **that boundary is reached 6 times in a 30-batch run and 46 times in a 1200-batch run** — a tight `await` cascade resolves through the `AsyncStep` fast path without pumping. Every release in between is held as an address in the quarantine `Vec`.
-- At BATCHES=30 that is 48,238 addresses (all of them — `pool_reuses` is literally **0**, the release does its work and harvests nothing), which at 8 B plus `Vec` doubling is ~0.7 MB, plus the ~80 KB page-touch cost. That is the +0.80 MB, fully accounted for.
-- Relaxing the boundary is not the lever it looks like: dropping the `MICROTASK_RUN_DEPTH == 1` clause was measured and moved flush count only 6 → 46, because `run_microtasks` itself is what runs that few times. `flush_attempts == flushes` at every size, so the empty-queue test never blocks a flush.
-
-**Capping or decaying the free list cannot fix this, and would cost most of the win.** Reuse is bounded by `flushes x cap`, so against the measured 46 intervals at BATCHES=1200:
-
-| cap | 1,024 | 4,096 | 8,192 | 16,384 | 32,768 | 65,536 |
-|---|--:|--:|--:|--:|--:|--:|
-| max reuse | 2.4% | 9.8% | 19.5% | 39.1% | 78.2% | 96.6% |
-
-The natural high-water mark, 65,915, *is* one flush interval's working set — the knee is already where the pool sits. And a cap would not return memory anyway: capped-out cells are still minted and, by design, never handed back to the allocator, so capping converts pooled cells into freshly-minted ones. Decay and page-return are blocked by the same invariant (cell memory is never returned, which is what perry#4898 and #7906 rest on).
-
-Removing the floor therefore means publishing released cells somewhere more frequent than the microtask-pump exit. That was investigated rather than assumed, and **no safe earlier publish point exists within this change's scope**:
-
-- *Per-kind split — refuted.* The tempting argument is that only the i32/i1 CONTROL cells need their parked terminal values, because generated code reads them raw, while body-local `Box` cells go through the registry-checked `js_box_get_bits` and so read `undefined` once de-registered no matter what their bytes hold — which would let body locals publish immediately at release. It does not hold. A stray resume **writes `__gen_sent` before it reads `__gen_done`** (`generator/lower/async_step.rs`: *"it writes `__gen_sent` before reading it, then short-circuits on the un-released `__gen_done`"*). `__gen_sent` is a plain `Box` cell. While it is merely de-registered that write is dropped, which is exactly why the current design is safe; but a republished cell is **re-registered to a different activation**, so the write would land on that activation's live local. Body-local cells are therefore no safer to publish early than the control cells.
-- *Dropping `MICROTASK_RUN_DEPTH == 1` — measured, rejected.* It moved flush count only 6 → 46, because `run_microtasks` itself runs that few times, and it spends a documented safety clause to buy almost nothing.
-
-What would work is **per-activation reachability**: refcount the queued `Task::AsyncStep`s per activation (increment on enqueue, decrement on dispatch) and publish an activation's cells when its count reaches zero. That is safe by construction rather than by a global queue predicate, and it would publish almost immediately after a terminal state — collapsing both the quarantine and the floor. It also puts an increment and a decrement on the async enqueue/dispatch hot path and changes the pump's contract, so it belongs in its own change with its own test pass, not bolted onto this one.
+- Each step invocation gets a nested `ReleasedBoxBatch`. Empty batches and their three `Vec` buffers are pooled per synchronous nesting depth, so a warm process does not allocate temporary vectors per activation.
+- After the step returns, the caller re-reads the potentially moved step closure from its runtime handle and scans the FIFO for a matching `Task::AsyncStep`. No match means the activation is quiescent and its batch can publish immediately.
+- A match preserves the terminal sentinels by appending the batch to the old global quarantine. The outermost empty-queue flush remains the conservative fallback, so the duplicate-resume path is unchanged.
 
 The GC ratchet passes: `gc_ratchet.py check --profile shared_ci` against the pinned baseline is **`gc-ratchet: OK`** with every gated retention/evacuation/promotion cell at +0.00% (runnable again now that #8214 unblocked the harness step #8204 broke). An A/B of both arms over all 14 probes independently compares 126 gated (probe, metric) cells — retention, evacuation and promotion counters — with **0 differences** and correctness `pass` on every probe in both arms (non-vacuous: `copied_objects` and `promoted_objects` are non-zero on several rows).
 
-Release and reuse run *while the collector is active*, not merely in GC-quiet code: `asyncpipe` at BATCHES=1200 reports `minors=15`, `copied_objects=600`, `promoted_objects=14`, `loop_polls=16` alongside its 1,928,428 releases and 1,862,513 pool reuses, with stdout unchanged.
+Release and reuse run *while the collector is active*, not merely in GC-quiet code: the earlier `asyncpipe` collection run reported `minors=15`, `copied_objects=600`, `promoted_objects=14`, and `loop_polls=16`; the final BATCHES=1200 run pairs 1,928,428 releases with 1,926,793 pool reuses and unchanged stdout.
 
-**Known limitation, measured.** Reuse is gated on reaching the outermost microtask-pump exit with an empty task queue — the boundary that makes a stray duplicate resume impossible. A program that never returns to an empty task queue until it ends (one continuous `await` cascade with no timer or I/O between stages) therefore performs its releases but never harvests them: `pool_reuses=0`, and the malloc residue is what it was before. On a synthetic fixture of exactly that shape (400 iterations over 7 async exit-path shapes, no timers) the release work is unrecovered overhead worth **+1.32% instructions and +0.3 MB peak RSS** (run-to-run spreads 0.79% / 0.07%, so both are real if small). Real event-driven workloads drain between events — which is why `asyncpipe`, whose `tick()` is a `setTimeout`, harvests 1.86 M of 1.93 M cells — and none of the ten corpus rows shows the degenerate shape. The boundary is deliberately not loosened here: every weaker rule permits a cell to be reused while an activation could still resume, which is the one way this change could corrupt state rather than merely fail to help.
+The former continuous-`await` limitation is gone: publication is keyed to the activation's own queued reachability, not to how often the global microtask pump happens to exit. At BATCHES=30 the old path reused zero of 48,238 releases; the final path reuses 46,603 and leaves only the 1,635-cell concurrency working set.
 
-**Exit-path coverage.** A fixture exercising normal return, `throw` after an `await`, early `return` from inside a loop after a suspend, `await` on a rejected promise, `try`/`finally` across a suspend on both terminal arms, loop-created closures capturing a per-iteration binding across a suspend, and async-generator `.return()` / full drain — 400 iterations each — produces output byte-identical to the Node oracle on **both** arms. The release is live on it (`releases=20027` of `allocs=25628`), and the 5,601 cells it does *not* release are exactly the ones still registered at exit, so every cell is accounted for as either released or still reachable.
+**Exit-path coverage.** A fixture exercising normal return, `throw` after an `await`, early `return` from inside a loop after a suspend, `await` on a rejected promise, `try`/`finally` across a suspend on both terminal arms, loop-created closures capturing a per-iteration binding across a suspend, and async-generator `.return()` / full drain — 400 iterations each — produces output byte-identical to the Node oracle on **both** arms. The release is live on it (`releases=20,027` of `allocs=25,628`); the final path reuses 19,997 cells and leaves 5,631 resident, only 30 above the 5,601 cells that remain registered and reachable at exit.
 
 `PERRY_GC_DIAG=1` now prints a `[box-stats]` line (allocs / pool_reuses / releases / resident_cells / registry sizes) at exit. Regression gates assert the counters, because the leak is behaviourally invisible and a test that merely runs to completion cannot catch it: `perry-runtime` `release_tests` (residue bounded not linear, parked-cell inertness, release idempotence, flush-gated reuse, foreign-pointer no-op) and `perry-codegen` `release_boxes_lowering` (an emitted release must reach the IR; kind selection; capture path).
 
@@ -65,7 +40,7 @@ Release and reuse run *while the collector is active*, not merely in GC-quiet co
 
 `scripts/gc_root_dominance_check.py`:
 
-- The "box" immovable-source exemption rested on *"boxes are never freed"*, which this change falsifies, while its probe only grepped for `dealloc(`/`arena_alloc(` — all of which a *recycle* path passes. The exemption would have stayed green on a dead premise, which the script's own docstring calls strictly worse than no exemption. Re-argued on the property the design actually preserves (cell memory is never returned to the allocator, so an address never stops naming box-cell memory and can never become another kind of object), and the probe now additionally requires the reuse path to stay quarantine-gated. Sabotage-tested: bypassing the quarantine, and introducing a real `dealloc`, each turn it red.
+- The "box" immovable-source exemption rested on *"boxes are never freed"*, which this change falsifies, while its probe only grepped for `dealloc(`/`arena_alloc(` — all of which a *recycle* path passes. The exemption would have stayed green on a dead premise, which the script's own docstring calls strictly worse than no exemption. Re-argued on the property the design actually preserves (cell memory is never returned to the allocator, so an address never stops naming box-cell memory and can never become another kind of object), and the probe now additionally requires every reuse path to remain behind either an activation-quiescence proof or the conservative global quarantine. Sabotage-tested: bypassing those gates, and introducing a real `dealloc`, each turn it red.
 - The three `js_*box_release` names were added to `gc_call_effects.rs` only, breaking the one-way containment four comments there assert — the same one-sided drift that cost #7510 358 spurious violations. They are now in `NONCOLLECTING` too, and `box_and_closure_helpers_stay_contained_in_the_checker_authority` machine-checks the relation for that family instead of trusting prose. (A whole-table subset is deliberately *not* asserted: 28 pre-existing entries diverge, and since the checker treats an unknown callee as collecting, closing that gap would make it *less* conservative — a separate decision needing per-name evidence.)
 
 Also refreshes every monotonicity claim the release invalidated, including the load-bearing correctness argument in `expr/literals_vars.rs` that let a `box_ptr` outlive a collecting call on the strength of "never freed".

--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -22,11 +22,13 @@ static BOOL_BOX_SET_NULL_COUNT: AtomicU64 = AtomicU64::new(0);
 static BOX_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 static BOX_POOL_REUSE_COUNT: AtomicU64 = AtomicU64::new(0);
 static BOX_RELEASE_COUNT: AtomicU64 = AtomicU64::new(0);
-// Diagnostic-only (#8208 tuning): how often the quarantine actually drains,
-// and how many cells that published. A pool whose high-water mark is 41x one
-// batch's working set is a flush-frequency question, not a pool-size question.
+// Diagnostic-only (#8208/#8213 tuning): how often the global quarantine and
+// per-activation scopes publish, and how many cells they publish in total.
+// A pool whose high-water mark is 41x one batch's working set is a publication-
+// frequency question, not a pool-size question.
 static BOX_FLUSH_COUNT: AtomicU64 = AtomicU64::new(0);
 static BOX_FLUSH_PUBLISHED: AtomicU64 = AtomicU64::new(0);
+static BOX_ACTIVATION_PUBLISH_COUNT: AtomicU64 = AtomicU64::new(0);
 
 /// Snapshot of the release/reuse counters: `(allocs, pool_reuses, releases)`.
 /// Sums all three box kinds.
@@ -62,9 +64,10 @@ pub fn report_box_stats_at_exit() {
     eprintln!(
         "[box-stats] allocs={allocs} pool_reuses={reuses} releases={releases} \
          resident_cells={} registry_len={reg} i32_registry_len={i32_reg} \
-         bool_registry_len={bool_reg} flushes={} published={}",
+         bool_registry_len={bool_reg} flushes={} activation_publishes={} published={}",
         allocs - reuses,
         BOX_FLUSH_COUNT.load(Ordering::Relaxed),
+        BOX_ACTIVATION_PUBLISH_COUNT.load(Ordering::Relaxed),
         BOX_FLUSH_PUBLISHED.load(Ordering::Relaxed),
     );
 }
@@ -127,6 +130,7 @@ crate::perry_thread_local! {
 const BOX_PTR_CACHE_SLOTS: usize = 8;
 
 type BoxPtrCache = crate::tls_hot::HotKey<[std::cell::Cell<usize>; BOX_PTR_CACHE_SLOTS]>;
+type BoxFreeHead = crate::tls_hot::HotKey<std::cell::Cell<usize>>;
 
 crate::perry_thread_local! {
     /// Direct-mapped **positive** cache over `BOX_REGISTRY`.
@@ -176,9 +180,13 @@ crate::perry_thread_local! {
     /// states, ONLY for cells the transform's escape analysis proved no
     /// closure can observe — `perry-transform/src/generator/box_release.rs`)
     /// clears the cell, removes it from its registry, and parks the address
-    /// in the QUARANTINE. The quarantine drains into the free list at the
-    /// outermost microtask-pump boundary once the task queue is empty
-    /// (`flush_released_boxes`, called from `promise/microtasks.rs`), and
+    /// in the current async-step invocation's release scope. Once that
+    /// invocation returns, its cells can move directly to the free list if
+    /// no resume for the same activation remains queued. If a duplicate
+    /// resume is still queued (or release happens outside an async step), the
+    /// cells fall back to the process-turn QUARANTINE. That quarantine drains
+    /// at the outermost empty-queue microtask-pump boundary
+    /// (`flush_released_boxes`, called from `promise/microtasks.rs`).
     /// `js_*box_alloc*` pops the pool before touching `std::alloc`.
     ///
     /// ## Why the boundary, and why this is sound
@@ -223,7 +231,8 @@ crate::perry_thread_local! {
     /// Overwriting the cell is why this list holds only cells that are PAST
     /// the quarantine. A quarantined cell must keep the parked terminal value
     /// a stray duplicate resume reads (`-1` / `true` / `undefined`); once
-    /// `flush_released_boxes` has run, the task queue is empty and no such
+    /// the owning step has returned with no matching resume queued — or
+    /// `flush_released_boxes` has run with the whole task queue empty — no such
     /// resume can exist, so the bytes are free to become a link.
     static BOX_FREE_HEAD: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static I32_BOX_FREE_HEAD: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
@@ -234,6 +243,153 @@ crate::perry_thread_local! {
         std::cell::RefCell::new(Vec::new());
     static BOOL_BOX_RELEASE_QUARANTINE: std::cell::RefCell<Vec<usize>> =
         std::cell::RefCell::new(Vec::new());
+    /// Nested because a step body may synchronously enter another async
+    /// activation, which may itself re-enter the microtask runner. Each scope
+    /// owns only the cells released by that one step invocation.
+    static ASYNC_BOX_RELEASE_SCOPES: std::cell::RefCell<Vec<ReleasedBoxBatch>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+    /// Empty batches retain their three Vec buffers here after a scope
+    /// finishes. A hot server therefore allocates at most one buffer cohort
+    /// per synchronous nesting depth, not three fresh Vecs per activation.
+    static ASYNC_BOX_RELEASE_BATCH_POOL: std::cell::RefCell<Vec<ReleasedBoxBatch>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[derive(Default)]
+struct ReleasedBoxBatch {
+    boxes: Vec<usize>,
+    i32_boxes: Vec<usize>,
+    bool_boxes: Vec<usize>,
+}
+
+impl ReleasedBoxBatch {
+    fn is_empty(&self) -> bool {
+        self.boxes.is_empty() && self.i32_boxes.is_empty() && self.bool_boxes.is_empty()
+    }
+}
+
+#[derive(Copy, Clone)]
+enum ReleasedBoxKind {
+    Box,
+    I32,
+    Bool,
+}
+
+/// One invocation of a compiler-generated async step. Releases stay local to
+/// this scope until the step returns, so they cannot be reused by allocations
+/// made later in the same terminal path. Nested async calls get nested scopes.
+pub(crate) struct AsyncBoxReleaseScope {
+    depth: usize,
+    finished: bool,
+}
+
+pub(crate) fn begin_async_box_release_scope() -> AsyncBoxReleaseScope {
+    let batch = ASYNC_BOX_RELEASE_BATCH_POOL
+        .with(|pool| pool.borrow_mut().pop())
+        .unwrap_or_default();
+    debug_assert!(batch.is_empty());
+    let depth = ASYNC_BOX_RELEASE_SCOPES.with(|scopes| {
+        let mut scopes = scopes.borrow_mut();
+        scopes.push(batch);
+        scopes.len()
+    });
+    AsyncBoxReleaseScope {
+        depth,
+        finished: false,
+    }
+}
+
+impl AsyncBoxReleaseScope {
+    /// Finish the step invocation. `activation_is_quiescent` is true only
+    /// after the caller has re-read the possibly moved step closure and
+    /// proved TASK_QUEUE has no `AsyncStep` for it. Otherwise preserve the
+    /// old empty-queue quarantine boundary.
+    pub(crate) fn finish(mut self, activation_is_quiescent: bool) {
+        self.finished = true;
+        finish_async_box_release_scope(self.depth, activation_is_quiescent);
+    }
+}
+
+impl Drop for AsyncBoxReleaseScope {
+    fn drop(&mut self) {
+        if !self.finished {
+            // A Rust unwind must never make a partly released activation's
+            // cells reusable. Falling back to the old global quarantine is
+            // conservative and keeps the terminal sentinels intact.
+            finish_async_box_release_scope(self.depth, false);
+        }
+    }
+}
+
+fn finish_async_box_release_scope(depth: usize, activation_is_quiescent: bool) {
+    let mut batch = ASYNC_BOX_RELEASE_SCOPES.with(|scopes| {
+        let mut scopes = scopes.borrow_mut();
+        assert_eq!(
+            scopes.len(),
+            depth,
+            "async box release scopes must finish in stack order"
+        );
+        scopes.pop().expect("async box release scope disappeared")
+    });
+    if !batch.is_empty() {
+        if activation_is_quiescent {
+            BOX_ACTIVATION_PUBLISH_COUNT.fetch_add(1, Ordering::Relaxed);
+            publish_released_batch(&mut batch);
+        } else {
+            BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().append(&mut batch.boxes));
+            I32_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().append(&mut batch.i32_boxes));
+            BOOL_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().append(&mut batch.bool_boxes));
+        }
+    }
+    debug_assert!(batch.is_empty());
+    ASYNC_BOX_RELEASE_BATCH_POOL.with(|pool| pool.borrow_mut().push(batch));
+}
+
+fn park_released_box(kind: ReleasedBoxKind, addr: usize) {
+    let parked_in_scope = ASYNC_BOX_RELEASE_SCOPES.with(|scopes| {
+        let mut scopes = scopes.borrow_mut();
+        let Some(batch) = scopes.last_mut() else {
+            return false;
+        };
+        match kind {
+            ReleasedBoxKind::Box => batch.boxes.push(addr),
+            ReleasedBoxKind::I32 => batch.i32_boxes.push(addr),
+            ReleasedBoxKind::Bool => batch.bool_boxes.push(addr),
+        }
+        true
+    });
+    if parked_in_scope {
+        return;
+    }
+    match kind {
+        ReleasedBoxKind::Box => BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr)),
+        ReleasedBoxKind::I32 => I32_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr)),
+        ReleasedBoxKind::Bool => BOOL_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr)),
+    }
+}
+
+fn publish_released_batch(batch: &mut ReleasedBoxBatch) {
+    publish_released_addresses(&mut batch.boxes, &BOX_FREE_HEAD);
+    publish_released_addresses(&mut batch.i32_boxes, &I32_BOX_FREE_HEAD);
+    publish_released_addresses(&mut batch.bool_boxes, &BOOL_BOX_FREE_HEAD);
+}
+
+fn publish_released_addresses(addresses: &mut Vec<usize>, head: &'static BoxFreeHead) {
+    if addresses.is_empty() {
+        return;
+    }
+    BOX_FLUSH_PUBLISHED.fetch_add(addresses.len() as u64, Ordering::Relaxed);
+    head.with(|h| {
+        let mut next = h.get();
+        for addr in addresses.drain(..) {
+            // Publishing is the first moment the parked terminal value is
+            // dead, so the cell's own bytes can become the free-list link.
+            debug_assert_eq!(addr % ALIGN_OF_BOX_CELL, 0);
+            unsafe { (addr as *mut usize).write(next) };
+            next = addr;
+        }
+        h.set(next);
+    });
 }
 
 /// Drain the release quarantines into the free pools. Called at the
@@ -248,22 +404,7 @@ pub fn flush_released_boxes() {
     ] {
         q.with(|q| {
             let mut q = q.borrow_mut();
-            if q.is_empty() {
-                return;
-            }
-            BOX_FLUSH_PUBLISHED.fetch_add(q.len() as u64, Ordering::Relaxed);
-            head.with(|h| {
-                let mut next = h.get();
-                for addr in q.drain(..) {
-                    // Publishing is the first moment the parked terminal value
-                    // is dead (queue empty => no resume can read it), so the
-                    // cell's own bytes become the link to the next free cell.
-                    debug_assert_eq!(addr % ALIGN_OF_BOX_CELL, 0);
-                    unsafe { (addr as *mut usize).write(next) };
-                    next = addr;
-                }
-                h.set(next);
-            });
+            publish_released_addresses(&mut q, head);
             // Deliberately NOT shrunk. The quarantine is refilled to roughly
             // the same size every interval, so handing the buffer back here
             // just makes the next interval re-grow it: measured, shrinking to
@@ -486,7 +627,7 @@ pub extern "C" fn js_box_release(ptr: *mut Box) {
         // root scanner only walks the registry, which no longer has it).
         (*ptr).value = crate::value::TAG_UNDEFINED;
     }
-    BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr));
+    park_released_box(ReleasedBoxKind::Box, addr);
     BOX_RELEASE_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -514,7 +655,7 @@ pub extern "C" fn js_i32_box_release(ptr: *mut I32Box) {
     unsafe {
         (*ptr).value = -1;
     }
-    I32_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr));
+    park_released_box(ReleasedBoxKind::I32, addr);
     BOX_RELEASE_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -543,7 +684,7 @@ pub extern "C" fn js_bool_box_release(ptr: *mut BoolBox) {
     unsafe {
         (*ptr).value = true;
     }
-    BOOL_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().push(addr));
+    park_released_box(ReleasedBoxKind::Bool, addr);
     BOX_RELEASE_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -989,6 +1130,8 @@ pub(crate) fn test_clear_box_registry() {
     BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().clear());
     I32_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().clear());
     BOOL_BOX_RELEASE_QUARANTINE.with(|q| q.borrow_mut().clear());
+    ASYNC_BOX_RELEASE_SCOPES.with(|scopes| scopes.borrow_mut().clear());
+    ASYNC_BOX_RELEASE_BATCH_POOL.with(|pool| pool.borrow_mut().clear());
     // Registry membership is not monotonic any more (#8208: `js_*box_release`
     // de-registers a completed activation's cells), so the positive cache is
     // kept coherent by an eviction on every un-registration rather than by
@@ -1315,6 +1458,77 @@ mod release_tests {
         );
         assert!(is_registered_box_ptr(third), "reused cell re-registers");
         assert_eq!(js_box_get_bits(third), 3.0f64.to_bits() as i64);
+    }
+
+    /// #8213: the normal terminal path no longer waits for the whole process
+    /// turn to drain. The current invocation keeps its cells quarantined while
+    /// generated terminal code is still running, then publishes them as soon
+    /// as the caller proves this activation has no queued resume.
+    #[test]
+    fn quiescent_async_activation_publishes_at_step_return() {
+        super::test_clear_box_registry();
+        let scope = begin_async_box_release_scope();
+        let first = js_box_alloc_bits(1.0f64.to_bits() as i64);
+        js_box_release(first);
+
+        let during_terminal_path = js_box_alloc_bits(2.0f64.to_bits() as i64);
+        assert_ne!(
+            first, during_terminal_path,
+            "a step must not reuse its own cell before the terminal path returns"
+        );
+
+        scope.finish(true);
+        let after_step_return = js_box_alloc_bits(3.0f64.to_bits() as i64);
+        assert_eq!(
+            first, after_step_return,
+            "a quiescent activation should publish without a global queue drain"
+        );
+    }
+
+    /// A queued duplicate resume keeps the pre-#8213 safety boundary: the
+    /// parked terminal value remains intact until the outer empty-queue flush.
+    #[test]
+    fn non_quiescent_async_activation_falls_back_to_global_quarantine() {
+        super::test_clear_box_registry();
+        let scope = begin_async_box_release_scope();
+        let first = js_bool_box_alloc(0);
+        js_bool_box_release(first);
+        scope.finish(false);
+
+        assert!(
+            unsafe { (*first).value },
+            "a queued duplicate resume must retain the terminal sentinel"
+        );
+        let before_empty_queue = js_bool_box_alloc(0);
+        assert_ne!(first, before_empty_queue);
+
+        flush_released_boxes();
+        let after_empty_queue = js_bool_box_alloc(0);
+        assert_eq!(first, after_empty_queue);
+    }
+
+    /// Nested async entry must not merge release ownership: the inner step may
+    /// become reusable while the synchronously suspended outer invocation is
+    /// still running and its own cell remains quarantined.
+    #[test]
+    fn nested_async_release_scopes_finish_independently() {
+        super::test_clear_box_registry();
+        let outer = begin_async_box_release_scope();
+        let outer_cell = js_box_alloc_bits(1.0f64.to_bits() as i64);
+        js_box_release(outer_cell);
+
+        let inner = begin_async_box_release_scope();
+        let inner_cell = js_box_alloc_bits(2.0f64.to_bits() as i64);
+        js_box_release(inner_cell);
+        inner.finish(true);
+
+        let reused_inner = js_box_alloc_bits(3.0f64.to_bits() as i64);
+        assert_eq!(inner_cell, reused_inner);
+        assert_ne!(outer_cell, reused_inner);
+
+        outer.finish(true);
+        let reused_outer = js_box_alloc_bits(4.0f64.to_bits() as i64);
+        assert_eq!(outer_cell, reused_outer);
     }
 
     /// Generated async-step code reads the compiler-private control cells

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -921,6 +921,10 @@ fn call_async_step_body(
 ) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let captured_h = scope.root_nanbox_f64(boxed_promise_or_undef(captured_trap_next));
+    // #8213: unlike the old implementation, the step is needed after the
+    // arbitrary user call so its release scope can prove that no resume for
+    // this activation remains queued. Keep it movable across that call.
+    let step_h = scope.root_nanbox_f64(boxed_closure_or_undef(step));
 
     // #691 Phase 2: when this thunk is invoked from the pending-Promise
     // fallback in js_async_step_chain (await of a still-pending inner),
@@ -940,10 +944,10 @@ fn call_async_step_body(
     let prev_step_h =
         scope.root_nanbox_f64(boxed_closure_or_undef(prev.current_step as ClosurePtr));
 
-    // `step` is needed only by this call and is never used afterward. Any
-    // future post-call use must root it and re-read its relocated address.
-    let result = crate::closure::js_closure_call2(step, value, is_error);
+    let release_scope = crate::r#box::begin_async_box_release_scope();
+    let result = crate::closure::js_closure_call2(unboxed_closure(&step_h), value, is_error);
     let result_h = scope.root_nanbox_f64(result);
+    release_scope.finish(!super::async_step_is_queued(unboxed_closure(&step_h)));
     INLINE_TRAP.with(|c| {
         c.set(InlineTrap {
             trap_next: unboxed_promise(&prev_trap_h),

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -844,11 +844,18 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
                     crate::async_hooks::before(step_async_id, step_trigger_id);
                     crate::v8::promise_hook_before(next);
                     // #7497: re-read both across the two calls above.
+                    // #8213: keep this invocation's releases private until it
+                    // returns. If it did not queue another resume for the same
+                    // activation, its cells can become reusable immediately;
+                    // otherwise `finish` falls back to the global quarantine.
+                    let release_scope = crate::r#box::begin_async_box_release_scope();
                     let result = call_async_step_direct(
                         rooted_closure(&step_handle),
                         value_handle.get_nanbox_f64(),
                         is_error_bits,
                     );
+                    release_scope
+                        .finish(!super::async_step_is_queued(rooted_closure(&step_handle)));
                     CURRENT_MICROTASK_VALUE.with(|c| c.set(result));
                     if let Some(t) = t1 {
                         MT_TIME_NS_CALLBACK

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -580,6 +580,23 @@ pub(crate) enum Task {
     AsyncStep(ClosurePtr, f64, *mut Promise, bool, AsyncContextSnapshot),
 }
 
+/// Whether the FIFO still contains a direct resume for `step`.
+///
+/// Called only after an invocation released async-activation boxes. At that
+/// point a matching queued `AsyncStep` is the sole remaining path that can
+/// reach the parked terminal cells; ordinary promise reactions are settle-once
+/// and cannot manufacture a second invocation after the terminal one.
+pub(crate) fn async_step_is_queued(step: ClosurePtr) -> bool {
+    if step.is_null() {
+        return false;
+    }
+    TASK_QUEUE.with(|q| {
+        q.borrow()
+            .iter()
+            .any(|task| matches!(task, Task::AsyncStep(queued, ..) if *queued == step))
+    })
+}
+
 // Global task queue for pending promise callbacks. Must be FIFO per
 // ECMAScript microtask semantics: `Promise.resolve(1).then(...)` and
 // `Promise.resolve(2).then(...)` registered in source order must run

--- a/crates/perry-transform/src/generator/box_release.rs
+++ b/crates/perry-transform/src/generator/box_release.rs
@@ -18,13 +18,14 @@
 //!
 //! #8208 makes the release real. `Stmt::ReleaseBoxes` lowers to
 //! `js_box_release` / `js_i32_box_release` / `js_bool_box_release`, which clear
-//! the cell, de-register it, evict its positive-cache slot, and park it in a
-//! per-kind quarantine; `flush_released_boxes` publishes the quarantine to a
-//! free pool at the outermost microtask-pump exit once the task queue is empty,
-//! and `js_*box_alloc*` pops that pool before calling `std::alloc`. Registry
-//! membership is therefore no longer monotonic — but the property perry#4898
-//! and #7906 actually depend on survives untouched, because cell memory is
-//! never handed back to the allocator: an address minted by `js_box_alloc*`
+//! the cell, de-register it, evict its positive-cache slot, and park it in the
+//! current async-step invocation's release scope. After that invocation
+//! returns, the runtime publishes its cells when no resume for the same step
+//! remains queued; the old outermost empty-queue quarantine is the conservative
+//! fallback. `js_*box_alloc*` pops the free pool before calling `std::alloc`.
+//! Registry membership is therefore no longer monotonic — but the property
+//! perry#4898 and #7906 actually depend on survives untouched, because cell
+//! memory is never handed back to the allocator: an address minted by `js_box_alloc*`
 //! stays 8 readable bytes of box cell for the life of the thread, so "was a
 //! box" can never become "is another object".
 //!

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -2635,8 +2635,10 @@ def _probe_boxes_outside_the_gc_heap():
 
     So the old `dealloc` grep is kept (it is still the thing that would break
     the address-validity leg) and a second check is added for the property that
-    now carries the reuse argument: release must PARK into a quarantine, and
-    only `flush_released_boxes` may feed the reuse pool. A release that pushed
+    now carries the reuse argument: release must PARK in the current async-step
+    scope (falling back to the global quarantine), and publication may happen
+    only after that step returns and no resume for the same activation remains
+    queued, or at the old outermost empty-queue boundary. A release that pushed
     straight onto the free pool could hand a cell to a second activation while
     the first can still resume, which is a use-after-release aliasing hazard
     that this exemption would otherwise silently suppress.
@@ -2662,34 +2664,74 @@ def _probe_boxes_outside_the_gc_heap():
                        "recycled address could become a non-box object, which "
                        "voids both perry#4898's pointer rejection and #7906's "
                        "positive cache")
-    # The reuse path must stay quarantine-gated. Each release parks into a
-    # *_RELEASE_QUARANTINE; only flush_released_boxes drains those into the
-    # intrusive free list (threaded through the cells) that
-    # js_*box_alloc* pops from.
-    for fn, quarantine in (("js_box_release", "BOX_RELEASE_QUARANTINE"),
-                           ("js_i32_box_release", "I32_BOX_RELEASE_QUARANTINE"),
-                           ("js_bool_box_release", "BOOL_BOX_RELEASE_QUARANTINE")):
+    # The reuse path must stay scope/quarantine-gated. Each release goes
+    # through park_released_box; it must never touch the intrusive free list.
+    for fn, kind in (("js_box_release", "ReleasedBoxKind::Box"),
+                     ("js_i32_box_release", "ReleasedBoxKind::I32"),
+                     ("js_bool_box_release", "ReleasedBoxKind::Bool")):
         rel = rust_fn_body("crates/perry-runtime/src/box.rs", fn)
         if rel is None:
             return (False, f"{fn} not found in box.rs; the #8208 release path "
                            "changed shape and this premise must be re-argued")
-        if quarantine not in rel:
-            return (False, f"{fn} no longer parks into {quarantine}")
+        if f"park_released_box({kind}" not in rel:
+            return (False, f"{fn} no longer parks through the activation "
+                           f"scope with {kind}")
         if "FREE_HEAD" in rel:
             return (False, f"{fn} touches the free list directly — release must "
-                           "park into the quarantine and let "
-                           "flush_released_boxes publish it. Publishing is also "
-                           "what overwrites the cell with its free-list link, so "
-                           "a release that published directly would destroy the "
-                           "parked terminal value a stray resume still reads.")
+                           "park first. Publishing overwrites the cell with its "
+                           "free-list link, so publishing here would destroy the "
+                           "terminal value a stray resume still reads.")
+    park = rust_fn_body("crates/perry-runtime/src/box.rs", "park_released_box")
+    if park is None:
+        return (False, "park_released_box not found; releases have no audited "
+                       "quarantine funnel")
+    for holder in ("ASYNC_BOX_RELEASE_SCOPES", "BOX_RELEASE_QUARANTINE",
+                   "I32_BOX_RELEASE_QUARANTINE", "BOOL_BOX_RELEASE_QUARANTINE"):
+        if holder not in park:
+            return (False, f"park_released_box no longer reaches {holder}")
+    if "FREE_HEAD" in park:
+        return (False, "park_released_box touches a free-list head directly")
+
+    finish = rust_fn_body("crates/perry-runtime/src/box.rs",
+                          "finish_async_box_release_scope")
+    if finish is None:
+        return (False, "finish_async_box_release_scope not found")
+    for required in ("if activation_is_quiescent", "publish_released_batch",
+                     "BOX_RELEASE_QUARANTINE", "I32_BOX_RELEASE_QUARANTINE",
+                     "BOOL_BOX_RELEASE_QUARANTINE"):
+        if required not in finish:
+            return (False, "activation-scope finish lost its quiescence gate "
+                           f"or conservative fallback: missing {required}")
+
+    queue_check = rust_fn_body("crates/perry-runtime/src/promise/mod.rs",
+                               "async_step_is_queued")
+    if queue_check is None or any(token not in queue_check for token in
+                                  ("TASK_QUEUE", "Task::AsyncStep",
+                                   "*queued == step")):
+        return (False, "async_step_is_queued no longer proves that the FIFO "
+                       "has no resume for the same activation")
+    for path, fn in (("crates/perry-runtime/src/promise/async_step.rs",
+                      "call_async_step_body"),
+                     ("crates/perry-runtime/src/promise/microtasks.rs",
+                      "run_microtasks")):
+        caller = rust_fn_body(path, fn)
+        if caller is None:
+            return (False, f"{fn} not found; async release publication is "
+                           "no longer bracketed at every step entry")
+        for required in ("begin_async_box_release_scope", "release_scope",
+                         ".finish(!super::async_step_is_queued"):
+            if required not in caller:
+                return (False, f"{fn} no longer gates activation publication "
+                               f"on the queued-resume proof: missing {required}")
     flush = rust_fn_body("crates/perry-runtime/src/box.rs",
                          "flush_released_boxes")
     if flush is None:
         return (False, "flush_released_boxes not found; nothing drains the "
                        "release quarantine into the reuse pool")
     return (True, "std::alloc::alloc, no arena allocation, cell memory never "
-                  "returned to the allocator; release is quarantine-gated and "
-                  "only flush_released_boxes publishes cells for reuse")
+                  "returned to the allocator; release is activation-scoped "
+                  "and publication requires either per-activation quiescence "
+                  "or the outermost empty-queue boundary")
 
 
 IMMOVABLE_SOURCES = (
@@ -2708,9 +2750,10 @@ IMMOVABLE_SOURCES = (
         not_reclaimable_because=(
             "box CELL MEMORY is never returned to the allocator: box.rs has no "
             "dealloc. #8208 made a completed async activation's cells "
-            "RECYCLABLE — released cells are parked in a quarantine, published "
-            "to a per-kind free pool by flush_released_boxes at the outermost "
-            "microtask-pump exit, and re-registered by a later js_box_alloc* — "
+            "RECYCLABLE — released cells are parked per async-step invocation, "
+            "published when that activation has no queued resume (or by "
+            "flush_released_boxes at the outermost microtask-pump exit), and "
+            "re-registered by a later js_box_alloc* — "
             "so BOX_REGISTRY membership is no longer monotonic. The exemption "
             "does not rest on that membership. It rests on the weaker property "
             "#8208 preserves deliberately: every address js_box_alloc* ever "


### PR DESCRIPTION
## Summary

- keep released async box cells scoped to the step invocation that released them
- publish that batch immediately once the step returns and no matching resume remains queued
- preserve the outermost empty-queue quarantine as the conservative duplicate-resume fallback
- extend the immovable-source safety audit and release diagnostics for both publication gates

This is stacked on #8208 and completes the remaining activation-reachability work for #8213. No package or crate version is bumped.

## Measurements

`asyncpipe`, best of five `/usr/bin/time -l` runs, with byte-identical output in every run:

| BATCHES | resident box cells | base RSS | #8208 RSS | this PR RSS |
| ---: | ---: | ---: | ---: | ---: |
| 30 | 1,635 | 21.92 MiB | 22.44 MiB | 20.84 MiB |
| 60 | 1,635 | 28.41 MiB | 29.20 MiB | 27.22 MiB |
| 1200 | 1,635 | 138.02 MiB | 79.08 MiB | 79.30 MiB |

The resident-cell count is constant across the 40x workload range, down from #8208's 65,915-cell inter-pump residue. The strict 30/60-batch RSS floor is also below the no-release base.

## Validation

- `cargo test -q -p perry-runtime --lib` (2,555 passed, 4 ignored)
- `cargo test -q -p perry-runtime --lib release_tests -- --test-threads=1`
- `cargo test -q -p perry-codegen --test release_boxes_lowering`
- `cargo test -q -p perry-transform box_release`
- `python3 scripts/check_thread_locals.py`
- `python3 scripts/gc_root_dominance_check.py --audit-immovable-sources`
- `python3 scripts/gc_root_dominance_check.py --self-test`
- Node/Perry exit-path fixture comparison (byte-identical stdout)

Fixes #8213
