### PR TITLE
test(ci): run native_proof_buffer_views per PR again after #8302

### DIFF
--- a/changelog.d/8321-restore-buffer-views-coverage.md
+++ b/changelog.d/8321-restore-buffer-views-coverage.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **`native_proof_buffer_views` runs in per-PR CI again.** #8302 restored the six
+  assertions that #8264 recorded as baseline reds, but their
+  `SUITE_EXCLUSIONS` entries in `scripts/ci_e2e_scope.py` stayed behind. A stale
+  exclusion is not a red build — it is silence: the suite keeps being skipped,
+  so the coverage the fix earned back stays dark, which is #7708's failure mode.
+
+  The six entries are removed and the suite is added to the mapped set (an
+  unexcluded suite must be mapped, or `--self-test` refuses it). Verified 45/45
+  passing on `main` at the merge of #8302.
+
+  The other two #8264 entries are still genuinely red and keep their exclusions:
+  `shadow_slot_hygiene::canonical_str_local_keeps_shadow_binding_and_tag_dispatched_ops`
+  and `typed_feedback::typed_feedback_guards_direct_class_field_specialization`
+  (re-checked at the same commit: 12/13 and 16/17).

--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -125,6 +125,7 @@ _CODEGEN_SUITES = [
     "loop_safepoint_purity",
     "macos_bundle_chdir_gate",
     "manifest_consistency",
+    "native_proof_buffer_views",
     # #7506/#7245: held out until its one failing test was triaged. The
     # composition it guards had drifted from three named callees to three
     # PROPERTIES (the guard-failure edge now reaches `$pshape`, which coerces
@@ -170,42 +171,6 @@ SOURCE_SUITE_MAP = {
 # 262 tests, and holding all 262 out for one of them is how 261 tests' worth of
 # coverage went dark.
 SUITE_EXCLUSIONS = [
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "artifact_records_buffer_read_double_as_f64",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "artifact_records_buffer_read_float_as_f32_and_float_extend_materialization",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "artifact_records_buffer_read_u32_and_unsigned_materialization",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "artifact_records_width_aware_buffer_numeric_read_facts",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "explicit_width_guard_proves_wide_buffer_read",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
-    (
-        "perry-codegen",
-        "native_proof_buffer_views",
-        "proven_buffer_and_typed_array_reads_are_numeric_operands",
-        "#8264 — red on main; current artifacts no longer satisfy this proof assertion.",
-    ),
     (
         "perry-codegen",
         "shadow_slot_hygiene",


### PR DESCRIPTION
## Summary

#8302 restored the six `native_proof_buffer_views` assertions that #8264
recorded as baseline reds. Their `SUITE_EXCLUSIONS` entries in
`scripts/ci_e2e_scope.py` stayed behind.

A stale exclusion does not produce a red build — it produces silence. The suite
keeps being skipped, so the coverage #8302 earned back never runs per PR. That
is exactly #7708's failure mode, and it is why #8264 wrote the entries as
self-invalidating in the first place.

## Changes

- Remove the six `native_proof_buffer_views` entries from `SUITE_EXCLUSIONS`.
- Add `native_proof_buffer_views` to the mapped set — `--self-test` refuses a
  suite that is in neither list, which is how I caught that removing the
  exclusions alone was not enough.

## What is still excluded

The other two #8264 entries are genuinely red and keep their exclusions.
Re-checked at the merge commit of #8302:

| suite | result |
|---|---|
| `native_proof_buffer_views` | **45 passed, 0 failed** — un-excluded here |
| `shadow_slot_hygiene` | 12 passed, **1 failed** (`canonical_str_local_…`) — stays excluded |
| `typed_feedback` | 16 passed, **1 failed** (`typed_feedback_guards_direct_class_field_specialization`) — stays excluded |

So #8264 goes from eight red assertions to two.

## Validation

- `python3 scripts/ci_e2e_scope.py --self-test` — exit 0
- `cargo test -p perry-codegen --test native_proof_buffer_views` — 45/45 on this branch
- `scripts/run_lint_gates.sh` — all 48 lint-tier gates pass
