### PR TITLE
fix(string): honor canonical equivalence in localeCompare

### DIFF
--- a/crates/perry-runtime/src/string/compare.rs
+++ b/crates/perry-runtime/src/string/compare.rs
@@ -567,26 +567,34 @@ fn throw_invalid_normalize_form() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
-/// String.prototype.localeCompare(other) — returns negative/zero/positive number.
-/// We don't ship a true ICU collator. We approximate the Unicode default
-/// collation with a two-pass comparison: first case-insensitive (so the
-/// character class wins) and then case-sensitive with lowercase < uppercase
-/// (matching V8's default ICU behavior where 'a' < 'A').
-#[no_mangle]
-pub extern "C" fn js_string_locale_compare(a: *const StringHeader, b: *const StringHeader) -> f64 {
-    let a_valid = is_valid_string_ptr(a);
-    let b_valid = is_valid_string_ptr(b);
-    if !a_valid && !b_valid {
+/// Apply the canonical-equivalence requirement shared by all locale-aware
+/// comparison modes before their approximate collation. NFC is sufficient:
+/// canonically equivalent strings have the same NFC representation.
+fn locale_compare_canonical(a: &str, b: &str, compare: fn(&str, &str) -> f64) -> f64 {
+    if a == b {
         return 0.0;
     }
-    if !a_valid {
-        return -1.0;
+    // ASCII is already NFC, which keeps the overwhelmingly common path
+    // allocation-free.
+    if a.is_ascii() && b.is_ascii() {
+        return compare(a, b);
     }
-    if !b_valid {
-        return 1.0;
+    #[cfg(feature = "string-normalize")]
+    {
+        use unicode_normalization::UnicodeNormalization;
+        let a_nfc: String = a.nfc().collect();
+        let b_nfc: String = b.nfc().collect();
+        compare(&a_nfc, &b_nfc)
     }
-    let a_str = string_as_str(a);
-    let b_str = string_as_str(b);
+    #[cfg(not(feature = "string-normalize"))]
+    compare(a, b)
+}
+
+/// Approximate the Unicode default collation with a two-pass comparison:
+/// first case-insensitive (so the character class wins) and then
+/// case-sensitive with lowercase < uppercase (matching V8's default ICU
+/// behavior where 'a' < 'A').
+fn locale_compare_default(a_str: &str, b_str: &str) -> f64 {
     // Case-insensitive primary comparison
     let a_lower = a_str.to_lowercase();
     let b_lower = b_str.to_lowercase();
@@ -622,12 +630,31 @@ pub extern "C" fn js_string_locale_compare(a: *const StringHeader, b: *const Str
     }
 }
 
+/// String.prototype.localeCompare(other) — returns negative/zero/positive number.
+/// We don't ship a true ICU collator, but canonical equivalence is a mandatory
+/// part of the String.prototype.localeCompare contract.
+#[no_mangle]
+pub extern "C" fn js_string_locale_compare(a: *const StringHeader, b: *const StringHeader) -> f64 {
+    let a_valid = is_valid_string_ptr(a);
+    let b_valid = is_valid_string_ptr(b);
+    if !a_valid && !b_valid {
+        return 0.0;
+    }
+    if !a_valid {
+        return -1.0;
+    }
+    if !b_valid {
+        return 1.0;
+    }
+    locale_compare_canonical(string_as_str(a), string_as_str(b), locale_compare_default)
+}
+
 /// Natural-order collation for `localeCompare(other, locales, { numeric: true })`:
 /// maximal runs of ASCII digits compare by numeric value (leading zeros
 /// ignored, then by digit-count and lexicographically), and non-digit runs
 /// compare with the same case-insensitive primary / case tertiary rule as
 /// `js_string_locale_compare`. So `"10" > "9"` and `"file10" > "file9"`.
-fn locale_compare_numeric(a: &str, b: &str) -> f64 {
+fn locale_compare_numeric_raw(a: &str, b: &str) -> f64 {
     let mut ai = a.chars().peekable();
     let mut bi = b.chars().peekable();
     loop {
@@ -685,6 +712,10 @@ fn locale_compare_numeric(a: &str, b: &str) -> f64 {
             }
         }
     }
+}
+
+fn locale_compare_numeric(a: &str, b: &str) -> f64 {
+    locale_compare_canonical(a, b, locale_compare_numeric_raw)
 }
 
 /// `String.prototype.localeCompare(other, locales, options)` — honors the
@@ -1040,7 +1071,7 @@ mod utf16_cmp_ascii_fast_path_tests {
 
 #[cfg(test)]
 mod numeric_collation_tests {
-    use super::locale_compare_numeric;
+    use super::{locale_compare_default, locale_compare_numeric};
 
     #[test]
     fn natural_order_compares_digit_runs_numerically() {
@@ -1059,6 +1090,23 @@ mod numeric_collation_tests {
         // A digit run vs the end of the shorter string.
         assert_eq!(locale_compare_numeric("x", "x10"), -1.0);
         assert_eq!(locale_compare_numeric("2foo", "10foo"), -1.0);
+    }
+
+    #[cfg(feature = "string-normalize")]
+    #[test]
+    fn locale_compare_treats_canonical_equivalents_as_equal() {
+        for (a, b) in [
+            ("o\u{0308}", "ö"),
+            ("a\u{0308}\u{0323}", "a\u{0323}\u{0308}"),
+            ("\u{1111}\u{1171}\u{11b6}", "퓛"),
+            ("Å", "A\u{030a}"),
+        ] {
+            assert_eq!(
+                super::locale_compare_canonical(a, b, locale_compare_default),
+                0.0
+            );
+            assert_eq!(locale_compare_numeric(a, b), 0.0);
+        }
     }
 }
 

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -56,6 +56,13 @@ fn debug_hir_uses_get_builtin_module(hir_debug: &str) -> bool {
             && hir_debug.contains("method: \"getBuiltinModule\""))
 }
 
+fn debug_hir_uses_string_normalization(hir_debug: &str) -> bool {
+    // `localeCompare` has several static/dynamic HIR spellings. A bare match
+    // deliberately over-includes the tables for a same-named user identifier;
+    // feature detection permits size-only false positives, not false negatives.
+    hir_debug.contains("property: \"normalize\"") || hir_debug.contains("localeCompare")
+}
+
 fn imports_fs_promises_glob(hir_module: &perry_hir::Module) -> bool {
     hir_module.imports.iter().any(|import| {
         !import.type_only
@@ -317,14 +324,14 @@ pub(super) fn detect_optional_feature_usage(
         }
     }
 
-    // Detect `String.prototype.normalize` (gates `unicode-normalization`,
-    // ~113 KB) and `Intl.Segmenter` (gates `unicode-segmentation`, ~73 KB).
-    // Both lower to method/namespace nodes carrying the name as a `property`,
-    // so we match the exact `property: "<name>"` token. (A bare `"Segmenter"`
-    // substring would also fire on a user identifier named `Segmenter`.)
+    // Detect `String.prototype.normalize` / `localeCompare` (both need
+    // `unicode-normalization`, ~113 KB) and `Intl.Segmenter` (gates
+    // `unicode-segmentation`, ~73 KB).
+    // `normalize` and `Segmenter` lower to nodes carrying the name as a
+    // `property`, so those use the exact `property: "<name>"` token.
     {
         let hir_debug: String = format!("{:?}{:?}", &hir_module.init, &hir_module.functions);
-        if hir_debug.contains("property: \"normalize\"") {
+        if debug_hir_uses_string_normalization(&hir_debug) {
             ctx.uses_string_normalize = true;
         }
         if hir_debug.contains("property: \"Segmenter\"") {
@@ -528,8 +535,9 @@ pub(super) fn detect_optional_feature_usage(
 #[cfg(test)]
 mod tests {
     use super::{
-        debug_hir_uses_get_builtin_module, debug_hir_uses_regex, debug_hir_uses_zlib_brotli,
-        debug_hir_uses_zlib_zstd, imports_fs_promises_glob,
+        debug_hir_uses_get_builtin_module, debug_hir_uses_regex,
+        debug_hir_uses_string_normalization, debug_hir_uses_zlib_brotli, debug_hir_uses_zlib_zstd,
+        imports_fs_promises_glob,
     };
     use perry_hir::{Import, ImportSpecifier, Module, ModuleKind};
 
@@ -582,6 +590,19 @@ mod tests {
         ));
         assert!(!debug_hir_uses_get_builtin_module(
             r#"NativeMethodCall { module: "process", method: "cwd" }"#
+        ));
+    }
+
+    #[test]
+    fn string_normalization_gate_covers_normalize_and_locale_compare() {
+        assert!(debug_hir_uses_string_normalization(
+            r#"PropertyGet { property: "normalize" }"#
+        ));
+        assert!(debug_hir_uses_string_normalization(
+            r#"StringMethod { method: "localeCompare" }"#
+        ));
+        assert!(!debug_hir_uses_string_normalization(
+            r#"StringMethod { method: "toLowerCase" }"#
         ));
     }
 

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -738,9 +738,10 @@ pub struct CompilationContext {
     /// URL parsing is otherwise hand-rolled, so a program with no URL API links
     /// none of the host-canonicalization/IDNA machinery.
     pub uses_url: bool,
-    /// Whether any TS module calls `String.prototype.normalize`. Gates
-    /// `perry-runtime/string-normalize` (`unicode-normalization`, ~113 KB of
-    /// NFC/NFD/NFKC/NFKD tables).
+    /// Whether any TS module calls `String.prototype.normalize` or
+    /// `String.prototype.localeCompare`. Gates `perry-runtime/string-normalize`
+    /// (`unicode-normalization`, ~113 KB of NFC/NFD/NFKC/NFKD tables); locale
+    /// comparison needs NFC to honor canonical equivalence.
     pub uses_string_normalize: bool,
     /// Whether any TS module constructs an `Intl.Segmenter`. Gates
     /// `perry-runtime/intl-segmenter` (`unicode-segmentation`, ~73 KB of UAX #29


### PR DESCRIPTION
## Summary

- normalize non-ASCII `localeCompare` operands to NFC before approximate collation
- apply canonical equivalence to both default and numeric comparison modes while keeping ASCII allocation-free
- retain the normalization engine in size-optimized builds that use `localeCompare`

Refs #5902.

## Testing

- `cargo test -p perry-runtime locale_compare_treats_canonical_equivalents_as_equal`
- `cargo test -p perry --bin perry string_normalization_gate_covers_normalize_and_locale_compare`
- `cargo fmt --all -- --check`
- `bash scripts/check_file_size.sh`
- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- focused Test262 localeCompare: 9 pass / 1 runtime-fail before; 10 pass / 0 runtime-fail after (2 unrelated compile failures unchanged)
- full Test262 `built-ins/String`: 839 pass, 12 runtime-fail, 81 compile-fail, 0 diff, 0 skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved locale-aware string comparisons by treating canonically equivalent text as equal when normalization support is enabled.
  - Added support for detecting string normalization and locale comparison usage during compilation.
  - Preserved efficient behavior for ASCII strings and environments without normalization support.

- **Documentation**
  - Clarified normalization requirements for locale-aware string comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->