### PR TITLE
perf(codegen): propagate array element shapes into callbacks

### DIFF
--- a/changelog.d/8103-array-callback-shape.md
+++ b/changelog.d/8103-array-callback-shape.md
@@ -1,0 +1,8 @@
+### Performance
+
+- Propagate proven local-array element shapes into direct inline arrow
+  callbacks for `forEach`, `map`, `reduce`, and `reduceRight`. Field reads on a
+  contained callback element now use fixed-offset loads instead of repeating
+  the class-shape and by-name lookup guards. Opaque, escaping, asynchronous,
+  generator, recursive, rest/`arguments`, and source-array-aliasing callbacks
+  remain on the guarded path.

--- a/crates/perry-codegen/src/codegen/closure.rs
+++ b/crates/perry-codegen/src/codegen/closure.rs
@@ -803,7 +803,7 @@ pub(super) fn compile_closure(
             .return_shape_class(func_id)
             .is_some(),
     );
-    let native_facts = crate::collectors::collect_native_region_fact_graph(
+    let mut native_facts = crate::collectors::collect_native_region_fact_graph(
         body,
         &[],
         &flat_const_ids,
@@ -817,6 +817,12 @@ pub(super) fn compile_closure(
         &cross_module.compile_time_constants,
         &cross_module.module_dispatch,
     );
+    if let Some(callback_shapes) = cross_module.array_callback_shapes.get(&func_id) {
+        native_facts
+            .shape_stability
+            .shape_proven_ptr_locals
+            .extend(callback_shapes.clone());
+    }
 
     // Representation-selection context gates (see codegen/function.rs).
     // Async-step closures (CPS-rewritten `async` closures — the rewrite clears

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1987,6 +1987,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         target_triple: triple.clone(),
         app_metadata: opts.app_metadata.clone(),
         module_dispatch: module_dispatch_facts,
+        array_callback_shapes: std::collections::HashMap::new(),
         // Inline-hot-small pre-pass (#6850 follow-up): FuncIds with an in-loop
         // call site AND few total call sites, so small hot callees can earn
         // `inlinehint` while the call-site cap bounds duplication.
@@ -2334,6 +2335,29 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         closure_lengths,
         closure_arrow_functions,
     } = closure_collect::collect_module_closures(hir);
+
+    // #8103: closure bodies are emitted before their enclosing regions. Prove
+    // inline array-callback element shapes module-wide now, while both sides
+    // of the boundary are available, then inject the vetted parameter facts
+    // when each closure is compiled.
+    let mut array_callback_shapes = crate::collectors::collect_array_callback_shapes(
+        hir,
+        &closures,
+        &module_boxed_vars,
+        &module_globals,
+        &module_receiver_types,
+        &class_table,
+        &cross_module.module_dispatch,
+    );
+    // Async/generator transforms clear the flags on the closure expression,
+    // but preserve the original identity in these module sets. Their callback
+    // parameters outlive the synchronous array HOF invocation and therefore
+    // cannot inherit its region-local containment fact.
+    array_callback_shapes.retain(|func_id, _| {
+        !cross_module.async_step_closures.contains(func_id)
+            && !cross_module.local_generator_funcs.contains(func_id)
+    });
+    cross_module.array_callback_shapes = array_callback_shapes;
 
     cross_module.typed_f64_closures.clear();
     cross_module.typed_i32_closures.clear();

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -785,6 +785,13 @@ pub(crate) struct CrossModuleCtx {
     /// the mutation usually lives in a *different* function (or a constructor,
     /// or a field initializer) than the `new`, so a per-function walk misses it.
     pub module_dispatch: crate::collectors::ModuleDispatchFacts,
+    /// #8103: inline array-callback element parameters whose enclosing region
+    /// proved an exact, stable element shape. Closures compile independently,
+    /// so this module pre-pass carries the fact across that boundary.
+    pub array_callback_shapes: std::collections::HashMap<
+        u32,
+        std::collections::HashMap<u32, crate::collectors::PtrShapeLocal>,
+    >,
     /// Functions with a 3-param clamp pattern: fid → true. Call sites
     /// emit `@llvm.smax.i32` + `@llvm.smin.i32` instead of a function call.
     pub clamp3_functions: std::collections::HashSet<u32>,

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -36,6 +36,7 @@ mod proven_this;
 mod proven_this_routing_tests;
 mod ptr_numarray;
 mod ptr_shape;
+mod ptr_shape_callbacks;
 mod ptr_shape_elements;
 mod ptr_shape_report;
 mod ptr_shape_returns;
@@ -84,6 +85,7 @@ pub(crate) use proven_this::{
 };
 pub(crate) use ptr_numarray::{NumArrayDensity, NumArrayLocal};
 pub(crate) use ptr_shape::{ptr_shape_locals_enabled, PtrShapeLocal};
+pub(crate) use ptr_shape_callbacks::collect_array_callback_shapes;
 pub(crate) use ptr_shape_returns::collect_exported_return_shapes;
 pub(crate) use refs::{
     collect_let_ids, collect_ref_ids_in_expr, collect_ref_ids_in_stmts, is_clamp_call,

--- a/crates/perry-codegen/src/collectors/ptr_shape.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape.rs
@@ -358,6 +358,14 @@ pub(crate) fn collect_shape_proven_ptr_locals(
         candidates.insert(id, class_name);
         element_seeded.insert(id);
     }
+    // #8103: a direct inline array callback's element parameter is the same
+    // provenance route as a licensed indexed read. Unlike every other seed it
+    // is a parameter binding, so the use walk expects zero `Let` sites.
+    let mut callback_seeded: HashSet<u32> = HashSet::new();
+    for (id, class_name) in element_facts.callback_param_seeds() {
+        candidates.insert(id, class_name.to_owned());
+        callback_seeded.insert(id);
+    }
     if candidates.is_empty() {
         return HashMap::new();
     }
@@ -487,7 +495,8 @@ pub(crate) fn collect_shape_proven_ptr_locals(
             );
             continue;
         }
-        if let_counts.get(id).copied().unwrap_or(0) != 1 {
+        let expected_let_count = if callback_seeded.contains(id) { 0 } else { 1 };
+        if let_counts.get(id).copied().unwrap_or(0) != expected_let_count {
             deny(id, class_name, report::MULTIPLE_LET);
             continue;
         }

--- a/crates/perry-codegen/src/collectors/ptr_shape_callbacks.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_callbacks.rs
@@ -1,0 +1,189 @@
+//! Module pre-pass for `Ptr<Shape>` facts that cross an inline array-callback
+//! boundary.
+//!
+//! Array HOF callbacks are emitted as separate LLVM functions before their
+//! enclosing HIR regions are compiled. The enclosing region is the only place
+//! that can prove the source array dense and monomorphic; this pass performs
+//! that proof early and routes only the fully-vetted element-parameter facts
+//! to the corresponding closure body.
+
+use std::collections::{HashMap, HashSet};
+
+use perry_hir::{Class, Expr, Module, Param, Stmt};
+
+use super::ptr_shape::PtrShapeLocal;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn collect_array_callback_shapes(
+    hir: &Module,
+    closures: &[(u32, Expr)],
+    boxed_vars: &HashSet<u32>,
+    module_globals: &HashMap<u32, String>,
+    binding_types: &HashMap<u32, perry_hir::types::Type>,
+    classes: &HashMap<String, &Class>,
+    module_dispatch: &super::ModuleDispatchFacts,
+) -> HashMap<u32, HashMap<u32, PtrShapeLocal>> {
+    let _suppress_report = super::ptr_shape_report::SuppressScope::new();
+    let mut out = HashMap::new();
+    let mut conflicted = HashSet::new();
+
+    collect_region(
+        &hir.init,
+        &[],
+        boxed_vars,
+        module_globals,
+        binding_types,
+        classes,
+        module_dispatch,
+        &mut out,
+        &mut conflicted,
+    );
+    for function in &hir.functions {
+        collect_function(
+            function,
+            boxed_vars,
+            module_globals,
+            binding_types,
+            classes,
+            module_dispatch,
+            &mut out,
+            &mut conflicted,
+        );
+    }
+    for class in &hir.classes {
+        if let Some(constructor) = &class.constructor {
+            collect_function(
+                constructor,
+                boxed_vars,
+                module_globals,
+                binding_types,
+                classes,
+                module_dispatch,
+                &mut out,
+                &mut conflicted,
+            );
+        }
+        for function in class
+            .methods
+            .iter()
+            .chain(class.getters.iter().map(|(_, f)| f))
+            .chain(class.setters.iter().map(|(_, f)| f))
+            .chain(class.static_methods.iter())
+            .chain(class.computed_members.iter().map(|m| &m.function))
+        {
+            collect_function(
+                function,
+                boxed_vars,
+                module_globals,
+                binding_types,
+                classes,
+                module_dispatch,
+                &mut out,
+                &mut conflicted,
+            );
+        }
+    }
+
+    // Each closure is its own executable region. This second layer discovers
+    // array callbacks nested inside callbacks or ordinary closure bodies.
+    for (_, closure) in closures {
+        if let Expr::Closure { params, body, .. } = closure {
+            collect_region(
+                body,
+                params,
+                boxed_vars,
+                module_globals,
+                binding_types,
+                classes,
+                module_dispatch,
+                &mut out,
+                &mut conflicted,
+            );
+        }
+    }
+
+    for func_id in conflicted {
+        out.remove(&func_id);
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_function(
+    function: &perry_hir::Function,
+    boxed_vars: &HashSet<u32>,
+    module_globals: &HashMap<u32, String>,
+    binding_types: &HashMap<u32, perry_hir::types::Type>,
+    classes: &HashMap<String, &Class>,
+    module_dispatch: &super::ModuleDispatchFacts,
+    out: &mut HashMap<u32, HashMap<u32, PtrShapeLocal>>,
+    conflicted: &mut HashSet<u32>,
+) {
+    collect_region(
+        &function.body,
+        &function.params,
+        boxed_vars,
+        module_globals,
+        binding_types,
+        classes,
+        module_dispatch,
+        out,
+        conflicted,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_region(
+    stmts: &[Stmt],
+    params: &[Param],
+    boxed_vars: &HashSet<u32>,
+    module_globals: &HashMap<u32, String>,
+    binding_types: &HashMap<u32, perry_hir::types::Type>,
+    classes: &HashMap<String, &Class>,
+    module_dispatch: &super::ModuleDispatchFacts,
+    out: &mut HashMap<u32, HashMap<u32, PtrShapeLocal>>,
+    conflicted: &mut HashSet<u32>,
+) {
+    let element_facts = super::ptr_shape_elements::collect_element_shape_facts(
+        stmts,
+        boxed_vars,
+        module_globals,
+        classes,
+        module_dispatch,
+    );
+    // Most regions contain no array HOF at all. Avoid duplicating the more
+    // expensive complete shape/numeric proof for those regions.
+    if element_facts.callback_param_sites().next().is_none() {
+        return;
+    }
+    let not_bigint =
+        super::not_bigint_locals::collect_not_bigint_locals(stmts, params, binding_types);
+    let shape_facts = super::ptr_shape::collect_shape_proven_ptr_locals(
+        stmts,
+        boxed_vars,
+        module_globals,
+        classes,
+        module_dispatch,
+        &not_bigint,
+        &element_facts,
+    );
+
+    for (func_id, param_id) in element_facts.callback_param_sites() {
+        let Some(fact) = shape_facts.get(&param_id) else {
+            continue;
+        };
+        if conflicted.contains(&func_id) {
+            continue;
+        }
+        let params = out.entry(func_id).or_default();
+        if let Some(existing) = params.get(&param_id) {
+            if existing.class_name != fact.class_name
+                || existing.numeric_fields != fact.numeric_fields
+            {
+                conflicted.insert(func_id);
+            }
+        } else {
+            params.insert(param_id, fact.clone());
+        }
+    }
+}

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
@@ -163,6 +163,10 @@ pub(crate) struct ElementShapeFacts {
     pushed: HashMap<u32, (u32, String)>,
     /// Element-read local -> (array root it was read from, element class).
     element_reads: HashMap<u32, (u32, String)>,
+    /// Inline array-callback element parameter -> (array root, element class,
+    /// callback FuncId). The closure expression is used directly at the
+    /// admitted iterator site, so this records its sole argument route.
+    callback_params: HashMap<u32, (u32, String, u32)>,
 }
 
 impl ElementShapeFacts {
@@ -180,6 +184,7 @@ impl ElementShapeFacts {
             && self.array_roots.is_empty()
             && self.pushed.is_empty()
             && self.element_reads.is_empty()
+            && self.callback_params.is_empty()
     }
 
     /// Is `value_local`'s push into `array_local` covered by a proven array,
@@ -201,7 +206,17 @@ impl ElementShapeFacts {
     /// Group integrity: `ptr_shape.rs` promotes all of these or none of them.
     pub(crate) fn group_members(&self) -> HashMap<u32, Vec<u32>> {
         let mut out: HashMap<u32, Vec<u32>> = HashMap::new();
-        for (id, (root, _)) in self.pushed.iter().chain(self.element_reads.iter()) {
+        for (id, root) in self
+            .pushed
+            .iter()
+            .chain(self.element_reads.iter())
+            .map(|(id, (root, _))| (id, root))
+            .chain(
+                self.callback_params
+                    .iter()
+                    .map(|(id, (root, _, _))| (id, root)),
+            )
+        {
             out.entry(*root).or_default().push(*id);
         }
         out
@@ -220,6 +235,7 @@ impl ElementShapeFacts {
             .get(&local)
             .or_else(|| self.element_reads.get(&local))
             .map(|(root, _)| *root)
+            .or_else(|| self.callback_params.get(&local).map(|(root, _, _)| *root))
     }
 
     /// The proven element class of array root `root`.
@@ -232,6 +248,24 @@ impl ElementShapeFacts {
     pub(crate) fn proven_array_root(&self, id: u32) -> Option<u32> {
         let root = self.array_roots.get(&id)?;
         self.arrays.contains_key(root).then_some(*root)
+    }
+
+    /// Callback element parameters licensed by this region, paired with the
+    /// closure body that owns them. Callers still intersect these sites with
+    /// the full Ptr<Shape> containment/use proof.
+    pub(crate) fn callback_param_sites(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.callback_params
+            .iter()
+            .map(|(param, (_, _, func_id))| (*func_id, *param))
+    }
+
+    /// Callback element-parameter seeds for the enclosing region's complete
+    /// Ptr<Shape> proof. These are not independently sufficient facts: the
+    /// caller must still validate the parameter's complete use graph.
+    pub(crate) fn callback_param_seeds(&self) -> impl Iterator<Item = (u32, &str)> + '_ {
+        self.callback_params
+            .iter()
+            .map(|(param, (_, class_name, _))| (*param, class_name.as_str()))
     }
 }
 
@@ -327,6 +361,7 @@ pub(crate) fn collect_element_shape_facts(
         disqualified: HashSet::new(),
         pushes: HashMap::new(),
         reads: Vec::new(),
+        callbacks: Vec::new(),
         idx_writes: HashMap::new(),
         bounded: Vec::new(),
         in_closure: false,
@@ -336,6 +371,7 @@ pub(crate) fn collect_element_shape_facts(
         mut disqualified,
         pushes,
         reads,
+        callbacks,
         idx_writes,
         ..
     } = walk;
@@ -447,11 +483,34 @@ pub(crate) fn collect_element_shape_facts(
         element_reads.insert(read.local, (read.root, class_name.clone()));
     }
 
+    // The callback parameter has the same provenance as an admitted indexed
+    // read, but its binding is a closure parameter rather than a `Let` in this
+    // region. Preserve the identical precise-root requirement: a declared
+    // scalar parameter would not receive a shadow slot while a moving minor
+    // can relocate the object during the callback.
+    let mut callback_params: HashMap<u32, (u32, String, u32)> = HashMap::new();
+    for callback in callbacks {
+        let Some(class_name) = arrays.get(&callback.root) else {
+            continue;
+        };
+        if boxed_vars.contains(&callback.param)
+            || module_globals.contains_key(&callback.param)
+            || is_definitely_non_pointer_type(&callback.param_ty)
+        {
+            continue;
+        }
+        callback_params.insert(
+            callback.param,
+            (callback.root, class_name.clone(), callback.func_id),
+        );
+    }
+
     ElementShapeFacts {
         arrays,
         array_roots,
         pushed,
         element_reads,
+        callback_params,
     }
 }
 
@@ -495,12 +554,20 @@ struct ReadSite {
     local: u32,
 }
 
+struct CallbackReadSite {
+    root: u32,
+    func_id: u32,
+    param: u32,
+    param_ty: Type,
+}
+
 struct ArrayWalk<'a> {
     roots: &'a HashMap<u32, u32>,
     alias_edges: &'a [(u32, u32)],
     disqualified: HashSet<u32>,
     pushes: HashMap<u32, Vec<PushValue>>,
     reads: Vec<ReadSite>,
+    callbacks: Vec<CallbackReadSite>,
     /// local id -> number of writes (`Let` / `LocalSet` / `Update`) anywhere
     /// in the region, closures included.
     idx_writes: HashMap<u32, u32>,
@@ -823,6 +890,36 @@ impl<'a> ArrayWalk<'a> {
 
     fn walk_expr(&mut self, e: &Expr) {
         match e {
+            // An inline callback is a closed, single-use argument route: the
+            // runtime passes the element at parameter 0 (or parameter 1 for
+            // reduce). Record that parameter as an element-read candidate and
+            // audit the closure body with the same escape walk as every other
+            // candidate. Non-inline callbacks remain opaque escapes.
+            Expr::ArrayForEach { array, callback } | Expr::ArrayMap { array, callback } => {
+                if !self.walk_inline_array_callback(array, callback, 0) {
+                    self.walk_expr(array);
+                    self.walk_expr(callback);
+                }
+            }
+            Expr::ArrayReduce {
+                array,
+                callback,
+                initial,
+            }
+            | Expr::ArrayReduceRight {
+                array,
+                callback,
+                initial,
+            } => {
+                let admitted = self.walk_inline_array_callback(array, callback, 1);
+                if let Some(initial) = initial {
+                    self.walk_expr(initial);
+                }
+                if !admitted {
+                    self.walk_expr(array);
+                    self.walk_expr(callback);
+                }
+            }
             // `A.length` — the only property read admitted on the array.
             Expr::PropertyGet {
                 object, property, ..
@@ -977,6 +1074,61 @@ impl<'a> ArrayWalk<'a> {
                 perry_hir::walker::walk_expr_children(e, &mut |c| self.walk_expr(c));
             }
         }
+    }
+
+    fn walk_inline_array_callback(
+        &mut self,
+        array: &Expr,
+        callback: &Expr,
+        element_param_index: usize,
+    ) -> bool {
+        let Expr::LocalGet(array_id) = array else {
+            return false;
+        };
+        let Some(root) = self.root_of(*array_id) else {
+            return false;
+        };
+        let Expr::Closure {
+            func_id,
+            params,
+            is_arrow,
+            is_async,
+            is_generator,
+            ..
+        } = callback
+        else {
+            self.disqualified.insert(root);
+            return false;
+        };
+        let Some(param) = params.get(element_param_index) else {
+            self.disqualified.insert(root);
+            return false;
+        };
+        // Array callbacks also receive the source array as their final
+        // argument: `(element, index, array)` or
+        // `(accumulator, element, index, array)`. Until that alias is tracked,
+        // admitting a declared source-array parameter would let the callback
+        // mutate the array behind this proof's back.
+        let max_params_without_array_alias = element_param_index + 2;
+        if !*is_arrow
+            || *is_async
+            || *is_generator
+            || param.is_rest
+            || params.len() > max_params_without_array_alias
+            || params.iter().any(|p| p.arguments_object.is_some())
+        {
+            self.disqualified.insert(root);
+            return false;
+        }
+
+        self.callbacks.push(CallbackReadSite {
+            root,
+            func_id: *func_id,
+            param: param.id,
+            param_ty: param.ty.clone(),
+        });
+        self.walk_expr(callback);
+        true
     }
 }
 

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
@@ -10,7 +10,7 @@
 use super::*;
 use crate::collectors::PtrShapeLocal;
 use perry_hir::types::Type;
-use perry_hir::{ClassField, CompareOp, Function, Module, UpdateOp};
+use perry_hir::{ClassField, CompareOp, Function, Module, Param, UpdateOp};
 
 // ── Fixture builders ───────────────────────────────────────────────────────
 
@@ -266,6 +266,250 @@ fn promote(stmts: &[Stmt], classes: &HashMap<String, &Class>) -> HashMap<u32, Pt
         &HashSet::new(),
         &els,
     )
+}
+
+fn callback_param(id: u32, ty: Type) -> Param {
+    Param {
+        id,
+        name: format!("p{id}"),
+        ty,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn inline_for_each(func_id: u32, params: Vec<Param>, body: Vec<Stmt>) -> Stmt {
+    Stmt::Expr(Expr::ArrayForEach {
+        array: Box::new(Expr::LocalGet(1)),
+        callback: Box::new(Expr::Closure {
+            func_id,
+            params,
+            return_type: Type::Any,
+            body,
+            captures: Vec::new(),
+            mutable_captures: Vec::new(),
+            captures_this: false,
+            captures_new_target: false,
+            enclosing_class: None,
+            is_arrow: true,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+        }),
+    })
+}
+
+// -- Inline array-callback element route (#8103) ---------------------------
+
+#[test]
+fn inline_array_callback_element_param_is_promoted() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        let_c(2, "row"),
+        push(1, Expr::LocalGet(2)),
+        inline_for_each(
+            99,
+            vec![callback_param(6, Type::Named("C".to_string()))],
+            vec![read_x(6)],
+        ),
+    ];
+
+    let promoted = promote(&stmts, &classes);
+    let callback = promoted
+        .get(&6)
+        .expect("the direct callback element parameter must inherit C's shape");
+    assert_eq!(callback.class_name, "C");
+    assert!(promoted.contains_key(&2), "the element group stays intact");
+}
+
+#[test]
+fn inline_map_element_param_is_promoted() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let Stmt::Expr(Expr::ArrayForEach { array, callback }) = inline_for_each(
+        99,
+        vec![callback_param(6, Type::Named("C".to_string()))],
+        vec![read_x(6)],
+    ) else {
+        unreachable!("inline_for_each fixture shape")
+    };
+    let stmts = vec![
+        let_arr(1, "rows"),
+        push(1, new_c()),
+        Stmt::Expr(Expr::ArrayMap { array, callback }),
+    ];
+
+    assert!(promote(&stmts, &classes).contains_key(&6));
+}
+
+#[test]
+fn inline_reduce_promotes_the_element_not_the_accumulator() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let Stmt::Expr(Expr::ArrayForEach { array, callback }) = inline_for_each(
+        99,
+        vec![
+            callback_param(5, Type::Number),
+            callback_param(6, Type::Named("C".to_string())),
+        ],
+        vec![read_x(6)],
+    ) else {
+        unreachable!("inline_for_each fixture shape")
+    };
+    let stmts = vec![
+        let_arr(1, "rows"),
+        push(1, new_c()),
+        Stmt::Expr(Expr::ArrayReduce {
+            array,
+            callback,
+            initial: Some(Box::new(Expr::Number(0.0))),
+        }),
+    ];
+
+    let promoted = promote(&stmts, &classes);
+    assert!(promoted.contains_key(&6));
+    assert!(
+        !promoted.contains_key(&5),
+        "the accumulator is not the source array's element route"
+    );
+}
+
+#[test]
+fn escaping_array_callback_element_denies_the_whole_group() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        let_c(2, "row"),
+        push(1, Expr::LocalGet(2)),
+        inline_for_each(
+            99,
+            vec![callback_param(6, Type::Named("C".to_string()))],
+            vec![Stmt::Expr(Expr::Call {
+                callee: Box::new(Expr::FuncRef(9)),
+                args: vec![Expr::LocalGet(6)],
+                type_args: Vec::new(),
+                byte_offset: 0,
+            })],
+        ),
+    ];
+
+    let promoted = promote(&stmts, &classes);
+    assert!(!promoted.contains_key(&6));
+    assert!(
+        !promoted.contains_key(&2),
+        "one escaping callback view can reshape every element"
+    );
+}
+
+#[test]
+fn opaque_array_callback_is_not_an_element_shape_route() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        let_c(2, "row"),
+        push(1, Expr::LocalGet(2)),
+        Stmt::Expr(Expr::ArrayForEach {
+            array: Box::new(Expr::LocalGet(1)),
+            callback: Box::new(Expr::LocalGet(8)),
+        }),
+    ];
+
+    assert!(promote(&stmts, &classes).is_empty());
+}
+
+#[test]
+fn element_returning_array_hof_is_not_a_contained_route() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let Stmt::Expr(Expr::ArrayForEach { array, callback }) = inline_for_each(
+        99,
+        vec![callback_param(6, Type::Named("C".to_string()))],
+        vec![read_x(6)],
+    ) else {
+        unreachable!("inline_for_each fixture shape")
+    };
+    let stmts = vec![
+        let_arr(1, "rows"),
+        push(1, new_c()),
+        Stmt::Expr(Expr::ArrayFilter { array, callback }),
+    ];
+
+    assert!(
+        promote(&stmts, &classes).is_empty(),
+        "filter returns source-element aliases independently of its callback"
+    );
+}
+
+#[test]
+fn source_array_callback_parameter_denies_the_route() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        let_c(2, "row"),
+        push(1, Expr::LocalGet(2)),
+        inline_for_each(
+            99,
+            vec![
+                callback_param(6, Type::Named("C".to_string())),
+                callback_param(7, Type::Number),
+                callback_param(8, Type::Array(Box::new(Type::Named("C".to_string())))),
+            ],
+            vec![read_x(6)],
+        ),
+    ];
+
+    assert!(
+        promote(&stmts, &classes).is_empty(),
+        "the callback's third argument aliases and can mutate the source array"
+    );
+}
+
+#[test]
+fn self_callable_function_expression_denies_the_route() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let mut callback_stmt = inline_for_each(
+        99,
+        vec![callback_param(6, Type::Named("C".to_string()))],
+        vec![read_x(6)],
+    );
+    let Stmt::Expr(Expr::ArrayForEach {
+        callback: callback_expr,
+        ..
+    }) = &mut callback_stmt
+    else {
+        unreachable!("inline_for_each fixture shape")
+    };
+    let Expr::Closure { is_arrow, .. } = callback_expr.as_mut() else {
+        unreachable!("inline_for_each callback shape")
+    };
+    *is_arrow = false;
+    let stmts = vec![
+        let_arr(1, "rows"),
+        let_c(2, "row"),
+        push(1, Expr::LocalGet(2)),
+        callback_stmt,
+    ];
+
+    assert!(
+        promote(&stmts, &classes).is_empty(),
+        "a named function expression can recursively call itself with arbitrary values"
+    );
 }
 
 // ── The producer half ──────────────────────────────────────────────────────

--- a/crates/perry-codegen/src/expr/array_callback_shape_tests.rs
+++ b/crates/perry-codegen/src/expr/array_callback_shape_tests.rs
@@ -1,0 +1,172 @@
+//! #8103: a proven local array's direct inline callback inherits the exact
+//! element shape in the separately emitted closure function.
+
+use crate::compile_module;
+use perry_hir::types::Type;
+use perry_hir::{Class, ClassField, Expr, Module, ModuleInitKind, Param, Stmt};
+
+const ARRAY_ID: u32 = 1;
+const ELEMENT_ID: u32 = 2;
+const INDEX_ID: u32 = 3;
+const SOURCE_ID: u32 = 4;
+const CLOSURE_ID: u32 = 99;
+
+fn row_class() -> Class {
+    Class {
+        id: 1,
+        name: "Row".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: vec![ClassField {
+            name: "value".to_string(),
+            key_expr: None,
+            ty: Type::Number,
+            init: None,
+            is_private: false,
+            is_readonly: false,
+            decorators: Vec::new(),
+        }],
+        constructor: None,
+        methods: Vec::new(),
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        computed_members: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        aliases: Vec::new(),
+        is_nested: false,
+        alloc_width_hint: 0,
+        specialized_from: None,
+    }
+}
+
+fn param(id: u32, name: &str, ty: Type) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn module_with_callback(declare_source_array_param: bool) -> Module {
+    let mut callback_params = vec![
+        param(ELEMENT_ID, "row", Type::Named("Row".to_string())),
+        param(INDEX_ID, "index", Type::Number),
+    ];
+    if declare_source_array_param {
+        callback_params.push(param(
+            SOURCE_ID,
+            "source",
+            Type::Array(Box::new(Type::Named("Row".to_string()))),
+        ));
+    }
+
+    let callback = Expr::Closure {
+        func_id: CLOSURE_ID,
+        params: callback_params,
+        return_type: Type::Number,
+        body: vec![Stmt::Return(Some(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(ELEMENT_ID)),
+            property: "value".to_string(),
+            byte_offset: 0,
+        }))],
+        captures: Vec::new(),
+        mutable_captures: Vec::new(),
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: true,
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+    };
+
+    let mut module = Module::new("array_callback_shape.ts");
+    module.classes = vec![row_class()];
+    module.init = vec![
+        Stmt::Let {
+            id: ARRAY_ID,
+            name: "rows".to_string(),
+            ty: Type::Array(Box::new(Type::Named("Row".to_string()))),
+            mutable: false,
+            init: Some(Expr::Array(Vec::new())),
+        },
+        Stmt::Expr(Expr::ArrayPush {
+            array_id: ARRAY_ID,
+            value: Box::new(Expr::New {
+                class_name: "Row".to_string(),
+                args: Vec::new(),
+                type_args: Vec::new(),
+                byte_offset: 0,
+                cap_args_appended: 0,
+            }),
+        }),
+        Stmt::Expr(Expr::ArrayForEach {
+            array: Box::new(Expr::LocalGet(ARRAY_ID)),
+            callback: Box::new(callback),
+        }),
+    ];
+    module.init_kind = ModuleInitKind::Eager;
+    module
+}
+
+fn emit(module: &Module) -> String {
+    String::from_utf8(
+        compile_module(module, super::class_field_barrier_tests::ir_opts())
+            .expect("callback-shape fixture compiles"),
+    )
+    .expect("LLVM IR is UTF-8")
+}
+
+fn callback_body(ir: &str) -> &str {
+    let start = ir
+        .lines()
+        .find(|line| {
+            line.starts_with("define ")
+                && line.contains("perry_closure_")
+                && line.contains(&format!("__{CLOSURE_ID}("))
+        })
+        .and_then(|line| ir.find(line))
+        .expect("closure definition is emitted");
+    let tail = &ir[start..];
+    let end = tail.find("\n}\n").expect("closure definition terminates") + 3;
+    &tail[..end]
+}
+
+#[test]
+fn inline_array_callback_field_read_has_no_shape_guard() {
+    let ir = emit(&module_with_callback(false));
+    let callback = callback_body(&ir);
+    assert!(
+        !callback.contains("js_typed_feedback_class_field_get_guard")
+            && !callback.contains("js_object_get_field_by_name_f64"),
+        "the proven element parameter must use a direct fixed-offset load:\n{callback}"
+    );
+    assert!(
+        callback.contains("getelementptr"),
+        "the test must observe a real direct field load:\n{callback}"
+    );
+}
+
+#[test]
+fn callback_source_array_alias_keeps_the_shape_guard() {
+    let ir = emit(&module_with_callback(true));
+    let callback = callback_body(&ir);
+    assert!(
+        callback.contains("js_typed_feedback_class_field_get_guard")
+            || callback.contains("js_object_get_field_by_name_f64"),
+        "declaring the source-array argument must deny the cross-boundary fact:\n{callback}"
+    );
+}

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -138,6 +138,8 @@ pub(crate) use write_barrier::{
 // and the `lower_expr` dispatch table moved into siblings to keep this file
 // under 2000 lines. Inherent methods (`record_value`) need no re-export.
 #[cfg(test)]
+mod array_callback_shape_tests;
+#[cfg(test)]
 mod array_push_guard_tests;
 #[cfg(test)]
 mod barrier_stem_census_tests;


### PR DESCRIPTION
## Summary

- carry a dense, monomorphic local array's proven element shape into a direct inline arrow callback
- reuse the existing full `Ptr<Shape>` escape, class, dispatch, numeric-field, and all-or-nothing group proofs before routing the fact into the separately compiled closure body
- keep opaque/reused callbacks, normal function expressions, async/generator callbacks, rest/`arguments`, source-array parameters, escaping elements, and element-returning HOFs on the guarded path
- add collector red tests plus emitted-LLVM regressions proving admitted field reads lose both shape-guard helpers while a denied alias case retains them

`reduce`/`reduceRight` propagate the current-element parameter only. Propagating a separate accumulator array is the distinct second shape described in the issue and is not widened here.

No version bump.

## Validation

- `cargo fmt -p perry-codegen -- --check`
- `cargo check -p perry-codegen`
- `cargo test -p perry-codegen collectors::ptr_shape_elements::tests:: --lib` (43 passed)
- `cargo test -p perry-codegen array_callback_shape_tests --lib` (2 passed)
- `cargo test -p perry-codegen --lib -- --skip native_emit::tests::split_native_construction_lowers_precise_roots_before_rs4gc --skip native_emit::tests::split_native_construction_propagates_shadow_backend_to_workers` (1072 passed before the final conflict-free rebase)

The unfiltered Windows suite has two unrelated existing failures in those skipped `native_emit` tests: they byte-compare COFF objects that embed different per-run temporary filenames. Both reproduce when run alone; all other 1072 tests pass.

Closes #8103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for eligible inline `forEach`, `map`, `reduce`, and `reduceRight` callbacks by enabling faster access to array element fields.
  * Field reads may now use optimized fixed-offset access when element shapes are proven stable.
  * Callbacks with unsupported or potentially unsafe behavior continue using guarded access.

* **Bug Fixes**
  * Added regression coverage for callback shape propagation, accumulator handling, escaping callbacks, aliases, and other edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->