### PR TITLE
fix(runtime): enumerate native module namespace values

### DIFF
--- a/changelog.d/8269-native-module-object-enumeration.md
+++ b/changelog.d/8269-native-module-object-enumeration.md
@@ -1,0 +1,8 @@
+### fix(runtime): enumerate native-module namespace values
+
+`Object.entries` and `Object.values` now expose a native module's public export
+surface instead of its internal `__module__` storage sentinel. Enumeration
+uses the same virtual key list as `Object.keys` and resolves each live value
+through the namespace property getter, including constants and callable
+exports. The receiver and intermediate arrays stay rooted across allocations
+that can trigger a moving collection. Fixes #8235.

--- a/crates/perry-runtime/src/object/field_get_set/enumeration.rs
+++ b/crates/perry-runtime/src/object/field_get_set/enumeration.rs
@@ -52,6 +52,69 @@ fn map_set_exotic_enum(stripped: *const ObjectHeader, what: MapSetEnum) -> *mut 
     out
 }
 
+/// Build `Object.values` / `Object.entries` from the virtual export surface of
+/// a native-module namespace.  Such namespaces physically contain only the
+/// internal `__module__` sentinel; their observable keys and values are
+/// supplied lazily by the native-module vtable.
+///
+/// Keep this in the generic enumeration module and call through the armed
+/// vtable so binaries that never create a namespace do not retain the native
+/// module export tables.  The receiver, key list, output, and per-key values
+/// are rooted because resolving a callable export can allocate and trigger a
+/// moving collection.
+unsafe fn native_module_enum(
+    obj: *const ObjectHeader,
+    what: MapSetEnum,
+) -> Option<*mut ArrayHeader> {
+    let vt = super::super::native_module::native_module_vtable()?;
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_h = scope.root_raw_const_ptr(obj);
+    let keys = obj_h.with_const_ptr(|obj| (vt.own_keys_array)(obj))?;
+    let keys_h = scope.root_raw_const_ptr(keys);
+    let count = crate::array::js_array_length(keys_h.get_raw_const_ptr::<ArrayHeader>());
+    let result = crate::array::js_array_alloc(count);
+    let result_h = scope.root_raw_mut_ptr(result);
+
+    for i in 0..count {
+        let iter_scope = crate::gc::RuntimeHandleScope::new();
+        let key = crate::array::js_array_get(keys_h.get_raw_const_ptr::<ArrayHeader>(), i);
+        let key_ptr = (key.bits() & crate::value::POINTER_MASK) as *const crate::StringHeader;
+        let key_h = iter_scope.root_string_ptr(key_ptr);
+        let value = obj_h.with_const_ptr(|obj| {
+            key_h.with_const_ptr(|key| js_object_get_field_by_name(obj, key))
+        });
+        let value_h = iter_scope.root_nanbox_u64(value.bits());
+
+        match what {
+            MapSetEnum::Values => {
+                crate::array::js_array_push_f64(
+                    result_h.get_raw_mut_ptr::<ArrayHeader>(),
+                    value_h.get_nanbox_f64(),
+                );
+            }
+            MapSetEnum::Entries => {
+                let pair = crate::array::js_array_alloc(2);
+                let pair_h = iter_scope.root_raw_mut_ptr(pair);
+                crate::array::js_array_push(
+                    pair_h.get_raw_mut_ptr::<ArrayHeader>(),
+                    JSValue::string_ptr(key_h.get_raw_mut_ptr::<crate::StringHeader>()),
+                );
+                crate::array::js_array_push_f64(
+                    pair_h.get_raw_mut_ptr::<ArrayHeader>(),
+                    value_h.get_nanbox_f64(),
+                );
+                crate::array::js_array_push(
+                    result_h.get_raw_mut_ptr::<ArrayHeader>(),
+                    JSValue::array_ptr(pair_h.get_raw_mut_ptr::<ArrayHeader>()),
+                );
+            }
+            MapSetEnum::Keys => unreachable!("native_module_enum is only used for values/entries"),
+        }
+    }
+
+    Some(result_h.get_raw_mut_ptr::<ArrayHeader>())
+}
+
 /// `Object.keys(value)` entry point that inspects the NaN-boxed *value* (not a
 /// raw pointer) so it handles primitives safely. A string yields its index
 /// keys `"0".."length-1"` (`Object.keys("abc") === ["0","1","2"]`); objects and
@@ -1381,6 +1444,11 @@ pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader
         return crate::array::js_array_alloc(0);
     }
     unsafe {
+        if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
+            if let Some(result) = native_module_enum(obj, MapSetEnum::Values) {
+                return result;
+            }
+        }
         // Iterate up to keys_len (logical property count), not
         // field_count — same fix as Object.entries above. Without
         // this, objects with overflow fields silently returned only
@@ -1566,6 +1634,11 @@ pub extern "C" fn js_object_entries(obj: *const ObjectHeader) -> *mut ArrayHeade
         return crate::array::js_array_alloc(0);
     }
     unsafe {
+        if (*obj).class_id == NATIVE_MODULE_CLASS_ID {
+            if let Some(result) = native_module_enum(obj, MapSetEnum::Entries) {
+                return result;
+            }
+        }
         let keys = (*obj).keys_array;
         // Iterate up to keys_len (the logical property count), not
         // field_count. Parser-built and dict-built objects with ≥9

--- a/test-parity/node-suite/perf_hooks/constants/all-gc-values.ts
+++ b/test-parity/node-suite/perf_hooks/constants/all-gc-values.ts
@@ -5,3 +5,4 @@ console.log(
     [key, value],
   ) => `${key}=${value}`).join(","),
 );
+console.log(Object.values(constants).sort((a, b) => a - b).join(","));


### PR DESCRIPTION
## Summary

Route `Object.entries` and `Object.values` on native-module namespace objects through the same virtual export surface used by `Object.keys`, so user code sees real module keys and values instead of the internal `__module__` sentinel.

## Changes

- enumerate namespace keys through the armed native-module vtable
- resolve each value through the authoritative namespace property getter
- root receivers, keys, output arrays, and allocated callable exports across moving GC
- extend the existing `perf_hooks.constants` parity fixture with `Object.values`

## Related issue

Fixes #8235

## Test plan

- [x] `cargo build --release -p perry-runtime`
- [x] `env RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime` (2557 passed, 0 failed, 4 ignored on rebased head)
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --suite node-suite --module perf_hooks --filter all-gc-values` (1/1 pass)
- [x] `cargo fmt --all -- --check`

## Additional surface check

`for...in` already uses the virtual `Object.keys` path, and spread / `Object.assign` already use the export-copy hook from #6667. `JSON.stringify` still has a separate raw-field serializer path and reproduces the sentinel leak; that broader compact/pretty/replacer serializer work is intentionally left as a follow-up rather than folded into this entries/values fix.

## Checklist

- [x] No workspace version, `CLAUDE.md`, or `CHANGELOG.md` bump
- [x] Conventional commit prefix used
- [x] Read `CONTRIBUTING.md` and agree to the Code of Conduct