### PR TITLE
perf(runtime): cache polymorphic closure dispatch

### DIFF
--- a/benchmarks/issue-8289/pipeline.ts
+++ b/benchmarks/issue-8289/pipeline.ts
@@ -1,0 +1,88 @@
+// A config-driven record-processing pipeline with generic containers,
+// closure-valued stages, and data crossing a dynamic JSON boundary.
+
+class Registry<K, V> {
+  private keys: K[] = [];
+  private vals: V[] = [];
+
+  set(k: K, v: V): void {
+    for (let i = 0; i < this.keys.length; i++) {
+      if (this.keys[i] === k) {
+        this.vals[i] = v;
+        return;
+      }
+    }
+    this.keys.push(k);
+    this.vals.push(v);
+  }
+
+  get(k: K): V | null {
+    for (let i = 0; i < this.keys.length; i++) {
+      if (this.keys[i] === k) return this.vals[i];
+    }
+    return null;
+  }
+
+  size(): number {
+    return this.keys.length;
+  }
+}
+
+function identity<T>(x: T): T {
+  return x;
+}
+
+type Record = { id: number; kind: string; amount: number; tag: string };
+type Stage = (r: Record) => Record;
+
+const CONFIG = '{"scale":3,"offset":7,"kinds":["alpha","beta","gamma"],"limit":900}';
+
+function makeScale(factor: number): Stage {
+  return (r: Record) => ({ id: r.id, kind: r.kind, amount: r.amount * factor, tag: r.tag });
+}
+
+function makeOffset(delta: number): Stage {
+  return (r: Record) => ({ id: r.id, kind: r.kind, amount: r.amount + delta, tag: r.tag });
+}
+
+function makeTagger(prefix: string): Stage {
+  return (r: Record) => ({ id: r.id, kind: r.kind, amount: r.amount, tag: prefix + r.kind });
+}
+
+function main(): void {
+  const cfg: any = JSON.parse(CONFIG);
+  const scale: number = cfg.scale;
+  const offset: number = cfg.offset;
+  const limit: number = cfg.limit;
+  const kinds: string[] = cfg.kinds;
+
+  const stages: Stage[] = [makeScale(scale), makeOffset(offset), makeTagger("t:")];
+  const stats = new Registry<Stage, number>();
+  for (let i = 0; i < stages.length; i++) {
+    stats.set(stages[i], 0);
+  }
+
+  const byKind = new Registry<string, number>();
+  const idf = identity;
+  let checksum = 0;
+
+  for (let round = 0; round < 400; round++) {
+    for (let i = 0; i < limit; i++) {
+      const kind = kinds[i % kinds.length];
+      let rec: Record = { id: i, kind: kind, amount: i % 97, tag: "" };
+      for (let s = 0; s < stages.length; s++) {
+        const stage = stages[s];
+        rec = stage(rec);
+        const prev = stats.get(stage);
+        stats.set(stage, (prev === null ? 0 : prev) + 1);
+      }
+      const seen = byKind.get(rec.kind);
+      byKind.set(rec.kind, (seen === null ? 0 : seen) + 1);
+      checksum = checksum + idf(rec.amount) + rec.tag.length;
+    }
+  }
+
+  console.log(checksum + " " + stats.size() + " " + byKind.size());
+}
+
+main();

--- a/changelog.d/8289-polymorphic-closure-dispatch-cache.md
+++ b/changelog.d/8289-polymorphic-closure-dispatch-cache.md
@@ -1,0 +1,6 @@
+Improved dynamic closure dispatch for small polymorphic call sites. The runtime
+now remembers the four most recently resolved closure strategies instead of
+only the last one, so stage pipelines that rotate among a few closure bodies no
+longer perform a thread-local hash-table lookup on every call. Monomorphic call
+sites retain their one-comparison first-slot path, and late closure-arity/rest
+registration still invalidates every matching cached entry.

--- a/crates/perry-runtime/src/closure/dispatch/direct.rs
+++ b/crates/perry-runtime/src/closure/dispatch/direct.rs
@@ -6,7 +6,7 @@
 //!   1. `get_valid_func_ptr` — two address-band checks plus a volatile
 //!      `CLOSURE_MAGIC` probe through `*(closure + 12)` and a volatile load of
 //!      `closure->func_ptr` (`dispatch/validate.rs`);
-//!   2. `resolve_strategy` — a `perry_thread_local!` single-slot cache, which
+//!   2. `resolve_strategy` — a `perry_thread_local!` polymorphic cache, which
 //!      on Darwin is a `tlv_get_addr` CALL plus a load and a compare even when
 //!      it hits (`closure/registry.rs`);
 //!   3. the `match` over `DispatchStrategy` before the indirect jump.

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -135,36 +135,93 @@ pub enum RestDispatchKind {
 }
 
 crate::perry_thread_local! {
-    /// Last-resolved (func_ptr, strategy) tuple — single-slot direct cache.
-    /// Avoids the per-call HashMap::get + RefCell::borrow when the same
-    /// closure body is invoked back-to-back, which is the steady-state
-    /// shape of:
+    /// Four-entry polymorphic cache for recently resolved closure bodies.
+    /// Avoids the per-call HashMap::get + RefCell::borrow both when one body
+    /// is invoked back-to-back and when a small set of bodies alternates,
+    /// which are the steady-state shapes of:
     ///   - microtask drain (same then_v_arrow / __step body each iter)
     ///   - tight `array.sort` callbacks (same comparator every comparison)
     ///   - hot `array.map` / `array.forEach` loops
-    /// Cache key is the func_ptr (usize) and is checked with a single
-    /// load + cmp.
-    static DISPATCH_LAST: std::cell::Cell<(usize, DispatchStrategy)> =
-        const { std::cell::Cell::new((0, DispatchStrategy::Direct)) };
+    ///   - stage pipelines that rotate through a few closure bodies
+    ///
+    /// Hits do not reorder the entries: that keeps the monomorphic first
+    /// slot to one comparison and makes a warmed polymorphic cache read-only.
+    static DISPATCH_RECENT: DispatchRecent = const { DispatchRecent::new() };
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static RESOLVE_STRATEGY_SLOW_CALLS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+#[derive(Clone, Copy)]
+struct DispatchCacheEntry {
+    key: usize,
+    strategy: DispatchStrategy,
+}
+
+impl DispatchCacheEntry {
+    const EMPTY: Self = Self {
+        key: 0,
+        strategy: DispatchStrategy::Direct,
+    };
+}
+
+struct DispatchRecent {
+    entries: [std::cell::Cell<DispatchCacheEntry>; 4],
+}
+
+impl DispatchRecent {
+    const fn new() -> Self {
+        Self {
+            entries: [const { std::cell::Cell::new(DispatchCacheEntry::EMPTY) }; 4],
+        }
+    }
+
+    #[inline(always)]
+    fn get(&self, key: usize) -> Option<DispatchStrategy> {
+        for entry in &self.entries {
+            let entry = entry.get();
+            if entry.key == key {
+                return Some(entry.strategy);
+            }
+        }
+        None
+    }
+
+    #[inline(always)]
+    fn insert(&self, key: usize, strategy: DispatchStrategy) {
+        self.entries[3].set(self.entries[2].get());
+        self.entries[2].set(self.entries[1].get());
+        self.entries[1].set(self.entries[0].get());
+        self.entries[0].set(DispatchCacheEntry { key, strategy });
+    }
+
+    fn invalidate(&self, key: usize) {
+        for entry in &self.entries {
+            if entry.get().key == key {
+                entry.set(DispatchCacheEntry::EMPTY);
+            }
+        }
+    }
 }
 
 #[inline(always)]
 pub fn resolve_strategy(func_ptr: *const u8) -> DispatchStrategy {
     let key = func_ptr as usize;
-    // Inline single-slot cache: 90%+ of microtask-drain hot paths
-    // dispatch the same func_ptr back-to-back. One Cell::get + one cmp
-    // beats the RefCell::borrow + HashMap::get of DISPATCH_CACHE.
-    let last = DISPATCH_LAST.with(|c| c.get());
-    if last.0 == key {
-        return last.1;
+    if let Some(strategy) = DISPATCH_RECENT.with(|cache| cache.get(key)) {
+        return strategy;
     }
     let strategy = resolve_strategy_slow(func_ptr);
-    DISPATCH_LAST.with(|c| c.set((key, strategy)));
+    DISPATCH_RECENT.with(|cache| cache.insert(key, strategy));
     strategy
 }
 
 #[inline(never)]
 fn resolve_strategy_slow(func_ptr: *const u8) -> DispatchStrategy {
+    #[cfg(test)]
+    RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.set(calls.get() + 1));
+
     let key = func_ptr as usize;
     // Fast path: read existing cache entry.
     if let Some(s) = DISPATCH_CACHE.with(|c| c.borrow().get(&key).copied()) {
@@ -202,7 +259,7 @@ fn resolve_strategy_slow(func_ptr: *const u8) -> DispatchStrategy {
 /// the rest array). Called once per closure literal at module init time.
 
 /// #6475: purge a func_ptr's cached dispatch strategy. The strategy caches
-/// (`DISPATCH_CACHE` + the single-slot `DISPATCH_LAST`) memoize the FIRST
+/// (`DISPATCH_CACHE` + `DISPATCH_RECENT`) memoize the FIRST
 /// resolution per func_ptr — but effect's module-init graph calls `.pipe`
 /// (an `arguments`-object method) during init, and inside an import cycle
 /// such a call can precede the module's own `js_register_closure_*` batch.
@@ -219,11 +276,69 @@ fn invalidate_dispatch_strategy(func_ptr: *const u8) {
     DISPATCH_CACHE.with(|c| {
         c.borrow_mut().remove(&key);
     });
-    DISPATCH_LAST.with(|c| {
-        if c.get().0 == key {
-            c.set((0, DispatchStrategy::Direct));
+    DISPATCH_RECENT.with(|cache| cache.invalidate(key));
+}
+
+#[cfg(test)]
+mod dispatch_recent_tests {
+    use super::*;
+
+    extern "C" fn body_a(_: *const ClosureHeader) -> f64 {
+        1.0
+    }
+    extern "C" fn body_b(_: *const ClosureHeader) -> f64 {
+        2.0
+    }
+    extern "C" fn body_c(_: *const ClosureHeader) -> f64 {
+        3.0
+    }
+    extern "C" fn body_d(_: *const ClosureHeader) -> f64 {
+        4.0
+    }
+
+    #[test]
+    fn four_alternating_bodies_stay_out_of_the_hash_lookup() {
+        let bodies = [
+            body_a as *const u8,
+            body_b as *const u8,
+            body_c as *const u8,
+            body_d as *const u8,
+        ];
+        let mut addresses = bodies.map(|body| body as usize);
+        addresses.sort_unstable();
+        assert!(addresses.windows(2).all(|pair| pair[0] != pair[1]));
+
+        for body in bodies {
+            invalidate_dispatch_strategy(body);
         }
-    });
+        RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.set(0));
+
+        for body in bodies {
+            assert!(matches!(resolve_strategy(body), DispatchStrategy::Direct));
+        }
+        assert_eq!(RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.get()), 4);
+
+        RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.set(0));
+        for body in bodies {
+            assert!(matches!(resolve_strategy(body), DispatchStrategy::Direct));
+        }
+        assert_eq!(
+            RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.get()),
+            0,
+            "a warm four-body rotation must not reach resolve_strategy_slow"
+        );
+
+        js_register_closure_arity(body_c as *const u8, 3);
+        assert!(matches!(
+            resolve_strategy(body_c as *const u8),
+            DispatchStrategy::Arity(3)
+        ));
+        assert_eq!(
+            RESOLVE_STRATEGY_SLOW_CALLS.with(|calls| calls.get()),
+            1,
+            "late registration must evict a body from every recent-cache slot"
+        );
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary

Avoid the thread-local hash-table lookup at small polymorphic closure call sites by retaining four recently resolved dispatch strategies. This targets the remaining `pipeline` row in #8289 while preserving the one-comparison monomorphic path.

## Changes

- Replace the single-entry closure dispatch cache with a four-entry, read-only-on-hit recent cache.
- Invalidate every matching recent entry when late arity/rest registration changes a closure body strategy.
- Add a regression test that verifies a four-body rotation has four cold misses and zero warm slow-path lookups.
- Check in the exact `pipeline` benchmark reproducer and add a changelog fragment.

## Related issue

Refs #8289

## Test plan

- [x] `cargo build --release -p perry-runtime-static`
- [x] `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime --lib four_alternating_bodies_stay_out_of_the_hash_lookup -- --nocapture`
- [x] `python3 scripts/check_thread_locals.py`
- [x] `python3 scripts/check_test_registration.py`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `node --experimental-strip-types benchmarks/issue-8289/pipeline.ts`
- [ ] Full workspace test suite (left to CI; 2,583 unrelated runtime tests were filtered out locally)
- [x] Added a `#[test]` in the affected runtime crate
- [x] Documentation update not applicable; no runtime API changed

## Screenshots / output

The checked-in fixture prints `55626000 3 3` under Node, the baseline Perry runtime, and the patched Perry runtime.

Seven interleaved production-build runs measured with `/usr/bin/time -lp`:

| | Median instructions retired |
|---|---:|
| `origin/main` | 3,525,933,321 |
| This PR | 3,412,162,252 |

That is a **3.23% reduction**. Wall time was not used because the shared host was heavily CPU-contended; retired-instruction counts were stable across all seven pairs.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log (`perf:` for a performance-only change)
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dynamic closure dispatch by caching up to four recently used closure strategies.
  * Reduced repeated slow-path lookups for alternating closure calls after the cache is warmed.
  * Ensured cached dispatch results are refreshed when new closure arities or rest parameters are registered.

* **Benchmarks**
  * Added a configurable record-processing benchmark covering multiple processing stages and result tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->