### PR TITLE
fix(test): classify warm-soak failures instead of counting them (#8286)

### DIFF
--- a/changelog.d/8290-warm-soak-classify.md
+++ b/changelog.d/8290-warm-soak-classify.md
@@ -1,0 +1,26 @@
+### Fixed — the warm-soak arm reported a client timeout as an #8163 residual
+
+`run_warm_soak` (added in #8215) counted non-zero `verify.mjs` exits instead of
+classifying them, and printed `#8163 residual` for every one. Two very different
+things produce that exit: the residual, where the server returns an **empty body**
+(`Unexpected end of JSON input`, plus `TypeError: value is not a function` and
+Next's `E180` in the host log), and a **client timeout** (`UND_ERR_HEADERS_TIMEOUT`),
+where the server was merely slow and its log is clean.
+
+The second happens on its own in the saturated regime the arm exists to reach — in
+the #8163 close-condition run, 12 passes lost requests to client timeouts, all
+inside collection storms (one pass ran **644** copying minors against a steady 84),
+while the three residual discriminators were **0 across 10,995 collections**. So the
+arm manufactured false residual reports exactly where it was most likely to be used,
+and #8163 is closed, so the next reader would have concluded it had regressed.
+
+It now classifies from the evidence already in the host log: an empty body fails the
+arm as the residual; a timeout with a clean host log is reported loudly with the
+offending pass's collection count and attributed to #8213 (a warm server slow enough
+to blow a default HTTP client timeout is a user-visible failure, but it is not this
+arm's subject, and failing on it would make the arm unusable in the regime it exists
+to reach); anything unrecognised fails with "do not assume a cause".
+
+The arm was written so a *green* run could not imply more than it proved. Its first
+real failure was the mirror image — a *red* verdict that was not true. A gate that
+cannot be trusted when it goes red is as useless as one that cannot go red at all.

--- a/tests/release/packages/next-app-route/fixture.sh
+++ b/tests/release/packages/next-app-route/fixture.sh
@@ -301,11 +301,38 @@ run_warm_soak() {
   done
   [[ "$ready" == "1" ]] || fail "warm soak did not become ready"
 
-  local failed_iterations=()
-  local pass
+  # #8286: CLASSIFY each failing pass from the evidence in the host log, never
+  # from the verifier's exit code alone. Two very different things make
+  # `verify.mjs` exit non-zero, and the first version of this arm called both
+  # of them "#8163 residual":
+  #
+  #   * the residual — the server returns an EMPTY BODY. The verifier reports
+  #     `Unexpected end of JSON input`, and the host log carries
+  #     `TypeError: value is not a function` and Next's `E180`.
+  #   * a client timeout — `UND_ERR_HEADERS_TIMEOUT`. The server was merely
+  #     slow; its log is clean and its answer, when it arrives, is correct.
+  #
+  # The second happens on its own in the saturated regime this arm exists to
+  # reach (#8213: one pass ran 644 copying minors against a steady 84 and 8 of
+  # its 21 concurrent requests timed out), so counting exits manufactures false
+  # residual reports exactly where the arm is most likely to be used. The arm
+  # was written so a GREEN run could not imply more than it proved; its first
+  # real failure was the mirror image, a RED verdict that was not true.
+  local residual_passes=() timeout_passes=() other_passes=()
+  local pass before_lines slice
   for pass in $(seq 1 "$passes"); do
+    before_lines="$(wc -l < "$log")"
     if ! BASE_URL="http://127.0.0.1:$port" node verify.mjs >>"$log" 2>&1; then
-      failed_iterations+=("$pass")
+      # Only the lines this pass appended — the host writes to the same log,
+      # so the slice carries both sides of the exchange.
+      slice="$(tail -n +$((before_lines + 1)) "$log")"
+      if grep -qE 'Unexpected end of JSON input|TypeError: value is not a function|failed to pipe response' <<<"$slice"; then
+        residual_passes+=("$pass")
+      elif grep -qE 'UND_ERR_[A-Z_]+|HeadersTimeoutError|BodyTimeoutError' <<<"$slice"; then
+        timeout_passes+=("$pass(+$(grep -c '\[gc-copy-minor\] ran' <<<"$slice") minors)")
+      else
+        other_passes+=("$pass")
+      fi
     fi
     kill -0 "$SERVER_PID" 2>/dev/null || fail "warm soak process died at pass $pass"
   done
@@ -315,14 +342,28 @@ run_warm_soak() {
   minors="$(grep -c '\[gc-copy-minor\] ran' "$log" || true)"
   local type_errors
   type_errors="$(grep -c 'TypeError: value is not a function' "$log" || true)"
-  echo "  [warm soak] passes=$passes failures=${#failed_iterations[@]} copying_minors=$minors host_type_errors=$type_errors"
+  echo "  [warm soak] passes=$passes copying_minors=$minors host_type_errors=$type_errors"
+  echo "  [warm soak] residual=${#residual_passes[@]} timeout=${#timeout_passes[@]} other=${#other_passes[@]}"
+
+  # A client timeout is NOT this arm's subject and must not fail it — that is
+  # #8286, and failing on latency would make the arm unusable in the very
+  # regime it exists to reach. It is still reported loudly, with the offending
+  # pass's collection count, because a warm server slow enough to blow a
+  # default HTTP client timeout is a user-visible failure and belongs to #8213.
+  if (( ${#timeout_passes[@]} > 0 )); then
+    echo "  [warm soak] NOTE: ${#timeout_passes[@]} pass(es) lost requests to a CLIENT timeout with a clean"
+    echo "               host log — a stall, not the residual. See #8213: ${timeout_passes[*]}"
+  fi
 
   # Order matters: an OBSERVED failure is reported even when the liveness
   # counter looks wrong, because a real broken request outranks a complaint
   # about the instrument. Reversing these two once masked a genuine failure
   # behind "exercised nothing" while this arm was being tested.
-  if (( ${#failed_iterations[@]} > 0 || type_errors > 0 )); then
-    fail "warm soak: ${#failed_iterations[@]} failing pass(es) [${failed_iterations[*]}], $type_errors host TypeError(s) — #8163 residual"
+  if (( ${#residual_passes[@]} > 0 || type_errors > 0 )); then
+    fail "warm soak: ${#residual_passes[@]} pass(es) with an empty body [${residual_passes[*]}], $type_errors host TypeError(s) — #8163 residual"
+  fi
+  if (( ${#other_passes[@]} > 0 )); then
+    fail "warm soak: ${#other_passes[@]} pass(es) failed for an UNCLASSIFIED reason [${other_passes[*]}] — read $log; do not assume a cause"
   fi
 
   # A soak that ran no collections proves nothing about a GC holder, so a clean


### PR DESCRIPTION
Closes #8286. My bug, in the arm I added in #8215.

## What was wrong

`run_warm_soak` treated **any** non-zero `verify.mjs` exit as a failure and printed `#8163 residual`. It counted exits; it never classified them. Two very different things produce that exit:

* **the residual** — the server returns an **empty body**. Signature: `Unexpected end of JSON input` in the verifier, plus `TypeError: value is not a function` and Next's `E180 failed to pipe response` in the host log.
* **a client timeout** — `UND_ERR_HEADERS_TIMEOUT`. The server was merely slow; its log is clean and its answer, when it arrives, is correct.

The second happens **on its own** in the saturated regime this arm exists to reach. In the #8163 close-condition run: 12 passes lost requests to client timeouts, all inside collection storms — one pass ran **644** copying minors against a steady 84 — while the three residual discriminators were **0 across 10,995 collections**. The arm would have reported `#8163 residual` for a run with no residual evidence at all, against an issue that is **closed**, so the next reader would reasonably conclude it had regressed.

Worth stating in one line, because it is the general lesson and not a Perry-specific one: **this arm was written so a green run could not imply more than it proved, and its first real failure was the mirror image — a red verdict that was not true.** I only designed against one direction. A gate that cannot be trusted when it goes red is as useless as one that cannot go red at all.

## The fix

Classify from the evidence already in the host log — the arm was collecting it and throwing it away. Per failing pass, the slice of log that pass appended is examined:

| observed | verdict |
|---|---|
| empty body / host `TypeError` / `E180` | **FAIL** — `#8163 residual`, naming the passes |
| `UND_ERR_*` / `HeadersTimeoutError` / `BodyTimeoutError`, clean host log | reported with the pass's **collection count**, attributed to #8213, does **not** fail |
| anything else | **FAIL** — "read the log; do not assume a cause" |

A timeout does not fail the arm deliberately: it is a real user-visible failure (#8213) but it is not this arm's subject, and failing on latency would make the arm unusable in the exact regime it was built to reach. It is reported loudly rather than swallowed, with the offending pass's collection count next to it — because that is the interesting quantity, and a run total hides a 7.7× single-pass storm entirely.

Note the precedence: a residual co-occurring with a timeout reads as **residual**. The bug must never be masked by the noise.

## Sabotage-tested in both directions

Not "it compiles" — each verdict was **planted and observed**:

| planted | result |
|---|---|
| empty-body signature on pass 2 | `residual=1 timeout=0` → **FAIL**, names pass 2 |
| client timeout on pass 2, **with real traffic and 3 real collections** | `residual=0 timeout=1` → **exit 0** + the #8213 note |
| clean run, 12 passes | exit 0, confidence line |
| zero copying minors | **FAIL** — "exercised nothing" (pre-existing liveness assert, unchanged, still fires ahead of a clean verdict) |

Plus a 10-case classifier test covering every branch, the precedence case above, and the **real bytes** from passes 203 and 238 of the close-condition run — so the classifier is checked against the actual failure it mis-read, not only against synthetic strings.

The first version of the timeout sabotage was itself wrong and worth mentioning: a stub verifier that printed a failure without making any HTTP requests produced zero collections, so the liveness assert fired instead and the test proved nothing. Fixed by having the sabotage drive the real verifier first and then inject — a harness that does not exercise the subject cannot test it, which is the same lesson this PR is about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved warm-soak verification failure classification.
  - Empty responses are now correctly identified as residual failures.
  - Client timeouts with clean host logs are reported separately and no longer fail the soak.
  - Unrecognized failures continue to fail verification with clear guidance not to assume a cause.
  - Timeout results now include collection counts for easier diagnosis.

- **Documentation**
  - Added supporting details and run data for the revised failure classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->