### PR TITLE
fix(perf_hooks): expose namespace default export

### DIFF
--- a/crates/perry-api-manifest/src/entries/part_3.rs
+++ b/crates/perry-api-manifest/src/entries/part_3.rs
@@ -1389,6 +1389,11 @@ pub(crate) const API_MANIFEST_PART_3: &[ApiEntry] = &[
     method("perf_hooks", "createHistogram", false, None),
     internal_property("perf_hooks", "timeOrigin"),
     internal_property("perf_hooks", "nodeTiming"),
+    // The ESM namespace exposes the underlying CJS `module.exports` object as
+    // `default`. Keep this in the manifest so the native-module member gate
+    // lets the runtime resolve that object instead of folding the read to
+    // `undefined` before codegen (#8236).
+    property("perf_hooks", "default"),
     property("perf_hooks", "performance"),
     property("perf_hooks", "constants"),
     class("perf_hooks", "Performance"),

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -273,14 +273,10 @@ export function perfHooksDefault() {
   return hooks.default;
 }
 "#;
-    let module = perry_parser::parse_typescript(source, "perf-hooks-default.ts")
-        .expect("source parses");
-    let hir = super::lower_module(
-        &module,
-        "perf-hooks-default",
-        "perf-hooks-default.ts",
-    )
-    .expect("source lowers");
+    let module =
+        perry_parser::parse_typescript(source, "perf-hooks-default.ts").expect("source parses");
+    let hir = super::lower_module(&module, "perf-hooks-default", "perf-hooks-default.ts")
+        .expect("source lowers");
     let function = hir
         .functions
         .iter()

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -266,6 +266,39 @@ fn test_native_module_binding_value_namespace() {
 }
 
 #[test]
+fn native_perf_hooks_namespace_default_reaches_runtime_lookup() {
+    let source = r#"
+import * as hooks from "node:perf_hooks";
+export function perfHooksDefault() {
+  return hooks.default;
+}
+"#;
+    let module = perry_parser::parse_typescript(source, "perf-hooks-default.ts")
+        .expect("source parses");
+    let hir = super::lower_module(
+        &module,
+        "perf-hooks-default",
+        "perf-hooks-default.ts",
+    )
+    .expect("source lowers");
+    let function = hir
+        .functions
+        .iter()
+        .find(|function| function.name == "perfHooksDefault")
+        .expect("exported function is lowered");
+
+    assert!(matches!(
+        function.body.as_slice(),
+        [Stmt::Return(Some(crate::ir::Expr::PropertyGet {
+            object,
+            property,
+            ..
+        }))] if property == "default"
+            && matches!(object.as_ref(), crate::ir::Expr::NativeModuleRef(module) if module == "perf_hooks")
+    ));
+}
+
+#[test]
 fn test_lower_type_param_scoping() {
     let mut ctx = make_ctx();
     assert!(!ctx.is_type_param("T"));


### PR DESCRIPTION
## Summary

- declare `perf_hooks.default` in the native API manifest so namespace reads reach the runtime resolver
- preserve the Node identity relationship between `hooks.default.performance` and `hooks.performance`
- add a lowering regression for the namespace default read
- no version bump

Closes #8236

## Tests

- `cargo test -p perry-hir native_perf_hooks_namespace_default_reaches_runtime_lookup`
- `PERRY_SKIP_BUILD=1 PERRY_BIN="$PWD/target/release/perry" PERRY_RUNTIME_DIR="$PWD/target/release" ./run_parity_tests.sh --suite node-suite --module perf_hooks` (142/148 parity passes; 0 compile failures; `imports/namespace-keys` passes; six pre-existing receiver-branding/timerify mismatches remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ESM namespace access to the CommonJS exports of `node:perf_hooks` through the `default` property.

* **Bug Fixes**
  * Fixed namespace imports from `node:perf_hooks` so the `default` export is preserved correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->