### PR TITLE
test(ci): give run_lint_gates a compile tier mirroring the warnings + check jobs

### DIFF
--- a/changelog.d/8344-run-lint-gates-compile-tier.md
+++ b/changelog.d/8344-run-lint-gates-compile-tier.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **`scripts/run_lint_gates.sh` now covers the compile-level CI gates too.** It
+  derived its command list from test.yml's `lint` job only, so it reported
+  "all 48 gates passed" while `main` was red on the separate `warnings` job —
+  which is what happened after #8333 left a test helper unused (fixed by
+  #8339), through every PR audited in between.
+
+  The new compile tier mirrors `warnings` (`cargo check --workspace
+  --all-targets` under `-D warnings`) and `check` (`cargo clippy --workspace`),
+  deriving the host-compatible package scope from
+  `scripts/workspace_architecture.py` exactly as both jobs do, so it cannot
+  drift from CI. `SKIP_COMPILE_GATES=1` keeps a fast path and the summary then
+  says `(compile tier SKIPPED)`, so a fast run cannot be mistaken for a full one.

--- a/scripts/run_lint_gates.sh
+++ b/scripts/run_lint_gates.sh
@@ -15,6 +15,21 @@
 # copied, so it cannot drift from what CI actually does. If the workflow gains a
 # gate, this picks it up on the next run.
 #
+# TWO TIERS. The script tier is the `lint` job's ~48 script/fmt commands. The
+# COMPILE tier mirrors the separate `warnings` and `check` jobs -- `cargo check
+# --workspace --all-targets` under `-D warnings`, and `cargo clippy --workspace`
+# -- both over the same host-compatible package scope CI uses, derived from
+# scripts/workspace_architecture.py rather than copied.
+#
+# The compile tier exists because deriving only from `lint` is not the same as
+# "what CI runs": on 2026-08-18 #8333 left a test helper unused, `main` went red
+# on the `warnings` job, and this script reported "all 48 gates passed" for
+# every PR audited in between. A tier you do not run is a tier that did not
+# pass -- the same argument this script was written to make.
+#
+# Set SKIP_COMPILE_GATES=1 to skip it while iterating. The summary line then
+# SAYS the tier was skipped, so a fast run cannot be mistaken for a full one.
+#
 # Usage:
 #   scripts/run_lint_gates.sh              # every gate; non-zero if any fails
 #   scripts/run_lint_gates.sh --list       # print what would run, run nothing
@@ -85,10 +100,48 @@ for cmd in "${CMDS[@]}"; do
     fi
 done
 
+# ---------------------------------------------------------------------------
+# Compile tier: the `warnings` and `check` jobs.
+compile_ran=0
+if [[ "${SKIP_COMPILE_GATES:-0}" == "1" ]]; then
+    echo
+    echo "  skip  compile tier (SKIP_COMPILE_GATES=1)"
+else
+    compile_ran=1
+    EXCLUDES=()
+    while IFS= read -r _pkg; do
+        [ -n "$_pkg" ] && EXCLUDES+=(--exclude "$_pkg")
+    done < <(python3 scripts/workspace_architecture.py --print-excluded-scope host-compatible)
+
+    echo
+    echo "run_lint_gates: compile tier (${#EXCLUDES[@]} exclude args from workspace_architecture.py)"
+
+    if out="$(RUSTFLAGS='-D warnings' cargo check --workspace --all-targets "${EXCLUDES[@]}" 2>&1)"; then
+        printf '  ok    warnings: cargo check --workspace --all-targets (-D warnings)\n'
+    else
+        printf '  FAIL  warnings: cargo check --workspace --all-targets (-D warnings)\n'
+        printf '%s\n' "$out" | grep -E '^(error|warning)' | head -6 | sed 's/^/          /'
+        failed+=("warnings: cargo check --workspace --all-targets")
+    fi
+
+    if out="$(cargo clippy --workspace "${EXCLUDES[@]}" 2>&1)"; then
+        printf '  ok    check: cargo clippy --workspace\n'
+    else
+        printf '  FAIL  check: cargo clippy --workspace\n'
+        printf '%s\n' "$out" | grep -E '^(error|warning)' | head -6 | sed 's/^/          /'
+        failed+=("check: cargo clippy --workspace")
+    fi
+fi
+
+total=${#CMDS[@]}
+((compile_ran)) && total=$((total + 2))
+suffix=""
+((compile_ran)) || suffix=" (compile tier SKIPPED)"
+
 echo
 if ((${#failed[@]})); then
-    echo "run_lint_gates: ${#failed[@]} of ${#CMDS[@]} FAILED"
+    echo "run_lint_gates: ${#failed[@]} of ${total} FAILED${suffix}"
     printf '  %s\n' "${failed[@]}"
     exit 1
 fi
-echo "run_lint_gates: all ${#CMDS[@]} gates passed"
+echo "run_lint_gates: all ${total} gates passed${suffix}"


### PR DESCRIPTION
## Why

`scripts/run_lint_gates.sh` derived its command list from test.yml's **`lint`
job only**. The compile-level gates live in two *separate* jobs:

- **`warnings`** — `cargo check --workspace --all-targets` under `-D warnings`
- **`check`** — `cargo clippy --workspace`

So the script could report `all 48 gates passed` while `main` was red.

That is not hypothetical. #8333 rewrote two assertions in
`crates/perry-codegen/tests/typed_feedback.rs` and left the `block_body` helper
with no callers. `main` went red on `warnings`:

```
error: function `block_body` is never used
error: could not compile `perry-codegen` (test "typed_feedback") due to 1 previous error
```

It was merged, and every PR audited afterwards got a green "48 gates" report
from this script while the repo was broken. #8339 fixed the warning; this fixes
the blind spot that let it through. A tier you do not run is a tier that did not
pass — which is the argument this script exists to make.

## What

- Add a compile tier running both jobs' commands.
- Derive the host-compatible package scope from
  `scripts/workspace_architecture.py --print-excluded-scope host-compatible`,
  exactly as both CI jobs do, so the anti-drift property is preserved rather
  than hardcoded (18 exclude args at time of writing).
- `SKIP_COMPILE_GATES=1` keeps a fast path for iteration. A skipped run prints
  `(compile tier SKIPPED)` in the summary, so it cannot be mistaken for a full
  one.

## Validation

- Clean `main` (with #8339): `run_lint_gates: all 50 gates passed`
- **Sabotage** — plant an unused fn in a test target: `run_lint_gates: 2 of 50 FAILED`,
  naming `warnings: cargo check --workspace --all-targets`. Run against `main`
  *before* #8339 it independently reported the real `block_body` error, i.e. it
  would have caught #8333.
- `SKIP_COMPILE_GATES=1` → `all 48 gates passed (compile tier SKIPPED)`
- `bash -n scripts/run_lint_gates.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compile validation to lint-gate checks, including warning-enforced checks and Clippy analysis.
  * Added architecture-aware package scoping for validation.
  * Added an option to skip compile checks with a clear skipped status.

* **Documentation**
  * Updated validation guidance and changelog details to describe the new compile tier and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->