### PR TITLE
fix(temporal): format Duration locale strings with Intl

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -95,6 +95,13 @@ const KIND_LIST_FORMAT: &str = "ListFormat";
 const KIND_PLURAL_RULES: &str = "PluralRules";
 const KIND_RELATIVE_TIME: &str = "RelativeTimeFormat";
 const KIND_DURATION_FORMAT: &str = "DurationFormat";
+
+/// Format a Temporal.Duration through the same initialization and formatting
+/// path as `new Intl.DurationFormat(locales, options).format(duration)`.
+#[cfg(feature = "temporal")]
+pub(crate) fn temporal_duration_to_locale_string(duration: f64, locales: f64, options: f64) -> f64 {
+    duration_format::format_temporal_duration(duration, locales, options)
+}
 const KIND_DISPLAY_NAMES: &str = "DisplayNames";
 
 const KEY_KIND: &str = "__intlKind";

--- a/crates/perry-runtime/src/intl/duration_format.rs
+++ b/crates/perry-runtime/src/intl/duration_format.rs
@@ -851,6 +851,17 @@ fn format_value(obj: *const ObjectHeader, duration: f64) -> f64 {
     string_value(&parts.iter().map(|p| p.value.as_str()).collect::<String>())
 }
 
+/// `Temporal.Duration.prototype.toLocaleString`: initialize an ephemeral
+/// DurationFormat with the supplied locales/options and format the receiver.
+pub(super) fn format_temporal_duration(duration: f64, locales: f64, options: f64) -> f64 {
+    let locale = locale_or_default(locales);
+    let obj = js_object_alloc(0, 8);
+    set_internal_field(obj, KEY_KIND, string_value(KIND_DURATION_FORMAT));
+    set_internal_field(obj, KEY_LOCALE, string_value(&locale));
+    configure(obj, options);
+    format_value(obj, duration)
+}
+
 pub(super) extern "C" fn format_thunk(_closure: *const ClosureHeader, duration: f64) -> f64 {
     let obj = this_intl_object("format", super::KIND_DURATION_FORMAT);
     format_value(obj, duration)

--- a/crates/perry-runtime/src/temporal/duration.rs
+++ b/crates/perry-runtime/src/temporal/duration.rs
@@ -221,14 +221,19 @@ pub fn call(recv: f64, d: &Duration, name: &str, args: &[f64]) -> f64 {
         ))),
         "with" => with(d, raw_arg(args, 0)),
         // `toString` honors a `{ fractionalSecondDigits, smallestUnit,
-        // roundingMode }` options bag; `toJSON`/`toLocaleString` always use the
-        // default precision.
+        // roundingMode }` options bag; `toJSON` always uses the default
+        // precision, while `toLocaleString` delegates to Intl.DurationFormat.
         "toString" => string(&ok_or_throw(d.as_temporal_string(
             super::options::to_string_rounding_options(raw_arg(args, 0)),
         ))),
-        "toJSON" | "toLocaleString" => string(&super::temporal_value_iso_string(
-            &TemporalValue::Duration(*d),
-        )),
+        "toJSON" => string(&super::temporal_value_iso_string(&TemporalValue::Duration(
+            *d,
+        ))),
+        "toLocaleString" => crate::intl::temporal_duration_to_locale_string(
+            recv,
+            raw_arg(args, 0),
+            raw_arg(args, 1),
+        ),
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "round" => {
             let (opts, rel) = super::options::duration_round_options(raw_arg(args, 0));


### PR DESCRIPTION
## Summary

- route `Temporal.Duration.prototype.toLocaleString` through the existing `Intl.DurationFormat` initialization and formatting path
- forward both `locales` and `options` while formatting the Duration from its internal slots
- keep `toJSON` on the ISO serialization path

## Verification

- targeted Test262 case: 0/1 before, 1/1 after
- complete 49-case #5900 snapshot: 4→5 passes, 43→42 runtime failures, no other result changes
- `cargo --config "profile.release.package.perry-runtime.codegen-units=16" build --release -p perry-runtime-static`
- `cargo fmt --all -- --check`
- `bash scripts/check_file_size.sh`

No version or release-metadata bump.

Refs #5900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale-aware formatting for `Temporal.Duration` values through `toLocaleString`, supporting provided locales and formatting options.

* **Bug Fixes**
  * Updated `Temporal.Duration.prototype.toJSON` to consistently use the standard ISO string representation, independently of locale formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->