### PR TITLE
fix(codegen): construct imported default parents once

### DIFF
--- a/changelog.d/8317-imported-default-ctor.md
+++ b/changelog.d/8317-imported-default-ctor.md
@@ -1,0 +1,4 @@
+Fixed construction of local subclasses whose imported parent inherits a default
+constructor. Perry now invokes the runtime parent once with the original arguments
+and preserves fields initialized by the imported constructor, fixing Drizzle MySQL
+column creation failures such as writes to `config.uniqueName`.

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -955,6 +955,11 @@ fn lower_new_impl_inner<'a>(
     let has_own_ctor = class.constructor.is_some();
     let has_extends = class.extends_name.is_some();
     let has_imported_ctor = ctx.imported_class_ctors.contains_key(class_name);
+    // A local class whose imported parent is represented by both a static
+    // name and a runtime heritage value must construct through that runtime
+    // value. The source module's standalone ctor owns all imported-parent
+    // field initialization; this module must only replay the local leaf.
+    let defer_to_dynamic_parent = class.extends_expr.is_some() && !has_imported_ctor;
     let builtin_parent_runtime = if !has_own_ctor && !has_imported_ctor {
         match class.extends_name.as_deref() {
             Some("Writable") => Some("js_node_stream_writable_subclass_init"),
@@ -1372,7 +1377,23 @@ fn lower_new_impl_inner<'a>(
         // PgSerial needs to dispatch to Column_constructor (forwarding the
         // ctor args). Without this walk, `new PgSerial(table, config)`
         // produced an empty object since none of the chain's bodies ran.
-        if !found_inherited_ctor {
+        // An imported identifier used as a local class's heritage carries both
+        // `extends_name` (for static shape/field metadata) and `extends_expr`
+        // (the authoritative runtime parent value). Do not also call the
+        // imported constructor symbol here: its consumer-side metadata records
+        // only the source class's own constructor arity, which is zero for a
+        // default-derived constructor even though the emitted source symbol
+        // forwards its ancestor's arguments. Calling it therefore runs the
+        // parent once with missing arguments, then the dynamic-parent arm below
+        // runs it again with the real arguments. Drizzle's
+        // `MySqlInt extends MySqlColumnWithAutoIncrement` reaches
+        // `MySqlColumn(table, config)` first as `(undefined, undefined)` and
+        // throws while assigning `config.uniqueName`.
+        //
+        // Imported leaf classes (`new ImportedClass(...)`) still use their own
+        // imported constructor symbol; only a LOCAL leaf whose parent is the
+        // dynamic cross-module value defers to `js_fetch_or_value_super`.
+        if !found_inherited_ctor && !defer_to_dynamic_parent {
             let lookup_class = class_name.to_string();
             let mut effective_class_name = lookup_class.clone();
             let mut effective_extends = class.extends_name.clone();
@@ -1619,7 +1640,8 @@ fn lower_new_impl_inner<'a>(
     // static `extends_name`, so include the `extends_expr` case (SelfOnly,
     // mirroring the explicit-`SuperCall` dynamic-parent arm in this_super_call.rs).
     if !has_own_ctor && (has_extends || class.extends_expr.is_some()) && !has_imported_ctor {
-        if builtin_parent_runtime.is_some()
+        if defer_to_dynamic_parent
+            || builtin_parent_runtime.is_some()
             || fetch_parent_runtime.is_some()
             || promise_parent_runtime
             || usp_parent_runtime

--- a/test-files/issue_8226_base.ts
+++ b/test-files/issue_8226_base.ts
@@ -1,0 +1,27 @@
+type ColumnConfig = {
+  name: string;
+  uniqueName?: string;
+  autoIncrement: boolean;
+};
+
+let constructorCalls = 0;
+
+class Column {
+  config: ColumnConfig;
+
+  constructor(table: string, config: ColumnConfig) {
+    constructorCalls++;
+    if (!config.uniqueName) {
+      config.uniqueName = `${table}_${config.name}_unique`;
+    }
+    this.config = config;
+  }
+}
+
+export class ColumnWithAutoIncrement extends Column {
+  autoIncrement = this.config.autoIncrement;
+}
+
+export function getConstructorCalls(): number {
+  return constructorCalls;
+}

--- a/test-files/test_issue_8226_imported_default_ctor.ts
+++ b/test-files/test_issue_8226_imported_default_ctor.ts
@@ -1,0 +1,17 @@
+import {
+  ColumnWithAutoIncrement,
+  getConstructorCalls,
+} from "./issue_8226_base.ts";
+
+class IntColumn extends ColumnWithAutoIncrement {}
+
+const config = {
+  name: "id",
+  uniqueName: undefined as string | undefined,
+  autoIncrement: true,
+};
+const column = new IntColumn("users", config);
+
+console.log(config.uniqueName);
+console.log(column.autoIncrement);
+console.log(getConstructorCalls());


### PR DESCRIPTION
## Summary

Fix local subclasses of imported default-derived classes so construction uses the authoritative runtime parent exactly once. This preserves forwarded arguments and imported parent field initializers, fixing the Drizzle MySQL uniqueName failure.

## Changes

- Defer mixed static/dynamic imported heritage to js_fetch_or_value_super instead of also calling a zero-arity imported constructor symbol.
- Replay only the local leaf fields after the imported parent constructor owns its field initialization.
- Add a two-module regression covering argument forwarding, config mutation, inherited field initialization, and single constructor invocation.

## Related issue

Fixes #8226

## Test plan

- [x] cargo build --profile perry-dev -p perry
- [x] Focused parity harness: test_issue_8226_imported_default_ctor (1/1, Node-identical)
- [x] Full tests/release/packages/drizzle-mysql/entry.ts against local MySQL: count=2, alice.age=31, after_delete=1, join_rows=2
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [ ] cargo test -p perry-codegen (host ran out of disk while compiling the separate debug profile; no tests executed)
- [x] Added a regression under test-files/
- [ ] Documentation update (not applicable; no API change)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose feat: / fix: / docs: / chore: prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct