### PR TITLE
fix(http): support raw request header arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
 name = "perry-ext-http"
 version = "0.5.1512"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http-body-util",

--- a/changelog.d/4975-http-header-array.md
+++ b/changelog.d/4975-http-header-array.md
@@ -1,0 +1,3 @@
+### Fixed
+
+**`http.request()` and `https.request()` now accept Node's raw header-pair array form.** Perry previously read `options.headers` only when it was an object, so `[[name, value], ...]` was silently discarded and array-valued object headers were serialized as JSON text. Request headers now normalize both forms, join duplicate cookies with `; `, derive Basic authorization from `options.auth` for object headers, and preserve Node's rule that raw header arrays suppress that implicit authorization header. This advances the behavioral parity tail tracked in #4975 and makes Node's `test-http-client-headers-array` contract pass end to end.

--- a/crates/perry-ext-http/Cargo.toml
+++ b/crates/perry-ext-http/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true }
 bytes.workspace = true
 serde_json.workspace = true
 lazy_static.workspace = true
+base64.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 socket2.workspace = true

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -92,6 +92,11 @@ mod transport_error;
 mod response_headers;
 use response_headers::build_response_headers_object;
 
+// Client request-header normalization (object and raw-pair forms), extracted
+// so this file stays below the workspace's 2000-line source ceiling.
+mod request_headers;
+use request_headers::headers_from_options;
+
 use bytes::Bytes;
 use lazy_static::lazy_static;
 use perry_ffi::{
@@ -569,22 +574,6 @@ fn url_from_options(opts: &serde_json::Value, default_protocol: &str) -> String 
         Some(p) if !p.is_empty() => format!("{}://{}:{}{}", protocol, hostname, p, path),
         _ => format!("{}://{}{}", protocol, hostname, path),
     }
-}
-
-fn headers_from_options(opts: &serde_json::Value) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    if let Some(headers) = opts.get("headers").and_then(|v| v.as_object()) {
-        for (k, v) in headers {
-            if let Some(s) = v.as_str() {
-                out.insert(k.clone(), s.to_string());
-            } else if let Some(n) = v.as_i64() {
-                out.insert(k.clone(), n.to_string());
-            } else {
-                out.insert(k.clone(), v.to_string());
-            }
-        }
-    }
-    out
 }
 
 fn timeout_from_options(opts: &serde_json::Value) -> Option<u64> {

--- a/crates/perry-ext-http/src/request_headers.rs
+++ b/crates/perry-ext-http/src/request_headers.rs
@@ -1,0 +1,88 @@
+//! Client-side `options.headers` normalization.
+//!
+//! Node accepts both an object and a raw `[[name, value], ...]` array. The raw
+//! form preserves duplicate fields and deliberately suppresses implicit
+//! `Authorization`/`Host` generation. Perry's transport uses a map, so duplicate
+//! values are combined with the separators Node exposes through
+//! `IncomingMessage.headers` (`; ` for cookies, `, ` otherwise).
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose, Engine as _};
+
+fn header_value_string(name: &str, value: &serde_json::Value) -> String {
+    if let Some(values) = value.as_array() {
+        let separator = if name.eq_ignore_ascii_case("cookie") {
+            "; "
+        } else {
+            ", "
+        };
+        return values
+            .iter()
+            .map(|value| header_value_string(name, value))
+            .collect::<Vec<_>>()
+            .join(separator);
+    }
+
+    match value {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn append_header(out: &mut HashMap<String, String>, name: &str, value: &serde_json::Value) {
+    let value = header_value_string(name, value);
+    if let Some(existing) = out
+        .iter_mut()
+        .find_map(|(key, current)| key.eq_ignore_ascii_case(name).then_some(current))
+    {
+        existing.push_str(if name.eq_ignore_ascii_case("cookie") {
+            "; "
+        } else {
+            ", "
+        });
+        existing.push_str(&value);
+    } else {
+        out.insert(name.to_string(), value);
+    }
+}
+
+pub(crate) fn headers_from_options(opts: &serde_json::Value) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let headers = opts.get("headers");
+    let headers_are_array = headers.is_some_and(serde_json::Value::is_array);
+
+    match headers {
+        Some(serde_json::Value::Object(headers)) => {
+            for (name, value) in headers {
+                append_header(&mut out, name, value);
+            }
+        }
+        Some(serde_json::Value::Array(headers)) => {
+            for pair in headers {
+                let Some(pair) = pair.as_array() else {
+                    continue;
+                };
+                let (Some(name), Some(value)) =
+                    (pair.first().and_then(|v| v.as_str()), pair.get(1))
+                else {
+                    continue;
+                };
+                append_header(&mut out, name, value);
+            }
+        }
+        _ => {}
+    }
+
+    let has_authorization = out
+        .keys()
+        .any(|name| name.eq_ignore_ascii_case("authorization"));
+    if !headers_are_array && !has_authorization {
+        if let Some(auth) = opts.get("auth").and_then(serde_json::Value::as_str) {
+            let encoded = general_purpose::STANDARD.encode(auth.as_bytes());
+            out.insert("Authorization".to_string(), format!("Basic {encoded}"));
+        }
+    }
+    out
+}

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -402,3 +402,36 @@ fn headers_from_options_extracts() {
     assert_eq!(h.get("X-Foo"), Some(&"bar".to_string()));
     assert_eq!(h.get("Authorization"), Some(&"Bearer x".to_string()));
 }
+
+#[test]
+fn headers_from_options_normalizes_arrays_and_auth() {
+    let object: serde_json::Value = serde_json::from_str(
+        r#"{"auth":"foo:bar","headers":{"x-foo":"boom","cookie":["a=1","b=2","c=3"]}}"#,
+    )
+    .unwrap();
+    let object_headers = headers_from_options(&object);
+    assert_eq!(object_headers.get("x-foo"), Some(&"boom".to_string()));
+    assert_eq!(
+        object_headers.get("cookie"),
+        Some(&"a=1; b=2; c=3".to_string())
+    );
+    assert_eq!(
+        object_headers.get("Authorization"),
+        Some(&"Basic Zm9vOmJhcg==".to_string())
+    );
+
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{"auth":"foo:bar","headers":[["x-foo","boom"],["cookie","a=1"],["cookie",["b=2","c=3"]],["Host","example.com"]]}"#,
+    )
+    .unwrap();
+    let raw_headers = headers_from_options(&raw);
+    assert_eq!(raw_headers.get("x-foo"), Some(&"boom".to_string()));
+    assert_eq!(
+        raw_headers.get("cookie"),
+        Some(&"a=1; b=2; c=3".to_string())
+    );
+    assert_eq!(raw_headers.get("Host"), Some(&"example.com".to_string()));
+    assert!(!raw_headers
+        .keys()
+        .any(|name| name.eq_ignore_ascii_case("authorization")));
+}

--- a/test-parity/node-suite/http/README.md
+++ b/test-parity/node-suite/http/README.md
@@ -38,12 +38,12 @@ Deno and Bun. We did not add a case just because upstream had many files.
 
 ## Coverage
 
-The suite contains 52 fixtures, up from 19:
+The suite contains 53 fixtures, up from 19:
 
 | Area                                 | Fixtures | Contracts                                                                                                                                           |
 | ------------------------------------ | -------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | exports                              |        9 | methods, status codes, helper tail, classes, inheritance, descriptors, WebSocket event constructors, and receiver checks                            |
-| request                              |        9 | URL and options overloads, `get()` auto-end, callback order, method/path/protocol/agent/signal validation, and coercion                             |
+| request                              |       10 | URL and options overloads, raw header arrays, `get()` auto-end, callback order, method/path/protocol/agent/signal validation, and coercion          |
 | `ClientRequest`                      |        4 | constructor state, header operations and validation, `flushHeaders()`, aliases, controls, and clean errors                                          |
 | `IncomingMessage`                    |        4 | constructor defaults, request and response metadata, raw/distinct headers, encoding, body state, and trailers                                       |
 | `ServerResponse` / `OutgoingMessage` |        5 | header mutation, `setHeaders()`, status and informational validation, and lifecycle state                                                           |
@@ -64,7 +64,7 @@ Every fixture maps to a Node 26.5.0 implementation file or upstream test family:
 | `agent/request-create-connection.ts`, `agent/request-create-socket.ts`                                                                                        | `Agent.prototype.addRequest`, `createSocket`, and `createConnection` in `lib/_http_agent.js`               |
 | `client-request/constructor-surface.ts`                                                                                                                       | `ClientRequest` in `lib/_http_client.js` and `OutgoingMessage` in `lib/_http_outgoing.js`                  |
 | `client-request/header-operations.ts`, `client-request/header-validation.ts`, `client-request/flush-headers-state.ts`                                         | `lib/_http_outgoing.js`; `test-http-invalidheaderfield`                                                    |
-| `request/url-options-overload.ts`, `request/url-validation.ts`, `request/get-auto-end.ts`, `request/callback-validation-order.ts`                             | `lib/http.js`, `lib/_http_client.js`; `test-http-request-url`                                              |
+| `request/url-options-overload.ts`, `request/header-array-options.ts`, `request/url-validation.ts`, `request/get-auto-end.ts`, `request/callback-validation-order.ts` | `lib/http.js`, `lib/_http_client.js`; `test-http-request-url`, `test-http-client-headers-array`             |
 | `request/method-validation.ts`, `request/path-validation.ts`, `request/protocol-validation.ts`, `request/agent-validation.ts`, `request/signal-validation.ts` | `ClientRequest` option validation in `lib/_http_client.js`; `test-http-request-invalid-method-error`       |
 | `incoming-message/constructor-defaults.ts`, `incoming-message/response-metadata.ts`                                                                           | `IncomingMessage` in `lib/_http_incoming.js` and response parsing in `lib/_http_client.js`                 |
 | `incoming-message/client-set-encoding.ts`, `incoming-message/server-headers-body.ts`                                                                          | `lib/_http_incoming.js`, `lib/_http_common.js`; `test-http-trailers`                                       |
@@ -91,7 +91,7 @@ The adjacent suites keep ownership of generic behavior:
 
 ## Repeated comparison
 
-All final runtime comparisons ran three times. Each runtime produced the same
+The original 52-fixture audit ran three times. Each runtime produced the same
 classification and output digest on every run:
 
 | Runtime     | Pass | Diff | Error | Compile failure | Crash | Timeout |
@@ -100,6 +100,9 @@ classification and output digest on every run:
 | Perry       |   22 |   29 |     0 |               1 |     0 |       0 |
 | Deno 2.9.3  |   42 |    6 |     4 |             n/a |     0 |       0 |
 | Bun 1.2.18  |   23 |   26 |     3 |             n/a |     0 |       0 |
+
+The raw-header-array fixture added for #4975 was checked separately under Node
+and Perry and produced byte-for-byte identical output.
 
 Deno's four clean errors come from missing Node 26.5.0 export-tail entries. Its
 six output differences cover only server disposal, close errors, parser options,

--- a/test-parity/node-suite/http/request/header-array-options.ts
+++ b/test-parity/node-suite/http/request/header-array-options.ts
@@ -1,0 +1,60 @@
+import { createServer, request } from "node:http";
+
+const seen: string[] = [];
+const server = createServer((req, res) => {
+  const kind = seen.length === 0 ? "object" : "array";
+  seen.push([
+    kind,
+    req.headers["x-foo"],
+    req.headers.cookie,
+    req.headers.authorization ?? "<missing>",
+    kind === "object"
+      ? String(req.headers.host?.startsWith("127.0.0.1:"))
+      : req.headers.host,
+  ].join("|"));
+  res.end("ok");
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+const address = server.address();
+if (!address || typeof address === "string") throw new Error("missing address");
+
+async function send(options: Record<string, unknown>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = request({
+      hostname: "127.0.0.1",
+      port: address.port,
+      path: "/",
+      ...options,
+    }, (res) => {
+      res.once("error", reject);
+      res.on("end", resolve);
+      res.resume();
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+try {
+  await send({
+    auth: "foo:bar",
+    headers: { "x-foo": "boom", cookie: ["a=1", "b=2", "c=3"] },
+  });
+  await send({
+    auth: "foo:bar",
+    headers: [
+      ["x-foo", "boom"],
+      ["cookie", "a=1"],
+      ["cookie", ["b=2", "c=3"]],
+      ["Host", "example.com"],
+    ],
+  });
+} finally {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+console.log(seen.join("\n"));


### PR DESCRIPTION
## Summary

- accept Node's raw `[[name, value], ...]` request-header form
- normalize array-valued and duplicate headers with Node-compatible separators
- derive Basic authorization from `options.auth` for object headers while preserving raw-array suppression
- add focused unit and end-to-end parity coverage for `test-http-client-headers-array`

## Testing

- `cargo test -p perry-ext-http` (69 passed)
- `cargo clippy -p perry-ext-http --all-targets` (passes with existing warnings)
- Node and compiled Perry runs of `header-array-options.ts` (byte-for-byte identical)
- `cargo fmt --all -- --check`
- `git diff --check`

The exact upstream Node corpus test was also attempted, but its optimized build exceeded the harness's 600-second compile timeout before execution.

Progresses #4975.

No version bump.
