### PR TITLE
fix(codegen): silence a pre-existing dead_code warning on a test helper

### DIFF
--- a/changelog.d/8339-codegen-dead-code-block-body.md
+++ b/changelog.d/8339-codegen-dead-code-block-body.md
@@ -1,0 +1,1 @@
+Suppress a `dead_code` warning on the unused `block_body` test helper in `crates/perry-codegen/tests/typed_feedback.rs` so the `warnings` (host-compatible, `-D warnings`) CI job stays green.

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -529,6 +529,7 @@ fn typed_feedback_guards_direct_class_field_specialization() {
 /// are indented, and are skipped. The body runs from the end of the label
 /// line to the blank line separating it from the next block (or to the
 /// function's closing brace).
+#[allow(dead_code)]
 fn block_body<'a>(ir: &'a str, label_prefix: &str) -> Option<&'a str> {
     let needle = format!("\n{label_prefix}");
     let mut from = 0;


### PR DESCRIPTION
Fixes the pre-existing `warnings` CI red on main: `rustc warnings host-compatible, all targets` fails on `dead_code` for the unused `block_body` test helper in `crates/perry-codegen/tests/typed_feedback.rs` (confirmed failing on main at `7441e1f73`, run 32081672871).

Adds `#[allow(dead_code)]` to the helper, plus a changelog fragment. Comment-only/test-helper change with no production-code impact.

Found while working PR [#8336](https://github.com/PerryTS/perry/pull/8336) — it's the `warnings` failure that PR (and main) currently carries, unrelated to that PR's changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Resolved an internal warning related to an unused test helper.
* **Documentation**
  * Added a changelog entry documenting the warning cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->