### PR TITLE
fix: preserve aliased native constructor proofs

### DIFF
--- a/changelog.d/8278-aliased-native-constructor-proofs.md
+++ b/changelog.d/8278-aliased-native-constructor-proofs.md
@@ -1,0 +1,7 @@
+### fix(codegen): preserve aliased native constructor proofs
+
+Native classes imported under a local alias now retain their canonical
+constructor proof through codegen. Reading `net.Socket` methods as values from
+an aliased instance therefore returns bound functions, matching the unaliased
+import. The proof remains gated to unambiguous native class entries in the API
+manifest. Fixes #8222.

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -51,6 +51,8 @@ pub(crate) use predicates::{
 // `super::*`) can keep calling `tuple_index_literal` directly.
 #[cfg(test)]
 pub(crate) use predicates::tuple_index_literal;
+#[cfg(test)]
+pub(crate) use refine::is_imported_native_constructor_class;
 pub(crate) use refine::{
     compute_auto_captures, declared_array_property_claim, is_crypto_digest_chain,
     is_global_constructor_expr, is_process_namespace_version_property, proven_type_from_init,

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -259,12 +259,64 @@ pub(crate) fn proven_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             is_async: *is_async,
             is_generator: *is_generator,
         })),
-        // A constructor can explicitly return a different object, so `new C`
-        // proves only Object, never C's class-specific layout.
+        // #8222: native constructors have a compiler-owned runtime contract,
+        // so their result keeps its canonical class identity. This matters for
+        // aliased named imports (`Socket as Sk`): HIR canonicalizes `new Sk()`
+        // to `New { class_name: "Socket" }`, and method-value reads need that
+        // runtime proof to bind `socket.connect` instead of doing a missing
+        // dynamic-property lookup. The manifest class gate keeps this narrower
+        // than arbitrary `new C()`; user constructors can explicitly return a
+        // different object and therefore remain proven only as Object.
+        Expr::New { class_name, .. }
+            if is_imported_native_constructor_class(
+                ctx.imported_class_sources,
+                ctx.imported_class_original_names,
+                class_name,
+            ) =>
+        {
+            Some(HirType::Named(class_name.clone()))
+        }
+        // A user constructor can explicitly return a different object, so
+        // `new C` proves only Object, never C's class-specific layout.
         Expr::New { .. } => Some(HirType::Object(Default::default())),
         Expr::BigInt(_) => Some(HirType::BigInt),
         _ => None,
     }
+}
+
+pub(crate) fn is_imported_native_constructor_class(
+    imported_class_sources: &std::collections::HashMap<String, String>,
+    imported_class_original_names: &std::collections::HashMap<String, String>,
+    class_name: &str,
+) -> bool {
+    let alias_sources = imported_class_original_names
+        .iter()
+        .filter(|(_, original)| original.as_str() == class_name)
+        .filter_map(|(local, _)| imported_class_sources.get(local));
+    let candidates = imported_class_sources
+        .get(class_name)
+        .into_iter()
+        .chain(alias_sources);
+    let mut resolved_module = None;
+    for source in candidates {
+        let module = source.strip_prefix("node:").unwrap_or(source);
+        if resolved_module.is_some_and(|resolved| resolved != module) {
+            // The canonical name can be imported from multiple sources in one
+            // module. Once HIR has erased an alias to the canonical name, that
+            // shape is ambiguous and must not become a class-specific proof.
+            return false;
+        }
+        resolved_module = Some(module);
+    }
+    let Some(module) = resolved_module else {
+        return false;
+    };
+
+    perry_api_manifest::API_MANIFEST.iter().any(|entry| {
+        entry.module == module
+            && entry.name == class_name
+            && matches!(entry.kind, perry_api_manifest::ApiKind::Class)
+    })
 }
 
 /// Refine an `Any`-typed local's static type based on its initializer

--- a/crates/perry-codegen/src/type_analysis_tests.rs
+++ b/crates/perry-codegen/src/type_analysis_tests.rs
@@ -3,6 +3,57 @@ use perry_hir::infer_expr_type;
 use std::collections::{HashMap, HashSet};
 
 #[test]
+fn imported_native_constructor_proof_recovers_canonical_alias() {
+    let aliased_sources = HashMap::from([("Sk".to_string(), "net".to_string())]);
+    let aliased_names = HashMap::from([("Sk".to_string(), "Socket".to_string())]);
+    assert!(is_imported_native_constructor_class(
+        &aliased_sources,
+        &aliased_names,
+        "Socket"
+    ));
+
+    let direct_sources = HashMap::from([("Socket".to_string(), "node:net".to_string())]);
+    assert!(is_imported_native_constructor_class(
+        &direct_sources,
+        &HashMap::new(),
+        "Socket"
+    ));
+}
+
+#[test]
+fn imported_native_constructor_proof_rejects_non_native_or_non_class_imports() {
+    let local_sources = HashMap::from([("Sk".to_string(), "./dep".to_string())]);
+    let socket_alias = HashMap::from([("Sk".to_string(), "Socket".to_string())]);
+    assert!(!is_imported_native_constructor_class(
+        &local_sources,
+        &socket_alias,
+        "Socket"
+    ));
+
+    let net_sources = HashMap::from([("c".to_string(), "net".to_string())]);
+    let function_alias = HashMap::from([("c".to_string(), "connect".to_string())]);
+    assert!(!is_imported_native_constructor_class(
+        &net_sources,
+        &function_alias,
+        "connect"
+    ));
+
+    let ambiguous_sources = HashMap::from([
+        ("Sk".to_string(), "net".to_string()),
+        ("LocalSocket".to_string(), "./dep".to_string()),
+    ]);
+    let ambiguous_aliases = HashMap::from([
+        ("Sk".to_string(), "Socket".to_string()),
+        ("LocalSocket".to_string(), "Socket".to_string()),
+    ]);
+    assert!(!is_imported_native_constructor_class(
+        &ambiguous_sources,
+        &ambiguous_aliases,
+        "Socket"
+    ));
+}
+
+#[test]
 fn hir_inferred_refinable_type_reuses_codegen_local_types() {
     let mut local_types = HashMap::new();
     local_types.insert(7, HirType::String);


### PR DESCRIPTION
## Summary

- preserve canonical runtime type proofs for constructors imported from native modules
- recover aliased named imports through their original export names
- reject non-class, non-native, and ambiguous import-source proofs

## Testing

- `cargo test -p perry-codegen --lib imported_native_constructor_proof --release -- --nocapture`
- `cargo test -p perry --test aliased_native_class_import --release aliased_net_socket_keeps_native_methods -- --exact --nocapture`
- `cargo test -p perry --test aliased_native_class_import --release aliased_matches_unaliased_for_native_class -- --exact --nocapture`
- `cargo fmt -p perry-codegen -- --check`
- `python scripts/check_test_registration.py`

Fixes #8222