### PR TITLE
fix(codegen): restore numeric loop safepoint purity

### DIFF
--- a/changelog.d/8263-loop-safepoint-purity.md
+++ b/changelog.d/8263-loop-safepoint-purity.md
@@ -1,0 +1,6 @@
+Numeric loops whose reassigned locals are proven to remain Numbers no longer
+emit moving-GC back-edge polls. The loop-purity predicate now consumes the
+existing whole-write `number_by_construction_locals` proof, preserving the
+call-free counted-loop optimization without trusting erased TypeScript
+annotations. The `loop_safepoint_purity` integration suite is restored to the
+per-PR codegen map and its temporary #8263 exclusion is removed.

--- a/crates/perry-codegen/src/expr/shadow_slot.rs
+++ b/crates/perry-codegen/src/expr/shadow_slot.rs
@@ -47,7 +47,7 @@ pub(crate) fn expr_is_known_non_pointer_shadow_value(ctx: &FnCtx<'_>, expr: &Exp
             // annotation and remains valid at every read, including loop
             // counters whose back-edge update makes an initializer-only
             // proof ineligible.
-            if ctx.integer_locals.contains(id) {
+            if ctx.integer_locals.contains(id) || ctx.number_by_construction_locals.contains(id) {
                 return true;
             }
             // A reserved shadow slot means the local is pointer-possible even

--- a/crates/perry-codegen/src/rooting/temp_root.rs
+++ b/crates/perry-codegen/src/rooting/temp_root.rs
@@ -430,13 +430,16 @@ pub(crate) fn expr_is_inert_primitive(ctx: &FnCtx<'_>, expr: &Expr) -> bool {
 ///    a genuine local and not for a global, so a global is never inert.
 ///
 /// A declaration is deliberately absent from this judgment. The type arm uses
-/// only runtime-derived initializer evidence; `integer_locals` is the separate
-/// whole-write structural proof for literal-seeded recurrences. A lying scalar
-/// annotation therefore retains its root and cannot make coercion look inert.
+/// only runtime-derived evidence; `integer_locals` and
+/// `number_by_construction_locals` are the separate whole-write structural
+/// proofs for integer recurrences and general Number-valued accumulators. A
+/// lying scalar annotation therefore retains its root and cannot make coercion
+/// look inert.
 pub(in crate::rooting) fn local_is_inert_primitive(ctx: &FnCtx<'_>, id: u32) -> bool {
     !ctx.shadow_slot_map.contains_key(&id)
         && !ctx.module_globals.contains_key(&id)
         && (ctx.integer_locals.contains(&id)
+            || ctx.number_by_construction_locals.contains(&id)
             || matches!(
                 ctx.stable_local_type_proof(&id),
                 Some(

--- a/crates/perry-codegen/tests/loop_safepoint_purity.rs
+++ b/crates/perry-codegen/tests/loop_safepoint_purity.rs
@@ -5,14 +5,15 @@
 //! whether a deferred minor collection could be waiting to be drained. Its
 //! whitelist used to omit relational comparisons, arithmetic `Binary` and
 //! `Update`, so `for (let i = 0; i < n; i++) { sum = sum + 1; }` failed the
-//! test on its own condition, body AND update — three runtime calls per
+//! test on its own condition, body AND update — three poll call sites per
 //! iteration in a loop that allocates nothing.
 //!
 //! The widening reuses `expr_is_inert_primitive` (#6975): those operators run
 //! ToPrimitive / ToNumeric, and a user-defined `valueOf` is arbitrary JS that
 //! allocates. The unit tests in `loop_purity.rs` pin the walk with an injected
-//! predicate; these compile real HIR so the REAL predicate — `local_types`,
-//! `shadow_slot_map`, `module_globals` and all — is the thing under test.
+//! predicate; these compile real HIR so the REAL predicate — runtime-derived
+//! stable types, whole-write numeric proofs, `shadow_slot_map`,
+//! `module_globals` and all — is the thing under test.
 //!
 //! Every "no poll" assertion below is paired with a case that differs in one
 //! operand and MUST keep its poll. That pairing is the point, and it was

--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -122,6 +122,7 @@ _CODEGEN_SUITES = [
     "destructure_call_location",
     "i64_spec_ternary_recursion",
     "large_object_barriers",
+    "loop_safepoint_purity",
     "macos_bundle_chdir_gate",
     "manifest_consistency",
     # #7506/#7245: held out until its one failing test was triaged. The
@@ -169,12 +170,6 @@ SOURCE_SUITE_MAP = {
 # 262 tests, and holding all 262 out for one of them is how 261 tests' worth of
 # coverage went dark.
 SUITE_EXCLUSIONS = [
-    (
-        "perry-codegen",
-        "loop_safepoint_purity",
-        "proven_numeric_counted_loop_emits_no_back_edge_poll",
-        "#8263 — red on main; current codegen emits guarded polls in this fixture.",
-    ),
     (
         "perry-codegen",
         "native_proof_buffer_views",


### PR DESCRIPTION
Fixes #8263

## Summary

- admit reassigned locals proven Number-valued by `number_by_construction_locals` to the inert/non-pointer predicates used by loop safepoint purity
- preserve polls for coercible, allocating, string-concatenating, and module-global loop shapes
- restore `loop_safepoint_purity` to per-PR codegen coverage and remove its temporary exclusion
- add a changelog fragment without changing package versions

## Validation

- `cargo test -p perry-codegen --test loop_safepoint_purity --test scalar_replaced_slot_roots --test temp_root_operand_temporaries --test native_proof_regressions` (309 passed)
- `cargo test -p perry-codegen` (1,094 unit tests passed; integration run then reached the six existing `native_proof_buffer_views` failures tracked by #8264)
- `python3 scripts/ci_e2e_scope.py --self-test`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved counted-loop execution by removing unnecessary garbage-collection safepoint checks when numeric safety can be proven.
  * Preserved optimizations for call-free loops.

* **Bug Fixes**
  * Improved detection of numeric, non-pointer values to support safer allocation and rooting decisions.

* **Tests**
  * Restored and expanded loop safepoint purity coverage.
  * Re-enabled the related integration suite in continuous testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->