### PR TITLE
fix(runtime): bind static handle method names

### DIFF
--- a/changelog.d/8284-static-handle-method-names.md
+++ b/changelog.d/8284-static-handle-method-names.md
@@ -1,0 +1,7 @@
+### fix(runtime): keep bound handle method names alive across GC
+
+Computed method-value reads on node:sqlite, TLS, EventEmitter, and
+AsyncLocalStorage handles now bind static method-name literals instead of
+retaining pointers into movable GC heap strings. Primitive-number method reads
+use the same static-name rule, so closures such as `(5).toString` cannot retain
+the computed key's interior after collection. Fixes #8178.

--- a/crates/perry-runtime/src/gc/tests/handle_bound_method_name.rs
+++ b/crates/perry-runtime/src/gc/tests/handle_bound_method_name.rs
@@ -1,5 +1,5 @@
-//! A bound TIMER-handle / TextDecoder / TextEncoder method closure must not
-//! capture a pointer into the key string.
+//! A bound TIMER-handle / TextDecoder / TextEncoder / primitive-receiver method
+//! closure must not capture a pointer into the key string.
 //!
 //! `js_class_method_bind` stores the method-name POINTER in the closure
 //! (capture 1) and `dispatch_bound_method` re-reads it at CALL time. Its
@@ -34,6 +34,9 @@
 //!   entry point, not a redundant copy.
 //! * `get_field_by_name.rs` — a third copy of the same timer block. Fixed
 //!   defensively; nothing guarantees it stays unreachable across refactors.
+//! * `get_field_by_name.rs`'s primitive-number receiver — `(5).toString` and
+//!   the inherited Object prototype methods used the computed key's movable
+//!   interior directly (#8178).
 //!
 //! ## Why these assert IDENTITY and not bytes
 //!
@@ -235,6 +238,23 @@ fn a_bound_text_encoder_method_never_captures_the_key_strings_interior() {
     }
 }
 
+/// ★ #8178's runtime regression: the helper shared by both primitive-number
+/// receiver guards must capture the static spelling, not the computed heap
+/// key's interior.
+#[test]
+fn a_bound_primitive_method_never_captures_the_key_strings_interior() {
+    let _guard = GcTestIsolationGuard::new();
+    unsafe {
+        let (key, key_interior) = heap_key("toString");
+        let key_bytes = std::slice::from_raw_parts(key_interior, (*key).byte_len as usize);
+        let bound = crate::object::bind_primitive_proto_method_static(5.0, key_bytes)
+            .expect("toString is a primitive prototype method");
+        let expected = crate::object::primitive_proto_method_name_static(b"toString")
+            .expect("toString is a primitive prototype method");
+        assert_names_the_literal(bound, expected, key_interior, "(5).toString");
+    }
+}
+
 /// The lookups must not simply echo their argument — a `|k| Some(k)` that
 /// type-checked would pass every identity assertion above while still handing
 /// back the caller's storage.
@@ -284,4 +304,28 @@ fn the_static_name_lookups_do_not_borrow_their_argument() {
             "every pre-#8133 timer-handle method must still resolve"
         );
     }
+
+    let owned = String::from("propertyIsEnumerable");
+    let found = crate::object::primitive_proto_method_name_static(owned.as_bytes())
+        .expect("propertyIsEnumerable is a primitive prototype method");
+    assert_ne!(
+        found.as_ptr(),
+        owned.as_ptr(),
+        "the primitive lookup must answer a literal, not borrow its argument"
+    );
+    for name in [
+        &b"toString"[..],
+        b"valueOf",
+        b"hasOwnProperty",
+        b"isPrototypeOf",
+        b"propertyIsEnumerable",
+        b"toLocaleString",
+    ] {
+        assert_eq!(
+            crate::object::primitive_proto_method_name_static(name),
+            Some(name),
+            "every primitive prototype method must still resolve"
+        );
+    }
+    assert!(crate::object::primitive_proto_method_name_static(b"notAPrototypeMethod").is_none());
 }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -330,8 +330,10 @@ pub(crate) use has_property::{
     wide_key_index_note_hit, WIDE_KEY_INDEX_MIN_KEYS,
 };
 pub use has_property::{js_in_operator, js_object_has_property};
+#[cfg(test)]
+pub(crate) use ic_miss::primitive_proto_method_name_static;
 pub(crate) use ic_miss::{
-    is_array_method_value_name, is_primitive_proto_method, set_method_value_name,
+    bind_primitive_proto_method_static, is_array_method_value_name, set_method_value_name,
     timer_handle_method_name_static,
 };
 pub use ic_miss::{

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -823,6 +823,11 @@ pub extern "C" fn js_object_get_field_by_name(
                     {
                         return v;
                     }
+                    if let Some(bound) =
+                        bind_primitive_proto_method_static(f64::from_bits(bits), key_bytes)
+                    {
+                        return bound;
+                    }
                 }
             }
             return JSValue::undefined();
@@ -1562,9 +1567,8 @@ pub extern "C" fn js_object_get_field_by_name(
                 if let Some(v) = primitive_builtin_prototype_property(b"Number", key, f) {
                     return v;
                 }
-                if is_primitive_proto_method(name_bytes) {
-                    let result = super::super::js_class_method_bind(f, name_ptr, name_len);
-                    return JSValue::from_bits(result.to_bits());
+                if let Some(bound) = bind_primitive_proto_method_static(f, name_bytes) {
+                    return bound;
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -94,16 +94,28 @@ pub extern "C" fn js_object_get_field_by_name_boxed(
 /// dispatchable through `js_native_call_method` (every name here has a
 /// corresponding dispatch arm). `constructor` is excluded: it is a property
 /// holding the `Number` function, not a bound method.
-pub(crate) fn is_primitive_proto_method(key: &[u8]) -> bool {
-    matches!(
-        key,
-        b"toString"
-            | b"valueOf"
-            | b"hasOwnProperty"
-            | b"isPrototypeOf"
-            | b"propertyIsEnumerable"
-            | b"toLocaleString"
-    )
+pub(crate) fn primitive_proto_method_name_static(key: &[u8]) -> Option<&'static [u8]> {
+    match key {
+        b"toString" => Some(b"toString"),
+        b"valueOf" => Some(b"valueOf"),
+        b"hasOwnProperty" => Some(b"hasOwnProperty"),
+        b"isPrototypeOf" => Some(b"isPrototypeOf"),
+        b"propertyIsEnumerable" => Some(b"propertyIsEnumerable"),
+        b"toLocaleString" => Some(b"toLocaleString"),
+        _ => None,
+    }
+}
+
+/// Bind a primitive receiver's inherited method without allowing the closure
+/// to retain the caller's key storage. Both finite-number guards route through
+/// this helper so the pointer-lifetime rule has a single implementation.
+pub(crate) unsafe fn bind_primitive_proto_method_static(
+    receiver: f64,
+    key: &[u8],
+) -> Option<JSValue> {
+    let method = primitive_proto_method_name_static(key)?;
+    let result = super::super::js_class_method_bind(receiver, method.as_ptr(), method.len());
+    Some(JSValue::from_bits(result.to_bits()))
 }
 
 /// Static-name lowering traffics in immutable AOT descriptors instead of

--- a/crates/perry-stdlib/src/common/dispatch/emitter_als.rs
+++ b/crates/perry-stdlib/src/common/dispatch/emitter_als.rs
@@ -1,6 +1,52 @@
 use super::super::handle::*;
 use super::*;
 
+/// `js_class_method_bind` retains the name pointer in the closure, so make a
+/// non-static forwarded property slice impossible to pass accidentally.
+unsafe fn bind_static_handle_method(handle: i64, method: &'static [u8]) -> f64 {
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    js_class_method_bind(nanbox_handle_value(handle), method.as_ptr(), method.len())
+}
+
+#[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+fn event_emitter_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "prependListener" => Some(b"prependListener"),
+        "prependOnceListener" => Some(b"prependOnceListener"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "emit" => Some(b"emit"),
+        "listenerCount" => Some(b"listenerCount"),
+        "listeners" => Some(b"listeners"),
+        "rawListeners" => Some(b"rawListeners"),
+        "eventNames" => Some(b"eventNames"),
+        "setMaxListeners" => Some(b"setMaxListeners"),
+        "getMaxListeners" => Some(b"getMaxListeners"),
+        _ => None,
+    }
+}
+
+fn async_local_storage_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "run" => Some(b"run"),
+        "getStore" => Some(b"getStore"),
+        "enterWith" => Some(b"enterWith"),
+        "exit" => Some(b"exit"),
+        "disable" => Some(b"disable"),
+        _ => None,
+    }
+}
+
 /// Dynamic dispatch for `AsyncLocalStorage` receivers whose static type the
 /// codegen lost (`any`-typed bindings, closure captures). Gated on registry
 /// type membership so no other subsystem's handle is claimed (#788).
@@ -162,17 +208,6 @@ pub(crate) unsafe fn dispatch_event_emitter_property(handle: i64, property: &str
         return None;
     }
 
-    let bind_method = |method: &[u8]| -> f64 {
-        extern "C" {
-            fn js_class_method_bind(
-                instance: f64,
-                method_name_ptr: *const u8,
-                method_name_len: usize,
-            ) -> f64;
-        }
-        js_class_method_bind(nanbox_handle_value(handle), method.as_ptr(), method.len())
-    };
-
     #[cfg(feature = "bundled-events")]
     if crate::events::is_event_emitter_async_resource_handle(handle) {
         match property {
@@ -189,31 +224,14 @@ pub(crate) unsafe fn dispatch_event_emitter_property(handle: i64, property: &str
             "asyncResource" => {
                 return Some(crate::events::js_event_emitter_async_resource_async_resource(handle));
             }
-            "emitDestroy" => return Some(bind_method(b"emitDestroy")),
+            "emitDestroy" => return Some(bind_static_handle_method(handle, b"emitDestroy")),
             _ => {}
         }
     }
 
-    let method = match property {
-        "on"
-        | "addListener"
-        | "once"
-        | "prependListener"
-        | "prependOnceListener"
-        | "off"
-        | "removeListener"
-        | "removeAllListeners"
-        | "emit"
-        | "listenerCount"
-        | "listeners"
-        | "rawListeners"
-        | "eventNames"
-        | "setMaxListeners"
-        | "getMaxListeners" => Some(property.as_bytes()),
-        _ => None,
-    }?;
+    let method = event_emitter_method_name_static(property)?;
 
-    Some(bind_method(method))
+    Some(bind_static_handle_method(handle, method))
 }
 
 /// `AsyncLocalStorage` METHOD-VALUE reads (the property-read counterpart of
@@ -230,26 +248,62 @@ pub(crate) unsafe fn dispatch_async_local_storage_property(
     handle: i64,
     property: &str,
 ) -> Option<f64> {
-    if !matches!(
-        property,
-        "run" | "getStore" | "enterWith" | "exit" | "disable"
-    ) {
-        return None;
-    }
+    let method = async_local_storage_method_name_static(property)?;
     if get_handle_mut::<crate::async_local_storage::AsyncLocalStorageHandle>(handle).is_none() {
         return None;
     }
-    extern "C" {
-        fn js_class_method_bind(
-            instance: f64,
-            method_name_ptr: *const u8,
-            method_name_len: usize,
-        ) -> f64;
+    Some(bind_static_handle_method(handle, method))
+}
+
+#[cfg(test)]
+mod static_method_name_tests {
+    use super::*;
+
+    fn assert_static_lookup(lookup: fn(&str) -> Option<&'static [u8]>, names: &[&str]) {
+        for name in names {
+            let owned = (*name).to_owned();
+            let found = lookup(&owned).expect("known method must resolve");
+            assert_eq!(found, name.as_bytes());
+            assert_ne!(
+                found.as_ptr(),
+                owned.as_ptr(),
+                "lookup borrowed the forwarded property name for {name}"
+            );
+            assert_eq!(found.as_ptr(), lookup(name).unwrap().as_ptr());
+        }
+        assert!(lookup("notAHandleMethod").is_none());
     }
-    let m = property.as_bytes();
-    Some(js_class_method_bind(
-        nanbox_handle_value(handle),
-        m.as_ptr(),
-        m.len(),
-    ))
+
+    #[test]
+    fn async_local_storage_method_name_lookup_returns_static_literals() {
+        assert_static_lookup(
+            async_local_storage_method_name_static,
+            &["run", "getStore", "enterWith", "exit", "disable"],
+        );
+    }
+
+    #[cfg(any(feature = "bundled-events", feature = "external-events-construct"))]
+    #[test]
+    fn event_emitter_method_name_lookup_returns_static_literals() {
+        assert_static_lookup(
+            event_emitter_method_name_static,
+            &[
+                "on",
+                "addListener",
+                "once",
+                "prependListener",
+                "prependOnceListener",
+                "off",
+                "removeListener",
+                "removeAllListeners",
+                "emit",
+                "listenerCount",
+                "listeners",
+                "rawListeners",
+                "eventNames",
+                "setMaxListeners",
+                "getMaxListeners",
+            ],
+        );
+    }
 }

--- a/crates/perry-stdlib/src/sqlite/dispatch.rs
+++ b/crates/perry-stdlib/src/sqlite/dispatch.rs
@@ -5,6 +5,80 @@ use perry_runtime::{
     js_string_from_bytes, ArrayHeader, JSValue,
 };
 
+/// `js_class_method_bind` retains the name pointer in the closure, so make a
+/// non-static forwarded property slice impossible to pass accidentally.
+unsafe fn bind_static_handle_method(handle: Handle, method: &'static [u8]) -> f64 {
+    extern "C" {
+        fn js_class_method_bind(
+            instance: f64,
+            method_name_ptr: *const u8,
+            method_name_len: usize,
+        ) -> f64;
+    }
+    js_class_method_bind(js_nanbox_pointer(handle), method.as_ptr(), method.len())
+}
+
+fn database_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "open" => Some(b"open"),
+        "close" => Some(b"close"),
+        "exec" => Some(b"exec"),
+        "prepare" => Some(b"prepare"),
+        "serialize" => Some(b"serialize"),
+        "deserialize" => Some(b"deserialize"),
+        "function" => Some(b"function"),
+        "aggregate" => Some(b"aggregate"),
+        "enableDefensive" => Some(b"enableDefensive"),
+        "setAuthorizer" => Some(b"setAuthorizer"),
+        "createTagStore" => Some(b"createTagStore"),
+        "createSession" => Some(b"createSession"),
+        "applyChangeset" => Some(b"applyChangeset"),
+        "enableLoadExtension" => Some(b"enableLoadExtension"),
+        "loadExtension" => Some(b"loadExtension"),
+        "location" => Some(b"location"),
+        "__perry_dispose__" => Some(b"__perry_dispose__"),
+        "@@__perry_wk_dispose" => Some(b"@@__perry_wk_dispose"),
+        _ => None,
+    }
+}
+
+fn tag_store_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "run" => Some(b"run"),
+        "get" => Some(b"get"),
+        "all" => Some(b"all"),
+        "iterate" => Some(b"iterate"),
+        "clear" => Some(b"clear"),
+        _ => None,
+    }
+}
+
+fn session_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "changeset" => Some(b"changeset"),
+        "patchset" => Some(b"patchset"),
+        "close" => Some(b"close"),
+        "__perry_dispose__" => Some(b"__perry_dispose__"),
+        "@@__perry_wk_dispose" => Some(b"@@__perry_wk_dispose"),
+        _ => None,
+    }
+}
+
+fn statement_method_name_static(property: &str) -> Option<&'static [u8]> {
+    match property {
+        "run" => Some(b"run"),
+        "get" => Some(b"get"),
+        "all" => Some(b"all"),
+        "iterate" => Some(b"iterate"),
+        "columns" => Some(b"columns"),
+        "setReadBigInts" => Some(b"setReadBigInts"),
+        "setReturnArrays" => Some(b"setReturnArrays"),
+        "setAllowBareNamedParameters" => Some(b"setAllowBareNamedParameters"),
+        "setAllowUnknownNamedParameters" => Some(b"setAllowUnknownNamedParameters"),
+        _ => None,
+    }
+}
+
 pub unsafe fn dispatch_node_sqlite_database_method(
     handle: Handle,
     method: &str,
@@ -97,39 +171,10 @@ pub unsafe fn dispatch_node_sqlite_database_property(
         "limits" => Some(js_nanbox_pointer(js_node_sqlite_database_sync_limits(
             handle,
         ))),
-        "open"
-        | "close"
-        | "exec"
-        | "prepare"
-        | "serialize"
-        | "deserialize"
-        | "function"
-        | "aggregate"
-        | "enableDefensive"
-        | "setAuthorizer"
-        | "createTagStore"
-        | "createSession"
-        | "applyChangeset"
-        | "enableLoadExtension"
-        | "loadExtension"
-        | "location"
-        | "__perry_dispose__"
-        | "@@__perry_wk_dispose" => {
-            extern "C" {
-                fn js_class_method_bind(
-                    instance: f64,
-                    method_name_ptr: *const u8,
-                    method_name_len: usize,
-                ) -> f64;
-            }
-            let instance = js_nanbox_pointer(handle);
-            Some(js_class_method_bind(
-                instance,
-                property_name.as_ptr(),
-                property_name.len(),
-            ))
-        }
-        _ => None,
+        _ => Some(bind_static_handle_method(
+            handle,
+            database_method_name_static(property_name)?,
+        )),
     }
 }
 
@@ -191,21 +236,10 @@ pub unsafe fn dispatch_node_sqlite_tag_store_property(
         "capacity" => Some(js_node_sqlite_sql_tag_store_capacity(handle)),
         "db" => Some(js_nanbox_pointer(js_node_sqlite_sql_tag_store_db(handle))),
         "constructor" => Some(sql_tag_store_constructor_value()),
-        "run" | "get" | "all" | "iterate" | "clear" => {
-            extern "C" {
-                fn js_class_method_bind(
-                    instance: f64,
-                    method_name_ptr: *const u8,
-                    method_name_len: usize,
-                ) -> f64;
-            }
-            Some(js_class_method_bind(
-                js_nanbox_pointer(handle),
-                property_name.as_ptr(),
-                property_name.len(),
-            ))
-        }
-        _ => None,
+        _ => Some(bind_static_handle_method(
+            handle,
+            tag_store_method_name_static(property_name)?,
+        )),
     }
 }
 
@@ -243,24 +277,10 @@ pub unsafe fn dispatch_node_sqlite_session_property(
     if js_node_sqlite_is_session_handle(handle) == 0 {
         return None;
     }
-    match property_name {
-        "changeset" | "patchset" | "close" | "__perry_dispose__" | "@@__perry_wk_dispose" => {
-            extern "C" {
-                fn js_class_method_bind(
-                    instance: f64,
-                    method_name_ptr: *const u8,
-                    method_name_len: usize,
-                ) -> f64;
-            }
-            let instance = js_nanbox_pointer(handle);
-            Some(js_class_method_bind(
-                instance,
-                property_name.as_ptr(),
-                property_name.len(),
-            ))
-        }
-        _ => None,
-    }
+    Some(bind_static_handle_method(
+        handle,
+        session_method_name_static(property_name)?,
+    ))
 }
 
 pub(crate) unsafe fn packed_args_array(args: &[f64]) -> *mut ArrayHeader {
@@ -338,29 +358,10 @@ pub unsafe fn dispatch_node_sqlite_statement_property(
         "expandedSQL" => Some(f64_from_jsvalue(JSValue::string_ptr(
             js_node_sqlite_statement_sync_expanded_sql(handle),
         ))),
-        "run"
-        | "get"
-        | "all"
-        | "iterate"
-        | "columns"
-        | "setReadBigInts"
-        | "setReturnArrays"
-        | "setAllowBareNamedParameters"
-        | "setAllowUnknownNamedParameters" => {
-            extern "C" {
-                fn js_class_method_bind(
-                    instance: f64,
-                    method_name_ptr: *const u8,
-                    method_name_len: usize,
-                ) -> f64;
-            }
-            Some(js_class_method_bind(
-                js_nanbox_pointer(handle),
-                property_name.as_ptr(),
-                property_name.len(),
-            ))
-        }
-        _ => None,
+        _ => Some(bind_static_handle_method(
+            handle,
+            statement_method_name_static(property_name)?,
+        )),
     }
 }
 
@@ -464,5 +465,84 @@ pub unsafe extern "C" fn js_node_sqlite_is_session_handle(handle: Handle) -> i32
         1
     } else {
         0
+    }
+}
+
+#[cfg(test)]
+mod static_method_name_tests {
+    use super::*;
+
+    fn assert_static_lookup(lookup: fn(&str) -> Option<&'static [u8]>, names: &[&str]) {
+        for name in names {
+            let owned = (*name).to_owned();
+            let found = lookup(&owned).expect("known method must resolve");
+            assert_eq!(found, name.as_bytes());
+            assert_ne!(
+                found.as_ptr(),
+                owned.as_ptr(),
+                "lookup borrowed the forwarded property name for {name}"
+            );
+            assert_eq!(
+                found.as_ptr(),
+                lookup(name).unwrap().as_ptr(),
+                "lookup must always return the same static literal for {name}"
+            );
+        }
+        assert!(lookup("notASqliteMethod").is_none());
+    }
+
+    #[test]
+    fn sqlite_method_name_lookups_return_static_literals() {
+        assert_static_lookup(
+            database_method_name_static,
+            &[
+                "open",
+                "close",
+                "exec",
+                "prepare",
+                "serialize",
+                "deserialize",
+                "function",
+                "aggregate",
+                "enableDefensive",
+                "setAuthorizer",
+                "createTagStore",
+                "createSession",
+                "applyChangeset",
+                "enableLoadExtension",
+                "loadExtension",
+                "location",
+                "__perry_dispose__",
+                "@@__perry_wk_dispose",
+            ],
+        );
+        assert_static_lookup(
+            tag_store_method_name_static,
+            &["run", "get", "all", "iterate", "clear"],
+        );
+        assert_static_lookup(
+            session_method_name_static,
+            &[
+                "changeset",
+                "patchset",
+                "close",
+                "__perry_dispose__",
+                "@@__perry_wk_dispose",
+            ],
+        );
+        assert_static_lookup(
+            statement_method_name_static,
+            &[
+                "run",
+                "get",
+                "all",
+                "iterate",
+                "columns",
+                "setReadBigInts",
+                "setReturnArrays",
+                "setAllowBareNamedParameters",
+                "setAllowUnknownNamedParameters",
+            ],
+        );
     }
 }

--- a/crates/perry-stdlib/src/tls/dispatch.rs
+++ b/crates/perry-stdlib/src/tls/dispatch.rs
@@ -23,61 +23,74 @@ use super::{
     undefined, TlsSocketCommand, TAG_UNDEFINED_BITS,
 };
 
-fn tls_server_method_name(method: &str) -> bool {
-    matches!(
-        method,
-        "listen"
-            | "close"
-            | "address"
-            | "on"
-            | "addListener"
-            | "once"
-            | "off"
-            | "removeListener"
-            | "removeAllListeners"
-            | "listenerCount"
-            | "eventNames"
-            | "setSecureContext"
-            | "getTicketKeys"
-            | "setTicketKeys"
-            | "ref"
-            | "unref"
-    )
+fn tls_server_method_name_static(method: &str) -> Option<&'static [u8]> {
+    match method {
+        "listen" => Some(b"listen"),
+        "close" => Some(b"close"),
+        "address" => Some(b"address"),
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "listenerCount" => Some(b"listenerCount"),
+        "eventNames" => Some(b"eventNames"),
+        "setSecureContext" => Some(b"setSecureContext"),
+        "getTicketKeys" => Some(b"getTicketKeys"),
+        "setTicketKeys" => Some(b"setTicketKeys"),
+        "ref" => Some(b"ref"),
+        "unref" => Some(b"unref"),
+        _ => None,
+    }
 }
 
-fn tls_socket_introspection_method_name(method: &str) -> bool {
-    matches!(
-        method,
-        "getProtocol"
-            | "getCipher"
-            | "getPeerCertificate"
-            | "getCertificate"
-            | "getSession"
-            | "isSessionReused"
-            | "exportKeyingMaterial"
-            | "setMaxSendFragment"
-            | "ref"
-            | "unref"
-    )
+fn tls_socket_introspection_method_name_static(method: &str) -> Option<&'static [u8]> {
+    match method {
+        "getProtocol" => Some(b"getProtocol"),
+        "getCipher" => Some(b"getCipher"),
+        "getPeerCertificate" => Some(b"getPeerCertificate"),
+        "getCertificate" => Some(b"getCertificate"),
+        "getSession" => Some(b"getSession"),
+        "isSessionReused" => Some(b"isSessionReused"),
+        "exportKeyingMaterial" => Some(b"exportKeyingMaterial"),
+        "setMaxSendFragment" => Some(b"setMaxSendFragment"),
+        "ref" => Some(b"ref"),
+        "unref" => Some(b"unref"),
+        _ => None,
+    }
 }
 
-fn tls_socket_server_method_name(method: &str) -> bool {
-    tls_socket_introspection_method_name(method)
-        || matches!(method, |"write"| "end"
-            | "destroy"
-            | "on"
-            | "addListener"
-            | "once"
-            | "off"
-            | "removeListener"
-            | "removeAllListeners"
-            | "listenerCount"
-            | "eventNames")
+fn tls_socket_server_method_name_static(method: &str) -> Option<&'static [u8]> {
+    tls_socket_introspection_method_name_static(method).or_else(|| match method {
+        "write" => Some(b"write"),
+        "end" => Some(b"end"),
+        "destroy" => Some(b"destroy"),
+        "on" => Some(b"on"),
+        "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "off" => Some(b"off"),
+        "removeListener" => Some(b"removeListener"),
+        "removeAllListeners" => Some(b"removeAllListeners"),
+        "listenerCount" => Some(b"listenerCount"),
+        "eventNames" => Some(b"eventNames"),
+        _ => None,
+    })
+}
+
+/// `js_class_method_bind` retains the name pointer in the closure, so make a
+/// non-static forwarded property slice impossible to pass accidentally.
+unsafe fn bind_static_handle_method(handle: i64, method: &'static [u8]) -> f64 {
+    perry_runtime::object::js_class_method_bind(
+        raw_handle_value(handle),
+        method.as_ptr(),
+        method.len(),
+    )
 }
 
 pub fn should_dispatch_tls_handle(handle: i64, method: &str) -> bool {
     if is_tls_server_handle(handle) {
-        return tls_server_method_name(method);
+        return tls_server_method_name_static(method).is_some();
     }
     sockets()
         .lock()
@@ -85,9 +98,9 @@ pub fn should_dispatch_tls_handle(handle: i64, method: &str) -> bool {
         .get(&handle)
         .map(|socket| {
             if socket.server_side {
-                tls_socket_server_method_name(method)
+                tls_socket_server_method_name_static(method).is_some()
             } else {
-                tls_socket_introspection_method_name(method)
+                tls_socket_introspection_method_name_static(method).is_some()
             }
         })
         .unwrap_or(false)
@@ -274,16 +287,10 @@ pub unsafe fn dispatch_tls_property(handle: i64, property: &str) -> Option<f64> 
                     .unwrap_or(false);
                 return Some(f64::from_bits(JSValue::bool(value).bits()));
             }
-            "listen" | "close" | "address" | "on" | "addListener" | "once" | "off"
-            | "removeListener" | "removeAllListeners" | "listenerCount" | "eventNames"
-            | "setSecureContext" | "getTicketKeys" | "setTicketKeys" | "ref" | "unref" => {
-                return Some(perry_runtime::object::js_class_method_bind(
-                    raw_handle_value(handle),
-                    property.as_ptr(),
-                    property.len(),
-                ));
-            }
             _ => {}
+        }
+        if let Some(method) = tls_server_method_name_static(property) {
+            return Some(bind_static_handle_method(handle, method));
         }
     }
     if is_tls_socket_handle(handle) {
@@ -303,27 +310,104 @@ pub unsafe fn dispatch_tls_property(handle: i64, property: &str) -> Option<f64> 
             }
             "servername" => return Some(nanbox_str("localhost")),
             "alpnProtocol" => return Some(f64::from_bits(perry_runtime::JSValue::null().bits())),
-            _ if sockets()
-                .lock()
-                .unwrap()
-                .get(&handle)
-                .map(|socket| {
-                    if socket.server_side {
-                        tls_socket_server_method_name(property)
-                    } else {
-                        tls_socket_introspection_method_name(property)
-                    }
-                })
-                .unwrap_or(false) =>
-            {
-                return Some(perry_runtime::object::js_class_method_bind(
-                    raw_handle_value(handle),
-                    property.as_ptr(),
-                    property.len(),
-                ));
-            }
             _ => {}
+        }
+        let method = sockets().lock().unwrap().get(&handle).and_then(|socket| {
+            if socket.server_side {
+                tls_socket_server_method_name_static(property)
+            } else {
+                tls_socket_introspection_method_name_static(property)
+            }
+        });
+        if let Some(method) = method {
+            return Some(bind_static_handle_method(handle, method));
         }
     }
     None
+}
+
+#[cfg(test)]
+mod static_method_name_tests {
+    use super::*;
+
+    fn assert_static_lookup(lookup: fn(&str) -> Option<&'static [u8]>, names: &[&str]) {
+        for name in names {
+            let owned = (*name).to_owned();
+            let found = lookup(&owned).expect("known method must resolve");
+            assert_eq!(found, name.as_bytes());
+            assert_ne!(
+                found.as_ptr(),
+                owned.as_ptr(),
+                "lookup borrowed the forwarded property name for {name}"
+            );
+            assert_eq!(found.as_ptr(), lookup(name).unwrap().as_ptr());
+        }
+        assert!(lookup("notATlsMethod").is_none());
+    }
+
+    #[test]
+    fn tls_method_name_lookups_return_static_literals() {
+        assert_static_lookup(
+            tls_server_method_name_static,
+            &[
+                "listen",
+                "close",
+                "address",
+                "on",
+                "addListener",
+                "once",
+                "off",
+                "removeListener",
+                "removeAllListeners",
+                "listenerCount",
+                "eventNames",
+                "setSecureContext",
+                "getTicketKeys",
+                "setTicketKeys",
+                "ref",
+                "unref",
+            ],
+        );
+        assert_static_lookup(
+            tls_socket_introspection_method_name_static,
+            &[
+                "getProtocol",
+                "getCipher",
+                "getPeerCertificate",
+                "getCertificate",
+                "getSession",
+                "isSessionReused",
+                "exportKeyingMaterial",
+                "setMaxSendFragment",
+                "ref",
+                "unref",
+            ],
+        );
+        assert_static_lookup(
+            tls_socket_server_method_name_static,
+            &[
+                "getProtocol",
+                "getCipher",
+                "getPeerCertificate",
+                "getCertificate",
+                "getSession",
+                "isSessionReused",
+                "exportKeyingMaterial",
+                "setMaxSendFragment",
+                "ref",
+                "unref",
+                "write",
+                "end",
+                "destroy",
+                "on",
+                "addListener",
+                "once",
+                "off",
+                "removeListener",
+                "removeAllListeners",
+                "listenerCount",
+                "eventNames",
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Closes #8178.

## Summary

`js_class_method_bind` retains its method-name pointer in the bound closure. The stdlib handle-property dispatchers were forwarding slices backed by the caller's movable GC heap string, so computed method reads could retain an interior pointer after the string moved or died.

- remap SQLite, TLS, EventEmitter, and AsyncLocalStorage method names to `&'static [u8]` literals before binding
- make the shared stdlib bind helpers accept only static names, so the unsafe call cannot consume a forwarded property slice
- replace the primitive-receiver predicate with a static lookup and route both finite-number guards through one safe-name binder
- add structural pointer-identity tests plus complete method-list coverage for every lookup
- intentionally leave workspace/package versions unchanged

## Validation

- `cargo test -p perry-runtime --lib handle_bound_method_name -- --nocapture` (7 passed)
- `cargo test -p perry-stdlib --lib static_method_name -- --nocapture` (4 passed)
- `RUSTFLAGS="-D warnings" cargo check -p perry-runtime -p perry-stdlib --all-targets`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `python3 scripts/ci_plan.py --self-test`
- `python3 scripts/gc_store_site_inventory.py --self-test && python3 scripts/gc_store_site_inventory.py`
- `python3 scripts/addr_class_inventory.py --self-test && python3 scripts/addr_class_inventory.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method access for primitive values and runtime handles so bound methods remain available after garbage collection.
  * Improved method dispatch across event handling, asynchronous storage, database, TLS, and socket APIs.
  * Unknown properties are now rejected more reliably instead of being treated as supported methods.
* **Tests**
  * Added regression coverage for primitive prototype methods, recognized API methods, and unknown property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->