### PR TITLE
chore(make): drive make fix with cargo-fixit, pinned as a devDep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,25 @@
 # Dev-facing targets. Perry is plain cargo (no mise), so this is intentionally
 # minimal — add targets here only when a plain `cargo <verb>` isn't enough.
 
-# Apply clippy's machine-applicable autofixes across the workspace. Run on a
-# dirty tree is intended (--allow-dirty --allow-staged); review the diff before
-# committing. The CI clippy gate is unchanged.
+# Apply clippy's machine-applicable autofixes across the workspace via
+# cargo-fixit (crate-ci/cargo-fixit, pinned in external-tools.json under the
+# `cargo-install` release type) — the drop-in, faster replacement for
+# `cargo clippy --fix` on repeated runs, because it skips the full re-check
+# compile between fix rounds. There is deliberately no `cargo clippy --fix`
+# fallback: install cargo-fixit with `make fix-deps` first. Run on a dirty
+# tree is intended (--allow-dirty --allow-staged); review the diff before
+# committing. The CI clippy gate is unchanged. Mirrors the fleet's
+# `scripts/fleet/lint-rust.mts --fix`.
 .PHONY: fix
 fix:
-	@set -e; cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings
+	@set -e; cargo fixit --clippy --workspace --all-targets --allow-dirty --allow-staged
+
+# Install the pinned cargo-fixit dev tool that `make fix` drives. cargo-fixit
+# is a cargo crate with NO prebuilt binaries (no cargo binstall, no GitHub
+# release assets), so it is pinned in external-tools.json under the
+# `cargo-install` release type and built from source with `--locked`.
+# The version is read from external-tools.json so the pin has one source of truth.
+.PHONY: fix-deps
+fix-deps:
+	@set -e; v=$$(node -e "console.log(require('./external-tools.json').tools['cargo-fixit'].version)"); \
+	cargo install cargo-fixit@$$v --locked

--- a/external-tools.json
+++ b/external-tools.json
@@ -216,6 +216,15 @@
       "repository": "github:NVIDIA/skillspector",
       "version": "2eb844780ab163f01468ecf142c40a2ec0fcaec0",
       "versionDate": "2026-05-18"
+    },
+    "cargo-fixit": {
+      "description": "cargo-fixit — crate-ci/cargo-fixit, the drop-in faster replacement for `cargo clippy --fix` (skips the re-check compile between fix rounds). Installed from source via `cargo install cargo-fixit@<version> --locked` because the crate publishes NO prebuilt binaries (no cargo binstall, no GitHub release assets). Backs the `make fix` target.",
+      "release": "cargo-install",
+      "crate": "cargo-fixit",
+      "version": "0.1.15",
+      "binary": "cargo-fixit",
+      "repository": "github:crate-ci/cargo-fixit",
+      "notes": "From-source install — no prebuilt binaries. --locked respects the published Cargo.lock (the supply-chain control). make fix-deps reads this pin and runs cargo install cargo-fixit@0.1.15 --locked."
     }
   }
 }


### PR DESCRIPTION
Apologies for the back-and-forth on this — earlier iterations removed cargo-fixit and then simplified to `cargo clippy --fix`; this is the simpler version we actually want.

`make fix` now runs `cargo fixit --clippy --workspace --all-targets --allow-dirty --allow-staged` — no `cargo clippy --fix` fallback. `cargo fixit` is faster than `cargo clippy --fix` on repeated runs because it skips the full re-check compile between fix rounds. It mirrors the fleet's `scripts/fleet/lint-rust.mts --fix`.

cargo-fixit is pinned as a devDep via a new `make fix-deps` target (`cargo install cargo-fixit@0.1.15 --locked`) — it ships no prebuilt `cargo binstall` binaries, so a from-source install is the pin. Run `make fix-deps` once to install it; `make fix` then uses it.

The CI clippy gate is unchanged (runs `cargo clippy`, not `make fix`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the automated code-fixing workflow for more consistent results across the project.
  * Added a setup command to install the required, pinned code-fixing tool with locked dependencies.
  * Updated development tooling configuration to ensure consistent code-quality fixes across supported project targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->