### PR TITLE
fix(runtime): support fork IPC on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
 name = "perry-ext-http"
 version = "0.5.1512"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http-body-util",

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Dev-facing targets. Perry is plain cargo (no mise), so this is intentionally
+# minimal — add targets here only when a plain `cargo <verb>` isn't enough.
+
+# Apply clippy's machine-applicable autofixes across the workspace. Prefers
+# cargo-fixit (crate-ci/cargo-fixit, pinned 0.1.13 by the fleet's
+# scripts/fleet/_shared/rust-tool-pins.mts) — the drop-in, ~20x-faster
+# replacement for `cargo clippy --fix` on repeated runs, because it skips the
+# full re-check compile between fix rounds. Falls back to `cargo clippy --fix`
+# when cargo-fixit isn't installed; install it with
+# `cargo install cargo-fixit@0.1.13 --locked`. Mirrors the fleet's
+# `scripts/fleet/lint-rust.mts --fix`. Run on a dirty tree is intended
+# (--allow-dirty --allow-staged); review the diff before committing. The CI
+# clippy gate is unchanged.
+.PHONY: fix
+fix:
+	@if cargo fixit --version >/dev/null 2>&1; then \
+		echo "fix: cargo fixit --clippy (cargo-fixit@0.1.13)"; \
+		cargo fixit --clippy --workspace --all-targets --allow-dirty --allow-staged; \
+	else \
+		echo "fix: cargo clippy --fix (cargo-fixit not installed; cargo install cargo-fixit@0.1.13 --locked for ~20x faster repeated runs)"; \
+		cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings; \
+	fi

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -1439,7 +1439,13 @@ equals = "width_aware_buffer_kernels:38314632556\n"
 detail = "width-aware buffer and typed-array semantic checksum"
 
 [workloads.width_aware_buffer_kernels.native_rep_checks]
-allow_materialization_reasons = ["function_abi", "runtime_api", "unknown_alias", "unknown_bounds"]
+allow_materialization_reasons = [
+  "function_abi",
+  "runtime_api",
+  "unknown_alias",
+  "unknown_bounds",
+  "unknown_call_escape",
+]
 
 [[workloads.width_aware_buffer_kernels.native_rep_checks.require_records]]
 name = "buffer_read_u32_be"
@@ -1523,14 +1529,14 @@ notes_contains = "typed_array_fallback=untracked_or_unproven"
 min = 2
 
 [[workloads.width_aware_buffer_kernels.native_rep_checks.require_records]]
-name = "typed_array_bounds_get_fallback"
+name = "typed_array_unproven_get_fallback"
 source_function = "typedArrayHazards"
 expr_kind = "TypedArrayGet"
 consumer = "TypedArrayGet.slow_path"
 native_rep_name = "js_value"
 access_mode = "dynamic_fallback"
 bounds_state = "unknown"
-materialization_reason = "unknown_bounds"
+materialization_reason = "unknown_call_escape"
 notes_contains = "typed_array_fallback=untracked_or_unproven"
 
 [[workloads.width_aware_buffer_kernels.native_rep_checks.require_records]]
@@ -1544,17 +1550,6 @@ bounds_state = "unknown"
 materialization_reason = "unknown_alias"
 notes_contains = "typed_array_fallback=untracked_or_unproven"
 min = 2
-
-[[workloads.width_aware_buffer_kernels.native_rep_checks.require_records]]
-name = "typed_array_bounds_set_fallback"
-source_function = "typedArrayHazards"
-expr_kind = "TypedArraySet"
-consumer = "TypedArraySet.slow_path"
-native_rep_name = "js_value"
-access_mode = "dynamic_fallback"
-bounds_state = "unknown"
-materialization_reason = "unknown_bounds"
-notes_contains = "typed_array_fallback=untracked_or_unproven"
 
 [workloads.native_owned_typed_views]
 source = "benchmarks/compiler_output/fixtures/native_owned_typed_views.ts"
@@ -1892,9 +1887,26 @@ kind = "native_abi_packet_typed"
 allow_hot_loop_conversions = true
 allow_dynamic_property_runtime = true
 allowed_hot_loop_runtime_calls = [
+  "js_dynamic_string_or_number_add",
+  "js_number_coerce",
   "js_shadow_frame_push",
   "js_shadow_slot_bind",
 ]
+
+# #8094's public trampoline contains a guarded specialized clone and the
+# semantics-preserving generic fallback. LLVM may inline both into the public
+# symbol, so the global hot-loop census legitimately sees dynamic helpers from
+# the fallback. Pin the actual optimization contract on the pre-opt clone: its
+# successful-guard body must remain free of those helpers (#8225).
+[[workloads.native_abi_packet_typed.ir_checks]]
+name = "packet_typed_specialized_clone_has_no_dynamic_numeric_helpers"
+section = "llvm_before"
+function_contains = "$spec_"
+regex_none = [
+  "call double @js_dynamic_string_or_number_add",
+  "call double @js_number_coerce",
+]
+detail = "the guarded typed-packet clone keeps numeric additions native while the generic fallback preserves erased-annotation semantics"
 
 [workloads.native_abi_packet_typed.vectorization]
 min_vectorized_loops = 0

--- a/changelog.d/4975-http-header-array.md
+++ b/changelog.d/4975-http-header-array.md
@@ -1,0 +1,3 @@
+### Fixed
+
+**`http.request()` and `https.request()` now accept Node's raw header-pair array form.** Perry previously read `options.headers` only when it was an object, so `[[name, value], ...]` was silently discarded and array-valued object headers were serialized as JSON text. Request headers now normalize both forms, join duplicate cookies with `; `, derive Basic authorization from `options.auth` for object headers, and preserve Node's rule that raw header arrays suppress that implicit authorization header. This advances the behavioral parity tail tracked in #4975 and makes Node's `test-http-client-headers-array` contract pass end to end.

--- a/changelog.d/8302-native-abi-evidence-proofs.md
+++ b/changelog.d/8302-native-abi-evidence-proofs.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- Restored native ABI evidence for compiler-owned Buffer, typed-array, arena,
+  POD-layout, and packed numeric-array values. Buffer numeric reads now retain
+  stable pointer facts (including `native_u32`), while optimized native paths
+  stay distinct from semantics-preserving erased-annotation fallbacks.
+
+  The failure came from runtime-derived identities being dropped after
+  TypeScript annotation trust was tightened: constructor facts were not carried
+  through `crates/perry-codegen/src/codegen/module_globals_emit.rs` and
+  `crates/perry-codegen/src/type_analysis/refine.rs`, Buffer numeric reads in
+  `crates/perry-codegen/src/lower_call/buffer_intrinsic.rs` did not attach their
+  view facts, and `crates/perry-codegen/src/collectors/ptr_shape_numeric.rs` did
+  not recognize native-view or POD-layout values as Number-producing. The repair
+  preserves those facts while explicitly excluding BigInt-backed typed arrays
+  and retaining guarded array stores. Regression coverage in
+  `crates/perry-codegen/tests/native_proof_buffer_views.rs`,
+  `crates/perry-codegen/src/collectors/ptr_shape_group_numeric_tests.rs`, and
+  `tests/test_native_abi_contract.sh` verifies the restored `u32`/`f32` records,
+  native numeric additions, BigInt mixed-add dispatch, and the full native-ABI
+  contract; the native ABI compiler-output suite validates the optimized and
+  fallback IR gates.

--- a/changelog.d/8315-native-pod-conversions.md
+++ b/changelog.d/8315-native-pod-conversions.md
@@ -1,0 +1,8 @@
+---
+category: Fixes
+authors:
+  - skelpo
+---
+
+Keep `perry/native` checked scalar conversions in verifier-backed POD storage
+when they initialize matching record fields.

--- a/changelog.d/8317-imported-default-ctor.md
+++ b/changelog.d/8317-imported-default-ctor.md
@@ -1,0 +1,4 @@
+Fixed construction of local subclasses whose imported parent inherits a default
+constructor. Perry now invokes the runtime parent once with the original arguments
+and preserves fields initialized by the imported constructor, fixing Drizzle MySQL
+column creation failures such as writes to `config.uniqueName`.

--- a/changelog.d/8318-windows-fork-ipc.md
+++ b/changelog.d/8318-windows-fork-ipc.md
@@ -1,0 +1,15 @@
+### Added
+
+- **`child_process.fork()` IPC on Windows (#6619).** Unix carried the IPC
+  channel on an inherited socketpair fd, which has no Windows equivalent, so
+  `fork()` there had no channel at all. Windows now gets a named-pipe transport
+  (`child_process/ipc_transport.rs`) and its own spawn path
+  (`child_process/windows_fork.rs`), both `#[cfg(windows)]` at the module
+  declaration.
+
+  The shared reactor is refactored rather than forked: the concrete
+  `Child` / `ChildStdin` types become boxed `CpReader` / `CpWriter` / `CpWaiter`
+  trait objects so one event loop serves both platforms. Unix semantics are
+  preserved through that change — the `pid` field is still published, and exit
+  reporting still extracts `status.signal()` via `ExitStatusExt` on each path
+  rather than losing the signal to a generic waiter.

--- a/crates/perry-codegen/src/codegen/module_globals_emit.rs
+++ b/crates/perry-codegen/src/codegen/module_globals_emit.rs
@@ -46,6 +46,26 @@ fn module_global_runtime_type(
         Expr::String(_) | Expr::WtfString(_) | Expr::I18nString { .. } | Expr::TypeOf(_) => {
             Some(Type::String)
         }
+        // Compiler-owned allocation HIR establishes these runtime classes
+        // independently of the erased binding annotation. Keep module-global
+        // facts aligned with `proven_type_from_init`; otherwise a value that
+        // becomes global only because a helper references it loses the same
+        // constructor proof that a function-local binding retains (#8225).
+        Expr::BufferAlloc { .. } | Expr::BufferAllocUnsafe(_) => {
+            Some(Type::Named("Buffer".to_string()))
+        }
+        Expr::Uint8ArrayNew(_) | Expr::Uint8ArrayFrom(_) => {
+            Some(Type::Named("Uint8Array".to_string()))
+        }
+        Expr::TypedArrayNew { kind, .. } | Expr::NativeArenaView { kind, .. } => {
+            super::spec_abi::spec_ta_kind_class_name(*kind)
+                .map(|class| Type::Named(class.to_string()))
+        }
+        Expr::NativeArenaAlloc(_) => Some(Type::Named("NativeArenaOwner".to_string())),
+        Expr::NativePodView {
+            view_type: Some(view_type),
+            ..
+        } => Some(view_type.clone()),
         Expr::New { class_name, .. }
             if class_name == "SharedArrayBuffer" && shared_array_buffer_is_intrinsic =>
         {

--- a/crates/perry-codegen/src/collectors/ptr_shape.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape.rs
@@ -1945,7 +1945,13 @@ pub(in crate::collectors) use numeric::collect_numeric_by_construction_locals as
 /// Conservative "cannot be a BigInt" for the spec Number-path argument.
 fn expr_provably_not_bigint(e: &Expr, not_bigint_locals: &HashSet<u32>) -> bool {
     match e {
-        Expr::Number(_) | Expr::Integer(_) | Expr::String(_) | Expr::Bool(_) => true,
+        Expr::Number(_)
+        | Expr::Integer(_)
+        | Expr::String(_)
+        | Expr::Bool(_)
+        | Expr::PodLayoutSizeOf { .. }
+        | Expr::PodLayoutAlignOf { .. }
+        | Expr::PodLayoutOffsetOf { .. } => true,
         Expr::LocalGet(id) => not_bigint_locals.contains(id),
         Expr::Unary { op, operand } => match op {
             perry_hir::UnaryOp::Pos => true, // `+x` throws for BigInt

--- a/crates/perry-codegen/src/collectors/ptr_shape_group_numeric_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_group_numeric_tests.rs
@@ -688,6 +688,50 @@ fn numeric_accumulator_is_numeric_by_construction() {
     assert!(numeric_locals_of(&stmts).contains(&3));
 }
 
+#[test]
+fn bigint_typed_view_addition_is_not_numeric_by_construction() {
+    for (offset, kind) in [
+        perry_hir::TYPED_ARRAY_KIND_BIGINT64,
+        perry_hir::TYPED_ARRAY_KIND_BIGUINT64,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let view_id = 30 + offset as u32 * 2;
+        let sum_id = view_id + 1;
+        let stmts = vec![
+            Stmt::Let {
+                id: view_id,
+                name: format!("bigint_view_{offset}"),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::TypedArrayNew {
+                    kind,
+                    arg: Some(Box::new(Expr::Integer(1))),
+                }),
+            },
+            Stmt::Let {
+                id: sum_id,
+                name: format!("mixed_sum_{offset}"),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Binary {
+                    op: BinaryOp::Add,
+                    left: Box::new(Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(view_id)),
+                        index: Box::new(Expr::Integer(0)),
+                    }),
+                    right: Box::new(Expr::Integer(1)),
+                }),
+            },
+        ];
+        assert!(
+            !numeric_locals_of(&stmts).contains(&sum_id),
+            "BigInt typed-array reads must retain mixed-addition TypeError semantics"
+        );
+    }
+}
+
 /// The poisons, one per rule: a no-init `Let` (undefined until assigned), a
 /// string write anywhere, a boxed id, and a param-like id with no `Let`.
 #[test]

--- a/crates/perry-codegen/src/collectors/ptr_shape_numeric.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_numeric.rs
@@ -437,6 +437,18 @@ pub(in crate::collectors) fn collect_numeric_by_construction_locals<'a>(
     let mut writes: HashMap<u32, Vec<Option<&'a Expr>>> = HashMap::new();
     let mut let_bound: HashSet<u32> = HashSet::new();
     super::super::not_bigint_locals::collect_writes(stmts, &mut writes, &mut let_bound);
+    // The standalone #8105 consumer does not run the Ptr<Shape> provenance
+    // walk that normally supplies `const_local_inits`. Reconstruct the same
+    // safe fact from the shared exhaustive write set: one initialized write
+    // means the binding's value is stable even when its source spelling was
+    // `let`. This lets the Add proof inspect compiler-owned typed-view
+    // constructors without trusting their erased annotation.
+    let mut stable_local_inits = const_local_inits.clone();
+    for (&id, local_writes) in &writes {
+        if let [Some(init)] = local_writes.as_slice() {
+            stable_local_inits.entry(id).or_insert(Some(*init));
+        }
+    }
     let empty_members: HashSet<u32> = HashSet::new();
     let empty_fields: HashSet<String> = HashSet::new();
     let mut numeric: HashSet<u32> = let_bound
@@ -457,7 +469,7 @@ pub(in crate::collectors) fn collect_numeric_by_construction_locals<'a>(
                             &empty_members,
                             &empty_fields,
                             not_bigint_locals,
-                            const_local_inits,
+                            &stable_local_inits,
                             &numeric,
                             0,
                         ),
@@ -511,8 +523,63 @@ pub(super) fn expr_numeric_by_construction(
             depth + 1,
         )
     };
+    // A numeric index into one of these compiler-owned constructors can only
+    // produce a Number or `undefined` (for an out-of-bounds read). Either is
+    // safe on one side of `+` once the other operand has the same property:
+    // neither operand can select string concatenation, and ToNumber(undefined)
+    // produces the Number NaN. Keep this weaker fact local to the Add rule;
+    // an out-of-bounds read is not itself a Number and must not become a
+    // general raw-f64 proof.
+    let numeric_view_value_or_undefined = |x: &Expr| {
+        let Expr::IndexGet { object, index } = x else {
+            return false;
+        };
+        let Expr::LocalGet(view_id) = object.as_ref() else {
+            return false;
+        };
+        let Some(Some(init)) = const_local_inits.get(view_id) else {
+            return false;
+        };
+        let number_valued_typed_array_kind = |kind: u8| {
+            matches!(
+                kind,
+                perry_hir::TYPED_ARRAY_KIND_INT8
+                    | perry_hir::TYPED_ARRAY_KIND_UINT8
+                    | perry_hir::TYPED_ARRAY_KIND_UINT8_CLAMPED
+                    | perry_hir::TYPED_ARRAY_KIND_INT16
+                    | perry_hir::TYPED_ARRAY_KIND_UINT16
+                    | perry_hir::TYPED_ARRAY_KIND_INT32
+                    | perry_hir::TYPED_ARRAY_KIND_UINT32
+                    | perry_hir::TYPED_ARRAY_KIND_FLOAT16
+                    | perry_hir::TYPED_ARRAY_KIND_FLOAT32
+                    | perry_hir::TYPED_ARRAY_KIND_FLOAT64
+            )
+        };
+        let numeric_storage = matches!(
+            init,
+            Expr::BufferAlloc { .. }
+                | Expr::BufferAllocUnsafe(_)
+                | Expr::Uint8ArrayNew(_)
+                | Expr::Uint8ArrayFrom(_)
+        ) || matches!(
+            init,
+            Expr::TypedArrayNew { kind, .. } | Expr::NativeArenaView { kind, .. }
+                if number_valued_typed_array_kind(*kind)
+        ) || matches!(
+            init,
+            Expr::Array(elements)
+                if elements
+                    .iter()
+                    .all(|element| matches!(element, Expr::Integer(_) | Expr::Number(_)))
+        );
+        numeric_storage && rec(index)
+    };
     match e {
-        Expr::Number(_) | Expr::Integer(_) => true,
+        Expr::Number(_)
+        | Expr::Integer(_)
+        | Expr::PodLayoutSizeOf { .. }
+        | Expr::PodLayoutAlignOf { .. }
+        | Expr::PodLayoutOffsetOf { .. } => true,
         Expr::Unary { op, operand } => match op {
             perry_hir::UnaryOp::Neg | perry_hir::UnaryOp::Pos | perry_hir::UnaryOp::BitNot => {
                 rec(operand)
@@ -521,7 +588,10 @@ pub(super) fn expr_numeric_by_construction(
         },
         Expr::Binary { op, left, right } => match op {
             // `+` concatenates strings; both sides must be numbers.
-            BinaryOp::Add => rec(left) && rec(right),
+            BinaryOp::Add => {
+                (rec(left) || numeric_view_value_or_undefined(left))
+                    && (rec(right) || numeric_view_value_or_undefined(right))
+            }
             // `- * / %` produce a BigInt only for BigInt⊗BigInt; mixing a
             // BigInt with anything else THROWS (no value is stored). ONE
             // provably-non-BigInt operand therefore forces the completed

--- a/crates/perry-codegen/src/lower_call/buffer_intrinsic.rs
+++ b/crates/perry-codegen/src/lower_call/buffer_intrinsic.rs
@@ -8,7 +8,7 @@
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{access_facts_for_spec, BufferAccessSpec, FnCtx};
+use crate::expr::{access_facts_for_spec, attach_buffer_view_facts, BufferAccessSpec, FnCtx};
 use crate::native_value::{BufferEndian, LoweredValue};
 use crate::types::{F32, I32};
 
@@ -479,6 +479,7 @@ pub(super) fn try_emit_buffer_read_intrinsic(
         proof.may_emit_noalias,
         vec![format!("width_bytes={}", spec.width_bytes)],
     );
+    attach_buffer_view_facts(ctx, &proof.view);
     let result_consumer = match result.rep.name() {
         "i32" => "BufferNumericRead.native_i32",
         "u32" => "BufferNumericRead.native_u32",
@@ -506,6 +507,7 @@ pub(super) fn try_emit_buffer_read_intrinsic(
             format!("endian={:?}", spec.endian),
         ],
     );
+    attach_buffer_view_facts(ctx, &proof.view);
     Ok(Some(result))
 }
 

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -955,6 +955,11 @@ fn lower_new_impl_inner<'a>(
     let has_own_ctor = class.constructor.is_some();
     let has_extends = class.extends_name.is_some();
     let has_imported_ctor = ctx.imported_class_ctors.contains_key(class_name);
+    // A local class whose imported parent is represented by both a static
+    // name and a runtime heritage value must construct through that runtime
+    // value. The source module's standalone ctor owns all imported-parent
+    // field initialization; this module must only replay the local leaf.
+    let defer_to_dynamic_parent = class.extends_expr.is_some() && !has_imported_ctor;
     let builtin_parent_runtime = if !has_own_ctor && !has_imported_ctor {
         match class.extends_name.as_deref() {
             Some("Writable") => Some("js_node_stream_writable_subclass_init"),
@@ -1372,7 +1377,23 @@ fn lower_new_impl_inner<'a>(
         // PgSerial needs to dispatch to Column_constructor (forwarding the
         // ctor args). Without this walk, `new PgSerial(table, config)`
         // produced an empty object since none of the chain's bodies ran.
-        if !found_inherited_ctor {
+        // An imported identifier used as a local class's heritage carries both
+        // `extends_name` (for static shape/field metadata) and `extends_expr`
+        // (the authoritative runtime parent value). Do not also call the
+        // imported constructor symbol here: its consumer-side metadata records
+        // only the source class's own constructor arity, which is zero for a
+        // default-derived constructor even though the emitted source symbol
+        // forwards its ancestor's arguments. Calling it therefore runs the
+        // parent once with missing arguments, then the dynamic-parent arm below
+        // runs it again with the real arguments. Drizzle's
+        // `MySqlInt extends MySqlColumnWithAutoIncrement` reaches
+        // `MySqlColumn(table, config)` first as `(undefined, undefined)` and
+        // throws while assigning `config.uniqueName`.
+        //
+        // Imported leaf classes (`new ImportedClass(...)`) still use their own
+        // imported constructor symbol; only a LOCAL leaf whose parent is the
+        // dynamic cross-module value defers to `js_fetch_or_value_super`.
+        if !found_inherited_ctor && !defer_to_dynamic_parent {
             let lookup_class = class_name.to_string();
             let mut effective_class_name = lookup_class.clone();
             let mut effective_extends = class.extends_name.clone();
@@ -1619,7 +1640,8 @@ fn lower_new_impl_inner<'a>(
     // static `extends_name`, so include the `extends_expr` case (SelfOnly,
     // mirroring the explicit-`SuperCall` dynamic-parent arm in this_super_call.rs).
     if !has_own_ctor && (has_extends || class.extends_expr.is_some()) && !has_imported_ctor {
-        if builtin_parent_runtime.is_some()
+        if defer_to_dynamic_parent
+            || builtin_parent_runtime.is_some()
             || fetch_parent_runtime.is_some()
             || promise_parent_runtime
             || usp_parent_runtime

--- a/crates/perry-codegen/src/native_value/buffer.rs
+++ b/crates/perry-codegen/src/native_value/buffer.rs
@@ -16,6 +16,26 @@ pub(crate) enum BufferElem {
     F64,
 }
 
+impl BufferElem {
+    /// Whether an indexed read produces a JavaScript Number. Keep this
+    /// exhaustive so adding a BigInt-backed element representation cannot
+    /// silently broaden numeric-expression proofs.
+    pub(crate) fn is_number_valued(&self) -> bool {
+        matches!(
+            self,
+            Self::I8
+                | Self::U8
+                | Self::U8Clamped
+                | Self::I16
+                | Self::U16
+                | Self::I32
+                | Self::U32
+                | Self::F32
+                | Self::F64
+        )
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum BufferIndexUnit {

--- a/crates/perry-codegen/src/native_value/pod.rs
+++ b/crates/perry-codegen/src/native_value/pod.rs
@@ -167,6 +167,10 @@ pub(crate) fn validate_exact_init(
 }
 
 fn pod_init_value_roundtrips_exact(rep: &NativeRep, value: &Expr) -> bool {
+    if checked_native_scalar_conversion_matches(rep, value) {
+        return true;
+    }
+
     match rep {
         NativeRep::I32 => {
             literal_i64(value).is_some_and(|n| i32::try_from(n).is_ok())
@@ -202,6 +206,33 @@ fn pod_init_value_roundtrips_exact(rep: &NativeRep, value: &Expr) -> bool {
         NativeRep::F32 => literal_f64(value).is_some_and(f32_roundtrips_exact),
         _ => false,
     }
+}
+
+fn checked_native_scalar_conversion_matches(rep: &NativeRep, value: &Expr) -> bool {
+    let Expr::NativeMethodCall {
+        module,
+        class_name,
+        object,
+        method,
+        args,
+    } = value
+    else {
+        return false;
+    };
+    if module != "perry/native" || class_name.is_some() || object.is_some() || args.len() != 1 {
+        return false;
+    }
+
+    matches!(
+        (rep, method.as_str()),
+        (NativeRep::I32, "i32")
+            | (NativeRep::I64, "i64")
+            | (NativeRep::U32, "u32")
+            | (NativeRep::U64, "u64")
+            | (NativeRep::USize, "usize")
+            | (NativeRep::F32, "f32")
+            | (NativeRep::F64, "f64")
+    )
 }
 
 fn literal_i64(value: &Expr) -> Option<i64> {

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -425,6 +425,20 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             let Expr::LocalGet(arr_id) = object.as_ref() else {
                 return false;
             };
+            if ctx.native_facts.num_array_local(*arr_id).is_some() {
+                return true;
+            }
+            // #8225: tracked BufferViewSlots come from compiler-owned
+            // Buffer/typed-array constructors (including NativeArena views),
+            // and every representable element kind is numeric. This runtime
+            // fact is stronger than the erasable declaration consulted below.
+            if ctx
+                .buffer_view_slots
+                .get(arr_id)
+                .is_some_and(|view| view.elem.is_number_valued())
+            {
+                return true;
+            }
             match ctx.stable_local_type_proof(arr_id) {
                 Some(HirType::Array(elem)) => {
                     matches!(**elem, HirType::Number | HirType::Int32)

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -555,6 +555,23 @@ pub(crate) fn numeric_proof_is_declared_only(ctx: &FnCtx<'_>, expr: &Expr) -> bo
                 if crate::expr::masked_window_fact_for_index(ctx, *arr_id, index).is_some() {
                     return false;
                 }
+                if ctx.native_facts.num_array_local(*arr_id).is_some() {
+                    return false;
+                }
+                // #8225: a live BufferViewSlot is compiler-owned runtime
+                // evidence for a typed-array/buffer representation. Its
+                // element load cannot produce a string: the checked slow arm
+                // is at worst `undefined` (coerced separately when needed),
+                // while a proven native-owned access is a raw numeric load.
+                // Do not discard that stronger fact and reclassify the read
+                // from its erasable source annotation.
+                if ctx
+                    .buffer_view_slots
+                    .get(arr_id)
+                    .is_some_and(|view| view.elem.is_number_valued())
+                {
+                    return false;
+                }
             }
             // A typed array's storage is native bytes — a non-numeric store is
             // converted on the way in, so the read cannot surface one.

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -248,6 +248,27 @@ pub(crate) fn proven_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         Expr::Uint8ArrayNew(_) | Expr::Uint8ArrayFrom(_) => {
             Some(HirType::Named("Uint8Array".to_string()))
         }
+        // Buffer shares Uint8Array's byte storage, but its runtime class
+        // identity is stronger: losing it makes Buffer-only numeric methods
+        // such as readUInt32BE fall through to generic property dispatch.
+        Expr::BufferAlloc { .. } | Expr::BufferAllocUnsafe(_) => {
+            Some(HirType::Named("Buffer".to_string()))
+        }
+        // #8225: NativeArena views are compiler-owned HIR constructors, not
+        // calls selected from erasable TypeScript metadata. Losing this
+        // runtime-derived identity when annotation trust was tightened made
+        // every numeric read look declared-only: the cold `+` arm regained
+        // js_dynamic_string_or_number_add/js_number_coerce and the native ABI
+        // evidence packet went red. The kind is the allocation contract, so it
+        // is the same strength of proof as Uint8ArrayNew above.
+        Expr::TypedArrayNew { .. } | Expr::NativeArenaView { .. } => {
+            hir_inferred_refinable_type(ctx, init)
+        }
+        Expr::NativeArenaAlloc(_) => Some(HirType::Named("NativeArenaOwner".to_string())),
+        Expr::NativePodView {
+            view_type: Some(view_type),
+            ..
+        } => Some(view_type.clone()),
         Expr::Object(_) | Expr::ObjectSpread { .. } => Some(HirType::Object(Default::default())),
         Expr::Closure {
             is_async,

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -628,6 +628,7 @@ fn artifact_records_buffer_read_u32_and_unsigned_materialization() {
                 && record["native_rep_name"] == "u32"
                 && record["llvm_ty"] == "i32"
                 && record["native_value_state"] == "region_local"
+                && record["buffer_view_pointer_state"]["state"] == "stable"
         }),
         "expected region-local u32 buffer numeric read record:\n{artifact:#}"
     );
@@ -1097,6 +1098,89 @@ fn artifact_records_native_owned_typed_array_facts() {
         "expected native-owned f64 typed-array store record:\n{artifact:#}"
     );
     assert_eq!(artifact["summary"]["native_owned_view_count"], 4);
+}
+
+#[test]
+fn native_owned_view_identity_keeps_numeric_add_on_the_native_path() {
+    let layout_ty = pod_type(&[("value", Type::Named("PerryU32".to_string()))]);
+    let body = vec![
+        native_arena_owner_let(1, "owner", int(64), false),
+        native_arena_view_let(
+            2,
+            "view",
+            1,
+            "Float64Array",
+            perry_hir::TYPED_ARRAY_KIND_FLOAT64,
+            int(0),
+            int(8),
+        ),
+        number_let(
+            5,
+            "layoutIndex",
+            false,
+            Expr::Binary {
+                op: BinaryOp::Div,
+                left: Box::new(Expr::PodLayoutSizeOf {
+                    ty: layout_ty.clone(),
+                }),
+                right: Box::new(Expr::PodLayoutSizeOf { ty: layout_ty }),
+            },
+        ),
+        number_let(
+            3,
+            "sum",
+            true,
+            add(index_get(2, local(5)), index_get(2, int(1))),
+        ),
+        for_loop(
+            4,
+            int(8),
+            vec![Stmt::Expr(Expr::LocalSet(
+                3,
+                Box::new(add(local(3), index_get(2, local(4)))),
+            ))],
+        ),
+        Stmt::Expr(Expr::NativeArenaDispose(Box::new(local(1)))),
+        Stmt::Return(Some(local(3))),
+    ];
+
+    let ir = compile_ir("native_owned_view_numeric_add.ts", body);
+    assert!(
+        !ir.contains("call double @js_dynamic_string_or_number_add")
+            && !ir.contains("call double @js_number_coerce"),
+        "a compiler-owned typed view is a runtime type proof, not an erasable annotation:\n{ir}"
+    );
+}
+
+#[test]
+fn bigint_typed_view_addition_keeps_dynamic_bigint_dispatch() {
+    for (class_name, kind) in [
+        ("BigInt64Array", perry_hir::TYPED_ARRAY_KIND_BIGINT64),
+        ("BigUint64Array", perry_hir::TYPED_ARRAY_KIND_BIGUINT64),
+    ] {
+        let module = module_with_classes_and_params(
+            &format!("{}_addition.ts", class_name.to_ascii_lowercase()),
+            Vec::new(),
+            Vec::new(),
+            Type::Any,
+            vec![
+                typed_array_let(1, "view", class_name, kind, int(1)),
+                Stmt::Let {
+                    id: 2,
+                    name: "sum".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(add(index_get(1, int(0)), int(1))),
+                },
+                Stmt::Return(Some(local(2))),
+            ],
+        );
+        let ir = compile_ir_for_module_with_opts(module, empty_opts());
+        assert!(
+            ir.contains("call double @js_dynamic_string_or_number_add"),
+            "{class_name} indexed reads are BigInt values and must preserve mixed-addition TypeError semantics:\n{ir}"
+        );
+    }
 }
 
 #[test]

--- a/crates/perry-codegen/tests/native_proof_regressions/pod_manifest.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/pod_manifest.rs
@@ -1,6 +1,158 @@
 use super::*;
 
 #[test]
+fn checked_native_scalar_conversions_keep_dynamic_pod_initializers_native() {
+    let packet_ty = pod_type(&[
+        ("signed", Type::Named("PerryI32".to_string())),
+        ("flags", Type::Named("PerryU32".to_string())),
+        ("signed64", Type::Named("PerryI64".to_string())),
+        ("sequence", Type::Named("PerryU64".to_string())),
+        ("pointerSize", Type::Named("PerryUSize".to_string())),
+        ("gain", Type::Named("PerryF32".to_string())),
+        ("ratio", Type::Named("PerryF64".to_string())),
+    ]);
+    let module = module(
+        "checked_native_scalar_pod_init.ts",
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "input".to_string(),
+                ty: Type::Number,
+                mutable: false,
+                init: Some(number(7.0)),
+            },
+            pod_let(
+                2,
+                "packet",
+                packet_ty,
+                vec![
+                    (
+                        "signed",
+                        native_module_call("perry/native", "i32", vec![local(1)]),
+                    ),
+                    (
+                        "flags",
+                        native_module_call("perry/native", "u32", vec![local(1)]),
+                    ),
+                    (
+                        "signed64",
+                        native_module_call("perry/native", "i64", vec![local(1)]),
+                    ),
+                    (
+                        "sequence",
+                        native_module_call("perry/native", "u64", vec![local(1)]),
+                    ),
+                    (
+                        "pointerSize",
+                        native_module_call("perry/native", "usize", vec![local(1)]),
+                    ),
+                    (
+                        "gain",
+                        native_module_call("perry/native", "f32", vec![local(1)]),
+                    ),
+                    (
+                        "ratio",
+                        native_module_call("perry/native", "f64", vec![local(1)]),
+                    ),
+                ],
+            ),
+            Stmt::Return(Some(int(0))),
+        ],
+    );
+
+    let ir = compile_ir_for_module_with_opts(module.clone(), empty_opts()).unwrap();
+    for helper in [
+        "js_perry_native_i32",
+        "js_perry_native_u32",
+        "js_perry_native_i64",
+        "js_perry_native_u64",
+        "js_perry_native_usize",
+        "js_perry_native_f32",
+        "js_perry_native_f64",
+    ] {
+        assert!(
+            ir.contains(&format!("call double @{helper}")),
+            "missing checked conversion {helper}:\n{ir}"
+        );
+    }
+
+    let artifact = compile_artifact_json_for_module(module);
+    assert!(
+        artifact["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|record| {
+                record["native_rep_name"] == "pod_record"
+                    && record["consumer"] == "pod_record_stack_alloc"
+                    && record["pod_layout"]["size"] == 48
+            }),
+        "checked conversions should preserve a region-local POD record:\n{artifact:#}"
+    );
+    assert!(
+        !artifact["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|record| {
+                record["consumer"] == "pod_record_fallback_to_js_object"
+                    && record["notes"].as_array().is_some_and(|notes| {
+                        notes.iter().any(|note| {
+                            note.as_str()
+                                .is_some_and(|note| note.contains("inexact_or_dynamic_initializer"))
+                        })
+                    })
+            }),
+        "checked conversions must not be rejected as inexact dynamic initializers:\n{artifact:#}"
+    );
+}
+
+#[test]
+fn mismatched_checked_native_scalar_conversion_does_not_prove_pod_field() {
+    let packet_ty = pod_type(&[("signed", Type::Named("PerryI32".to_string()))]);
+    let module = module(
+        "mismatched_checked_native_scalar_pod_init.ts",
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "input".to_string(),
+                ty: Type::Number,
+                mutable: false,
+                init: Some(number(7.0)),
+            },
+            pod_let(
+                2,
+                "packet",
+                packet_ty,
+                vec![(
+                    "signed",
+                    native_module_call("perry/native", "u32", vec![local(1)]),
+                )],
+            ),
+            Stmt::Return(Some(int(0))),
+        ],
+    );
+
+    let artifact = compile_artifact_json_for_module(module);
+    assert!(
+        artifact["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|record| {
+                record["consumer"] == "pod_record_fallback_to_js_object"
+                    && record["notes"].as_array().is_some_and(|notes| {
+                        notes.iter().any(|note| {
+                            note.as_str()
+                                .is_some_and(|note| note.contains("inexact_or_dynamic_initializer"))
+                        })
+                    })
+            }),
+        "a u32 conversion must not prove an i32 POD field:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn native_library_manifest_pod_param_lowers_region_local_record_to_ptr() {
     let packet_ty = pod_type(&[
         ("tag", Type::Named("PerryU32".to_string())),

--- a/crates/perry-ext-http/Cargo.toml
+++ b/crates/perry-ext-http/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true }
 bytes.workspace = true
 serde_json.workspace = true
 lazy_static.workspace = true
+base64.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 socket2.workspace = true

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -92,6 +92,11 @@ mod transport_error;
 mod response_headers;
 use response_headers::build_response_headers_object;
 
+// Client request-header normalization (object and raw-pair forms), extracted
+// so this file stays below the workspace's 2000-line source ceiling.
+mod request_headers;
+use request_headers::headers_from_options;
+
 use bytes::Bytes;
 use lazy_static::lazy_static;
 use perry_ffi::{
@@ -569,22 +574,6 @@ fn url_from_options(opts: &serde_json::Value, default_protocol: &str) -> String 
         Some(p) if !p.is_empty() => format!("{}://{}:{}{}", protocol, hostname, p, path),
         _ => format!("{}://{}{}", protocol, hostname, path),
     }
-}
-
-fn headers_from_options(opts: &serde_json::Value) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    if let Some(headers) = opts.get("headers").and_then(|v| v.as_object()) {
-        for (k, v) in headers {
-            if let Some(s) = v.as_str() {
-                out.insert(k.clone(), s.to_string());
-            } else if let Some(n) = v.as_i64() {
-                out.insert(k.clone(), n.to_string());
-            } else {
-                out.insert(k.clone(), v.to_string());
-            }
-        }
-    }
-    out
 }
 
 fn timeout_from_options(opts: &serde_json::Value) -> Option<u64> {

--- a/crates/perry-ext-http/src/request_headers.rs
+++ b/crates/perry-ext-http/src/request_headers.rs
@@ -1,0 +1,88 @@
+//! Client-side `options.headers` normalization.
+//!
+//! Node accepts both an object and a raw `[[name, value], ...]` array. The raw
+//! form preserves duplicate fields and deliberately suppresses implicit
+//! `Authorization`/`Host` generation. Perry's transport uses a map, so duplicate
+//! values are combined with the separators Node exposes through
+//! `IncomingMessage.headers` (`; ` for cookies, `, ` otherwise).
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose, Engine as _};
+
+fn header_value_string(name: &str, value: &serde_json::Value) -> String {
+    if let Some(values) = value.as_array() {
+        let separator = if name.eq_ignore_ascii_case("cookie") {
+            "; "
+        } else {
+            ", "
+        };
+        return values
+            .iter()
+            .map(|value| header_value_string(name, value))
+            .collect::<Vec<_>>()
+            .join(separator);
+    }
+
+    match value {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn append_header(out: &mut HashMap<String, String>, name: &str, value: &serde_json::Value) {
+    let value = header_value_string(name, value);
+    if let Some(existing) = out
+        .iter_mut()
+        .find_map(|(key, current)| key.eq_ignore_ascii_case(name).then_some(current))
+    {
+        existing.push_str(if name.eq_ignore_ascii_case("cookie") {
+            "; "
+        } else {
+            ", "
+        });
+        existing.push_str(&value);
+    } else {
+        out.insert(name.to_string(), value);
+    }
+}
+
+pub(crate) fn headers_from_options(opts: &serde_json::Value) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let headers = opts.get("headers");
+    let headers_are_array = headers.is_some_and(serde_json::Value::is_array);
+
+    match headers {
+        Some(serde_json::Value::Object(headers)) => {
+            for (name, value) in headers {
+                append_header(&mut out, name, value);
+            }
+        }
+        Some(serde_json::Value::Array(headers)) => {
+            for pair in headers {
+                let Some(pair) = pair.as_array() else {
+                    continue;
+                };
+                let (Some(name), Some(value)) =
+                    (pair.first().and_then(|v| v.as_str()), pair.get(1))
+                else {
+                    continue;
+                };
+                append_header(&mut out, name, value);
+            }
+        }
+        _ => {}
+    }
+
+    let has_authorization = out
+        .keys()
+        .any(|name| name.eq_ignore_ascii_case("authorization"));
+    if !headers_are_array && !has_authorization {
+        if let Some(auth) = opts.get("auth").and_then(serde_json::Value::as_str) {
+            let encoded = general_purpose::STANDARD.encode(auth.as_bytes());
+            out.insert("Authorization".to_string(), format!("Basic {encoded}"));
+        }
+    }
+    out
+}

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -402,3 +402,36 @@ fn headers_from_options_extracts() {
     assert_eq!(h.get("X-Foo"), Some(&"bar".to_string()));
     assert_eq!(h.get("Authorization"), Some(&"Bearer x".to_string()));
 }
+
+#[test]
+fn headers_from_options_normalizes_arrays_and_auth() {
+    let object: serde_json::Value = serde_json::from_str(
+        r#"{"auth":"foo:bar","headers":{"x-foo":"boom","cookie":["a=1","b=2","c=3"]}}"#,
+    )
+    .unwrap();
+    let object_headers = headers_from_options(&object);
+    assert_eq!(object_headers.get("x-foo"), Some(&"boom".to_string()));
+    assert_eq!(
+        object_headers.get("cookie"),
+        Some(&"a=1; b=2; c=3".to_string())
+    );
+    assert_eq!(
+        object_headers.get("Authorization"),
+        Some(&"Basic Zm9vOmJhcg==".to_string())
+    );
+
+    let raw: serde_json::Value = serde_json::from_str(
+        r#"{"auth":"foo:bar","headers":[["x-foo","boom"],["cookie","a=1"],["cookie",["b=2","c=3"]],["Host","example.com"]]}"#,
+    )
+    .unwrap();
+    let raw_headers = headers_from_options(&raw);
+    assert_eq!(raw_headers.get("x-foo"), Some(&"boom".to_string()));
+    assert_eq!(
+        raw_headers.get("cookie"),
+        Some(&"a=1; b=2; c=3".to_string())
+    );
+    assert_eq!(raw_headers.get("Host"), Some(&"example.com".to_string()));
+    assert!(!raw_headers
+        .keys()
+        .any(|name| name.eq_ignore_ascii_case("authorization")));
+}

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -349,6 +349,8 @@ libmimalloc-sys = { version = "0.1", features = ["extended"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_Foundation",
     # `GetAdaptersAddresses` backs `os.networkInterfaces()` on Windows.
@@ -356,6 +358,8 @@ windows-sys = { version = "0.61", features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_System_LibraryLoader",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
     # `Win32_System_Threading` powers the Windows arm of `process.kill`
     # (`OpenProcess` / `TerminateProcess` / `GetExitCodeProcess`, mirroring
     # libuv's `uv_kill`) in `src/os/signal.rs`.

--- a/crates/perry-runtime/src/child_process/fork.rs
+++ b/crates/perry-runtime/src/child_process/fork.rs
@@ -4,17 +4,17 @@
 //! has no embedded interpreter to "fork into", so — like Node, whose `fork`
 //! launches `process.execPath` (the `node` binary) on the module — we launch a
 //! configurable interpreter (`options.execPath`, else `$PERRY_FORK_EXECPATH`,
-//! else `node`) on `modulePath`. The IPC channel is a `socketpair(2)`: the
-//! parent keeps one end; the child inherits the other as fd 3 with
-//! `NODE_CHANNEL_FD=3` (Node's convention), so a Node child's
+//! else `node`) on `modulePath`. The IPC channel is a Unix `socketpair(2)` or
+//! Windows named pipe: the parent keeps one end; the child inherits the other
+//! as fd 3 with `NODE_CHANNEL_FD=3` (Node's convention), so a Node child's
 //! `process.send` / `process.on('message')` interoperate out of the box.
 //!
 //! The returned ChildProcess reuses the #1934 reactor for its lifecycle
 //! (`spawn`/`data`/`end`/`exit`/`close`, live `kill`) and adds
 //! `send` / `disconnect` / `connected` / `channel` plus `'message'` delivery.
 //! Messages are newline-delimited JSON (Node's default `'json'` IPC
-//! serialization). The IPC wiring is Unix-only; on other platforms `fork`
-//! launches the child but reports `connected: false`.
+//! serialization). Windows additionally wraps payloads in libuv's IPC pipe
+//! frame so Node and compiled Perry children share the same byte stream.
 
 use super::*;
 use std::process::Command;
@@ -190,6 +190,11 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     };
     cp_apply_argv0(&mut command, opts_val);
     cp_apply_options(&mut command, opts_val);
+    command.env("NODE_CHANNEL_FD", ipc_fd.to_string());
+    command.env(
+        "NODE_CHANNEL_SERIALIZATION_MODE",
+        if advanced { "advanced" } else { "json" },
+    );
     if let Some(exec_argv) = native_exec_argv {
         command.env("PERRY_PROCESS_EXEC_ARGV", exec_argv);
     }
@@ -216,6 +221,7 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
             abort_signal,
             opts_val,
             ipc_fd,
+            &stdio_kinds,
         ),
         Err(error) => Err(error),
     };
@@ -241,9 +247,8 @@ pub extern "C" fn js_child_process_fork(module_ptr: i64, args_ptr: i64, opts_ptr
     cp
 }
 
-/// Wire up the IPC socketpair, launch the child, and register it with the
-/// reactor. Returns whether the child spawned. Unix-only IPC; elsewhere the
-/// child is launched without a channel.
+/// Wire up the platform IPC transport, launch the child, and register it with
+/// the reactor.
 #[cfg(unix)]
 fn fork_launch(
     cp: f64,
@@ -258,6 +263,7 @@ fn fork_launch(
     abort_signal: Option<f64>,
     opts_val: f64,
     ipc_fd: usize,
+    _stdio_kinds: &[CpStdio],
 ) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
     use std::os::unix::net::UnixStream;
@@ -273,12 +279,6 @@ fn fork_launch(
     // NODE_CHANNEL_FD — the convention a Node child reads to enable
     // `process.send` / `process.on('message')`.
     let child_fd = child_sock.as_raw_fd();
-    command.env("NODE_CHANNEL_FD", ipc_fd.to_string());
-    // #2130: tell a node child to use V8 structured-clone framing on the channel.
-    command.env(
-        "NODE_CHANNEL_SERIALIZATION_MODE",
-        if advanced { "advanced" } else { "json" },
-    );
     unsafe {
         command.pre_exec(move || {
             if libc::dup2(child_fd, ipc_fd as i32) < 0 {
@@ -320,7 +320,56 @@ fn fork_launch(
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+#[allow(clippy::too_many_arguments)]
+fn fork_launch(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    extra_pipes: Vec<(usize, f64, std::fs::File)>,
+    command: Command,
+    advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
+    abort_signal: Option<f64>,
+    opts_val: f64,
+    ipc_fd: usize,
+    stdio_kinds: &[CpStdio],
+) -> std::io::Result<()> {
+    let clear_environment = cp_object_ptr(cp_get_field(opts_val, b"env")).is_some();
+    let detached = cp_get_field(opts_val, b"detached").to_bits() == TAG_TRUE_F64.to_bits();
+    match super::windows_fork::spawn(&command, stdio_kinds, ipc_fd, clear_environment, detached) {
+        Ok((child, parent_pipe)) => {
+            cp_set_field(cp, b"connected", TAG_TRUE_F64);
+            let channel = cp_build_object(
+                &[
+                    ("ref", cp_cast0(cp_method_this0)),
+                    ("unref", cp_cast0(cp_method_this0)),
+                ],
+                CP_SHAPE_ID + 0x40,
+            );
+            cp_set_field(cp, b"channel", cp_box_ptr(channel as *const u8));
+            let handle = reactor::cp_register_windows_live_child(
+                cp,
+                stdout_obj,
+                stderr_obj,
+                stdin_obj,
+                extra_pipes,
+                child,
+                parent_pipe,
+                advanced,
+                timeout,
+                kill_signal,
+            );
+            reactor::cp_install_abort_signal(handle, abort_signal, opts_val);
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn fork_launch(
     cp: f64,
     stdout_obj: f64,
@@ -328,14 +377,14 @@ fn fork_launch(
     stdin_obj: f64,
     extra_pipes: Vec<(usize, f64, std::fs::File)>,
     mut command: Command,
-    advanced: bool,
+    _advanced: bool,
     timeout: Option<Duration>,
     kill_signal: i32,
     abort_signal: Option<f64>,
     opts_val: f64,
     _ipc_fd: usize,
+    _stdio_kinds: &[CpStdio],
 ) -> std::io::Result<()> {
-    let _ = advanced;
     match command.spawn() {
         Ok(child) => {
             let handle = reactor::cp_register_live_child(

--- a/crates/perry-runtime/src/child_process/ipc_transport.rs
+++ b/crates/perry-runtime/src/child_process/ipc_transport.rs
@@ -1,0 +1,304 @@
+//! Blocking Windows named-pipe stream used by fork IPC.
+//!
+//! The child end is opened with `FILE_FLAG_OVERLAPPED`, as required by Node's
+//! libuv IPC bootstrap. Perry drives that same handle with one OVERLAPPED
+//! operation per blocking read/write so the transport also works when the
+//! forked executable is another compiled Perry program.
+
+use std::io::{self, Read, Write};
+use std::sync::{
+    atomic::{AtomicIsize, Ordering},
+    Arc, Mutex,
+};
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_PENDING, ERROR_OPERATION_ABORTED,
+    ERROR_PIPE_NOT_CONNECTED, HANDLE, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows_sys::Win32::System::Pipes::DisconnectNamedPipe;
+use windows_sys::Win32::System::Threading::CreateEventW;
+use windows_sys::Win32::System::IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED};
+
+struct Inner {
+    handle: AtomicIsize,
+    overlapped: bool,
+    server: bool,
+    write_lock: Mutex<()>,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let handle = self.handle.swap(0, Ordering::AcqRel);
+        if handle != 0 {
+            unsafe {
+                CloseHandle(handle as HANDLE);
+            }
+        }
+    }
+}
+
+/// Cloneable full-duplex byte stream. Clones deliberately share one OS handle:
+/// closing the IPC channel must wake the reader clone as well as stop writes.
+pub(crate) struct IpcStream {
+    inner: Arc<Inner>,
+    read_remaining: u32,
+}
+
+impl Clone for IpcStream {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            read_remaining: 0,
+        }
+    }
+}
+
+impl IpcStream {
+    /// Take ownership of a valid named-pipe handle.
+    ///
+    /// # Safety
+    /// `handle` must be uniquely owned by the caller and must not be closed
+    /// after this call.
+    pub(crate) unsafe fn from_raw_handle(handle: HANDLE, overlapped: bool, server: bool) -> Self {
+        debug_assert!(!handle.is_null() && handle != INVALID_HANDLE_VALUE);
+        Self {
+            inner: Arc::new(Inner {
+                handle: AtomicIsize::new(handle as isize),
+                overlapped,
+                server,
+                write_lock: Mutex::new(()),
+            }),
+            read_remaining: 0,
+        }
+    }
+
+    pub(crate) fn try_clone(&self) -> io::Result<Self> {
+        Ok(self.clone())
+    }
+
+    pub(crate) fn shutdown(&self) -> io::Result<()> {
+        let handle = self.inner.handle.swap(0, Ordering::AcqRel);
+        if handle == 0 {
+            return Ok(());
+        }
+        unsafe {
+            // Cancel every outstanding overlapped read/write before closing.
+            // The server disconnect also wakes synchronous parent-side reads.
+            let _ = CancelIoEx(handle as HANDLE, std::ptr::null());
+            if self.inner.server {
+                let _ = DisconnectNamedPipe(handle as HANDLE);
+            }
+            if CloseHandle(handle as HANDLE) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
+    fn handle(&self) -> io::Result<HANDLE> {
+        let handle = self.inner.handle.load(Ordering::Acquire);
+        if handle == 0 {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "IPC channel closed",
+            ))
+        } else {
+            Ok(handle as HANDLE)
+        }
+    }
+
+    fn raw_io(&self, buf: *mut u8, len: usize, write: bool) -> io::Result<usize> {
+        let handle = self.handle()?;
+        let len = len.min(u32::MAX as usize) as u32;
+        if !self.inner.overlapped {
+            let mut transferred = 0u32;
+            let ok = unsafe {
+                if write {
+                    WriteFile(
+                        handle,
+                        buf.cast_const(),
+                        len,
+                        &mut transferred,
+                        std::ptr::null_mut(),
+                    )
+                } else {
+                    ReadFile(handle, buf, len, &mut transferred, std::ptr::null_mut())
+                }
+            };
+            if ok != 0 {
+                return Ok(transferred as usize);
+            }
+            return pipe_result_error();
+        }
+
+        let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
+        if event.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let mut overlapped = OVERLAPPED {
+            hEvent: event,
+            ..Default::default()
+        };
+        let mut transferred = 0u32;
+        let ok = unsafe {
+            if write {
+                WriteFile(
+                    handle,
+                    buf.cast_const(),
+                    len,
+                    &mut transferred,
+                    &mut overlapped,
+                )
+            } else {
+                ReadFile(handle, buf, len, &mut transferred, &mut overlapped)
+            }
+        };
+        let result = if ok != 0 {
+            Ok(transferred as usize)
+        } else {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(ERROR_IO_PENDING as i32) {
+                let completed =
+                    unsafe { GetOverlappedResult(handle, &overlapped, &mut transferred, 1) };
+                if completed != 0 {
+                    Ok(transferred as usize)
+                } else {
+                    pipe_result_error()
+                }
+            } else {
+                pipe_error(error)
+            }
+        };
+        unsafe {
+            CloseHandle(event);
+        }
+        result
+    }
+
+    fn raw_read_exact(&self, mut buf: &mut [u8]) -> io::Result<()> {
+        while !buf.is_empty() {
+            match self.raw_io(buf.as_mut_ptr(), buf.len(), false)? {
+                0 => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+                n => buf = &mut buf[n..],
+            }
+        }
+        Ok(())
+    }
+
+    fn raw_write_all(&self, mut buf: &[u8]) -> io::Result<()> {
+        while !buf.is_empty() {
+            match self.raw_io(buf.as_ptr().cast_mut(), buf.len(), true)? {
+                0 => return Err(io::Error::from(io::ErrorKind::WriteZero)),
+                n => buf = &buf[n..],
+            }
+        }
+        Ok(())
+    }
+
+    /// Strip libuv's Windows IPC frame and expose only its data payload.
+    fn begin_read_frame(&mut self) -> io::Result<()> {
+        const HAS_DATA: u32 = 0x01;
+        const HAS_SOCKET_XFER: u32 = 0x02;
+        const XFER_IS_TCP_CONNECTION: u32 = 0x04;
+        const VALID_FLAGS: u32 = HAS_DATA | HAS_SOCKET_XFER | XFER_IS_TCP_CONNECTION;
+        const SOCKET_XFER_SIZE: usize = 632;
+
+        loop {
+            let mut header = [0u8; 16];
+            self.raw_read_exact(&mut header)?;
+            let flags = u32::from_le_bytes(header[0..4].try_into().unwrap());
+            let data_length = u32::from_le_bytes(header[8..12].try_into().unwrap());
+            let reserved2 = u32::from_le_bytes(header[12..16].try_into().unwrap());
+            let xfer_flags = flags & (HAS_SOCKET_XFER | XFER_IS_TCP_CONNECTION);
+            let valid_xfer = xfer_flags == 0
+                || xfer_flags == HAS_SOCKET_XFER
+                || xfer_flags == (HAS_SOCKET_XFER | XFER_IS_TCP_CONNECTION);
+            if flags & !VALID_FLAGS != 0
+                || reserved2 != 0
+                || !valid_xfer
+                || (flags & HAS_DATA == 0 && data_length != 0)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid libuv IPC frame",
+                ));
+            }
+            if flags & HAS_SOCKET_XFER != 0 {
+                // Perry does not yet expose transferred TCP handles on Windows,
+                // but consuming the libuv metadata preserves any accompanying
+                // user message and keeps the byte stream synchronized.
+                let mut xfer = [0u8; SOCKET_XFER_SIZE];
+                self.raw_read_exact(&mut xfer)?;
+            }
+            self.read_remaining = data_length;
+            if self.read_remaining != 0 {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn pipe_result_error() -> io::Result<usize> {
+    pipe_error(io::Error::last_os_error())
+}
+
+fn pipe_error(error: io::Error) -> io::Result<usize> {
+    match error.raw_os_error().map(|code| code as u32) {
+        Some(
+            ERROR_BROKEN_PIPE
+            | ERROR_HANDLE_EOF
+            | ERROR_OPERATION_ABORTED
+            | ERROR_PIPE_NOT_CONNECTED,
+        ) => Ok(0),
+        _ => Err(error),
+    }
+}
+
+impl Read for IpcStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.read_remaining == 0 {
+            if let Err(error) = self.begin_read_frame() {
+                return if error.kind() == io::ErrorKind::UnexpectedEof {
+                    Ok(0)
+                } else {
+                    Err(error)
+                };
+            }
+        }
+        let len = buf.len().min(self.read_remaining as usize);
+        let read = self.raw_io(buf.as_mut_ptr(), len, false)?;
+        self.read_remaining -= read as u32;
+        Ok(read)
+    }
+}
+
+impl Write for IpcStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let len: u32 = buf
+            .len()
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "IPC frame too large"))?;
+        let _guard = self
+            .inner
+            .write_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut header = [0u8; 16];
+        header[0..4].copy_from_slice(&1u32.to_le_bytes());
+        header[8..12].copy_from_slice(&len.to_le_bytes());
+        self.raw_write_all(&header)?;
+        self.raw_write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -6,6 +6,10 @@ pub mod reactor;
 // #1933: `fork()` + IPC channel (parent `send`/`'message'`/`disconnect`, child
 // `process.send`/`process.on('message')`).
 pub mod fork;
+#[cfg(windows)]
+pub(crate) mod ipc_transport;
+#[cfg(windows)]
+mod windows_fork;
 // #2130: V8 structured-clone codec for `serialization: 'advanced'` IPC.
 mod v8_serde;
 // #2555: sync buffered `input`, `timeout`, and `maxBuffer` execution options.

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -25,10 +25,10 @@
 //! GC mutable-root scanner.
 
 use std::collections::HashMap;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::io::BufRead;
 use std::io::{Read, Write};
-use std::process::{Child, ChildStdin};
+use std::process::Child;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, PoisonError};
 use std::time::Duration;
@@ -40,8 +40,14 @@ use super::*;
 
 #[cfg(unix)]
 type IpcStream = std::os::unix::net::UnixStream;
-#[cfg(not(unix))]
+#[cfg(windows)]
+type IpcStream = super::ipc_transport::IpcStream;
+#[cfg(not(any(unix, windows)))]
 type IpcStream = ();
+
+type CpReader = Box<dyn Read + Send>;
+type CpWriter = Box<dyn Write + Send>;
+type CpWaiter = Box<dyn FnOnce() -> (Option<i32>, Option<i32>) + Send>;
 
 /// Monotonic registry key for live children.
 static CP_NEXT_LIVE_ID: AtomicU64 = AtomicU64::new(1);
@@ -94,7 +100,7 @@ struct LiveChild {
     /// NaN-boxed ChildProcess object — a GC root (see `cp_reactor_scan_roots_mut`).
     cp_bits: u64,
     pid: i32,
-    stdin: Option<ChildStdin>,
+    stdin: Option<CpWriter>,
     stdout_open: bool,
     stderr_open: bool,
     /// Hold stdout EOF until stderr EOF when both pipes exist. Node drains
@@ -248,21 +254,9 @@ fn cp_spawn_reader<R: Read + Send + 'static>(handle: u64, mut pipe: R, fd: usize
 }
 
 /// Spawn the waiter thread that reaps `child` and reports its exit status.
-fn cp_spawn_waiter(handle: u64, mut child: Child) {
+fn cp_spawn_waiter(handle: u64, waiter: CpWaiter) {
     std::thread::spawn(move || {
-        let (code, signal) = match child.wait() {
-            Ok(status) => {
-                #[cfg(unix)]
-                let signal = {
-                    use std::os::unix::process::ExitStatusExt;
-                    status.signal()
-                };
-                #[cfg(not(unix))]
-                let signal: Option<i32> = None;
-                (status.code(), signal)
-            }
-            Err(_) => (Some(-1), None),
-        };
+        let (code, signal) = waiter();
         cp_push_event(CpEvent::Exited {
             handle,
             code,
@@ -283,7 +277,7 @@ fn cp_spawn_timeout(handle: u64, timeout: Duration, signal: i32) {
 /// `serialization: 'advanced'` (#2130) the framing is instead a 4-byte
 /// big-endian length prefix followed by that many V8-serialized payload bytes
 /// (Node's `parseChannelMessages` shape).
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn cp_spawn_ipc_reader(handle: u64, sock: IpcStream, advanced: bool) {
     if advanced {
         cp_spawn_ipc_reader_advanced(handle, sock);
@@ -307,7 +301,7 @@ fn cp_spawn_ipc_reader(handle: u64, sock: IpcStream, advanced: bool) {
 /// [`CpEvent::MessageAdvanced`] per `[u32 BE length][payload]` frame. Robust to
 /// a length field or payload split across socket reads (the
 /// `advanced-serialization-splitted-length-field` case).
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn cp_spawn_ipc_reader_advanced(handle: u64, mut sock: IpcStream) {
     std::thread::spawn(move || {
         let mut acc: Vec<u8> = Vec::with_capacity(8192);
@@ -362,15 +356,124 @@ pub(super) fn cp_register_live_child(
     kill_signal: i32,
 ) -> u64 {
     let pid = child.id();
-    cp_set_field(cp, b"pid", pid as f64);
     // Duplicate the process handle BEFORE `child` moves to the waiter thread —
     // the kill paths act on it instead of the recyclable pid.
     #[cfg(windows)]
     let win_proc_handle = cp_win_dup_proc_handle(&child);
 
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-    let stdin_pipe = child.stdin.take();
+    let stdout_pipe = child.stdout.take().map(|pipe| Box::new(pipe) as CpReader);
+    let stderr_pipe = child.stderr.take().map(|pipe| Box::new(pipe) as CpReader);
+    let stdin_pipe = child.stdin.take().map(|pipe| Box::new(pipe) as CpWriter);
+    let waiter: CpWaiter = Box::new(move || match child.wait() {
+        Ok(status) => {
+            #[cfg(unix)]
+            let signal = {
+                use std::os::unix::process::ExitStatusExt;
+                status.signal()
+            };
+            #[cfg(not(unix))]
+            let signal: Option<i32> = None;
+            (status.code(), signal)
+        }
+        Err(_) => (Some(-1), None),
+    });
+    cp_register_live_child_parts(
+        cp,
+        stdout_obj,
+        stderr_obj,
+        stdin_obj,
+        extra_pipes,
+        pid,
+        stdin_pipe,
+        stdout_pipe,
+        stderr_pipe,
+        waiter,
+        ipc,
+        ipc_advanced,
+        timeout,
+        kill_signal,
+        #[cfg(windows)]
+        win_proc_handle,
+    )
+}
+
+#[cfg(windows)]
+pub(super) fn cp_register_windows_live_child(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    extra_pipes: Vec<(usize, f64, std::fs::File)>,
+    child: super::windows_fork::WindowsForkChild,
+    ipc: IpcStream,
+    ipc_advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
+) -> u64 {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, WaitForSingleObject, INFINITE,
+    };
+
+    let super::windows_fork::WindowsForkChild {
+        process,
+        pid,
+        stdin,
+        stdout,
+        stderr,
+    } = child;
+    let win_proc_handle = cp_win_dup_raw_proc_handle(process.as_raw_handle());
+    let waiter: CpWaiter = Box::new(move || {
+        let raw = process.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+        if unsafe { WaitForSingleObject(raw, INFINITE) } == u32::MAX {
+            return (Some(-1), None);
+        }
+        let mut code = 0u32;
+        if unsafe { GetExitCodeProcess(raw, &mut code) } == 0 {
+            (Some(-1), None)
+        } else {
+            (Some(code as i32), None)
+        }
+    });
+
+    cp_register_live_child_parts(
+        cp,
+        stdout_obj,
+        stderr_obj,
+        stdin_obj,
+        extra_pipes,
+        pid,
+        stdin.map(|pipe| Box::new(pipe) as CpWriter),
+        stdout.map(|pipe| Box::new(pipe) as CpReader),
+        stderr.map(|pipe| Box::new(pipe) as CpReader),
+        waiter,
+        Some(ipc),
+        ipc_advanced,
+        timeout,
+        kill_signal,
+        win_proc_handle,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cp_register_live_child_parts(
+    cp: f64,
+    stdout_obj: f64,
+    stderr_obj: f64,
+    stdin_obj: f64,
+    extra_pipes: Vec<(usize, f64, std::fs::File)>,
+    pid: u32,
+    stdin_pipe: Option<CpWriter>,
+    stdout_pipe: Option<CpReader>,
+    stderr_pipe: Option<CpReader>,
+    waiter: CpWaiter,
+    ipc: Option<IpcStream>,
+    ipc_advanced: bool,
+    timeout: Option<Duration>,
+    kill_signal: i32,
+    #[cfg(windows)] win_proc_handle: isize,
+) -> u64 {
+    cp_set_field(cp, b"pid", pid as f64);
     let stdout_open = stdout_pipe.is_some();
     let stderr_open = stderr_pipe.is_some();
 
@@ -386,9 +489,9 @@ pub(super) fn cp_register_live_child(
 
     // For fork, keep a clone of the IPC socket for send/disconnect; the reader
     // thread owns the original.
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     let ipc_send = ipc.as_ref().and_then(|s| s.try_clone().ok());
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let ipc_send = {
         let _ = &ipc;
         None
@@ -435,11 +538,11 @@ pub(super) fn cp_register_live_child(
     for (fd, _, pipe) in extra_pipes {
         cp_spawn_reader(handle, pipe, fd);
     }
-    cp_spawn_waiter(handle, child);
+    cp_spawn_waiter(handle, waiter);
     if let Some(timeout) = timeout {
         cp_spawn_timeout(handle, timeout, kill_signal);
     }
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         if let Some(sock) = ipc {
             cp_spawn_ipc_reader(handle, sock, ipc_advanced);
@@ -543,13 +646,13 @@ fn cp_cleanup_abort_listener(signal_bits: u64, listener_bits: u64) {
 /// it newline-delimited to the IPC socket. Returns whether the write
 /// succeeded. #1933.
 pub(super) fn cp_ipc_send(handle: u64, message: f64) -> bool {
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (handle, message);
         return false;
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         // Determine the channel's framing without holding the lock across the
         // (potentially GC-triggering) serialization below.
@@ -599,12 +702,12 @@ pub(super) fn cp_ipc_send(handle: u64, message: f64) -> bool {
 /// appended). Used by the cluster primary's `queryServerReply` (#4962); shares
 /// the live-child lock so it never interleaves with `cp_ipc_send`.
 pub fn cp_ipc_send_raw_json(handle: u64, json: &str) -> bool {
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (handle, json);
         return false;
     }
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         use std::io::Write;
         // Match the channel's selected framing. Cluster's query-server reply
@@ -667,19 +770,22 @@ pub fn cp_ipc_send_fd(handle: u64, key_id: u32, payload_fd: std::os::unix::io::R
 /// `child.disconnect()` — shut the IPC socket down (the reader thread then sees
 /// EOF and exits). Returns whether a channel was present. #1933.
 pub(super) fn cp_ipc_disconnect(handle: u64) -> bool {
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = handle;
         return false;
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         let mut guard = cp_live_lock();
         if let Some(map) = guard.as_mut() {
             if let Some(lc) = map.get_mut(&handle) {
                 if let Some(sock) = lc.ipc_send.take() {
+                    #[cfg(unix)]
                     let _ = sock.shutdown(std::net::Shutdown::Both);
+                    #[cfg(windows)]
+                    let _ = sock.shutdown();
                     return true;
                 }
             }
@@ -1024,7 +1130,20 @@ pub(super) fn cp_exec_async(
             if let Some(e) = stderr_pipe {
                 cp_spawn_reader(handle, e, 2);
             }
-            cp_spawn_waiter(handle, child);
+            let waiter: CpWaiter = Box::new(move || match child.wait() {
+                Ok(status) => {
+                    #[cfg(unix)]
+                    let signal = {
+                        use std::os::unix::process::ExitStatusExt;
+                        status.signal()
+                    };
+                    #[cfg(not(unix))]
+                    let signal: Option<i32> = None;
+                    (status.code(), signal)
+                }
+                Err(_) => (Some(-1), None),
+            });
+            cp_spawn_waiter(handle, waiter);
             if let Some(timeout) = timeout {
                 cp_spawn_timeout(handle, timeout, kill_signal);
             }
@@ -1493,13 +1612,18 @@ pub(super) fn cp_live_stdin_close(handle: u64) {
 #[cfg(windows)]
 fn cp_win_dup_proc_handle(child: &Child) -> isize {
     use std::os::windows::io::AsRawHandle;
+    cp_win_dup_raw_proc_handle(child.as_raw_handle())
+}
+
+#[cfg(windows)]
+fn cp_win_dup_raw_proc_handle(raw: std::os::windows::io::RawHandle) -> isize {
     use windows_sys::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
     use windows_sys::Win32::System::Threading::GetCurrentProcess;
     let mut dup: HANDLE = std::ptr::null_mut();
     let ok = unsafe {
         DuplicateHandle(
             GetCurrentProcess(),
-            child.as_raw_handle() as HANDLE,
+            raw as HANDLE,
             GetCurrentProcess(),
             &mut dup,
             0,

--- a/crates/perry-runtime/src/child_process/windows_fork.rs
+++ b/crates/perry-runtime/src/child_process/windows_fork.rs
@@ -1,0 +1,548 @@
+//! Windows process creation for `child_process.fork()`.
+//!
+//! Rust's `std::process::Command` only populates the three Win32 standard
+//! handles. Node/libuv additionally passes fd 3 (or the selected IPC slot) in
+//! the Microsoft CRT descriptor table at `STARTUPINFO.lpReserved2`. This module
+//! mirrors that ABI so `NODE_CHANNEL_FD` resolves in both Node and Perry child
+//! processes.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io;
+use std::mem::{size_of, zeroed};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, DuplicateHandle, GetLastError, SetHandleInformation, DUPLICATE_SAME_ACCESS,
+    ERROR_IO_PENDING, ERROR_PIPE_CONNECTED, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, GetFileType, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    FILE_TYPE_CHAR, FILE_TYPE_PIPE, OPEN_EXISTING, PIPE_ACCESS_DUPLEX,
+};
+use windows_sys::Win32::System::Console::{
+    GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
+use windows_sys::Win32::System::Pipes::{
+    ConnectNamedPipe, CreateNamedPipeW, CreatePipe, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+};
+use windows_sys::Win32::System::Threading::{
+    CreateEventW, CreateProcessW, DeleteProcThreadAttributeList, GetCurrentProcess,
+    InitializeProcThreadAttributeList, UpdateProcThreadAttribute, CREATE_NEW_PROCESS_GROUP,
+    CREATE_UNICODE_ENVIRONMENT, DETACHED_PROCESS, EXTENDED_STARTUPINFO_PRESENT,
+    LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW,
+};
+use windows_sys::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
+
+use super::ipc_transport::IpcStream;
+use super::CpStdio;
+
+const FOPEN: u8 = 0x01;
+const FPIPE: u8 = 0x08;
+const FDEV: u8 = 0x40;
+
+static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(super) struct WindowsForkChild {
+    pub(super) process: OwnedHandle,
+    pub(super) pid: u32,
+    pub(super) stdin: Option<File>,
+    pub(super) stdout: Option<File>,
+    pub(super) stderr: Option<File>,
+}
+
+pub(super) fn spawn(
+    command: &Command,
+    stdio: &[CpStdio],
+    ipc_fd: usize,
+    clear_environment: bool,
+    detached: bool,
+) -> io::Result<(WindowsForkChild, IpcStream)> {
+    let count = stdio.len().max(ipc_fd + 1).max(3);
+    if count > u8::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Windows child stdio supports at most 255 descriptors",
+        ));
+    }
+
+    let mut child_handles: Vec<Option<OwnedHandle>> =
+        std::iter::repeat_with(|| None).take(count).collect();
+    let mut parent_stdin = None;
+    let mut parent_stdout = None;
+    let mut parent_stderr = None;
+
+    for (fd, slot) in child_handles.iter_mut().enumerate().take(3) {
+        if fd == ipc_fd {
+            continue;
+        }
+        let kind = stdio.get(fd).copied().unwrap_or(CpStdio::Pipe);
+        let (child, parent) = child_stdio(fd, kind)?;
+        *slot = Some(child);
+        match fd {
+            0 => parent_stdin = parent,
+            1 => parent_stdout = parent,
+            2 => parent_stderr = parent,
+            _ => unreachable!(),
+        }
+    }
+
+    let (parent_ipc, child_ipc) = create_ipc_pair()?;
+    child_handles[ipc_fd] = Some(child_ipc);
+
+    // Descriptors above stderr are otherwise ignored today. Keep their CRT
+    // slots invalid, matching libuv's UV_IGNORE representation.
+    let mut crt = crt_descriptor_table(&child_handles);
+    let inherited: Vec<HANDLE> = child_handles
+        .iter()
+        .filter_map(|handle| handle.as_ref().map(|h| h.as_raw_handle() as HANDLE))
+        .collect();
+    let mut attributes = AttributeList::with_handles(&inherited)?;
+
+    let mut startup: STARTUPINFOEXW = unsafe { zeroed() };
+    startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+    startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup.StartupInfo.cbReserved2 = crt.len().try_into().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "CRT descriptor table is too large",
+        )
+    })?;
+    startup.StartupInfo.lpReserved2 = crt.as_mut_ptr();
+    startup.StartupInfo.hStdInput = raw_handle(&child_handles[0]);
+    startup.StartupInfo.hStdOutput = raw_handle(&child_handles[1]);
+    startup.StartupInfo.hStdError = raw_handle(&child_handles[2]);
+    startup.lpAttributeList = attributes.as_mut_ptr();
+
+    let mut command_line = command_line(command)?;
+    let environment = environment_block(command, clear_environment)?;
+    let cwd = command
+        .get_current_dir()
+        .map(|path| wide_nul(path.as_os_str()))
+        .transpose()?;
+    let cwd_ptr = cwd
+        .as_ref()
+        .map_or(std::ptr::null(), |value| value.as_ptr());
+    let mut creation_flags = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
+    if detached {
+        creation_flags |= DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
+    }
+    let mut info: PROCESS_INFORMATION = unsafe { zeroed() };
+    let created = unsafe {
+        CreateProcessW(
+            std::ptr::null(),
+            command_line.as_mut_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            1,
+            creation_flags,
+            environment.as_ptr().cast(),
+            cwd_ptr,
+            &startup.StartupInfo,
+            &mut info,
+        )
+    };
+    if created == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    unsafe {
+        CloseHandle(info.hThread);
+    }
+    let process = unsafe { OwnedHandle::from_raw_handle(info.hProcess as RawHandle) };
+    Ok((
+        WindowsForkChild {
+            process,
+            pid: info.dwProcessId,
+            stdin: parent_stdin,
+            stdout: parent_stdout,
+            stderr: parent_stderr,
+        },
+        parent_ipc,
+    ))
+}
+
+fn child_stdio(fd: usize, kind: CpStdio) -> io::Result<(OwnedHandle, Option<File>)> {
+    match kind {
+        CpStdio::Pipe => create_stdio_pipe(fd == 0),
+        CpStdio::Inherit => duplicate_std_handle(fd)
+            .or_else(|_| open_nul(fd == 0))
+            .map(|handle| (handle, None)),
+        CpStdio::Fd(source) => duplicate_fd(source)
+            .or_else(|_| open_nul(fd == 0))
+            .map(|handle| (handle, None)),
+        CpStdio::Ignore => open_nul(fd == 0).map(|handle| (handle, None)),
+    }
+}
+
+fn inheritable_attributes() -> SECURITY_ATTRIBUTES {
+    SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: std::ptr::null_mut(),
+        bInheritHandle: 1,
+    }
+}
+
+fn create_stdio_pipe(child_reads: bool) -> io::Result<(OwnedHandle, Option<File>)> {
+    let attributes = inheritable_attributes();
+    let mut read = INVALID_HANDLE_VALUE;
+    let mut write = INVALID_HANDLE_VALUE;
+    if unsafe { CreatePipe(&mut read, &mut write, &attributes, 0) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let (child, parent) = if child_reads {
+        (read, write)
+    } else {
+        (write, read)
+    };
+    if unsafe { SetHandleInformation(parent, HANDLE_FLAG_INHERIT, 0) } == 0 {
+        unsafe {
+            CloseHandle(read);
+            CloseHandle(write);
+        }
+        return Err(io::Error::last_os_error());
+    }
+    let child = unsafe { OwnedHandle::from_raw_handle(child as RawHandle) };
+    let parent = unsafe { File::from_raw_handle(parent as RawHandle) };
+    Ok((child, Some(parent)))
+}
+
+fn duplicate_std_handle(fd: usize) -> io::Result<OwnedHandle> {
+    let which = match fd {
+        0 => STD_INPUT_HANDLE,
+        1 => STD_OUTPUT_HANDLE,
+        _ => STD_ERROR_HANDLE,
+    };
+    let handle = unsafe { GetStdHandle(which) };
+    duplicate_handle(handle)
+}
+
+fn duplicate_fd(fd: i32) -> io::Result<OwnedHandle> {
+    let handle = unsafe { libc::get_osfhandle(fd) } as HANDLE;
+    duplicate_handle(handle)
+}
+
+fn duplicate_handle(handle: HANDLE) -> io::Result<OwnedHandle> {
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE || handle as isize == -2 {
+        return Err(io::Error::from_raw_os_error(6));
+    }
+    let mut duplicate = INVALID_HANDLE_VALUE;
+    let process = unsafe { GetCurrentProcess() };
+    let ok = unsafe {
+        DuplicateHandle(
+            process,
+            handle,
+            process,
+            &mut duplicate,
+            0,
+            1,
+            DUPLICATE_SAME_ACCESS,
+        )
+    };
+    if ok == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(duplicate as RawHandle) })
+    }
+}
+
+fn open_nul(readable: bool) -> io::Result<OwnedHandle> {
+    let name = wide_nul(OsStr::new("NUL"))?;
+    let attributes = inheritable_attributes();
+    let access = if readable {
+        GENERIC_READ
+    } else {
+        GENERIC_WRITE
+    };
+    let handle = unsafe {
+        CreateFileW(
+            name.as_ptr(),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            &attributes,
+            OPEN_EXISTING,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(handle as RawHandle) })
+    }
+}
+
+fn create_ipc_pair() -> io::Result<(IpcStream, OwnedHandle)> {
+    let id = NEXT_PIPE_ID.fetch_add(1, Ordering::Relaxed);
+    let name = format!(r"\\.\pipe\perry-ipc-{}-{id}", std::process::id());
+    let wide_name = wide_nul(OsStr::new(&name))?;
+    let server = unsafe {
+        CreateNamedPipeW(
+            wide_name.as_ptr(),
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            1,
+            65_536,
+            65_536,
+            0,
+            std::ptr::null(),
+        )
+    };
+    if server == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let attributes = inheritable_attributes();
+    let client = unsafe {
+        CreateFileW(
+            wide_name.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            0,
+            &attributes,
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED,
+            std::ptr::null_mut(),
+        )
+    };
+    if client == INVALID_HANDLE_VALUE {
+        unsafe {
+            CloseHandle(server);
+        }
+        return Err(io::Error::last_os_error());
+    }
+    let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
+    if event.is_null() {
+        unsafe {
+            CloseHandle(server);
+            CloseHandle(client);
+        }
+        return Err(io::Error::last_os_error());
+    }
+    let mut overlapped = OVERLAPPED {
+        hEvent: event,
+        ..Default::default()
+    };
+    let connected = unsafe { ConnectNamedPipe(server, &mut overlapped) };
+    let connect_error = if connected != 0 {
+        None
+    } else {
+        match unsafe { GetLastError() } {
+            ERROR_PIPE_CONNECTED => None,
+            ERROR_IO_PENDING => {
+                let mut transferred = 0u32;
+                if unsafe { GetOverlappedResult(server, &overlapped, &mut transferred, 1) } != 0 {
+                    None
+                } else {
+                    Some(io::Error::last_os_error())
+                }
+            }
+            _ => Some(io::Error::last_os_error()),
+        }
+    };
+    unsafe {
+        CloseHandle(event);
+    }
+    if let Some(error) = connect_error {
+        unsafe {
+            CloseHandle(server);
+            CloseHandle(client);
+        }
+        return Err(error);
+    }
+
+    let parent = unsafe { IpcStream::from_raw_handle(server, true, true) };
+    let child = unsafe { OwnedHandle::from_raw_handle(client as RawHandle) };
+    Ok((parent, child))
+}
+
+fn raw_handle(handle: &Option<OwnedHandle>) -> HANDLE {
+    handle
+        .as_ref()
+        .map_or(INVALID_HANDLE_VALUE, |h| h.as_raw_handle() as HANDLE)
+}
+
+fn crt_descriptor_table(handles: &[Option<OwnedHandle>]) -> Vec<u8> {
+    let handle_size = size_of::<HANDLE>();
+    let mut table = vec![0xff; size_of::<u32>() + handles.len() + handle_size * handles.len()];
+    table[..size_of::<u32>()].copy_from_slice(&(handles.len() as u32).to_ne_bytes());
+    let handle_base = size_of::<u32>() + handles.len();
+    for (fd, handle) in handles.iter().enumerate() {
+        let Some(handle) = handle else {
+            table[size_of::<u32>() + fd] = 0;
+            continue;
+        };
+        let raw = handle.as_raw_handle() as isize;
+        table[size_of::<u32>() + fd] = crt_flags(raw as HANDLE);
+        let start = handle_base + fd * handle_size;
+        table[start..start + handle_size].copy_from_slice(&raw.to_ne_bytes());
+    }
+    table
+}
+
+fn crt_flags(handle: HANDLE) -> u8 {
+    match unsafe { GetFileType(handle) } {
+        FILE_TYPE_PIPE => FOPEN | FPIPE,
+        FILE_TYPE_CHAR => FOPEN | FDEV,
+        _ => FOPEN,
+    }
+}
+
+struct AttributeList {
+    storage: Vec<usize>,
+    initialized: bool,
+}
+
+impl AttributeList {
+    fn with_handles(handles: &[HANDLE]) -> io::Result<Self> {
+        let mut bytes = 0usize;
+        unsafe {
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), 1, 0, &mut bytes);
+        }
+        if bytes == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let words = bytes.div_ceil(size_of::<usize>());
+        let mut list = Self {
+            storage: vec![0usize; words],
+            initialized: false,
+        };
+        if unsafe { InitializeProcThreadAttributeList(list.as_mut_ptr(), 1, 0, &mut bytes) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        list.initialized = true;
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list.as_mut_ptr(),
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+                handles.as_ptr().cast(),
+                std::mem::size_of_val(handles),
+                std::ptr::null_mut(),
+                std::ptr::null(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(list)
+    }
+
+    fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.storage.as_mut_ptr().cast()
+    }
+}
+
+impl Drop for AttributeList {
+    fn drop(&mut self) {
+        if self.initialized {
+            unsafe {
+                DeleteProcThreadAttributeList(self.as_mut_ptr());
+            }
+        }
+    }
+}
+
+fn command_line(command: &Command) -> io::Result<Vec<u16>> {
+    let mut out = Vec::new();
+    append_quoted(&mut out, command.get_program())?;
+    for arg in command.get_args() {
+        out.push(b' ' as u16);
+        append_quoted(&mut out, arg)?;
+    }
+    out.push(0);
+    Ok(out)
+}
+
+fn append_quoted(out: &mut Vec<u16>, value: &OsStr) -> io::Result<()> {
+    let encoded: Vec<u16> = value.encode_wide().collect();
+    if encoded.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "argument contains NUL",
+        ));
+    }
+    let quote = encoded.is_empty()
+        || encoded
+            .iter()
+            .any(|c| *c == b' ' as u16 || *c == b'\t' as u16 || *c == b'"' as u16);
+    if !quote {
+        out.extend_from_slice(&encoded);
+        return Ok(());
+    }
+
+    out.push(b'"' as u16);
+    let mut slashes = 0usize;
+    for c in encoded {
+        if c == b'\\' as u16 {
+            slashes += 1;
+        } else if c == b'"' as u16 {
+            out.extend(std::iter::repeat_n(b'\\' as u16, slashes * 2 + 1));
+            out.push(c);
+            slashes = 0;
+        } else {
+            out.extend(std::iter::repeat_n(b'\\' as u16, slashes));
+            out.push(c);
+            slashes = 0;
+        }
+    }
+    out.extend(std::iter::repeat_n(b'\\' as u16, slashes * 2));
+    out.push(b'"' as u16);
+    Ok(())
+}
+
+fn environment_block(command: &Command, clear: bool) -> io::Result<Vec<u16>> {
+    let mut values: BTreeMap<String, (OsString, OsString)> = BTreeMap::new();
+    if !clear {
+        for (key, value) in std::env::vars_os() {
+            values.insert(key.to_string_lossy().to_uppercase(), (key, value));
+        }
+    }
+    for (key, value) in command.get_envs() {
+        let folded = key.to_string_lossy().to_uppercase();
+        match value {
+            Some(value) => {
+                values.insert(folded, (key.to_os_string(), value.to_os_string()));
+            }
+            None => {
+                values.remove(&folded);
+            }
+        }
+    }
+
+    let mut block = Vec::new();
+    for (_, (key, value)) in values {
+        let key: Vec<u16> = key.encode_wide().collect();
+        let value: Vec<u16> = value.encode_wide().collect();
+        if key.contains(&0) || value.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "environment contains NUL",
+            ));
+        }
+        block.extend_from_slice(&key);
+        block.push(b'=' as u16);
+        block.extend_from_slice(&value);
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
+}
+
+fn wide_nul(value: &OsStr) -> io::Result<Vec<u16>> {
+    let mut wide: Vec<u16> = value.encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "value contains NUL",
+        ));
+    }
+    wide.push(0);
+    Ok(wide)
+}

--- a/crates/perry-runtime/src/process/ipc.rs
+++ b/crates/perry-runtime/src/process/ipc.rs
@@ -12,18 +12,23 @@ use crate::closure::{
     js_register_closure_arity, js_register_closure_length, ClosureHeader,
 };
 use crate::string::js_string_from_bytes;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::string::StringHeader;
 use crate::value::{JSValue, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED};
 use std::collections::VecDeque;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::io::{BufRead, Read, Write};
 #[cfg(unix)]
 use std::os::fd::FromRawFd;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
+
+#[cfg(unix)]
+type IpcStream = UnixStream;
+#[cfg(windows)]
+type IpcStream = crate::child_process::ipc_transport::IpcStream;
 
 enum IpcEvent {
     Message(String),
@@ -38,8 +43,8 @@ struct ChildIpcState {
     refed: bool,
     disconnect_emitted: bool,
     advanced: bool,
-    #[cfg(unix)]
-    send: Option<UnixStream>,
+    #[cfg(any(unix, windows))]
+    send: Option<IpcStream>,
     queue: VecDeque<IpcEvent>,
 }
 
@@ -52,7 +57,7 @@ impl ChildIpcState {
             refed: false,
             disconnect_emitted: false,
             advanced: false,
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             send: None,
             queue: VecDeque::new(),
         }
@@ -136,7 +141,10 @@ pub(crate) fn process_ipc_ensure_initialized() {
     #[cfg(unix)]
     initialize_unix_ipc(fd_var, &serialization_mode);
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    initialize_windows_ipc(fd_var, &serialization_mode);
+
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (fd_var, serialization_mode);
     }
@@ -168,11 +176,67 @@ fn initialize_unix_ipc(fd_var: Option<String>, serialization_mode: &str) {
     state.send = Some(send);
 }
 
-#[cfg(unix)]
-fn spawn_ipc_reader(sock: UnixStream, advanced: bool) {
+#[cfg(windows)]
+fn initialize_windows_ipc(fd_var: Option<String>, serialization_mode: &str) {
+    use windows_sys::Win32::Foundation::{
+        DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let Some(fd) = fd_var
+        .and_then(|s| s.parse::<i32>().ok())
+        .filter(|fd| *fd >= 0)
+    else {
+        return;
+    };
+    let inherited = unsafe { libc::get_osfhandle(fd) } as HANDLE;
+    if inherited.is_null() || inherited == INVALID_HANDLE_VALUE || inherited as isize == -2 {
+        return;
+    }
+    let mut duplicate = INVALID_HANDLE_VALUE;
+    let process = unsafe { GetCurrentProcess() };
+    if unsafe {
+        DuplicateHandle(
+            process,
+            inherited,
+            process,
+            &mut duplicate,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    } == 0
+    {
+        return;
+    }
+    // The CRT owns the inherited descriptor. Close that entry after duplicating
+    // so only the transport's shared handle remains live.
+    unsafe {
+        libc::close(fd);
+    }
+    let stream = unsafe { IpcStream::from_raw_handle(duplicate, true, false) };
+    let send = match stream.try_clone() {
+        Ok(send) => send,
+        Err(_) => return,
+    };
+    let advanced = serialization_mode == "advanced";
+    spawn_ipc_reader(stream, advanced);
+
+    let mut state = ipc_lock();
+    state.available = true;
+    state.connected = true;
+    state.refed = false;
+    state.disconnect_emitted = false;
+    state.advanced = advanced;
+    state.send = Some(send);
+}
+
+#[cfg(any(unix, windows))]
+fn spawn_ipc_reader(sock: IpcStream, advanced: bool) {
     // Cluster workers (#4962) need a recvmsg-based reader to receive SCM_RIGHTS
     // connection fds for SCHED_RR in both serialization modes. Plain forks
     // keep the lighter framing-specific readers.
+    #[cfg(unix)]
     if crate::cluster::is_cluster_worker() {
         std::thread::spawn(move || {
             crate::cluster_sched::worker_recv_loop(
@@ -202,8 +266,8 @@ fn spawn_ipc_reader(sock: UnixStream, advanced: bool) {
     });
 }
 
-#[cfg(unix)]
-fn spawn_ipc_reader_advanced(mut sock: UnixStream) {
+#[cfg(any(unix, windows))]
+fn spawn_ipc_reader_advanced(mut sock: IpcStream) {
     std::thread::spawn(move || {
         let mut acc = Vec::with_capacity(8192);
         let mut chunk = [0u8; 8192];
@@ -371,13 +435,13 @@ fn process_ipc_send_message(message: f64) -> bool {
         return false;
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = message;
         false
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         let advanced = ipc_lock().advanced;
         let frame = if advanced {
@@ -425,12 +489,12 @@ fn process_ipc_send_message(message: f64) -> bool {
 /// never exists as a JS value.
 pub(crate) fn process_ipc_send_raw_json(json: &str) -> bool {
     process_ipc_ensure_initialized();
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = json;
         false
     }
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         let advanced = ipc_lock().advanced;
         let frame = if advanced {
@@ -454,7 +518,7 @@ pub(crate) fn process_ipc_send_raw_json(json: &str) -> bool {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn advanced_frame(message: f64) -> Vec<u8> {
     let payload = crate::child_process::v8_serialize(message);
     let mut frame = Vec::with_capacity(payload.len() + 4);
@@ -463,7 +527,7 @@ fn advanced_frame(message: f64) -> Vec<u8> {
     frame
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn json_frame(message: f64) -> Option<Vec<u8>> {
     let sh = unsafe { crate::json::js_json_stringify(message, 0) };
     if sh.is_null() {
@@ -513,7 +577,7 @@ fn channel_closed_error() -> f64 {
 
 fn process_ipc_disconnect_local() {
     process_ipc_ensure_initialized();
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     let send = {
         let mut state = ipc_lock();
         if !state.available {
@@ -523,9 +587,12 @@ fn process_ipc_disconnect_local() {
         state.refed = false;
         state.send.take()
     };
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     if let Some(sock) = send {
+        #[cfg(unix)]
         let _ = sock.shutdown(std::net::Shutdown::Both);
+        #[cfg(windows)]
+        let _ = sock.shutdown();
     }
 
     if mark_disconnect_emitted() {
@@ -540,7 +607,7 @@ fn mark_closed_from_event() -> bool {
     }
     state.connected = false;
     state.refed = false;
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         state.send = None;
     }

--- a/docs/src/language/native-values.md
+++ b/docs/src/language/native-values.md
@@ -29,6 +29,12 @@ type PacketHeader = pod<{
   gain: f32;
 }>;
 
+const header: PacketHeader = {
+  flags: u32(inputFlags),
+  sequence: u64(inputSequence),
+  gain: f32(inputGain),
+};
+
 const byteLength = sizeof<PacketHeader>();
 const alignment = alignof<PacketHeader>();
 const sequenceOffset = offsetof<PacketHeader>("sequence");
@@ -78,7 +84,10 @@ const ratio = f32(computation);
 ```
 
 The scalar aliases establish representation inside a `pod` layout and at
-supported native ABI boundaries. They do not change the semantics of
+supported native ABI boundaries. A matching checked conversion may initialize
+a POD field from a dynamic value without forcing the whole record back to an
+ordinary object; the conversion guard runs before the value enters the native
+record. They do not change the semantics of
 standalone TypeScript arithmetic. Additional widths (`i8`, `i16`, `u8`,
 `u16`, and `isize`) and guaranteed native lanes across general-purpose
 collections are later parts of the native value profile.

--- a/test-files/issue_8226_base.ts
+++ b/test-files/issue_8226_base.ts
@@ -1,0 +1,27 @@
+type ColumnConfig = {
+  name: string;
+  uniqueName?: string;
+  autoIncrement: boolean;
+};
+
+let constructorCalls = 0;
+
+class Column {
+  config: ColumnConfig;
+
+  constructor(table: string, config: ColumnConfig) {
+    constructorCalls++;
+    if (!config.uniqueName) {
+      config.uniqueName = `${table}_${config.name}_unique`;
+    }
+    this.config = config;
+  }
+}
+
+export class ColumnWithAutoIncrement extends Column {
+  autoIncrement = this.config.autoIncrement;
+}
+
+export function getConstructorCalls(): number {
+  return constructorCalls;
+}

--- a/test-files/test_issue_6619_windows_fork_ipc.ts
+++ b/test-files/test_issue_6619_windows_fork_ipc.ts
@@ -1,0 +1,28 @@
+// #6619 — Windows fork IPC uses a libuv-framed named pipe. Exercise both
+// directions against a real Node child so handle inheritance and framing are
+// covered together.
+import { fork } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const helper = join(tmpdir(), `perry-windows-ipc-${process.pid}.js`);
+writeFileSync(
+  helper,
+  "process.once('message', (message) => process.send({ echo: message.value }, () => process.disconnect()));",
+);
+
+const child = fork(helper);
+child.once("error", (error: any) => {
+  console.log("error", error.code, error.errno, error.syscall);
+  rmSync(helper, { force: true });
+});
+child.once("message", (message: any) => {
+  console.log("message", message.echo);
+});
+child.once("close", (code, signal) => {
+  console.log("close", code, signal);
+  rmSync(helper, { force: true });
+});
+console.log("connected", child.connected);
+console.log("send", child.send({ value: 6619 }));

--- a/test-files/test_issue_8226_imported_default_ctor.ts
+++ b/test-files/test_issue_8226_imported_default_ctor.ts
@@ -1,0 +1,17 @@
+import {
+  ColumnWithAutoIncrement,
+  getConstructorCalls,
+} from "./issue_8226_base.ts";
+
+class IntColumn extends ColumnWithAutoIncrement {}
+
+const config = {
+  name: "id",
+  uniqueName: undefined as string | undefined,
+  autoIncrement: true,
+};
+const column = new IntColumn("users", config);
+
+console.log(config.uniqueName);
+console.log(column.autoIncrement);
+console.log(getConstructorCalls());

--- a/test-parity/node-suite/http/README.md
+++ b/test-parity/node-suite/http/README.md
@@ -38,12 +38,12 @@ Deno and Bun. We did not add a case just because upstream had many files.
 
 ## Coverage
 
-The suite contains 52 fixtures, up from 19:
+The suite contains 53 fixtures, up from 19:
 
 | Area                                 | Fixtures | Contracts                                                                                                                                           |
 | ------------------------------------ | -------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | exports                              |        9 | methods, status codes, helper tail, classes, inheritance, descriptors, WebSocket event constructors, and receiver checks                            |
-| request                              |        9 | URL and options overloads, `get()` auto-end, callback order, method/path/protocol/agent/signal validation, and coercion                             |
+| request                              |       10 | URL and options overloads, raw header arrays, `get()` auto-end, callback order, method/path/protocol/agent/signal validation, and coercion          |
 | `ClientRequest`                      |        4 | constructor state, header operations and validation, `flushHeaders()`, aliases, controls, and clean errors                                          |
 | `IncomingMessage`                    |        4 | constructor defaults, request and response metadata, raw/distinct headers, encoding, body state, and trailers                                       |
 | `ServerResponse` / `OutgoingMessage` |        5 | header mutation, `setHeaders()`, status and informational validation, and lifecycle state                                                           |
@@ -64,7 +64,7 @@ Every fixture maps to a Node 26.5.0 implementation file or upstream test family:
 | `agent/request-create-connection.ts`, `agent/request-create-socket.ts`                                                                                        | `Agent.prototype.addRequest`, `createSocket`, and `createConnection` in `lib/_http_agent.js`               |
 | `client-request/constructor-surface.ts`                                                                                                                       | `ClientRequest` in `lib/_http_client.js` and `OutgoingMessage` in `lib/_http_outgoing.js`                  |
 | `client-request/header-operations.ts`, `client-request/header-validation.ts`, `client-request/flush-headers-state.ts`                                         | `lib/_http_outgoing.js`; `test-http-invalidheaderfield`                                                    |
-| `request/url-options-overload.ts`, `request/url-validation.ts`, `request/get-auto-end.ts`, `request/callback-validation-order.ts`                             | `lib/http.js`, `lib/_http_client.js`; `test-http-request-url`                                              |
+| `request/url-options-overload.ts`, `request/header-array-options.ts`, `request/url-validation.ts`, `request/get-auto-end.ts`, `request/callback-validation-order.ts` | `lib/http.js`, `lib/_http_client.js`; `test-http-request-url`, `test-http-client-headers-array`             |
 | `request/method-validation.ts`, `request/path-validation.ts`, `request/protocol-validation.ts`, `request/agent-validation.ts`, `request/signal-validation.ts` | `ClientRequest` option validation in `lib/_http_client.js`; `test-http-request-invalid-method-error`       |
 | `incoming-message/constructor-defaults.ts`, `incoming-message/response-metadata.ts`                                                                           | `IncomingMessage` in `lib/_http_incoming.js` and response parsing in `lib/_http_client.js`                 |
 | `incoming-message/client-set-encoding.ts`, `incoming-message/server-headers-body.ts`                                                                          | `lib/_http_incoming.js`, `lib/_http_common.js`; `test-http-trailers`                                       |
@@ -91,7 +91,7 @@ The adjacent suites keep ownership of generic behavior:
 
 ## Repeated comparison
 
-All final runtime comparisons ran three times. Each runtime produced the same
+The original 52-fixture audit ran three times. Each runtime produced the same
 classification and output digest on every run:
 
 | Runtime     | Pass | Diff | Error | Compile failure | Crash | Timeout |
@@ -100,6 +100,9 @@ classification and output digest on every run:
 | Perry       |   22 |   29 |     0 |               1 |     0 |       0 |
 | Deno 2.9.3  |   42 |    6 |     4 |             n/a |     0 |       0 |
 | Bun 1.2.18  |   23 |   26 |     3 |             n/a |     0 |       0 |
+
+The raw-header-array fixture added for #4975 was checked separately under Node
+and Perry and produced byte-for-byte identical output.
 
 Deno's four clean errors come from missing Node 26.5.0 export-tail entries. Its
 six output differences cover only server disposal, close errors, parser options,

--- a/test-parity/node-suite/http/request/header-array-options.ts
+++ b/test-parity/node-suite/http/request/header-array-options.ts
@@ -1,0 +1,60 @@
+import { createServer, request } from "node:http";
+
+const seen: string[] = [];
+const server = createServer((req, res) => {
+  const kind = seen.length === 0 ? "object" : "array";
+  seen.push([
+    kind,
+    req.headers["x-foo"],
+    req.headers.cookie,
+    req.headers.authorization ?? "<missing>",
+    kind === "object"
+      ? String(req.headers.host?.startsWith("127.0.0.1:"))
+      : req.headers.host,
+  ].join("|"));
+  res.end("ok");
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+const address = server.address();
+if (!address || typeof address === "string") throw new Error("missing address");
+
+async function send(options: Record<string, unknown>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = request({
+      hostname: "127.0.0.1",
+      port: address.port,
+      path: "/",
+      ...options,
+    }, (res) => {
+      res.once("error", reject);
+      res.on("end", resolve);
+      res.resume();
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+try {
+  await send({
+    auth: "foo:bar",
+    headers: { "x-foo": "boom", cookie: ["a=1", "b=2", "c=3"] },
+  });
+  await send({
+    auth: "foo:bar",
+    headers: [
+      ["x-foo", "boom"],
+      ["cookie", "a=1"],
+      ["cookie", ["b=2", "c=3"]],
+      ["Host", "example.com"],
+    ],
+  });
+} finally {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+console.log(seen.join("\n"));

--- a/tests/fixtures/native_value_profile.ts
+++ b/tests/fixtures/native_value_profile.ts
@@ -13,6 +13,11 @@ const aliasedHeaders = headers;
 const convertedFlags = Word(4_294_967_295);
 const convertedSequence = LongWord(9_007_199_254_740_991);
 const convertedGain = FloatWord(0.1);
+const convertedHeader: Header = {
+  flags: Word(7),
+  sequence: LongWord(42),
+  gain: FloatWord(0.1),
+};
 let rejectedFraction = false;
 let rejectedType = false;
 try {
@@ -47,6 +52,7 @@ console.log(
     ",flags=" + convertedFlags +
     ",sequenceValue=" + convertedSequence +
     ",gainRounded=" + (convertedGain > 0.1) +
+    ",header=" + convertedHeader.flags + ":" + convertedHeader.sequence + ":" + (convertedHeader.gain > 0.1) +
     ",rejectedFraction=" + rejectedFraction +
     ",rejectedType=" + rejectedType,
 );

--- a/tests/test_native_abi_contract.sh
+++ b/tests/test_native_abi_contract.sh
@@ -228,6 +228,23 @@ function throughDynamicBoundary(value: any): any {
   return value;
 }
 
+// Keep the Buffer-read representation proof in a function with no native ABI
+// calls. Whole-function escape analysis must conservatively deopt views in the
+// ABI exercise below; this helper makes the BufferNumericRead assertion test a
+// genuinely non-escaping buffer instead of depending on unrelated call order.
+function readNativeBufferChecksum(): number {
+  const readBuf = Buffer.alloc(8);
+  readBuf[0] = 18;
+  readBuf[1] = 52;
+  readBuf[2] = 86;
+  readBuf[3] = 120;
+  readBuf[4] = 0;
+  readBuf[5] = 0;
+  readBuf[6] = 200;
+  readBuf[7] = 64;
+  return readBuf.readUInt32BE(0) + readBuf.readFloatLE(4);
+}
+
 export function runNativeAbiContract(): number {
   const buf = Buffer.alloc(12);
   buf[0] = 18;
@@ -249,8 +266,7 @@ export function runNativeAbiContract(): number {
   const promise = Promise.resolve(1);
   const packet: AbiPacket = { tag: 7, gain: 1.5, total: 2.25, count: 4 };
   const bufferLen = buf.length;
-  const bufferU32 = buf.readUInt32BE(0);
-  const bufferF32 = buf.readFloatLE(4);
+  const bufferReadChecksum = readNativeBufferChecksum();
 
   if (abi_contract_check_all(u32Value, u64Value, usizeValue, f32Value, bufferLen, buf, handle, promise) !== 777) {
     return 10;
@@ -268,8 +284,7 @@ export function runNativeAbiContract(): number {
   if (nativeBufferLen !== 12) return 70;
   if (!nativePromise) return 75;
   if (bufferLen !== 12) return 80;
-  if (bufferU32 !== 305419896) return 90;
-  if (bufferF32 !== 6.25) return 100;
+  if (bufferReadChecksum !== 305419902.25) return 90;
   return 1;
 }
 EOF

--- a/tests/test_native_value_profile.sh
+++ b/tests/test_native_value_profile.sh
@@ -30,7 +30,7 @@ cp "$SCRIPT_DIR/fixtures/native_value_profile.ts" "$TEST_TMPDIR/main.ts"
 cd "$TEST_TMPDIR"
 "$PERRY" compile main.ts --output native_value_profile --no-cache >/dev/null
 
-EXPECTED="size=24,align=8,sequence=8,length=1,flags=4294967295,sequenceValue=9007199254740991,gainRounded=true,rejectedFraction=true,rejectedType=true"
+EXPECTED="size=24,align=8,sequence=8,length=1,flags=4294967295,sequenceValue=9007199254740991,gainRounded=true,header=7:42:true,rejectedFraction=true,rejectedType=true"
 ACTUAL=$(./native_value_profile)
 if [ "$ACTUAL" != "$EXPECTED" ]; then
   echo "FAIL: perry/native output mismatch"


### PR DESCRIPTION
## Summary
- add a Windows named-pipe IPC transport with libuv-compatible payload framing
- launch fork children with an inherited CRT fd table so `NODE_CHANNEL_FD` works for Node and compiled Perry children
- enable parent/child JSON and advanced IPC reactor paths on Windows, including cluster message routing and clean disconnects
- add a Node-interoperability regression for #6619

## Validation
- `cargo build -p perry`
- `cargo check -p perry-runtime`
- `cargo clippy -p perry-runtime --no-deps` (passes with existing warnings)
- `cargo check -p perry-runtime --target x86_64-unknown-linux-gnu --no-default-features`
- `cargo fmt -p perry-runtime -- --check`
- `python scripts/check_test_registration.py`
- Windows JSON fork IPC: single and multi-message Node round trips
- Windows advanced serialization: Buffer, Uint8Array, large and mixed payload round trips
- Windows compiled Perry parent/child IPC round trip
- Windows `cluster.fork()` bidirectional message round trip

No version bump.

Closes #6619