### PR TITLE
fix(gc): drop stale shape entries at recycled keys-array addresses

### DIFF
--- a/changelog.d/8324-stale-shape-recycled-address.md
+++ b/changelog.d/8324-stale-shape-recycled-address.md
@@ -1,0 +1,1 @@
+Fixed garbage-collector shape metadata so a dead keys-array address reused by a different object type cannot be retained or rekeyed onto the replacement object during a copying minor.

--- a/crates/perry-runtime/src/gc/tests/shape_keys_descriptor_edge.rs
+++ b/crates/perry-runtime/src/gc/tests/shape_keys_descriptor_edge.rs
@@ -24,7 +24,7 @@
 //! alive by something else entirely".
 
 use super::super::*;
-use super::support::{collect_minor_trace, ptr_bits, CopyingNurseryTestGuard};
+use super::support::{collect_minor_trace, init_test_closure, ptr_bits, CopyingNurseryTestGuard};
 use crate::object::shapes;
 
 /// Facts the assertions compare, read exclusively through the descriptor.
@@ -268,4 +268,173 @@ fn a_keys_array_whose_last_carrier_died_is_still_reclaimed() {
          be reclaimed by the dead-key prune; it survived, which is what \
          unconditional table rooting would look like"
     );
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RecycledKeysReport {
+    replacement_before: usize,
+    replacement_after: usize,
+    copied_objects: usize,
+    old_index_exists: bool,
+    new_index_exists: bool,
+    descriptor_keys: Option<u64>,
+}
+
+/// Reproduce the two-cycle stale-key shape: a dead keys-array address is
+/// reused by a closure, then that closure moves on the next copying minor.
+/// Seeding after exact reuse isolates the cleanup under test from the earlier
+/// collection's ordinary dead-owner prune.
+fn collect_recycled_keys_report(suppress_type_check: bool) -> RecycledKeysReport {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    shapes::test_clear_shape_table();
+    gc_register_mutable_root_scanner(shapes::scan_shape_table_rekey_mut);
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let dead_keys = crate::arena::arena_alloc_gc(
+        std::mem::size_of::<crate::array::ArrayHeader>(),
+        std::mem::align_of::<crate::array::ArrayHeader>(),
+        GC_TYPE_ARRAY,
+    ) as *mut crate::array::ArrayHeader;
+    unsafe {
+        (*dead_keys).length = 0;
+        (*dead_keys).capacity = 0;
+    }
+    let recycled_addr = dead_keys as usize;
+
+    // No roots: the array dies and the copied-minor Eden reset makes its first
+    // allocation address available again.
+    let _ = collect_minor_trace(GcTriggerKind::Direct);
+
+    let replacement = crate::arena::arena_alloc_gc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        std::mem::align_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe { init_test_closure(replacement) };
+    let replacement_before = replacement as usize;
+    assert_eq!(
+        replacement_before, recycled_addr,
+        "test premise: Eden must reuse the dead keys array's exact address"
+    );
+    js_shadow_slot_set(0, ptr_bits(replacement_before));
+
+    // This is the stale table state observed in the original workload: the
+    // keys address now names a live object of another type.
+    shapes::test_seed_shape_entry(recycled_addr);
+    let shape_id = shapes::test_shape_id_for_keys(recycled_addr)
+        .expect("the stale shape entry must include a descriptor");
+
+    let trace = {
+        let _sabotage = suppress_type_check.then(shapes::TestRecycledKeysCheckSuppression::new);
+        collect_minor_trace(GcTriggerKind::Direct)
+    };
+    let replacement_after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    let report = RecycledKeysReport {
+        replacement_before,
+        replacement_after,
+        copied_objects: trace.copying_nursery.copied_objects,
+        old_index_exists: shapes::test_shape_entry_exists(recycled_addr),
+        new_index_exists: shapes::test_shape_entry_exists(replacement_after),
+        descriptor_keys: shapes::shape_descriptor_by_id(shape_id).map(|descriptor| descriptor.keys),
+    };
+
+    shapes::test_clear_shape_table();
+    js_shadow_slot_set(0, crate::value::TAG_UNDEFINED);
+    report
+}
+
+#[test]
+fn recycled_non_array_shape_keys_are_dropped_after_a_copying_minor() {
+    let report = collect_recycled_keys_report(false);
+    assert!(
+        report.copied_objects > 0,
+        "the fixture requires a copying minor; copied_objects was zero"
+    );
+    assert_ne!(
+        report.replacement_after, report.replacement_before,
+        "the replacement tenant must move for metadata rewrite to be exercised"
+    );
+    assert!(
+        !report.old_index_exists && !report.new_index_exists,
+        "a stale shape index must be neither retained at {:#x} nor rekeyed onto \
+         the replacement closure at {:#x}",
+        report.replacement_before,
+        report.replacement_after
+    );
+    assert_eq!(
+        report.descriptor_keys, None,
+        "a descriptor whose keys address was recycled by a closure must be removed"
+    );
+}
+
+#[test]
+fn recycled_non_array_shape_keys_sabotage_is_detected() {
+    let report = collect_recycled_keys_report(true);
+    assert!(
+        report.copied_objects > 0,
+        "the sabotage fixture requires a copying minor; copied_objects was zero"
+    );
+    assert_ne!(
+        report.replacement_after, report.replacement_before,
+        "the replacement tenant must move for the sabotage to discriminate"
+    );
+
+    // Suppressing the new type check re-creates the bug: metadata follows the
+    // closure's forwarding record and transfers both shape records onto it.
+    assert!(
+        report.new_index_exists && report.descriptor_keys == Some(report.replacement_after as u64),
+        "SABOTAGE ARM: suppressing recycled-address validation did not preserve \
+         and rekey the stale shape records, so the green fix arm proves nothing \
+         (report: {report:?})"
+    );
+}
+
+#[test]
+fn dead_owner_prune_rejects_a_non_forwarded_non_array_tenant() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    shapes::test_clear_shape_table();
+
+    let closure = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_CLOSURE) as usize;
+    let header = unsafe { header_from_user_ptr(closure as *const u8) };
+    assert_eq!(
+        unsafe { (*header).gc_flags } & GC_FLAG_FORWARDED,
+        0,
+        "test premise: the replacement tenant must not be forwarded"
+    );
+    shapes::test_seed_shape_entry(closure);
+
+    // The replacement is live according to the ordinary predicate. Its type,
+    // not a forwarding flag, must still prove that it is not the keys array.
+    shapes::prune_dead_shape_keys(&|_| false);
+
+    assert!(!shapes::test_shape_entry_exists(closure));
+    assert!(shapes::test_shape_id_for_keys(closure).is_none());
+    shapes::test_clear_shape_table();
+}
+
+#[test]
+fn metadata_rewrite_validates_the_post_visit_non_array_address() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    shapes::test_clear_shape_table();
+
+    let from = crate::arena::arena_alloc_gc(64, 8, GC_TYPE_CLOSURE) as usize;
+    let valid_ptrs = build_valid_pointer_set();
+    let to = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_CLOSURE) as usize;
+    let from_header = unsafe { header_from_user_ptr(from as *const u8) as *mut GcHeader };
+    unsafe { set_forwarding_address(from_header, to as *mut u8) };
+    shapes::test_seed_shape_entry(from);
+
+    shapes::scan_shape_table_rekey_mut(&mut RuntimeRootVisitor::for_rewrite(&valid_ptrs));
+
+    unsafe { (*from_header).gc_flags &= !GC_FLAG_FORWARDED };
+    assert!(
+        !shapes::test_shape_entry_exists(from) && !shapes::test_shape_entry_exists(to),
+        "the index must be dropped instead of following a closure's forwarding record"
+    );
+    assert!(
+        shapes::test_shape_id_for_keys(from).is_none()
+            && shapes::test_shape_id_for_keys(to).is_none(),
+        "the descriptor must validate the rewritten address before publishing it"
+    );
+    shapes::test_clear_shape_table();
 }

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -1213,6 +1213,25 @@ pub(crate) fn shape_drop(keys: *const ArrayHeader) {
     inner.indices.remove(&keys);
 }
 
+/// True when a shape's keys address is currently occupied by another GC type.
+/// A tracked non-array allocation proves that the original keys array died and
+/// its address was recycled; unreadable/off-arena addresses remain governed by
+/// the collector's ordinary dead-owner predicate.
+#[inline]
+fn shape_keys_address_is_recycled(addr: usize) -> bool {
+    #[cfg(test)]
+    if RECYCLED_KEYS_CHECK_SUPPRESSED.with(std::cell::Cell::get) {
+        return false;
+    }
+
+    unsafe {
+        crate::value::addr_class::try_read_tracked_gc_header(addr).is_some_and(|header| {
+            let obj_type = (*header.as_ptr()).obj_type;
+            obj_type != crate::gc::GC_TYPE_ARRAY && obj_type != crate::gc::GC_TYPE_LAZY_ARRAY
+        })
+    }
+}
+
 /// Post-trace weak-table prune: drop slot indices and by-id descriptors whose
 /// keys array is dead. A live object has already traced its authoritative
 /// header edge and synchronized the descriptor named by its ShapeId, so a
@@ -1220,13 +1239,29 @@ pub(crate) fn shape_drop(keys: *const ArrayHeader) {
 /// closed on a missing lookup, independently of pruning.
 pub(crate) fn prune_dead_shape_keys(is_dead_owner: &dyn Fn(usize) -> bool) {
     let mut inner = crate::state::state().shapes.inner.borrow_mut();
+    // A shape keys entry is keyed by the address of its keys array — a
+    // `GC_TYPE_ARRAY` (or `GC_TYPE_LAZY_ARRAY`). When the keys array dies
+    // and the arena recycles its address for a different object type
+    // (closure, string, …), the `is_dead_owner` predicate sees the NEW
+    // object's flags (MARKED/FORWARDED) and reports the address as alive,
+    // leaving a stale entry that makes property lookups on objects whose
+    // descriptor still points at the old address read the wrong shape.
+    // Guard the retain with a type check: if the object at the key address
+    // is not an array/lazy-array, the keys array is dead regardless of what
+    // `is_dead_owner` says about the recycled tenant.
     if !inner.indices.is_empty() {
-        inner.indices.retain(|keys_id, _| !is_dead_owner(*keys_id));
+        inner.indices.retain(|keys_id, _| {
+            !is_dead_owner(*keys_id) && !shape_keys_address_is_recycled(*keys_id)
+        });
     }
     let stale: Vec<u32> = inner
         .descriptors
         .iter()
-        .filter_map(|(&id, descriptor)| is_dead_owner(descriptor.keys as usize).then_some(id))
+        .filter_map(|(&id, descriptor)| {
+            let keys = descriptor.keys as usize;
+            (is_dead_owner(descriptor.keys as usize) || shape_keys_address_is_recycled(keys))
+                .then_some(id)
+        })
         .collect();
     if !stale.is_empty() {
         for id in stale {
@@ -1247,7 +1282,8 @@ pub(crate) fn prune_dead_shape_keys(is_dead_owner: &dyn Fn(usize) -> bool) {
 pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     let mut inner = crate::state::state().shapes.inner.borrow_mut();
     let mut descriptor_moved = false;
-    for descriptor in inner.descriptors.values_mut() {
+    let mut dead_descriptor_ids: Vec<u32> = Vec::new();
+    for (id, descriptor) in inner.descriptors.iter_mut() {
         let mut addr = descriptor.keys as usize;
         // #8112 ephemeron gate. A shape with an OLD carrier is rooted here:
         // the minor that has to keep its keys array alive never enumerates the
@@ -1261,10 +1297,22 @@ pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVis
         } else {
             visitor.visit_metadata_usize_slot(&mut addr)
         };
-        if moved {
+        // Validate the POST-visit address. A stale shape key can follow the
+        // forwarding record of the non-array tenant that recycled its address;
+        // checking only an unmoved old address misses that case.
+        if visitor.is_metadata_rewrite_phase() && shape_keys_address_is_recycled(addr) {
+            dead_descriptor_ids.push(*id);
+        } else if moved {
             descriptor.keys = addr as u64;
             descriptor_moved = true;
         }
+    }
+    // Remove descriptors whose keys array was recycled.
+    if !dead_descriptor_ids.is_empty() {
+        for id in &dead_descriptor_ids {
+            inner.descriptors.remove(id);
+        }
+        descriptor_moved = true;
     }
     // Rebuild throughout rewrite phase even when this pass itself observed no
     // move: an immediate live-object header callback may already have rekeyed
@@ -1290,6 +1338,26 @@ pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVis
             inner.indices.insert(new, shape);
         }
     }
+    // Drop indices entries whose keys-array address was recycled: the
+    // forwarding record at the old address points to a DIFFERENT object
+    // (not a keys array), so `visit_metadata_usize_slot` either rekeyed
+    // it to the wrong address (caught above by the type mismatch on the
+    // new address) or returned false because the forwarding walk could
+    // not classify the address. Either way the keys array is dead; remove
+    // the stale entry so property lookups don't resolve the wrong shape.
+    let recycled: Vec<usize> = inner
+        .indices
+        .keys()
+        .filter(|&&keys_id| shape_keys_address_is_recycled(keys_id))
+        .copied()
+        .collect();
+    let recycled_count = recycled.len();
+    for old in recycled {
+        inner.indices.remove(&old);
+    }
+    if recycled_count > 0 {
+        rebuild_descriptor_reverse_indices(&mut inner);
+    }
 }
 
 // #8112 sabotage switch. Suppressing the descriptor edge proves the fixture's
@@ -1302,6 +1370,7 @@ pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVis
 #[cfg(test)]
 thread_local! {
     static KEYS_EDGE_SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static RECYCLED_KEYS_CHECK_SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 #[cfg(test)]
@@ -1331,6 +1400,30 @@ impl TestKeysEdgeSuppression {
 impl Drop for TestKeysEdgeSuppression {
     fn drop(&mut self) {
         KEYS_EDGE_SUPPRESSED.with(|c| c.set(self.edge));
+    }
+}
+
+/// Test-only sabotage of the recycled-address type check. Keeping this scoped
+/// and unshipped lets the regression fixture prove its detector would fail if
+/// both prune and metadata rewrite trusted the replacement tenant.
+#[cfg(test)]
+pub(crate) struct TestRecycledKeysCheckSuppression {
+    previous: bool,
+}
+
+#[cfg(test)]
+impl TestRecycledKeysCheckSuppression {
+    pub(crate) fn new() -> Self {
+        Self {
+            previous: RECYCLED_KEYS_CHECK_SUPPRESSED.with(|cell| cell.replace(true)),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestRecycledKeysCheckSuppression {
+    fn drop(&mut self) {
+        RECYCLED_KEYS_CHECK_SUPPRESSED.with(|cell| cell.set(self.previous));
     }
 }
 


### PR DESCRIPTION
## Summary

Prevent weak shape indices and descriptors from surviving when a dead keys-array address has been recycled by a different GC object type. This is scoped shape-table hardening found during the seeded-GC investigation; the observed `node-machine-id` / `Function("return this")()` TypeError had a separate unrooted-global cause fixed by #8333.

## Changes

- Validate tracked shape-key objects during dead-owner pruning and reject non-array/lazy-array tenants even when the replacement object is live.
- Validate descriptor keys after metadata visitation, and drop descriptors or indices rather than rekeying them through a replacement object's forwarding record.
- Remove the unused temporary `diagnose_shape_rekey_gap` diagnostic.
- Add exact Eden-address reuse coverage with a real copying minor, nonzero-copy and movement gates, a sabotage arm, and focused tests for both review findings.
- Add `changelog.d/8324-stale-shape-recycled-address.md`.

## Related issue

n/a — follow-up hardening discovered while diagnosing the failure resolved by #8333.

## Test plan

- `cargo test -p perry-runtime shape_keys_descriptor_edge -- --nocapture` (8 passed)
- `cargo test -p perry-runtime shapes -- --nocapture` (24 passed)
- `cargo test -p perry-runtime test_shape_ -- --nocapture` (4 passed)
- `cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `python3 scripts/shape_descriptor_census.py`
- `python3 scripts/addr_class_inventory.py`
- `python3 scripts/gc_rekeyed_key_tables.py`
- `./scripts/check_file_size.sh`
- `BASE_SHA=origin/main SKIP_COMPILE_GATES=1 ./scripts/run_lint_gates.sh` (47 passing; the one initial census failure was fixed and its gate rerun successfully)

- [ ] `cargo build --release` clean
- [ ] Full affected-workspace test scope passes locally
- [x] Added a `#[test]` regression in the affected runtime crate
- [x] Runtime API docs unchanged; no user-facing API update needed
- [x] No platform UI backend touched

## Screenshots / output

n/a

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository's `fix:` prefix convention
- [x] I've read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime handling of moved objects to prevent stale shape and metadata references.
  - Removed invalid entries when memory addresses are recycled for different object types.
  - Rebuilt internal indexes after object forwarding to keep shape information consistent.
  - Improved garbage collection reliability when memory is reused across different object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->