### PR TITLE
fix(worker_threads): track MessagePort ref state

### DIFF
--- a/changelog.d/8347-message-port-ref-state.md
+++ b/changelog.d/8347-message-port-ref-state.md
@@ -1,0 +1,3 @@
+- **`MessagePort.ref()`, `unref()`, and `hasRef()` now expose real per-port state.** New ports begin unreferenced, their first message listener references them, explicit ref/unref calls update the state, and removing or consuming the final listener releases the reference. Closing either endpoint also leaves both ports unreferenced.
+
+- **`onmessage` now participates in MessagePort reference and listener accounting.** Assigning a callable handler references the port and contributes to `listenerCount("message")`; replacing or clearing it reverses both effects. This closes the focused `ref-state`, `ref-after-peer-close`, `unref-delivery`, and `onmessage-nonfunction` gaps from #6763.

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -140,6 +140,14 @@ struct MessagePortState {
     closed: bool,
     /// Whether a close event still needs to be delivered.
     close_pending: bool,
+    /// Node's MessagePort handle reference state. A newly-created port is
+    /// unreferenced; attaching its first message listener references it, and
+    /// ref()/unref() then update this flag explicitly.
+    refed: bool,
+    /// Last observed callability of the public `onmessage` slot. Property
+    /// writes use the ordinary object path, so hasRef() folds a transition in
+    /// this slot into the handle state lazily.
+    onmessage_callable: bool,
 }
 
 #[derive(Default)]
@@ -494,10 +502,6 @@ fn listener_once(options: f64) -> bool {
 
 extern "C" fn worker_threads_noop0(_closure: *const ClosureHeader) -> f64 {
     js_undefined()
-}
-
-extern "C" fn worker_threads_has_ref(_closure: *const ClosureHeader) -> f64 {
-    js_bool(true)
 }
 
 /// Build a closure that captures a single f64 (the port id) in capture slot 0.

--- a/crates/perry-stdlib/src/worker_threads/channel_pump.rs
+++ b/crates/perry-stdlib/src/worker_threads/channel_pump.rs
@@ -55,6 +55,12 @@ pub extern "C" fn js_worker_threads_channels_process_pending() -> i32 {
                     state.message_cbs.retain(|listener| !listener.once);
                     let event_cbs = state.message_event_cbs.clone();
                     state.message_event_cbs.retain(|listener| !listener.once);
+                    if state.message_cbs.is_empty()
+                        && state.message_event_cbs.is_empty()
+                        && handler_cb.is_none()
+                    {
+                        state.refed = false;
+                    }
                     MessageDispatch {
                         target_bits: state.object_bits,
                         raw_cbs,

--- a/crates/perry-stdlib/src/worker_threads/message_port.rs
+++ b/crates/perry-stdlib/src/worker_threads/message_port.rs
@@ -73,17 +73,17 @@ pub(super) fn message_port_object(port_id: u64) -> *mut perry_runtime::object::O
     set_object_field(
         obj,
         "ref",
-        closure_value(worker_threads_noop0 as *const u8, 0),
+        port_bound_closure(port_ref as *const u8, 0, port_id),
     );
     set_object_field(
         obj,
         "unref",
-        closure_value(worker_threads_noop0 as *const u8, 0),
+        port_bound_closure(port_unref as *const u8, 0, port_id),
     );
     set_object_field(
         obj,
         "hasRef",
-        closure_value(worker_threads_has_ref as *const u8, 0),
+        port_bound_closure(port_has_ref as *const u8, 0, port_id),
     );
     set_object_field(obj, "__perryPortId", f64::from_bits(port_id));
     set_object_field(obj, "onmessage", js_null());
@@ -160,6 +160,9 @@ fn port_add_node_listener(
         if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
             match event_name.as_str() {
                 "message" => {
+                    let first_listener = state.message_cbs.is_empty()
+                        && state.message_event_cbs.is_empty()
+                        && object_event_handler(state.object_bits, "onmessage").is_none();
                     if !state
                         .message_cbs
                         .iter()
@@ -169,6 +172,9 @@ fn port_add_node_listener(
                             callback_bits: cb_bits,
                             once,
                         });
+                        if first_listener {
+                            state.refed = true;
+                        }
                     }
                     // Attaching a `message` listener implicitly starts the port.
                     state.started = true;
@@ -210,9 +216,17 @@ extern "C" fn port_off(closure: *const ClosureHeader, event: f64, callback: f64)
     MESSAGE_PORTS.with(|ports| {
         if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
             match event_name.as_str() {
-                "message" => state
-                    .message_cbs
-                    .retain(|listener| listener.callback_bits != cb_bits),
+                "message" => {
+                    state
+                        .message_cbs
+                        .retain(|listener| listener.callback_bits != cb_bits);
+                    if state.message_cbs.is_empty()
+                        && state.message_event_cbs.is_empty()
+                        && object_event_handler(state.object_bits, "onmessage").is_none()
+                    {
+                        state.refed = false;
+                    }
+                }
                 "close" => state
                     .close_cbs
                     .retain(|listener| listener.callback_bits != cb_bits),
@@ -232,7 +246,15 @@ extern "C" fn port_listener_count(closure: *const ClosureHeader, event: f64) -> 
             return 0.0;
         };
         match event_name.as_str() {
-            "message" => (state.message_cbs.len() + state.message_event_cbs.len()) as f64,
+            "message" => {
+                (state.message_cbs.len()
+                    + state.message_event_cbs.len()
+                    + if object_event_handler(state.object_bits, "onmessage").is_some() {
+                        1
+                    } else {
+                        0
+                    }) as f64
+            }
             "close" => (state.close_cbs.len() + state.close_event_cbs.len()) as f64,
             _ => 0.0,
         }
@@ -256,6 +278,9 @@ extern "C" fn port_add_event_listener(
         if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
             match event_name.as_str() {
                 "message" => {
+                    let first_listener = state.message_cbs.is_empty()
+                        && state.message_event_cbs.is_empty()
+                        && object_event_handler(state.object_bits, "onmessage").is_none();
                     state.started = true;
                     if !state
                         .message_event_cbs
@@ -266,6 +291,9 @@ extern "C" fn port_add_event_listener(
                             callback_bits: cb_bits,
                             once: listener_once(options),
                         });
+                        if first_listener {
+                            state.refed = true;
+                        }
                     }
                 }
                 "close" => {
@@ -301,9 +329,17 @@ extern "C" fn port_remove_event_listener(
     MESSAGE_PORTS.with(|ports| {
         if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
             match event_name.as_str() {
-                "message" => state
-                    .message_event_cbs
-                    .retain(|listener| listener.callback_bits != cb_bits),
+                "message" => {
+                    state
+                        .message_event_cbs
+                        .retain(|listener| listener.callback_bits != cb_bits);
+                    if state.message_cbs.is_empty()
+                        && state.message_event_cbs.is_empty()
+                        && object_event_handler(state.object_bits, "onmessage").is_none()
+                    {
+                        state.refed = false;
+                    }
+                }
                 "close" => state
                     .close_event_cbs
                     .retain(|listener| listener.callback_bits != cb_bits),
@@ -325,6 +361,66 @@ extern "C" fn port_start(closure: *const ClosureHeader) -> f64 {
     js_undefined()
 }
 
+extern "C" fn port_ref(closure: *const ClosureHeader) -> f64 {
+    let port_id = port_id_from_closure(closure);
+    let has_handler = MESSAGE_PORTS.with(|ports| {
+        ports
+            .borrow()
+            .get(&port_id)
+            .is_some_and(|state| object_event_handler(state.object_bits, "onmessage").is_some())
+    });
+    MESSAGE_PORTS.with(|ports| {
+        if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
+            if !state.closed {
+                state.refed = true;
+                state.onmessage_callable = has_handler;
+            }
+        }
+    });
+    js_undefined()
+}
+
+extern "C" fn port_unref(closure: *const ClosureHeader) -> f64 {
+    let port_id = port_id_from_closure(closure);
+    let has_handler = MESSAGE_PORTS.with(|ports| {
+        ports
+            .borrow()
+            .get(&port_id)
+            .is_some_and(|state| object_event_handler(state.object_bits, "onmessage").is_some())
+    });
+    MESSAGE_PORTS.with(|ports| {
+        if let Some(state) = ports.borrow_mut().get_mut(&port_id) {
+            if !state.closed {
+                state.refed = false;
+                state.onmessage_callable = has_handler;
+            }
+        }
+    });
+    js_undefined()
+}
+
+extern "C" fn port_has_ref(closure: *const ClosureHeader) -> f64 {
+    let port_id = port_id_from_closure(closure);
+    let has_handler = MESSAGE_PORTS.with(|ports| {
+        let ports = ports.borrow();
+        ports
+            .get(&port_id)
+            .is_some_and(|state| object_event_handler(state.object_bits, "onmessage").is_some())
+    });
+    let refed = MESSAGE_PORTS.with(|ports| {
+        let mut ports = ports.borrow_mut();
+        let Some(state) = ports.get_mut(&port_id) else {
+            return false;
+        };
+        if has_handler != state.onmessage_callable {
+            state.onmessage_callable = has_handler;
+            state.refed = has_handler;
+        }
+        !state.closed && state.refed
+    });
+    js_bool(refed)
+}
+
 /// port.close() — mark closed and queue `close` events on both ends (#3157).
 extern "C" fn port_close(closure: *const ClosureHeader) -> f64 {
     let port_id = port_id_from_closure(closure);
@@ -336,6 +432,7 @@ extern "C" fn port_close(closure: *const ClosureHeader) -> f64 {
                 state.close_pending = true;
             }
             state.closed = true;
+            state.refed = false;
             state.inbox.clear();
         }
         if let Some(peer_id) = peer_id {
@@ -344,6 +441,7 @@ extern "C" fn port_close(closure: *const ClosureHeader) -> f64 {
                     peer.close_pending = true;
                 }
                 peer.closed = true;
+                peer.refed = false;
                 peer.inbox.clear();
             }
         }

--- a/crates/perry/tests/issue_6763_broadcast_clone.rs
+++ b/crates/perry/tests/issue_6763_broadcast_clone.rs
@@ -268,3 +268,83 @@ sender.postMessage("second");
         )
     );
 }
+
+#[test]
+fn message_port_reference_state_tracks_listeners_and_close() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+import { MessageChannel } from "node:worker_threads";
+
+const { port1, port2 } = new MessageChannel();
+console.log("initial", port1.hasRef());
+
+const listener = () => {};
+port1.on("message", listener);
+console.log("listener", port1.hasRef(), port1.listenerCount("message"));
+console.log("unref", port1.unref(), port1.hasRef());
+console.log("ref", port1.ref(), port1.hasRef());
+port1.off("message", listener);
+console.log("removed", port1.hasRef(), port1.listenerCount("message"));
+
+port1.onmessage = () => {};
+console.log("handler", port1.hasRef(), port1.listenerCount("message"));
+(port1 as any).onmessage = { not: "callable" };
+console.log("cleared", port1.hasRef(), port1.listenerCount("message"));
+port1.onmessage = () => {};
+port1.ref();
+port1.onmessage = null;
+console.log("handler removed", port1.hasRef(), port1.listenerCount("message"));
+
+port2.ref();
+console.log("peer refed", port2.hasRef());
+port1.close();
+console.log("closed", port1.hasRef(), port2.hasRef());
+"#,
+    )
+    .expect("write fixture");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "initial false\n",
+            "listener true 1\n",
+            "unref undefined false\n",
+            "ref undefined true\n",
+            "removed false 0\n",
+            "handler true 1\n",
+            "cleared false 0\n",
+            "handler removed false 0\n",
+            "peer refed true\n",
+            "closed false false\n",
+        )
+    );
+}


### PR DESCRIPTION
## Summary

Implement Node-compatible MessagePort reference state so `ref()`, `unref()`, and `hasRef()` reflect listeners, `onmessage`, one-shot delivery, and closure of either endpoint.

## Changes

- replace the constant `hasRef()` stub with per-port state and bound `ref()` / `unref()` methods
- automatically reference the first message listener and unreference the port when its last listener is removed or consumed
- include callable `onmessage` handlers in both reference state and `listenerCount("message")`
- clear reference state when either endpoint closes
- add a focused issue #6763 integration regression

## Related issue

Progress on #6763.

## Test plan

- [x] `cargo check -p perry-stdlib`
- [x] `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- [x] `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR=target/release cargo test --profile perry-dev -p perry --test issue_6763_broadcast_clone -- --test-threads=1`
- [x] focused node-suite differentials: `message-port/ref-state`, `message-port/ref-after-peer-close`, `message-port/unref-delivery`, and `message-port/onmessage-nonfunction` (all 1/1)
- [x] `./scripts/check_file_size.sh`
- [x] `python3 scripts/gc_runtime_root_holders.py`
- [x] `python3 scripts/check_test_registration.py`

- [x] Release build is clean
- [ ] Full workspace test suite passes (not run)
- [x] Added or updated a focused integration test
- [x] Docs not required; existing API behavior only

## Checklist

- [x] No workspace version bump and no edits to `CLAUDE.md` / `CHANGELOG.md`
- [x] Commit follows the repository prefix convention
- [x] Read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `MessagePort` reference management through `ref()`, `unref()`, and `hasRef()`.
  * Reference state now reflects message listeners and callable `onmessage` handlers.
  * Listener counts include handlers assigned through `onmessage`.
  * Closing a port or its connected peer clears reference state.

* **Bug Fixes**
  * Corrected reference tracking when handlers are added, removed, replaced, or set to non-callable values.

* **Tests**
  * Added coverage for reference state, listener counts, handler changes, peer behavior, and closed ports.

* **Documentation**
  * Documented `MessagePort` reference-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->