### PR TITLE
fix(release): build Linux GNU artifacts on glibc 2.31

### DIFF
--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -44,12 +44,14 @@ jobs:
       - name: install.sh is valid POSIX sh
         run: sh -n packaging/install.sh
 
-  # End-to-end on the platform from #6298: Ubuntu 22.04 = glibc 2.35, older than
-  # the glibc 2.39 the release matrix builds the linux-gnu binaries against.
-  # Installs the *published* platform packages and runs this repo's launcher
-  # against them.
+  # Published-package verification for the platform from #6298. This is manual
+  # because a PR changes the launcher before the matching old-glibc binary can
+  # exist in npm; release-packages.yml exercises the just-built artifact inside
+  # the glibc 2.31 build container before publication. Run this after a release to verify that
+  # the registry package uses the native glibc build on Ubuntu 22.04.
   ubuntu-2204:
-    name: Ubuntu 22.04 (glibc 2.35) end-to-end
+    if: github.event_name == 'workflow_dispatch'
+    name: Ubuntu 22.04 native glibc end-to-end
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -77,43 +79,25 @@ jobs:
           echo "installed platform packages:"
           ls node_modules/@perryts/
 
-      - name: Show the bug — the glibc binary npm picked cannot load here
+      - name: Native glibc binary loads on Ubuntu 22.04
         run: |
           cd /tmp/e2e
-          set +e
-          out=$(./node_modules/@perryts/perry-linux-x64/bin/perry --version 2>&1)
-          code=$?
-          set -e
-          echo "exit=$code"
-          echo "$out"
-          if [ "$code" -eq 0 ]; then
-            echo "::warning::the prebuilt glibc binary loaded on glibc 2.35 — the floor in bin/detect.cjs may be too high"
-          else
-            echo "$out" | grep -qi "GLIBC" || { echo "failed for some other reason than glibc"; exit 1; }
-          fi
+          ./node_modules/@perryts/perry-linux-x64/bin/perry --version
 
-      - name: "Install the static build (npm skips it here: libc is musl)"
-        run: |
-          cd /tmp/e2e
-          version=$(node -p "require('@perryts/perry/package.json').version")
-          npm install --force "@perryts/perry-linux-x64-musl@$version" --no-audit --no-fund
-
-      - name: Launcher under test routes to the static build
+      - name: Launcher under test routes to the native build
         run: |
           cd /tmp/e2e
           cp "$GITHUB_WORKSPACE/npm/perry/bin/perry.js" node_modules/@perryts/perry/bin/perry.js
           cp "$GITHUB_WORKSPACE/npm/perry/bin/detect.cjs" node_modules/@perryts/perry/bin/detect.cjs
           node node_modules/@perryts/perry/bin/perry.js --version
 
-      # Perry's LLVM backend emits opaque-pointer IR (`ptr`) and shells out to
-      # `clang -c`. Jammy's default clang is 14, which predates opaque pointers
-      # and rejects the IR with "expected type" — nothing to do with libc, and it
-      # bites the glibc binary just as hard. Ubuntu 22.04 users need clang >= 15
-      # (in the jammy archive) on PATH or in PERRY_LLVM_CLANG.
+      # The in-process LLVM backend emits objects itself, but the final native
+      # link still needs a system C toolchain. Install clang 15 explicitly so
+      # this smoke does not depend on jammy's older default clang 14.
       - name: Install clang 15 (jammy default clang is too old for opaque-pointer IR)
         run: sudo apt-get update && sudo apt-get install -y clang-15
 
-      - name: Compile and run a TypeScript program with the fallback binary
+      - name: Compile and run a TypeScript program with the native binary
         env:
           PERRY_LLVM_CLANG: /usr/bin/clang-15
         run: |

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -312,27 +312,35 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: perry-macos-aarch64
+            old_glibc_image: ""
           - os: macos-15
             target: x86_64-apple-darwin
             artifact: perry-macos-x86_64
+            old_glibc_image: ""
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact: perry-linux-x86_64
+            old_glibc_image: debian:bullseye-slim@sha256:f313b4bd62667092a59b3a664d7d3ab8b5e65f41675f48e81455a15dc5abe792
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: perry-linux-aarch64
+            old_glibc_image: debian:bullseye-slim@sha256:f313b4bd62667092a59b3a664d7d3ab8b5e65f41675f48e81455a15dc5abe792
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             artifact: perry-linux-x86_64-musl
+            old_glibc_image: ""
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             artifact: perry-linux-aarch64-musl
+            old_glibc_image: ""
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: perry-windows-x86_64
+            old_glibc_image: ""
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
             artifact: perry-windows-aarch64
+            old_glibc_image: ""
 
     runs-on: ${{ matrix.os }}
     env:
@@ -352,7 +360,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # The old-sysroot image carries LLVM 22 under /usr/lib/llvm-22.
+      # Its host-side GTK4 build does not depend on perry-codegen, so avoid
+      # installing a second LLVM copy on the noble runner for these two legs.
       - uses: ./.github/actions/setup-llvm22
+        if: matrix.old_glibc_image == ''
 
       # Cache cargo registry + target/ per (matrix.target, Cargo.lock).
       # First run on a target is still a cold build, but every subsequent
@@ -362,6 +374,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-${{ matrix.target }}"
+          workspaces: |
+            . -> target
+            . -> target-glibc231
+            . -> target-glibc231-abort
 
       # #4856 — evict workspace-crate fingerprints from the restored cache.
       # rust-cache's own workspace cleanup misses cross-target dirs, so a
@@ -379,7 +395,11 @@ jobs:
           set -euo pipefail
           while IFS= read -r pkg; do
             rm -rf target/dist/.fingerprint/"$pkg"-* \
-                   target/*/dist/.fingerprint/"$pkg"-*
+                   target/*/dist/.fingerprint/"$pkg"-* \
+                   target-glibc231/dist/.fingerprint/"$pkg"-* \
+                   target-glibc231/*/dist/.fingerprint/"$pkg"-* \
+                   target-glibc231-abort/dist/.fingerprint/"$pkg"-* \
+                   target-glibc231-abort/*/dist/.fingerprint/"$pkg"-*
           done < <(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
 
       # Closes #394: Homebrew bottle was missing libperry_ui_ios.a so
@@ -435,9 +455,11 @@ jobs:
         # the next step. (Perry is V8-free — the former perry-jsruntime
         # crate, which downloaded a prebuilt V8 that 404'd on musl, was
         # removed.)
+        if: matrix.old_glibc_image == ''
         run: cargo build --profile dist --target ${{ matrix.target }} -p perry
 
       - name: Build runtime libraries
+        if: matrix.old_glibc_image == ''
         run: |
           cargo build --profile dist --target ${{ matrix.target }} -p perry-runtime -p perry-runtime-static
           cargo build --profile dist --target ${{ matrix.target }} -p perry-stdlib -p perry-stdlib-static
@@ -450,7 +472,7 @@ jobs:
         # See optimized_libs.rs (find_runtime_abort_library selection).
         # Separate CARGO_TARGET_DIR so the profile override doesn't
         # invalidate the main build's incremental cache.
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.old_glibc_image == ''
         run: |
           CARGO_TARGET_DIR=target-abort CARGO_PROFILE_DIST_PANIC=abort \
             cargo build --profile dist --target ${{ matrix.target }} -p perry-runtime -p perry-runtime-static
@@ -474,7 +496,7 @@ jobs:
         # Best-effort per crate: a wrapper that can't build on this host must
         # not fail the whole release — the packaging glob below ships
         # whatever was produced.
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.old_glibc_image == ''
         run: |
           for d in crates/perry-ext-*; do
             [ -d "$d" ] || continue
@@ -484,6 +506,52 @@ jobs:
               -p perry -p perry-runtime-static -p perry-stdlib-static -p "$name" \
               || echo "  (skipped $name — failed to build on this host)"
             echo "::endgroup::"
+          done
+
+      # #6351: only GTK4 needs noble. Build the compiler, runtime, stdlib and
+      # extension archives in a Debian 11 container so their ABI floor is
+      # glibc 2.31, then let the ordinary host step below add GTK4 to the same
+      # package. apt.llvm.org still publishes LLVM 22 for this sysroot, keeping
+      # the now-default in-process backend enabled.
+      - name: Build Linux GNU core artifacts on glibc 2.31
+        if: matrix.old_glibc_image != ''
+        env:
+          OLD_GLIBC_IMAGE: ${{ matrix.old_glibc_image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg "OLD_GLIBC_IMAGE=$OLD_GLIBC_IMAGE" \
+            --tag perry-glibc-2.31-llvm22 \
+            --file scripts/linux-glibc-2.31.Dockerfile \
+            .
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --env HOME=/tmp/perry-home \
+            --env CARGO_HOME=/tmp/cargo-home \
+            --env RUSTUP_HOME=/tmp/rustup-home \
+            --env LLVM_SYS_221_PREFIX=/usr/lib/llvm-22 \
+            --env CARGO_TARGET_DIR=/work/target-glibc231 \
+            --env PERRY_ABORT_TARGET_DIR=/work/target-glibc231-abort \
+            --env PERRY_CLI_UPDATE_PUBLIC_KEYS \
+            --volume "$HOME/.cargo:/tmp/cargo-home" \
+            --volume "$HOME/.rustup:/tmp/rustup-home" \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work \
+            perry-glibc-2.31-llvm22 \
+            bash scripts/build_linux_glibc_2_31.sh "$TARGET"
+
+          # Keep old-sysroot objects isolated from the noble GTK4 build. Only
+          # the outputs release packaging consumes cross that boundary.
+          src="target-glibc231/$TARGET/dist"
+          dst="target/$TARGET/dist"
+          mkdir -p "$dst"
+          for artifact in perry libperry_runtime.a libperry_runtime_abort.a libperry_stdlib.a; do
+            test -s "$src/$artifact"
+            cp "$src/$artifact" "$dst/$artifact"
+          done
+          for archive in "$src"/libperry_ext_*.a; do
+            [ -f "$archive" ] && cp "$archive" "$dst/"
           done
 
       - name: Build UI library (macOS)
@@ -1803,7 +1871,7 @@ jobs:
           require_staging_file libperry_runtime.a
           require_staging_file libperry_stdlib.a
 
-          MAIN_DEPENDS="gcc | clang, perry-runtime (= ${VERSION}), perry-stdlib (= ${VERSION})"
+          MAIN_DEPENDS="libc6 (>= 2.31), gcc | clang, perry-runtime (= ${VERSION}), perry-stdlib (= ${VERSION})"
           if [ -f staging/libperry_ui_gtk4.a ]; then
             MAIN_DEPENDS="${MAIN_DEPENDS}, perry-ui-gtk4 (= ${VERSION})"
           fi

--- a/changelog.d/8350-old-glibc-linux-artifacts.md
+++ b/changelog.d/8350-old-glibc-linux-artifacts.md
@@ -1,0 +1,8 @@
+Linux GNU compiler, runtime, stdlib, and extension artifacts now build against
+glibc 2.31 while the GTK4 archive continues to build separately on Ubuntu
+24.04. Native packages now run on Ubuntu 20.04+, Debian 11+, RHEL 9, and Amazon
+Linux 2023; older glibc systems continue to use the static musl fallback.
+
+Release CI also checks the compiler's imported GLIBC symbol versions and runs a
+compiled TypeScript program inside the old-glibc build environment. Debian
+packages declare the matching `libc6 (>= 2.31)` requirement.

--- a/docs/src/contributing/releasing.md
+++ b/docs/src/contributing/releasing.md
@@ -98,9 +98,11 @@ triggers on a published GitHub Release or manual `workflow_dispatch`. Matrix
 runners build:
 
 - `macos-14` / `macos-15` — arm64 + x86_64 Darwin binaries
-- `ubuntu-24.04` / `ubuntu-24.04-arm` — glibc x86_64 + aarch64 (glibc 2.39 floor:
-  the npm launcher and `install.sh` route older-glibc hosts to the musl build — if
-  you move these runners, update `GLIBC_BUILD_FLOOR` in `npm/perry/bin/detect.cjs`)
+- `ubuntu-24.04` / `ubuntu-24.04-arm` — glibc x86_64 + aarch64; the compiler,
+  runtime, stdlib and extension archives build inside architecture-matched
+  Debian 11 (glibc 2.31) containers, while GTK4 builds on the noble host and is added
+  afterward (glibc 2.31 compiler floor; keep `GLIBC_BUILD_FLOOR` in
+  `npm/perry/bin/detect.cjs` synchronized)
 - `ubuntu-24.04` / `ubuntu-24.04-arm` — musl x86_64 + aarch64 (fully static)
 - `windows-latest` — x86_64 MSVC
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -73,9 +73,9 @@ npx -y @perryts/perry compile src/main.ts -o myapp
 
 #### Linux glibc requirement
 
-The Linux **glibc** binaries are built on Ubuntu 24.04, so they require **glibc ≥ 2.39**. Older distributions — Ubuntu 22.04 (glibc 2.35), Debian 12 (2.36), RHEL 9 / Amazon Linux 2023 (2.34) — cannot load them; the dynamic loader fails with `GLIBC_2.39 not found` before Perry starts.
+The Linux **glibc** binaries are built against a glibc 2.31 sysroot, so they require **glibc ≥ 2.31**. This includes Ubuntu 20.04+, Debian 11+, RHEL 9+ and Amazon Linux 2023. Release CI checks the compiler's imported glibc symbol versions and exercises a compiled program inside that environment.
 
-On those hosts Perry uses the **fully-static musl build** instead, which has no libc dependency and runs on any Linux:
+On older glibc hosts Perry uses the **fully-static musl build** instead, which has no libc dependency and runs on any Linux:
 
 - **`install.sh`** detects the glibc version and downloads `perry-linux-<arch>-musl.tar.gz` automatically.
 - **npm** — the launcher routes to `@perryts/perry-linux-x64-musl` (or `-arm64-musl`) and prints a one-time notice. npm does not install that package on a glibc machine by itself (its `libc` selector says `musl`), so install it once:
@@ -84,7 +84,7 @@ On those hosts Perry uses the **fully-static musl build** instead, which has no 
   npm install --force @perryts/perry-linux-x64-musl
   ```
 
-The static build is the same compiler and produces the same binaries. The only feature it does not support is `perry/ui` (GTK4 desktop apps), which needs glibc. Tracking issue: [#6298](https://github.com/PerryTS/perry/issues/6298).
+The static build is the same compiler and produces the same binaries. The only feature it does not support is `perry/ui` (GTK4 desktop apps), which needs glibc. The glibc package includes the GTK4 archive, built separately on Ubuntu 24.04; linking a UI app still requires the GTK4, WebKitGTK, libshumate and GStreamer development libraries. Tracking issues: [#6298](https://github.com/PerryTS/perry/issues/6298), [#6351](https://github.com/PerryTS/perry/issues/6351).
 
 ### Homebrew (macOS)
 

--- a/npm/perry/README.md
+++ b/npm/perry/README.md
@@ -27,7 +27,7 @@ Installing picks the right prebuilt binary for your platform automatically — `
 
 ### Linux: glibc version
 
-The glibc packages are built on Ubuntu 24.04 (glibc 2.39), so they need **glibc ≥ 2.39**. On an older glibc — Ubuntu 22.04 (2.35), Debian 12 (2.36), RHEL 9 / Amazon Linux 2023 (2.34) — the launcher automatically runs the fully-static musl build instead, which has no libc dependency at all and works everywhere ([#6298](https://github.com/PerryTS/perry/issues/6298)). It prints a one-time notice when it does; set `PERRY_NO_FALLBACK_NOTICE=1` to silence it.
+The glibc packages are built against a glibc 2.31 sysroot, so they need **glibc ≥ 2.31**. That covers Ubuntu 20.04+, Debian 11+, RHEL 9+ and Amazon Linux 2023 with the native glibc build. On an older glibc the launcher automatically runs the fully-static musl build instead, which has no libc dependency ([#6298](https://github.com/PerryTS/perry/issues/6298), [#6351](https://github.com/PerryTS/perry/issues/6351)). It prints a one-time notice when it does; set `PERRY_NO_FALLBACK_NOTICE=1` to silence it.
 
 npm only installs the musl package when it thinks the machine is musl-based, so on an old-glibc host you have to ask for it once:
 
@@ -35,7 +35,7 @@ npm only installs the musl package when it thinks the machine is musl-based, so 
 npm install --force @perryts/perry-linux-x64-musl   # or -arm64-musl
 ```
 
-The launcher tells you this (with the exact command) instead of letting the binary die with `GLIBC_2.39 not found`. The static build is the same compiler; the one thing it cannot do is build `perry/ui` GTK4 desktop apps.
+The launcher tells you this (with the exact command) instead of letting the binary fail in the dynamic loader. The static build is the same compiler; the one thing it cannot do is build `perry/ui` GTK4 desktop apps. The glibc package includes GTK4 support, whose system development libraries must be available when linking a UI app.
 
 ## Host requirements
 

--- a/npm/perry/bin/detect.cjs
+++ b/npm/perry/bin/detect.cjs
@@ -19,11 +19,9 @@ const PLATFORM_PACKAGES = {
 // Minimum glibc the prebuilt *glibc* Linux binaries can run on.
 //
 // KEEP IN SYNC WITH THE BUILDER IMAGE. `.github/workflows/release-packages.yml`
-// builds `x86_64-unknown-linux-gnu` on `ubuntu-24.04` and
-// `aarch64-unknown-linux-gnu` on `ubuntu-24.04-arm`. Both images ship glibc
-// 2.39, so the emitted ELF carries GLIBC_2.39 symbol-version references and the
-// dynamic loader refuses to start it on anything older — the process dies with
-// `GLIBC_2.39 not found` before Perry's own code runs (#6298).
+// builds both GNU targets in architecture-matched glibc 2.31 containers.
+// The release build checks the final ELF symbol versions and runs a compile
+// smoke test inside that container before packaging it (#6351).
 //
 // A binary only requires the glibc version whose symbols it actually pulls in,
 // so this is an upper bound: it is the version of the builder image, and the
@@ -32,7 +30,7 @@ const PLATFORM_PACKAGES = {
 // otherwise hosts that *could* run the glibc build get silently pushed onto the
 // static build (too high a value), or hosts that can't get the loader error back
 // (too low a value).
-const GLIBC_BUILD_FLOOR = "2.39";
+const GLIBC_BUILD_FLOOR = "2.31";
 
 // Compare two dotted numeric versions ("2.35", "2.39.1"). Returns <0, 0, >0.
 // Non-numeric components sort as 0 — glibc versions are always numeric, and a

--- a/npm/perry/bin/perry.js
+++ b/npm/perry/bin/perry.js
@@ -130,7 +130,7 @@ function reportResolutionFailure() {
     // spell the command out rather than leaving the user with a loader error.
     console.error(
       `[perry] This system has glibc ${detected.glibc}, but Perry's prebuilt Linux binary\n` +
-        `        needs glibc >= ${GLIBC_BUILD_FLOOR} (it is built on ubuntu-24.04). Running it would fail\n` +
+        `        needs glibc >= ${GLIBC_BUILD_FLOOR} (it is built on a glibc 2.31 sysroot). Running it would fail\n` +
         `        in the dynamic loader with "GLIBC_${GLIBC_BUILD_FLOOR} not found".\n` +
         `\n` +
         `        Perry also ships a fully-static Linux build that needs no glibc at all, but\n` +

--- a/npm/perry/test/detect.test.cjs
+++ b/npm/perry/test/detect.test.cjs
@@ -10,7 +10,7 @@
 // It also cross-checks the launcher against the things it has to agree with:
 //   * every package it can name is a real optionalDependency of @perryts/perry
 //   * the release matrix really does build the musl targets it falls back to
-//   * the glibc targets are still built on the image GLIBC_BUILD_FLOOR assumes
+//   * the glibc targets are still built in the old-sysroot image the floor assumes
 
 const assert = require("assert");
 const fs = require("fs");
@@ -58,11 +58,13 @@ console.log("\nglibc / musl routing (linux-x64, floor = " + GLIBC_BUILD_FLOOR + 
 console.log("  glibc            → package                          reason");
 console.log("  ---------------------------------------------------------------");
 const table = [
-  ["2.31 (Ubuntu 20.04)", glibcHost("x64", "2.31"), "linux-x64-musl", "glibc-too-old"],
-  ["2.34 (RHEL 9 / AL2023)", glibcHost("x64", "2.34"), "linux-x64-musl", "glibc-too-old"],
-  ["2.35 (Ubuntu 22.04)", glibcHost("x64", "2.35"), "linux-x64-musl", "glibc-too-old"],
-  ["2.36 (Debian 12)", glibcHost("x64", "2.36"), "linux-x64-musl", "glibc-too-old"],
-  ["2.39 (Ubuntu 24.04)", glibcHost("x64", "2.39"), "linux-x64", "native"],
+  ["2.27 (older)", glibcHost("x64", "2.27"), "linux-x64-musl", "glibc-too-old"],
+  ["2.28 (RHEL 8)", glibcHost("x64", "2.28"), "linux-x64-musl", "glibc-too-old"],
+  ["2.30 (older)", glibcHost("x64", "2.30"), "linux-x64-musl", "glibc-too-old"],
+  ["2.31 (build floor / Ubuntu 20.04)", glibcHost("x64", "2.31"), "linux-x64", "native"],
+  ["2.34 (RHEL 9 / AL2023)", glibcHost("x64", "2.34"), "linux-x64", "native"],
+  ["2.35 (Ubuntu 22.04)", glibcHost("x64", "2.35"), "linux-x64", "native"],
+  ["2.36 (Debian 12)", glibcHost("x64", "2.36"), "linux-x64", "native"],
   ["2.41 (newer)", glibcHost("x64", "2.41"), "linux-x64", "native"],
   ["(musl / Alpine)", muslHost("x64"), "linux-x64-musl", "musl"],
 ];
@@ -78,13 +80,13 @@ for (const [label, host, wantKey, wantReason] of table) {
 }
 
 console.log("\nother platforms");
-check("linux-arm64 glibc 2.35 → linux-arm64-musl", () => {
-  const got = detectPlatform(glibcHost("arm64", "2.35"));
+check("linux-arm64 glibc 2.30 → linux-arm64-musl", () => {
+  const got = detectPlatform(glibcHost("arm64", "2.30"));
   assert.strictEqual(got.candidates[0], "linux-arm64-musl");
   assert.strictEqual(got.reason, "glibc-too-old");
 });
-check("linux-arm64 glibc 2.39 → linux-arm64", () => {
-  assert.strictEqual(detectPlatform(glibcHost("arm64", "2.39")).candidates[0], "linux-arm64");
+check("linux-arm64 glibc 2.31 → linux-arm64", () => {
+  assert.strictEqual(detectPlatform(glibcHost("arm64", "2.31")).candidates[0], "linux-arm64");
 });
 check("linux-arm64 musl → linux-arm64-musl", () => {
   assert.strictEqual(detectPlatform(muslHost("arm64")).candidates[0], "linux-arm64-musl");
@@ -135,19 +137,19 @@ check("empty glibcVersionRuntime (musl) falls back to the glibc pkg — #116", (
 });
 check("glibc-too-old does NOT fall back to the glibc pkg", () => {
   // That binary physically cannot load — a fallback would just resurrect the
-  // "GLIBC_2.39 not found" error the user reported.
-  const got = detectPlatform(glibcHost("x64", "2.35"));
+  // Avoid resurrecting the dynamic-loader error on pre-2.31 systems.
+  const got = detectPlatform(glibcHost("x64", "2.30"));
   assert.deepStrictEqual(got.candidates, ["linux-x64-musl"]);
 });
 
 console.log("\nversion comparison");
 check("compareVersions is numeric, not lexical", () => {
-  assert.ok(compareVersions("2.35", "2.39") < 0);
-  assert.ok(compareVersions("2.39", "2.39") === 0);
-  assert.ok(compareVersions("2.40", "2.39") > 0);
-  assert.ok(compareVersions("2.9", "2.39") < 0, "2.9 must sort below 2.39");
-  assert.ok(compareVersions("3.0", "2.39") > 0);
-  assert.ok(compareVersions("2.39.1", "2.39") > 0);
+  assert.ok(compareVersions("2.30", "2.31") < 0);
+  assert.ok(compareVersions("2.31", "2.31") === 0);
+  assert.ok(compareVersions("2.32", "2.31") > 0);
+  assert.ok(compareVersions("2.9", "2.31") < 0, "2.9 must sort below 2.31");
+  assert.ok(compareVersions("3.0", "2.31") > 0);
+  assert.ok(compareVersions("2.31.1", "2.31") > 0);
 });
 check("a garbage glibc string is not treated as 'newer than the floor'", () => {
   const got = detectPlatform({
@@ -191,36 +193,39 @@ check("release matrix builds the musl targets the fallback relies on", () => {
   assert.ok(wf.includes("x86_64-unknown-linux-musl"), "x86_64 musl target missing");
   assert.ok(wf.includes("aarch64-unknown-linux-musl"), "aarch64 musl target missing");
 });
-check(`glibc legs still build on the image GLIBC_BUILD_FLOOR=${GLIBC_BUILD_FLOOR} assumes`, () => {
-  // The floor is a property of the *builder image*, not of Perry. If the glibc
-  // legs move to another runner, this fails and whoever moved them has to
-  // revisit GLIBC_BUILD_FLOOR in bin/detect.cjs instead of silently shipping a
-  // binary that the launcher's routing no longer describes.
-  //   ubuntu-24.04 / ubuntu-24.04-arm → glibc 2.39
+check(`glibc legs use glibc ${GLIBC_BUILD_FLOOR} builders`, () => {
+  // GTK4 still builds on the matrix's noble runner, but the compiler and core
+  // archives must come from the old-sysroot image. Pin this coupling so a
+  // workflow refactor cannot silently make the launcher floor a lie.
   const wf = fs.readFileSync(
     path.join(REPO_ROOT, ".github", "workflows", "release-packages.yml"),
     "utf8"
   );
-  const entries = [
-    ...wf.matchAll(/-\s+os:\s*(\S+)\s*\n\s+target:\s*(\S+)/g),
-  ].map((m) => ({ os: m[1], target: m[2] }));
+  const entries = [...wf.matchAll(
+    /-\s+os:\s*(\S+)\s*\n\s+target:\s*(\S+)\s*\n\s+artifact:\s*(\S+)\s*\n\s+old_glibc_image:\s*(\S+)/g
+  )].map((m) => ({ os: m[1], target: m[2], image: m[4] }));
   const gnu = entries.filter((e) => e.target.endsWith("-unknown-linux-gnu"));
-  assert.ok(gnu.length >= 2, `expected the linux-gnu legs in the matrix, saw ${gnu.length}`);
-  const IMAGE_GLIBC = { "ubuntu-24.04": "2.39", "ubuntu-24.04-arm": "2.39" };
+  assert.strictEqual(gnu.length, 2, `expected two linux-gnu legs, saw ${gnu.length}`);
   for (const leg of gnu) {
-    const glibc = IMAGE_GLIBC[leg.os];
     assert.ok(
-      glibc,
-      `${leg.target} now builds on '${leg.os}', an image this test doesn't know the ` +
-        `glibc of. Add it to IMAGE_GLIBC and re-check GLIBC_BUILD_FLOOR in bin/detect.cjs.`
-    );
-    assert.strictEqual(
-      glibc,
-      GLIBC_BUILD_FLOOR,
-      `${leg.target} builds on ${leg.os} (glibc ${glibc}) but GLIBC_BUILD_FLOOR is ` +
-        `${GLIBC_BUILD_FLOOR} — update bin/detect.cjs.`
+      leg.image.includes("debian:bullseye-slim@sha256:"),
+      `${leg.target} uses ${leg.image}; expected the pinned Debian 11 builder image`
     );
   }
+  assert.deepStrictEqual(
+    gnu.map((leg) => leg.target).sort(),
+    ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+  );
+  assert.strictEqual(GLIBC_BUILD_FLOOR, "2.31");
+  assert.ok(wf.includes("scripts/build_linux_glibc_2_31.sh"));
+  assert.ok(wf.includes(`libc6 (>= ${GLIBC_BUILD_FLOOR})`));
+
+  const dockerfile = fs.readFileSync(
+    path.join(REPO_ROOT, "scripts", "linux-glibc-2.31.Dockerfile"),
+    "utf8"
+  );
+  assert.ok(dockerfile.includes("debian:bullseye-slim@sha256:"));
+  assert.ok(dockerfile.includes("llvm-toolchain-bullseye-22"));
 });
 
 console.log("");

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -46,17 +46,14 @@ esac
 # Pick the glibc or the fully-static (musl) Linux build.
 #
 # The Linux glibc tarballs are built by .github/workflows/release-packages.yml
-# on ubuntu-24.04 / ubuntu-24.04-arm, whose glibc is 2.39. Their ELF carries
-# GLIBC_2.39 symbol-version references, so the dynamic loader refuses to start
-# them on anything older — Ubuntu 22.04 (2.35), Debian 12 (2.36), RHEL 9 and
-# Amazon Linux 2023 (2.34) all die with "GLIBC_2.39 not found" before Perry runs
-# (#6298). The musl tarball is a fully-static binary with no interpreter and no
-# libc dependency at all, so it runs on every one of them.
+# in old-sysroot containers and checked for a glibc 2.31 symbol floor. This
+# covers Ubuntu 20.04+, Debian 11+, RHEL 9+ and Amazon Linux 2023 natively. The
+# musl tarball remains the fully-static fallback for older glibc and musl hosts.
 #
 # KEEP IN SYNC with the builder image and with GLIBC_BUILD_FLOOR in
 # npm/perry/bin/detect.cjs.
 GLIBC_FLOOR_MAJOR=2
-GLIBC_FLOOR_MINOR=39
+GLIBC_FLOOR_MINOR=31
 
 LIBC="glibc"
 if [ "$OS" = "linux" ]; then

--- a/scripts/build_linux_glibc_2_31.sh
+++ b/scripts/build_linux_glibc_2_31.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Build the Linux GNU release payload inside a glibc 2.31 container.
+#
+# GTK4 is deliberately absent here. Its WebKitGTK/libshumate dependencies need
+# the Ubuntu 24.04 host used by release-packages.yml; that job adds the UI
+# archive after this script has produced the compiler and non-UI archives.
+
+set -euo pipefail
+
+target="${1:?usage: build_linux_glibc_2_31.sh <rust-target>}"
+target_dir="${CARGO_TARGET_DIR:-target}"
+abort_target_dir="${PERRY_ABORT_TARGET_DIR:-target-abort}"
+
+case "$target" in
+  x86_64-unknown-linux-gnu)
+    expected_machine=x86_64
+    ;;
+  aarch64-unknown-linux-gnu)
+    expected_machine=aarch64
+    ;;
+  *)
+    echo "unsupported old-glibc release target: $target" >&2
+    exit 2
+    ;;
+esac
+
+machine=$(uname -m)
+if [ "$machine" != "$expected_machine" ]; then
+  echo "container architecture is $machine; $target needs $expected_machine" >&2
+  exit 1
+fi
+
+glibc_version=$(getconf GNU_LIBC_VERSION | awk '{print $2}')
+if [ "$glibc_version" != "2.31" ]; then
+  echo "expected the glibc 2.31 sysroot, found glibc $glibc_version" >&2
+  exit 1
+fi
+
+: "${LLVM_SYS_221_PREFIX:=/usr/lib/llvm-22}"
+export LLVM_SYS_221_PREFIX
+"$LLVM_SYS_221_PREFIX/bin/llvm-config" --version | grep -q '^22\.' || {
+  echo "old-sysroot image does not provide LLVM 22 under $LLVM_SYS_221_PREFIX" >&2
+  exit 1
+}
+
+rustup target add "$target"
+
+cargo build --profile dist --target "$target" -p perry
+cargo build --profile dist --target "$target" -p perry-runtime -p perry-runtime-static
+cargo build --profile dist --target "$target" -p perry-stdlib -p perry-stdlib-static
+
+# Ship the panic=abort runtime variant from the same old sysroot.
+CARGO_TARGET_DIR="$abort_target_dir" CARGO_PROFILE_DIST_PANIC=abort \
+  cargo build --profile dist --target "$target" -p perry-runtime -p perry-runtime-static
+cp "$abort_target_dir/$target/dist/libperry_runtime.a" \
+   "$target_dir/$target/dist/libperry_runtime_abort.a"
+
+# Match the ordinary release leg's best-effort extension-library build. Keep
+# perry and both wrappers in each invocation so Cargo resolves one feature
+# union and the final linker can deduplicate their shared dependencies.
+for dir in crates/perry-ext-*; do
+  [ -d "$dir" ] || continue
+  package=$(basename "$dir")
+  echo "::group::build $package"
+  cargo build --profile dist --target "$target" \
+    -p perry -p perry-runtime-static -p perry-stdlib-static -p "$package" \
+    || echo "  (skipped $package -- failed to build on the glibc 2.31 sysroot)"
+  echo "::endgroup::"
+done
+
+compiler="$target_dir/$target/dist/perry"
+max_glibc=$(
+  readelf --version-info "$compiler" \
+    | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' \
+    | sed 's/^GLIBC_//' \
+    | sort -Vu \
+    | tail -1
+)
+if [ -z "$max_glibc" ] || [ "$(printf '%s\n' "$max_glibc" "2.31" | sort -V | tail -1)" != "2.31" ]; then
+  echo "compiler requires GLIBC_${max_glibc:-unknown}; expected no newer than GLIBC_2.31" >&2
+  exit 1
+fi
+
+# Exercise both the compiler (which statically links LLVM 22) and the shipped
+# runtime/stdlib archives before the noble-built GTK4 archive is added.
+smoke_dir=$(mktemp -d)
+trap 'rm -rf "$smoke_dir"' EXIT
+cat > "$smoke_dir/hello.ts" <<'TS'
+const values = [1, 2, 3].map((value) => value * 2);
+console.log(`old-glibc ${values.join(",")}`);
+TS
+"$compiler" --version
+"$compiler" "$smoke_dir/hello.ts" -o "$smoke_dir/hello"
+test "$("$smoke_dir/hello")" = "old-glibc 2,4,6"
+
+echo "Linux GNU release payload built and exercised on glibc $glibc_version (max symbol GLIBC_$max_glibc)"

--- a/scripts/linux-glibc-2.31.Dockerfile
+++ b/scripts/linux-glibc-2.31.Dockerfile
@@ -1,0 +1,32 @@
+# Debian 11 provides the glibc 2.31 sysroot. Use the archive mirror so this
+# build remains reproducible after bullseye leaves the normal mirror, while
+# apt.llvm.org provides architecture-matched LLVM 22 development packages.
+ARG OLD_GLIBC_IMAGE=debian:bullseye-slim@sha256:f313b4bd62667092a59b3a664d7d3ab8b5e65f41675f48e81455a15dc5abe792
+FROM ${OLD_GLIBC_IMAGE}
+
+# The archived slim image has no CA bundle. Debian Release signatures are still
+# checked while bootstrapping ca-certificates; only TLS peer validation is
+# disabled for this first signed archive fetch.
+RUN printf '%s\n' \
+      'deb [check-valid-until=no] https://archive.debian.org/debian bullseye main' \
+      'deb https://deb.debian.org/debian-security bullseye-security main' \
+      > /etc/apt/sources.list \
+    && apt-get -o Acquire::https::Verify-Peer=false update \
+    && DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::https::Verify-Peer=false \
+      install -y --no-install-recommends ca-certificates \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential cmake curl gnupg libssl-dev libzstd-dev \
+      perl pkg-config xz-utils zlib1g-dev \
+    && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+      -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && printf '%s\n' \
+      'deb https://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-22 main' \
+      > /etc/apt/sources.list.d/llvm22.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      clang-22 libpolly-22-dev llvm-22-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm-22


### PR DESCRIPTION
Closes #6351.

## Summary

- build the Linux GNU compiler, runtime, stdlib, abort runtime, and extension archives in pinned architecture-native Debian 11 containers
- keep GTK4 on the Ubuntu 24.04 host, then combine the old-glibc core with the GTK archive during packaging
- lower launcher/install routing and Debian package metadata to a glibc 2.31 floor
- verify the final compiler's imported GLIBC versions and compile/run a TypeScript smoke program inside the old sysroot
- isolate old-sysroot Cargo targets so cached Ubuntu 24.04 dependencies cannot leak a newer glibc requirement

The current in-process backend requires LLVM 22 development libraries. apt.llvm.org does not publish LLVM 22 packages for Debian 10/glibc 2.28, but does for Debian 11/glibc 2.31. This is therefore the oldest practical builder without disabling the default backend, and it covers every affected distribution named in #6351: Ubuntu 22.04, Debian 12, RHEL 9, and Amazon Linux 2023 (plus Ubuntu 20.04 and Debian 11). Older systems keep the existing static-musl fallback.

## Verification

- full ARM64 dist compiler built against glibc 2.31 and LLVM 22; final compiler's highest imported version is GLIBC_2.30
- node npm/perry/test/detect.test.cjs
- sh -n packaging/install.sh
- bash -n and ShellCheck for the old-glibc build script
- actionlint for both modified workflows
- scripts/check_file_size.sh
- git diff --check

No version bump is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux glibc packages now support systems with glibc 2.31 or newer, expanding compatibility across older distributions.
  * The installer automatically falls back to the static musl package on older glibc systems.
* **Documentation**
  * Updated installation and release guidance with supported distributions, compatibility requirements, fallback behavior, and GTK4 system dependencies.
* **Bug Fixes**
  * Improved compatibility messaging to clearly identify the required glibc version and installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->