### PR TITLE
fix(tls): match Node server identity semantics

### DIFF
--- a/crates/perry-runtime/src/tls.rs
+++ b/crates/perry-runtime/src/tls.rs
@@ -8,7 +8,7 @@ mod roots;
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
 use crate::string::StringHeader;
-use crate::value::{JSValue, TAG_NULL, TAG_UNDEFINED};
+use crate::value::{JSValue, TAG_UNDEFINED};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 pub const CLASS_ID_TLS_SECURE_CONTEXT: u32 = 0xFFFF_00B5;
@@ -470,19 +470,96 @@ pub(crate) fn is_secure_context_instance(value: f64) -> bool {
         .unwrap_or(false)
 }
 
-fn dns_name_matches(host: &str, pattern: &str) -> bool {
-    let host = host.to_ascii_lowercase();
-    let pattern = pattern.to_ascii_lowercase();
-    if host == pattern {
-        return true;
+/// Canonicalize a `checkServerIdentity` host using Node's `domainToASCII` rules.
+pub fn tls_domain_to_ascii(host: &str) -> String {
+    let normalized = host
+        .replace(['\u{3002}', '\u{ff0e}', '\u{ff61}'], ".")
+        .trim_end_matches('.')
+        .to_string();
+
+    if normalized.contains(':')
+        || normalized.chars().any(|c| {
+            c.is_ascii_control()
+                || matches!(
+                    c,
+                    ' ' | '#' | '/' | '<' | '>' | '?' | '@' | '[' | '\\' | ']' | '^' | '|'
+                )
+        })
+    {
+        return String::new();
     }
-    if let Some(suffix) = pattern.strip_prefix("*.") {
-        return host.ends_with(&format!(".{}", suffix))
-            && host[..host.len().saturating_sub(suffix.len() + 1)]
-                .find('.')
-                .is_none();
+
+    #[cfg(feature = "url-engine")]
+    {
+        return idna::domain_to_ascii(&normalized)
+            .ok()
+            .and_then(|ascii| crate::url::whatwg_canonicalize_host(&ascii))
+            .unwrap_or_default();
     }
-    false
+
+    #[cfg(not(feature = "url-engine"))]
+    {
+        // The reduced TLS runtime deliberately omits the URL/IDNA tables. Keep
+        // Node's important numeric-host coercion and reject non-ASCII input
+        // conservatively instead of treating it as a literal DNS label.
+        if normalized.bytes().all(|byte| byte.is_ascii_digit()) {
+            return normalized
+                .parse::<u32>()
+                .map(std::net::Ipv4Addr::from)
+                .map(|ip| ip.to_string())
+                .unwrap_or_default();
+        }
+        if normalized.is_ascii() {
+            normalized
+        } else {
+            String::new()
+        }
+    }
+}
+
+fn split_dns_name(name: &str) -> Vec<String> {
+    name.trim_end_matches('.')
+        .split('.')
+        .map(|part| part.to_ascii_lowercase())
+        .collect()
+}
+
+/// Match a canonical host against a certificate DNS pattern using RFC 6125 rules.
+pub fn tls_dns_name_matches(host: &str, pattern: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+
+    let host_parts = split_dns_name(host);
+    let pattern_parts = split_dns_name(pattern);
+    if host_parts.len() != pattern_parts.len()
+        || pattern_parts.iter().any(String::is_empty)
+        || pattern_parts
+            .iter()
+            .any(|part| part.bytes().any(|byte| !(0x21..=0x7f).contains(&byte)))
+    {
+        return false;
+    }
+
+    if host_parts[1..] != pattern_parts[1..] {
+        return false;
+    }
+
+    let host_label = &host_parts[0];
+    let pattern_label = &pattern_parts[0];
+    let wildcard_parts: Vec<&str> = pattern_label.splitn(3, '*').collect();
+    if wildcard_parts.len() == 1 || pattern_label.contains("xn--") {
+        return host_label == pattern_label;
+    }
+    if wildcard_parts.len() > 2 || pattern_parts.len() <= 2 {
+        return false;
+    }
+
+    let prefix = wildcard_parts[0];
+    let suffix = wildcard_parts[1];
+    prefix.len() + suffix.len() <= host_label.len()
+        && host_label.starts_with(prefix)
+        && host_label.ends_with(suffix)
 }
 
 fn san_entries(subject_alt_name: &str, prefix: &str) -> Vec<String> {
@@ -493,11 +570,19 @@ fn san_entries(subject_alt_name: &str, prefix: &str) -> Vec<String> {
         .collect()
 }
 
-fn cert_common_name(cert: *mut ObjectHeader) -> Option<String> {
+fn cert_common_names(cert: *mut ObjectHeader) -> Vec<String> {
     let subject = get_field(cert, "subject");
-    let subject_obj = object_ptr(subject)?;
+    let Some(subject_obj) = object_ptr(subject) else {
+        return Vec::new();
+    };
     let cn = get_field(subject_obj, "CN");
-    value_to_string(cn)
+    if let Some(array) = array_ptr(cn) {
+        let len = crate::array::js_array_length(array);
+        return (0..len)
+            .filter_map(|index| value_to_string(crate::array::js_array_get_f64(array, index)))
+            .collect();
+    }
+    value_to_string(cn).into_iter().collect()
 }
 
 fn altname_error(host: &str, cert_value: f64, reason: String) -> f64 {
@@ -505,17 +590,17 @@ fn altname_error(host: &str, cert_value: f64, reason: String) -> f64 {
         "Hostname/IP does not match certificate's altnames: {}",
         reason
     );
-    let obj = crate::object::js_object_alloc(crate::error::CLASS_ID_ERROR, 6);
+    let message_ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_error_new_with_message(message_ptr);
+    let obj = error as *mut ObjectHeader;
     let set = |name: &str, value: f64| {
         crate::object::js_object_set_field_by_name(obj, key(name), value);
     };
-    set("name", string_value("Error"));
-    set("message", string_value(&message));
     set("code", string_value("ERR_TLS_CERT_ALTNAME_INVALID"));
     set("reason", string_value(&reason));
     set("host", string_value(host));
     set("cert", cert_value);
-    ptr_value(obj)
+    ptr_value(error)
 }
 
 #[no_mangle]
@@ -524,43 +609,71 @@ pub extern "C" fn js_tls_check_server_identity(hostname: f64, cert: f64) -> f64 
     let Some(cert_obj) = object_ptr(cert) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let subject_alt_name = get_field(cert_obj, "subjectaltname");
-    if let Some(san) = value_to_string(subject_alt_name) {
-        let host_is_ip = host.parse::<std::net::IpAddr>().is_ok();
-        if host_is_ip {
-            if san_entries(&san, "IP Address:")
-                .iter()
-                .any(|candidate| candidate == &host)
-            {
-                return f64::from_bits(TAG_UNDEFINED);
-            }
-        } else if san_entries(&san, "DNS:")
+    let match_host = tls_domain_to_ascii(&host);
+    let san = value_to_string(get_field(cert_obj, "subjectaltname")).unwrap_or_default();
+    let dns_names = if san.is_empty() {
+        Vec::new()
+    } else {
+        san_entries(&san, "DNS:")
+    };
+    let ip_names: Vec<String> = if san.is_empty() {
+        Vec::new()
+    } else {
+        san_entries(&san, "IP Address:")
+            .into_iter()
+            .filter_map(|candidate| candidate.parse::<std::net::IpAddr>().ok())
+            .map(|candidate| candidate.to_string())
+            .collect()
+    };
+
+    if let Ok(ip) = match_host.parse::<std::net::IpAddr>() {
+        let canonical_ip = ip.to_string();
+        if ip_names.iter().any(|candidate| candidate == &canonical_ip) {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        return altname_error(
+            &host,
+            cert,
+            format!(
+                "IP: {} is not in the cert's list: {}",
+                host,
+                ip_names.join(", ")
+            ),
+        );
+    }
+
+    let common_names = cert_common_names(cert_obj);
+    if !dns_names.is_empty() || !common_names.is_empty() {
+        if dns_names
             .iter()
-            .any(|candidate| dns_name_matches(&host, candidate))
+            .any(|candidate| tls_dns_name_matches(&match_host, candidate))
+        {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        if !dns_names.is_empty() {
+            return altname_error(
+                &host,
+                cert,
+                format!("Host: {}. is not in the cert's altnames: {}", host, san),
+            );
+        }
+        if common_names
+            .iter()
+            .any(|candidate| tls_dns_name_matches(&match_host, candidate))
         {
             return f64::from_bits(TAG_UNDEFINED);
         }
         return altname_error(
             &host,
             cert,
-            format!("Host: {}. is not in the cert's altnames: {}", host, san),
+            format!(
+                "Host: {}. is not cert's CN: {}",
+                host,
+                common_names.join(",")
+            ),
         );
     }
 
-    if let Some(cn) = cert_common_name(cert_obj) {
-        if dns_name_matches(&host, &cn) {
-            return f64::from_bits(TAG_UNDEFINED);
-        }
-        return altname_error(
-            &host,
-            cert,
-            format!("Host: {}. is not cert's CN: {}", host, cn),
-        );
-    }
-
-    if JSValue::from_bits(cert.to_bits()).is_null() {
-        return f64::from_bits(TAG_NULL);
-    }
     altname_error(&host, cert, "Cert does not contain a DNS name".to_string())
 }
 
@@ -613,7 +726,29 @@ mod tests {
 
     #[test]
     fn wildcard_dns_match_is_single_label() {
-        assert!(dns_name_matches("api.example.com", "*.example.com"));
-        assert!(!dns_name_matches("deep.api.example.com", "*.example.com"));
+        assert!(tls_dns_name_matches("api.example.com", "*.example.com"));
+        assert!(!tls_dns_name_matches(
+            "deep.api.example.com",
+            "*.example.com"
+        ));
+        assert!(tls_dns_name_matches("a-cb.a.com", "*b.a.com"));
+        assert!(!tls_dns_name_matches("a.com", "*.com"));
+        assert!(tls_dns_name_matches("a.co.uk", "*.co.uk"));
+        assert!(tls_dns_name_matches("a.example", "A.EXAMPLE."));
+        assert!(!tls_dns_name_matches(
+            "bad.x.example.com",
+            "bad..example.com"
+        ));
+        assert!(!tls_dns_name_matches("x.example.com", "café.example.com"));
+    }
+
+    #[test]
+    fn tls_hostname_canonicalization_matches_node_identity_inputs() {
+        assert_eq!(tls_domain_to_ascii("123"), "0.0.0.123");
+        assert_eq!(tls_domain_to_ascii("::1"), "");
+        assert_eq!(
+            tls_domain_to_ascii("foo。bar.example.com"),
+            "foo.bar.example.com"
+        );
     }
 }

--- a/crates/perry-stdlib/src/tls/module_api.rs
+++ b/crates/perry-stdlib/src/tls/module_api.rs
@@ -8,7 +8,7 @@
 //! `pub use tls::*` glob in `lib.rs`) keep resolving them unchanged.
 
 use perry_runtime::array::js_array_get_f64;
-use perry_runtime::{js_array_length, js_nanbox_pointer, js_object_alloc, JSValue, ObjectHeader};
+use perry_runtime::{js_array_length, js_nanbox_pointer, JSValue, ObjectHeader};
 
 use super::secure_context::{
     ca_store, cert_list_from_array_value, make_secure_context, root_certificates,
@@ -113,30 +113,9 @@ fn split_subject_alt_names(san: &str) -> Vec<(String, String)> {
             out.push(("DNS".to_string(), rest.trim().to_string()));
         } else if let Some(rest) = item.strip_prefix("IP Address:") {
             out.push(("IP".to_string(), rest.trim().to_string()));
-        } else if let Some(rest) = item.strip_prefix("IP:") {
-            out.push(("IP".to_string(), rest.trim().to_string()));
         }
     }
     out
-}
-
-fn hostname_is_ip(host: &str) -> bool {
-    host.parse::<std::net::IpAddr>().is_ok()
-}
-
-fn dns_matches(pattern: &str, host: &str) -> bool {
-    let pattern = pattern.trim_end_matches('.').to_ascii_lowercase();
-    let host = host.trim_end_matches('.').to_ascii_lowercase();
-    if pattern == host {
-        return true;
-    }
-    if let Some(suffix) = pattern.strip_prefix("*.") {
-        let Some(rest) = host.strip_suffix(suffix) else {
-            return false;
-        };
-        return rest.ends_with('.') && rest[..rest.len().saturating_sub(1)].find('.').is_none();
-    }
-    false
 }
 
 unsafe fn cn_values(subject_value: f64) -> Vec<String> {
@@ -162,14 +141,15 @@ unsafe fn cn_values(subject_value: f64) -> Vec<String> {
 
 unsafe fn make_altname_error(reason: String, host: &str, cert: f64) -> f64 {
     let message = format!("Hostname/IP does not match certificate's altnames: {reason}");
-    let obj = js_object_alloc(perry_runtime::error::CLASS_ID_ERROR, 0);
-    set_str_field(obj, "name", "Error");
-    set_str_field(obj, "message", &message);
+    let message_ptr =
+        perry_runtime::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = perry_runtime::error::js_error_new_with_message(message_ptr);
+    let obj = error as *mut ObjectHeader;
     set_str_field(obj, "code", "ERR_TLS_CERT_ALTNAME_INVALID");
     set_str_field(obj, "reason", &reason);
     set_str_field(obj, "host", host);
     set_field(obj, "cert", cert);
-    js_nanbox_pointer(obj as i64)
+    js_nanbox_pointer(error as i64)
 }
 
 pub unsafe extern "C" fn js_tls_get_ciphers() -> *mut perry_runtime::ArrayHeader {
@@ -243,13 +223,14 @@ pub unsafe extern "C" fn js_tls_check_server_identity(hostname_bits: i64, cert_b
     let hostname_value = f64_from_raw_bits(hostname_bits);
     let cert = f64_from_raw_bits(cert_bits);
     let host = value_to_string(hostname_value).unwrap_or_default();
-    let host_is_ip = hostname_is_ip(&host);
+    let match_host = perry_runtime::tls::tls_domain_to_ascii(&host);
     let san = object_field_string(cert, "subjectaltname").unwrap_or_default();
     let san_entries = split_subject_alt_names(&san);
     let ip_names: Vec<String> = san_entries
         .iter()
         .filter(|(kind, _)| kind == "IP")
-        .map(|(_, value)| value.clone())
+        .filter_map(|(_, value)| value.parse::<std::net::IpAddr>().ok())
+        .map(|value| value.to_string())
         .collect();
     let dns_names: Vec<String> = san_entries
         .iter()
@@ -257,8 +238,11 @@ pub unsafe extern "C" fn js_tls_check_server_identity(hostname_bits: i64, cert_b
         .map(|(_, value)| value.clone())
         .collect();
 
-    if host_is_ip {
-        if ip_names.iter().any(|ip| ip == &host) {
+    if let Ok(ip) = match_host.parse::<std::net::IpAddr>() {
+        if ip_names
+            .iter()
+            .any(|candidate| candidate == &ip.to_string())
+        {
             return undefined();
         }
         let reason = format!(
@@ -269,7 +253,10 @@ pub unsafe extern "C" fn js_tls_check_server_identity(hostname_bits: i64, cert_b
     }
 
     if !dns_names.is_empty() {
-        if dns_names.iter().any(|pattern| dns_matches(pattern, &host)) {
+        if dns_names
+            .iter()
+            .any(|pattern| perry_runtime::tls::tls_dns_name_matches(&match_host, pattern))
+        {
             return undefined();
         }
         let reason = format!("Host: {host}. is not in the cert's altnames: {san}");
@@ -278,11 +265,14 @@ pub unsafe extern "C" fn js_tls_check_server_identity(hostname_bits: i64, cert_b
 
     let subject = object_field(cert, "subject");
     let cns = cn_values(subject);
-    if cns.iter().any(|cn| dns_matches(cn, &host)) {
+    if cns
+        .iter()
+        .any(|cn| perry_runtime::tls::tls_dns_name_matches(&match_host, cn))
+    {
         return undefined();
     }
     let reason = if cns.is_empty() {
-        format!("Host: {host}. is not cert's CN: ")
+        "Cert does not contain a DNS name".to_string()
     } else {
         format!("Host: {host}. is not cert's CN: {}", cns.join(","))
     };

--- a/crates/perry/tests/issue_6765_tls_identity.rs
+++ b/crates/perry/tests/issue_6765_tls_identity.rs
@@ -1,0 +1,84 @@
+//! Regression coverage for Node-compatible TLS server identity matching (#6765).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn tls_check_server_identity_matches_node_patterns_and_error_shape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+import tls from "node:tls";
+
+function ok(host: any, cert: any) {
+  return tls.checkServerIdentity(host, cert) === undefined;
+}
+function code(host: any, cert: any) {
+  return (tls.checkServerIdentity(host, cert) as any)?.code;
+}
+
+console.log("numeric:", code(123, { subject: { CN: "123" } }));
+console.log("trailing:", ok("a.example", { subject: { CN: "A.EXAMPLE." } }));
+console.log("partial:", ok("a-cb.a.com", { subject: { CN: "*b.a.com" } }));
+console.log("top-level:", code("a.com", { subject: { CN: "*.com" } }));
+console.log("multiple:", ok("second.example", { subject: { CN: ["first.example", "second.example"] } }));
+console.log("unicode separator:", code("foo。bar.example.com", { subject: { CN: "*.example.com" } }));
+
+const ipError: any = tls.checkServerIdentity("127.0.0.1", {
+  subject: { CN: "127.0.0.1" },
+});
+console.log("ip cn:", ipError.code, ipError.reason);
+
+const cert = { subjectaltname: "DNS:good.example" };
+const error: any = tls.checkServerIdentity("bad.example", cert);
+console.log("error:", error instanceof Error, error.name, Object.keys(error).sort().join(","));
+"#,
+    )
+    .expect("write fixture");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "numeric: ERR_TLS_CERT_ALTNAME_INVALID\n",
+            "trailing: true\n",
+            "partial: true\n",
+            "top-level: ERR_TLS_CERT_ALTNAME_INVALID\n",
+            "multiple: true\n",
+            "unicode separator: ERR_TLS_CERT_ALTNAME_INVALID\n",
+            "ip cn: ERR_TLS_CERT_ALTNAME_INVALID IP: 127.0.0.1 is not in the cert's list: \n",
+            "error: true Error cert,code,host,reason\n",
+        )
+    );
+}


### PR DESCRIPTION
## Summary

Aligns `tls.checkServerIdentity` with Node 26 hostname canonicalization, DNS wildcard matching, IP handling, CN-array behavior, and error property semantics. This turns the six deterministic identity mismatches in the #6765 TLS tracker into parity passes.

## Changes

- canonicalize numeric, IDNA, Unicode-separator, and trailing-dot hostnames before certificate matching
- implement Node-compatible RFC 6125 wildcard rules, including partial leftmost wildcards and top-level wildcard rejection
- support certificate CN arrays and canonical IP SAN comparison while preserving Node error reasons
- construct native `Error` values so `name` and `message` remain non-enumerable
- share the matching helpers between runtime and stdlib dispatch paths
- add an end-to-end regression test for issue #6765

## Related issue

Refs #6765. This resolves the six `tls/identity` mismatches; the broad TLS tracker retains unrelated context, handshake, ALPN, SNI, session, and socket-state work.

## Test plan

- [ ] `cargo build --release` clean (full workspace build not run)
- [ ] Full workspace test command passes (not run)
- [x] `cargo build --release -p perry-runtime-static -p perry-stdlib-static --no-default-features --features perry-runtime/full,perry-stdlib/async-runtime,perry-stdlib/tls,perry-runtime/alloc-mimalloc`
- [x] `cargo test -p perry-runtime tls::tests --lib`
- [x] `cargo check -p perry-stdlib --no-default-features --features tls,async-runtime`
- [x] `cargo test -p perry --test issue_6765_tls_identity`
- [x] Each affected fixture passes individually with `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --suite node-suite --module tls --filter <fixture>`: `check-server-identity`, `dns-patterns`, `error-shape`, `idna-and-invalid-labels`, `ip-addresses`, and `san-kinds-and-wildcards`
- [x] Added `crates/perry/tests/issue_6765_tls_identity.rs`
- [x] Documentation not needed: this corrects existing Node API semantics without adding surface area

## Screenshots / output

Before: all six targeted identity fixtures reported output mismatches.

After: all six pass at 100% parity with zero compile failures or crashes.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the loose `fix:` prefix convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS certificate hostname verification with case-insensitive matching, trailing-dot normalization, wildcard restrictions, and support for multiple certificate names.
  - Added reliable handling for IP addresses, numeric hosts, Unicode hostnames, and alternate separators.
  - Improved certificate identity errors and support for IP address entries in subject alternative names.

- **Tests**
  - Added regression coverage for hostname matching, wildcard behavior, Unicode normalization, IP validation, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->