### PR TITLE
fix(gc): root raw pointers in dynamic-object get, add a PROCESS_EMITTER scanner

### DIFF
--- a/changelog.d/8282-dynamic-object-rooting-process-emitter.md
+++ b/changelog.d/8282-dynamic-object-rooting-process-emitter.md
@@ -1,0 +1,20 @@
+**GC: two #8220-class rooting fixes, and a native-stack diagnostic.**
+
+`js_dynamic_object_get_property` held the receiver as a raw pointer across
+`js_string_from_bytes`, which allocates. It now opens a `RuntimeHandleScope` and
+takes the key through `across_const`, so the receiver is re-read after the
+allocation rather than naming from-space if a copying minor lands in the window.
+
+Process `EventEmitter` listener closures are held as raw `*const ClosureHeader`
+in a TLS `HashMap`, which the precise root map cannot see — a copying minor that
+evacuated one left the table pointing at from-space. `PROCESS_EMITTER` now has a
+registered mutable root scanner.
+
+Adds `PERRY_GC_SCAN_NATIVE_STACK=1`, a debug-only scan for stale from-space
+pointers on the native stack after a copying minor, with
+`PERRY_GC_SCAN_NATIVE_STACK_ABORT=1` to stop at the first offender. **Abort
+implies scan**, matching `fromspace_scan::resolve_scan_knobs`: the abort switch
+alone would otherwise return at the enabled-gate, never run, and report success.
+
+Neither fix resolves the seeded rooting crash — seeds 8, 11 and 22 still fail.
+They are landed as correct fixes in their own right, not as a resolution.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1523,6 +1523,12 @@ pub(super) fn run_copied_minor_attempt(
     // the root enumeration the rewrite pass and the evacuation verifier share.
     super::fromspace_scan::run_fromspace_scan(&snapshot);
 
+    // #8220 diagnostic: scan the native (Rust) stack for stale from-space
+    // pointers — raw pointers held in Rust frame locals that the precise root
+    // map can't see and the conservative scan is disabled in production. MUST
+    // run here, same window as fromspace_scan (after rewrite, before reset).
+    super::native_stack_scan::run_native_stack_scan();
+
     crate::promise::cleanup_copied_minor_promise_contexts_for_gc();
     finalize_dead_copied_minor_from_space_side_allocations();
     // #7742: on a promoting cycle the young blocks are handed to old-gen

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -172,6 +172,9 @@ mod verify;
 /// the rewrite pass own root enumeration. Debug-only
 /// (`PERRY_GC_FROMSPACE_SCAN=1`).
 mod fromspace_scan;
+/// #8220 diagnostic: native-stack scan for stale from-space pointers after a
+/// copying minor. Debug-only (`PERRY_GC_SCAN_NATIVE_STACK=1`).
+mod native_stack_scan;
 /// #7742: the measured policy behind whole-block in-place promotion. The
 /// mechanism is `arena/promote.rs`; this decides when to use it.
 mod promote_in_place;
@@ -1015,6 +1018,11 @@ pub fn gc_init() {
     reg_scanner!(crate::process::scan_process_env_cache_roots_mut);
     reg_scanner!(crate::process::scan_permission_cache_roots_mut);
     reg_scanner!(crate::process::scan_report_cache_roots_mut);
+    // #8220: process EventEmitter listener closures are held as raw
+    // `*const ClosureHeader` in a TLS `HashMap` — invisible to the precise
+    // root map. Without this scanner a copying minor that evacuates a
+    // listener closure leaves the raw pointer stale.
+    reg_scanner!(crate::os::process_emitter_root_scanner);
     // #7231: the raw `Error` constructor address behind
     // `Error.prepareStackTrace`. The closure is reachable through `globalThis`
     // so it is not swept, but this duplicate lives outside the object graph

--- a/crates/perry-runtime/src/gc/native_stack_scan.rs
+++ b/crates/perry-runtime/src/gc/native_stack_scan.rs
@@ -1,0 +1,360 @@
+//! Diagnostic native-stack scan for stale from-space pointers (#8220 class).
+//!
+//! After a copying minor rewrites all known roots and moves survivors, but
+//! BEFORE `copying_reset_from_spaces_and_flip` recycles from-space, this pass
+//! walks the native (Rust) stack looking for words that decode to a from-space
+//! address whose target carries `GC_FLAG_FORWARDED`. Such a word is an
+//! unambiguous stale pointer: the object moved this cycle and this stack slot
+//! was not updated — exactly the #8220 class (a raw pointer held in a native
+//! Rust frame across a copying minor, invisible to the precise root map).
+//!
+//! Gated behind `PERRY_GC_SCAN_NATIVE_STACK=1`. Non-fatal by default;
+//! `PERRY_GC_SCAN_NATIVE_STACK_ABORT=1` aborts after the first offender so a
+//! debugger catches the cycle.
+
+use crate::arena::classify_heap_space_in_range;
+use crate::gc::types::{forwarding_address, GC_FLAG_FORWARDED, GC_HEADER_SIZE};
+
+/// Is the native-stack diagnostic enabled?
+fn native_stack_scan_enabled() -> bool {
+    crate::gc::env_flag_enabled("PERRY_GC_SCAN_NATIVE_STACK")
+}
+
+/// Should we abort on the first stale pointer found?
+fn native_stack_scan_abort() -> bool {
+    crate::gc::env_flag_enabled("PERRY_GC_SCAN_NATIVE_STACK_ABORT")
+}
+
+/// Run the diagnostic native-stack scan. Call this after the rewrite pass and
+/// before from-space reset, inside the copying minor.
+pub(super) fn run_native_stack_scan() {
+    if !native_stack_scan_enabled() {
+        return;
+    }
+
+    // Capture the backtrace so we can attribute stack slots to frames.
+    let bt = std::backtrace::Backtrace::force_capture();
+
+    // Walk the frame pointer chain to get frame boundaries. On arm64/x86_64
+    // macOS, FP (x29 / rbp) points to [prev_fp, return_addr]. We walk
+    // upward and record (sp, return_addr_symbol) for each frame so we can
+    // match stale pointer stack addresses to the frame that holds them.
+    let frames = walk_frame_pointers();
+
+    // Get the stack bounds so we don't read past the valid stack.
+    // On macOS, pthread_get_stackaddr_np gives the TOP of the stack
+    // (highest address), and pthread_get_stacksize_np gives the total size.
+    // The stack grows downward, so valid range is [top - size, top].
+    #[cfg(target_os = "macos")]
+    let (stack_lo, stack_hi) = {
+        let top = unsafe { libc::pthread_get_stackaddr_np(libc::pthread_self()) } as usize;
+        let size = unsafe { libc::pthread_get_stacksize_np(libc::pthread_self()) } as usize;
+        (top - size, top)
+    };
+    #[cfg(not(target_os = "macos"))]
+    let (stack_lo, stack_hi) = {
+        // Fallback: use a local variable address and scan 256KB upward.
+        let marker: usize = 0;
+        let sp = std::ptr::addr_of!(marker) as usize;
+        (sp, sp + 256 * 1024)
+    };
+
+    // Get a reference point on the stack. On x86_64/aarch64 the stack grows
+    // downward, so we scan from this address upward (toward higher addresses).
+    let stack_marker: usize = 0;
+    let scan_start = std::ptr::addr_of!(stack_marker) as usize;
+    // Align upward to 8 bytes.
+    let scan_start = (scan_start + 7) & !7;
+    // Don't scan past the stack top.
+    let scan_end = stack_hi;
+
+    let mut offenders: Vec<StaleStackSlot> = Vec::new();
+    let mut words_scanned: usize = 0;
+
+    let mut addr = scan_start;
+    while addr + 8 <= scan_end {
+        words_scanned += 1;
+        // SAFETY: we are scanning the stack above our own frame. These pages
+        // are all mapped (they are the active stack). We only READ.
+        let word = unsafe { *(addr as *const u64) };
+
+        // Try decoding as a raw address (plain *const T).
+        if let Some(slot) = check_word_as_heap_pointer(word, addr) {
+            offenders.push(slot);
+        }
+
+        // Try decoding as a NaN-boxed pointer. Perry uses several tags:
+        // POINTER_TAG (0x7FFD) for objects/arrays, STRING_TAG (0x7FFF) for
+        // heap strings, BIGINT_TAG for bigints. All encode the pointer in the
+        // lower 48 bits.
+        let nanboxed_addr = word & 0x0000_FFFF_FFFF_FFFF;
+        let tag = word & 0xFFFF_0000_0000_0000;
+        if tag == 0x7FFD_0000_0000_0000      // POINTER_TAG
+            || tag == 0x7FFF_0000_0000_0000  // STRING_TAG
+        {
+            if let Some(slot) = check_word_as_heap_pointer(nanboxed_addr, addr) {
+                offenders.push(slot);
+            }
+        }
+
+        addr += 8;
+    }
+
+    eprintln!(
+        "[native-stack-scan] scanned {words_scanned} words on stack [{scan_start:#x}..{scan_end:#x}], found {n} stale pointer(s)",
+        words_scanned = words_scanned,
+        scan_start = scan_start,
+        scan_end = scan_end,
+        n = offenders.len(),
+    );
+
+    // Dump ALL words in the generated code's frame (the last few frames
+    // in the walk) to see what's actually on the stack.
+    if !frames.is_empty() {
+        // The generated code's frame is above js_gc_loop_safepoint_armed's
+        // frame. Find it by looking for the frame that returns to
+        // src_lib_util_graceful_exit_ts__init_body.
+        for (i, frame) in frames.iter().enumerate() {
+            let sym = resolve_symbol(frame.return_addr);
+            if sym.contains("graceful_exit") || sym.contains("init_body") {
+                let dump_start = frame.sp;
+                let dump_end = frame.sp + frame.size;
+                eprintln!(
+                    "[native-stack-scan] generated code frame {i}: sp=0x{sp:x}..0x{end:x} ({size} bytes)",
+                    i = i,
+                    sp = frame.sp,
+                    end = dump_end,
+                    size = frame.size,
+                );
+                let mut off = 0usize;
+                let mut a = dump_start;
+                while a + 8 <= dump_end && off < 64 {
+                    let w = unsafe { *(a as *const u64) };
+                    if w != 0 {
+                        eprintln!(
+                            "  sp+{off:#04x}: 0x{w:016x}",
+                            off = (a - dump_start),
+                            w = w,
+                        );
+                    }
+                    a += 8;
+                    off += 1;
+                }
+            }
+        }
+    }
+
+    if offenders.is_empty() {
+        return;
+    }
+
+    eprintln!("[native-stack-scan] backtrace at scan point:\n{}", bt);
+
+    // Print frame boundaries so we can match stale pointers to frames.
+    for (i, frame) in frames.iter().enumerate() {
+        // Resolve the symbol for the return address using dladdr.
+        let sym = resolve_symbol(frame.return_addr);
+        eprintln!(
+            "[native-stack-scan] frame {i}: sp=0x{sp:x}..0x{sp_end:x} ret={ret:#x} sym={sym}",
+            i = i,
+            sp = frame.sp,
+            sp_end = frame.sp + frame.size,
+            ret = frame.return_addr,
+            sym = sym,
+        );
+    }
+
+    for (i, slot) in offenders.iter().enumerate() {
+        // Find which frame this stale pointer belongs to.
+        let frame_idx = frames.iter().position(|f| {
+            slot.stack_addr >= f.sp && slot.stack_addr < f.sp + f.size
+        });
+        // Read the raw word for debugging.
+        let raw_word = unsafe { *(slot.stack_addr as *const u64) };
+        eprintln!(
+            "[native-stack-scan] #{i}: stack_addr=0x{stack_addr:x} (offset +{offset:#x} from scan_start) \
+             raw_word=0x{raw_word:016x} from_space_addr=0x{from_space:x} -> forwarded_to=0x{new_addr:x} \
+             target_obj_type={obj_type} target_space={space:?} nanboxed={nanboxed} \
+             frame_idx={frame_idx:?}",
+            i = i,
+            stack_addr = slot.stack_addr,
+            offset = slot.stack_addr - scan_start,
+            raw_word = raw_word,
+            from_space = slot.from_space_addr,
+            new_addr = slot.forwarded_to,
+            obj_type = slot.target_obj_type,
+            space = slot.target_space,
+            nanboxed = slot.nanboxed,
+            frame_idx = frame_idx,
+        );
+    }
+
+    if native_stack_scan_abort() {
+        std::process::abort();
+    }
+}
+
+/// One frame in the native call stack, from the frame pointer chain.
+#[derive(Clone, Copy)]
+struct FrameInfo {
+    /// Stack pointer (lowest address) of this frame.
+    sp: usize,
+    /// Size of this frame in bytes (distance to the next frame's SP).
+    size: usize,
+    /// Return address (the instruction after the call in the caller).
+    return_addr: usize,
+}
+
+/// Walk the arm64 frame pointer chain to collect frame boundaries.
+///
+/// On arm64, the frame pointer (FP / x29) points to a saved [prev_fp, lr]
+/// pair on the stack. Starting from the current FP, we walk upward:
+///
+/// ```text
+///   [current FP] -> [prev_fp] [return_addr]
+///                    |
+///                    v
+///                    [prev_prev_fp] [return_addr_2]
+///                    ...
+/// ```
+///
+/// Each frame's SP is the address of its saved FP slot, and its size is
+/// the distance to the previous frame's FP slot.
+#[cfg(target_arch = "aarch64")]
+fn walk_frame_pointers() -> Vec<FrameInfo> {
+    let mut frames = Vec::new();
+    let mut fp: usize;
+
+    // Get the current frame pointer.
+    #[cfg(target_os = "macos")]
+    unsafe {
+        std::arch::asm!(
+            "mov {fp}, x29",
+            fp = out(reg) fp,
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let marker: usize = 0;
+        fp = std::ptr::addr_of!(marker) as usize;
+    }
+
+    let mut prev_fp: usize = 0;
+    let mut return_addr: usize = 0;
+    let mut depth = 0;
+
+    while fp != 0 && depth < 64 {
+        // On arm64, [fp] = prev_fp, [fp+8] = return_addr (LR).
+        let saved_fp = unsafe { *(fp as *const usize) };
+        let saved_lr = unsafe { *((fp + 8) as *const usize) };
+
+        if saved_fp == 0 || saved_fp <= fp {
+            // End of chain or invalid (fp should increase as we go up).
+            return_addr = saved_lr;
+            frames.push(FrameInfo {
+                sp: fp,
+                size: 4096, // unknown, give a generous bound
+                return_addr,
+            });
+            break;
+        }
+
+        let frame_size = saved_fp - fp;
+        frames.push(FrameInfo {
+            sp: fp,
+            size: frame_size,
+            return_addr: saved_lr,
+        });
+
+        prev_fp = fp;
+        fp = saved_fp;
+        depth += 1;
+    }
+
+    frames
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn walk_frame_pointers() -> Vec<FrameInfo> {
+    Vec::new()
+}
+
+/// Resolve a code address to a symbol name using `dladdr`.
+fn resolve_symbol(addr: usize) -> String {
+    unsafe {
+        let mut info: libc::Dl_info = std::mem::zeroed();
+        if libc::dladdr(addr as *const libc::c_void, &mut info) != 0 {
+            let sym = if info.dli_sname.is_null() {
+                "?".to_string()
+            } else {
+                std::ffi::CStr::from_ptr(info.dli_sname).to_string_lossy().into_owned()
+            };
+            let fname = if info.dli_fname.is_null() {
+                "?".to_string()
+            } else {
+                std::ffi::CStr::from_ptr(info.dli_fname).to_string_lossy().into_owned()
+            };
+            let offset = addr - (info.dli_saddr as usize);
+            format!("{sym}+{offset:#x} in {fname}")
+        } else {
+            format!("0x{addr:x} (dladdr failed)")
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct StaleStackSlot {
+    stack_addr: usize,
+    from_space_addr: usize,
+    forwarded_to: usize,
+    target_obj_type: u8,
+    target_space: crate::arena::HeapSpace,
+    nanboxed: bool,
+}
+
+/// Check if `word` is a heap pointer to a forwarded from-space object.
+/// Returns `Some(StaleStackSlot)` if it is, `None` otherwise.
+fn check_word_as_heap_pointer(word: u64, stack_addr: usize) -> Option<StaleStackSlot> {
+    if word == 0 {
+        return None;
+    }
+    let addr = word as usize;
+
+    // Check if this address is in a nursery space (from-space).
+    let (space, base) = classify_heap_space_in_range(addr)?;
+    if !space.is_nursery() {
+        return None;
+    }
+
+    // The word could be a user pointer (payload start) or a header pointer.
+    // Try both: first as a user pointer (header is at addr - GC_HEADER_SIZE),
+    // then as a header pointer itself.
+    let header_addr = if addr >= base + GC_HEADER_SIZE {
+        addr - GC_HEADER_SIZE
+    } else {
+        addr
+    };
+
+    // SAFETY: the address is classified as nursery/from-space, which means
+    // it's in a registered arena block. The from-space is still intact (we
+    // run before the reset), so the header is valid.
+    let header = header_addr as *const crate::gc::types::GcHeader;
+    let flags = unsafe { (*header).gc_flags };
+    if flags & GC_FLAG_FORWARDED == 0 {
+        return None;
+    }
+
+    // This is a stale pointer! The object was forwarded (moved) but this
+    // stack slot still points to the old location.
+    let forwarded_to = unsafe { forwarding_address(header) } as usize;
+    let obj_type = unsafe { (*header).obj_type };
+
+    Some(StaleStackSlot {
+        stack_addr,
+        from_space_addr: addr,
+        forwarded_to,
+        target_obj_type: obj_type,
+        target_space: space,
+        nanboxed: (word & 0xFFFF_0000_0000_0000) == 0x7FFD_0000_0000_0000,
+    })
+}

--- a/crates/perry-runtime/src/gc/native_stack_scan.rs
+++ b/crates/perry-runtime/src/gc/native_stack_scan.rs
@@ -16,8 +16,16 @@ use crate::arena::classify_heap_space_in_range;
 use crate::gc::types::{forwarding_address, GC_FLAG_FORWARDED, GC_HEADER_SIZE};
 
 /// Is the native-stack diagnostic enabled?
+///
+/// **ABORT IMPLIES SCAN** — the same rule `fromspace_scan::resolve_scan_knobs`
+/// carries for #7154's pair. Without it `PERRY_GC_SCAN_NATIVE_STACK_ABORT=1`
+/// alone is completely inert: `run_native_stack_scan` returns at this gate, the
+/// scan never runs, there is nothing to abort, and the run reports success. A
+/// knob that reads as "abort on the first offender" and silently does nothing
+/// is exactly what the GC knob kill-policy exists to prevent, and exactly what
+/// an investigator reaching for the abort switch mid-hunt would be misled by.
 fn native_stack_scan_enabled() -> bool {
-    crate::gc::env_flag_enabled("PERRY_GC_SCAN_NATIVE_STACK")
+    crate::gc::env_flag_enabled("PERRY_GC_SCAN_NATIVE_STACK") || native_stack_scan_abort()
 }
 
 /// Should we abort on the first stale pointer found?
@@ -90,7 +98,8 @@ pub(super) fn run_native_stack_scan() {
         let nanboxed_addr = word & 0x0000_FFFF_FFFF_FFFF;
         let tag = word & 0xFFFF_0000_0000_0000;
         if tag == 0x7FFD_0000_0000_0000      // POINTER_TAG
-            || tag == 0x7FFF_0000_0000_0000  // STRING_TAG
+            || tag == 0x7FFF_0000_0000_0000
+        // STRING_TAG
         {
             if let Some(slot) = check_word_as_heap_pointer(nanboxed_addr, addr) {
                 offenders.push(slot);
@@ -131,11 +140,7 @@ pub(super) fn run_native_stack_scan() {
                 while a + 8 <= dump_end && off < 64 {
                     let w = unsafe { *(a as *const u64) };
                     if w != 0 {
-                        eprintln!(
-                            "  sp+{off:#04x}: 0x{w:016x}",
-                            off = (a - dump_start),
-                            w = w,
-                        );
+                        eprintln!("  sp+{off:#04x}: 0x{w:016x}", off = (a - dump_start), w = w,);
                     }
                     a += 8;
                     off += 1;
@@ -166,9 +171,9 @@ pub(super) fn run_native_stack_scan() {
 
     for (i, slot) in offenders.iter().enumerate() {
         // Find which frame this stale pointer belongs to.
-        let frame_idx = frames.iter().position(|f| {
-            slot.stack_addr >= f.sp && slot.stack_addr < f.sp + f.size
-        });
+        let frame_idx = frames
+            .iter()
+            .position(|f| slot.stack_addr >= f.sp && slot.stack_addr < f.sp + f.size);
         // Read the raw word for debugging.
         let raw_word = unsafe { *(slot.stack_addr as *const u64) };
         eprintln!(
@@ -287,12 +292,16 @@ fn resolve_symbol(addr: usize) -> String {
             let sym = if info.dli_sname.is_null() {
                 "?".to_string()
             } else {
-                std::ffi::CStr::from_ptr(info.dli_sname).to_string_lossy().into_owned()
+                std::ffi::CStr::from_ptr(info.dli_sname)
+                    .to_string_lossy()
+                    .into_owned()
             };
             let fname = if info.dli_fname.is_null() {
                 "?".to_string()
             } else {
-                std::ffi::CStr::from_ptr(info.dli_fname).to_string_lossy().into_owned()
+                std::ffi::CStr::from_ptr(info.dli_fname)
+                    .to_string_lossy()
+                    .into_owned()
             };
             let offset = addr - (info.dli_saddr as usize);
             format!("{sym}+{offset:#x} in {fname}")
@@ -321,7 +330,9 @@ fn check_word_as_heap_pointer(word: u64, stack_addr: usize) -> Option<StaleStack
     let addr = word as usize;
 
     // Check if this address is in a nursery space (from-space).
-    let (space, base) = classify_heap_space_in_range(addr)?;
+    // #8277 widened this to (space, base, object_start_bitmap); the diagnostic
+    // only needs the space and the block base.
+    let (space, base, _starts) = classify_heap_space_in_range(addr)?;
     if !space.is_nursery() {
         return None;
     }

--- a/crates/perry-runtime/src/os/os_process_emitter.rs
+++ b/crates/perry-runtime/src/os/os_process_emitter.rs
@@ -48,6 +48,32 @@ thread_local! {
     static PROCESS_EMITTER: RefCell<ProcessEmitter> = RefCell::new(ProcessEmitter::new());
 }
 
+/// #8220: GC root scanner for `PROCESS_EMITTER`. Each `ProcessListener` holds
+/// raw `*const ClosureHeader` pointers (`callback`, `raw_wrapper`) that the
+/// precise root map cannot see — they live in a TLS `HashMap`, not in a
+/// codegen root slot or a registered global. Without this scanner, a copying
+/// minor that evacuates a listener closure leaves the raw pointer pointing at
+/// retired from-space, and the next `emit` dereferences stale memory.
+pub(crate) fn process_emitter_root_scanner(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    PROCESS_EMITTER.with(|emitter| {
+        let mut emitter = emitter.borrow_mut();
+        for listeners in emitter.events.values_mut() {
+            for listener in listeners.iter_mut() {
+                visitor.visit_raw_const_ptr_slot(&mut listener.callback);
+                visitor.visit_raw_const_ptr_slot(&mut listener.raw_wrapper);
+            }
+        }
+    });
+}
+
+/// Register the process-emitter root scanner (called once during runtime init).
+pub(crate) fn register_process_emitter_root_scanner() {
+    crate::gc::gc_register_mutable_root_scanner_named(
+        "process_emitter",
+        process_emitter_root_scanner,
+    );
+}
+
 pub(crate) fn read_event_name(event_ptr: *const StringHeader) -> Option<String> {
     if event_ptr.is_null() {
         return None;

--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -647,16 +647,23 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
         }
     }
 
-    // Create a Perry string for the key
-    let key_ptr =
-        crate::string::js_string_from_bytes(property_name.as_ptr(), property_name.len() as u32);
+    // #8220: root the receiver across the key-string allocation. `ptr` was
+    // extracted at the top of this function from the NaN-boxed `obj_value` and
+    // is a raw `*const` to a nursery-eligible heap object. `js_string_from_bytes`
+    // allocates a fresh StringHeader on every call and can trigger a copying
+    // minor that evacuates the receiver. Without rooting, `ptr` becomes a stale
+    // from-space pointer and the `js_object_get_field_by_name_f64` call below
+    // dereferences retired memory — the #8220 class (raw pointer in a Rust
+    // frame local, invisible to the precise root map).
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_raw_const_ptr(ptr as *const crate::object::ObjectHeader);
+    let (key_ptr, obj_ptr) = receiver.across_const(|| {
+        crate::string::js_string_from_bytes(property_name.as_ptr(), property_name.len() as u32)
+    });
 
-    // Call native object property access
+    // Call native object property access with the post-collection pointer.
 
-    crate::object::js_object_get_field_by_name_f64(
-        ptr as *const crate::object::ObjectHeader,
-        key_ptr,
-    )
+    crate::object::js_object_get_field_by_name_f64(obj_ptr, key_ptr)
 }
 
 /// Dynamic method dispatch for Map/Set collection types.


### PR DESCRIPTION
Rebased version of #8282 by @jdalton, which cannot merge as-is — it does not compile against current `main`. Two fixes on top of the original work; the rooting changes themselves are unmodified and correct.

## The two blockers

**1. It does not build.** #8277 widened `classify_heap_space_in_range` to return `(HeapSpace, usize, *mut u64)` — the third element is the object-start bitmap. `native_stack_scan.rs` was written against the 2-tuple:

```
error[E0308]: mismatched types
   --> crates/perry-runtime/src/gc/native_stack_scan.rs:332
332 |     let (space, base) = classify_heap_space_in_range(addr)?;
    |         expected a tuple with 3 elements, found one with 2 elements
```

Git merged both cleanly because the lines never overlap. Fixed by destructuring the third element as `_starts`.

**2. `PERRY_GC_SCAN_NATIVE_STACK_ABORT=1` alone was inert** — and this is the defect the repo already fixed once. `run_native_stack_scan` returns at the `native_stack_scan_enabled()` gate, so with only the abort switch set the scan never runs, there is nothing to abort, and the run reports success. `fromspace_scan.rs:124` documents exactly this for #7154's pair:

> **ABORT IMPLIES SCAN** (#7154 tooling). `PERRY_GC_FROMSPACE_SCAN_ABORT=1` on its own used to be completely inert […] A knob that reads as "abort on the first offender" and silently does nothing is exactly the class of defect the GC knob kill-policy exists for — and exactly what an investigator reaching for the abort switch mid-hunt would be misled by.

`native_stack_scan_enabled()` now ORs in the abort flag, matching that precedent.

Also added the missing `changelog.d/` fragment.

## The original work, unchanged

- **`js_dynamic_object_get_property`** held the receiver as a raw pointer across `js_string_from_bytes`, which allocates. Now a `RuntimeHandleScope` with `across_const` — the idiom that expresses the ordering in one call and never binds the pre-call address.
- **`PROCESS_EMITTER`** listener closures live as raw `*const ClosureHeader` in a TLS `HashMap`, structurally invisible to the precise root map. Now has a registered mutable root scanner. This is the "runtime-side cache of a raw heap pointer is a GC root, and the static checker cannot see it" class — the right disposition.

## Verification

`cargo test -p perry-runtime --lib` — **2568 passed, 0 failed, 4 ignored**. `cargo fmt --all --check` clean. `gc_runtime_root_holders`, `check_thread_locals`, `addr_class_inventory`, `unrooted_local_shape --check`, and `check_gc_env_knobs` all clean.

@jdalton's framing is right and worth preserving: **this does not resolve the seeded rooting crash** — seeds 8, 11 and 22 still fail. It lands as two correct fixes plus a diagnostic, not as a resolution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection reliability when accessing dynamic object properties.
  * Preserved process event listeners correctly during garbage collection.
  * Added safeguards to detect stale native-stack references after collection.

* **Diagnostics**
  * Added optional native-stack scanning and abort-on-detection controls for investigating garbage-collection issues.
  * Included additional diagnostic information, including stack frames and generated-frame details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->