### PR TITLE
test(ci): close out #8264 — no suite exclusions remain

### DIFF
--- a/changelog.d/8335-close-8264-exclusions.md
+++ b/changelog.d/8335-close-8264-exclusions.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **No `perry-codegen` integration suite is held out of per-PR CI any more.**
+  #8264 recorded eight assertions as baseline reds and parked their suites in
+  `scripts/ci_e2e_scope.py`'s `SUITE_EXCLUSIONS`. #8302 fixed the six
+  `native_proof_buffer_views` ones (un-excluded in #8321) and #8333 fixed the
+  remaining two; this removes their entries and maps both suites, leaving
+  `SUITE_EXCLUSIONS` empty.
+
+  A stale exclusion is not a red build — it is silence. The suite keeps being
+  skipped, so coverage a fix earned back never runs, which is #7708's failure
+  mode. Un-excluding also requires mapping the suite: `--self-test` refuses a
+  suite that appears in neither list, and that is what catches the half-done
+  version of this change.

--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -126,6 +126,8 @@ _CODEGEN_SUITES = [
     "macos_bundle_chdir_gate",
     "manifest_consistency",
     "native_proof_buffer_views",
+    "shadow_slot_hygiene",
+    "typed_feedback",
     # #7506/#7245: held out until its one failing test was triaged. The
     # composition it guards had drifted from three named callees to three
     # PROPERTIES (the guard-failure edge now reaches `$pshape`, which coerces
@@ -171,18 +173,6 @@ SOURCE_SUITE_MAP = {
 # 262 tests, and holding all 262 out for one of them is how 261 tests' worth of
 # coverage went dark.
 SUITE_EXCLUSIONS = [
-    (
-        "perry-codegen",
-        "shadow_slot_hygiene",
-        "canonical_str_local_keeps_shadow_binding_and_tag_dispatched_ops",
-        "#8264 — red on main; current IR no longer satisfies this shadow-slot assertion.",
-    ),
-    (
-        "perry-codegen",
-        "typed_feedback",
-        "typed_feedback_guards_direct_class_field_specialization",
-        "#8264 — red on main; current IR lacks the asserted class-field fast block.",
-    ),
 ]
 
 # Suites reached through `SOURCE_SUITE_MAP` are exempt from `--cap` and carry a


### PR DESCRIPTION
## Summary

#8333 fixed the last two assertions #8264 recorded as baseline reds. Their
`SUITE_EXCLUSIONS` entries in `scripts/ci_e2e_scope.py` stayed behind, which
does not produce a red build — it produces silence: both suites keep being
skipped in per-PR CI, so the coverage the fix earned back never runs. That is
#7708's failure mode, and it is the same thing #8321 cleaned up after #8302.

**`SUITE_EXCLUSIONS` is now empty.**

## #8264, start to finish

| assertion group | fixed by | status |
|---|---|---|
| six `native_proof_buffer_views` | #8302 | un-excluded in #8321 |
| `shadow_slot_hygiene::canonical_str_local_keeps_shadow_binding_and_tag_dispatched_ops` | #8333 | un-excluded here |
| `typed_feedback::typed_feedback_guards_direct_class_field_specialization` | #8333 | un-excluded here |

Eight red assertions → zero.

## Changes

- Remove both remaining `SUITE_EXCLUSIONS` entries.
- Add `shadow_slot_hygiene` and `typed_feedback` to the mapped set — `--self-test`
  refuses a suite that is in neither list, which is what catches the half-done
  version of this change.

## Validation

Verified on this branch, at the merge of #8333:

```
native_proof_buffer_views  45 passed; 0 failed
shadow_slot_hygiene        13 passed; 0 failed
typed_feedback             17 passed; 0 failed
```

- `python3 scripts/ci_e2e_scope.py --self-test` — exit 0
- `scripts/run_lint_gates.sh` — all 48 lint-tier gates pass

#8264 can be closed once this lands.
