### PR TITLE
perf(codegen): skip unbounded guards for bounded bodies

### DIFF
--- a/changelog.d/8296-bound-structural-guards.md
+++ b/changelog.d/8296-bound-structural-guards.md
@@ -1,0 +1,7 @@
+### perf(codegen): skip unbounded guards for bounded bodies
+
+Perry no longer walks runtime-sized arrays, maps, sets, or recursive object
+graphs to enter a function whose own work is statically bounded. This removes
+the costly structural parameter guards from the interpreter benchmark's
+`peek` and `asNum` helpers while retaining fixed-size object guards and guards
+for looping consumers that can amortize validation. Fixes #8202.

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -2615,6 +2615,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 f.id,
                 &module_prefix,
                 &f.params,
+                &f.body,
                 &demoted,
                 &guard_blocked,
                 &cross_module.type_aliases,

--- a/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
+++ b/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
@@ -352,37 +352,38 @@ fn nonsuspending_async_function_needs_no_direct_call_site_for_its_guarded_clone(
 #[test]
 fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
     // Renamed from `guarded_discriminant_branch_routes_recursive_field_to_clone`.
-    // The routing half of that name described a RECURSIVE union walk, which
-    // `guard_blocked` no longer admits: a call in the body can reach the
-    // guarded object through an alias the caller arranged before entry, so a
-    // reference-typed parameter cannot keep a descriptor proof across it. The
-    // narrowing machinery it was really exercising survives on a call-free
-    // body, and the recursive shape is kept below as the negative that pins
-    // the rule.
-    let node = Type::Union(vec![
-        Type::Object(ObjectType {
-            name: None,
-            properties: HashMap::from([
-                (
-                    "kind".to_string(),
-                    PropertyInfo {
-                        ty: Type::StringLiteral("num".to_string()),
-                        optional: false,
-                        readonly: false,
-                    },
-                ),
-                (
-                    "num".to_string(),
-                    PropertyInfo {
-                        ty: Type::Number,
-                        optional: false,
-                        readonly: false,
-                    },
-                ),
-            ]),
-            property_order: Some(vec!["kind".to_string(), "num".to_string()]),
-            index_signature: None,
-        }),
+    // The routing half of that name described a recursive CALL, which
+    // `guard_blocked` does not admit for a reference parameter: a call can
+    // reach the guarded object through an alias the caller arranged before
+    // entry, so a reference-typed parameter cannot keep a descriptor proof
+    // across it. The narrowing machinery it was really exercising survives
+    // on a call-free body, and the recursive call is kept below as the
+    // negative that pins the rule.
+    let numeric_node = Type::Object(ObjectType {
+        name: None,
+        properties: HashMap::from([
+            (
+                "kind".to_string(),
+                PropertyInfo {
+                    ty: Type::StringLiteral("num".to_string()),
+                    optional: false,
+                    readonly: false,
+                },
+            ),
+            (
+                "num".to_string(),
+                PropertyInfo {
+                    ty: Type::Number,
+                    optional: false,
+                    readonly: false,
+                },
+            ),
+        ]),
+        property_order: Some(vec!["kind".to_string(), "num".to_string()]),
+        index_signature: None,
+    });
+    let flat_node = Type::Union(vec![
+        numeric_node,
         Type::Object(ObjectType {
             name: None,
             properties: HashMap::from([
@@ -397,7 +398,7 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
                 (
                     "left".to_string(),
                     PropertyInfo {
-                        ty: Type::Named("Node".to_string()),
+                        ty: Type::Number,
                         optional: false,
                         readonly: false,
                     },
@@ -427,7 +428,7 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
         params: vec![Param {
             id: 310,
             name: "node".to_string(),
-            ty: Type::Named("Node".to_string()),
+            ty: Type::Named("FlatNode".to_string()),
             default: None,
             decorators: Vec::new(),
             is_rest: false,
@@ -476,7 +477,7 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
         params: vec![Param {
             id: 320,
             name: "node".to_string(),
-            ty: Type::Named("Node".to_string()),
+            ty: Type::Named("FlatNode".to_string()),
             default: None,
             decorators: Vec::new(),
             is_rest: false,
@@ -493,11 +494,7 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
                 },
                 then_branch: vec![Stmt::Return(Some(Expr::Call {
                     callee: Box::new(Expr::FuncRef(32)),
-                    args: vec![Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(320)),
-                        property: "left".to_string(),
-                        byte_offset: 0,
-                    }],
+                    args: vec![Expr::LocalGet(320)],
                     type_args: Vec::new(),
                     byte_offset: 0,
                 }))],
@@ -517,9 +514,9 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
     let mut module = Module::new("recursive_guard_narrowing.ts");
     module.type_aliases.push(TypeAlias {
         id: 31,
-        name: "Node".to_string(),
+        name: "FlatNode".to_string(),
         type_params: Vec::new(),
-        ty: node.clone(),
+        ty: flat_node.clone(),
         is_exported: false,
     });
     module.functions.push(eval);
@@ -536,7 +533,7 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
         output_type: "executable".to_string(),
         ..Default::default()
     };
-    opts.type_aliases.insert("Node".to_string(), node);
+    opts.type_aliases.insert("FlatNode".to_string(), flat_node);
     let ir = String::from_utf8(compile_module(&module, opts).expect("module compiles"))
         .expect("LLVM IR is UTF-8");
     let public = function_ir(&ir, "@perry_fn_recursive_guard_narrowing_ts__evalNode(");

--- a/crates/perry-codegen/src/codegen/param_guard.rs
+++ b/crates/perry-codegen/src/codegen/param_guard.rs
@@ -582,35 +582,36 @@ fn encode_node(node: &GuardNode) -> Option<Vec<u8>> {
 /// runtime-sized object graph. Everything else visits a fixed graph of fields
 /// and union arms whose size the compiler owns.
 fn descriptor_walk_is_bounded(nodes: &[GuardNode], root: u32) -> bool {
-    fn visit(nodes: &[GuardNode], node: u32, state: &mut [u8]) -> bool {
-        let index = node as usize;
-        let Some(entry) = state.get_mut(index) else {
+    let children: Vec<Vec<u32>> = nodes.iter().map(node_children).collect();
+    let cycle = cycle_members(&children);
+    let mut seen = vec![false; nodes.len()];
+    let mut work = vec![root];
+    while let Some(node) = work.pop() {
+        let Ok(index) = usize::try_from(node) else {
             return false;
         };
-        match *entry {
-            1 => return false,
-            2 => return true,
-            _ => *entry = 1,
-        }
-        let Some(node) = nodes.get(index) else {
+        let (Some(entry), Some(children), Some(on_cycle), Some(visited)) = (
+            nodes.get(index),
+            children.get(index),
+            cycle.get(index),
+            seen.get_mut(index),
+        ) else {
             return false;
         };
-        if matches!(
-            node,
-            GuardNode::Array(_) | GuardNode::Map { .. } | GuardNode::Set(_)
-        ) {
+        if std::mem::replace(visited, true) {
+            continue;
+        }
+        if *on_cycle
+            || matches!(
+                entry,
+                GuardNode::Array(_) | GuardNode::Map { .. } | GuardNode::Set(_)
+            )
+        {
             return false;
         }
-        for child in node_children(node) {
-            if !visit(nodes, child, state) {
-                return false;
-            }
-        }
-        state[index] = 2;
-        true
+        work.extend(children);
     }
-
-    visit(nodes, root, &mut vec![0; nodes.len()])
+    true
 }
 
 fn descriptor_for_type_with_walk_bound(
@@ -851,11 +852,13 @@ pub(crate) fn body_contains_await(stmts: &[perry_hir::Stmt]) -> bool {
 }
 
 /// A single-node scalar descriptor whose predicate an existing typed-abi
-/// leaf guard already decides EXACTLY (#8079: the interpretive
-/// `js_param_type_guard` costs ~450 instructions per call — descriptor
-/// parse plus a 768-byte `GuardState` init — which measured as 16-34% of
-/// ALL retired instructions on the tree/tree_wide/interp/iso_miss corpus
-/// rows, because every unproven call routes through the public wrapper):
+/// leaf guard already decides exactly. Before #8201, a single-node
+/// `js_param_type_guard` call cost ~450 instructions and measured as 16-34%
+/// of ALL retired instructions on the
+/// tree/tree_wide/interp/iso_miss corpus rows, because every unproven call
+/// routes through the public wrapper. The descriptor parse is only a small
+/// part of that cost, and LLVM already elides the inline visited array's
+/// initialization; the win here comes from avoiding the interpretive call:
 ///
 /// * `OP_NUMBER` (1) = `js_typed_f64_arg_guard` = `is_number || is_int32`
 /// * `OP_INT32` (2) — the validator literally calls `js_typed_i32_arg_guard`

--- a/crates/perry-codegen/src/codegen/param_guard.rs
+++ b/crates/perry-codegen/src/codegen/param_guard.rs
@@ -577,13 +577,49 @@ fn encode_node(node: &GuardNode) -> Option<Vec<u8>> {
     Some(out)
 }
 
-fn descriptor_for_type(
+/// Whether validation has a value-independent upper bound. Arrays, maps and
+/// sets walk a runtime-sized collection; a descriptor cycle can walk a
+/// runtime-sized object graph. Everything else visits a fixed graph of fields
+/// and union arms whose size the compiler owns.
+fn descriptor_walk_is_bounded(nodes: &[GuardNode], root: u32) -> bool {
+    fn visit(nodes: &[GuardNode], node: u32, state: &mut [u8]) -> bool {
+        let index = node as usize;
+        let Some(entry) = state.get_mut(index) else {
+            return false;
+        };
+        match *entry {
+            1 => return false,
+            2 => return true,
+            _ => *entry = 1,
+        }
+        let Some(node) = nodes.get(index) else {
+            return false;
+        };
+        if matches!(
+            node,
+            GuardNode::Array(_) | GuardNode::Map { .. } | GuardNode::Set(_)
+        ) {
+            return false;
+        }
+        for child in node_children(node) {
+            if !visit(nodes, child, state) {
+                return false;
+            }
+        }
+        state[index] = 2;
+        true
+    }
+
+    visit(nodes, root, &mut vec![0; nodes.len()])
+}
+
+fn descriptor_for_type_with_walk_bound(
     ty: &Type,
     type_aliases: &HashMap<String, Type>,
     interfaces: &HashMap<String, perry_hir::Interface>,
     classes: &HashMap<String, &perry_hir::Class>,
     class_ids: &HashMap<String, u32>,
-) -> Option<Vec<u8>> {
+) -> Option<(Vec<u8>, bool)> {
     let mut builder = GuardGraphBuilder {
         nodes: Vec::new(),
         named: HashMap::new(),
@@ -594,6 +630,7 @@ fn descriptor_for_type(
         class_ids,
     };
     let root = builder.build_type(ty, false)?;
+    let walk_is_bounded = descriptor_walk_is_bounded(&builder.nodes, root);
     let mut bodies = builder
         .nodes
         .iter()
@@ -624,13 +661,69 @@ fn descriptor_for_type(
     for body in bodies {
         out.extend_from_slice(&body);
     }
-    Some(out)
+    Some((out, walk_is_bounded))
+}
+
+#[cfg(test)]
+fn descriptor_for_type(
+    ty: &Type,
+    type_aliases: &HashMap<String, Type>,
+    interfaces: &HashMap<String, perry_hir::Interface>,
+    classes: &HashMap<String, &perry_hir::Class>,
+    class_ids: &HashMap<String, u32>,
+) -> Option<Vec<u8>> {
+    descriptor_for_type_with_walk_bound(ty, type_aliases, interfaces, classes, class_ids)
+        .map(|(descriptor, _)| descriptor)
+}
+
+/// A loop makes the body's own work potentially unbounded, so a collection or
+/// recursive graph walk can still be amortizable. With no loop, validating an
+/// unbounded input to enter a bounded body cannot win as the input grows.
+/// Nested closure bodies are not part of the enclosing function's work.
+fn body_contains_loop(stmts: &[perry_hir::Stmt]) -> bool {
+    use perry_hir::Stmt;
+    stmts.iter().any(|stmt| match stmt {
+        Stmt::While { .. } | Stmt::DoWhile { .. } | Stmt::For { .. } => true,
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            body_contains_loop(then_branch)
+                || else_branch.as_deref().is_some_and(body_contains_loop)
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            body_contains_loop(body)
+                || catch
+                    .as_ref()
+                    .is_some_and(|catch| body_contains_loop(&catch.body))
+                || finally.as_deref().is_some_and(body_contains_loop)
+        }
+        Stmt::Switch { cases, .. } => cases.iter().any(|case| body_contains_loop(&case.body)),
+        Stmt::Labeled { body, .. } => body_contains_loop(std::slice::from_ref(body.as_ref())),
+        Stmt::Expr(_)
+        | Stmt::Throw(_)
+        | Stmt::Return(_)
+        | Stmt::Let { .. }
+        | Stmt::Break
+        | Stmt::Continue
+        | Stmt::LabeledBreak(_)
+        | Stmt::LabeledContinue(_)
+        | Stmt::PreallocateBoxes(_)
+        | Stmt::PreallocateTdzBoxes(_)
+        | Stmt::ReleaseBoxes(_) => false,
+    })
 }
 
 pub(crate) fn declaration_guards(
     function_id: u32,
     module_prefix: &str,
     params: &[perry_hir::Param],
+    body: &[perry_hir::Stmt],
     demoted_params: &[bool],
     // (#8094) Guard-only ineligibility, kept SEPARATE from `demoted_params`
     // because that mask also drives raw representation selection: a reference
@@ -642,6 +735,7 @@ pub(crate) fn declaration_guards(
     classes: &HashMap<String, &perry_hir::Class>,
     class_ids: &HashMap<String, u32>,
 ) -> Vec<Option<SpecParamGuard>> {
+    let body_can_amortize_unbounded_walk = body_contains_loop(body);
     params
         .iter()
         .zip(demoted_params.iter())
@@ -651,19 +745,31 @@ pub(crate) fn declaration_guards(
             if *demoted || *blocked || matches!(param.ty, Type::Any | Type::Unknown | Type::Never) {
                 return None;
             }
+            let (descriptor, walk_is_bounded) = descriptor_for_type_with_walk_bound(
+                &param.ty,
+                type_aliases,
+                interfaces,
+                classes,
+                class_ids,
+            )?;
+            // #8202: `peek(p: Parser)` walked every token to enter an O(1)
+            // body, while `asNum(v: Value)` admitted a recursive 123-node
+            // graph to read one discriminant and one field. The validator was
+            // 9.8-12% of those programs and the clone it licensed was worth
+            // only 0.1-0.2%. Do not emit a guard whose work grows with the
+            // input when the guarded body itself is statically bounded. A
+            // loop leaves the decision unchanged: array reducers and similar
+            // consumers can amortize validation over their own traversal.
+            if !walk_is_bounded && !body_can_amortize_unbounded_walk {
+                return None;
+            }
             Some(SpecParamGuard {
                 proof: param.ty.clone(),
                 descriptor_name: format!(
                     "perry_param_guard_{}_{}_{}",
                     module_prefix, function_id, index
                 ),
-                descriptor: descriptor_for_type(
-                    &param.ty,
-                    type_aliases,
-                    interfaces,
-                    classes,
-                    class_ids,
-                )?,
+                descriptor,
             })
         })
         .collect()
@@ -846,6 +952,76 @@ mod tests {
         assert_eq!(scalar_descriptor_rep(&build(&Type::Null)), None);
         assert_eq!(scalar_descriptor_rep(&build(&Type::Number)[..20]), None);
         assert_eq!(scalar_descriptor_rep(b"PGT1"), None);
+    }
+
+    fn declaration_guard_for(
+        ty: Type,
+        body: &[perry_hir::Stmt],
+        aliases: &HashMap<String, Type>,
+    ) -> Option<SpecParamGuard> {
+        let params = [perry_hir::Param {
+            id: 1,
+            name: "value".to_string(),
+            ty,
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }];
+        declaration_guards(
+            1,
+            "walk_bound_test",
+            &params,
+            body,
+            &[false],
+            &[false],
+            aliases,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .into_iter()
+        .next()
+        .flatten()
+    }
+
+    /// #8202: a runtime-sized validation walk cannot amortize against a body
+    /// with statically bounded work. Keep bounded structural objects and the
+    /// existing loop-consumer case, but decline arrays and recursive graphs
+    /// for constant-work helpers such as `peek` and `asNum`.
+    #[test]
+    fn constant_work_bodies_decline_unbounded_descriptor_walks() {
+        let flat = object_alias("Flat", &[("value", Type::Number)]);
+        let flat_aliases = HashMap::from([flat]);
+        assert!(
+            declaration_guard_for(Type::Named("Flat".to_string()), &[], &flat_aliases).is_some(),
+            "a fixed field walk remains eligible"
+        );
+
+        let array = Type::Array(Box::new(Type::Number));
+        assert!(declaration_guard_for(array.clone(), &[], &HashMap::new()).is_none());
+
+        let loop_body = [perry_hir::Stmt::While {
+            condition: perry_hir::Expr::Bool(false),
+            body: Vec::new(),
+        }];
+        assert!(
+            declaration_guard_for(array, &loop_body, &HashMap::new()).is_some(),
+            "a loop consumer keeps the existing structural specialization"
+        );
+
+        let recursive_aliases = HashMap::from([object_alias(
+            "Link",
+            &[(
+                "next",
+                Type::Union(vec![Type::Named("Link".to_string()), Type::Null]),
+            )],
+        )]);
+        assert!(
+            declaration_guard_for(Type::Named("Link".to_string()), &[], &recursive_aliases)
+                .is_none(),
+            "a recursive value walk is runtime-sized too"
+        );
     }
 
     fn object_alias(name: &str, fields: &[(&str, Type)]) -> (String, Type) {


### PR DESCRIPTION
## Summary

- classify parameter descriptors by whether their runtime validation walk has a value-independent bound
- decline array/map/set and recursive structural guards when the guarded function body contains no loop
- retain bounded object/union guards and preserve structural guards for looping consumers that can amortize the walk

This applies the profitability result recorded in #8202: `peek(p: Parser)` walked every token to license an O(1) body, while `asNum(v: Value)` admitted a recursive 123-node graph to license a discriminant read. The issue’s same-runtime diagnostic measured those guards as a net loss.

On current `benchmarks/tls-budget/interp.ts`, the generated IR goes from exactly two `js_param_type_guard` call sites (`peek` and `asNum`) to zero; both helpers become direct `alwaysinline` bodies.

## Validation

- `cargo test -p perry-codegen --lib --no-fail-fast` (1068 passed)
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `python3 scripts/local_binding_type_audit.py`
- rebuilt `benchmarks/tls-budget/interp.ts` with `--trace llvm` and verified zero `call i32 @js_param_type_guard` sites

No version bump, as requested.

Fixes #8202