### PR TITLE
fix(gc): validate arena object starts during copying

### DIFF
--- a/crates/perry-codegen/src/expr/array_literal.rs
+++ b/crates/perry-codegen/src/expr/array_literal.rs
@@ -201,6 +201,26 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
             // GC_STORE_AUDIT(INIT): freshly allocated array header starts pointer-free until slot notes below.
             blk.store(I64, &gc_packed.to_string(), &raw);
 
+            // Publish the exact header boundary in the current arena block's
+            // object-start bitmap (InlineArenaState field at byte 24). The
+            // slow arm may have replaced the current block, so compute the
+            // slot from the merged raw pointer rather than `aligned_off`.
+            let current_data = blk.load(PTR, &state_ptr);
+            let raw_addr = blk.ptrtoint(&raw, I64);
+            let data_addr = blk.ptrtoint(&current_data, I64);
+            let relative = blk.sub(I64, &raw_addr, &data_addr);
+            let start_slot = blk.lshr(I64, &relative, "3");
+            let start_word = blk.lshr(I64, &start_slot, "6");
+            let start_bit = blk.and(I64, &start_slot, "63");
+            let bitmap_field = blk.gep(I8, &state_ptr, &[(I64, "24")]);
+            let bitmap = blk.load(PTR, &bitmap_field);
+            let bitmap_word = blk.gep(I64, &bitmap, &[(I64, &start_word)]);
+            let prior_starts = blk.load(I64, &bitmap_word);
+            let start_mask = blk.shl(I64, "1", &start_bit);
+            let updated_starts = blk.or(I64, &prior_starts, &start_mask);
+            // GC_STORE_AUDIT(INIT): side metadata for a freshly initialized GC header.
+            blk.store(I64, &updated_starts, &bitmap_word);
+
             // Packed ArrayHeader at raw+8 (length low 32 / capacity high 32).
             let arr_header_addr = blk.gep(I8, &raw, &[(I64, "8")]);
             let arr_header_packed = (n as u64) | ((n as u64) << 32);

--- a/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
+++ b/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
@@ -342,6 +342,10 @@ fn the_inline_allocator_stores_its_header_prefix_as_one_vector_image() {
         ir.contains(HEADER_IMAGE_STORE),
         "the inline allocation site must store the `<2 x i64>` header image:\n{ir}"
     );
+    assert!(
+        ir.contains("shl i64 1,") && ir.contains("lshr i64") && ir.contains(", 6"),
+        "the inline allocation site must set its exact boundary in the arena object-start bitmap:\n{ir}"
+    );
     // The compose lives beside the ShapeId mint in module init, i.e. after the
     // mint call and outside the allocating function's own body.
     let compose_at = ir.find(HEADER_IMAGE_COMPOSE).unwrap();

--- a/crates/perry-codegen/src/lower_call/new_alloc.rs
+++ b/crates/perry-codegen/src/lower_call/new_alloc.rs
@@ -644,6 +644,26 @@ fn emit_instance_alloc_inner(
                 header_image, raw
             ));
 
+            // Publish the exact header boundary in the current arena block's
+            // object-start bitmap (InlineArenaState field at byte 24). The
+            // slow arm may install a new block, so derive the slot from the
+            // merged raw pointer and the state data pointer after the merge.
+            let current_data = blk.load(PTR, &state_ptr);
+            let raw_addr = blk.ptrtoint(&raw, I64);
+            let data_addr = blk.ptrtoint(&current_data, I64);
+            let relative = blk.sub(I64, &raw_addr, &data_addr);
+            let start_slot = blk.lshr(I64, &relative, "3");
+            let start_word = blk.lshr(I64, &start_slot, "6");
+            let start_bit = blk.and(I64, &start_slot, "63");
+            let bitmap_field = blk.gep(I8, &state_ptr, &[(I64, "24")]);
+            let bitmap = blk.load(PTR, &bitmap_field);
+            let bitmap_word = blk.gep(I64, &bitmap, &[(I64, &start_word)]);
+            let prior_starts = blk.load(I64, &bitmap_word);
+            let start_mask = blk.shl(I64, "1", &start_bit);
+            let updated_starts = blk.or(I64, &prior_starts, &start_mask);
+            // GC_STORE_AUDIT(INIT): side metadata for a freshly initialized GC header.
+            blk.store(I64, &updated_starts, &bitmap_word);
+
             // Second 8 bytes: keys_array pointer. The keys_ptr we loaded
             // above is an i64 (carries the ArrayHeader address); store as
             // i64 since the underlying memory is 8 bytes either way.

--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -33,15 +33,21 @@ pub fn arena_alloc(size: usize, align: usize) -> *mut u8 {
         let ptr = crate::arena::arena_cell_alloc(arena_ptr, size, align);
         // Resync block → inline (may have advanced to a new block).
         if !(*inline_ptr).data.is_null() {
-            let (data, offset, block_size) = {
+            let (data, offset, block_size, object_starts) = {
                 let arena = &*arena_ptr;
                 let block = &arena.blocks[arena.current];
-                (block.data, block.offset, block.size)
+                (
+                    block.data,
+                    block.offset,
+                    block.size,
+                    block.object_starts_ptr(),
+                )
             };
             let inline = &mut *inline_ptr;
             inline.data = data;
             inline.offset = offset;
             inline.size = block_size;
+            inline.object_starts = object_starts;
         }
         ptr
     }
@@ -102,6 +108,7 @@ pub(crate) fn arena_alloc_gc_no_collect(size: usize, align: usize, obj_type: u8)
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
@@ -128,15 +135,21 @@ fn arena_alloc_no_collect(size: usize, align: usize) -> *mut u8 {
             return std::ptr::null_mut();
         };
         if !(*inline_ptr).data.is_null() {
-            let (data, offset, block_size) = {
+            let (data, offset, block_size, object_starts) = {
                 let arena = &*arena_ptr;
                 let block = &arena.blocks[arena.current];
-                (block.data, block.offset, block.size)
+                (
+                    block.data,
+                    block.offset,
+                    block.size,
+                    block.object_starts_ptr(),
+                )
             };
             let inline = &mut *inline_ptr;
             inline.data = data;
             inline.offset = offset;
             inline.size = block_size;
+            inline.object_starts = object_starts;
         }
         ptr
     }
@@ -179,6 +192,7 @@ pub fn arena_alloc_gc_longlived(size: usize, align: usize, obj_type: u8) -> *mut
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
 
@@ -241,6 +255,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
+        record_arena_object_start(raw as usize);
         defer_old_object_page_registration(raw as usize, total);
         return user_ptr as *mut u8;
     }
@@ -254,6 +269,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
     defer_old_object_page_registration(raw as usize, total);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
@@ -311,6 +327,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
+        record_arena_object_start(raw as usize);
         register_old_object_pages(raw as usize, total);
         return user_ptr as *mut u8;
     }
@@ -324,6 +341,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
     register_old_object_pages(raw as usize, total);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
@@ -384,6 +402,7 @@ pub(crate) fn arena_alloc_gc_survivor(size: usize, align: usize, obj_type: u8) -
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
@@ -475,6 +494,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
+        record_arena_object_start(user_ptr as usize - GC_HEADER_SIZE);
         return user_ptr;
     }
 
@@ -507,6 +527,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
+    record_arena_object_start(raw as usize);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }

--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -318,6 +318,7 @@ fn try_alloc_block(min_size: usize, injectable: bool) -> Option<ArenaBlock> {
             data,
             size,
             offset: 0,
+            object_starts: new_object_start_bitmap(size),
             dead_cycles: 0,
         });
     }
@@ -329,8 +330,18 @@ fn try_alloc_block(min_size: usize, injectable: bool) -> Option<ArenaBlock> {
         data,
         size,
         offset: 0,
+        object_starts: new_object_start_bitmap(size),
         dead_cycles: 0,
     })
+}
+
+/// Arena allocations are at least 8-byte aligned. One bit per possible header
+/// address therefore records exact object boundaries at 1/64 the block size.
+pub(crate) const OBJECT_START_SHIFT: usize = 3;
+const OBJECT_START_BYTES_PER_WORD: usize = 64 << OBJECT_START_SHIFT;
+
+pub(crate) fn new_object_start_bitmap(size: usize) -> Box<[u64]> {
+    vec![0; size.div_ceil(OBJECT_START_BYTES_PER_WORD)].into_boxed_slice()
 }
 
 /// Reserve a block, running one emergency full collection if the OS refuses
@@ -380,6 +391,10 @@ pub(crate) struct ArenaBlock {
     pub(crate) data: *mut u8,
     pub(crate) size: usize,
     pub(crate) offset: usize,
+    /// Exact GC-object header starts in this block, one bit per 8-byte slot.
+    /// The boxed allocation stays stable when this struct moves in a `Vec`;
+    /// page metadata caches its raw pointer.
+    pub(crate) object_starts: Box<[u64]>,
     /// Issue #73: number of consecutive GC cycles this block has been
     /// observed with zero live objects. Reset requires TWO consecutive
     /// dead observations so a block can't be reclaimed on the same
@@ -396,6 +411,16 @@ impl ArenaBlock {
     /// while the arena does not exist yet, so nothing may collect here.
     fn new() -> Self {
         alloc_block_no_gc(BLOCK_SIZE)
+    }
+
+    #[inline]
+    pub(crate) fn object_starts_ptr(&self) -> *mut u64 {
+        self.object_starts.as_ptr() as *mut u64
+    }
+
+    #[inline]
+    pub(crate) fn clear_object_starts(&mut self) {
+        self.object_starts.fill(0);
     }
 
     /// Try to allocate within this block, respecting alignment
@@ -501,7 +526,13 @@ impl Drop for Arena {
 impl Arena {
     fn new(generation: HeapGeneration, space: HeapSpace) -> Self {
         let initial = ArenaBlock::new();
-        register_block_space(initial.data as usize, initial.size, generation, space);
+        register_block_space_with_object_starts(
+            initial.data as usize,
+            initial.size,
+            generation,
+            space,
+            initial.object_starts_ptr(),
+        );
         ARENA_TOTAL_BYTES.with(|t| t.set(t.get() + initial.size));
         Arena {
             blocks: vec![initial],
@@ -528,6 +559,7 @@ impl Arena {
                 data: std::ptr::null_mut(),
                 size: 0,
                 offset: 0,
+                object_starts: Box::new([]),
                 dead_cycles: 0,
             }],
             current: 0,
@@ -592,6 +624,7 @@ impl Arena {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     }
@@ -606,7 +639,13 @@ impl Arena {
     pub(crate) fn install_reserved_block(&mut self, fresh: ArenaBlock) {
         let fresh_size = fresh.size;
         let fresh_base = fresh.data as usize;
-        register_block_space(fresh_base, fresh_size, self.generation, self.space);
+        register_block_space_with_object_starts(
+            fresh_base,
+            fresh_size,
+            self.generation,
+            self.space,
+            fresh.object_starts_ptr(),
+        );
         let mut tomb_idx: Option<usize> = None;
         for i in 0..self.blocks.len() {
             if self.blocks[i].data.is_null() {
@@ -1019,18 +1058,19 @@ thread_local! {
         UnsafeCell::new(Arena::new_lazy(HeapGeneration::Old, HeapSpace::Old));
 
     /// Inline allocator state — a cache of the current arena block's
-    /// `(data, offset, size)` triple, exposed via a stable pointer so
+    /// `(data, offset, size, object_starts)` tuple, exposed via a stable pointer so
     /// codegen can emit inline bump-allocate IR without going through
     /// any function call or `LocalKey::with` wrapper.
     ///
     /// `#[repr(C)]` on `InlineArenaState` keeps the field offsets stable
-    /// (data=0, offset=8, size=16). The codegen reads/writes these fields
+    /// (data=0, offset=8, size=16, object_starts=24). The codegen reads/writes these fields
     /// directly via fixed GEPs, so changing the struct layout would
     /// silently break every emitted `new ClassName()`.
     pub(crate) static INLINE_STATE: UnsafeCell<InlineArenaState> = const { UnsafeCell::new(InlineArenaState {
         data: std::ptr::null_mut(),
         offset: 0,
         size: 0,
+        object_starts: std::ptr::null_mut(),
     }) };
 }
 

--- a/crates/perry-runtime/src/arena/inline.rs
+++ b/crates/perry-runtime/src/arena/inline.rs
@@ -2,17 +2,19 @@ use super::*;
 
 /// Inline bump-allocator state. The codegen emits inline LLVM IR that
 /// reads `data` and `offset`, computes `aligned + size`, checks against
-/// `size`, stores the new offset, and returns `data + aligned`. The
+/// `size`, stores the new offset, records the allocation boundary through
+/// `object_starts`, and returns `data + aligned`. The
 /// underlying thread-local Arena is the source of truth between
 /// inline-alloc bursts; this state is the source of truth during them.
 ///
 /// Field offsets are load-bearing — the codegen GEPs into this struct
-/// at hard-coded byte offsets (0/8/16). Do not reorder.
+/// at hard-coded byte offsets (0/8/16/24). Do not reorder.
 #[repr(C)]
 pub struct InlineArenaState {
-    pub data: *mut u8, // offset  0  — current block's data pointer
-    pub offset: usize, // offset  8  — bump pointer (mutated inline)
-    pub size: usize,   // offset 16  — current block's size
+    pub data: *mut u8,           // offset  0  — current block's data pointer
+    pub offset: usize,           // offset  8  — bump pointer (mutated inline)
+    pub size: usize,             // offset 16  — current block's size
+    pub object_starts: *mut u64, // offset 24 — one bit per 8-byte slot
 }
 
 /// Get the per-thread inline arena state pointer. Called once per JS
@@ -44,6 +46,7 @@ pub extern "C" fn js_inline_arena_state() -> *mut InlineArenaState {
             state.data = block.data;
             state.offset = block.offset;
             state.size = block.size;
+            state.object_starts = block.object_starts_ptr();
         }
         state as *mut InlineArenaState
     }
@@ -87,15 +90,21 @@ pub extern "C" fn js_inline_arena_slow_alloc(
         // Allocate via existing path (may push a new block + run GC).
         let ptr = crate::arena::arena_cell_alloc(arena_ptr, size, align);
         // Resync inline state to the (possibly new) current block.
-        let (data, block_offset, block_size) = {
+        let (data, block_offset, block_size, object_starts) = {
             let arena = &*arena_ptr;
             let block = &arena.blocks[arena.current];
-            (block.data, block.offset, block.size)
+            (
+                block.data,
+                block.offset,
+                block.size,
+                block.object_starts_ptr(),
+            )
         };
         let state_ref = &mut *state;
         state_ref.data = data;
         state_ref.offset = block_offset;
         state_ref.size = block_size;
+        state_ref.object_starts = object_starts;
         ptr
     })
 }
@@ -146,6 +155,7 @@ pub fn arena_start_fresh_general_block() {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     });

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -35,10 +35,11 @@ pub(crate) use allocators::{
 };
 pub(crate) use block::{
     arena_cell_alloc, arena_cell_try_alloc_current, drain_block_pool_if_requested,
-    old_gen_in_use_bytes_sub, release_arena_block, request_block_pool_drain, Arena, ArenaBlock,
-    ArenaBlockRelease, BlockPoolDrainStats, ACTIVE_SURVIVOR, ARENA, ARENA_TOTAL_BYTES, BLOCK_SIZE,
-    FRESH_GENERAL_BLOCK_MIN_USED_BYTES, INLINE_STATE, LONGLIVED_ARENA, OLD_ARENA,
-    OLD_GEN_IN_USE_BYTES, SURVIVOR_ARENA_0, SURVIVOR_ARENA_1,
+    new_object_start_bitmap, old_gen_in_use_bytes_sub, release_arena_block,
+    request_block_pool_drain, Arena, ArenaBlock, ArenaBlockRelease, BlockPoolDrainStats,
+    ACTIVE_SURVIVOR, ARENA, ARENA_TOTAL_BYTES, BLOCK_SIZE, FRESH_GENERAL_BLOCK_MIN_USED_BYTES,
+    INLINE_STATE, LONGLIVED_ARENA, OBJECT_START_SHIFT, OLD_ARENA, OLD_GEN_IN_USE_BYTES,
+    SURVIVOR_ARENA_0, SURVIVOR_ARENA_1,
 };
 /// #7469 hot-TLS plumbing — see `crate::tls_hot`. The `*_hot_addr` half is
 /// consumed by `tls_hot::fill`; the `hot_*` half is the cached accessor the
@@ -51,9 +52,10 @@ pub(crate) use block::{
     reset_gc_trigger_arena_probe,
 };
 pub(crate) use page_meta::{
-    address_span_overlaps_pages, defer_old_object_page_registration, register_block_space,
-    register_old_object_pages, unregister_block_generation, unregister_old_block_pages,
-    OLD_GEN_RECLAIM_POOLED_BYTES, OLD_GEN_RECLAIM_RETURNED_BYTES, OLD_GEN_RECLAIM_REUSABLE_BYTES,
+    address_span_overlaps_pages, defer_old_object_page_registration,
+    register_block_space_with_object_starts, register_old_object_pages,
+    unregister_block_generation, unregister_old_block_pages, OLD_GEN_RECLAIM_POOLED_BYTES,
+    OLD_GEN_RECLAIM_RETURNED_BYTES, OLD_GEN_RECLAIM_REUSABLE_BYTES,
 };
 pub(crate) use page_meta::{page_generation_cache_hot_addr, page_generations_hot_addr};
 
@@ -131,22 +133,22 @@ pub(crate) use stats::{old_gen_in_use_bytes_recomputed, old_gen_in_use_bytes_res
 
 // page_meta.rs (public + pub(crate) classification/page-meta API)
 pub(crate) use page_meta::{
-    classify_heap_generation, classify_heap_space, classify_heap_space_in_range,
-    generation_page_for_addr, materialize_all_promoted_page_runs,
+    arena_header_is_object_start, classify_heap_generation, classify_heap_space,
+    classify_heap_space_in_range, generation_page_for_addr, materialize_all_promoted_page_runs,
     old_arena_page_index_remove_object, old_arena_source_blocks_for_pages,
     old_arena_walk_objects_on_pages, old_object_page_overlaps, old_page_account_dirty_slot,
     old_page_account_dirty_slots, old_page_account_promoted_object, old_page_account_swept_object,
     old_page_clear_dirty, old_page_mark_dirty, old_page_meta_snapshot, old_page_summary,
-    old_pages_begin_gc_cycle, old_pages_reset_sweep_accounting, unregister_old_object_pages,
-    HeapGeneration, HeapSpace, OldArenaPageObjectCursor, OldArenaSourceBlockSelection, OldPageMeta,
-    OldPageSummary,
+    old_pages_begin_gc_cycle, old_pages_reset_sweep_accounting, record_arena_object_start,
+    unregister_old_object_pages, HeapGeneration, HeapSpace, OldArenaPageObjectCursor,
+    OldArenaSourceBlockSelection, OldPageMeta, OldPageSummary,
 };
 
 #[cfg(test)]
 pub(crate) use page_meta::{
     deferred_old_page_registrations_len, generation_page_base,
     old_arena_page_index_clear_for_tests, old_page_meta_for_tests,
-    old_page_meta_snapshot_calls_for_tests, pending_promoted_page_runs, register_promoted_page_run,
-    reset_old_page_meta_snapshot_calls_for_tests, DEFERRED_OLD_PAGE_REGISTRATION_CAP,
-    GENERATION_CLASS_SHIFT, GENERATION_PAGE_SIZE,
+    old_page_meta_snapshot_calls_for_tests, pending_promoted_page_runs, register_block_space,
+    register_promoted_page_run, reset_old_page_meta_snapshot_calls_for_tests,
+    DEFERRED_OLD_PAGE_REGISTRATION_CAP, GENERATION_CLASS_SHIFT, GENERATION_PAGE_SIZE,
 };

--- a/crates/perry-runtime/src/arena/page_meta.rs
+++ b/crates/perry-runtime/src/arena/page_meta.rs
@@ -54,6 +54,7 @@ struct PageGenerationRange {
     end: usize,
     generation: HeapGeneration,
     space: HeapSpace,
+    object_starts: *mut u64,
 }
 
 impl PageGenerationRange {
@@ -113,6 +114,7 @@ impl PageGenerationCache {
                 end: 0,
                 generation: HeapGeneration::Unknown,
                 space: HeapSpace::Unknown,
+                object_starts: std::ptr::null_mut(),
             },
             valid: false,
         }
@@ -478,11 +480,22 @@ pub(crate) fn address_span_overlaps_pages(
     (first_page..=last_page).any(|page| pages.contains(&page))
 }
 
+#[cfg(test)]
 pub(crate) fn register_block_space(
     base: usize,
     size: usize,
     generation: HeapGeneration,
     space: HeapSpace,
+) {
+    register_block_space_with_object_starts(base, size, generation, space, std::ptr::null_mut());
+}
+
+pub(crate) fn register_block_space_with_object_starts(
+    base: usize,
+    size: usize,
+    generation: HeapGeneration,
+    space: HeapSpace,
+    object_starts: *mut u64,
 ) {
     if base == 0 || size == 0 || matches!(generation, HeapGeneration::Unknown) {
         return;
@@ -493,6 +506,7 @@ pub(crate) fn register_block_space(
         end,
         generation,
         space,
+        object_starts,
     };
     let first_key = generation_class_key_for_addr(base);
     let last_key = generation_class_key_for_addr(end - 1);
@@ -927,7 +941,7 @@ fn classify_heap_generation_uncached(addr: usize, key: usize) -> HeapGeneration 
 
 #[inline]
 pub(crate) fn classify_heap_space(addr: usize) -> HeapSpace {
-    classify_heap_space_in_range(addr).map_or(HeapSpace::Unknown, |(space, _)| space)
+    classify_heap_space_in_range(addr).map_or(HeapSpace::Unknown, |(space, _, _)| space)
 }
 
 /// [`classify_heap_space`] plus the base of the registered range `addr` fell
@@ -948,21 +962,24 @@ pub(crate) fn classify_heap_space(addr: usize) -> HeapSpace {
 /// `CopyingPointerSet::classify_arena` calls it once per visited slot — so on a
 /// promotion-heavy cycle it runs millions of times per collection.
 #[inline(always)]
-pub(crate) fn classify_heap_space_in_range(addr: usize) -> Option<(HeapSpace, usize)> {
+pub(crate) fn classify_heap_space_in_range(addr: usize) -> Option<(HeapSpace, usize, *mut u64)> {
     if addr == 0 {
         return None;
     }
     let key = generation_class_key_for_addr(addr);
     // SAFETY: thread-local, single-threaded, and the borrow ends here.
     if let Some(range) = unsafe { (*hot_page_generation_cache()).lookup(key, addr) } {
-        return Some((range.space, range.base));
+        return Some((range.space, range.base, range.object_starts));
     }
     classify_heap_space_in_range_uncached(addr, key)
 }
 
 /// Cache-miss arm of [`classify_heap_space_in_range`].
 #[inline(never)]
-fn classify_heap_space_in_range_uncached(addr: usize, key: usize) -> Option<(HeapSpace, usize)> {
+fn classify_heap_space_in_range_uncached(
+    addr: usize,
+    key: usize,
+) -> Option<(HeapSpace, usize, *mut u64)> {
     let found = {
         let pages = hot_page_generations().borrow();
         pages.get(&key).and_then(|slot| slot.find(addr))
@@ -970,7 +987,53 @@ fn classify_heap_space_in_range_uncached(addr: usize, key: usize) -> Option<(Hea
     let range = found?;
     // SAFETY: thread-local, single-threaded, and the borrow ends here.
     unsafe { (*hot_page_generation_cache()).insert(key, range) };
-    Some((range.space, range.base))
+    Some((range.space, range.base, range.object_starts))
+}
+
+/// Record a newly initialized GC header in its owning block's exact-start
+/// bitmap. Runtime allocation paths call this after publishing the header;
+/// compiler-generated inline bump allocators perform the equivalent bit store
+/// directly through `InlineArenaState::object_starts`.
+#[inline]
+pub(crate) fn record_arena_object_start(header_addr: usize) {
+    let Some((_space, range_base, bitmap)) = classify_heap_space_in_range(header_addr) else {
+        debug_assert!(false, "arena allocation was not in a registered block");
+        return;
+    };
+    debug_assert!(
+        !bitmap.is_null(),
+        "registered arena block has no object-start bitmap"
+    );
+    if bitmap.is_null() || header_addr < range_base {
+        return;
+    }
+    let slot = (header_addr - range_base) >> super::OBJECT_START_SHIFT;
+    let word = slot / u64::BITS as usize;
+    let bit = slot % u64::BITS as usize;
+    unsafe {
+        *bitmap.add(word) |= 1u64 << bit;
+    }
+}
+
+/// True only when `header_addr` is a recorded allocation boundary in the
+/// registered block beginning at `range_base`.
+#[inline(always)]
+pub(crate) fn arena_header_is_object_start(
+    header_addr: usize,
+    range_base: usize,
+    bitmap: *mut u64,
+) -> bool {
+    if bitmap.is_null() || header_addr < range_base {
+        return false;
+    }
+    let relative = header_addr - range_base;
+    if relative & ((1 << super::OBJECT_START_SHIFT) - 1) != 0 {
+        return false;
+    }
+    let slot = relative >> super::OBJECT_START_SHIFT;
+    let word = slot / u64::BITS as usize;
+    let bit = slot % u64::BITS as usize;
+    unsafe { *bitmap.add(word) & (1u64 << bit) != 0 }
 }
 
 pub(crate) fn old_object_page_overlaps(
@@ -1763,6 +1826,7 @@ mod page_generation_hasher_tests {
                     end: addr + (1 << GENERATION_CLASS_SHIFT),
                     generation: HeapGeneration::Old,
                     space: HeapSpace::Old,
+                    object_starts: std::ptr::null_mut(),
                 }),
             );
         }

--- a/crates/perry-runtime/src/arena/promote.rs
+++ b/crates/perry-runtime/src/arena/promote.rs
@@ -388,6 +388,7 @@ fn take_block(block: PromotedBlock) -> Option<ArenaBlock> {
                 data: std::ptr::null_mut(),
                 size: 0,
                 offset: 0,
+                object_starts: Box::new([]),
                 dead_cycles: 0,
             },
         ))
@@ -572,6 +573,7 @@ fn reset_young_after_promotion() {
     ARENA.with(|arena| unsafe {
         let arena = &mut *arena.get();
         for block in arena.blocks.iter_mut() {
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
         }
@@ -593,6 +595,7 @@ fn reset_young_after_promotion() {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -600,6 +603,7 @@ fn reset_young_after_promotion() {
     for idx in [0usize, 1usize] {
         with_survivor_arena_mut(idx, |arena| {
             for block in arena.blocks.iter_mut() {
+                block.clear_object_starts();
                 block.offset = 0;
                 block.dead_cycles = 0;
             }

--- a/crates/perry-runtime/src/arena/quarantine.rs
+++ b/crates/perry-runtime/src/arena/quarantine.rs
@@ -557,6 +557,7 @@ pub(crate) fn copying_quarantine_from_spaces_and_flip() -> ArenaResetStats {
                 data: block.data,
                 size: block.size,
                 offset: 0,
+                object_starts: new_object_start_bitmap(block.size),
                 dead_cycles: 0,
             });
         }
@@ -570,6 +571,7 @@ pub(crate) fn copying_quarantine_from_spaces_and_flip() -> ArenaResetStats {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -610,6 +612,7 @@ unsafe fn detach_used_blocks(arena: &mut Arena) -> Vec<(*mut u8, usize, usize)> 
         detached.push((block.data, size, used));
         block.data = std::ptr::null_mut();
         block.size = 0;
+        block.object_starts = Box::new([]);
         block.offset = 0;
         block.dead_cycles = 0;
     }
@@ -1102,6 +1105,7 @@ mod tombstone_tests {
             data: std::ptr::null_mut(),
             size: 0,
             offset: 0,
+            object_starts: Box::new([]),
             dead_cycles: 0,
         }
     }
@@ -1136,6 +1140,7 @@ mod tombstone_tests {
                 data: backing,
                 size: SIZE,
                 offset: 0,
+                object_starts: new_object_start_bitmap(SIZE),
                 dead_cycles: 0,
             }],
             current: 0,

--- a/crates/perry-runtime/src/arena/reset.rs
+++ b/crates/perry-runtime/src/arena/reset.rs
@@ -16,6 +16,7 @@ pub fn arena_reset_all_blocks_to_zero() {
     ARENA.with(|arena| unsafe {
         let arena = &mut *arena.get();
         for block in arena.blocks.iter_mut() {
+            block.clear_object_starts();
             block.offset = 0;
         }
         arena.current = 0;
@@ -30,6 +31,7 @@ pub fn arena_reset_all_blocks_to_zero() {
                 inline.data = block.data;
                 inline.offset = 0;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -90,6 +92,7 @@ fn reset_region_to_zero(arena: &mut Arena) -> (usize, usize) {
             reset_blocks += 1;
             reusable_bytes = reusable_bytes.saturating_add(block.offset);
         }
+        block.clear_object_starts();
         block.offset = 0;
         block.dead_cycles = 0;
     }
@@ -216,6 +219,7 @@ pub(crate) fn copying_reset_from_spaces_and_flip() -> ArenaResetStats {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
+                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -326,6 +330,7 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) -> ArenaResetStats {
             // protection above, which is where the scan-miss risk
             // actually lives.
             reset_block_ranges.push((block.data as usize, block.size, block.offset));
+            block.clear_object_starts();
             block.offset = 0;
             // Don't write dead_cycles — the dealloc-candidate loop
             // below sees offset==0 + outside-recent-window and
@@ -409,6 +414,7 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) -> ArenaResetStats {
                 ARENA_TOTAL_BYTES.with(|t| t.set(t.get().saturating_sub(block.size)));
                 block.data = std::ptr::null_mut();
                 block.size = 0;
+                block.object_starts = Box::new([]);
                 block.offset = 0;
                 block.dead_cycles = 0;
             }
@@ -489,6 +495,7 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) -> ArenaResetStats {
                         inline.data = block.data;
                         inline.offset = block.offset;
                         inline.size = block.size;
+                        inline.object_starts = block.object_starts_ptr();
                     }
                 }
             });
@@ -630,6 +637,7 @@ impl ArenaResetEmptyBlocksState {
             let base = block.data as usize;
             let size = block.size;
             let used = block.offset;
+            block.clear_object_starts();
             block.offset = 0;
             self.changed = true;
             Some((base, size, used))
@@ -681,6 +689,7 @@ impl ArenaResetEmptyBlocksState {
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             self.changed = true;
@@ -736,6 +745,7 @@ impl ArenaResetEmptyBlocksState {
                             inline.data = block.data;
                             inline.offset = block.offset;
                             inline.size = block.size;
+                            inline.object_starts = block.object_starts_ptr();
                         }
                     }
                 }
@@ -852,6 +862,7 @@ impl SurvivorArenaReclaimState {
             if used != 0 {
                 self.stats.reset_blocks = self.stats.reset_blocks.saturating_add(1);
             }
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
             self.changed = true;
@@ -868,6 +879,7 @@ impl SurvivorArenaReclaimState {
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             self.stats.record_block_release(size, release);
@@ -1121,6 +1133,7 @@ impl OldArenaReclaimDeadBlocksState {
             if used != 0 {
                 self.stats.reset_blocks = self.stats.reset_blocks.saturating_add(1);
             }
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
             old_gen_in_use_bytes_sub(used);
@@ -1136,6 +1149,7 @@ impl OldArenaReclaimDeadBlocksState {
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             self.stats.record_block_release(size, release);
@@ -1207,6 +1221,7 @@ pub(crate) fn old_arena_reclaim_dead_blocks(block_has_live: &[bool]) -> ArenaRes
             if used != 0 {
                 stats.reset_blocks = stats.reset_blocks.saturating_add(1);
             }
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
             old_gen_in_use_bytes_sub(used);
@@ -1224,6 +1239,7 @@ pub(crate) fn old_arena_reclaim_dead_blocks(block_has_live: &[bool]) -> ArenaRes
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             stats.record_block_release(size, release);
@@ -1306,6 +1322,7 @@ pub(crate) fn old_arena_reclaim_selected_dead_blocks(
             if used != 0 {
                 stats.reset_blocks = stats.reset_blocks.saturating_add(1);
             }
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
             old_gen_in_use_bytes_sub(used);
@@ -1321,6 +1338,7 @@ pub(crate) fn old_arena_reclaim_selected_dead_blocks(
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             stats.record_block_release(size, release);
@@ -1397,6 +1415,7 @@ fn reclaim_dead_survivor_arena_blocks(
             if used != 0 {
                 stats.reset_blocks = stats.reset_blocks.saturating_add(1);
             }
+            block.clear_object_starts();
             block.offset = 0;
             block.dead_cycles = 0;
             changed = true;
@@ -1415,6 +1434,7 @@ fn reclaim_dead_survivor_arena_blocks(
             ARENA_TOTAL_BYTES.with(|total| total.set(total.get().saturating_sub(size)));
             block.data = std::ptr::null_mut();
             block.size = 0;
+            block.object_starts = Box::new([]);
             block.offset = 0;
             block.dead_cycles = 0;
             stats.record_block_release(size, release);

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -106,6 +106,30 @@ fn reset_single_reclaimable_nursery_block(
 }
 
 #[test]
+fn object_start_bitmap_tracks_boundaries_and_clears_on_reset() {
+    run_with_fresh_arenas(|| {
+        let user = arena_alloc_gc(64, 8, GC_TYPE_ARRAY) as usize;
+        let header = user - GC_HEADER_SIZE;
+        let (_, range_base, bitmap) =
+            classify_heap_space_in_range(user).expect("allocation must be in an arena range");
+
+        assert!(arena_header_is_object_start(header, range_base, bitmap));
+        assert!(
+            !arena_header_is_object_start(header + 8, range_base, bitmap),
+            "an aligned payload word must not be recorded as an object start"
+        );
+
+        arena_reset_all_blocks_to_zero();
+        let (_, reset_base, reset_bitmap) =
+            classify_heap_space_in_range(user).expect("reset retains the arena block registration");
+        assert!(
+            !arena_header_is_object_start(header, reset_base, reset_bitmap),
+            "reset must clear stale object boundaries before block reuse"
+        );
+    });
+}
+
+#[test]
 fn survivor_reclaim_resets_dead_blocks() {
     run_with_fresh_arenas(|| {
         let baseline = arena_telemetry_snapshot();

--- a/crates/perry-runtime/src/gc/copying_pointer_set.rs
+++ b/crates/perry-runtime/src/gc/copying_pointer_set.rs
@@ -101,7 +101,9 @@ impl CopyingPointerSet {
         // becoming a read of the unmapped page below it. Before #7742 this was
         // two `classify_heap_space` calls for addresses 8 bytes apart, on
         // EVERY visited slot.
-        let Some((space, range_base)) = crate::arena::classify_heap_space_in_range(addr) else {
+        let Some((space, range_base, object_starts)) =
+            crate::arena::classify_heap_space_in_range(addr)
+        else {
             return None;
         };
         let header_addr = addr - GC_HEADER_SIZE;
@@ -122,6 +124,14 @@ impl CopyingPointerSet {
                 | crate::arena::HeapSpace::Old
                 | crate::arena::HeapSpace::PromotedYoung
         ) {
+            return None;
+        }
+        // Header fields alone cannot distinguish a genuine allocation from
+        // payload bytes that happen to encode the same type, flags and size.
+        // The per-block bitmap is allocation-authored evidence that this exact
+        // address is an object boundary; test it before dereferencing bytes as
+        // a `GcHeader`.
+        if !crate::arena::arena_header_is_object_start(header_addr, range_base, object_starts) {
             return None;
         }
         let header = header_addr as *mut GcHeader;

--- a/crates/perry-runtime/src/gc/forwarding.rs
+++ b/crates/perry-runtime/src/gc/forwarding.rs
@@ -150,7 +150,8 @@ pub(super) fn forwarding_walk_header(user_addr: usize) -> Option<*mut GcHeader> 
     // #7742: one page-map probe answers both classifications. The range base
     // is the guard that keeps a garbage candidate at the very start of a
     // registered range from becoming a read of the unmapped page below it.
-    let (_space, range_base) = crate::arena::classify_heap_space_in_range(user_addr)?;
+    let (_space, range_base, _object_starts) =
+        crate::arena::classify_heap_space_in_range(user_addr)?;
     let header_addr = user_addr - GC_HEADER_SIZE;
     if header_addr < range_base {
         return None;
@@ -190,7 +191,9 @@ pub(super) fn forwarding_target_is_object_start(user_addr: usize) -> bool {
     if user_addr < GC_HEADER_SIZE {
         return false;
     }
-    if let Some((_space, range_base)) = crate::arena::classify_heap_space_in_range(user_addr) {
+    if let Some((_space, range_base, _object_starts)) =
+        crate::arena::classify_heap_space_in_range(user_addr)
+    {
         let header_addr = user_addr - GC_HEADER_SIZE;
         return header_addr >= range_base
             && unsafe { plausible_gc_header(header_addr as *mut GcHeader, true) };

--- a/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
@@ -14,10 +14,11 @@
 //!     check in the old `plausible_gc_header`)
 //!   * `gc_flags` = second byte, needs `GC_FLAG_ARENA` (0x02) — ~coin flip
 //!
-//! The fix: `plausible_gc_header` now requires `size == 24` (the known
-//! fixed total for Map: 8-byte header + 16-byte `MapHeader` payload) for
-//! fixed-layout types. A fabricated header has `size ≈ 1024`, which is
-//! rejected.
+//! The size check rejects the observed `size ≈ 1024` corruption, but payload
+//! bytes can also encode the genuine Map total of 24. The complete fix is the
+//! arena's allocation-authored object-start bitmap: `classify_arena` requires
+//! the candidate header address to be recorded there before it reads header
+//! fields.
 
 use super::*;
 
@@ -190,11 +191,8 @@ fn test_classify_arena_rejects_interior_pointer_as_map() {
         "interior pointer with fabricated Map header (size=1024) must NOT classify"
     );
 
-    // Also verify a genuine-size fabricated header (size=24) at the same
-    // location WOULD have been accepted without the fix — but with the
-    // fix, the fixed-layout check passes, so classify_arena returns Some.
-    // This confirms the check is specific to the size, not a blanket
-    // rejection of the address.
+    // The core #8256 case: header fields are now entirely indistinguishable
+    // from a genuine Map, but the address is not an allocation boundary.
     let genuine_size_header = GcHeader {
         obj_type: GC_TYPE_MAP,
         gc_flags: GC_FLAG_ARENA,
@@ -205,20 +203,8 @@ fn test_classify_arena_rejects_interior_pointer_as_map() {
         std::ptr::write(array_ptr as *mut GcHeader, genuine_size_header);
     }
     let result_genuine = ptrs.classify_arena(fabricated_user_addr);
-    // This SHOULD classify — the header now has the correct fixed size.
-    // (If it doesn't, the array payload may not be in a recognized heap
-    // space, which would also block the fabricated bug — so None is
-    // acceptable here. The key assertion is the previous one: size=1024
-    // is rejected.)
-    if result_genuine.is_some() {
-        // It classified — verify it claims to be a Map.
-        let ptr = result_genuine.unwrap();
-        unsafe {
-            assert_eq!(
-                (*ptr.header).obj_type,
-                GC_TYPE_MAP,
-                "classified fabricated-as-genuine should be Map"
-            );
-        }
-    }
+    assert!(
+        result_genuine.is_none(),
+        "correct-size fabricated Map must be rejected because its header is not an object start"
+    );
 }

--- a/crates/perry-runtime/src/gc/tests/copying_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/copying_side_tables.rs
@@ -161,6 +161,9 @@ fn test_copying_minor_rewrites_old_overflow_object_child_without_reentrant_borro
     let _overflow_guard = OverflowFieldsRootGuard;
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     crate::object::test_clear_overflow_fields_root();
+    // This focused fixture bypasses the normal runtime initialization that
+    // registers the shape table's authoritative shared keys edge.
+    crate::gc::gc_register_mutable_root_scanner(crate::object::shapes::scan_shape_table_rekey_mut);
 
     let (owner, _) = unsafe { alloc_old_test_object(8) };
     let owner_addr = owner as usize;

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1888,7 +1888,8 @@ unsafe fn set_object_keys_array_with_live(
     // #8067/#8113: every visible ShapeId resolves to the exact rooted
     // ordered-keys/live-slot descriptor. Same-pointer appends are versioned
     // inside the helper.
-    shapes::publish_object_shape_from(obj, predecessor, keys_array, live_inline_slot_count);
+    let successor_shape_id =
+        shapes::publish_object_shape_from(obj, predecessor, keys_array, live_inline_slot_count);
     // GC_STORE_AUDIT(BARRIERED): keys_array pointer field is followed by an object-slot barrier.
     (*obj).keys_array = keys_array;
     crate::gc::runtime_write_barrier_slot(
@@ -1896,6 +1897,14 @@ unsafe fn set_object_keys_array_with_live(
         &(*obj).keys_array as *const _ as usize,
         keys_array as u64,
     );
+    // An old receiver is invisible to an ordinary minor root walk. Arm the
+    // shared descriptor edge at publication time so its keys array is copied
+    // during the same first minor, rather than relying on a later pass over a
+    // stale from-space address. Exact object-start validation deliberately
+    // rejects that stale address once the nursery block is reset (#8256).
+    if !crate::arena::pointer_in_nursery(obj as usize) {
+        shapes::note_old_generation_carrier(shapes::shape_descriptor_by_id(successor_shape_id));
+    }
 }
 
 #[inline]

--- a/crates/perry-runtime/src/value/addr_class.rs
+++ b/crates/perry-runtime/src/value/addr_class.rs
@@ -287,7 +287,7 @@ pub(crate) unsafe fn try_read_tracked_gc_header(
 ) -> Option<std::ptr::NonNull<GcHeader>> {
     let (header_addr, storage) = classify_tracked_gc_header_with(
         addr,
-        |candidate| crate::arena::classify_heap_space_in_range(candidate).map(|(_, base)| base),
+        |candidate| crate::arena::classify_heap_space_in_range(candidate).map(|(_, base, _)| base),
         crate::gc::gc_malloc_header_is_tracked,
     )?;
     if header_addr % std::mem::align_of::<GcHeader>() != 0 {


### PR DESCRIPTION
Fixes #8256

## Summary

- add a per-arena-block object-start bitmap with one bit per 8-byte allocation slot (1.5625% metadata overhead)
- stamp both runtime and compiler-generated inline allocations, and keep the bitmap synchronized across block reset, promotion, quarantine, and reuse
- require an exact recorded allocation boundary in the copying-minor classifier, rejecting correct-size fabricated Map/Set headers in payload bytes with an O(1) lookup and no all-object walk
- arm old-object shared shape edges at publication so their young keys arrays are rewritten in the same minor under exact-start validation

## Tests

- cargo test -p perry-runtime --lib (2558 passed, 4 ignored)
- cargo check -p perry-codegen --lib
- cargo test -p perry-codegen --lib the_inline_allocator_stores_its_header_prefix_as_one_vector_image
- cargo fmt --all -- --check
- git diff --check

No version bump included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection accuracy by tracking valid object boundaries during arena allocation.
  * Prevented invalid or fabricated memory addresses from being mistaken for live objects.
  * Improved handling of shared object metadata during minor collections.
  * Ensured allocation metadata is correctly reset when memory blocks are recycled or cleared.
* **Tests**
  * Added regression coverage for object-boundary validation, arena resets, and overflow-object collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->