### PR TITLE
runtime: add zero-copy bun:ffi memory views (#6562)

### DIFF
--- a/changelog.d/8329-bun-ffi-memory-views.md
+++ b/changelog.d/8329-bun-ffi-memory-views.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Zero-copy native memory views for `bun:ffi` (#6562).**
+  `toArrayBuffer` and `toBuffer` now wrap caller-owned native memory without
+  copying it, including byte offsets and NUL-terminated spans when the length
+  is omitted. The GC owns only a non-moving wrapper and removes its external
+  backing-store entry when collected; it never frees the native allocation.
+  Optimized `Uint8Array` construction now resolves the actual backing pointer,
+  preserving bidirectional native/JavaScript aliasing.

--- a/crates/perry-api-manifest/src/entries/part_1.rs
+++ b/crates/perry-api-manifest/src/entries/part_1.rs
@@ -203,25 +203,23 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
     method("better-sqlite3", "pluck", true, None),
     method("better-sqlite3", "columns", true, None),
     method("better-sqlite3", "transaction", true, None),
-    // bun:ffi (#6562) — stage-1 surface. `FFIType` and `suffix` are
+    // bun:ffi (#6562) — stage-1/2 surface. `FFIType` and `suffix` are
     // constants; symbol-table call stubs live on the object `dlopen`
-    // returns, so the module surface itself is small. The stage-2/3
-    // exports (toArrayBuffer / JSCallback / linkSymbols / CFunction /
-    // viewSource / read / toBuffer) are declared and throw a descriptive
+    // returns, so the module surface itself is small. The later-stage
+    // exports (JSCallback / linkSymbols / CFunction / viewSource / read) are
+    // declared and throw a descriptive
     // ERR_NOT_IMPLEMENTED at runtime.
     method("bun:ffi", "dlopen", false, None),
     method("bun:ffi", "ptr", false, None),
     method("bun:ffi", "CString", false, None),
     property("bun:ffi", "FFIType"),
     property("bun:ffi", "suffix"),
-    // Stage ≥2 surface: declared so feature-probes get a clear error rather
+    method("bun:ffi", "toArrayBuffer", false, None),
+    method("bun:ffi", "toBuffer", false, None),
+    // Stage ≥3 surface: declared so feature-probes get a clear error rather
     // than `undefined is not a function`, but NOT implemented yet — each
     // throws at runtime. Marked `.stub_note` so the generated `.d.ts` /
     // `reference.md` say so instead of reading as usable APIs (#6562).
-    method("bun:ffi", "toArrayBuffer", false, None)
-        .stub_note("stage 2 — not yet implemented, throws at runtime (#6562)"),
-    method("bun:ffi", "toBuffer", false, None)
-        .stub_note("stage 2 — not yet implemented, throws at runtime (#6562)"),
     method("bun:ffi", "JSCallback", false, None)
         .stub_note("stage 3 — not yet implemented, throws at runtime (#6562)"),
     method("bun:ffi", "CFunction", false, None)

--- a/crates/perry-api-manifest/tests/stub_inventory.rs
+++ b/crates/perry-api-manifest/tests/stub_inventory.rs
@@ -93,11 +93,11 @@ fn stub_inventory_matches_known_clusters() {
         // event-loop refcount), mongodb.findOne (parsed document),
         // exponential-backoff options (honored, incl. retry predicate).
         ("#4917", 9),
-        // #6562 (bun:ffi stage 1) — the stage-≥2 FFI surface is declared so
+        // #6562 (bun:ffi stages 1-2) — the later FFI surface is declared so
         // feature probes get a clear error, but throws at runtime until the
-        // later stages land: toArrayBuffer, toBuffer, JSCallback, CFunction,
-        // linkSymbols, viewSource, read.
-        ("#6562", 7),
+        // later stages land: JSCallback, CFunction, linkSymbols, viewSource,
+        // read.
+        ("#6562", 5),
     ];
     let expected_map: BTreeMap<String, usize> =
         expected.iter().map(|(k, v)| (k.to_string(), *v)).collect();
@@ -124,7 +124,7 @@ fn stubs_only_appear_in_allowlisted_modules() {
         "exponential-backoff",
         "inspector",
         "repl",
-        // #6562: bun:ffi stage-≥2 exports are declared-but-throwing stubs.
+        // #6562: bun:ffi later-stage exports are declared-but-throwing stubs.
         "bun:ffi",
     ];
     for e in iter_entries().filter(|e| e.stub) {

--- a/crates/perry-codegen/src/stmt/let_buffer_views.rs
+++ b/crates/perry-codegen/src/stmt/let_buffer_views.rs
@@ -19,6 +19,9 @@ pub(super) struct BufferViewInit {
     native_owner_local_id: Option<u32>,
     native_byte_offset: Option<i64>,
     native_byte_length: Option<i64>,
+    /// Resolve element zero through the runtime's buffer-view registry instead
+    /// of assuming bytes start inline at `header + data_offset_bytes`.
+    resolve_buffer_backing: bool,
     /// See `BufferViewSlot::storage_inline_proven` — true only when the
     /// construction form proves fresh inline (non-view) storage.
     storage_inline_proven: bool,
@@ -45,6 +48,17 @@ pub(super) fn register_noalias_buffer_view(
             &[(I32, &init.data_offset_bytes.to_string())],
         );
         blk.load(PTR, &data_field)
+    } else if init.resolve_buffer_backing {
+        // `new Uint8Array(arrayBuffer)` has a local snapshot after its header,
+        // but reads and writes belong to the ArrayBuffer's real backing. This
+        // also covers bun:ffi external ArrayBuffers, whose bytes are not inline
+        // in the wrapper at all (#6562). Resolve once at construction and cache
+        // the stable backing pointer in the normal view slot.
+        blk.call(
+            PTR,
+            "js_native_buffer_data_ptr",
+            &[(crate::types::DOUBLE, value)],
+        )
     } else {
         blk.gep(
             I8,
@@ -129,6 +143,7 @@ fn buffer_view_init_for_expr(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> Option<
             native_owner_local_id: None,
             native_byte_offset: None,
             native_byte_length: None,
+            resolve_buffer_backing: false,
             // copyBytesFrom always allocates a fresh inline buffer.
             storage_inline_proven: true,
         }),
@@ -143,6 +158,7 @@ fn buffer_view_init_for_expr(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> Option<
                 native_owner_local_id: None,
                 native_byte_offset: None,
                 native_byte_length: None,
+                resolve_buffer_backing: false,
                 // Buffer.alloc/allocUnsafe always allocate fresh inline bytes.
                 storage_inline_proven: true,
             })
@@ -157,6 +173,7 @@ fn buffer_view_init_for_expr(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> Option<
             native_owner_local_id: None,
             native_byte_offset: None,
             native_byte_length: None,
+            resolve_buffer_backing: true,
             // `new Uint8Array(buffer)` is the VIEW form — only a literal
             // length (or no argument) proves inline storage.
             storage_inline_proven: ctor_arg_is_literal_length(arg.as_deref()),
@@ -173,6 +190,7 @@ fn buffer_view_init_for_expr(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> Option<
                 native_owner_local_id: None,
                 native_byte_offset: None,
                 native_byte_length: None,
+                resolve_buffer_backing: false,
                 // Same view-form hazard as Uint8ArrayNew: only a literal
                 // length proves the non-view construction here (the pre-pass
                 // proves the plain-array-source form separately for params).
@@ -204,6 +222,7 @@ fn buffer_view_init_for_expr(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> Option<
                 native_owner_local_id: Some(owner_local_id),
                 native_byte_offset: byte_offset_const,
                 native_byte_length,
+                resolve_buffer_backing: false,
                 // Arena views have their own owner/dispose lifecycle — never
                 // eligible for the proven checked tier.
                 storage_inline_proven: false,

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -78,6 +78,12 @@ pub type CryptoKeyMeta = (u8, u8, u8, bool, u32, u32);
 
 crate::perry_thread_local! {
     static BUFFER_REGISTRY: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
+    /// `BufferHeader` wrappers whose bytes live in memory owned by native
+    /// code. The wrapper itself is an ordinary, non-moving GC object; only
+    /// its data pointer is external. `bun:ffi.toArrayBuffer`/`toBuffer` use
+    /// this to expose native memory without copying it or taking ownership.
+    static FOREIGN_BACKING_REGISTRY: RefCell<PtrHashMap<usize, usize>> =
+        RefCell::new(new_ptr_hash_map());
     /// Buffers that were specifically created via `new Uint8Array(...)` —
     /// formatted as `Uint8Array(N) [ a, b, c ]` instead of `<Buffer aa bb cc>`.
     static UINT8ARRAY_FROM_CTOR: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
@@ -156,6 +162,10 @@ use crate::registry_latch::RegistryLatch;
 /// load rather than one per registry — hence [`note_buffer_like_registered`],
 /// which `shared_sab::alloc_shared_sab` calls before publishing a backing.
 static BUFFER_LIKE_EVER_REGISTERED: RegistryLatch = RegistryLatch::new();
+/// Avoid a thread-local map probe in `buffer_data{,_mut}` until the first
+/// foreign-backed buffer is created. The latch is deliberately monotone;
+/// these accessors are among the hottest paths in the runtime.
+static FOREIGN_BACKING_EVER_REGISTERED: RegistryLatch = RegistryLatch::new();
 
 /// Arm the `is_registered_buffer` latch from outside this module.
 ///
@@ -605,6 +615,43 @@ pub fn buffer_alloc(capacity: u32) -> *mut BufferHeader {
     ptr
 }
 
+/// Allocate a Buffer-shaped GC wrapper over native-owned memory.
+///
+/// Only the `BufferHeader` is allocated in Perry's old arena. The byte span
+/// remains owned by the native caller and is never freed by the GC. Callers
+/// must keep that span alive for at least as long as the returned JS value.
+/// The external mapping is removed when the wrapper is collected, preventing
+/// recycled GC addresses from inheriting stale backing pointers.
+pub(crate) fn buffer_alloc_foreign(data: *mut u8, length: u32) -> *mut BufferHeader {
+    let ptr = crate::arena::arena_alloc_gc_old(
+        std::mem::size_of::<BufferHeader>(),
+        8,
+        crate::gc::GC_TYPE_BUFFER,
+    ) as *mut BufferHeader;
+    unsafe {
+        let header = (ptr as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+        (*header).gc_flags |= crate::gc::GC_FLAG_TENURED;
+        (*ptr).length = length;
+        (*ptr).capacity = length;
+    }
+    register_buffer(ptr);
+    // Arm before publishing the map entry; see `RegistryLatch`'s ordering
+    // contract and the analogous buffer-registration path above.
+    FOREIGN_BACKING_EVER_REGISTERED.arm();
+    FOREIGN_BACKING_REGISTRY.with(|r| {
+        r.borrow_mut().insert(ptr as usize, data as usize);
+    });
+    ptr
+}
+
+#[inline]
+fn foreign_backing(addr: usize) -> Option<usize> {
+    if FOREIGN_BACKING_EVER_REGISTERED.is_idle() {
+        return None;
+    }
+    FOREIGN_BACKING_REGISTRY.with(|r| r.borrow().get(&addr).copied())
+}
+
 /// Post-trace registry pruning (mirrors the #6010 Map/Set pattern): collect
 /// registered buffers whose header is genuinely dead so the sweep subphase
 /// can drop their side-table state. All buffers are TENURED old-arena
@@ -674,6 +721,9 @@ unsafe fn registered_buffer_is_dead_post_trace(
 /// the #6080 ABA class) and the entries leak forever.
 pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
     BUFFER_REGISTRY.with(|r| {
+        r.borrow_mut().remove(&addr);
+    });
+    FOREIGN_BACKING_REGISTRY.with(|r| {
         r.borrow_mut().remove(&addr);
     });
     ARRAY_BUFFER_REGISTRY.with(|r| {
@@ -776,10 +826,14 @@ pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
 
 /// Get the data pointer for a buffer
 pub fn buffer_data(buf: *const BufferHeader) -> *const u8 {
-    unsafe { (buf as *const u8).add(std::mem::size_of::<BufferHeader>()) }
+    foreign_backing(buf as usize)
+        .map(|addr| addr as *const u8)
+        .unwrap_or_else(|| unsafe { (buf as *const u8).add(std::mem::size_of::<BufferHeader>()) })
 }
 
 /// Get the mutable data pointer for a buffer
 pub fn buffer_data_mut(buf: *mut BufferHeader) -> *mut u8 {
-    unsafe { (buf as *mut u8).add(std::mem::size_of::<BufferHeader>()) }
+    foreign_backing(buf as usize)
+        .map(|addr| addr as *mut u8)
+        .unwrap_or_else(|| unsafe { (buf as *mut u8).add(std::mem::size_of::<BufferHeader>()) })
 }

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -56,7 +56,8 @@ pub use header::{
     resolve_buffer_ab_alias, set_buffer_ab_alias, CryptoKeyDeathHookFn,
 };
 pub(crate) use header::{
-    collect_dead_registered_buffers_post_trace, finalize_collected_dead_buffer,
+    buffer_alloc_foreign, collect_dead_registered_buffers_post_trace,
+    finalize_collected_dead_buffer,
 };
 #[cfg(test)]
 pub(crate) use header::{test_data_view_registry_len, test_shared_array_buffer_registry_len};

--- a/crates/perry-runtime/src/bun_ffi/memory.rs
+++ b/crates/perry-runtime/src/bun_ffi/memory.rs
@@ -1,0 +1,150 @@
+//! Native-memory views for `bun:ffi` (#6562 stage 2).
+//!
+//! `toArrayBuffer` and `toBuffer` create GC-managed JS wrappers whose data
+//! pointer refers directly to memory owned by the native library. Perry never
+//! frees that memory: as in Bun, the caller is responsible for keeping the
+//! allocation alive while the returned view is reachable.
+
+use crate::value::JSValue;
+
+fn throw_type(message: &str) -> ! {
+    crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn throw_range(message: &str) -> ! {
+    crate::fs::validate::throw_range_error_with_code(message)
+}
+
+unsafe fn pointer_address(value: f64) -> usize {
+    let jv = JSValue::from_bits(value.to_bits());
+    let address = if jv.is_int32() {
+        let n = jv.as_int32();
+        if n < 0 {
+            throw_type("ptr must be a non-negative number or bigint");
+        }
+        n as usize
+    } else if jv.is_number() {
+        let n = jv.as_number();
+        if !n.is_finite() || n < 0.0 || n.fract() != 0.0 || n > usize::MAX as f64 {
+            throw_type("ptr must be a non-negative integer number or bigint");
+        }
+        n as usize
+    } else if jv.is_bigint() {
+        let raw = crate::value::js_nanbox_get_bigint(value);
+        if raw == 0 {
+            0
+        } else {
+            let bigint = &*(raw as usize as *const crate::bigint::BigIntHeader);
+            if bigint.limbs[1..].iter().any(|&limb| limb != 0) {
+                throw_type("ptr bigint is outside the native pointer range");
+            }
+            bigint.limbs[0] as usize
+        }
+    } else {
+        throw_type("ptr must be a number or bigint");
+    };
+    if address == 0 {
+        throw_type("ptr cannot be zero");
+    }
+    address
+}
+
+fn optional_integer(value: f64, name: &str) -> Option<i64> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if jv.is_undefined() {
+        return None;
+    }
+    let n = if jv.is_int32() {
+        jv.as_int32() as f64
+    } else if jv.is_number() {
+        jv.as_number()
+    } else {
+        throw_type(&format!("{name} must be a number"));
+    };
+    if !n.is_finite() || n < i64::MIN as f64 || n > i64::MAX as f64 {
+        throw_range(&format!("{name} is out of range"));
+    }
+    Some(n.trunc() as i64)
+}
+
+fn address_with_offset(address: usize, offset: i64) -> usize {
+    let start = address as i128 + offset as i128;
+    if start <= 0 || start > usize::MAX as i128 {
+        throw_range("ptr + byteOffset is outside the native pointer range");
+    }
+    start as usize
+}
+
+unsafe fn nul_terminated_len(start: usize) -> u32 {
+    let ptr = start as *const u8;
+    let mut len = 0u32;
+    while *ptr.add(len as usize) != 0 {
+        if len == u32::MAX {
+            throw_range("native memory view exceeds Perry's maximum byteLength");
+        }
+        len += 1;
+    }
+    len
+}
+
+/// `toArrayBuffer(ptr[, byteOffset[, byteLength]])` and the sibling
+/// `toBuffer` operation. When `byteLength` is omitted the span is treated as
+/// NUL-terminated, matching Bun's public API.
+pub(crate) unsafe fn view_value(
+    pointer_arg: f64,
+    offset_arg: f64,
+    length_arg: f64,
+    array_buffer: bool,
+) -> f64 {
+    let address = pointer_address(pointer_arg);
+    let offset = optional_integer(offset_arg, "byteOffset").unwrap_or(0);
+    let start = address_with_offset(address, offset);
+    let length = match optional_integer(length_arg, "byteLength") {
+        Some(n) if n < 0 => throw_range("byteLength is out of range"),
+        Some(n) if n > u32::MAX as i64 => {
+            throw_range("byteLength exceeds Perry's maximum ArrayBuffer size")
+        }
+        Some(n) => n as u32,
+        None => nul_terminated_len(start),
+    };
+
+    let buffer = crate::buffer::buffer_alloc_foreign(start as *mut u8, length);
+    if array_buffer {
+        crate::buffer::mark_as_array_buffer(buffer as usize);
+    }
+    f64::from_bits(JSValue::pointer(buffer as *mut u8).bits())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_pointer_offset_accepts_both_directions() {
+        assert_eq!(address_with_offset(0x2000, 17), 0x2011);
+        assert_eq!(address_with_offset(0x2000, -17), 0x1fef);
+    }
+
+    #[test]
+    fn external_array_buffer_aliases_native_memory_without_copying() {
+        let mut bytes = [10u8, 20, 30, 0];
+        let value = unsafe { view_value(bytes.as_mut_ptr() as usize as f64, 1.0, 2.0, true) };
+        let address = crate::value::js_nanbox_get_pointer(value) as usize;
+        let buffer = address as *mut crate::buffer::BufferHeader;
+
+        assert!(crate::buffer::is_array_buffer(address));
+        assert_eq!(unsafe { (*buffer).length }, 2);
+        assert_eq!(crate::buffer::buffer_data(buffer), unsafe {
+            bytes.as_ptr().add(1)
+        });
+
+        unsafe {
+            *crate::buffer::buffer_data_mut(buffer).add(1) = 99;
+        }
+        assert_eq!(bytes, [10, 20, 99, 0]);
+
+        // The wrapper owns no native bytes; finalization only forgets the
+        // mapping so a recycled GC address cannot inherit this stack pointer.
+        crate::buffer::finalize_collected_dead_buffer(address);
+    }
+}

--- a/crates/perry-runtime/src/bun_ffi/mod.rs
+++ b/crates/perry-runtime/src/bun_ffi/mod.rs
@@ -1,4 +1,4 @@
-//! `bun:ffi` — C-ABI foreign-function interface, stage 1 (#6562).
+//! `bun:ffi` — C-ABI foreign-function interface, stages 1-2 (#6562).
 //!
 //! Implements the Bun FFI API shape for perry-compiled programs:
 //!
@@ -10,10 +10,12 @@
 //!   TypedArray / ArrayBuffer / DataView's bytes.
 //! - `CString(ptr[, byteOffset[, byteLength]])` — read a NUL-terminated
 //!   (or length-bounded) UTF-8 string from a native pointer.
+//! - `toArrayBuffer` / `toBuffer` — zero-copy JS views over native-owned
+//!   memory. The native allocation remains caller-owned.
 //! - `suffix` — platform dylib suffix ("dylib" / "so" / "dll").
 //!
-//! Stage-1 scope: `toArrayBuffer` (external backing stores), `JSCallback` /
-//! `FFIType.function` (native→JS trampolines), `linkSymbols`, `CFunction`,
+//! Remaining scope: `JSCallback` / `FFIType.function` (native→JS
+//! trampolines), `linkSymbols`, `CFunction`,
 //! `viewSource` and `read` are declared but throw a clear "not yet
 //! supported" error. The dispatch/type plumbing here is shaped so those can
 //! be added without reworking stage 1 (see `types::` for the reserved
@@ -72,6 +74,7 @@
 
 pub mod call;
 pub mod dlopen;
+pub mod memory;
 pub mod types;
 
 use crate::value::JSValue;
@@ -117,14 +120,14 @@ pub fn scan_bun_ffi_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     types::scan_ffi_type_cache_mut(visitor);
 }
 
-/// Stage-1 boundary: named exports that exist in `bun:ffi` but are not yet
+/// Later-stage boundary: named exports that exist in `bun:ffi` but are not yet
 /// implemented in perry. Kept callable so real-world feature probes fail
 /// with an actionable message instead of `undefined is not a function`.
-fn throw_stage1_unsupported(what: &str) -> ! {
+fn throw_unsupported(what: &str) -> ! {
     crate::fs::validate::throw_error_with_code(
         &format!(
-            "bun:ffi: {what} is not supported yet in perry (stage 1, #6562). \
-             Available: dlopen, FFIType, ptr, CString, suffix."
+            "bun:ffi: {what} is not supported yet in perry (#6562). \
+             Available: dlopen, FFIType, ptr, CString, toArrayBuffer, toBuffer, suffix."
         ),
         "ERR_NOT_IMPLEMENTED",
     )
@@ -157,13 +160,13 @@ pub(crate) unsafe fn dispatch(
         // but destructured/dynamic reads can land here too.
         "FFIType" => Some(types::ffi_type_object_value()),
         "suffix" => Some(string_value(suffix_str())),
-        "toArrayBuffer" => throw_stage1_unsupported("toArrayBuffer (external backing stores)"),
-        "JSCallback" => throw_stage1_unsupported("JSCallback (native-to-JS callbacks)"),
-        "CFunction" => throw_stage1_unsupported("CFunction"),
-        "linkSymbols" => throw_stage1_unsupported("linkSymbols"),
-        "viewSource" => throw_stage1_unsupported("viewSource"),
-        "read" => throw_stage1_unsupported("the read namespace"),
-        "toBuffer" => throw_stage1_unsupported("toBuffer"),
+        "toArrayBuffer" => Some(memory::view_value(arg(0), arg(1), arg(2), true)),
+        "JSCallback" => throw_unsupported("JSCallback (native-to-JS callbacks)"),
+        "CFunction" => throw_unsupported("CFunction"),
+        "linkSymbols" => throw_unsupported("linkSymbols"),
+        "viewSource" => throw_unsupported("viewSource"),
+        "read" => throw_unsupported("the read namespace"),
+        "toBuffer" => Some(memory::view_value(arg(0), arg(1), arg(2), false)),
         _ => None,
     }
 }

--- a/crates/perry/tests/bun_ffi_stage1.rs
+++ b/crates/perry/tests/bun_ffi_stage1.rs
@@ -1,4 +1,4 @@
-//! bun:ffi stage 1 (#6562) — e2e: compile TS that dlopens real C-ABI
+//! bun:ffi stages 1-2 (#6562) — e2e: compile TS that dlopens real C-ABI
 //! dylibs and drive them through the typed call stubs.
 //!
 //! Two tiers:
@@ -8,8 +8,9 @@
 //!    bool, mixed int/float register assignment (the classic ABI trap),
 //!    8-int / 8-double register limits, ptr round-trips through pinned
 //!    Buffers (JS→native reads AND native→JS writes), cstring in both
-//!    directions, NULL pointers, and the error surfaces (missing symbol,
-//!    bad library, stage-1 rejections).
+//!    directions, zero-copy native-memory ArrayBuffer/Buffer views, NULL
+//!    pointers, and the error surfaces (missing symbol, bad library,
+//!    stage-1 rejections).
 //! 2. A bun-pty smoke test against the real third-party
 //!    `librust_pty` dylib (17-symbol pty FFI table): spawn a shell,
 //!    write/read round-trip, resize, kill. Runs when the dylib is
@@ -152,10 +153,17 @@ EXPORT const char *ffi_concat(const char *a, const char *b) {
     return g_concat_buf;
 }
 EXPORT const char *ffi_utf8(void) { return "caf\xC3\xA9 \xE2\x9C\x93"; }
+
+static uint8_t g_external_bytes[] = { 65, 66, 0, 67, 68 };
+EXPORT uint8_t *ffi_external_ptr(void) { return g_external_bytes; }
+EXPORT uint8_t ffi_external_get(int32_t index) { return g_external_bytes[index]; }
+EXPORT void ffi_external_set(int32_t index, uint8_t value) {
+    g_external_bytes[index] = value;
+}
 "#;
 
 const TIER1_TS: &str = r#"
-import { dlopen, FFIType, ptr, CString, suffix } from "bun:ffi";
+import { dlopen, FFIType, ptr, CString, suffix, toArrayBuffer, toBuffer } from "bun:ffi";
 
 console.log("suffix-ok:", suffix === "dylib" || suffix === "so");
 console.log("ffitype:", FFIType.i32, FFIType.cstring, FFIType.ptr, FFIType.void, FFIType.u64);
@@ -203,6 +211,9 @@ const lib = dlopen(process.env.FFI_TEST_LIB!, {
   ffi_strlen: { args: [FFIType.cstring], returns: FFIType.i32 },
   ffi_concat: { args: [FFIType.cstring, FFIType.cstring], returns: FFIType.cstring },
   ffi_utf8: { args: [], returns: FFIType.ptr },
+  ffi_external_ptr: { args: [], returns: FFIType.ptr },
+  ffi_external_get: { args: [FFIType.i32], returns: FFIType.u8 },
+  ffi_external_set: { args: [FFIType.i32, FFIType.u8], returns: FFIType.void },
 });
 const s = lib.symbols;
 
@@ -267,6 +278,29 @@ console.log("concat:", s.ffi_concat(Buffer.from("foo\0"), Buffer.from("bar\0")))
 // CString: read a NUL-terminated string from a raw pointer
 const utf8Ptr = s.ffi_utf8();
 console.log("cstring-read:", CString(utf8Ptr));
+
+// Stage 2: zero-copy native-memory wrappers. Both directions must alias the
+// C static allocation; a copy would fail one of these checks.
+const externalPtr = s.ffi_external_ptr();
+const externalAB = toArrayBuffer(externalPtr, 1, 3);
+const externalView = new Uint8Array(externalAB);
+console.log("external-ab:", externalAB instanceof ArrayBuffer, externalAB.byteLength);
+console.log("external-initial:", externalView[0], externalView[1], externalView[2]);
+s.ffi_external_set(2, 88);
+console.log("external-native-write:", externalView[1]);
+externalView[2] = 90;
+console.log("external-js-write:", s.ffi_external_get(3));
+console.log("external-ptr-offset:", ptr(externalAB) === externalPtr + 1);
+
+const externalBuffer = toBuffer(externalPtr, 0, 2);
+console.log("external-buffer:", Buffer.isBuffer(externalBuffer), externalBuffer.length, externalBuffer[0]);
+externalBuffer[0] = 81;
+console.log("external-buffer-write:", s.ffi_external_get(0));
+
+// Omitted byteLength uses the first NUL terminator.
+s.ffi_external_set(2, 0);
+const terminated = toArrayBuffer(externalPtr);
+console.log("external-terminated:", terminated.byteLength);
 
 lib.close();
 
@@ -334,6 +368,14 @@ fn tier1_every_ffi_type_against_test_dylib() {
         "strlen: 11",
         "concat: foobar",
         "cstring-read: caf\u{e9} \u{2713}",
+        "external-ab: true 3",
+        "external-initial: 66 0 67",
+        "external-native-write: 88",
+        "external-js-write: 90",
+        "external-ptr-offset: true",
+        "external-buffer: true 2 65",
+        "external-buffer-write: 81",
+        "external-terminated: 2",
         "closed-throws: true",
         "TIER1-DONE",
     ] {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -323,9 +323,9 @@ declare module "bun:ffi" {
   export function ptr(...args: any[]): any;
   /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
   export function read(...args: any[]): any;
-  /** stdlib @perryStub stage 2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function toArrayBuffer(...args: any[]): any;
-  /** stdlib @perryStub stage 2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function toBuffer(...args: any[]): any;
   /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
   export function viewSource(...args: any[]): any;

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -373,8 +373,8 @@ Total: 2946 entries across 125 modules.
 - `linkSymbols` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
 - `ptr` — module
 - `read` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
-- `toArrayBuffer` — module ⚠ **stub** — stage 2 — not yet implemented, throws at runtime (#6562)
-- `toBuffer` — module ⚠ **stub** — stage 2 — not yet implemented, throws at runtime (#6562)
+- `toArrayBuffer` — module
+- `toBuffer` — module
 - `viewSource` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
 
 ### Properties


### PR DESCRIPTION
## Summary

Implements stage 2 of #6562 by adding zero-copy `bun:ffi` `toArrayBuffer` and `toBuffer` views over native-owned memory.

## Changes

- Add GC-managed, non-owning external backing-store wrappers with dead-address cleanup.
- Route optimized `Uint8Array` views through the actual ArrayBuffer backing pointer.
- Expose `toArrayBuffer` and `toBuffer` as implemented APIs and regenerate the API docs.
- Extend the C dylib integration fixture with bidirectional zero-copy aliasing coverage.

## Related issue

Refs #6562 (stage 2; native-to-JS callbacks remain tracked by the issue).

## Test plan

- [x] `cargo check -p perry-runtime -p perry-codegen -p perry-api-manifest`
- [x] `cargo test -p perry-runtime bun_ffi -- --test-threads=1`
- [x] `cargo test -p perry-api-manifest --test stub_inventory`
- [x] `cargo test -p perry --test bun_ffi_stage1 tier1_every_ffi_type_against_test_dylib -- --test-threads=1 --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] API docs regenerated with `./scripts/regen_api_docs.sh`
- [x] Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [x] Updated `docs/src/` for the runtime API change

The repository-wide affected-crate suite was not run locally; the focused runtime/compiler checks and the real dylib integration test passed.

## Screenshots / output

N/A.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct
