### PR TITLE
fix(hir): preserve existing global var descriptors in eval

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -30,7 +30,8 @@ use crate::ir::Expr;
 
 use super::expr_function::lower_fn_expr;
 use super::global_eval_hoist::{
-    apply_function_eval_hoist, apply_global_eval_hoist, collect_nested_fn_decl_names,
+    apply_function_eval_hoist, apply_global_eval_hoist, apply_global_eval_hoist_with_script_vars,
+    collect_nested_fn_decl_names,
 };
 use super::lower_expr::lower_expr;
 use super::LoweringContext;
@@ -802,7 +803,9 @@ pub(crate) fn try_indirect_eval_general(
         // stay invisible). Strict eval keeps its own variable environment, which
         // the completion IIFE already models, so it skips the hoist.
         if !eval_strict {
-            if let Some(hoisted) = apply_global_eval_hoist(&body_stmts) {
+            if let Some(hoisted) =
+                apply_global_eval_hoist_with_script_vars(&body_stmts, &ctx.script_var_decl_names)
+            {
                 return build_eval_completion_iife(ctx, hoisted, false, span);
             }
         }
@@ -1655,7 +1658,9 @@ fn try_const_fold_eval(
     // folding (otherwise the completion IIFE traps them as arrow-locals). Strict
     // eval keeps its own variable environment (the IIFE already models that).
     if !eval_strict && eval_is_module_top_global(ctx) {
-        if let Some(hoisted) = apply_global_eval_hoist(&body_stmts) {
+        if let Some(hoisted) =
+            apply_global_eval_hoist_with_script_vars(&body_stmts, &ctx.script_var_decl_names)
+        {
             return build_eval_completion_iife(ctx, hoisted, eval_strict, span);
         }
     }

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -133,6 +133,7 @@ impl LoweringContext {
             resolved_types: None,
             pre_registered_module_vars: HashSet::new(),
             pre_registered_module_var_decls: HashSet::new(),
+            script_var_decl_names: HashSet::new(),
             module_level_ids: HashSet::new(),
             sloppy_implicit_globals: Vec::new(),
             sloppy_implicit_global_ids: HashSet::new(),

--- a/crates/perry-hir/src/lower/global_eval_hoist.rs
+++ b/crates/perry-hir/src/lower/global_eval_hoist.rs
@@ -118,6 +118,45 @@ fn synth_inert_assign_stmt(sink: &str, name: &str, init: Box<ast::Expr>) -> Opti
     Some(block)
 }
 
+/// Completion-inert publish for an eval `var` that reuses a Script-level
+/// `var` binding. Perry keeps the Script binding in a module slot, so update
+/// both that slot and its reflected global-object property in one initializer:
+/// `{ let <sink> = (globalThis["x"] = (x = <init>)); }`.
+fn synth_inert_existing_script_var_assign_stmt(
+    sink: &str,
+    name: &str,
+    init: Box<ast::Expr>,
+) -> Option<ast::Stmt> {
+    let local_assign = synth_assign_stmt(name, init)?;
+    let ast::Stmt::Expr(local_es) = local_assign else {
+        return None;
+    };
+
+    let mut global_assign = parse_single_stmt(&format!("globalThis[{name:?}] = 0;"))?;
+    let ast::Stmt::Expr(global_es) = &mut global_assign else {
+        return None;
+    };
+    let ast::Expr::Assign(global) = global_es.expr.as_mut() else {
+        return None;
+    };
+    global.right = local_es.expr;
+
+    let mut block = parse_single_stmt("{ let __perry_eval_void = 0; }")?;
+    let ast::Stmt::Block(b) = &mut block else {
+        return None;
+    };
+    let Some(ast::Stmt::Decl(ast::Decl::Var(var))) = b.stmts.first_mut() else {
+        return None;
+    };
+    let decl = var.decls.first_mut()?;
+    let ast::Pat::Ident(binding) = &mut decl.name else {
+        return None;
+    };
+    binding.id.sym = sink.into();
+    decl.init = Some(global_es.expr.clone());
+    Some(block)
+}
+
 /// CreateGlobalFunctionBinding for a renamed hidden *top-level* function:
 /// publish its value to the global name `<name>` with the spec's descriptor
 /// rules. This is declaration-instantiation machinery, not a statement of the
@@ -211,6 +250,19 @@ fn synth_create_if_absent_stmt(name: &str) -> Option<ast::Stmt> {
               {{ throw new TypeError(\"Cannot declare global var: {name}\"); }} \
             void Object.defineProperty(globalThis, {name:?}, \
               {{ value: void 0, writable: true, enumerable: true, configurable: true }}); }}"
+    ))
+}
+
+/// Materialize Perry's module-slot representation of an existing Script
+/// `var` as the non-configurable global-object property that
+/// GlobalDeclarationInstantiation created before the Script began executing.
+/// The value is copied at eval entry, immediately before the eval declaration
+/// checks whether the global binding already exists (#5903).
+fn synth_materialize_existing_script_var_stmt(name: &str) -> Option<ast::Stmt> {
+    parse_single_stmt(&format!(
+        "if (!({{}}).hasOwnProperty.call(globalThis, {name:?})) \
+         {{ void Object.defineProperty(globalThis, {name:?}, \
+              {{ value: {name}, writable: true, enumerable: true, configurable: false }}); }}"
     ))
 }
 
@@ -620,6 +672,10 @@ struct GlobalEvalHoist {
     /// `void (x = init)` global publish (the `void` keeps the statement's empty
     /// completion value). (test262 `language/eval-code/*/var-env-var-*`.)
     var_prelude_names: Vec<String>,
+    /// Script-level `var` names already backed by module slots. Eval reuses
+    /// these non-configurable bindings and must mirror initializer writes to
+    /// both representations (#5903).
+    existing_script_vars: std::collections::HashSet<String>,
     /// Top-level `function` declarations — CreateGlobalFunctionBinding: the
     /// function value is present at instantiation, so each is renamed to a hidden
     /// binding and published with a `void (f = <hidden>)` at the top of the body
@@ -795,7 +851,16 @@ impl GlobalEvalHoist {
                             // is in TDZ while `init` evaluates, so a name the
                             // user's `init` could reference would throw spuriously.
                             let sink = self.fresh_hidden();
-                            match synth_inert_assign_stmt(&sink, &name, init.clone()) {
+                            let publish = if self.existing_script_vars.contains(&name) {
+                                synth_inert_existing_script_var_assign_stmt(
+                                    &sink,
+                                    &name,
+                                    init.clone(),
+                                )
+                            } else {
+                                synth_inert_assign_stmt(&sink, &name, init.clone())
+                            };
+                            match publish {
                                 Some(s) => publishes.push(s),
                                 None => {
                                     self.ok = false;
@@ -935,6 +1000,13 @@ impl GlobalEvalHoist {
 /// the unmodified fold. Operates on a clone, so a mid-way bail never leaves a
 /// partially rewritten body.
 pub(super) fn apply_global_eval_hoist(stmts: &[ast::Stmt]) -> Option<Vec<ast::Stmt>> {
+    apply_global_eval_hoist_with_script_vars(stmts, &std::collections::HashSet::new())
+}
+
+pub(super) fn apply_global_eval_hoist_with_script_vars(
+    stmts: &[ast::Stmt],
+    existing_script_vars: &std::collections::HashSet<String>,
+) -> Option<Vec<ast::Stmt>> {
     // The prelude / publishes read `globalThis` and `Object` (the
     // create-if-absent slot and CreateGlobalFunctionBinding); if the eval body
     // rebinds either name at function scope (`var globalThis`, top-level
@@ -950,6 +1022,7 @@ pub(super) fn apply_global_eval_hoist(stmts: &[ast::Stmt]) -> Option<Vec<ast::St
         counter: 0,
         prelude_names: Vec::new(),
         var_prelude_names: Vec::new(),
+        existing_script_vars: existing_script_vars.clone(),
         top_fn_publishes: Vec::new(),
         // `rewrite_list` adds each block scope's lexical bindings as it descends,
         // starting from the eval body's own top level.
@@ -976,7 +1049,13 @@ pub(super) fn apply_global_eval_hoist(stmts: &[ast::Stmt]) -> Option<Vec<ast::St
         .chain(hoist.var_prelude_names.iter())
     {
         if seen.insert(name.clone()) {
-            result.push(synth_create_if_absent_stmt(name)?);
+            let reuses_script_var = hoist.existing_script_vars.contains(name)
+                && hoist.var_prelude_names.iter().any(|var| var == name);
+            result.push(if reuses_script_var {
+                synth_materialize_existing_script_var_stmt(name)?
+            } else {
+                synth_create_if_absent_stmt(name)?
+            });
         }
     }
     // Top-level functions are published (CreateGlobalFunctionBinding) with their
@@ -1016,6 +1095,7 @@ pub(super) fn apply_function_eval_hoist(
         counter: 0,
         prelude_names: Vec::new(),
         var_prelude_names: Vec::new(),
+        existing_script_vars: std::collections::HashSet::new(),
         top_fn_publishes: Vec::new(),
         lexical: std::collections::HashSet::new(),
         ok: true,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -736,6 +736,9 @@ pub fn lower_module_full(
                 }
                 if let ast::Pat::Ident(ident) = &decl.name {
                     let name = ident.id.sym.to_string();
+                    if var_decl.kind == ast::VarDeclKind::Var {
+                        ctx.script_var_decl_names.insert(name.clone());
+                    }
                     if decl.init.as_deref().and_then(require_literal_specifier) == Some("util")
                         || decl.init.as_deref().and_then(require_literal_specifier)
                             == Some("node:util")
@@ -788,6 +791,9 @@ pub fn lower_module_full(
                     let mut leaf_names = Vec::new();
                     crate::lower_patterns::collect_binding_names(&decl.name, &mut leaf_names);
                     for name in leaf_names {
+                        if var_decl.kind == ast::VarDeclKind::Var {
+                            ctx.script_var_decl_names.insert(name.clone());
+                        }
                         if ctx.lookup_local(&name).is_none() {
                             ctx.define_local(name.clone(), Type::Any);
                             ctx.pre_registered_module_vars.insert(name.clone());
@@ -825,6 +831,7 @@ pub fn lower_module_full(
         names.sort();
         names.dedup();
         for name in names {
+            ctx.script_var_decl_names.insert(name.clone());
             if ctx.lookup_local(&name).is_none() {
                 let id = ctx.define_local(name.clone(), Type::Any);
                 ctx.var_hoisted_ids.insert(id);
@@ -883,6 +890,7 @@ pub fn lower_module_full(
         names.sort();
         names.dedup();
         for name in names {
+            ctx.script_var_decl_names.insert(name.clone());
             // Reuse an existing global `var`, else mint a fresh hoisted slot;
             // either way emit an entry slot so the block's B.3.3 write (which
             // runs before any source-position `var f = …`) has storage to target.

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -378,6 +378,12 @@ pub struct LoweringContext {
     /// declarations. Sloppy assignments before a later `var` need an early
     /// backing slot; `let`/`const` should not use that path.
     pub(crate) pre_registered_module_var_decls: HashSet<String>,
+    /// Persistent names introduced by Script-level `var` declarations.
+    /// Unlike `pre_registered_module_var_decls`, entries are not consumed when
+    /// the declaration is lowered: constant global eval needs to know that an
+    /// eval `var` reuses an existing non-configurable global binding rather
+    /// than creating a fresh configurable one (#5903).
+    pub(crate) script_var_decl_names: HashSet<String>,
     /// LocalIds that are defined at module top level (outside any function or
     /// block). Closure `captures` referencing these IDs are filtered out at
     /// lowering time because codegen loads module-level bindings from their

--- a/crates/perry/tests/issue_5841_eval_global_descriptor.rs
+++ b/crates/perry/tests/issue_5841_eval_global_descriptor.rs
@@ -55,10 +55,9 @@ fn run_global(src: &str) -> (bool, String) {
     );
 
     let run = Command::new(&output).output().expect("run compiled binary");
-    (
-        run.status.success(),
-        String::from_utf8_lossy(&run.stdout).to_string(),
-    )
+    let mut output = String::from_utf8_lossy(&run.stdout).to_string();
+    output.push_str(&String::from_utf8_lossy(&run.stderr));
+    (run.status.success(), output)
 }
 
 /// A block-scoped function declaration hoisted by a *global* direct `eval` must
@@ -106,23 +105,22 @@ fn direct_eval_new_global_var_binding_is_configurable() {
     assert!(out.contains("PASS"), "{out}");
 }
 
-/// A `var` declared inside `eval` for a name that already exists as a global
-/// must update the value via a plain assignment, not the create-if-absent
-/// `Object.defineProperty` prelude this PR touches (test262 `language/eval-
-/// code/direct/var-env-var-init-global-exstng`, which additionally asserts the
-/// pre-existing descriptor's `configurable: false` survives untouched — not
-/// checked here: Perry does not yet reify a top-level *script* `var`
-/// declaration as a real `globalThis` own-property until something touches it
-/// via reflection, so `hasOwnProperty` reads `false` before the eval runs and
-/// the create-if-absent prelude (correctly, per its own contract) creates a
-/// fresh `configurable: true` binding — a separate, pre-existing gap in how
-/// Perry models module-top `var`, orthogonal to this PR's eval-configurable
-/// fix and out of scope here).
+/// A direct-eval `var` that reuses a Script-level global must update its value
+/// without changing the Script binding's non-configurable descriptor (test262
+/// `language/eval-code/direct/var-env-var-init-global-exstng`, #5903).
 const DIRECT_EXISTING_VAR_VALUE_UPDATED: &str = r#"
+var initial;
 var __perry_5841_existing = 23;
-eval("var __perry_5841_existing = 45;");
+eval("initial = __perry_5841_existing; var __perry_5841_existing = 45;");
+if (initial !== 23) {
+  throw new Error("expected initial value 23, got " + initial);
+}
 if (__perry_5841_existing !== 45) {
   throw new Error("expected value 45, got " + __perry_5841_existing);
+}
+var d = Object.getOwnPropertyDescriptor(globalThis, "__perry_5841_existing");
+if (d.value !== 45 || d.writable !== true || d.enumerable !== true || d.configurable !== false) {
+  throw new Error("unexpected descriptor: " + JSON.stringify(d));
 }
 console.log("PASS");
 "#;
@@ -170,6 +168,32 @@ console.log("PASS");
 #[test]
 fn indirect_eval_new_global_var_binding_is_configurable() {
     let (ok, out) = run_global(INDIRECT_NEW_VAR_CONFIGURABLE);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}
+
+/// Indirect-eval form of [`direct_eval_existing_global_var_value_is_updated`]
+/// (test262 `language/eval-code/indirect/var-env-var-init-global-exstng`).
+const INDIRECT_EXISTING_VAR_VALUE_UPDATED: &str = r#"
+var initial;
+var __perry_5903_existing = 23;
+(0, eval)("initial = __perry_5903_existing; var __perry_5903_existing = 45;");
+if (initial !== 23) {
+  throw new Error("expected initial value 23, got " + initial);
+}
+if (__perry_5903_existing !== 45) {
+  throw new Error("expected value 45, got " + __perry_5903_existing);
+}
+var d = Object.getOwnPropertyDescriptor(globalThis, "__perry_5903_existing");
+if (d.value !== 45 || d.writable !== true || d.enumerable !== true || d.configurable !== false) {
+  throw new Error("unexpected descriptor: " + JSON.stringify(d));
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn indirect_eval_existing_global_var_value_and_descriptor_are_updated() {
+    let (ok, out) = run_global(INDIRECT_EXISTING_VAR_VALUE_UPDATED);
     assert!(ok, "binary did not exit cleanly\n{out}");
     assert!(out.contains("PASS"), "{out}");
 }


### PR DESCRIPTION
## Summary

- keep Script-level `var` names available through constant-eval lowering
- materialize reused Script globals with their non-configurable descriptor before EvalDeclarationInstantiation checks
- mirror eval initializer writes to Perry's module slot and the reflected global property
- cover both direct and indirect `var-env-var-init-global-exstng` regressions

Refs #5903.

## Verification

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test -p perry-hir global_eval_hoist_tests --lib` (15 passed)
- `RUST_TEST_THREADS=1 cargo test -p perry --test issue_5841_eval_global_descriptor -- --nocapture` (6 passed)
- exact Test262 direct/indirect existing-global cases: 2/2 passed
- requested Annex B + language eval-code slice: 779 passed, 21 pre-existing runtime mismatches, 2 documented AOT skips; 8 compile-timeout cases rerun with a 180s limit and passed 8/8 (effective 787 passed, 0 compile failures)
- `cargo fmt --all -- --check`
- `bash scripts/check_file_size.sh`
- `git diff --check`

Code-only change: no version, lockfile, changelog, or `CLAUDE.md` update.