### PR TITLE
fix: throw for array-only methods on typed arrays

### DIFF
--- a/changelog.d/8280-typed-array-method-availability.md
+++ b/changelog.d/8280-typed-array-method-availability.md
@@ -1,0 +1,5 @@
+### fix(typedarray): keep array-only methods absent
+
+Typed arrays now throw a `TypeError` when array-only methods such as `flat`,
+`push`, or `toSpliced` are missing, instead of silently returning the receiver.
+Own and prototype overrides remain callable. Fixes #8138.

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -16,7 +16,9 @@ use crate::lower_string_method::{
     is_known_string_method_name, lower_string_method, lower_string_method_from_proven_box,
 };
 use crate::rooting::{any_operand_may_collect, open_rooted_group, Repr};
-use crate::type_analysis::{is_array_expr, is_string_expr, receiver_class_name};
+use crate::type_analysis::{
+    is_array_expr, is_string_expr, is_typed_array_expr, receiver_class_name,
+};
 use crate::types::{DOUBLE, I1, I64};
 
 mod dynamic_dispatch;
@@ -33,6 +35,7 @@ mod static_dispatch;
 pub(crate) use helpers::{
     class_chain_has_field_named, is_array_only_method_name, is_date_receiver,
     is_inherited_object_prototype_method, resolve_static_dispatch_cls, string_only_method_arity_ok,
+    typed_array_lacks_array_method,
 };
 
 /// Preserve the old String-method fast path for an unproven receiver without
@@ -161,7 +164,10 @@ pub fn try_lower_property_get_method_call(
     // `trim`/`split`/`charAt` method (Zod schemas are the reported case).
     // Keep the static fast path positive-proof-only; the runtime dispatcher
     // below handles both genuine Any-typed strings and user methods.
-    if is_array_expr(ctx, object) && !is_inherited_object_prototype_method(property) {
+    if is_array_expr(ctx, object)
+        && !is_inherited_object_prototype_method(property)
+        && !(is_typed_array_expr(ctx, object) && typed_array_lacks_array_method(property))
+    {
         return Ok(Some(lower_array_method(ctx, object, property, args)?));
     }
 

--- a/crates/perry-codegen/src/lower_call/property_get/helpers.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/helpers.rs
@@ -28,6 +28,14 @@ pub(crate) fn is_array_only_method_name(name: &str) -> bool {
     )
 }
 
+/// Array methods that are deliberately absent from `%TypedArray%.prototype`.
+pub(crate) fn typed_array_lacks_array_method(name: &str) -> bool {
+    matches!(
+        name,
+        "flat" | "flatMap" | "push" | "pop" | "shift" | "unshift" | "splice" | "toSpliced"
+    )
+}
+
 /// Whether an unproven receiver's argument count can use the selected static
 /// String lowering. Invalid counts must bypass the tag diamond because its
 /// String arm is emitted eagerly and may reject them before runtime dispatch.

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -38,7 +38,7 @@ pub(crate) use numeric::{
 pub(crate) use pod::{
     add_operands_have_pod_materialization_hazard,
     expr_may_return_boxed_value_from_raw_f64_fallback, expression_has_numeric_length,
-    is_fixed_width_buffer_numeric_read, is_numeric_typed_array_class,
+    is_fixed_width_buffer_numeric_read, is_numeric_typed_array_class, is_typed_array_expr,
     numeric_proof_is_declared_only, pod_record_field_is_numeric,
     scalar_replaced_array_element_is_raw_f64, scalar_replaced_field_is_raw_f64,
     scalar_replaced_field_raw_f64_store_state,

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -10,7 +10,7 @@ use perry_hir::Expr;
 use crate::expr::FnCtx;
 use crate::type_analysis_class_fields::{class_field_declared_type, declared_field_type};
 
-pub(crate) fn is_numeric_typed_array_class(name: &str) -> bool {
+pub(crate) fn is_typed_array_class(name: &str) -> bool {
     matches!(
         name,
         "Int8Array"
@@ -23,7 +23,22 @@ pub(crate) fn is_numeric_typed_array_class(name: &str) -> bool {
             | "Float16Array"
             | "Float32Array"
             | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
     )
+}
+
+pub(crate) fn is_numeric_typed_array_class(name: &str) -> bool {
+    is_typed_array_class(name) && !matches!(name, "BigInt64Array" | "BigUint64Array")
+}
+
+pub(crate) fn is_typed_array_expr(ctx: &FnCtx<'_>, object: &Expr) -> bool {
+    matches!(
+        static_type_of(ctx, object),
+        Some(HirType::Named(name)) if is_typed_array_class(&name)
+    ) || receiver_class_name(ctx, object)
+        .as_deref()
+        .is_some_and(is_typed_array_class)
 }
 
 pub(crate) fn expression_has_numeric_length(ctx: &FnCtx<'_>, object: &Expr) -> bool {

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -8,6 +8,8 @@ use swc_ecma_ast as ast;
 
 use crate::ir::*;
 
+use super::typed_array_lacks_array_method;
+
 /// Is `expr` a reference to a node:stream class constructor — bare
 /// (`Readable`) or namespaced (`stream.Readable`)? Used by
 /// [`chain_roots_at_stream`].
@@ -338,6 +340,17 @@ pub(super) fn try_array_only_methods(
         if let ast::Expr::Member(member) = expr.as_ref() {
             if let ast::MemberProp::Ident(method_ident) = &member.prop {
                 let method_name = method_ident.sym.as_ref();
+                // #8138: these Array-only names may only use dense Array HIR
+                // folds when the receiver is positively known to be an Array.
+                // Unknown and typed-array receivers need real property lookup.
+                if typed_array_lacks_array_method(method_name) {
+                    let recv_ty = crate::lower_types::infer_type_from_expr(&member.obj, ctx);
+                    let provably_array = matches!(recv_ty, Type::Array(_) | Type::Tuple(_))
+                        || matches!(&recv_ty, Type::Generic { base, .. } if base == "Array");
+                    if !provably_array {
+                        return Ok(Err(args));
+                    }
+                }
                 // #6718: the `args` vector holds the EVALUATED spread expression
                 // with the spread token dropped, so any arm reading a positional
                 // slot (callback, comparator, index, search value, …) would bind

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use swc_ecma_ast as ast;
 
 use super::url_search_params::build_url_search_params_method_call;
+use super::{is_typed_array_type, typed_array_lacks_array_method};
 use crate::ir::*;
 
 use super::super::{lower_expr, LoweringContext};
@@ -18,25 +19,8 @@ use super::super::{lower_expr, LoweringContext};
 /// rewritten into the corresponding `Expr::Array*` fast path. TypedArray
 /// `Named` types are deliberately treated as arrays (not class instances).
 fn receiver_is_class_instance(recv_ty: Option<&Type>) -> bool {
-    let is_typed_array = |n: &str| {
-        matches!(
-            n,
-            "Int8Array"
-                | "Int16Array"
-                | "Int32Array"
-                | "Uint8Array"
-                | "Uint8ClampedArray"
-                | "Uint16Array"
-                | "Uint32Array"
-                | "Float16Array"
-                | "Float32Array"
-                | "Float64Array"
-                | "BigInt64Array"
-                | "BigUint64Array"
-        )
-    };
     match recv_ty {
-        Some(Type::Named(n)) => !is_typed_array(n),
+        Some(ty @ Type::Named(_)) => !is_typed_array_type(ty),
         Some(Type::Generic { base, .. }) => base != "Array",
         _ => false,
     }
@@ -120,6 +104,14 @@ pub(super) fn try_local_array_methods(
                 // includes, split) — those are handled by the general dispatch which
                 // checks is_string at codegen time.
                 let type_info = ctx.lookup_local_type(&arr_name);
+                // #8138: these methods exist on Array.prototype but not on
+                // %TypedArray%.prototype. Preserve ordinary property lookup so
+                // a user-installed method wins and an absent one throws.
+                if type_info.is_some_and(is_typed_array_type)
+                    && typed_array_lacks_array_method(method_name)
+                {
+                    return Ok(Err(args));
+                }
                 // `Union<String, Void>` (e.g. `JSON.stringify` return type) is
                 // a possible-string — must NOT be treated as definitely not-a-
                 // string, otherwise `.indexOf`/`.includes` get routed through

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -19,8 +19,38 @@ use swc_ecma_ast as ast;
 
 use crate::ir::*;
 use crate::lower_types::extract_ts_type_with_ctx;
+use crate::types::Type;
 
 use super::{lower_expr, LoweringContext};
+
+fn is_typed_array_type(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Named(name)
+            if matches!(
+                name.as_str(),
+                "Int8Array"
+                    | "Int16Array"
+                    | "Int32Array"
+                    | "Uint8Array"
+                    | "Uint8ClampedArray"
+                    | "Uint16Array"
+                    | "Uint32Array"
+                    | "Float16Array"
+                    | "Float32Array"
+                    | "Float64Array"
+                    | "BigInt64Array"
+                    | "BigUint64Array"
+            )
+    )
+}
+
+fn typed_array_lacks_array_method(name: &str) -> bool {
+    matches!(
+        name,
+        "flat" | "flatMap" | "push" | "pop" | "shift" | "unshift" | "splice" | "toSpliced"
+    )
+}
 
 mod array_only_methods;
 mod crypto;

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -152,6 +152,13 @@ pub(super) unsafe fn dispatch_handle(
             if let Some(r) = dispatch_typed_array_method(ta, method_name, args_ptr, args_len) {
                 return Some(r);
             }
+            if typed_array_lacks_array_method(method_name) {
+                return Some(dispatch_absent_typed_array_array_method(
+                    ta,
+                    method_name,
+                    arg_handles,
+                ));
+            }
         }
 
         // Builtin-prototype borrowing is lowered to a direct receiver call

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -821,6 +821,13 @@ pub(super) unsafe fn dispatch_primitive(
                 if let Some(r) = dispatch_typed_array_method(ta, method_name, args_ptr, args_len) {
                     return Some(r);
                 }
+                if typed_array_lacks_array_method(method_name) {
+                    return Some(dispatch_absent_typed_array_array_method(
+                        ta,
+                        method_name,
+                        arg_handles,
+                    ));
+                }
             }
         }
     }

--- a/crates/perry-runtime/src/object/native_call_method/typed_array.rs
+++ b/crates/perry-runtime/src/object/native_call_method/typed_array.rs
@@ -1,5 +1,35 @@
 use super::*;
 
+pub(super) fn typed_array_lacks_array_method(name: &str) -> bool {
+    matches!(
+        name,
+        "flat" | "flatMap" | "push" | "pop" | "shift" | "unshift" | "splice" | "toSpliced"
+    )
+}
+
+/// Resolve an Array-only method name on a typed-array receiver. Although the
+/// intrinsic prototype lacks these methods, an own property or user-patched
+/// prototype may provide one and must win before the not-callable TypeError.
+pub(super) unsafe fn dispatch_absent_typed_array_array_method(
+    ta: *mut crate::typedarray::TypedArrayHeader,
+    method_name: &str,
+    arg_handles: &[crate::gc::RuntimeHandle],
+) -> f64 {
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let value = crate::object::js_object_get_field_by_name(ta as *const ObjectHeader, key);
+    let args = crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(arg_handles);
+    let receiver = f64::from_bits(JSValue::pointer(ta as *mut u8).bits());
+    if let Some(result) = call_primitive_closure_value(receiver, value, args.as_ptr(), args.len()) {
+        return result;
+    }
+    crate::error::js_throw_type_error_not_a_function(
+        std::ptr::null(),
+        0,
+        method_name.as_ptr(),
+        method_name.len(),
+    )
+}
+
 /// Dispatch a `%TypedArray%` instance method on an already-resolved
 /// `TypedArrayHeader` pointer. Returns `Some(result)` when handled, `None` when
 /// the method isn't a typed-array method (caller falls through to the generic

--- a/crates/perry/tests/issue_8138_typed_array_method_availability.rs
+++ b/crates/perry/tests/issue_8138_typed_array_method_availability.rs
@@ -1,0 +1,167 @@
+//! Regression tests for #8138: Array-only methods must not resolve on
+//! `%TypedArray%` instances.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn runtime_dir() -> PathBuf {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static")
+            .output()
+            .expect("build static runtime archives");
+        assert!(
+            build.status.success(),
+            "static runtime build failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        // Windows' RS4GC path cannot lower the try/catch assertions in this
+        // fixture yet (#7354); this issue is independent of native roots.
+        .env("PERRY_RS4GC", "0")
+        // Link the archives built from this worktree, not an auto-optimized
+        // runtime cache that may predate the fix.
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn array_only_methods_throw_on_typed_arrays_without_mutating_them() {
+    let stdout = compile_and_run(
+        r#"
+function opaque(value: any): any { return value; }
+
+function report(name: string, array: Int32Array, action: () => any) {
+  let threw = false;
+  let errorName = "none";
+  try {
+    action();
+  } catch (error: any) {
+    threw = true;
+    errorName = error.name;
+  }
+  console.log(name + ":" + threw + ":" + errorName + ":" + array.join(","));
+}
+
+const flat = new Int32Array([1, 2, 3]);
+report("flat", flat, () => (flat as any).flat());
+
+const flatMap = new Int32Array([1, 2, 3]);
+report("flatMap", flatMap, () => (flatMap as any).flatMap((x: number) => [x]));
+
+const push = new Int32Array([1, 2, 3]);
+report("push", push, () => (push as any).push(9));
+
+const pop = new Int32Array([1, 2, 3]);
+report("pop", pop, () => (pop as any).pop());
+
+const shift = new Int32Array([1, 2, 3]);
+report("shift", shift, () => (shift as any).shift());
+
+const unshift = new Int32Array([1, 2, 3]);
+report("unshift", unshift, () => (unshift as any).unshift(9));
+
+const splice = new Int32Array([1, 2, 3]);
+report("splice", splice, () => (splice as any).splice(1, 1));
+
+const toSpliced = new Int32Array([1, 2, 3]);
+report("toSpliced", toSpliced, () => (toSpliced as any).toSpliced(1, 1));
+
+const dynamic = new Int32Array([1, 2, 3]);
+report("dynamic-flatMap", dynamic, () => opaque(dynamic).flatMap((x: number) => [x]));
+
+const own = new Int32Array([1, 2, 3]);
+(own as any).flat = () => 42;
+console.log("own-flat:" + (own as any).flat() + ":" + own.join(","));
+
+(Int32Array.prototype as any).flat = () => 43;
+const inherited = new Int32Array([1, 2, 3]);
+console.log("prototype-flat:" + (inherited as any).flat() + ":" + inherited.join(","));
+
+const control = new Int32Array([1, 2, 3]);
+report("control", control, () => { throw new TypeError("control"); });
+"#,
+    );
+
+    for name in [
+        "flat",
+        "flatMap",
+        "push",
+        "pop",
+        "shift",
+        "unshift",
+        "splice",
+        "toSpliced",
+        "dynamic-flatMap",
+        "control",
+    ] {
+        let expected = format!("{name}:true:TypeError:1,2,3");
+        assert!(
+            stdout.lines().any(|line| line.trim() == expected),
+            "{name} must throw TypeError without changing the receiver (got:\n{stdout})"
+        );
+    }
+    assert!(stdout
+        .lines()
+        .any(|line| line.trim() == "own-flat:42:1,2,3"));
+    assert!(stdout
+        .lines()
+        .any(|line| line.trim() == "prototype-flat:43:1,2,3"));
+}


### PR DESCRIPTION
## Summary
- keep array-only methods absent from `%TypedArray%.prototype` out of Array-specific lowering
- preserve own and prototype user methods before throwing `TypeError` for missing methods
- cover all eight affected methods, dynamic dispatch, non-mutation, and overrides end to end

Fixes #8138

## Testing
- `cargo test --profile perry-dev -p perry --test issue_8138_typed_array_method_availability -- --nocapture`
- `cargo test --profile perry-dev -p perry-hir -p perry-runtime --lib`
- `cargo test --profile perry-dev -p perry-codegen --lib` (1,063 passed; two unrelated Windows object-byte determinism tests fail because temporary object paths differ)
- `./scripts/test_affected_crates.sh --base origin/main` (runtime: 2,498 passed, 4 ignored; the subsequent rebuild stopped with Windows `os error 112` because the drive ran out of space)
- `python scripts/check_test_registration.py`
- `cargo fmt -p perry-hir -p perry-codegen -p perry-runtime -p perry -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected typed-array behavior for array-only methods.
  * Unsupported methods now throw `TypeError` instead of incorrectly returning the typed array.
  * Own-property and prototype overrides remain callable.
  * Prevented unsupported method calls from mutating typed arrays.

* **Tests**
  * Added regression coverage for numeric and dynamically typed typed-array calls, overrides, and error handling.

* **Documentation**
  * Added a changelog entry describing the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->