### PR TITLE
fix(codegen): bound failed LLVM scratch retention

### DIFF
--- a/changelog.d/8283-bound-llvm-scratch.md
+++ b/changelog.d/8283-bound-llvm-scratch.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Bound automatic LLVM failure retention to one diagnostic scratch directory
+  per Perry process, preventing a failed multi-module compile from retaining a
+  large IR copy for every module. Unix startup now also reaps scratch older
+  than two hours when its owning process is gone, while preserving live and
+  explicitly kept artifacts.

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -16,6 +16,12 @@ use std::sync::OnceLock;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+#[path = "linker_temp.rs"]
+mod linker_temp;
+use linker_temp::{
+    reap_stale_llvm_scratch_once, FailedScratch, FailureRetention, PROCESS_FAILURE_RETENTION,
+};
+
 /// Cached result of the pre-flight clang probe — evaluated once per process.
 /// `Some(default_triple)` if the probe succeeded, `None` if it failed.
 static CLANG_PROBE: OnceLock<Option<String>> = OnceLock::new();
@@ -690,14 +696,17 @@ fn compile_ll_to_object_with_native_roots(
     target_triple: Option<&str>,
     native_roots: bool,
 ) -> Result<Vec<u8>> {
+    let tmp_dir = env::temp_dir();
+    reap_stale_llvm_scratch_once(&tmp_dir);
     let rs4gc_ll = maybe_rs4gc_preprocess(ll_text, native_roots)?;
     let ll_text: &str = rs4gc_ll.as_deref().unwrap_or(ll_text);
-    compile_ll_to_object_in(
-        &env::temp_dir(),
+    compile_ll_to_object_in_with_retention(
+        &tmp_dir,
         ll_text,
         target_triple,
         TempFilePolicy::from_env(),
         native_roots,
+        &PROCESS_FAILURE_RETENTION,
     )
 }
 
@@ -713,9 +722,8 @@ fn compile_ll_to_object_with_native_roots(
 ///
 /// * **success**: the object is read into memory, and the per-call directory
 ///   goes with it — a compile leaves nothing behind (#7144).
-/// * **failure** (clang non-zero, or the object cannot be read): everything is
-///   left on disk. The error message names the `.ll`, and a failed compile is
-///   exactly when someone wants to look at the IR that produced it.
+/// * **failure** (clang non-zero, or the object cannot be read): the first
+///   failure's IR is retained for diagnosis; later failures are removed (#8249).
 /// * **`PERRY_LLVM_KEEP_IR`**: everything is kept and its location printed,
 ///   plus the compile plan as JSON.
 /// * **`PERRY_DEBUG_SYMBOLS`**: no effect on any of the above. It was believed
@@ -849,8 +857,15 @@ fn compile_ll_inprocess_in(
     target_triple: Option<&str>,
     policy: TempFilePolicy,
     native_roots: bool,
+    failure_retention: &FailureRetention,
 ) -> Result<Vec<u8>> {
     let (paths, _pid, _nonce) = llvm_temp_paths(tmp_dir, ll_text);
+    let failed_scratch = FailedScratch::new(
+        &paths.scratch_dir,
+        &paths.ll_path,
+        policy.keep,
+        failure_retention,
+    );
     // Same decision inputs as the clang path — opt level (#4880 fallback
     // included), CPU tuning, inlinehint threshold — via the same plan
     // constructor, so the backends cannot drift on a decision independently.
@@ -892,41 +907,35 @@ fn compile_ll_inprocess_in(
         &module_name,
         native_roots,
     ) {
-        // The statepoint backends ask for `-S`, because #7314's compact-map
-        // rewriter rewrites `.llvm_stackmaps` at ASSEMBLY time — that is where
-        // LLVM prints function addresses as symbol names, so one text parser
-        // replaces Mach-O and ELF relocation parsing plus a second link pass.
-        //
-        // So what came back is assembly, not an object. Write it where the
-        // clang path would have, run the same rewrite-and-assemble step, and
-        // return the resulting object. Skipping this wrote assembly text into a
-        // `.o` and the link died with `ld: unknown file type`.
+        // Statepoint plans ask for `-S`: #7314's compact-map rewriter operates
+        // on assembly. Rewrite and assemble those bytes before returning them.
         Ok(bytes) if plan.asm_path.is_some() => {
             let asm_path = plan.asm_path.as_ref().expect("checked");
             if let Some(parent) = asm_path.parent() {
                 fs::create_dir_all(parent).ok();
             }
             fs::write(asm_path, &bytes)
-                .with_context(|| format!("Failed to write {}", asm_path.display()))?;
-            // `plan.clang` is the literal `(in-process)` placeholder here, so
-            // resolve a real assembler. Using the system clang for this step is
-            // sound: the version skew that motivated the in-process backend was
-            // an *IR* parse failure (`unterminated attribute group`), and by
-            // this point the IR is gone — what is being assembled is text this
-            // LLVM just printed, which any contemporary assembler accepts.
-            let assembler = find_clang().context(
-                "the statepoint compact-map rewrite needs an assembler to turn \
+                .with_context(|| format!("Failed to write {}", asm_path.display()))
+                .map_err(|error| failed_scratch.finish_with_ir(error, ll_text))?;
+            // The in-process version-skew problem concerns IR parsing; any
+            // contemporary system clang can assemble the emitted text.
+            let assembler = find_clang()
+                .context(
+                    "the statepoint compact-map rewrite needs an assembler to turn \
                  the emitted assembly into an object, and no clang was found",
-            )?;
+                )
+                .map_err(|error| failed_scratch.finish_with_ir(error, ll_text))?;
             crate::gc_map::compact_and_assemble(
                 &assembler,
                 &plan.effective_target,
                 asm_path,
                 &plan.obj_path,
                 &plan.clang_args,
-            )?;
+            )
+            .map_err(|error| failed_scratch.finish_with_ir(error, ll_text))?;
             let obj = fs::read(&plan.obj_path)
-                .with_context(|| format!("Failed to read assembled {}", plan.obj_path.display()))?;
+                .with_context(|| format!("Failed to read assembled {}", plan.obj_path.display()))
+                .map_err(|error| failed_scratch.finish_with_ir(error, ll_text))?;
             if policy.keep {
                 // This arm retains the object too — `compact_and_assemble`
                 // wrote it to `plan.obj_path` and the scratch dir survives
@@ -938,13 +947,8 @@ fn compile_ll_inprocess_in(
                 // workloads fail on exactly this, never reaching their subject).
                 eprintln!("[perry-codegen] kept object: {}", plan.obj_path.display());
             } else {
-                // `remove_dir_all`, not the two names we know about — the same
-                // reason the clang path gives. This arm is the only in-process
-                // one that CREATES the scratch dir (writing the assembly), so
-                // unlinking just the files left an empty husk per compile: a
-                // leak counted in compiles rather than in distinct IR, which is
-                // what turned the temp-hygiene gate red once this backend
-                // became the default and the clang cleanup stopped running.
+                // Remove the whole private directory so assembler side-files
+                // and the directory itself cannot leak (#8072).
                 let _ = fs::remove_dir_all(&paths.scratch_dir);
             }
             Ok(obj)
@@ -969,20 +973,15 @@ fn compile_ll_inprocess_in(
             Ok(bytes)
         }
         Err(e) => {
-            // Same contract as a failed clang compile: the IR that produced
-            // the failure is left on disk and named in the error.
-            let _ = fs::create_dir_all(&paths.scratch_dir);
-            let _ = fs::write(&paths.ll_path, ll_text);
-            Err(anyhow!(
+            let error = anyhow!(
                 "in-process LLVM compile failed (PERRY_LLVM_INPROCESS).\n\
                  requested -target: {}\n\
-                 LLVM IR left at: {}\n\
                  \n\
                  {}",
                 plan.effective_target,
-                paths.ll_path.display(),
                 e
-            ))
+            );
+            Err(failed_scratch.finish_with_ir(error, ll_text))
         }
     }
 }
@@ -994,6 +993,7 @@ fn compile_ll_inprocess_in(
     _target_triple: Option<&str>,
     _policy: TempFilePolicy,
     _native_roots: bool,
+    _failure_retention: &FailureRetention,
 ) -> Result<Vec<u8>> {
     // Fail loudly rather than silently falling back: an A/B arm that asked
     // for the in-process backend must never be served the text path.
@@ -1006,15 +1006,23 @@ fn compile_ll_inprocess_in(
     )
 }
 
-fn compile_ll_to_object_in(
+fn compile_ll_to_object_in_with_retention(
     tmp_dir: &Path,
     ll_text: &str,
     target_triple: Option<&str>,
     policy: TempFilePolicy,
     native_roots: bool,
+    failure_retention: &FailureRetention,
 ) -> Result<Vec<u8>> {
     if inprocess_requested() {
-        return compile_ll_inprocess_in(tmp_dir, ll_text, target_triple, policy, native_roots);
+        return compile_ll_inprocess_in(
+            tmp_dir,
+            ll_text,
+            target_triple,
+            policy,
+            native_roots,
+            failure_retention,
+        );
     }
     // Validate the toolchain before creating the potentially large `.ll`
     // scratch file. Unsupported clang releases should fail without leaving
@@ -1054,6 +1062,7 @@ fn compile_ll_to_object_in(
     fs::create_dir_all(&scratch_dir)
         .with_context(|| format!("Failed to create temp dir at {}", scratch_dir.display()))?;
     write_ll_atomically(&ll_path, ll_text, write_pid, write_nonce)?;
+    let failed_scratch = FailedScratch::new(&scratch_dir, &ll_path, policy.keep, failure_retention);
 
     let plan = build_clang_compile_plan(
         clang.clone(),
@@ -1097,9 +1106,9 @@ fn compile_ll_to_object_in(
     // disables tuning entirely. See `cpu_tuning_arg_for` (#6125).
 
     log::debug!("perry-codegen: {:?}", cmd);
-    let output = cmd
-        .output()
-        .with_context(|| format!("Failed to invoke {}", clang.display()))?;
+    let output = cmd.output().map_err(|error| {
+        failed_scratch.finish(anyhow!("Failed to invoke {}: {error}", clang.display()))
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1115,12 +1124,11 @@ fn compile_ll_to_object_in(
             .map(|s| s.trim().to_string())
             .unwrap_or_else(|| "(unable to query --version)".to_string());
         let hint = build_clang_failure_hint(&stderr, &clang_version, &plan.effective_target);
-        return Err(anyhow!(
+        let error = anyhow!(
             "clang -c failed (status={}).\n\
              clang:           {}\n\
              clang --version: {}\n\
              requested -target: {}\n\
-             LLVM IR left at: {}\n\
              \n\
              stderr:\n{}\n\
              {}",
@@ -1128,10 +1136,10 @@ fn compile_ll_to_object_in(
             plan.clang.display(),
             clang_version.lines().next().unwrap_or("?"),
             plan.effective_target,
-            plan.ll_path.display(),
             stderr,
             hint
-        ));
+        );
+        return Err(failed_scratch.finish(error));
     }
 
     if let Some(asm_path) = &plan.asm_path {
@@ -1141,11 +1149,13 @@ fn compile_ll_to_object_in(
             asm_path,
             &obj_path,
             &plan.clang_args,
-        )?;
+        )
+        .map_err(|error| failed_scratch.finish(error))?;
     }
 
     let bytes = fs::read(&obj_path)
-        .with_context(|| format!("Failed to read clang output at {}", obj_path.display()))?;
+        .with_context(|| format!("Failed to read clang output at {}", obj_path.display()))
+        .map_err(|error| failed_scratch.finish(error))?;
 
     // Clean up on success.
     //

--- a/crates/perry-codegen/src/linker_temp.rs
+++ b/crates/perry-codegen/src/linker_temp.rs
@@ -1,0 +1,202 @@
+//! Failure-retention and stale-reaping policy for LLVM scratch directories.
+//!
+//! Kept separate from `linker.rs` so the driver stays below the repository's
+//! 2,000-line source-file limit.
+
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::time::SystemTime;
+
+use anyhow::Error;
+
+const SCRATCH_PREFIX: &str = "perry_llvm_scratch_";
+const FAILED_MARKER: &str = ".perry-failed";
+const EXPLICIT_KEEP_MARKER: &str = ".perry-keep";
+const STALE_AFTER: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// One ordinary failed module is enough to diagnose a compiler invocation.
+/// `PERRY_LLVM_KEEP_IR` bypasses this cap because retaining every intermediate
+/// is its explicit contract.
+pub(super) struct FailureRetention {
+    claimed: AtomicBool,
+}
+
+impl FailureRetention {
+    pub(super) const fn new() -> Self {
+        Self {
+            claimed: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) fn should_retain(&self, explicit_keep: bool) -> bool {
+        explicit_keep || !self.claimed.swap(true, Ordering::AcqRel)
+    }
+}
+
+pub(super) static PROCESS_FAILURE_RETENTION: FailureRetention = FailureRetention::new();
+
+/// Decide whether this failure owns the diagnostic slot, then make the error
+/// agree with what remains on disk.
+pub(super) struct FailedScratch<'a> {
+    scratch_dir: &'a Path,
+    ll_path: &'a Path,
+    explicit_keep: bool,
+    retention: &'a FailureRetention,
+}
+
+impl<'a> FailedScratch<'a> {
+    pub(super) fn new(
+        scratch_dir: &'a Path,
+        ll_path: &'a Path,
+        explicit_keep: bool,
+        retention: &'a FailureRetention,
+    ) -> Self {
+        Self {
+            scratch_dir,
+            ll_path,
+            explicit_keep,
+            retention,
+        }
+    }
+
+    pub(super) fn finish(&self, error: Error) -> Error {
+        self.finish_with(error, None)
+    }
+
+    pub(super) fn finish_with_ir(&self, error: Error, ll_text: &str) -> Error {
+        self.finish_with(error, Some(ll_text))
+    }
+
+    fn finish_with(&self, error: Error, ll_text: Option<&str>) -> Error {
+        let retained = self.retention.should_retain(self.explicit_keep);
+        if !retained {
+            let _ = fs::remove_dir_all(self.scratch_dir);
+            return error.context(
+                "LLVM IR not retained: another LLVM failure in this Perry process already kept \
+                 its IR (set PERRY_LLVM_KEEP_IR=1 to keep every intermediate)",
+            );
+        }
+        if let Some(ll_text) = ll_text {
+            let _ = fs::create_dir_all(self.scratch_dir);
+            let _ = fs::write(self.ll_path, ll_text);
+        }
+        let marker = if self.explicit_keep {
+            EXPLICIT_KEEP_MARKER
+        } else {
+            FAILED_MARKER
+        };
+        let _ = fs::write(self.scratch_dir.join(marker), b"");
+        error.context(format!("LLVM IR left at: {}", self.ll_path.display()))
+    }
+}
+
+/// Best-effort startup cleanup. A live owner always wins, even when its scratch
+/// is old; explicit `PERRY_LLVM_KEEP_IR` output is never treated as stale.
+pub(super) fn reap_stale_llvm_scratch_once(tmp_dir: &Path) {
+    static REAPED: OnceLock<()> = OnceLock::new();
+    REAPED.get_or_init(|| {
+        let removed = reap_stale_llvm_scratch(tmp_dir, STALE_AFTER);
+        if removed > 0 {
+            log::debug!("perry-codegen: reaped {removed} stale LLVM scratch directories");
+        }
+    });
+}
+
+#[cfg(unix)]
+pub(super) fn reap_stale_llvm_scratch(tmp_dir: &Path, min_age: Duration) -> usize {
+    let Ok(entries) = fs::read_dir(tmp_dir) else {
+        return 0;
+    };
+    let now = SystemTime::now();
+    let mut removed = 0;
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(scratch_owner_pid) else {
+            continue;
+        };
+        let path = entry.path();
+        let old_enough = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age >= min_age);
+        if !old_enough || process_is_alive(pid) || was_explicitly_kept(&path) {
+            continue;
+        }
+        if fs::remove_dir_all(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+#[cfg(not(unix))]
+pub(super) fn reap_stale_llvm_scratch(_tmp_dir: &Path, _min_age: Duration) -> usize {
+    // Windows has no `kill(pid, 0)` equivalent in the standard library. Keep
+    // the retention cap there, but do not risk deleting another process's IR.
+    0
+}
+
+#[cfg(unix)]
+fn scratch_owner_pid(name: &str) -> Option<u32> {
+    let suffix = name.strip_prefix(SCRATCH_PREFIX)?;
+    let (pid, counter) = suffix.split_once('_')?;
+    if pid.is_empty()
+        || counter.is_empty()
+        || counter.contains('_')
+        || !counter.bytes().all(|b| b.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    let pid = u32::from_str_radix(pid, 16).ok()?;
+    (pid != 0).then_some(pid)
+}
+
+#[cfg(unix)]
+fn was_explicitly_kept(path: &Path) -> bool {
+    if path.join(EXPLICIT_KEEP_MARKER).is_file() {
+        return true;
+    }
+    // Successful artifacts retained before #8249 have no marker, but do have
+    // compile-plan metadata. Preserve that pre-existing KEEP_IR contract.
+    fs::read_dir(path).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.ends_with(".compile-plan.json"))
+        })
+    })
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    use std::os::raw::c_int;
+
+    if pid > c_int::MAX as u32 {
+        return false;
+    }
+    extern "C" {
+        fn kill(pid: c_int, signal: c_int) -> c_int;
+    }
+    // Signal 0 performs permission/existence checks without sending a signal.
+    if unsafe { kill(pid as c_int, 0) } == 0 {
+        return true;
+    }
+    // ESRCH is 3 on the Unix targets Perry supports. EPERM and other failures
+    // mean the process may exist but is not inspectable, so preserve its files.
+    std::io::Error::last_os_error().raw_os_error() != Some(3)
+}

--- a/crates/perry-codegen/src/linker_temp_lifecycle_tests.rs
+++ b/crates/perry-codegen/src/linker_temp_lifecycle_tests.rs
@@ -110,6 +110,23 @@ const CLEAN: TempFilePolicy = TempFilePolicy {
     debug_symbols: false,
 };
 
+fn compile_ll_to_object_in(
+    tmp_dir: &Path,
+    ll_text: &str,
+    target_triple: Option<&str>,
+    policy: TempFilePolicy,
+    native_roots: bool,
+) -> Result<Vec<u8>> {
+    compile_ll_to_object_in_with_retention(
+        tmp_dir,
+        ll_text,
+        target_triple,
+        policy,
+        native_roots,
+        &FailureRetention::new(),
+    )
+}
+
 #[test]
 fn successful_compile_leaves_nothing_behind() {
     // THE #7144 regression test. Before the fix each compile left one
@@ -217,6 +234,119 @@ fn failed_compile_keeps_the_ll_for_diagnosis() {
         message.contains(&surviving[0].display().to_string()),
         "the failure must name the file it left: {message}"
     );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn only_the_first_failed_compile_keeps_ir() {
+    use std::thread;
+
+    let Some(root) = temp_root_if_clang_available("failure-cap") else {
+        return;
+    };
+    let retention = FailureRetention::new();
+    let errors = thread::scope(|scope| {
+        ["not LLVM IR: first\n", "not LLVM IR: second\n"]
+            .into_iter()
+            .map(|ir| {
+                let root = root.clone();
+                let retention = &retention;
+                scope.spawn(move || {
+                    compile_ll_to_object_in_with_retention(&root, ir, None, CLEAN, false, retention)
+                        .expect_err("invalid module must fail")
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|handle| format!("{:#}", handle.join().unwrap()))
+            .collect::<Vec<_>>()
+    });
+
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| e.contains("LLVM IR left at:"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| e.contains("LLVM IR not retained:"))
+            .count(),
+        1
+    );
+    let surviving = ll_files_under(&root);
+    assert_eq!(
+        surviving.len(),
+        1,
+        "one process-wide diagnostic sample is enough: {surviving:?}"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn keep_ir_bypasses_the_failure_cap() {
+    let Some(root) = temp_root_if_clang_available("failure-keep") else {
+        return;
+    };
+    let retention = FailureRetention::new();
+    let policy = TempFilePolicy {
+        keep: true,
+        debug_symbols: false,
+    };
+    for ir in ["not LLVM IR: first\n", "not LLVM IR: second\n"] {
+        let error =
+            compile_ll_to_object_in_with_retention(&root, ir, None, policy, false, &retention)
+                .expect_err("invalid module must fail");
+        assert!(format!("{error:#}").contains("LLVM IR left at:"));
+    }
+    assert_eq!(ll_files_under(&root).len(), 2);
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_reaper_removes_only_dead_unkept_scratch() {
+    let root = env::temp_dir().join(format!(
+        "perry_linker_test_reap_{}_{:x}",
+        std::process::id(),
+        TEMP_NONCE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+
+    let live = root.join(format!("perry_llvm_scratch_{:x}_0", std::process::id()));
+    let dead = root.join("perry_llvm_scratch_ffffffff_0");
+    let kept = root.join("perry_llvm_scratch_ffffffff_1");
+    let legacy_kept = root.join("perry_llvm_scratch_ffffffff_2");
+    let unrelated = root.join("perry_llvm_scratch_not-a-pid_2");
+    for dir in [&live, &dead, &kept, &legacy_kept, &unrelated] {
+        fs::create_dir_all(dir).unwrap();
+    }
+    fs::write(kept.join(".perry-keep"), b"").unwrap();
+    fs::write(legacy_kept.join("old.compile-plan.json"), b"{}").unwrap();
+
+    assert_eq!(
+        linker_temp::reap_stale_llvm_scratch(&root, std::time::Duration::from_secs(60 * 60)),
+        0,
+        "dead but recent scratch is not stale yet"
+    );
+    assert_eq!(
+        linker_temp::reap_stale_llvm_scratch(&root, std::time::Duration::ZERO),
+        1
+    );
+    assert!(live.is_dir(), "a live owner's scratch must survive");
+    assert!(
+        !dead.exists(),
+        "a dead owner's stale scratch must be reaped"
+    );
+    assert!(kept.is_dir(), "explicit KEEP_IR output must survive");
+    assert!(
+        legacy_kept.is_dir(),
+        "pre-marker KEEP_IR output must survive"
+    );
+    assert!(unrelated.is_dir(), "unrecognized names must survive");
     let _ = fs::remove_dir_all(&root);
 }
 
@@ -497,8 +627,10 @@ fn inprocess_statepoint_compile_leaves_no_empty_scratch_dir() {
         return;
     };
     for nth in 0..3 {
-        let bytes = compile_ll_inprocess_in(&root, &test_ir(100 + nth), None, CLEAN, true)
-            .unwrap_or_else(|e| panic!("in-process compile {nth} failed: {e:#}"));
+        let retention = FailureRetention::new();
+        let bytes =
+            compile_ll_inprocess_in(&root, &test_ir(100 + nth), None, CLEAN, true, &retention)
+                .unwrap_or_else(|e| panic!("in-process compile {nth} failed: {e:#}"));
         assert!(!bytes.is_empty(), "compile {nth} produced no object bytes");
         assert_eq!(
             entries(&root),


### PR DESCRIPTION
## Summary

Bounds failed LLVM scratch retention so one broken multi-module compile cannot leave one large IR directory per module, while preserving a useful first diagnostic sample and the explicit `PERRY_LLVM_KEEP_IR` contract.

## Changes

- Atomically retain only the first automatic LLVM failure artifact per Perry process across both in-process and external-clang paths; later failures remove their private scratch directories and report that decision.
- Reap Unix scratch directories older than two hours on startup only when their PID-derived owner is gone; preserve live owners, explicit keep markers, and pre-marker compile-plan output.
- Extend lifecycle coverage for simultaneous failures, `PERRY_LLVM_KEEP_IR` bypass behavior, stale/live-owner handling, and legacy kept artifacts.

## Related issue

Fixes #8249

## Test plan

- [x] `PERRY_LLVM_INPROCESS=off cargo test -p perry-codegen --no-default-features --lib linker_temp_lifecycle_tests -- --test-threads=1` (13 passed)
- [x] Default-backend `cargo test -p perry-codegen --no-default-features linker_temp_lifecycle_tests -- --test-threads=1` (13 passed)
- [x] `scripts/check_file_size.sh`
- [x] `cargo fmt --all` and `git diff --check`
- [ ] `cargo build --release` clean
- [ ] Full affected-crate/workspace suite (targeted lifecycle suite run instead)
- [x] Added or updated a `#[test]` in the affected crate
- [ ] Docs update (not applicable: no CLI, stdlib, or runtime API change)
- [ ] Platform UI backend build (not applicable)

## Screenshots / output

Not applicable.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `fix:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLVM compilation failure handling by retaining diagnostic artifacts from the first failure while automatically cleaning up subsequent temporary files.
  * Removed stale scratch artifacts from inactive processes after two hours, while preserving active or explicitly retained diagnostics.
* **New Features**
  * Added an option to retain LLVM intermediate representations from all failures for deeper troubleshooting.
* **Documentation**
  * Documented the updated LLVM diagnostic scratch-retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->