### PR TITLE
fix(node:test): expose test context assertions

### DIFF
--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -1256,17 +1256,141 @@ extern "C" fn test_context_todo(_closure: *const ClosureHeader, reason: f64) -> 
     undefined_value()
 }
 
+fn record_test_context_assertion() {
+    CURRENT_ASSERT_COUNT.with(|count| count.set(count.get() + 1));
+}
+
+macro_rules! test_context_assertion3 {
+    ($name:ident, $assertion:path) => {
+        extern "C" fn $name(
+            _closure: *const ClosureHeader,
+            actual: f64,
+            expected: f64,
+            message: f64,
+        ) -> f64 {
+            record_test_context_assertion();
+            $assertion(actual, expected, message)
+        }
+    };
+}
+
+test_context_assertion3!(
+    test_context_assert_deep_equal,
+    crate::object::js_assert_deep_equal
+);
+test_context_assertion3!(
+    test_context_assert_deep_strict_equal,
+    crate::object::js_assert_deep_strict_equal
+);
+test_context_assertion3!(
+    test_context_assert_does_not_match,
+    crate::object::js_assert_does_not_match
+);
+test_context_assertion3!(
+    test_context_assert_does_not_reject,
+    crate::object::js_assert_does_not_reject
+);
+test_context_assertion3!(
+    test_context_assert_does_not_throw,
+    crate::object::js_assert_does_not_throw
+);
+test_context_assertion3!(test_context_assert_equal, crate::object::js_assert_equal);
+test_context_assertion3!(test_context_assert_match, crate::object::js_assert_match);
+test_context_assertion3!(
+    test_context_assert_not_deep_equal,
+    crate::object::js_assert_not_deep_equal
+);
+test_context_assertion3!(
+    test_context_assert_not_strict_equal,
+    crate::object::js_assert_not_strict_equal
+);
+test_context_assertion3!(
+    test_context_assert_rejects,
+    crate::object::js_assert_rejects
+);
+test_context_assertion3!(
+    test_context_assert_strict_equal,
+    crate::object::js_assert_strict_equal
+);
+test_context_assertion3!(test_context_assert_throws, crate::object::js_assert_throws);
+
+extern "C" fn test_context_assert_ok(
+    _closure: *const ClosureHeader,
+    value: f64,
+    message: f64,
+) -> f64 {
+    record_test_context_assertion();
+    crate::object::js_assert_ok(value, message)
+}
+
+extern "C" fn test_context_assert_fail(_closure: *const ClosureHeader, message: f64) -> f64 {
+    record_test_context_assertion();
+    crate::object::js_assert_fail(message)
+}
+
+extern "C" fn test_context_assert_if_error(_closure: *const ClosureHeader, value: f64) -> f64 {
+    record_test_context_assertion();
+    crate::object::js_assert_if_error(value)
+}
+
 fn test_context_value(name: &str) -> f64 {
-    let assert = js_object_alloc(0, 2);
+    let assert = js_object_alloc(0, 17);
+    for (name, func, arity) in [
+        ("deepEqual", test_context_assert_deep_equal as *const u8, 3),
+        (
+            "deepStrictEqual",
+            test_context_assert_deep_strict_equal as *const u8,
+            3,
+        ),
+        (
+            "doesNotMatch",
+            test_context_assert_does_not_match as *const u8,
+            3,
+        ),
+        (
+            "doesNotReject",
+            test_context_assert_does_not_reject as *const u8,
+            3,
+        ),
+        (
+            "doesNotThrow",
+            test_context_assert_does_not_throw as *const u8,
+            3,
+        ),
+        ("equal", test_context_assert_equal as *const u8, 3),
+        ("fail", test_context_assert_fail as *const u8, 1),
+        ("ifError", test_context_assert_if_error as *const u8, 1),
+        ("match", test_context_assert_match as *const u8, 3),
+        (
+            "notDeepEqual",
+            test_context_assert_not_deep_equal as *const u8,
+            3,
+        ),
+        (
+            "notStrictEqual",
+            test_context_assert_not_strict_equal as *const u8,
+            3,
+        ),
+        ("ok", test_context_assert_ok as *const u8, 2),
+        ("rejects", test_context_assert_rejects as *const u8, 3),
+        (
+            "strictEqual",
+            test_context_assert_strict_equal as *const u8,
+            3,
+        ),
+        ("throws", test_context_assert_throws as *const u8, 3),
+    ] {
+        set_field(assert, name, closure_value(func, arity));
+    }
     set_field(
         assert,
         "snapshot",
-        closure_value(assert_snapshot as *const u8, 1),
+        closure_value(assert_snapshot as *const u8, 2),
     );
     set_field(
         assert,
         "fileSnapshot",
-        closure_value(assert_file_snapshot as *const u8, 2),
+        closure_value(assert_file_snapshot as *const u8, 3),
     );
     let ctx = js_object_alloc(0, 8);
     let test_fn = closure_value(thunk_test as *const u8, 3);

--- a/crates/perry-runtime/src/node_submodules/test_snapshot.rs
+++ b/crates/perry-runtime/src/node_submodules/test_snapshot.rs
@@ -48,8 +48,19 @@ pub(super) extern "C" fn snapshot_set_resolve_snapshot_path(
     undefined_value()
 }
 
-pub(super) extern "C" fn assert_snapshot(_closure: *const ClosureHeader, value: f64) -> f64 {
+fn validate_snapshot_assertion_options(options: f64) {
+    if !is_undefined_value(options) && !is_non_null_object(options) {
+        throw_invalid_arg_type("options", "object", options);
+    }
+}
+
+pub(super) extern "C" fn assert_snapshot(
+    _closure: *const ClosureHeader,
+    value: f64,
+    options: f64,
+) -> f64 {
     CURRENT_ASSERT_COUNT.with(|count| count.set(count.get() + 1));
+    validate_snapshot_assertion_options(options);
     let resolver = SNAPSHOT_RESOLVER.with(|slot| slot.get());
     if !is_callable_value(resolver) {
         throw_error_with_code(
@@ -103,8 +114,10 @@ pub(super) extern "C" fn assert_file_snapshot(
     _closure: *const ClosureHeader,
     value: f64,
     path_value: f64,
+    options: f64,
 ) -> f64 {
     CURRENT_ASSERT_COUNT.with(|count| count.set(count.get() + 1));
+    validate_snapshot_assertion_options(options);
     let Some(path) = value_to_string(path_value) else {
         throw_invalid_arg_type("path", "string", path_value);
     };


### PR DESCRIPTION
## Summary

- expose the standard Node assertion methods on `TestContext.assert`
- delegate to the existing `node:assert` runtime and count calls toward assertion plans
- validate snapshot assertion options before resolver and file-state checks
- resolve four parity cases tracked by #6767
- no version bump

## Testing

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/amlug/projects/perry/perry/target cargo check -p perry-runtime --features mod-node-test`
- `PERRY_SKIP_BUILD=1 PERRY_BIN=/Users/amlug/projects/perry/perry/target/release/perry PERRY_RUNTIME_DIR=/Users/amlug/projects/perry/perry/target/release ./run_parity_tests.sh --suite node-suite --module test --filter assertion` (4/4, 100%)

Part of #6767