### PR TITLE
perf(gc): stamp exact starts only for Maps

### DIFF
--- a/changelog.d/8297-map-only-object-start-stamping.md
+++ b/changelog.d/8297-map-only-object-start-stamping.md
@@ -1,0 +1,12 @@
+### perf(gc): stamp exact starts only for Maps
+
+Arena allocation no longer updates the object-start bitmap for every Object
+and Array. Only Maps need allocation-authored boundary evidence: their type tag
+is 8-aligned and their copying descriptor follows an external entries pointer.
+The classifier retains that exact-start check for Maps and rejects malloc-only
+descriptors before arena dispatch.
+
+On the clean 19-row M1 mini sweep, allocation-class instructions improve from
+**+3.69% to -0.01%** versus the pre-bitmap baseline; the prior -48.3% cohort
+remains improved at **-48.90%**. Peak Perry RSS is 404,520,960 bytes versus
+421,429,248 bytes at baseline. Fixes #8288.

--- a/crates/perry-codegen/src/expr/array_literal.rs
+++ b/crates/perry-codegen/src/expr/array_literal.rs
@@ -201,26 +201,6 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
             // GC_STORE_AUDIT(INIT): freshly allocated array header starts pointer-free until slot notes below.
             blk.store(I64, &gc_packed.to_string(), &raw);
 
-            // Publish the exact header boundary in the current arena block's
-            // object-start bitmap (InlineArenaState field at byte 24). The
-            // slow arm may have replaced the current block, so compute the
-            // slot from the merged raw pointer rather than `aligned_off`.
-            let current_data = blk.load(PTR, &state_ptr);
-            let raw_addr = blk.ptrtoint(&raw, I64);
-            let data_addr = blk.ptrtoint(&current_data, I64);
-            let relative = blk.sub(I64, &raw_addr, &data_addr);
-            let start_slot = blk.lshr(I64, &relative, "3");
-            let start_word = blk.lshr(I64, &start_slot, "6");
-            let start_bit = blk.and(I64, &start_slot, "63");
-            let bitmap_field = blk.gep(I8, &state_ptr, &[(I64, "24")]);
-            let bitmap = blk.load(PTR, &bitmap_field);
-            let bitmap_word = blk.gep(I64, &bitmap, &[(I64, &start_word)]);
-            let prior_starts = blk.load(I64, &bitmap_word);
-            let start_mask = blk.shl(I64, "1", &start_bit);
-            let updated_starts = blk.or(I64, &prior_starts, &start_mask);
-            // GC_STORE_AUDIT(INIT): side metadata for a freshly initialized GC header.
-            blk.store(I64, &updated_starts, &bitmap_word);
-
             // Packed ArrayHeader at raw+8 (length low 32 / capacity high 32).
             let arr_header_addr = blk.gep(I8, &raw, &[(I64, "8")]);
             let arr_header_packed = (n as u64) | ((n as u64) << 32);

--- a/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
+++ b/crates/perry-codegen/src/lower_call/alloc_hot_tests.rs
@@ -342,9 +342,14 @@ fn the_inline_allocator_stores_its_header_prefix_as_one_vector_image() {
         ir.contains(HEADER_IMAGE_STORE),
         "the inline allocation site must store the `<2 x i64>` header image:\n{ir}"
     );
+    let merge_at = ir.find("\nalloc.merge").unwrap();
+    let merge_end = ir[merge_at + 1..]
+        .find("\nshadow.root.barrier")
+        .map_or(ir.len(), |at| merge_at + 1 + at);
+    let allocation_merge = &ir[merge_at..merge_end];
     assert!(
-        ir.contains("shl i64 1,") && ir.contains("lshr i64") && ir.contains(", 6"),
-        "the inline allocation site must set its exact boundary in the arena object-start bitmap:\n{ir}"
+        !allocation_merge.contains("shl i64 1,") && !allocation_merge.contains("lshr i64"),
+        "ordinary inline objects must not pay to update the Map-only object-start bitmap:\n{allocation_merge}"
     );
     // The compose lives beside the ShapeId mint in module init, i.e. after the
     // mint call and outside the allocating function's own body.

--- a/crates/perry-codegen/src/lower_call/new_alloc.rs
+++ b/crates/perry-codegen/src/lower_call/new_alloc.rs
@@ -644,26 +644,6 @@ fn emit_instance_alloc_inner(
                 header_image, raw
             ));
 
-            // Publish the exact header boundary in the current arena block's
-            // object-start bitmap (InlineArenaState field at byte 24). The
-            // slow arm may install a new block, so derive the slot from the
-            // merged raw pointer and the state data pointer after the merge.
-            let current_data = blk.load(PTR, &state_ptr);
-            let raw_addr = blk.ptrtoint(&raw, I64);
-            let data_addr = blk.ptrtoint(&current_data, I64);
-            let relative = blk.sub(I64, &raw_addr, &data_addr);
-            let start_slot = blk.lshr(I64, &relative, "3");
-            let start_word = blk.lshr(I64, &start_slot, "6");
-            let start_bit = blk.and(I64, &start_slot, "63");
-            let bitmap_field = blk.gep(I8, &state_ptr, &[(I64, "24")]);
-            let bitmap = blk.load(PTR, &bitmap_field);
-            let bitmap_word = blk.gep(I64, &bitmap, &[(I64, &start_word)]);
-            let prior_starts = blk.load(I64, &bitmap_word);
-            let start_mask = blk.shl(I64, "1", &start_bit);
-            let updated_starts = blk.or(I64, &prior_starts, &start_mask);
-            // GC_STORE_AUDIT(INIT): side metadata for a freshly initialized GC header.
-            blk.store(I64, &updated_starts, &bitmap_word);
-
             // Second 8 bytes: keys_array pointer. The keys_ptr we loaded
             // above is an i64 (carries the ArrayHeader address); store as
             // i64 since the underlying memory is 8 bytes either way.

--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -33,21 +33,15 @@ pub fn arena_alloc(size: usize, align: usize) -> *mut u8 {
         let ptr = crate::arena::arena_cell_alloc(arena_ptr, size, align);
         // Resync block → inline (may have advanced to a new block).
         if !(*inline_ptr).data.is_null() {
-            let (data, offset, block_size, object_starts) = {
+            let (data, offset, block_size) = {
                 let arena = &*arena_ptr;
                 let block = &arena.blocks[arena.current];
-                (
-                    block.data,
-                    block.offset,
-                    block.size,
-                    block.object_starts_ptr(),
-                )
+                (block.data, block.offset, block.size)
             };
             let inline = &mut *inline_ptr;
             inline.data = data;
             inline.offset = offset;
             inline.size = block_size;
-            inline.object_starts = object_starts;
         }
         ptr
     }
@@ -108,7 +102,7 @@ pub(crate) fn arena_alloc_gc_no_collect(size: usize, align: usize, obj_type: u8)
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
@@ -135,21 +129,15 @@ fn arena_alloc_no_collect(size: usize, align: usize) -> *mut u8 {
             return std::ptr::null_mut();
         };
         if !(*inline_ptr).data.is_null() {
-            let (data, offset, block_size, object_starts) = {
+            let (data, offset, block_size) = {
                 let arena = &*arena_ptr;
                 let block = &arena.blocks[arena.current];
-                (
-                    block.data,
-                    block.offset,
-                    block.size,
-                    block.object_starts_ptr(),
-                )
+                (block.data, block.offset, block.size)
             };
             let inline = &mut *inline_ptr;
             inline.data = data;
             inline.offset = offset;
             inline.size = block_size;
-            inline.object_starts = object_starts;
         }
         ptr
     }
@@ -192,7 +180,7 @@ pub fn arena_alloc_gc_longlived(size: usize, align: usize, obj_type: u8) -> *mut
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
 
@@ -255,7 +243,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
-        record_arena_object_start(raw as usize);
+        record_arena_object_start(raw as usize, obj_type);
         defer_old_object_page_registration(raw as usize, total);
         return user_ptr as *mut u8;
     }
@@ -269,7 +257,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
     defer_old_object_page_registration(raw as usize, total);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
@@ -327,7 +315,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
-        record_arena_object_start(raw as usize);
+        record_arena_object_start(raw as usize, obj_type);
         register_old_object_pages(raw as usize, total);
         return user_ptr as *mut u8;
     }
@@ -341,7 +329,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
     register_old_object_pages(raw as usize, total);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
@@ -402,7 +390,7 @@ pub(crate) fn arena_alloc_gc_survivor(size: usize, align: usize, obj_type: u8) -
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }
@@ -494,7 +482,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             (*header)._reserved = 0;
             (*header).size = total as u32;
         }
-        record_arena_object_start(user_ptr as usize - GC_HEADER_SIZE);
+        record_arena_object_start(user_ptr as usize - GC_HEADER_SIZE, obj_type);
         return user_ptr;
     }
 
@@ -527,7 +515,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
-    record_arena_object_start(raw as usize);
+    record_arena_object_start(raw as usize, obj_type);
 
     unsafe { raw.add(GC_HEADER_SIZE) }
 }

--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -624,7 +624,6 @@ impl Arena {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     }
@@ -1058,19 +1057,18 @@ thread_local! {
         UnsafeCell::new(Arena::new_lazy(HeapGeneration::Old, HeapSpace::Old));
 
     /// Inline allocator state — a cache of the current arena block's
-    /// `(data, offset, size, object_starts)` tuple, exposed via a stable pointer so
+    /// `(data, offset, size)` tuple, exposed via a stable pointer so
     /// codegen can emit inline bump-allocate IR without going through
     /// any function call or `LocalKey::with` wrapper.
     ///
     /// `#[repr(C)]` on `InlineArenaState` keeps the field offsets stable
-    /// (data=0, offset=8, size=16, object_starts=24). The codegen reads/writes these fields
+    /// (data=0, offset=8, size=16). The codegen reads/writes these fields
     /// directly via fixed GEPs, so changing the struct layout would
     /// silently break every emitted `new ClassName()`.
     pub(crate) static INLINE_STATE: UnsafeCell<InlineArenaState> = const { UnsafeCell::new(InlineArenaState {
         data: std::ptr::null_mut(),
         offset: 0,
         size: 0,
-        object_starts: std::ptr::null_mut(),
     }) };
 }
 

--- a/crates/perry-runtime/src/arena/inline.rs
+++ b/crates/perry-runtime/src/arena/inline.rs
@@ -2,19 +2,17 @@ use super::*;
 
 /// Inline bump-allocator state. The codegen emits inline LLVM IR that
 /// reads `data` and `offset`, computes `aligned + size`, checks against
-/// `size`, stores the new offset, records the allocation boundary through
-/// `object_starts`, and returns `data + aligned`. The
+/// `size`, stores the new offset, and returns `data + aligned`. The
 /// underlying thread-local Arena is the source of truth between
 /// inline-alloc bursts; this state is the source of truth during them.
 ///
 /// Field offsets are load-bearing — the codegen GEPs into this struct
-/// at hard-coded byte offsets (0/8/16/24). Do not reorder.
+/// at hard-coded byte offsets (0/8/16). Do not reorder.
 #[repr(C)]
 pub struct InlineArenaState {
-    pub data: *mut u8,           // offset  0  — current block's data pointer
-    pub offset: usize,           // offset  8  — bump pointer (mutated inline)
-    pub size: usize,             // offset 16  — current block's size
-    pub object_starts: *mut u64, // offset 24 — one bit per 8-byte slot
+    pub data: *mut u8, // offset  0  — current block's data pointer
+    pub offset: usize, // offset  8  — bump pointer (mutated inline)
+    pub size: usize,   // offset 16 — current block's size
 }
 
 /// Get the per-thread inline arena state pointer. Called once per JS
@@ -46,7 +44,6 @@ pub extern "C" fn js_inline_arena_state() -> *mut InlineArenaState {
             state.data = block.data;
             state.offset = block.offset;
             state.size = block.size;
-            state.object_starts = block.object_starts_ptr();
         }
         state as *mut InlineArenaState
     }
@@ -90,21 +87,15 @@ pub extern "C" fn js_inline_arena_slow_alloc(
         // Allocate via existing path (may push a new block + run GC).
         let ptr = crate::arena::arena_cell_alloc(arena_ptr, size, align);
         // Resync inline state to the (possibly new) current block.
-        let (data, block_offset, block_size, object_starts) = {
+        let (data, block_offset, block_size) = {
             let arena = &*arena_ptr;
             let block = &arena.blocks[arena.current];
-            (
-                block.data,
-                block.offset,
-                block.size,
-                block.object_starts_ptr(),
-            )
+            (block.data, block.offset, block.size)
         };
         let state_ref = &mut *state;
         state_ref.data = data;
         state_ref.offset = block_offset;
         state_ref.size = block_size;
-        state_ref.object_starts = object_starts;
         ptr
     })
 }
@@ -155,7 +146,6 @@ pub fn arena_start_fresh_general_block() {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     });

--- a/crates/perry-runtime/src/arena/page_meta.rs
+++ b/crates/perry-runtime/src/arena/page_meta.rs
@@ -990,12 +990,16 @@ fn classify_heap_space_in_range_uncached(
     Some((range.space, range.base, range.object_starts))
 }
 
-/// Record a newly initialized GC header in its owning block's exact-start
-/// bitmap. Runtime allocation paths call this after publishing the header;
-/// compiler-generated inline bump allocators perform the equivalent bit store
-/// directly through `InlineArenaState::object_starts`.
-#[inline]
-pub(crate) fn record_arena_object_start(header_addr: usize) {
+/// Record a newly initialized Map header in its owning block's exact-start
+/// bitmap. Map is the only arena type whose tag can be fabricated by an
+/// 8-aligned interior pointer and whose rewrite descriptor follows an external
+/// payload pointer. Keeping all other allocations off this path avoids a
+/// metadata read-modify-write on every bump allocation.
+#[inline(always)]
+pub(crate) fn record_arena_object_start(header_addr: usize, obj_type: u8) {
+    if obj_type != crate::gc::GC_TYPE_MAP {
+        return;
+    }
     let Some((_space, range_base, bitmap)) = classify_heap_space_in_range(header_addr) else {
         debug_assert!(false, "arena allocation was not in a registered block");
         return;

--- a/crates/perry-runtime/src/arena/promote.rs
+++ b/crates/perry-runtime/src/arena/promote.rs
@@ -595,7 +595,6 @@ fn reset_young_after_promotion() {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     });

--- a/crates/perry-runtime/src/arena/quarantine.rs
+++ b/crates/perry-runtime/src/arena/quarantine.rs
@@ -571,7 +571,6 @@ pub(crate) fn copying_quarantine_from_spaces_and_flip() -> ArenaResetStats {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     });

--- a/crates/perry-runtime/src/arena/reset.rs
+++ b/crates/perry-runtime/src/arena/reset.rs
@@ -31,7 +31,6 @@ pub fn arena_reset_all_blocks_to_zero() {
                 inline.data = block.data;
                 inline.offset = 0;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -219,7 +218,6 @@ pub(crate) fn copying_reset_from_spaces_and_flip() -> ArenaResetStats {
                 inline.data = block.data;
                 inline.offset = block.offset;
                 inline.size = block.size;
-                inline.object_starts = block.object_starts_ptr();
             }
         });
     });
@@ -495,7 +493,6 @@ pub fn arena_reset_empty_blocks(block_has_live: &[bool]) -> ArenaResetStats {
                         inline.data = block.data;
                         inline.offset = block.offset;
                         inline.size = block.size;
-                        inline.object_starts = block.object_starts_ptr();
                     }
                 }
             });
@@ -745,7 +742,6 @@ impl ArenaResetEmptyBlocksState {
                             inline.data = block.data;
                             inline.offset = block.offset;
                             inline.size = block.size;
-                            inline.object_starts = block.object_starts_ptr();
                         }
                     }
                 }

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::gc::{
     GcHeader, GC_FLAG_MARKED, GC_FLAG_TENURED, GC_HEADER_SIZE, GC_TYPE_ARRAY, GC_TYPE_BUFFER,
-    GC_TYPE_STRING, GC_TYPE_TYPED_ARRAY, LARGE_OBJECT_THRESHOLD_BYTES,
+    GC_TYPE_MAP, GC_TYPE_STRING, GC_TYPE_TYPED_ARRAY, LARGE_OBJECT_THRESHOLD_BYTES,
 };
 
 fn general_block_index_for(addr: usize) -> Option<usize> {
@@ -106,9 +106,21 @@ fn reset_single_reclaimable_nursery_block(
 }
 
 #[test]
-fn object_start_bitmap_tracks_boundaries_and_clears_on_reset() {
+fn object_start_bitmap_stamps_only_maps_and_clears_on_reset() {
     run_with_fresh_arenas(|| {
-        let user = arena_alloc_gc(64, 8, GC_TYPE_ARRAY) as usize;
+        let unstamped_array = arena_alloc_gc(64, 8, GC_TYPE_ARRAY) as usize;
+        let (_, array_base, array_bitmap) = classify_heap_space_in_range(unstamped_array)
+            .expect("allocation must be in an arena range");
+        assert!(
+            !arena_header_is_object_start(
+                unstamped_array - GC_HEADER_SIZE,
+                array_base,
+                array_bitmap,
+            ),
+            "ordinary arena allocations must not pay to stamp exact starts"
+        );
+
+        let user = arena_alloc_gc(16, 8, GC_TYPE_MAP) as usize;
         let header = user - GC_HEADER_SIZE;
         let (_, range_base, bitmap) =
             classify_heap_space_in_range(user).expect("allocation must be in an arena range");

--- a/crates/perry-runtime/src/gc/copying_pointer_set.rs
+++ b/crates/perry-runtime/src/gc/copying_pointer_set.rs
@@ -126,16 +126,19 @@ impl CopyingPointerSet {
         ) {
             return None;
         }
-        // Header fields alone cannot distinguish a genuine allocation from
-        // payload bytes that happen to encode the same type, flags and size.
-        // The per-block bitmap is allocation-authored evidence that this exact
-        // address is an object boundary; test it before dereferencing bytes as
-        // a `GcHeader`.
-        if !crate::arena::arena_header_is_object_start(header_addr, range_base, object_starts) {
-            return None;
-        }
         let header = header_addr as *mut GcHeader;
         if unsafe { !plausible_gc_header(header, true) } {
+            return None;
+        }
+        // An aligned interior pointer can only fabricate an arena type whose
+        // numeric tag is itself 8-aligned. Map (8) is the sole such arena
+        // type, and its rewrite descriptor follows an external entries
+        // pointer. Require allocation-authored boundary evidence for that
+        // dangerous arm. Other arena objects need no bitmap stamp, keeping
+        // their allocation path to the bump and header stores alone.
+        if unsafe { (*header).obj_type == crate::gc::GC_TYPE_MAP }
+            && !crate::arena::arena_header_is_object_start(header_addr, range_base, object_starts)
+        {
             return None;
         }
         // The two survivor-space readings are TLS loads, and Darwin has no
@@ -250,6 +253,13 @@ pub(super) unsafe fn plausible_gc_header(header: *mut GcHeader, arena: bool) -> 
         Some(info) => info,
         None => return false,
     };
+    // A multiple-of-eight malloc-only type tag (currently NativePodView = 16)
+    // can appear in aligned payload bytes too. It can never be a legitimate
+    // arena header, so reject it before descriptor dispatch rather than
+    // expanding the exact-start set beyond the one arena-resident risky type.
+    if arena && matches!(info.allocation_policy, GcAllocationPolicy::Malloc) {
+        return false;
+    }
     let size = (*header).size as usize;
     if size < GC_HEADER_SIZE || size as u64 > (1u64 << 34) {
         return false;

--- a/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
@@ -8,8 +8,8 @@
 //!
 //! For an 8-aligned arena pointer near `0x400_0000_0000`, the fabricated
 //! `GcHeader` supplies:
-//!   * `obj_type` = low byte = 0x08 = `GC_TYPE_MAP` (the only valid type
-//!     that is a multiple of 8)
+//!   * `obj_type` = low byte = 0x08 = `GC_TYPE_MAP` (the only arena-eligible
+//!     type that is a multiple of 8)
 //!   * `size` = top 32 bits ≈ 1024 (always passes the `[8, 2^34]` range
 //!     check in the old `plausible_gc_header`)
 //!   * `gc_flags` = second byte, needs `GC_FLAG_ARENA` (0x02) — ~coin flip
@@ -17,8 +17,8 @@
 //! The size check rejects the observed `size ≈ 1024` corruption, but payload
 //! bytes can also encode the genuine Map total of 24. The complete fix is the
 //! arena's allocation-authored object-start bitmap: `classify_arena` requires
-//! the candidate header address to be recorded there before it reads header
-//! fields.
+//! a candidate Map header address to be recorded there before dispatching its
+//! rewrite descriptor. Other arena types do not need to stamp the bitmap.
 
 use super::*;
 
@@ -127,6 +127,20 @@ fn test_plausible_gc_header_still_accepts_variable_size_types() {
     assert!(
         unsafe { plausible_gc_header(&mut string_header as *mut GcHeader, true) },
         "variable-size type (string) with arbitrary size must be plausible"
+    );
+}
+
+#[test]
+fn test_plausible_gc_header_rejects_malloc_only_type_in_arena() {
+    let mut fabricated = GcHeader {
+        obj_type: GC_TYPE_NATIVE_POD_VIEW,
+        gc_flags: GC_FLAG_ARENA,
+        _reserved: 0,
+        size: 32,
+    };
+    assert!(
+        !unsafe { plausible_gc_header(&mut fabricated as *mut GcHeader, true) },
+        "a malloc-only descriptor must never dispatch from arena payload bytes"
     );
 }
 


### PR DESCRIPTION
Closes #8288

## Summary

- remove object-start bitmap read/modify/write IR from inline Object and Array allocation
- stamp exact starts only for runtime-allocated Maps, the arena-resident 8-aligned tag that needs allocation-authored evidence
- reject malloc-only type descriptors during arena classification and retain the correct-size fabricated-Map guard
- shrink `InlineArenaState` back to its three hot bump-allocation fields

## Performance

Clean quiet-M1-mini four-engine sweep, best-of-five interleaved, against `38cf15336` (same 19-source corpus):

| workload class | instructions retired, geomean | peak RSS geomean |
|---|---:|---:|
| allocation class (12 rows) | **-0.01%** (was +3.69%) | **-6.02%** |
| prior -48.3% cohort (7 rows) | **-48.90%** | **-5.46%** |

Peak observed Perry RSS is **404,520,960 B**, down from **421,429,248 B** at the baseline. The fixed branch is -3.56% instructions versus current main across the allocation class. Sweep verdict: `CLEAN` (load 1.02 -> 2.02, no foreign processes); all 19 Perry binaries passed output checks.

## Tests

- `cargo check -p perry-runtime --lib`
- `cargo check -p perry-codegen --lib`
- `cargo test -p perry-runtime --lib` (2,569 passed, 4 ignored)
- `cargo test -p perry-codegen --lib the_inline_allocator_stores_its_header_prefix_as_one_vector_image`
- `bash scripts/check_file_size.sh`
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved garbage-collection allocation efficiency by reducing unnecessary object-start tracking for ordinary objects.
  - Optimized Map allocation handling, with benchmark results showing improved allocation performance and lower peak memory usage.

- **Bug Fixes**
  - Strengthened arena object classification to reject invalid or incompatible allocation records.
  - Preserved accurate tracking for Map objects while preventing false classifications for arrays and other object types.

- **Tests**
  - Added coverage for allocation tracking, arena resets, and invalid object classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->