### PR TITLE
test(fs): cover recursive mkdir options-object decoding

### DIFF
--- a/changelog.d/8309-mkdir-options-object-regression.md
+++ b/changelog.d/8309-mkdir-options-object-regression.md
@@ -1,0 +1,1 @@
+Add an end-to-end regression test for recursive `fs.mkdirSync` calls that pass an options object.

--- a/crates/perry/tests/issue_8122_fs_mkdir_options_object.rs
+++ b/crates/perry/tests/issue_8122_fs_mkdir_options_object.rs
@@ -1,0 +1,68 @@
+//! Regression test for the fs options-object crash fixed alongside #8122.
+//!
+//! `mkdirSync(path, { recursive: true })` passes an object where the runtime
+//! also accepts a string mode. Before #8204, the generic string helper accepted
+//! any plausible NaN-boxed pointer and read the options object's ShapeId as a
+//! `StringHeader::byte_len`. ShapeIds have the high bit set, so the runtime
+//! attempted a roughly 2 GiB string copy and crashed in `memcpy`.
+//!
+//! Claude Code exercises this exact call shape during normal startup, while its
+//! `--version` fast path exits before touching the filesystem.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+const SOURCE: &str = r#"
+import * as fs from "node:fs";
+
+const root = ".perry-issue-8122-mkdir";
+fs.mkdirSync(root + "/a/b", { recursive: true });
+const ok = fs.statSync(root + "/a/b").isDirectory();
+console.log(ok ? "PASS" : "FAIL");
+fs.rmSync(root, { recursive: true, force: true });
+"#;
+
+fn compile(dir: &Path, entry: &Path, output: &Path) {
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+}
+
+#[test]
+fn recursive_mkdir_options_object_is_not_decoded_as_a_string() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+
+    compile(dir.path(), &entry, &output);
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success() && stdout.contains("PASS"),
+        "recursive mkdir with an options object failed (status {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end regression test for the `fs.mkdirSync(path, { recursive: true })` options-object crash fixed in #8204. Claude Code exercises this exact call during normal startup, while its `--version` fast path exits before reaching it.

## Changes

- Compile and run a minimal TypeScript program that passes an options object to recursive `mkdirSync`.
- Assert that the nested directory is created and the native program exits successfully.
- Document how the old fs string helper misread an object header as a `StringHeader` and attempted a roughly 2 GiB copy.

## Related issue

Follow-up to #8204; refs #8122.

## Test plan

- [ ] `cargo build --release` clean (not run; test-only change)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run)
- [x] `rustfmt --edition 2024 --check crates/perry/tests/issue_8122_fs_mkdir_options_object.rs`
- [x] `git diff --cached --check`
- [x] Compiled and ran the same reproducer with the corrected release runtime and `PERRY_GC_VERIFY_EVACUATION=1`: `PASS`, exit 0
- [x] Added a user-facing regression test in the affected crate
- [ ] Updated `docs/src/` (not applicable; no API or behavior change)
- [ ] Built a platform UI backend (not applicable)

The focused Cargo invocation was also attempted on Windows. It currently stops while compiling clean `main` because `native_stack_scan.rs` references Unix-only `libc::Dl_info` / `libc::dladdr`; it does not reach this test. Workspace-wide `cargo fmt` likewise hits Windows path error 206, while the new file passes standalone rustfmt.

## Screenshots / output

```text
Wrote executable: claude-code-build\repro-mkdir-options.exe
PASS
RUN_EXIT=0
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the repository's conventional prefix style
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `fs.mkdirSync` could crash when called with an options object containing `recursive: true`.
  * Recursive directory creation now works correctly with nested paths.

* **Tests**
  * Added regression coverage validating directory creation, execution success, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->