### PR TITLE
test(parity): make class field layout fixture valid for Node 26 (#8271)

### DIFF
--- a/test-files/test_class_field_layout.ts
+++ b/test-files/test_class_field_layout.ts
@@ -81,7 +81,7 @@ console.log(acct.getBalance());  // 100
 acct.deposit(50);
 console.log(acct.getBalance());  // 150
 console.log(acct.checkPin(1234)); // true
-console.log(acct.checkPin(0000)); // false
+console.log(acct.checkPin(0)); // false
 
 // === Multiple inheritance levels ===
 class Base {

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -37,15 +37,6 @@
       "linux"
     ]
   },
-  "test_class_field_layout": {
-    "issue": "8271",
-    "added": "2026-08-17",
-    "category": "untriaged",
-    "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
-    "platforms": [
-      "linux"
-    ]
-  },
   "test_date_fns_format": {
     "issue": "8271",
     "added": "2026-08-17",


### PR DESCRIPTION
## Summary

Makes `test_class_field_layout` executable by the pinned Node 26 oracle. The fixture used the legacy octal literal `0000`, which Node rejected before execution while Perry accepted it; the equivalent decimal `0` preserves the assertion and lets the intended class-layout parity test run.

## Changes

- Replace the invalid legacy octal literal with decimal `0`.
- Remove `test_class_field_layout` from the #8271 known-failure ratchet after verifying byte-for-byte parity.

## Related issue

Refs #8271

## Test plan

- [x] `PERRY_SKIP_BUILD=1 PERRY_BIN=/Users/amlug/projects/perry/perry/target/release/perry PERRY_RUNTIME_DIR=/Users/amlug/projects/perry/perry/target/release ./run_parity_tests.sh --filter test_class_field_layout`
- [x] `python3 scripts/parity_known_failures.py --audit`
- [x] `python3 scripts/parity_known_failures.py --self-test`
- [x] `git diff --check`
- [ ] `cargo build --release` clean (not run; fixture/ratchet-only change)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run; fixture/ratchet-only change)
- [x] Updated the affected existing test under `test-files/`
- [ ] Updated docs (not applicable)
- [ ] Built a platform UI backend (not applicable)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository commit convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated private-field PIN test input while preserving the expected result.
  * Removed the corresponding known-failure designation, reflecting improved test parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->