### PR TITLE
fix(gc): register the process-emitter root scanner, and clear -D warnings on main

### DIFF
--- a/changelog.d/8295-process-emitter-scanner-registration.md
+++ b/changelog.d/8295-process-emitter-scanner-registration.md
@@ -1,0 +1,14 @@
+**GC: actually register the process-emitter root scanner.**
+
+#8294 added `process_emitter_root_scanner` and a
+`register_process_emitter_root_scanner()` wrapper, but nothing ever called the
+wrapper — so the scanner was never registered and process `EventEmitter`
+listener closures, held as raw `*const ClosureHeader` in a TLS map, remained
+invisible to the collector. The fix was inert. `gc_init` now calls it, and the
+census reports 96 holders reached by a registered scanner where it previously
+reported 94.
+
+`rustc` had been saying so: `function 'register_process_emitter_root_scanner'
+is never used` was one of five dead-code errors that made `main` red under
+`RUSTFLAGS="-D warnings"`. The others were unused frame-walk locals in
+`native_stack_scan.rs`. All cleared.

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -956,6 +956,10 @@ pub fn gc_init() {
     reg_scanner!(small_int_cache_mutable_root_scanner);
     reg_scanner!(crate::builtins::scan_console_log_singleton_roots_mut);
     reg_scanner!(crate::builtins::scan_structured_clone_memo_roots_mut);
+    // #8282/#8294: process EventEmitter listener closures live as raw
+    // `*const ClosureHeader` in a TLS map. The scanner existed but was never
+    // called, so the table stayed invisible to the collector.
+    crate::os::os_process_emitter::register_process_emitter_root_scanner();
     reg_scanner!(crate::builtins::scan_boxed_primitive_payload_roots_mut);
     reg_scanner!(crate::weakref::scan_pending_finalization_jobs_roots_mut);
     // #6182: keep the weak-holder registry's stored holder ADDRESSES current

--- a/crates/perry-runtime/src/gc/native_stack_scan.rs
+++ b/crates/perry-runtime/src/gc/native_stack_scan.rs
@@ -54,7 +54,7 @@ pub(super) fn run_native_stack_scan() {
     // (highest address), and pthread_get_stacksize_np gives the total size.
     // The stack grows downward, so valid range is [top - size, top].
     #[cfg(target_os = "macos")]
-    let (stack_lo, stack_hi) = {
+    let (_stack_lo, stack_hi) = {
         let top = unsafe { libc::pthread_get_stackaddr_np(libc::pthread_self()) } as usize;
         let size = unsafe { libc::pthread_get_stacksize_np(libc::pthread_self()) } as usize;
         (top - size, top)
@@ -244,8 +244,7 @@ fn walk_frame_pointers() -> Vec<FrameInfo> {
         fp = std::ptr::addr_of!(marker) as usize;
     }
 
-    let mut prev_fp: usize = 0;
-    let mut return_addr: usize = 0;
+    let return_addr: usize;
     let mut depth = 0;
 
     while fp != 0 && depth < 64 {
@@ -270,8 +269,6 @@ fn walk_frame_pointers() -> Vec<FrameInfo> {
             size: frame_size,
             return_addr: saved_lr,
         });
-
-        prev_fp = fp;
         fp = saved_fp;
         depth += 1;
     }

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -802,7 +802,7 @@ fn extract_hrtime_prior(value: f64) -> (i64, i64) {
 
 // `process` EventEmitter surface lives in the `os_process_emitter`
 // submodule; split out to keep this file under the 2000-line gate.
-mod os_process_emitter;
+pub(crate) mod os_process_emitter;
 pub use os_process_emitter::*;
 
 // `process.chdir()` + its Node-shaped error live in the `chdir` submodule


### PR DESCRIPTION
Follow-up to #8294, which I merged with a latent defect.

**The scanner was never registered.** #8294 added `process_emitter_root_scanner` and a `register_process_emitter_root_scanner()` wrapper, but nothing called the wrapper — so process `EventEmitter` listener closures, held as raw `*const ClosureHeader` in a TLS map, stayed invisible to the collector. That half of the PR was inert.

**`rustc` had been telling us**: `function ... is never used` was one of five dead-code errors that left `main` red under `RUSTFLAGS="-D warnings"` — the `warnings` job is in `gate`'s `needs`. I merged #8294 without running it. That is the second gate I broke today the same way (the first was `gc_runtime_root_holders` after #8270), and the lesson is the same: run the whole gate set, not the subset that seems relevant.

**Evidence the registration now takes effect**, rather than just silencing the warning: the census goes from **94 to 96** holders reached by a registered scanner.

Also cleared the four unused frame-walk locals in `native_stack_scan.rs` and made `os_process_emitter` `pub(crate)` so `gc_init` can reach it.

Verified: `perry-runtime --lib` **2568/0/4**, `RUSTFLAGS="-D warnings" cargo check -p perry-runtime --all-targets` clean, `gc_runtime_root_holders` OK, `cargo fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection coverage for process event listeners, helping ensure listener closures are properly detected and reclaimed when no longer needed.
  * Enhanced runtime cleanup and memory management for applications using process events.

* **Chores**
  * Removed unnecessary runtime code and warnings, with no expected changes to public APIs or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->