### PR TITLE
fix(runtime): drop the duplicated `use super::*` in release_tests

### DIFF
--- a/crates/perry-runtime/src/box/release_tests.rs
+++ b/crates/perry-runtime/src/box/release_tests.rs
@@ -3,8 +3,6 @@
 
 use super::*;
 
-use super::*;
-
 fn install_test_activation(activation: *mut AsyncBoxActivation) -> crate::promise::InlineTrap {
     crate::promise::INLINE_TRAP.with(|trap| {
         trap.replace(crate::promise::InlineTrap {


### PR DESCRIPTION
`warnings` is **red on main** and fails the sweep tier's `main-gate`:

```
warning: unused import: `super::*`
 --> crates/perry-runtime/src/box/release_tests.rs:6:5
```

The file opens with `use super::*;` **twice**, four lines apart. #8303 split these tests out of `box.rs` to stay under the 2000-line cap, and the import came along in both halves of the move. The job runs with `RUSTFLAGS: -D warnings`, so a redundant import is a build failure.

## Validation

Verified with the job's own condition — `RUSTFLAGS="-D warnings" cargo test -p perry-runtime --lib --no-run` builds clean, where before it emitted the unused-import warning. `cargo fmt --all --check` clean.

Found while triaging the sweep run on `99e19c228`, which is red on `warnings`, `cargo-test`, `gc-stress` and `compiler-output-regression`. The other three are separate and tracked apart from this.