### PR TITLE
fix(lint): underscore the Linux arm's stack_lo too — #8298 fixed only the macOS arm

### DIFF
--- a/crates/perry-runtime/src/gc/native_stack_scan.rs
+++ b/crates/perry-runtime/src/gc/native_stack_scan.rs
@@ -60,7 +60,10 @@ pub(super) fn run_native_stack_scan() {
         (top - size, top)
     };
     #[cfg(not(target_os = "macos"))]
-    let (stack_lo, stack_hi) = {
+    // `_stack_lo`: same unused-on-this-arm shape #8298 underscore-fixed on the
+    // macOS arm; the Linux arm kept the bare name and turned `warnings`
+    // (-D warnings, host-compatible scope) red on main.
+    let (_stack_lo, stack_hi) = {
         // Fallback: use a local variable address and scan 256KB upward.
         let marker: usize = 0;
         let sp = std::ptr::addr_of!(marker) as usize;


### PR DESCRIPTION
One-liner unbreaking the `warnings` job (`-D warnings`, host-compatible scope) on `main`: #8298 underscore-fixed the unused `stack_lo` on the **macOS** arm of `gc/native_stack_scan.rs` but left the bare name on the `#[cfg(not(target_os = "macos"))]` arm — the one Linux CI actually compiles. Caught on #8291's rerun (job 95306309639's sibling run 32015928121); verified still live on `main` tip `85a60d4a3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal stack-bound handling for non-macOS builds without changing stack-scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->