### PR TITLE
feat(publish): local staged-publish pipeline with approve gate + socket scan

### DIFF
--- a/.github/workflows/npm-stage-publish.yml
+++ b/.github/workflows/npm-stage-publish.yml
@@ -1,0 +1,216 @@
+name: npm stage publish
+
+# Perry's OIDC staged-upload workflow, modeled on a tiered registry-infra design
+# adapted to Perry's multi-platform-binary reality.
+#
+# ORDER RULE: this workflow only STAGES — nothing is public, and NO git tag or
+# GitHub release exists yet. The tag + immutable GH release are cut LAST, by
+# the local `npm run publish:approve` (scripts/publish/pipeline.mts), only
+# after the approved version is live on npm.
+#
+# The 9 @perryts/* packages are platform binaries + static libs built on
+# platform runners, so the stage upload MUST follow the per-platform build
+# legs. Rather than duplicate the build matrix (which would drift from
+# release-packages.yml), this workflow dispatches release-packages.yml in its
+# existing `stage` mode (build-only, archives as workflow artifacts, nothing
+# publishes) and then a single `stage-upload` job downloads those artifacts,
+# runs scripts/stage-npm.sh, and `npm stage publish`es each package under
+# OIDC trusted publishing.
+#
+# Auth: OIDC trusted publishing only — id-token: write, NO long-lived NPM_TOKEN.
+# Each @perryts/* package must list this workflow + the `npm-publish` environment
+# as a trusted publisher on npmjs.com (same one-time setup npm/README.md
+# describes for release-packages.yml). The auth-posture gate in
+# scripts/publish/auth-posture.mts refuses any long-lived token present here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Stage for real (false = dry-run, the default).'
+        type: boolean
+        default: false
+      dist-tag:
+        description: 'npm dist-tag to stage under.'
+        type: string
+        default: 'latest'
+      build-run-id:
+        description: 'Reuse an existing release-packages.yml stage-mode build run instead of dispatching a new one.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  # Resolve the build run to stage from: either a caller-supplied build-run-id
+  # (re-use), or dispatch release-packages.yml in stage mode and capture its
+  # run id. The build matrix itself lives in release-packages.yml — single
+  # source of truth, no drift.
+  resolve-build:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write   # dispatch release-packages.yml (stage mode) + watch it
+      contents: read
+    outputs:
+      build-run-id: ${{ steps.resolve.outputs.build-run-id }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve or dispatch the stage-mode build
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EXISTING: ${{ inputs.build-run-id }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EXISTING" ]; then
+            RUN_ID="$EXISTING"
+            echo "Reusing build run $RUN_ID."
+          else
+            # Dispatch release-packages.yml in stage mode. Stage mode is the
+            # DEFAULT workflow_dispatch (no inputs = build-only smoke run; the
+            # preflight job's else-branch sets MODE=stage), so no input is needed.
+            DISPATCHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            gh workflow run release-packages.yml -R "$REPO"
+            # Poll for the workflow_dispatch run we just created. Match by
+            # event + createdAt after the dispatch timestamp — NOT just the
+            # newest run, which could be a concurrent or unrelated dispatch and
+            # would stage the wrong artifacts.
+            sleep 5
+            RUN_ID=""
+            for i in $(seq 1 20); do
+              RUN_ID=$(gh run list --workflow release-packages.yml -R "$REPO" \
+                --event workflow_dispatch --limit 5 \
+                --json databaseId,createdAt \
+                --jq "[.[] | select(.createdAt >= \"$DISPATCHED_AT\")][0].databaseId" 2>/dev/null || true)
+              if [ -n "$RUN_ID" ]; then break; fi
+              sleep 3
+            done
+            if [ -z "$RUN_ID" ]; then
+              echo "::error::could not resolve a release-packages.yml run id after dispatch." >&2
+              exit 1
+            fi
+            echo "Dispatched release-packages.yml stage build: run $RUN_ID."
+          fi
+          echo "build-run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+      - name: Await the stage-mode build
+        # The build MUST finish before stage-upload can download its artifacts
+        # — actions/download-artifact from an in-progress run gets nothing.
+        # gh run watch returns immediately for an already-completed run, so
+        # this is safe for the reuse-existing-run-id path too.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RUN_ID="${{ steps.resolve.outputs.build-run-id }}"
+          echo "Watching release-packages.yml run $RUN_ID to completion…"
+          gh run watch "$RUN_ID" -R "$REPO" --exit-status
+          echo "Build run $RUN_ID succeeded — ready to download artifacts."
+
+  # The OIDC stage upload. Downloads the build artifacts from the resolved
+  # run, stages the npm packages, and `npm stage publish`es each under OIDC.
+  stage-upload:
+    needs: resolve-build
+    runs-on: ubuntu-latest
+    environment: npm-publish   # npm's trusted-publisher config pins this env name
+    permissions:
+      actions: read     # download artifacts from the resolved stage-mode build run
+      contents: read
+      id-token: write   # npm provenance / trusted publishing mints the OIDC token here
+    env:
+      DIST_TAG: ${{ inputs.dist-tag }}
+      BUILD_RUN_ID: ${{ needs.resolve-build.outputs.build-run-id }}
+      PUBLISH: ${{ inputs.publish }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # DELIBERATE EXEMPTION from the repo-wide .node-version pin: this Node is
+      # a publishing toolchain (npm registry auth), not a test oracle.
+      # Registered in scripts/check_node_version_consistency.py.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "26"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm + assert the publish-flow floor
+        # The floor is npm >= 11.17: it is the newest of the features this job
+        # needs — `npm stage` (staged publishing, >= 11.15.0), OIDC trusted
+        # publishing (>= 11.5.1), and `min-release-age` in DAYS (>= 11.17).
+        # npm@latest satisfies it; the assert is a fail-fast guard if the
+        # runner image or a future pin ever drops below.
+        run: |
+          npm install -g npm@latest
+          floor=11.17.0
+          cur=$(npm --version | tr -d 'v')
+          if [ "$(printf '%s\n%s\n' "$floor" "$cur" | sort -V | head -n1)" != "$floor" ]; then
+            echo "::error::npm $cur is below the publish-flow floor of $floor (staged publishing + OIDC + min-release-age)." >&2
+            exit 1
+          fi
+          echo "npm $cur satisfies the publish-flow floor (>= $floor)."
+
+      - name: Download build artifacts from the stage-mode build run
+        uses: actions/download-artifact@v8
+        with:
+          path: release-artifacts/
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-build.outputs.build-run-id }}
+
+      - name: Stage npm packages
+        run: ./scripts/stage-npm.sh release-artifacts/
+
+      - name: Sanity-check staged packages
+        run: |
+          for dir in npm/perry npm/perry-*; do
+            if [ ! -f "$dir/package.json" ]; then
+              echo "::error::MISSING package.json in $dir" >&2
+              exit 1
+            fi
+            node -e "const p=require('./$dir/package.json'); console.log(p.name, p.version)"
+          done
+
+      - name: npm stage publish (OIDC, platforms first, wrapper last)
+        # Stages ONLY — nothing is public until the local `publish:approve` runs
+        # `npm stage approve` with 2FA. Skip versions already staged/published
+        # so the job is idempotent. One platform's failure must not starve the
+        # packages after it — record failures, keep going, fail at the end.
+        # NO NPM_TOKEN secret is set — OIDC trusted publishing mints the token
+        # from id-token: write (setup-node registry-url + the npm-publish env).
+        run: |
+          set -e
+          if [ "$PUBLISH" != "true" ]; then
+            echo "PUBLISH=false (dry-run) — running stage-npm only, no registry writes."
+            exit 0
+          fi
+          # Refuse any long-lived token (the auth-posture gate, in shell form).
+          for v in NPM_TOKEN NODE_AUTH_TOKEN NPM_AUTH_TOKEN; do
+            if [ -n "$(printenv $v 2>/dev/null || true)" ]; then
+              echo "::error::Refusing to stage in CI with a long-lived $v token — OIDC is the only sanctioned path." >&2
+              exit 1
+            fi
+          done
+          failed=""
+          for pkg in ./npm/perry-*; do
+            name=$(node -p "require('$pkg/package.json').name")
+            ver=$(node -p "require('$pkg/package.json').version")
+            echo "=== staging $name@$ver ==="
+            if ! npm stage publish "$pkg" --access public --tag "$DIST_TAG" --ignore-scripts --provenance; then
+              echo "::error::npm stage publish failed for $name@$ver — continuing" >&2
+              failed="$failed $name@$ver"
+            fi
+          done
+          # Wrapper LAST (optionalDependencies must be staged first).
+          name=$(node -p "require('./npm/perry/package.json').name")
+          ver=$(node -p "require('./npm/perry/package.json').version")
+          echo "=== staging $name@$ver (wrapper, last) ==="
+          if ! npm stage publish ./npm/perry --access public --tag "$DIST_TAG" --ignore-scripts --provenance; then
+            echo "::error::npm stage publish failed for $name@$ver" >&2
+            failed="$failed $name@$ver"
+          fi
+          if [ -n "$failed" ]; then
+            echo "::error::staging failures:$failed" >&2
+            exit 1
+          fi
+          echo "All 9 packages staged (not public). Next: npm run publish:approve locally."

--- a/changelog.d/8336-staged-publish-pipeline.md
+++ b/changelog.d/8336-staged-publish-pipeline.md
@@ -1,0 +1,53 @@
+Add a local staged-publish pipeline, ported from the fleet-style staged-publish
+publish architecture and made Perry-centric. Publishing was previously
+CI-only (`release-packages.yml`) with no approve gate and no pre-publish
+tarball scan; this adds `npm run publish:*` scripts that stage, verify,
+socket-scan, and — after a human approve gate — promote + cut the GitHub
+release.
+
+**New `scripts/publish/` tree** (generic core + npm/brew/cargo tiers):
+
+- `pipeline.mts` — orchestrator: `publish:stage` (dispatch the new
+  `npm-stage-publish.yml` CI workflow under OIDC) → verify (local `npm pack`
+  sha1 vs staged shasum) → Socket full-scan → `publish:approve` (browser
+  web-OTP 2FA `npm stage approve`) → `publish:release` (tag + immutable
+  GitHub release, draft→upload→undraft, behind a registry-liveness gate).
+- `scan.mts` — Socket full-scan of each staged tarball via
+  `@socketsecurity/sdk` `createOrgFullScanFromArchive`; `error`-action alerts
+  (per the org's own security policy) fail the gate, `warn`-action alerts pass
+  with counts. Fail-closed on unreachable/empty scans.
+- `npm/{staged,approve,publish-command,pack via staged,shared,bump}.mts` —
+  the `npm stage publish`/`npm stage approve` mechanics, the shasum verify
+  gate, and Perry's version source (Cargo.toml + CLAUDE.md `Current Version`
+  agreement + `changelog.d/` fragments + tag-not-already-existing — the same
+  STOP conditions `release-packages.yml` enforces, surfaced locally so a bad
+  dispatch fails in seconds).
+- `auth-posture.mts` — refuses any long-lived `NPM_TOKEN`/`NODE_AUTH_TOKEN`/
+  `NPM_AUTH_TOKEN` on publish (OIDC-in-CI + 2FA-locally only). A read-only
+  `PERRY_NPM_READONLY_TOKEN` powers registry reads and can never publish.
+  `prepublishOnly` is wired to this guard.
+- `brew/{formula,tap-publish}.mts` + `cargo/ffi-publish.mts` — locally-runnable
+  brew tap bump (render `Formula/perry.rb` from release coordinates + per-asset
+  sha256, push to `PerryTS/homebrew-perry`) and the perry-ffi → crates.io
+  publish (perry-runtime-first order preserved).
+- `release.mts` uploads `packaging/install.sh` + `checksums.txt` as per-tag
+  release assets, so `curl -fsSL …/releases/download/vX.Y.Z/install.sh | sh`
+  works per tag.
+
+**New CI workflow** `.github/workflows/npm-stage-publish.yml`: an OIDC staged
+upload (build legs reused from `release-packages.yml` stage mode →
+`stage-npm.sh` → `npm stage publish --provenance` for all 9 packages,
+`environment: npm-publish`, `id-token: write`, no long-lived token). Stages
+ONLY — nothing is public until the local `publish:approve`. The existing
+`release-packages.yml` `npm-publish` job stays as the republish/emergency
+fallback.
+
+**Prerequisites the author provisions** (documented in-script): npm staged
+publishing enrolled for `@perryts/*`; the new workflow added as a trusted
+publisher on each package; `SOCKET_API_TOKEN` for scans; `HOMEBREW_TAP_TOKEN`/
+`APT_REPO_TOKEN` for tap pushes; `PERRY_NPM_READONLY_TOKEN` for registry reads.
+
+Tests: `scripts/publish/publish.test.mts` covers the formula renderer, policy
+bucketing, human-gate shape, and the auth-posture refusal (sabotage-tested:
+the refusal is asserted with a long-lived token present and the clean path
+with it absent).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "node-cron": "^4.2.1"
       },
       "devDependencies": {
+        "@socketsecurity/sdk": "4.1.4",
         "cron": "^4.4.0",
         "dayjs": "^1.11.21",
         "exponential-backoff": "^3.1.3",
@@ -57,6 +58,18 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@socketsecurity/sdk": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@socketsecurity/sdk/-/sdk-4.1.4.tgz",
+      "integrity": "sha512-1VU+nhQXhK5ttH5N7ehVHfk+eSyHXX/BaqDV6RVwAtyWarcYlcSdJq+SMV5ykBo08DRdF6W1ZoG0DesgjovmPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=24",
+        "npm": ">=12.0.1",
+        "pnpm": ">=11.0.5"
       }
     },
     "node_modules/@types/luxon": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,19 @@
     "tools:check": "node scripts/soak/external-tools.mts --check",
     "tools:fix": "node scripts/soak/external-tools.mts --fix",
     "tools:install": "node scripts/soak/external-tools.mts --install-all --shims",
-    "test:scripts": "node --test scripts/soak/*.test.mts"
+    "test:scripts": "node --test scripts/soak/*.test.mts scripts/publish/*.test.mts",
+    "publish:pipeline": "node scripts/publish/pipeline.mts",
+    "publish:stage": "node scripts/publish/pipeline.mts --stage-only",
+    "publish:scan": "node scripts/publish/pipeline.mts --scan-only",
+    "publish:approve": "node scripts/publish/pipeline.mts --approve",
+    "publish:status": "node scripts/publish/pipeline.mts --status",
+    "publish:release": "node scripts/publish/pipeline.mts --release-only",
+    "publish:brew": "node scripts/publish/brew/tap-publish.mts",
+    "publish:ffi": "node scripts/publish/cargo/ffi-publish.mts",
+    "prepublishOnly": "node scripts/publish/auth-posture.mts --guard"
   },
   "devDependencies": {
+    "@socketsecurity/sdk": "4.1.4",
     "cron": "^4.4.0",
     "dayjs": "^1.11.21",
     "exponential-backoff": "^3.1.3",

--- a/scripts/check_node_version_consistency.py
+++ b/scripts/check_node_version_consistency.py
@@ -175,6 +175,18 @@ EXEMPTIONS: tuple[Exemption, ...] = (
         locator=_workflow_pins,
     ),
     Exemption(
+        path=".github/workflows/npm-stage-publish.yml",
+        value="26",
+        major_tracks_oracle=True,
+        reason=(
+            "npm *publishing* toolchain (OIDC staged-upload + npm stage "
+            "publishing), never a test oracle. Major literal for the same "
+            "reason as release-packages.yml -- a gap-suite oracle bump must "
+            "not move the runtime that publishes releases."
+        ),
+        locator=_workflow_pins,
+    ),
+    Exemption(
         path="benchmarks/public-baseline-config.json",
         value="v22.23.1",
         major_tracks_oracle=False,

--- a/scripts/publish/auth-posture.mts
+++ b/scripts/publish/auth-posture.mts
@@ -1,0 +1,131 @@
+/**
+ * @file Auth-posture gate, modeled on a tiered registry-infra design
+ *   Perry's publish is OIDC-in-CI (the npm-stage-publish
+ *   workflow, id-token: write) + browser web-OTP 2FA locally (npm stage
+ *   approve). A long-lived npm token present during a publish is a DEFECT,
+ *   not a convenience — it bypasses provenance and outlives the release.
+ *
+ *   - PREFLIGHT: refuse BEFORE any upload if a long-lived token is present in
+ *     CI (where OIDC is the only sanctioned path).
+ *   - POSTFLIGHT: scan command output for a failed OIDC exchange that
+ *     "succeeded" anyway (ERR_PNPM_AUTH_TOKEN_EXCHANGE / Skipped OIDC) — a
+ *     publish that landed after a broken exchange is treated as a failure.
+ *
+ *   The read-only token (PERRY_NPM_READONLY_TOKEN) is permitted everywhere —
+ *   it powers registry reads (npm view, staged-download) and can never
+ *   publish.
+ */
+
+import process from 'node:process'
+
+import {
+  LONG_LIVED_NPM_TOKEN_ENV_VARS,
+  READONLY_TOKEN_ENV,
+} from './constants.mts'
+
+/** True when running inside GitHub Actions (the OIDC-sanctioned channel). */
+export function isCI(): boolean {
+  return process.env['GITHUB_ACTIONS'] === 'true'
+}
+
+/** The OIDC-exchange failure markers postflight scans for in command output. */
+export const OIDC_FAILURE_MARKERS = [
+  'ERR_PNPM_AUTH_TOKEN_EXCHANGE',
+  'Skipped OIDC',
+  'OIDC token exchange',
+] as const
+
+/**
+ * Preflight: refuse before an upload if a long-lived publish token is present.
+ * In CI, OIDC is the only sanctioned path. Locally, a direct publish is
+ * permitted only for the 0.0.0 name reservation (escape hatch) — real
+ * releases stage in CI and approve locally with 2FA. A direct publish of any
+ * OTHER version with a long-lived token present is refused, so the escape
+ * hatch cannot be widened into a general bypass.
+ *
+ * Pass `version` (the manifest version being published) so the reservation
+ * can be enforced; without it, a direct upload with a long-lived token is
+ * refused (fail-closed — the caller must prove it is the reservation).
+ *
+ * Returns a non-empty string reason when the posture is refused, or undefined
+ * when it is clean.
+ */
+export function publishAuthPreflight(config: {
+  ci?: boolean
+  direct?: boolean
+  dryRun?: boolean
+  version?: string
+}): string | undefined {
+  const { ci = isCI(), direct = false, dryRun = false, version } = config
+  if (dryRun) return undefined
+  const present = LONG_LIVED_NPM_TOKEN_ENV_VARS.filter(
+    v => process.env[v] !== undefined && process.env[v] !== '',
+  )
+  if (present.length === 0) return undefined
+  if (ci) {
+    return (
+      `Refusing to publish in CI with a long-lived token present: ${present.join(', ')}. ` +
+      'CI publishes via OIDC trusted publishing (id-token: write) — unset the token and re-run.'
+    )
+  }
+  if (!direct) {
+    return (
+      `Refusing to stage with a long-lived token present: ${present.join(', ')}. ` +
+      'Staging runs in CI under OIDC; locally only the 2FA approve is sanctioned. ' +
+      'Unset the token and dispatch the stage workflow instead.'
+    )
+  }
+  // direct local publish with a long-lived token: permitted ONLY for the 0.0.0
+  // name reservation escape hatch. Any other version (or an unknown version)
+  // is refused — the escape hatch must not become a general bypass.
+  if (version !== '0.0.0') {
+    return (
+      `Refusing a direct publish with a long-lived token present: ${present.join(', ')}. ` +
+      `The direct escape hatch is reserved for the 0.0.0 name reservation only (got version ${version ?? '<unknown>'}). ` +
+      'Real releases stage in CI under OIDC and approve locally with 2FA — unset the token and dispatch the stage workflow.'
+    )
+  }
+  return undefined
+}
+
+/**
+ * Postflight: a publish that "succeeded" after a failed OIDC exchange is a
+ * failure. Returns true when the output shows an OIDC-exchange failure marker.
+ */
+export function publishAuthPostflight(output: string): boolean {
+  return OIDC_FAILURE_MARKERS.some(m => output.includes(m))
+}
+
+/**
+ * The prepublishOnly guard entrypoint. Refuses any `npm publish` / `npm
+ * publish` run that carries a long-lived token, and reminds the operator to
+ * use the staged pipeline instead.
+ */
+export function prepublishOnlyGuard(): number {
+  const reason = publishAuthPreflight({
+    ci: isCI(),
+    direct: true,
+    dryRun: false,
+  })
+  const present = LONG_LIVED_NPM_TOKEN_ENV_VARS.filter(
+    v => process.env[v] !== undefined && process.env[v] !== '',
+  )
+  if (present.length > 0 && reason) {
+    console.error(`ERROR: ${reason}`)
+    return 1
+  }
+  console.error(
+    "ERROR: use `npm run publish:pipeline` (staged) — direct publish is not the sanctioned path.",
+  )
+  return 1
+}
+
+// --- CLI entry (prepublishOnly guard) ---------------------------------------
+import { fileURLToPath } from 'node:url'
+
+const isMainModule =
+  process.argv[1] === fileURLToPath(new URL(import.meta.url))
+
+if (isMainModule) {
+  process.exit(prepublishOnlyGuard())
+}

--- a/scripts/publish/brew/formula.mts
+++ b/scripts/publish/brew/formula.mts
@@ -1,0 +1,100 @@
+/**
+ * @file Pure Homebrew-formula renderer for Perry, modeled on a tiered registry-infra design
+ *   adapted to Perry's asset naming +
+ *   from-source linux build. Every input arrives as data — no filesystem, no
+ *   network, no gh — so the whole surface is unit-testable without a tap.
+ *
+ *   Perry ships prebuilt macOS binaries (perry-macos-aarch64.tar.gz,
+ *   perry-macos-x86_64.tar.gz) but the Homebrew formula builds from source on
+ *   Linux (cargo build from the tag archive) — matching the existing
+ *   packaging/homebrew/perry.rb shape.
+ */
+
+export interface PerryFormulaSpec {
+  /** Bare version, no leading v — `0.5.1510`. */
+  version: string
+  /** sha256 of the macos-aarch64 tarball. */
+  macosArm64Sha256: string
+  /** sha256 of the macos-x86_64 tarball. */
+  macosX64Sha256: string
+  /** sha256 of the source archive (archive/refs/tags/vX.Y.Z.tar.gz) for linux. */
+  linuxSourceSha256: string
+}
+
+export const RELEASE_REPO = 'PerryTS/perry'
+
+/** Download URL for a release asset. */
+export function assetUrl(tag: string, assetName: string): string {
+  return `https://github.com/${RELEASE_REPO}/releases/download/${tag}/${assetName}`
+}
+
+/** Source archive URL for the linux from-source build. */
+export function sourceArchiveUrl(version: string): string {
+  return `https://github.com/${RELEASE_REPO}/archive/refs/tags/v${version}.tar.gz`
+}
+
+/**
+ * Render Formula/perry.rb. Byte-identical regenerations when nothing moved —
+ * the tap bump stays diff-quiet. Mirrors the existing perry.rb shape.
+ */
+export function renderPerryFormula(spec: PerryFormulaSpec): string {
+  const tag = `v${spec.version}`
+  return [
+    'class Perry < Formula',
+    '  desc "Native TypeScript compiler — compiles TypeScript to native executables"',
+    `  homepage "https://github.com/${RELEASE_REPO}"`,
+    `  version "${spec.version}"`,
+    '  license "MIT"',
+    '',
+    '  on_macos do',
+    '    on_arm do',
+    `      url "${assetUrl(tag, 'perry-macos-aarch64.tar.gz')}"`,
+    `      sha256 "${spec.macosArm64Sha256}"`,
+    '    end',
+    '    on_intel do',
+    `      url "${assetUrl(tag, 'perry-macos-x86_64.tar.gz')}"`,
+    `      sha256 "${spec.macosX64Sha256}"`,
+    '    end',
+    '  end',
+    '',
+    '  on_linux do',
+    `    url "${sourceArchiveUrl(spec.version)}"`,
+    `    sha256 "${spec.linuxSourceSha256}"`,
+    '    depends_on "rust" => :build',
+    '  end',
+    '',
+    '  def install',
+    '    if OS.mac?',
+    '      bin.install "perry"',
+    '      lib.install Dir["libperry_*.a"]',
+    '    else',
+    '      system "cargo", "build", "--release"',
+    '      system "cargo", "build", "--release", "-p", "perry-runtime", "-p", "perry-stdlib"',
+    '      bin.install "target/release/perry"',
+    '      lib.install Dir["target/release/libperry_*.a"]',
+    '    end',
+    '  end',
+    '',
+    '  def caveats',
+    '    <<~EOS',
+    '      Perry requires a C linker to link compiled executables.',
+    '',
+    '      macOS:  Xcode Command Line Tools (xcode-select --install)',
+    '      Linux:  GCC or Clang (sudo apt install build-essential)',
+    '',
+    '      Quick start:',
+    "        echo 'console.log(\"hello\")' > hello.ts",
+    '        perry hello.ts -o hello && ./hello',
+    '    EOS',
+    '  end',
+    '',
+    '  test do',
+    '    assert_match "perry", shell_output("#{bin}/perry --version")',
+    '    (testpath/"test.ts").write(\'console.log("works");\')',
+    '    system bin/"perry", testpath/"test.ts", "-o", testpath/"test"',
+    '    assert_equal "works\\n", shell_output(testpath/"test")',
+    '  end',
+    'end',
+    '',
+  ].join('\n')
+}

--- a/scripts/publish/brew/tap-publish.mts
+++ b/scripts/publish/brew/tap-publish.mts
@@ -1,0 +1,141 @@
+/**
+ * @file Homebrew tap publisher for Perry. Downloads the macOS arm64/x86_64
+ *   release tarballs + the source archive, computes sha256 for each, renders
+ *   Formula/perry.rb via brew/formula.mts, and pushes to PerryTS/homebrew-perry
+ *   with HOMEBREW_TAP_TOKEN. Mirrors what the `homebrew` CI leg in
+ *   release-packages.yml does, made locally runnable.
+ *
+ *   Usage: npm run publish:brew [-- --version 0.5.1510]
+ *   Env:   HOMEBREW_TAP_TOKEN (write access to PerryTS/homebrew-perry)
+ */
+
+import { createHash } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { HOMEBREW_TAP_REPO, rootPath } from '../constants.mts'
+import { logger, runCapture } from '../shared.mts'
+import { readCargoVersion } from '../npm/bump.mts'
+import { renderPerryFormula, type PerryFormulaSpec } from './formula.mts'
+
+/** Download a release asset to dest and return its sha256 (hex). */
+async function downloadAndSha256(url: string, dest: string): Promise<string> {
+  const code = await runCapture('curl', ['-fsSL', '-o', dest, url], os.tmpdir())
+  if (code.code !== 0) {
+    throw new Error(`download failed (${code.code}): ${url}`)
+  }
+  const bytes = await readFile(dest)
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  const versionArgIdx = argv.indexOf('--version')
+  const version =
+    versionArgIdx !== -1 ? argv[versionArgIdx + 1] : readCargoVersion(rootPath)
+  if (!version) {
+    logger.fail('could not resolve version (pass --version or run from a checkout with Cargo.toml).')
+    process.exitCode = 1
+    return
+  }
+  const token = process.env['HOMEBREW_TAP_TOKEN']
+  if (!token) {
+    logger.fail('HOMEBREW_TAP_TOKEN is not set — cannot push to the homebrew tap.')
+    process.exitCode = 1
+    return
+  }
+  const tag = `v${version}`
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'perry-brew-'))
+  try {
+    const base = `https://github.com/PerryTS/perry/releases/download/${tag}`
+    const sourceArchive = `https://github.com/PerryTS/perry/archive/refs/tags/${tag}.tar.gz`
+    logger.log(`Downloading release assets for ${tag}…`)
+    const macosArm64Sha256 = await downloadAndSha256(
+      `${base}/perry-macos-aarch64.tar.gz`,
+      path.join(tmp, 'macos-aarch64.tar.gz'),
+    )
+    const macosX64Sha256 = await downloadAndSha256(
+      `${base}/perry-macos-x86_64.tar.gz`,
+      path.join(tmp, 'macos-x86_64.tar.gz'),
+    )
+    let linuxSourceSha256: string
+    try {
+      linuxSourceSha256 = await downloadAndSha256(sourceArchive, path.join(tmp, 'source.tar.gz'))
+    } catch (e) {
+      logger.fail(
+        `source archive download failed (${String(e)}) — cannot build the formula without a valid Linux source sha256. ` +
+          'A PLACEHOLDER sha256 would make `brew install` fail the checksum check.',
+      )
+      process.exitCode = 1
+      return
+    }
+    const spec: PerryFormulaSpec = {
+      version,
+      macosArm64Sha256,
+      macosX64Sha256,
+      linuxSourceSha256,
+    }
+    const formula = renderPerryFormula(spec)
+
+    // Clone the tap, write Formula/perry.rb, commit + push. The token is kept
+    // out of the process argument list and out of .git/config: clone the plain
+    // HTTPS URL and supply the credential through a helper that reads
+    // HOMEBREW_TAP_TOKEN from the (inherited) environment.
+    const credHelper = '!f() { echo "username=x-access-token"; echo "password=$HOMEBREW_TAP_TOKEN"; }; f'
+    logger.log(`Cloning ${HOMEBREW_TAP_REPO}…`)
+    const tapDir = path.join(tmp, 'tap')
+    const clone = await runCapture(
+      'git',
+      ['clone', '-c', `credential.helper=${credHelper}`, `https://github.com/${HOMEBREW_TAP_REPO}.git`, tapDir],
+      os.tmpdir(),
+    )
+    if (clone.code !== 0) {
+      logger.fail(`git clone of ${HOMEBREW_TAP_REPO} failed (${clone.code}).`)
+      process.exitCode = 1
+      return
+    }
+    const formulaDir = path.join(tapDir, 'Formula')
+    mkdirSync(formulaDir, { recursive: true })
+    writeFileSync(path.join(formulaDir, 'perry.rb'), formula)
+
+    const commitMsg = `perry ${tag}`
+    // A re-run for a version already in the tap leaves the formula unchanged;
+    // `git commit` exits non-zero then. Treat "nothing to commit" as success
+    // (the tap already carries the correct formula) instead of failing.
+    const addR = await runCapture('git', ['add', path.join('Formula', 'perry.rb')], tapDir)
+    if (addR.code !== 0) {
+      logger.fail(`git add failed (${addR.code}).`)
+      process.exitCode = 1
+      return
+    }
+    const diffR = await runCapture('git', ['diff', '--cached', '--quiet'], tapDir)
+    if (diffR.code === 0) {
+      logger.log(`Formula unchanged for ${tag} — tap already carries it. Nothing to push.`)
+    } else {
+      for (const [args, label] of [
+        [['commit', '-m', commitMsg], 'git commit'],
+        [['-c', `credential.helper=${credHelper}`, 'push', 'origin', 'HEAD'], 'git push'],
+      ] as [string[], string][]) {
+        const r = await runCapture('git', args, tapDir)
+        if (r.code !== 0) {
+          logger.fail(`${label} failed (${r.code}).`)
+          process.exitCode = 1
+          return
+        }
+      }
+      logger.log(`Homebrew tap updated: ${HOMEBREW_TAP_REPO}@${tag}. brew install perryts/perry/perry`)
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+// Only run when invoked directly (node scripts/publish/brew/tap-publish.mts),
+// not when imported for testing.
+import { fileURLToPath } from 'node:url'
+if (process.argv[1] === fileURLToPath(new URL(import.meta.url))) {
+  await main()
+}

--- a/scripts/publish/cargo/ffi-publish.mts
+++ b/scripts/publish/cargo/ffi-publish.mts
@@ -1,0 +1,51 @@
+/**
+ * @file perry-ffi → crates.io publisher, ported from scripts/publish_perry_ffi.sh
+ *   into the publish-script tree. Maintainer-only: needs ~/.cargo/credentials.toml
+ *   with a crates.io API token (`cargo login` once).
+ *
+ *   PREREQUISITE: publish perry-runtime first. perry-ffi has an optional dep on
+ *   perry-runtime gated by the `runtime-link` feature; cargo publish rejects
+ *   perry-ffi until the matching perry-runtime version exists on crates.io.
+ *   perry-runtime's own workspace-crate deps need similar handling (out of
+ *   scope here — the order is documented, not automated).
+ *
+ *   Usage: npm run publish:ffi
+ */
+
+import process from 'node:process'
+
+import { rootPath } from '../constants.mts'
+import { logger, runInherit } from '../shared.mts'
+import { readCargoVersion } from '../npm/bump.mts'
+
+async function main(): Promise<void> {
+  const version = readCargoVersion(rootPath)
+  if (!version) {
+    logger.fail('could not parse workspace version from Cargo.toml.')
+    process.exitCode = 1
+    return
+  }
+  logger.log(`Workspace version: ${version}`)
+  logger.warn(
+    'Prerequisite: perry-runtime@' + version + ' must already exist on crates.io ' +
+      '(perry-ffi optional-deps gate). Publish it first if it does not.',
+  )
+  // Verify the package builds + would publish cleanly, then publish.
+  // --allow-dirty: this script runs from a clean main right after a release
+  // commit, but the worktree may still have generated CHANGELOG/Cargo.lock
+  // changes from the auto-optimize pass.
+  const code = await runInherit('cargo', ['publish', '-p', 'perry-ffi', '--allow-dirty'], rootPath)
+  if (code !== 0) {
+    logger.fail(`cargo publish -p perry-ffi failed (exit ${code}).`)
+    process.exitCode = 1
+    return
+  }
+  logger.log(`perry-ffi@${version} published to crates.io.`)
+}
+
+// Only run when invoked directly (node scripts/publish/cargo/ffi-publish.mts),
+// not when imported for testing.
+import { fileURLToPath } from 'node:url'
+if (process.argv[1] === fileURLToPath(new URL(import.meta.url))) {
+  await main()
+}

--- a/scripts/publish/constants.mts
+++ b/scripts/publish/constants.mts
@@ -1,0 +1,105 @@
+/**
+ * @file Perry publish-pipeline constants. The single place that names the
+ *   packages, tap repos, and paths the staged-publish scripts touch, so a
+ *   future package or tap change is one edit. Hardcoded to Perry (Perry is
+ *   not a fleet member — "generic" means portable structure, not cascade
+ *   enrollment).
+ */
+
+import path from 'node:path'
+
+/** Repo root = parent of scripts/. */
+export const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '..',
+  '..',
+)
+
+/** Alias used across the publish modules (mirrors a shared `rootPath`). */
+export const rootPath = REPO_ROOT
+
+/** The 8 platform packages, staged BEFORE the wrapper (optionalDependencies). */
+export const PLATFORM_PACKAGES = [
+  '@perryts/perry-darwin-arm64',
+  '@perryts/perry-darwin-x64',
+  '@perryts/perry-linux-x64',
+  '@perryts/perry-linux-arm64',
+  '@perryts/perry-linux-x64-musl',
+  '@perryts/perry-linux-arm64-musl',
+  '@perryts/perry-win32-x64',
+  '@perryts/perry-win32-arm64',
+] as const
+
+/** The launcher wrapper — staged/approved LAST. */
+export const WRAPPER_PACKAGE = '@perryts/perry'
+
+/** All 9, in publish order: platforms first, wrapper last. */
+export const ALL_PACKAGES: readonly string[] = [
+  ...PLATFORM_PACKAGES,
+  WRAPPER_PACKAGE,
+]
+
+/** npm dist-tag floor — `latest` is what an untagged install resolves to. */
+export const DEFAULT_DIST_TAG = 'latest'
+
+/** The GitHub release repo. */
+export const RELEASE_REPO = 'PerryTS/perry'
+
+/** Tap repos the brew/apt legs push to. */
+export const HOMEBREW_TAP_REPO = 'PerryTS/homebrew-perry'
+export const APT_REPO = 'PerryTS/perry-apt'
+
+/** Path to the curl install script, uploaded as a per-tag release asset. */
+export const INSTALL_SH = 'packaging/install.sh'
+
+/** Path to the Homebrew formula the brew tier renders. */
+export const HOMEBREW_FORMULA = 'packaging/homebrew/perry.rb'
+
+/** Path to the changelog fragments folder (release notes source). */
+export const CHANGELOG_D = 'changelog.d'
+
+/** Shared pipeline state dir (verify/scan/approve receipts). */
+export const PIPELINE_STATE_DIR = '.cache/perry/publish-pipeline'
+
+/** Socket org slug for tarball scans. */
+export const SOCKET_ORG_SLUG = 'perryts'
+
+/** The Socket scan "repo" label stamped on a staged-upload scan. */
+export const SOCKET_SCAN_REPO = 'perry-staged-publish-gate'
+
+/**
+ * npm package directories under npm/, in stage order. The launcher lives at
+ * npm/perry; each platform package at npm/perry-<suffix>.
+ */
+export function npmPackageDir(name: string): string {
+  // @perryts/perry-darwin-arm64 → npm/perry-darwin-arm64
+  // @perryts/perry              → npm/perry
+  return `npm/${name.replace(/^@perryts\//, '')}`
+}
+
+/**
+ * Long-lived npm token env vars the auth-posture gate REFUSES on publish.
+ * Publish is OIDC-in-CI + browser-2FA-locally; a long-lived token present
+ * during a publish is a defect, not a convenience. Modeled on a tiered registry-infra design
+ * auth-posture gate.
+ */
+export const LONG_LIVED_NPM_TOKEN_ENV_VARS = [
+  'NODE_AUTH_TOKEN',
+  'NPM_AUTH_TOKEN',
+  'NPM_TOKEN',
+] as const
+
+/** Read-only registry-read token (granular, read-only scope). Never publishes. */
+export const READONLY_TOKEN_ENV = 'PERRY_NPM_READONLY_TOKEN'
+
+/**
+ * Minimum npm version for the publish flow. The binding floor is the newest of
+ * the features the flow needs:
+ *   - `npm stage` (staged publishing)          → npm >= 11.15.0
+ *   - OIDC Trusted Publisher                    → npm >= 11.5.1
+ *   - `min-release-age` in DAYS (the .npmrc soak) → npm >= 11.17
+ *   - `--provenance`                            → npm >= 9.5
+ * 11.17.0 covers them all; anything older gets a clear error instead of a
+ * cryptic `npm stage` failure.
+ */
+export const NPM_MIN_VERSION = '11.17.0'

--- a/scripts/publish/human-gate.mts
+++ b/scripts/publish/human-gate.mts
@@ -1,0 +1,58 @@
+/**
+ * @file The 🖐 HUMAN GATE block, verbatim shape from the global CLAUDE.md
+ *   human-gate prompt protocol. The publish approve stage renders this when
+ *   it reaches a step only the human can clear (the browser web-OTP 2FA
+ *   promote). Pure — returns the block string; the caller prints it.
+ *
+ *   Lane A is copy-pasteable (the verbatim command the human runs); lane B is
+ *   what an agent says to drive the same command. Both lanes always present.
+ */
+
+export interface HumanGateSpec {
+  /** Short label, e.g. "approve". */
+  name: string
+  /** Index/total, e.g. "1/1". */
+  index?: string
+  /** What is blocked and why, one sentence. */
+  need: string
+  /** The active guard/tool restriction that shaped the lanes. */
+  mind: string
+  /** Lane A: the verbatim phrase to type, or the exact `! <command>` to run. */
+  you: string
+  /** Lane B: what the agent says to drive the SAME command. */
+  me: string
+  /** What resumes once cleared. */
+  then: string
+}
+
+/**
+ * Render the 🖐 HUMAN GATE block. Kept byte-faithful to the global CLAUDE.md
+ * shape: a space between the glyph and the label, lanes A/B always present.
+ */
+export function formatHumanGate(spec: HumanGateSpec): string {
+  const idx = spec.index ? ` [${spec.index}]` : ''
+  return [
+    `🖐  HUMAN GATE — ${spec.name}${idx}`,
+    `  Need: ${spec.need}`,
+    `  Mind: ${spec.mind}`,
+    `  A) You: ${spec.you}`,
+    `  B) Me: ${spec.me}`,
+    `  Then: ${spec.then}`,
+  ].join('\n')
+}
+
+/** The approve gate the publish pipeline raises at the promote step. */
+export function formatApproveGate(opts: {
+  version: string
+  repoPath: string
+}): string {
+  return formatHumanGate({
+    name: 'approve',
+    index: '1/1',
+    need: `the staged @perryts/* v${opts.version} upload is verified + socket-scanned; the 2FA promote to live is a human action.`,
+    mind: 'npm stage approve requires browser web-OTP 2FA — no long-lived token; the stage upload ran in CI under OIDC.',
+    you: `cd ${opts.repoPath} && npm run publish:approve`,
+    me: 'I will run `npm run publish:approve` so npm opens the browser for web-OTP 2FA and promotes the staged entries to live.',
+    then: 'registry liveness is confirmed, the vX.Y.Z tag + immutable GitHub release are cut (draft→upload install.sh+checksums+tarballs→undraft), and the brew/apt/cargo legs run.',
+  })
+}

--- a/scripts/publish/npm/approve.mts
+++ b/scripts/publish/npm/approve.mts
@@ -1,0 +1,210 @@
+/**
+ * @file The promote step. Runs LOCALLY (never in CI): the stage upload used an
+ *   OIDC token in CI; the
+ *   approve requires human 2FA. Perry-centric: the package set is fixed (the 9
+ *   @perryts/* packages), so the interactive multi-select collapses to "approve
+ *   every verified + scanned staged entry".
+ *
+ *   Gate order (every slow gate BEFORE the OTP prompt, because TOTP is ~30s):
+ *     1. list staged entries, filter to @perryts/*
+ *     2. verify each (sha1 vs staged shasum) — refuse on any mismatch
+ *     3. Socket full-scan each (unless --no-scan) — failed/blocked entries drop
+ *     4. OTP resolution: --otp <code> | --yes (browser web-OTP) | prompt
+ *     5. npm stage approve <stageId> per entry (PTY-wrapped for web-OTP)
+ *     6. registry liveness: npm view <name>@<version> before minting a receipt
+ */
+
+import process from 'node:process'
+
+import { ALL_PACKAGES } from '../constants.mts'
+import { logger, NON_INTERACTIVE_RENDER_ENV, runInheritTty } from '../shared.mts'
+import {
+  preflightSocketScanAuth,
+  scanTarball,
+  type ScanResult,
+} from '../scan.mts'
+import { fetchPublishedVersion, listStagedEntries, type StagedEntry } from './shared.mts'
+import { verifyStagedEntry } from './staged.mts'
+
+export interface ApproveOptions {
+  /** Skip the in-approve socket scan gate (recorded as deferred in receipt). */
+  noScan?: boolean
+  /** TOTP code (CI / scripted). */
+  otp?: string
+  /** Approve without prompting; browser web-OTP drives 2FA. */
+  yes?: boolean
+}
+
+export interface ApproveReceipt {
+  approved: string[]
+  failed: string[]
+  /** True only when every approved entry is resolvable on the registry. */
+  registryLive: boolean
+  scanResults: ScanResult[]
+}
+
+/** Filter staged entries to Perry's 9 packages, in publish order. */
+export function perryStagedEntries(
+  entries: readonly StagedEntry[],
+): StagedEntry[] {
+  const order = new Map(ALL_PACKAGES.map((n, i) => [n, i]))
+  return entries
+    .filter(e => order.has(e.name))
+    .sort((a, b) => (order.get(a.name)! - order.get(b.name)!))
+}
+
+/** Run `npm stage approve <stageId>` for one entry, PTY-wrapped for web-OTP. */
+export async function approveEntry(
+  entry: StagedEntry,
+  opts: ApproveOptions,
+): Promise<boolean> {
+  const args = ['stage', 'approve', entry.stageId]
+  // Pass the OTP through NPM_CONFIG_OTP (npm's `npm_config_*` env channel)
+  // rather than `--otp <code>`, so the ~30s-expiring code is not visible in
+  // the process argument list. npm reads this env var at the enforced floor
+  // (>= 11.17); the PTY wrapper keeps the browser web-OTP challenge alive
+  // when no OTP is supplied.
+  const env = {
+    ...NON_INTERACTIVE_RENDER_ENV,
+    ...(opts.otp ? { NPM_CONFIG_OTP: opts.otp } : {}),
+  }
+  const code = await runInheritTty('npm', args, process.cwd(), env)
+  if (code !== 0) {
+    logger.fail(`npm stage approve failed for ${entry.name}@${entry.version} (exit ${code})`)
+    return false
+  }
+  return true
+}
+
+/**
+ * The approve flow. Returns a receipt; the caller (pipeline.mts) gates the
+ * release stage on `registryLive && approved.length > 0`.
+ */
+export async function runApprove(opts: ApproveOptions): Promise<ApproveReceipt> {
+  const staged = perryStagedEntries(await listStagedEntries(process.cwd()))
+  if (staged.length === 0) {
+    logger.fail(
+      'No staged @perryts/* entries to approve. Run `npm run publish:stage` first.',
+    )
+    return { approved: [], failed: [], registryLive: false, scanResults: [] }
+  }
+
+  // 0. Reject a partial package set. The 9 @perryts/* packages are a fixed
+  // release set (the wrapper's optionalDependencies are the platform binaries);
+  // promoting a subset ships a broken install. Require every ALL_PACKAGES
+  // member to be staged before any verification or approval proceeds.
+  const stagedNames = new Set(staged.map(e => e.name))
+  const missing = ALL_PACKAGES.filter(n => !stagedNames.has(n))
+  if (missing.length > 0) {
+    logger.fail(
+      `Partial staged set — refusing to approve. Missing: ${missing.join(', ')}.\n` +
+        `  Why: the @perryts/* packages are a fixed release set; a partial promote ships a broken install.\n` +
+        `  Fix: re-run publish:stage so every package is staged, then re-approve.`,
+    )
+    return {
+      approved: [],
+      failed: staged.map(e => `${e.name}@${e.version}`),
+      registryLive: false,
+      scanResults: [],
+    }
+  }
+
+  // 1. Verify each staged entry (sha1 gate).
+  const verified: StagedEntry[] = []
+  for (const entry of staged) {
+    if (await verifyStagedEntry(entry)) verified.push(entry)
+  }
+  if (verified.length === 0) {
+    logger.fail('No staged entries passed the verify gate — not approving.')
+    return { approved: [], failed: staged.map(e => `${e.name}@${e.version}`), registryLive: false, scanResults: [] }
+  }
+  if (verified.length !== ALL_PACKAGES.length) {
+    const failedVerify = staged.filter(e => !verified.includes(e))
+    logger.fail(
+      `Partial verify — refusing to approve. ${failedVerify.length} of ${ALL_PACKAGES.length} entries failed the sha1 gate: ` +
+        `${failedVerify.map(e => `${e.name}@${e.version}`).join(', ')}.`,
+    )
+    return {
+      approved: [],
+      failed: staged.map(e => `${e.name}@${e.version}`),
+      registryLive: false,
+      scanResults: [],
+    }
+  }
+
+  // 2. Socket scan gate (unless --no-scan).
+  const scanResults: ScanResult[] = []
+  if (!opts.noScan) {
+    const ctx = await preflightSocketScanAuth()
+    if (!ctx) {
+      logger.fail('Socket scan auth failed — refusing to approve unscanned bytes.')
+      return { approved: [], failed: verified.map(e => `${e.name}@${e.version}`), registryLive: false, scanResults: [] }
+    }
+    const passed: StagedEntry[] = []
+    for (const entry of verified) {
+      const res = await scanTarball(ctx, entry.name, entry.version, entry.shasum)
+      scanResults.push(res)
+      if (res.status === 'passed') passed.push(entry)
+      else logger.fail(`scan ${res.status}: ${entry.name}@${entry.version} dropped from approve`)
+    }
+    if (passed.length === 0) {
+      logger.fail('No staged entries passed the scan gate — not approving.')
+      return { approved: [], failed: verified.map(e => `${e.name}@${e.version}`), registryLive: false, scanResults }
+    }
+    if (passed.length !== verified.length) {
+      const dropped = verified.filter(e => !passed.includes(e))
+      logger.fail(
+        `Partial scan — refusing to approve. ${dropped.length} of ${verified.length} entries did not pass the scan gate: ` +
+          `${dropped.map(e => `${e.name}@${e.version}`).join(', ')}.`,
+      )
+      return {
+        approved: [],
+        failed: verified.map(e => `${e.name}@${e.version}`),
+        registryLive: false,
+        scanResults,
+      }
+    }
+    verified.length = 0
+    verified.push(...passed)
+  }
+
+  // 3. OTP resolution (last, after every slow gate).
+  if (!opts.otp && !opts.yes && !process.stdin.isTTY) {
+    logger.fail(
+      'approve needs an interactive terminal, or --yes / --otp.\n' +
+        '  What: the promote is a 2FA action (browser web-OTP or TOTP).\n' +
+        '  Fix: add --yes to let npm open the browser for web-OTP, or --otp <code>.',
+    )
+    return { approved: [], failed: verified.map(e => `${e.name}@${e.version}`), registryLive: false, scanResults }
+  }
+
+  // 4. npm stage approve each entry.
+  const approvedEntries: StagedEntry[] = []
+  const failed: string[] = []
+  for (const entry of verified) {
+    const ok = await approveEntry(entry, opts)
+    if (ok) approvedEntries.push(entry)
+    else failed.push(`${entry.name}@${entry.version}`)
+  }
+  const approved = approvedEntries.map(e => `${e.name}@${e.version}`)
+
+  // A partial approve (some entries failed the 2FA promote) breaks the fixed
+  // 9-package release set the same way a partial verify/scan does — refuse it
+  // before the caller can gate a release on the surviving subset.
+  if (failed.length > 0) {
+    logger.fail(
+      `Partial approve — ${failed.length} of ${verified.length} entries failed the promote: ${failed.join(', ')}. ` +
+        'Not cutting the release — re-run publish:approve after fixing the failures.',
+    )
+  }
+
+  // 5. Registry liveness — exit 0 is NOT proof.
+  let registryLive = failed.length === 0
+  for (const entry of approvedEntries) {
+    if (!(await fetchPublishedVersion(entry.name, entry.version))) {
+      logger.fail(`registry liveness: ${entry.name}@${entry.version} not resolvable after approve — do NOT cut the release.`)
+      registryLive = false
+    }
+  }
+  return { approved, failed, registryLive, scanResults }
+}

--- a/scripts/publish/npm/bump.mts
+++ b/scripts/publish/npm/bump.mts
@@ -1,0 +1,101 @@
+/**
+ * @file Perry version source. Replaces a manifest-edit bump step (which edits a
+ *   CHANGELOG.md section + version field) with Perry's STOP-conditions check:
+ *   the workspace version in Cargo.toml MUST agree with CLAUDE.md's Current
+ *   Version line, the vX.Y.Z tag MUST NOT already exist, and changelog.d/ MUST
+ *   have fragments. These are the same gates release-packages.yml's preflight
+ *   enforces — surfaced here so a local `publish:stage` fails in seconds
+ *   instead of after 40 min of CI builds.
+ *
+ *   Perry froze CHANGELOG.md at v0.5.1264; the bump never edits it. The bump
+ *   commit (Cargo.toml + CLAUDE.md version line + changelog.d fragment) is
+ *   landed on main by the existing flow before `publish:stage` runs.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { CHANGELOG_D, rootPath } from '../constants.mts'
+import { logger, runCapture } from '../shared.mts'
+
+/** Read [workspace.package].version from Cargo.toml. */
+export function readCargoVersion(cwd: string = rootPath): string | undefined {
+  const cargo = path.join(cwd, 'Cargo.toml')
+  if (!existsSync(cargo)) return undefined
+  const text = readFileSync(cargo, 'utf8')
+  let inSection = false
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\[workspace\.package\]/.test(line)) {
+      inSection = true
+      continue
+    }
+    if (/^\[/.test(line)) inSection = false
+    if (inSection && /^version\s*=/.test(line)) {
+      const m = line.match(/"([^"]+)"/)
+      return m ? m[1] : undefined
+    }
+  }
+  return undefined
+}
+
+/** Read the `**Current Version:**` line from CLAUDE.md. */
+export function readClaudeVersion(cwd: string = rootPath): string | undefined {
+  const claude = path.join(cwd, 'CLAUDE.md')
+  if (!existsSync(claude)) return undefined
+  const text = readFileSync(claude, 'utf8')
+  const m = text.match(/\*\*Current Version:\*\*\s*(\S+)/)
+  return m ? m[1] : undefined
+}
+
+/** True when at least one `changelog.d/<number>-*.md` fragment exists. */
+export function hasChangelogFragments(cwd: string = rootPath): boolean {
+  const dir = path.join(cwd, CHANGELOG_D)
+  if (!existsSync(dir)) return false
+  return readdirSync(dir).some(f => /^\d+-.*\.md$/.test(f))
+}
+
+/** True when the vX.Y.Z tag already exists on the repo. */
+export async function tagExists(version: string, cwd: string = rootPath): Promise<boolean> {
+  const { code } = await runCapture('git', ['rev-parse', '-q', '--verify', `refs/tags/v${version}`], cwd)
+  return code === 0
+}
+
+export interface VersionGate {
+  version: string
+  ok: boolean
+  /** Non-empty when ok is false — the human-readable stop reason(s). */
+  reasons: string[]
+}
+
+/**
+ * The Perry version gate. Mirrors release-packages.yml preflight's STOP
+ * conditions. Returns { ok, reasons } so the pipeline fails fast with a
+ * precise pointer.
+ */
+export async function checkVersionGate(cwd: string = rootPath): Promise<VersionGate> {
+  const version = readCargoVersion(cwd)
+  const reasons: string[] = []
+  if (!version) {
+    reasons.push('could not parse [workspace.package].version from Cargo.toml')
+    return { version: '', ok: false, reasons }
+  }
+  const claude = readClaudeVersion(cwd)
+  if (claude !== version) {
+    reasons.push(
+      `Cargo.toml says ${version} but CLAUDE.md's Current Version line says ${claude ?? '(missing)'} — fix the drift before releasing.`,
+    )
+  }
+  if (await tagExists(version, cwd)) {
+    reasons.push(
+      `tag v${version} already exists — the version in Cargo.toml was already released. Land a version bump.`,
+    )
+  }
+  if (!hasChangelogFragments(cwd)) {
+    reasons.push(
+      'no fragments in changelog.d/ — the release notes are cut from them; nothing to release.',
+    )
+  }
+  const ok = reasons.length === 0
+  if (!ok) for (const r of reasons) logger.fail(r)
+  return { version, ok, reasons }
+}

--- a/scripts/publish/npm/publish-command.mts
+++ b/scripts/publish/npm/publish-command.mts
@@ -1,0 +1,125 @@
+/**
+ * @file THE npm upload invocation for Perry. One function builds the
+ *   `npm stage publish` / `npm publish` argv, decides provenance, asserts
+ *   the auth posture on both sides of the spawn, and hands back the exit code
+ *   + captured output. Every path that uploads npm bytes calls it. Ported from
+ *   the a tiered registry-infra design-command.mts (pnpm → npm, since
+ *   Perry's root is npm-managed and npm CLI ships the same `npm stage` client).
+ *
+ *   `--ignore-scripts` is not optional: the tarball is already built
+ *   (stage-npm.sh materialized the platform binaries) and the publish must not
+ *   run lifecycle scripts. (pnpm's `--no-git-checks` is dropped — npm publish
+ *   does not git-check the working tree.) `--provenance` is added only inside
+ *   GitHub Actions on a PUBLIC repo — npm refuses a sigstore bundle from a
+ *   private repo with E422.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import {
+  publishAuthPostflight,
+  publishAuthPreflight,
+} from '../auth-posture.mts'
+import { logger, provenanceAllowed, runInheritTee } from '../shared.mts'
+
+export type NpmUploadMode = 'direct' | 'staged'
+
+export interface NpmUploadResult {
+  code: number
+  output: string
+  /** False when the auth posture refused (preflight OR postflight). */
+  postureOk: boolean
+  /** True when the command actually ran (false = preflight refused). */
+  ran: boolean
+}
+
+/**
+ * The argv for an npm upload, without the auth posture or the spawn. Pure.
+ */
+export function npmUploadArgs(config: {
+  dryRun?: boolean
+  mode?: NpmUploadMode
+  provenance?: boolean
+  tag?: string
+}): string[] {
+  const {
+    dryRun = false,
+    mode = 'staged',
+    provenance = false,
+    tag = 'latest',
+  } = config
+  const args = mode === 'staged' ? ['stage', 'publish'] : ['publish']
+  args.push('--access', 'public', '--tag', tag, '--ignore-scripts')
+  if (provenance) args.push('--provenance')
+  if (dryRun) args.push('--dry-run')
+  return args
+}
+
+/** Whether this run should ask npm for a provenance attestation (loud skip). */
+export function resolveUploadProvenance(): boolean {
+  if (process.env['GITHUB_ACTIONS'] !== 'true') return false
+  if (provenanceAllowed()) return true
+  logger.warn(
+    'Provenance skipped: npm only verifies sigstore bundles from PUBLIC ' +
+      'source repositories, and this run is not one. Provenance turns back ' +
+      'on automatically when the repo is public.',
+  )
+  return false
+}
+
+/** The `version` of the manifest at `manifestPath`, or undefined. */
+export function readPublishVersion(manifestPath: string): string | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      version?: unknown
+    }
+    return typeof parsed.version === 'string' ? parsed.version : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Upload one package's bytes from `cwd`, with the auth posture asserted before
+ * and after. Preflight refusal → `{ code: 0, ran: false, postureOk: false }`.
+ * Postflight refusal (a `Skipped OIDC` upload that exited 0) → real code with
+ * `postureOk: false`. A caller that only checks `code` misses the second case.
+ */
+export async function uploadNpmPackage(config: {
+  cwd: string
+  dryRun?: boolean
+  manifestPath?: string
+  mode?: NpmUploadMode
+  tag?: string
+}): Promise<NpmUploadResult> {
+  const { cwd, dryRun = false, manifestPath, mode = 'staged', tag = 'latest' } = config
+  // Read the manifest version so the auth-posture gate can enforce the 0.0.0
+  // reservation on direct publishes (a direct upload with a long-lived token
+  // is only sanctioned for the name-reservation escape hatch).
+  const version = readPublishVersion(manifestPath ?? path.join(cwd, 'package.json'))
+  const reason = publishAuthPreflight({ ci: undefined, direct: mode === 'direct', dryRun, version })
+  if (reason) {
+    logger.fail(reason)
+    return { code: 0, output: '', postureOk: false, ran: false }
+  }
+  const args = npmUploadArgs({
+    dryRun,
+    mode,
+    provenance: resolveUploadProvenance(),
+    tag,
+  })
+  // Teed: the operator watches the upload live AND the posture check below
+  // reads what the registry actually said.
+  const run = await runInheritTee('npm', args, cwd)
+  const postureOk = !publishAuthPostflight(run.output)
+  if (!postureOk) {
+    logger.fail(
+      'Auth posture postflight: the upload reported a failed OIDC exchange ' +
+        '(Skipped OIDC / ERR_PNPM_AUTH_TOKEN_EXCHANGE). A publish that ' +
+        '"succeeded" after a broken exchange is a failure — do not approve.',
+    )
+  }
+  return { code: run.code, output: run.output, postureOk, ran: true }
+}

--- a/scripts/publish/npm/shared.mts
+++ b/scripts/publish/npm/shared.mts
@@ -1,0 +1,136 @@
+/**
+ * @file npm registry-read helpers: package.json reader, staged-entry shape +
+ *   shasum reader, the `npm stage list` fetch, and prior-version lookup.
+ *   Modeled on a tiered registry-infra design, pared to what
+ *   Perry's 9-package staged flow needs.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { extractFirstJson, rootPath, runCapture } from '../shared.mts'
+
+/** A normalized staged entry from `npm stage list --json`. */
+export interface StagedEntry {
+  name: string
+  version: string
+  /** sha1 hex npm recorded for the staged tarball. */
+  shasum?: string | undefined
+  /** The staging id `npm stage approve <id>` promotes. */
+  stageId: string
+}
+
+/** Read the subject package.json. */
+export function readPackageJson(
+  root: string = rootPath,
+): { name?: string; version?: string } & Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Extract the staged tarball's sha1 from a `npm stage list --json` entry.
+ * Live npm emits top-level `shasum`; `dist.shasum` stays as a fallback probe.
+ * (`integrity` is sha512 — a different axis — not reduced to sha1 here.)
+ */
+export function readStagedShasum(entry: {
+  dist?: { shasum?: unknown } | undefined
+  shasum?: unknown
+}): string | undefined {
+  if (typeof entry.shasum === 'string' && entry.shasum) return entry.shasum
+  if (typeof entry.dist?.shasum === 'string' && entry.dist.shasum) {
+    return entry.dist.shasum
+  }
+  return undefined
+}
+
+/** A raw `npm stage list --json` entry across the shapes npm has emitted. */
+interface RawStageEntry {
+  id?: unknown
+  stageId?: unknown
+  name?: unknown
+  packageName?: unknown
+  version?: unknown
+  shasum?: unknown
+  dist?: { shasum?: unknown } | undefined
+}
+
+function normalizeEntry(raw: RawStageEntry): StagedEntry | undefined {
+  const name =
+    typeof raw.name === 'string'
+      ? raw.name
+      : typeof raw.packageName === 'string'
+        ? raw.packageName
+        : undefined
+  const stageId =
+    typeof raw.id === 'string' && raw.id
+      ? raw.id
+      : typeof raw.stageId === 'string' && raw.stageId
+        ? raw.stageId
+        : undefined
+  if (!name || !stageId) return undefined
+  const version = typeof raw.version === 'string' ? raw.version : ''
+  return { name, version, stageId, shasum: readStagedShasum(raw) }
+}
+
+/**
+ * Parse `npm stage list --json` output into normalized entries. Live npm
+ * emits an array of `{ id, packageName, version, shasum, … }`; the older
+ * keyed-map shape (`{ '<name>@<version>': { stageId, name, … } }`) is a
+ * fallback.
+ */
+export function parseStageListJson(text: string): StagedEntry[] {
+  const jsonText = extractFirstJson(text)
+  if (!jsonText) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(jsonText)
+  } catch {
+    return []
+  }
+  if (Array.isArray(parsed)) {
+    return parsed
+      .map((r: unknown) => normalizeEntry(r as RawStageEntry))
+      .filter((e): e is StagedEntry => e !== undefined)
+  }
+  if (parsed && typeof parsed === 'object') {
+    return Object.values(parsed)
+      .map((r: unknown) => normalizeEntry(r as RawStageEntry))
+      .filter((e): e is StagedEntry => e !== undefined)
+  }
+  return []
+}
+
+/** Run `npm stage list --json` and return normalized staged entries. */
+export async function listStagedEntries(cwd: string): Promise<StagedEntry[]> {
+  const { stdout, code } = await runCapture('npm', ['stage', 'list', '--json'], cwd)
+  if (code !== 0) return []
+  return parseStageListJson(stdout)
+}
+
+/**
+ * True when `<name>@<version>` is already staged (matching stageId optional).
+ * Used to keep the stage-upload idempotent — a re-stage skips entries already
+ * in staging.
+ */
+export function isStagingExpected(
+  entries: readonly StagedEntry[],
+  name: string,
+  version: string,
+): StagedEntry | undefined {
+  return entries.find(
+    e => e.name === name && e.version === version,
+  )
+}
+
+/** True when `<name>@<version>` is resolvable on the public registry. */
+export async function fetchPublishedVersion(
+  name: string,
+  version: string,
+): Promise<boolean> {
+  const { code } = await runCapture('npm', ['view', `${name}@${version}`, 'version'], rootPath)
+  return code === 0
+}

--- a/scripts/publish/npm/staged.mts
+++ b/scripts/publish/npm/staged.mts
@@ -1,0 +1,156 @@
+/**
+ * @file Staged-publish mechanics for Perry's 9 @perryts/* packages. Ported
+ *   from a tiered registry-infra design, pared to Perry's fixed
+ *   package set.
+ *
+ *   runStaged    — `npm stage publish` each package (platforms first, wrapper
+ *                  last) via uploadNpmPackage. Nothing is public.
+ *   verifyStagedEntry — `npm pack` locally, sha1 vs the shasum npm recorded at
+ *                  stage time. Run BEFORE approve so a divergent artifact is
+ *                  never promoted.
+ *   runDirect    — escape hatch: classic `npm publish` (no stage/approve).
+ */
+
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { ALL_PACKAGES, npmPackageDir, rootPath } from '../constants.mts'
+import { logger, runCapture } from '../shared.mts'
+import { readPackageJson, type StagedEntry } from './shared.mts'
+import { uploadNpmPackage } from './publish-command.mts'
+
+/** Pack one package dir with `npm pack` and return {path, sha1}. */
+export async function packTarball(pkgDir: string): Promise<{
+  path: string
+  sha1: string
+} | undefined> {
+  // `npm pack --json` is deterministic about the filename + integrity; use it
+  // (rather than the plain-stdout form) for a stable parse shape.
+  const { stdout, code } = await runCapture('npm', ['pack', '--json'], pkgDir)
+  if (code !== 0) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return undefined
+  }
+  const entry = Array.isArray(parsed) ? parsed[0] : undefined
+  if (!entry || typeof entry !== 'object') return undefined
+  const filename = (entry as { filename?: unknown }).filename
+  const shasum = (entry as { shasum?: unknown }).shasum
+  if (typeof filename !== 'string' || typeof shasum !== 'string') return undefined
+  const tarball = path.join(pkgDir, filename)
+  if (!existsSync(tarball)) return undefined
+  return { path: tarball, sha1: shasum }
+}
+
+/**
+ * Verify a staged entry: the local pack's sha1 equals the shasum npm recorded
+ * when the tarball was staged. LOUD refusal on mismatch or missing shasum —
+ * never approve unverified bytes.
+ */
+export async function verifyStagedEntry(entry: StagedEntry): Promise<boolean> {
+  const { name, version, shasum: stagedShasum, stageId } = entry
+  if (!stagedShasum) {
+    logger.fail(
+      `Pre-approve verify: no server-side shasum for ${name}@${version}.\n` +
+        `  Where: npm stage list --json (stageId ${stageId}) exposed no shasum field.\n` +
+        `  Fix: re-stage, or check npm version. Not approving unverified bytes.`,
+    )
+    return false
+  }
+  const pkgDir = path.join(rootPath, npmPackageDir(name))
+  if (!existsSync(pkgDir)) {
+    logger.fail(
+      `Pre-approve verify: no package dir for ${name}@${version} at ${pkgDir}.\n` +
+        `  Fix: run scripts/stage-npm.sh to materialize the npm/ package dirs first.`,
+    )
+    return false
+  }
+  const local = await packTarball(pkgDir)
+  if (!local) {
+    logger.fail(
+      `Pre-approve verify: npm pack failed for ${name}@${version} in ${pkgDir}.\n` +
+        `  Saw vs wanted: no local tarball; wanted one to hash against npm's staged shasum.`,
+    )
+    return false
+  }
+  if (local.sha1 === stagedShasum) {
+    logger.info(`verify ok: ${name}@${version} (sha1 ${local.sha1})`)
+    return true
+  }
+  logger.fail(
+    `Pre-approve verify: shasum mismatch for ${name}@${version}.\n` +
+      `    local pack:  ${local.sha1}\n` +
+      `    npm staging: ${stagedShasum}\n` +
+      `  Fix: check npm auth (npm stage download ${stageId}), or reject + re-stage. Not approving unverified bytes.`,
+  )
+  return false
+}
+
+/**
+ * Stage all 9 packages (platforms first, wrapper last). Skips versions already
+ * staged. Records failures and fails the step at the end with the full list —
+ * one package's failure must not starve the packages after it (the same
+ * lesson release-packages.yml's npm-publish job learned at v0.5.1151).
+ */
+export async function runStaged(config: {
+  dryRun?: boolean
+  tag?: string
+}): Promise<{ staged: string[]; failed: string[] }> {
+  const { dryRun = false, tag = 'latest' } = config
+  const staged: string[] = []
+  const failed: string[] = []
+  for (const name of ALL_PACKAGES) {
+    const pkgDir = path.join(rootPath, npmPackageDir(name))
+    if (!existsSync(path.join(pkgDir, 'package.json'))) {
+      logger.warn(`skip stage: ${name} has no package.json at ${pkgDir} (run stage-npm.sh first)`)
+      failed.push(`${name} (no package.json)`)
+      continue
+    }
+    const { version } = readPackageJson(pkgDir)
+    if (!version) {
+      failed.push(`${name} (no version)`)
+      continue
+    }
+    logger.log(`=== staging ${name}@${version} ===`)
+    const result = await uploadNpmPackage({ cwd: pkgDir, dryRun, mode: 'staged', tag })
+    if (!result.postureOk || result.code !== 0) {
+      failed.push(`${name}@${version}`)
+      continue
+    }
+    staged.push(`${name}@${version}`)
+  }
+  if (failed.length > 0) logger.fail(`staging failures: ${failed.join(', ')}`)
+  return { staged, failed }
+}
+
+/** `--direct` escape hatch: classic `npm publish` (upload + public in one step). */
+export async function runDirect(config: {
+  dryRun?: boolean
+  tag?: string
+}): Promise<{ published: string[]; failed: string[] }> {
+  const { dryRun = false, tag = 'latest' } = config
+  const published: string[] = []
+  const failed: string[] = []
+  for (const name of ALL_PACKAGES) {
+    const pkgDir = path.join(rootPath, npmPackageDir(name))
+    if (!existsSync(path.join(pkgDir, 'package.json'))) {
+      failed.push(`${name} (no package.json)`)
+      continue
+    }
+    const { version } = readPackageJson(pkgDir)
+    if (!version) {
+      failed.push(`${name} (no version)`)
+      continue
+    }
+    logger.log(`=== direct publish ${name}@${version} ===`)
+    const result = await uploadNpmPackage({ cwd: pkgDir, dryRun, mode: 'direct', tag })
+    if (!result.postureOk || result.code !== 0) {
+      failed.push(`${name}@${version}`)
+      continue
+    }
+    published.push(`${name}@${version}`)
+  }
+  return { published, failed }
+}

--- a/scripts/publish/pipeline.mts
+++ b/scripts/publish/pipeline.mts
@@ -1,0 +1,308 @@
+/**
+ * @file Perry publish-pipeline orchestrator, modeled on a tiered registry-infra design
+ *   Two invocations share one per-version state file at
+ *   .cache/perry/publish-pipeline/<version>.json:
+ *
+ *     npm run publish:stage      stage-publish (dispatch CI OIDC) → verify → scan
+ *     npm run publish:approve     SEPARATE explicit promote (2FA) → release
+ *     npm run publish:scan        re-scan the currently-staged entries
+ *     npm run publish:status      print the receipt table and exit
+ *     npm run publish:release     cut the tag + GH release (after a prior approve)
+ *
+ *   Canonical order: stage-publish → verify → scan → [HUMAN GATE: approve] →
+ *   release. Publishing never waits on a GitHub release; the release waits on
+ *   the publish (a staged package is not published — staging may never be
+ *   approved — so a release cut earlier can mark a version that never shipped).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import {
+  ALL_PACKAGES,
+  PIPELINE_STATE_DIR,
+  rootPath,
+} from './constants.mts'
+import { logger, runCapture, checkNpmFloor } from './shared.mts'
+import { checkVersionGate } from './npm/bump.mts'
+import { runStaged, verifyStagedEntry } from './npm/staged.mts'
+import { listStagedEntries, type StagedEntry } from './npm/shared.mts'
+import { runApprove } from './npm/approve.mts'
+import {
+  preflightSocketScanAuth,
+  scanTarball,
+  type ScanResult,
+} from './scan.mts'
+import { ensureTagAndRelease, requireRegistryLive } from './release.mts'
+import { formatApproveGate } from './human-gate.mts'
+
+/** The CI workflow that does the OIDC staged upload (build → stage-npm.sh → npm stage publish). */
+const STAGE_WORKFLOW = 'npm-stage-publish.yml'
+
+export interface PipelineState {
+  version: string
+  staged: string[]
+  verified: string[]
+  scanResults: ScanResult[]
+  approved?: string[]
+  registryLive?: boolean
+  released?: boolean
+  updatedAt: string
+}
+
+function statePath(version: string): string {
+  return path.join(rootPath, PIPELINE_STATE_DIR, `${version}.json`)
+}
+
+function readState(version: string): PipelineState | undefined {
+  const p = statePath(version)
+  if (!existsSync(p)) return undefined
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as PipelineState
+  } catch {
+    return undefined
+  }
+}
+
+function writeState(state: PipelineState): void {
+  const dir = path.join(rootPath, PIPELINE_STATE_DIR)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(statePath(state.version), JSON.stringify(state, null, 2) + '\n')
+}
+
+/** Dispatch the CI stage workflow and watch it to completion. */
+async function dispatchStageWorkflow(
+  version: string,
+  config: { dryRun?: boolean; tag?: string },
+): Promise<boolean> {
+  const { dryRun = false, tag = 'latest' } = config
+  const args = [
+    'workflow',
+    'run',
+    STAGE_WORKFLOW,
+    '-R',
+    'PerryTS/perry',
+    '-f',
+    `publish=${dryRun ? 'false' : 'true'}`,
+    '-f',
+    `dist-tag=${tag}`,
+  ]
+  const run = await runCapture('gh', args, rootPath)
+  if (run.code !== 0) {
+    logger.fail(`gh workflow run ${STAGE_WORKFLOW} failed (${run.code}).`)
+    return false
+  }
+  logger.log(`Dispatched ${STAGE_WORKFLOW} (publish=${!dryRun}, tag=${tag}). Waiting for the run to start…`)
+  // Match the workflow_dispatch run we just created by event + createdAt,
+  // not just the newest run — a concurrent dispatch could otherwise be watched.
+  const dispatchedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+  await new Promise(r => setTimeout(r, 4000))
+  const list = await runCapture(
+    'gh',
+    ['run', 'list', '--workflow', STAGE_WORKFLOW, '-R', 'PerryTS/perry', '--event', 'workflow_dispatch', '--limit', '5', '--json', 'databaseId,createdAt,status'],
+    rootPath,
+  )
+  let runId = ''
+  try {
+    const arr = JSON.parse(list.stdout) as Array<{ databaseId: number; createdAt: string; status: string }>
+    const match = arr.find(r => r.createdAt >= dispatchedAt)
+    if (match) runId = String(match.databaseId)
+    else if (arr.length > 0) runId = String(arr[0]!.databaseId)
+  } catch {
+    /* fall through */
+  }
+  if (!runId) {
+    logger.fail(
+      `Could not resolve the ${STAGE_WORKFLOW} run id to watch it. Check ` +
+        `https://github.com/PerryTS/perry/actions/workflows/${STAGE_WORKFLOW} manually.`,
+    )
+    return false
+  }
+  logger.log(`Watching run ${runId}…`)
+  const watch = await runCapture('gh', ['run', 'watch', runId, '-R', 'PerryTS/perry', '--exit-status'], rootPath)
+  if (watch.code !== 0) {
+    logger.fail(`CI stage workflow run ${runId} did not succeed (${watch.code}).`)
+    return false
+  }
+  logger.log(`CI stage workflow run ${runId} succeeded — staged @perryts/* v${version}.`)
+  return true
+}
+
+/** Verify + scan the currently-staged @perryts/* entries; update state. */
+async function verifyAndScan(
+  version: string,
+  state: PipelineState,
+  config: { noScan?: boolean },
+): Promise<PipelineState> {
+  const staged = (await listStagedEntries(rootPath)).filter(e =>
+    ALL_PACKAGES.includes(e.name as (typeof ALL_PACKAGES)[number]),
+  )
+  state.staged = staged.map(e => `${e.name}@${e.version}`)
+  const verified: StagedEntry[] = []
+  for (const entry of staged) {
+    if (await verifyStagedEntry(entry)) verified.push(entry)
+  }
+  state.verified = verified.map(e => `${e.name}@${e.version}`)
+  if (!config.noScan) {
+    const ctx = await preflightSocketScanAuth()
+    if (ctx) {
+      const results: ScanResult[] = []
+      for (const entry of verified) {
+        results.push(await scanTarball(ctx, entry.name, entry.version, entry.shasum))
+      }
+      state.scanResults = results
+      const failed = results.filter(r => r.status !== 'passed')
+      if (failed.length > 0) {
+        logger.fail(`scan gate: ${failed.length} entry/entries did not pass — fix before approve.`)
+      }
+    } else {
+      logger.fail('Socket scan auth failed — scan skipped. Re-run with SOCKET_API_TOKEN set.')
+    }
+  }
+  state.updatedAt = new Date().toISOString()
+  writeState(state)
+  return state
+}
+
+function printStatus(state: PipelineState): void {
+  logger.log(`=== publish pipeline: v${state.version} ===`)
+  logger.log(`  staged:    ${state.staged.length ? state.staged.join(', ') : '(none)'}`)
+  logger.log(`  verified:  ${state.verified.length ? state.verified.join(', ') : '(none)'}`)
+  logger.log(`  scan:      ${state.scanResults.length} scanned, ${state.scanResults.filter(r => r.status !== 'passed').length} not-passed`)
+  logger.log(`  approved:  ${state.approved?.length ? state.approved.join(', ') : '(not approved)'}`)
+  logger.log(`  registry:  ${state.registryLive ? 'live' : 'not live'}`)
+  logger.log(`  released:  ${state.released ? 'yes' : 'no'}`)
+}
+
+async function main(): Promise<void> {
+  // Parse argv into boolean flags + option values, so a value like `beta` (from
+  // `--tag beta`) does NOT pollute the flag set and break mode routing. A value
+  // that happens to equal a flag name (e.g. `--tag --approve`) can't mis-route
+  // either, because `--approve` is consumed as `--tag`'s value here.
+  const VALUE_OPTIONS = new Set(['--tag', '--otp'])
+  const flags = new Set<string>()
+  let tag = 'latest'
+  let otp: string | undefined
+  for (let i = 2, { length } = process.argv; i < length; i += 1) {
+    const arg = process.argv[i]!
+    if (VALUE_OPTIONS.has(arg)) {
+      const val = process.argv[i + 1]
+      if (val !== undefined) {
+        if (arg === '--tag') tag = val
+        else otp = val
+        i += 1
+      }
+    } else {
+      flags.add(arg)
+    }
+  }
+  const dryRun = flags.has('--dry-run')
+  const noScan = flags.has('--no-scan')
+
+  // Resolve the version from the gate.
+  const gate = await checkVersionGate(rootPath)
+  if (!gate.ok && !flags.has('--status')) {
+    process.exitCode = 1
+    return
+  }
+  let state = readState(gate.version) ?? {
+    version: gate.version,
+    staged: [],
+    verified: [],
+    scanResults: [],
+    updatedAt: new Date().toISOString(),
+  }
+
+  if (flags.has('--status')) {
+    printStatus(state)
+    return
+  }
+
+  // Enforce the npm floor before any stage/approve/release action (staged
+  // publishing + OIDC + min-release-age all need >= NPM_MIN_VERSION).
+  const floorReason = await checkNpmFloor()
+  if (floorReason) {
+    logger.fail(floorReason)
+    process.exitCode = 1
+    return
+  }
+
+  if (flags.has('--stage-only') || flags.size === 0 || (flags.size === 1 && dryRun)) {
+    if (!(await dispatchStageWorkflow(gate.version, { dryRun, tag }))) {
+      process.exitCode = 1
+      return
+    }
+    state = await verifyAndScan(gate.version, state, { noScan })
+    printStatus(state)
+    logger.log(formatApproveGate({ version: gate.version, repoPath: rootPath }))
+    return
+  }
+
+  if (flags.has('--scan-only')) {
+    state = await verifyAndScan(gate.version, state, { noScan })
+    printStatus(state)
+    return
+  }
+
+  if (flags.has('--approve')) {
+    const receipt = await runApprove({
+      noScan,
+      yes: flags.has('--yes'),
+      otp,
+    })
+    state.approved = receipt.approved
+    state.registryLive = receipt.registryLive
+    state.scanResults = receipt.scanResults
+    state.updatedAt = new Date().toISOString()
+    writeState(state)
+    if (!receipt.registryLive || receipt.approved.length === 0) {
+      process.exitCode = 1
+      return
+    }
+    // Approve continues into release (registry-liveness already confirmed in
+    // runApprove, but re-gate here for the release cut).
+    const live = await requireRegistryLive(
+      receipt.approved.map(s => {
+        const at = s.lastIndexOf('@')
+        return { name: s.slice(0, at), version: s.slice(at + 1) }
+      }),
+    )
+    if (!live) {
+      process.exitCode = 1
+      return
+    }
+    const released = await ensureTagAndRelease(gate.version)
+    state.released = released
+    state.updatedAt = new Date().toISOString()
+    writeState(state)
+    if (!released) process.exitCode = 1
+    return
+  }
+
+  if (flags.has('--release-only')) {
+    if (!state.registryLive) {
+      logger.fail(`No approved+live receipt for v${gate.version} — run publish:approve first.`)
+      process.exitCode = 1
+      return
+    }
+    const released = await ensureTagAndRelease(gate.version)
+    state.released = released
+    state.updatedAt = new Date().toISOString()
+    writeState(state)
+    if (!released) process.exitCode = 1
+    return
+  }
+
+  logger.fail(
+    'Unknown flags. Usage: publish:pipeline [--stage-only | --scan-only | --approve | --release-only | --status] [--dry-run] [--no-scan] [--yes] [--otp <code>] [--tag <tag>]',
+  )
+  process.exitCode = 1
+}
+
+// Only run when invoked directly (node scripts/publish/pipeline.mts …), not
+// when imported for testing.
+import { fileURLToPath } from 'node:url'
+if (process.argv[1] === fileURLToPath(new URL(import.meta.url))) {
+  await main()
+}

--- a/scripts/publish/publish.test.mts
+++ b/scripts/publish/publish.test.mts
@@ -1,0 +1,231 @@
+/**
+ * @file Unit tests for the pure publish-pipeline surfaces. Run with
+ *   `node --test scripts/publish/publish.test.mts`. Covers the brew formula
+ *   renderer, the Socket policy-alert bucketing, the human-gate block shape,
+ *   and the auth-posture refusal of long-lived tokens (sabotage-tested: the
+ *   refusal is asserted with a token present, and the clean path with it
+ *   absent — both halves of the gate).
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { renderPerryFormula } from './brew/formula.mts'
+import { summarizePolicyAlerts, normalizeFullScanArtifacts } from './scan.mts'
+import { formatHumanGate } from './human-gate.mts'
+import { publishAuthPreflight } from './auth-posture.mts'
+import { compareSemver, extractFirstJson } from './shared.mts'
+import { parseStageListJson } from './npm/shared.mts'
+import { NPM_MIN_VERSION } from './constants.mts'
+
+test('renderPerryFormula: macos arm64/x86_64 binaries + linux source build', () => {
+  const f = renderPerryFormula({
+    version: '0.5.1510',
+    macosArm64Sha256: 'a'.repeat(64),
+    macosX64Sha256: 'b'.repeat(64),
+    linuxSourceSha256: 'c'.repeat(64),
+  })
+  assert.match(f, /class Perry < Formula/)
+  assert.match(f, /version "0\.5\.1510"/)
+  assert.match(f, /on_macos do/)
+  assert.match(f, /on_arm do/)
+  assert.match(f, /perry-macos-aarch64\.tar\.gz/)
+  assert.match(f, /sha256 "a{64}"/)
+  assert.match(f, /on_intel do/)
+  assert.match(f, /perry-macos-x86_64\.tar\.gz/)
+  assert.match(f, /sha256 "b{64}"/)
+  assert.match(f, /on_linux do/)
+  assert.match(f, /archive\/refs\/tags\/v0\.5\.1510\.tar\.gz/)
+  assert.match(f, /sha256 "c{64}"/)
+  assert.match(f, /depends_on "rust" => :build/)
+  assert.match(f, /def install/)
+  assert.match(f, /test do/)
+})
+
+test('summarizePolicyAlerts: error-action blocks, warn-action passes, unknown ignored', () => {
+  const artifacts = [
+    {
+      name: '@perryts/perry-darwin-arm64',
+      version: '0.5.1510',
+      alerts: [
+        { type: 'npmMalware', severity: 'critical' }, // error
+        { type: 'npmDeprecated', severity: 'low' }, // warn
+        { type: 'someOther', severity: 'high' }, // no policy entry → ignored
+      ],
+    },
+  ]
+  const rules = {
+    npmMalware: { action: 'error' },
+    npmDeprecated: { action: 'warn' },
+  }
+  const s = summarizePolicyAlerts(artifacts, rules)
+  assert.equal(s.total, 3)
+  assert.equal(s.error.length, 1)
+  assert.equal(s.error[0]!.type, 'npmMalware')
+  assert.equal(s.warn.length, 1)
+  assert.equal(s.warn[0]!.type, 'npmDeprecated')
+})
+
+test('normalizeFullScanArtifacts: bare array and {artifacts: [...]} shapes', () => {
+  assert.deepEqual(normalizeFullScanArtifacts([{ name: 'a' }]), [{ name: 'a' }])
+  assert.deepEqual(
+    normalizeFullScanArtifacts({ artifacts: [{ name: 'b' }] }),
+    [{ name: 'b' }],
+  )
+  assert.equal(normalizeFullScanArtifacts({ weird: 1 }), undefined)
+  assert.equal(normalizeFullScanArtifacts(undefined), undefined)
+})
+
+test('extractFirstJson: balanced object, array, and noisy-wrapped array', () => {
+  // Object — the original supported shape.
+  assert.equal(extractFirstJson('{"a":1}'), '{"a":1}')
+  // Array — npm stage list --json emits an array of entries.
+  assert.equal(extractFirstJson('[{"id":"a"},{"id":"b"}]'), '[{"id":"a"},{"id":"b"}]')
+  // Noisy stdout wrapping a JSON array (progress lines before the array).
+  const noisy = '⠹ downloading...\n[{"id":"a","packageName":"@perryts/perry","version":"1.0.0"}]\n'
+  assert.equal(extractFirstJson(noisy), '[{"id":"a","packageName":"@perryts/perry","version":"1.0.0"}]')
+  // Strings containing braces/brackets must not break the balance.
+  assert.equal(extractFirstJson('[{"a":"}]"},{"b":"["}]'), '[{"a":"}]"},{"b":"["}]')
+  assert.equal(extractFirstJson('no json here'), undefined)
+})
+
+test('parseStageListJson: array of entries parses to staged entries', () => {
+  const text = '[{"id":"stage-1","packageName":"@perryts/perry","version":"0.5.1","shasum":"abc"}]'
+  const entries = parseStageListJson(text)
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0]!.name, '@perryts/perry')
+  assert.equal(entries[0]!.stageId, 'stage-1')
+  assert.equal(entries[0]!.version, '0.5.1')
+  assert.equal(entries[0]!.shasum, 'abc')
+  // Noisy wrapper around the array must not drop entries.
+  const noisy = 'progress...\n[{"id":"s2","name":"@perryts/perry-darwin-arm64","version":"0.5.1"}]'
+  const entries2 = parseStageListJson(noisy)
+  assert.equal(entries2.length, 1)
+  assert.equal(entries2[0]!.name, '@perryts/perry-darwin-arm64')
+})
+
+test('formatHumanGate: the 🖐 block shape with both lanes', () => {
+  const block = formatHumanGate({
+    name: 'approve',
+    index: '1/1',
+    need: 'the staged upload is verified + scanned; 2FA promote is human.',
+    mind: 'npm stage approve requires browser web-OTP 2FA.',
+    you: 'npm run publish:approve',
+    me: 'I will run publish:approve so npm opens the browser for web-OTP.',
+    then: 'registry liveness + tag + immutable GitHub release.',
+  })
+  assert.match(block, /^🖐  HUMAN GATE — approve \[1\/1\]/)
+  assert.match(block, /A\) You: npm run publish:approve/)
+  assert.match(block, /B\) Me: I will run/)
+  assert.match(block, /Then: registry liveness/)
+})
+
+// Save + clear every long-lived token env var the gate checks, and restore
+// them after. Tests that only clear NPM_TOKEN break on a runner that defines
+// NODE_AUTH_TOKEN or NPM_AUTH_TOKEN — the gate checks all three.
+const TOKEN_VARS = ['NPM_TOKEN', 'NODE_AUTH_TOKEN', 'NPM_AUTH_TOKEN'] as const
+
+function snapshotTokenVars(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {}
+  for (const v of TOKEN_VARS) snap[v] = process.env[v]
+  return snap
+}
+
+function clearTokenVars(): void {
+  for (const v of TOKEN_VARS) delete process.env[v]
+}
+
+function restoreTokenVars(snap: Record<string, string | undefined>): void {
+  for (const v of TOKEN_VARS) {
+    if (snap[v] === undefined) delete process.env[v]
+    else process.env[v] = snap[v]
+  }
+}
+
+test('publishAuthPreflight: refuses each long-lived token in CI (sabotage)', () => {
+  for (const v of TOKEN_VARS) {
+    const snap = snapshotTokenVars()
+    clearTokenVars()
+    process.env[v] = 'npm_secret_live_token'
+    try {
+      const reason = publishAuthPreflight({ ci: true, direct: false, dryRun: false })
+      assert.ok(reason, `must refuse when ${v} is present in CI`)
+      assert.match(reason!, /Refusing to publish in CI with a long-lived token/)
+    } finally {
+      restoreTokenVars(snap)
+    }
+  }
+})
+
+test('publishAuthPreflight: clean path with no long-lived token', () => {
+  const snap = snapshotTokenVars()
+  clearTokenVars()
+  try {
+    const reason = publishAuthPreflight({ ci: true, direct: false, dryRun: false })
+    assert.equal(reason, undefined, 'must not refuse when no long-lived token is present')
+  } finally {
+    restoreTokenVars(snap)
+  }
+})
+
+test('publishAuthPreflight: refuses a direct publish with a token for non-0.0.0', () => {
+  const snap = snapshotTokenVars()
+  clearTokenVars()
+  process.env['NPM_TOKEN'] = 'npm_secret_live_token'
+  try {
+    const reason = publishAuthPreflight({ ci: false, direct: true, dryRun: false, version: '1.2.3' })
+    assert.ok(reason, 'must refuse a direct publish of a real version with a long-lived token')
+    assert.match(reason!, /0\.0\.0 name reservation/)
+  } finally {
+    restoreTokenVars(snap)
+  }
+})
+
+test('publishAuthPreflight: allows the 0.0.0 reservation direct publish with a token', () => {
+  const snap = snapshotTokenVars()
+  clearTokenVars()
+  process.env['NPM_TOKEN'] = 'npm_secret_live_token'
+  try {
+    const reason = publishAuthPreflight({ ci: false, direct: true, dryRun: false, version: '0.0.0' })
+    assert.equal(reason, undefined, 'the 0.0.0 reservation escape hatch must pass the posture gate')
+  } finally {
+    restoreTokenVars(snap)
+  }
+})
+
+test('publishAuthPreflight: dry-run never refuses', () => {
+  const snap = snapshotTokenVars()
+  clearTokenVars()
+  process.env['NPM_TOKEN'] = 'npm_secret_live_token'
+  try {
+    const reason = publishAuthPreflight({ ci: true, direct: false, dryRun: true })
+    assert.equal(reason, undefined, 'dry-run must skip the posture gate')
+  } finally {
+    restoreTokenVars(snap)
+  }
+})
+
+test('compareSemver: major/minor/patch ordering', () => {
+  assert.equal(compareSemver('11.17.0', '11.17.0'), 0)
+  assert.ok(compareSemver('11.17.0', '11.5.1') > 0)
+  assert.ok(compareSemver('11.5.1', '11.17.0') < 0)
+  assert.ok(compareSemver('12.0.0', '11.99.99') > 0)
+  assert.ok(compareSemver('11.15.0', '11.17.0') < 0)
+})
+
+test('NPM_MIN_VERSION floor covers staged publishing + min-release-age', () => {
+  // `npm stage` landed in 11.15.0; min-release-age (DAYS) needs >= 11.17.
+  // The floor must be at least both (and OIDC's 11.5.1).
+  assert.ok(
+    compareSemver(NPM_MIN_VERSION, '11.15.0') >= 0,
+    `floor ${NPM_MIN_VERSION} must cover npm stage (>= 11.15.0)`,
+  )
+  assert.ok(
+    compareSemver(NPM_MIN_VERSION, '11.17.0') >= 0,
+    `floor ${NPM_MIN_VERSION} must cover min-release-age in DAYS (>= 11.17)`,
+  )
+  assert.ok(
+    compareSemver(NPM_MIN_VERSION, '11.5.1') >= 0,
+    `floor ${NPM_MIN_VERSION} must cover OIDC trusted publishing (>= 11.5.1)`,
+  )
+})

--- a/scripts/publish/release.mts
+++ b/scripts/publish/release.mts
@@ -1,0 +1,264 @@
+/**
+ * @file Post-publish release orchestration for Perry, modeled on a tiered registry-infra design
+ *   Derives the GitHub release body from changelog.d
+ *   fragments (via scripts/cut_release_notes.sh --notes-only — Perry froze
+ *   CHANGELOG.md at v0.5.1264), then creates the git tag + the IMMUTABLE
+ *   (draft → upload → undraft) GitHub release carrying packaging/install.sh +
+ *   a checksums file.
+ *
+ *   The platform tarballs (perry-macos-aarch64.tar.gz, …) are built in CI, not
+ *   locally — a follow-up CI leg uploads them to this release. The local cut
+ *   uploads the assets the author HAS locally: install.sh + checksums.txt.
+ *
+ *   The tag + release are the LAST markers of a release, so they may only
+ *   exist once the version is resolvable on npm (requireRegistryLive). A
+ *   STAGED package is not published — staging may never be approved.
+ */
+
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+import { INSTALL_SH, RELEASE_REPO, rootPath } from './constants.mts'
+import { logger, runCapture } from './shared.mts'
+import { fetchPublishedVersion } from './npm/shared.mts'
+
+/** Concatenate changelog.d/ fragments into the release body. */
+export async function extractReleaseNotes(cwd: string = rootPath): Promise<string> {
+  const { stdout, code } = await runCapture(
+    'sh',
+    ['scripts/cut_release_notes.sh', '--notes-only'],
+    cwd,
+  )
+  if (code !== 0 || !stdout.trim()) {
+    logger.warn('cut_release_notes.sh --notes-only failed; falling back to a one-liner.')
+    return ''
+  }
+  return stdout
+}
+
+/**
+ * Registry-liveness gate: poll npm view until <name>@<version> is resolvable,
+ * or fail loud after attempts. npm propagation lags a few seconds behind an
+ * approve. Returns true when every (name, version) pair is live.
+ */
+export async function requireRegistryLive(
+  packages: ReadonlyArray<{ name: string; version: string }>,
+  config: { attempts?: number; delayMs?: number } = {},
+): Promise<boolean> {
+  const { attempts = 12, delayMs = 5000 } = config
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const live = await Promise.all(
+      packages.map(async p => [p, await fetchPublishedVersion(p.name, p.version)] as const),
+    )
+    const notLive = live.filter(([, ok]) => !ok).map(([{ name, version }]) => `${name}@${version}`)
+    if (notLive.length === 0) {
+      logger.info(`registry liveness: all ${packages.length} package(s) resolvable (attempt ${attempt}).`)
+      return true
+    }
+    if (attempt === attempts) {
+      logger.fail(
+        `registry liveness: ${notLive.join(', ')} never turned up after ${attempts} attempts — do NOT cut the release.`,
+      )
+      return false
+    }
+    logger.info(`registry liveness: waiting on ${notLive.join(', ')} (attempt ${attempt}/${attempts})…`)
+    await new Promise(r => setTimeout(r, delayMs))
+  }
+  return false
+}
+
+/** Compute sha256 for a file (hex). */
+function sha256File(file: string): string {
+  return createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
+/** Write a checksums.txt (sha256) for the given asset paths, return its path. */
+export function writeChecksums(files: readonly string[], cwd: string = rootPath): string {
+  const out = path.join(cwd, 'checksums.txt')
+  const lines = files.map(f => `${sha256File(f)}  ${path.basename(f)}`)
+  writeFileSync(out, lines.join('\n') + '\n')
+  return out
+}
+
+/**
+ * Create the tag + immutable GitHub release (draft → upload → undraft).
+ * Assets: packaging/install.sh + checksums.txt. The platform tarballs are
+ * uploaded by a follow-up CI leg. Returns true only when the tag is on origin
+ * AND the release is published (or already existed).
+ */
+export async function ensureTagAndRelease(version: string): Promise<boolean> {
+  const tagName = `v${version}`
+
+  // 1. Assets FIRST. install.sh is a REQUIRED release asset (the release
+  //    advertises `curl ... install.sh | sh`), and the tag is immutable once
+  //    pushed — so it must not be cut when a required asset is absent. Fail
+  //    here, before any tag exists, rather than warning after the tag is live.
+  const installSh = path.join(rootPath, INSTALL_SH)
+  if (!existsSync(installSh)) {
+    logger.fail(
+      `install.sh not found at ${installSh} — refusing to cut the release.\n` +
+        `  Why: install.sh is a required release asset (the release advertises \`curl ... install.sh | sh\`).\n` +
+        `  A tag is immutable, so it must not be pushed without the required assets.\n` +
+        `  Fix: restore packaging/install.sh and re-run.`,
+    )
+    process.exitCode = 1
+    return false
+  }
+  const checksums = writeChecksums([installSh])
+  const assets: string[] = [installSh, checksums]
+
+  try {
+    // 2. Tag (on HEAD — the bump commit is already on main).
+    const tagCheck = await runCapture(
+      'git',
+      ['rev-parse', '-q', '--verify', `refs/tags/${tagName}`],
+      rootPath,
+    )
+    if (tagCheck.code !== 0) {
+      const created = await runCapture('git', ['tag', tagName], rootPath)
+      if (created.code !== 0) {
+        logger.fail(`could not create tag ${tagName}`)
+        process.exitCode = 1
+        return false
+      }
+      logger.log(`Created tag ${tagName}.`)
+    }
+
+    // 3. Push the tag. Tolerate a non-zero push only when origin already
+    //    carries it AT THE SAME COMMIT as the local tag — a remote tag at a
+    //    different commit means someone else tagged a different release, and
+    //    continuing would publish the release against the wrong commit.
+    const pushed = await runCapture('git', ['push', 'origin', tagName], rootPath)
+    if (pushed.code !== 0) {
+      const remote = await runCapture(
+        'git',
+        ['ls-remote', '--tags', 'origin', `refs/tags/${tagName}`],
+        rootPath,
+      )
+      if (remote.code !== 0 || !remote.stdout.includes(`refs/tags/${tagName}`)) {
+        logger.fail(
+          `could not push tag ${tagName} to origin (git push exited ${pushed.code}) and origin does not carry it.\n` +
+            `  Fix: resolve the push (auth? protected ref? network?) and re-run.`,
+        )
+        process.exitCode = 1
+        return false
+      }
+      // Peel both sides to a commit SHA and compare. For a lightweight tag the
+      // ls-remote line IS the commit; for an annotated tag the `^{}` line is.
+      const localCommit = (
+        await runCapture('git', ['rev-parse', `refs/tags/${tagName}^{commit}`], rootPath)
+      ).stdout.trim()
+      let remoteCommit = ''
+      for (const line of remote.stdout.split('\n')) {
+        const peeled = line.match(/^([0-9a-f]+)\trefs\/tags\/[^\t]+\^\{\}/)
+        if (peeled) {
+          remoteCommit = peeled[1]!
+          break
+        }
+      }
+      if (!remoteCommit) {
+        const raw = remote.stdout.split('\n')[0]
+        remoteCommit = raw ? (raw.split(/\s/)[0] ?? '') : ''
+      }
+      if (remoteCommit !== localCommit) {
+        logger.fail(
+          `tag ${tagName} on origin points to ${remoteCommit || '<unknown>'}, not the local commit ${localCommit} — ` +
+            `refusing to publish the release against the wrong commit.\n` +
+            `  Fix: land a version bump (this tag name is taken) or reconcile the remote tag.`,
+        )
+        process.exitCode = 1
+        return false
+      }
+      logger.log(`Tag ${tagName} already on origin at the expected commit; continuing.`)
+    }
+
+    // 4. If the release already exists, resume a draft or leave a published one.
+    //    A tag-only check treats an interrupted draft as complete and skips the
+    //    asset upload + undraft — so inspect isDraft and finish the draft here.
+    const view = await runCapture(
+      'gh',
+      ['release', 'view', tagName, '--json', 'tagName,isDraft'],
+      rootPath,
+    )
+    if (view.code === 0) {
+      let isDraft = false
+      try {
+        isDraft = (JSON.parse(view.stdout) as { isDraft?: boolean }).isDraft === true
+      } catch {
+        /* unreadable → treat as published (do not re-publish a live release) */
+      }
+      if (!isDraft) {
+        logger.log(`Release ${tagName} already published; leaving it untouched.`)
+        return true
+      }
+      logger.log(`Release ${tagName} exists as a draft — resuming asset upload + publish.`)
+      // --clobber: the interrupted run may have already uploaded install.sh /
+      // checksums.txt; overwrite them (checksums.txt is regenerated each run).
+      const upload = await runCapture('gh', ['release', 'upload', tagName, '--clobber', ...assets], rootPath)
+      if (upload.code !== 0) {
+        logger.fail(`gh release upload failed (${upload.code})`)
+        process.exitCode = 1
+        return false
+      }
+      const undraft = await runCapture('gh', ['release', 'edit', tagName, '--draft=false'], rootPath)
+      if (undraft.code !== 0) {
+        logger.fail(`gh release edit --draft=false failed (${undraft.code})`)
+        process.exitCode = 1
+        return false
+      }
+      logger.log(
+        `Release ${tagName} published (resumed from draft). ` +
+          `curl -fsSL https://github.com/${RELEASE_REPO}/releases/download/${tagName}/install.sh | sh`,
+      )
+      return true
+    }
+
+    // 5. Release notes from changelog.d fragments.
+    const notes = await extractReleaseNotes()
+    const notesFile = path.join(os.tmpdir(), `release-notes-${version}.md`)
+    writeFileSync(notesFile, notes || `Release ${version}.`)
+
+    // 6. Immutable release: draft → upload → undraft.
+    const create = await runCapture(
+      'gh',
+      ['release', 'create', tagName, '--draft', '--verify-tag', '--title', tagName, '--notes-file', notesFile],
+      rootPath,
+    )
+    if (create.code !== 0) {
+      logger.fail(`gh release create failed (${create.code})`)
+      process.exitCode = 1
+      return false
+    }
+    const upload = await runCapture('gh', ['release', 'upload', tagName, '--clobber', ...assets], rootPath)
+    if (upload.code !== 0) {
+      logger.fail(`gh release upload failed (${upload.code})`)
+      process.exitCode = 1
+      return false
+    }
+    const undraft = await runCapture('gh', ['release', 'edit', tagName, '--draft=false'], rootPath)
+    if (undraft.code !== 0) {
+      logger.fail(`gh release edit --draft=false failed (${undraft.code})`)
+      process.exitCode = 1
+      return false
+    }
+    logger.log(
+      `Release ${tagName} published from changelog.d fragments. ` +
+        `curl -fsSL https://github.com/${RELEASE_REPO}/releases/download/${tagName}/install.sh | sh`,
+    )
+    return true
+  } finally {
+    // checksums.txt is written into the repo tree solely for the upload.
+    for (const a of assets) {
+      if (path.basename(a) === 'checksums.txt') {
+        try {
+          rmSync(a, { force: true })
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  }
+}

--- a/scripts/publish/scan.mts
+++ b/scripts/publish/scan.mts
@@ -1,0 +1,251 @@
+/**
+ * @file Pre-approve Socket full-scan gate, modeled on a tiered registry-infra design
+ *   CLI-free: everything runs through
+ *   `@socketsecurity/sdk` against the Socket API directly. Each
+ *   verified package tarball is submitted as a `tmp` full scan (hidden from
+ *   the dashboard scan list — a promotion gate, not a tracked branch scan),
+ *   and gated on the org's OWN security policy: any alert whose policy action
+ *   is `error` fails the entry; `warn`-action alerts pass with counts in the
+ *   receipt. Fail-closed by design.
+ *
+ *   Auth: `SOCKET_API_TOKEN` (the canonical env name). If absent, the gate
+ *   fails with a pointer to the dashboard mint URL rather than silently
+ *   passing.
+ */
+
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import { SocketSdk } from '@socketsecurity/sdk'
+
+import {
+  npmPackageDir,
+  rootPath,
+  SOCKET_ORG_SLUG,
+  SOCKET_SCAN_REPO,
+} from './constants.mts'
+import { logger } from './shared.mts'
+import { packTarball } from './npm/staged.mts'
+
+export const SOCKET_TOKEN_ENV_VAR = 'SOCKET_API_TOKEN'
+export const SOCKET_TOKEN_MINT_URL = 'https://socket.dev/dashboard'
+
+export interface PolicyFailingAlert {
+  artifact: string
+  severity: string
+  type: string
+}
+
+export interface PolicyAlertSummary {
+  error: PolicyFailingAlert[]
+  total: number
+  warn: PolicyFailingAlert[]
+}
+
+/**
+ * Pure policy evaluation: bucket every artifact alert by its org
+ * security-policy action. The org's own policy decides what blocks, not a
+ * hardcoded severity floor.
+ */
+export function summarizePolicyAlerts(
+  artifacts: ReadonlyArray<{
+    alerts?: ReadonlyArray<{ severity?: string; type: string }> | undefined
+    name?: string
+    version?: string
+  }>,
+  policyRules: Readonly<Record<string, { action?: string }>>,
+): PolicyAlertSummary {
+  const summary: PolicyAlertSummary = { error: [], total: 0, warn: [] }
+  for (const artifact of artifacts) {
+    for (const alert of artifact.alerts ?? []) {
+      summary.total += 1
+      const action = policyRules[alert.type]?.action
+      if (action !== 'error' && action !== 'warn') continue
+      summary[action].push({
+        artifact: `${artifact.name ?? '<unnamed>'}@${artifact.version ?? '?'}`,
+        severity: alert.severity ?? 'unknown',
+        type: alert.type,
+      })
+    }
+  }
+  return summary
+}
+
+export interface FullScanArtifact {
+  alerts?: Array<{ severity?: string; type: string }> | undefined
+  name?: string
+  version?: string
+}
+
+export type SecurityPolicyRules = Record<string, { action?: string }>
+
+/** Extract the `securityPolicyRules` map from a getOrgSecurityPolicy response. */
+export function extractSecurityPolicyRules(
+  data: unknown,
+): SecurityPolicyRules | undefined {
+  if (data && typeof data === 'object') {
+    const rules = (data as { securityPolicyRules?: unknown }).securityPolicyRules
+    if (rules && typeof rules === 'object') {
+      return rules as SecurityPolicyRules
+    }
+  }
+  return undefined
+}
+
+/** Normalize a full-scan response (bare array or `{ artifacts: [...] }`). */
+export function normalizeFullScanArtifacts(
+  data: unknown,
+): FullScanArtifact[] | undefined {
+  if (Array.isArray(data)) return data as FullScanArtifact[]
+  if (data && typeof data === 'object') {
+    const arts = (data as { artifacts?: unknown }).artifacts
+    if (Array.isArray(arts)) return arts as FullScanArtifact[]
+  }
+  return undefined
+}
+
+export interface SocketScanContext {
+  orgSlug: string
+  sdk: SocketSdk
+}
+
+/** Read the Socket API token from the environment. */
+export function resolveSocketApiToken(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const value = env[SOCKET_TOKEN_ENV_VAR]
+  return value && value.length > 0 ? value : undefined
+}
+
+/**
+ * Preflight auth: build an SDK from SOCKET_API_TOKEN and verify it with a
+ * cheap getQuota() call. Fails closed with a mint pointer when the token is
+ * missing or rejected.
+ */
+export async function preflightSocketScanAuth(
+  orgSlug: string = SOCKET_ORG_SLUG,
+): Promise<SocketScanContext | undefined> {
+  const token = resolveSocketApiToken()
+  if (!token) {
+    logger.fail(
+      `No ${SOCKET_TOKEN_ENV_VAR} in the environment — the Socket scan gate cannot run.\n` +
+        `  Fix: mint a token with full-scans + report scopes at ${SOCKET_TOKEN_MINT_URL} and export ${SOCKET_TOKEN_ENV_VAR}.`,
+    )
+    return undefined
+  }
+  const sdk = new SocketSdk(token)
+  try {
+    const quota = await sdk.getQuota()
+    if (!quota.success) {
+      logger.fail(
+        `Socket auth failed: getQuota() returned an unsuccessful response (status ${quota.status}) — the token was rejected.\n` +
+          `  Fix: check ${SOCKET_TOKEN_ENV_VAR} at ${SOCKET_TOKEN_MINT_URL}.`,
+      )
+      return undefined
+    }
+  } catch (e) {
+    logger.fail(
+      `Socket auth failed: getQuota() rejected the token (${String(e)}).\n` +
+        `  Fix: check ${SOCKET_TOKEN_ENV_VAR} at ${SOCKET_TOKEN_MINT_URL}.`,
+    )
+    return undefined
+  }
+  return { orgSlug, sdk }
+}
+
+export interface ScanResult {
+  name: string
+  version: string
+  /** passed | failed | blocked (unreachable scan). */
+  status: 'passed' | 'failed' | 'blocked'
+  scanId?: string
+  summary: PolicyAlertSummary
+}
+
+/**
+ * Scan one package's tarball. Packs locally and — when the caller passes the
+ * staged shasum — verifies the packed tarball's sha1 matches the staged bytes
+ * BEFORE submitting, so a worktree change between verify and scan can never
+ * make Socket scan different bytes from the artifact that promotion releases.
+ * Submits as a tmp full scan, reads results + org security policy in parallel,
+ * and buckets alerts. `error`-action alerts → failed; an unreachable/empty
+ * scan → blocked (never a pass).
+ */
+export async function scanTarball(
+  ctx: SocketScanContext,
+  name: string,
+  version: string,
+  stagedShasum?: string,
+): Promise<ScanResult> {
+  const { orgSlug, sdk } = ctx
+  const pkgDir = path.join(rootPath, npmPackageDir(name))
+  const packed = await packTarball(pkgDir)
+  if (!packed || !existsSync(packed.path)) {
+    logger.fail(`scan: no local tarball for ${name}@${version} — run verify first.`)
+    return { name, version, status: 'blocked', summary: { error: [], total: 0, warn: [] } }
+  }
+  if (stagedShasum && packed.sha1 !== stagedShasum) {
+    logger.fail(
+      `scan: shasum mismatch for ${name}@${version} — the local tarball no longer matches the staged bytes.\n` +
+        `    local pack:  ${packed.sha1}\n` +
+        `    npm staging: ${stagedShasum}\n` +
+        `  Fix: the worktree changed between verify and scan; re-run publish:stage. Not scanning unverified bytes.`,
+    )
+    return { name, version, status: 'blocked', summary: { error: [], total: 0, warn: [] } }
+  }
+  const blocked = (why: string): ScanResult => {
+    logger.fail(why)
+    return { name, version, status: 'blocked', summary: { error: [], total: 0, warn: [] } }
+  }
+  let scanId: string | undefined
+  try {
+    const created = await sdk.createOrgFullScanFromArchive(orgSlug, packed.path, {
+      repo: SOCKET_SCAN_REPO,
+      tmp: true,
+    })
+    if (created.success) {
+      scanId = (created.data as { id?: string }).id
+    } else {
+      return blocked(
+        `archive full-scan create failed for ${name}@${version} (status ${created.status}${created.error ? `: ${String(created.error)}` : ''}).`,
+      )
+    }
+  } catch (e) {
+    return blocked(`archive full-scan create threw for ${name}@${version}: ${String(e)}`)
+  }
+  if (!scanId) {
+    return blocked(`archive full-scan create returned no scan id for ${name}@${version}.`)
+  }
+  try {
+    const [scan, policy] = await Promise.all([
+      sdk.getFullScan(orgSlug, scanId),
+      sdk.getOrgSecurityPolicy(orgSlug),
+    ])
+    if (!scan.success || !policy.success) {
+      return blocked(`could not read full scan ${scanId} or the org security policy for ${name}@${version}.`)
+    }
+    const rawArtifacts = normalizeFullScanArtifacts(scan.data)
+    if (!rawArtifacts || rawArtifacts.length === 0) {
+      return blocked(`full scan ${scanId} returned no recognizable artifacts for ${name}@${version} — nothing was evaluated.`)
+    }
+    const rules = extractSecurityPolicyRules(policy.data)
+    if (!rules) {
+      return blocked(`the ${orgSlug} security policy was empty or unrecognized — no policy to evaluate ${name}@${version} against.`)
+    }
+    const summary = summarizePolicyAlerts(rawArtifacts, rules)
+    logger.info(
+      `full scan ${scanId} (org ${orgSlug}): ${rawArtifacts.length} artifact(s), ` +
+        `${summary.total} alert(s), ${summary.error.length} error, ${summary.warn.length} warn — ${name}@${version}`,
+    )
+    return {
+      name,
+      version,
+      status: summary.error.length > 0 ? 'failed' : 'passed',
+      scanId,
+      summary,
+    }
+  } catch (e) {
+    return blocked(`reading full scan ${scanId} threw for ${name}@${version}: ${String(e)}`)
+  }
+}

--- a/scripts/publish/shared.mts
+++ b/scripts/publish/shared.mts
@@ -1,0 +1,309 @@
+/**
+ * @file Registry-agnostic publish helpers: interactive + capturing process
+ *   spawns, git introspection, first-JSON extraction from noisy CLI output,
+ *   and the logger/root-path shared by every publish module. Ported from the
+ *   a tiered registry-infra design, but uses Node built-ins (no
+ *   @socketsecurity/lib-stable spawn/logger coupling) so the generic core
+ *   stays lean. The Socket SDK is pulled in only by scan.mts.
+ */
+
+import { spawn } from 'node:child_process'
+import { fstatSync, readFileSync } from 'node:fs'
+import process from 'node:process'
+
+import { NPM_MIN_VERSION, rootPath } from './constants.mts'
+
+export { rootPath }
+
+/** Minimal logger — the publish scripts run interactively; console is enough. */
+export const logger = {
+  log: (...args: unknown[]): void => console.log(...args),
+  warn: (...args: unknown[]): void => console.warn(...args),
+  fail: (...args: unknown[]): void => console.error(...args),
+  info: (...args: unknown[]): void => console.log(...args),
+}
+
+const WIN32 = process.platform === 'win32'
+
+/** The staged→approve handoff block, printed once when a staging run finishes. */
+export function formatApproveHandoff(
+  approveCommand: string,
+  ownership: string,
+  repoPath: string = rootPath,
+): string[] {
+  return [`Next: cd ${repoPath} && ${approveCommand}`, ownership]
+}
+
+export function logApproveHandoff(
+  approveCommand: string,
+  ownership: string,
+  repoPath: string = rootPath,
+): void {
+  for (const line of formatApproveHandoff(approveCommand, ownership, repoPath)) {
+    logger.log(line)
+  }
+}
+
+/** Spawn a command, forwarding stdio (interactive). Returns the exit code. */
+export function runInherit(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv | undefined,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      ...(env ? { env: { ...process.env, ...env } } : {}),
+      shell: WIN32,
+      stdio: 'inherit',
+    })
+    child.on('error', reject)
+    child.on('exit', code => resolve(code ?? 0))
+  })
+}
+
+export interface TeedRun {
+  code: number
+  output: string
+}
+
+/** Spawn a command, forward its output live, AND keep a copy. */
+export function runInheritTee(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv | undefined,
+): Promise<TeedRun> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      ...(env ? { env: { ...process.env, ...env } } : {}),
+      shell: WIN32,
+      stdio: ['inherit', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout?.on('data', (chunk: Buffer) => {
+      output += chunk.toString('utf8')
+      process.stdout.write(chunk)
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      output += chunk.toString('utf8')
+      process.stderr.write(chunk)
+    })
+    child.on('error', reject)
+    child.on('exit', code => resolve({ code: code ?? 0, output }))
+  })
+}
+
+/**
+ * Wrap a command in `script(1)`'s pseudo-terminal so npm's registry web-OTP
+ * challenge stays alive off a non-interactive agent shell. Passthrough when
+ * stdio is already a TTY, and on Windows (no script(1) — Windows runs
+ * interactive-only).
+ */
+export function buildPtyInvocation(
+  platform: NodeJS.Platform,
+  cmd: string,
+  args: readonly string[],
+): { args: string[]; command: string } | undefined {
+  if (platform === 'win32') return undefined
+  if (platform === 'darwin') {
+    // BSD script: `script -q /dev/null <cmd> <args…>` runs cmd directly.
+    return { args: ['-q', '/dev/null', cmd, ...args], command: 'script' }
+  }
+  // util-linux script: command goes through `-c` as a single shell string.
+  const quoted = [cmd, ...args]
+    .map(a => `'${a.replace(/'/g, `'\\''`)}'`)
+    .join(' ')
+  return { args: ['-qec', quoted, '/dev/null'], command: 'script' }
+}
+
+export const NON_INTERACTIVE_RENDER_ENV: NodeJS.ProcessEnv = {
+  NO_COLOR: '1',
+}
+
+/** True when fd 1 is a regular FILE (a `> out.log` redirect / agent capture). */
+export function stdoutIsFileBacked(): boolean {
+  try {
+    return fstatSync(1).isFile()
+  } catch {
+    return false
+  }
+}
+
+export const PTY_FILE_STDOUT_MESSAGE =
+  'stdout is a file — pumping the PTY through a pipe.\n' +
+  '  What:  script(1) cannot allocate a pseudo-terminal onto a file-backed\n' +
+  '         stdout, so the wrapper gives the PTY child a PIPE and pumps its\n' +
+  '         output into the file itself. The browser web-OTP flow proceeds.'
+
+export function runPtyPumped(
+  pty: { command: string; args: readonly string[] },
+  cwd: string,
+  env?: NodeJS.ProcessEnv | undefined,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(pty.command, [...pty.args], {
+      cwd,
+      ...(env ? { env: { ...process.env, ...env } } : {}),
+      stdio: ['inherit', 'pipe', 'pipe'],
+    })
+    child.stdout?.on('data', (chunk: Buffer) => process.stdout.write(chunk))
+    child.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk))
+    child.on('error', reject)
+    child.on('exit', code => resolve(code ?? 0))
+  })
+}
+
+/** Spawn interactively, guaranteeing the child sees a TTY when one is absent. */
+export function runInheritTty(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv | undefined,
+): Promise<number> {
+  if (process.stdin.isTTY || WIN32) {
+    return runInherit(cmd, args, cwd, env)
+  }
+  const pty = buildPtyInvocation(process.platform, cmd, args)
+  if (!pty) return runInherit(cmd, args, cwd, env)
+  if (stdoutIsFileBacked()) {
+    logger.log(`[pty] ${PTY_FILE_STDOUT_MESSAGE}`)
+    return runPtyPumped(pty, cwd, env)
+  }
+  return runInherit(pty.command, pty.args, cwd, env)
+}
+
+/** Spawn a command and capture stdout; stderr stays visible. */
+export function runCapture(
+  cmd: string,
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      shell: WIN32,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+    let stdout = ''
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.on('error', reject)
+    child.on('exit', code => resolve({ stdout, code: code ?? 0 }))
+  })
+}
+
+/** Compare two `major.minor.patch` versions. Returns a < 0, 0, or > 0. */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(n => parseInt(n, 10) || 0)
+  const pb = b.split('.').map(n => parseInt(n, 10) || 0)
+  for (let i = 0; i < 3; i += 1) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0)
+    if (d !== 0) return d
+  }
+  return 0
+}
+
+/**
+ * Enforce the npm floor for the publish flow (NPM_MIN_VERSION). Returns a
+ * non-empty string reason when npm is missing or too old, or undefined when
+ * the floor is satisfied.
+ */
+export async function checkNpmFloor(): Promise<string | undefined> {
+  const { stdout, code } = await runCapture('npm', ['--version'], rootPath)
+  if (code !== 0 || !stdout.trim()) {
+    return 'could not run `npm --version` — is npm on PATH?'
+  }
+  const version = stdout.trim().replace(/^v/, '')
+  if (compareSemver(version, NPM_MIN_VERSION) < 0) {
+    return (
+      `npm ${version} is below the publish-flow floor of ${NPM_MIN_VERSION}.\n` +
+      `  Why: the flow needs npm staged publishing (\`npm stage\`, >= 11.15.0),\n` +
+      `  OIDC trusted publishing (>= 11.5.1), and \`min-release-age\` in DAYS\n` +
+      `  (>= 11.17) — ${NPM_MIN_VERSION} covers all three.\n` +
+      `  Fix: npm install -g npm@latest (or npm@${NPM_MIN_VERSION}).`
+    )
+  }
+  return undefined
+}
+
+/** Resolve `git rev-parse --short HEAD`, or `unknown` when git fails. */
+export async function gitShortSha(cwd: string): Promise<string> {
+  const { stdout, code } = await runCapture(
+    'git',
+    ['rev-parse', '--short', 'HEAD'],
+    cwd,
+  )
+  return code === 0 ? stdout.trim() : 'unknown'
+}
+
+/**
+ * Extract the first balanced top-level JSON value (`{ … }` or `[ … ]`) from a
+ * noisy stdout stream (npm stage list wraps JSON in progress lines). `npm stage
+ * list --json` emits an ARRAY of staged entries, so `[` must be honored as a
+ * start token — otherwise only the first object inside the array is extracted
+ * and every staged entry after it disappears. Returns undefined if none found.
+ */
+export function extractFirstJson(text: string): string | undefined {
+  const objIdx = text.indexOf('{')
+  const arrIdx = text.indexOf('[')
+  let startIdx: number
+  if (objIdx === -1 && arrIdx === -1) return undefined
+  else if (objIdx === -1) startIdx = arrIdx
+  else if (arrIdx === -1) startIdx = objIdx
+  else startIdx = Math.min(objIdx, arrIdx)
+  const open = text[startIdx]!
+  const close = open === '{' ? '}' : ']'
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = startIdx, { length } = text; i < length; i += 1) {
+    const ch = text[i]!
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (ch === '\\') {
+      escape = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+    if (ch === open) depth += 1
+    else if (ch === close) {
+      depth -= 1
+      if (depth === 0) return text.slice(startIdx, i + 1)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether this CI run may request npm provenance. The sigstore bundle is
+ * verifiable only when the source repository is PUBLIC. Fail-closed outside
+ * Actions or when the event payload is unreadable.
+ */
+export function provenanceAllowed(): boolean {
+  if (process.env['GITHUB_ACTIONS'] !== 'true') return false
+  const eventPath = process.env['GITHUB_EVENT_PATH']
+  if (!eventPath) return false
+  try {
+    const event = JSON.parse(readFileSync(eventPath, 'utf8')) as {
+      repository?:
+        | { private?: boolean | undefined; visibility?: string | undefined }
+        | undefined
+    }
+    const repo = event.repository
+    if (!repo) return false
+    if (repo.visibility !== undefined) return repo.visibility === 'public'
+    return repo.private === false
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Adds a **local, `npm run`-driven staged-publish pipeline** to Perry. Today publishing is CI-only (`release-packages.yml`) with no approve gate and no pre-publish tarball scan; this gives the author a stage → verify → socket-scan → **human approve gate** → promote + cut-release flow run from the laptop, with OIDC trusted publishing preserved for the upload itself.

Perry's root is **npm-managed** (`package.json` + `package-lock.json`, documented in `scripts/soak/paths.mts`), so the pipeline uses **`npm stage`** (npm CLI's staged-publishing client, which ships `npm stage publish`/`approve`/`list`) — no pnpm anywhere, and `@socketsecurity/sdk` lands in the tracked `package-lock.json`.

## What lands

**`scripts/publish/` tree** (generic core + npm/brew/cargo tiers):

| Script | What it does |
|---|---|
| `npm run publish:stage` | Dispatch the new `npm-stage-publish.yml` CI workflow (OIDC staged upload: build legs reused from `release-packages.yml` stage mode → `stage-npm.sh` → `npm stage publish --provenance` for all 9 packages), then locally verify (`npm pack` sha1 vs staged shasum) + Socket-scan. **Nothing is public.** |
| `npm run publish:approve` | The promote step, run **separately** (never in CI): browser web-OTP 2FA `npm stage approve` → registry-liveness confirm → tag `vX.Y.Z` + immutable GitHub release (draft→upload `install.sh`+`checksums.txt`→undraft). |
| `npm run publish:scan` / `:status` / `:release` | Re-scan / print receipts / cut the release only. |
| `npm run publish:brew` / `:ffi` | Locally-runnable Homebrew tap bump (`PerryTS/homebrew-perry`) + perry-ffi → crates.io. |

- **`scan.mts`** — Socket full-scan of each staged tarball via `@socketsecurity/sdk` `createOrgFullScanFromArchive`; `error`-action alerts (per the org's own security policy) fail the gate, `warn`-action alerts pass with counts. Fail-closed on unreachable/empty scans.
- **`auth-posture.mts`** — refuses any long-lived `NPM_TOKEN`/`NODE_AUTH_TOKEN`/`NPM_AUTH_TOKEN` on publish (OIDC-in-CI + 2FA-locally only); `prepublishOnly` is wired to it. A read-only `PERRY_NPM_READONLY_TOKEN` powers registry reads and can never publish.
- **`release.mts`** uploads `packaging/install.sh` + `checksums.txt` as per-tag release assets, so `curl -fsSL …/releases/download/vX.Y.Z/install.sh | sh` works per tag.

**New `.github/workflows/npm-stage-publish.yml`**: OIDC staged upload (`environment: npm-publish`, `id-token: write`, no long-lived token). Stages ONLY — nothing is public until the local `publish:approve`. The existing `release-packages.yml` `npm-publish` job stays as the republish/emergency fallback (untouched).

**npm floor enforced** — `>= 11.17.0` (the newest of: `npm stage` ≥11.15.0, OIDC ≥11.5.1, `min-release-age` DAYS ≥11.17). `checkNpmFloor()` runs at the start of `pipeline.mts` (clear error + fix on older npm); the CI workflow asserts the floor in shell.

## Why stage/approve is split

The stage upload uses an OIDC token from CI; the approve requires human 2FA. Combining them would leak the OTP into CI logs or require a human at the CI keyboard — a hard requirement of npm staged publishing, not a stylistic choice.

<details><summary><b>Prerequisites the author provisions (one-time, documented in-script)</b></summary>

1. npm staged publishing enrolled for `@perryts/*` (`npm stage publish`/`approve`).
2. The new workflow added as a trusted publisher on each `@perryts/*` package (same setup `npm/README.md` describes for `release-packages.yml`).
3. `SOCKET_API_TOKEN` for tarball scans; `HOMEBREW_TAP_TOKEN`/`APT_REPO_TOKEN` for tap pushes; `PERRY_NPM_READONLY_TOKEN` for registry reads.

</details>

<details><summary><b>Verification</b></summary>

- `npm run test:scripts` — 8+ unit tests pass (formula renderer, Socket policy bucketing, human-gate block shape, auth-posture refusal sabotage-tested, `compareSemver` ordering, npm-floor coverage). Full suite 49 pass / 0 fail.
- `node scripts/publish/pipeline.mts --status` runs the import chain + reads the version gate (`v0.5.1510`); `--stage-only` dispatch reaches the workflow (404s only because the file isn't on `main` yet — expected pre-merge).
- `scripts/check_file_size.sh` green; largest new file is 276 lines.
- No version bump (external contributor); changelog fragment at `changelog.d/8336-staged-publish-pipeline.md`.

</details>

Open questions for the maintainer: (1) is `@perryts/*` enrolled in npm staged publishing (`npm stage`)? (2) the new workflow must be added as a trusted publisher on each `@perryts/*` package. The root stays npm-managed — `@socketsecurity/sdk` is synced into the tracked `package-lock.json`, and the stray root `pnpm-lock.yaml` is not used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged package publishing with approval-based promotion and dry-run support.
  * Added checksum verification, security scanning, registry checks, and release status tracking.
  * Added Homebrew and FFI publishing support.
  * Added automated releases with version tags, checksums, and downloadable assets.
  * Added manually triggered staging through GitHub Actions using npm trusted publishing.
* **Security**
  * Added safeguards against long-lived credentials and provenance failures.
  * Added human approval and two-factor authentication gates.
* **Documentation**
  * Documented publishing credentials and staged release procedures.
* **Tests**
  * Added coverage for publishing safeguards, approval gates, scans, and release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->