### PR TITLE
fix(runtime): keep builtin alias dispatch in optimized builds

### DIFF
--- a/changelog.d/8292-auto-optimize-builtin-alias.md
+++ b/changelog.d/8292-auto-optimize-builtin-alias.md
@@ -1,0 +1,4 @@
+Auto-optimized builds now retain builtin constructor dispatch independently of
+the optional fetch globals. Constructing collections and other builtins through
+aliases or `globalThis` therefore matches the full prebuilt runtime, while the
+`Headers` constructor remains correctly gated behind `global-webfetch`.

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -537,12 +537,15 @@ pub unsafe extern "C" fn js_new_function_construct(
                     options,
                 );
             }
-            #[cfg(feature = "global-webfetch")]
             // Global builtins reached through a VALUE (alias variable,
             // intrinsic lookup, cross-module re-export) rather than by name.
+            // This arm must stay independent of the optional globalThis member-
+            // table features: it also owns always-available collection aliases,
+            // while URL/Text aliases have their own feature selection.
             n if builtin_alias_construct::handles(n) => {
                 return builtin_alias_construct::construct(n, args);
             }
+            #[cfg(feature = "global-webfetch")]
             "Headers" => {
                 let init = args
                     .first()


### PR DESCRIPTION
## Summary

Fix builtin constructor aliases in auto-optimized builds by removing their accidental dependency on the unrelated `global-webfetch` feature.

## Changes

- Keep the shared builtin-alias construct dispatcher available in feature-stripped runtimes.
- Restore the `global-webfetch` guard to the `Headers` arm it originally gated.
- Document why alias dispatch must remain independent of optional globalThis member-table features.

## Related issue

Fixes #8223

## Test plan

Each reported fixture was compiled with auto-optimize from this worktree, executed, and byte-compared with `node --experimental-strip-types`:

- [x] `test_gap_builtin_alias_construct_7524` (`global-url` + `global-text`, no `global-webfetch`)
- [x] `test_gap_dynamic_builtin_construct_dispatch` (`global-text`, no `global-webfetch`)
- [x] `test_gap_new_globalthis_builtin_6726` (no optional global namespace features)
- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate (existing gap fixtures cover the regression)
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` (not an API change)
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform (not applicable)

## Screenshots / output

All three targeted runs completed with `node_status=0 compile_status=0 perry_status=0 diff_status=0`.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)