### PR TITLE
chore(fmt): format optimized_libs after #8337

### DIFF
--- a/changelog.d/8354-fmt-after-8337.md
+++ b/changelog.d/8354-fmt-after-8337.md
@@ -1,0 +1,1 @@
+Apply `cargo fmt` to `optimized_libs/{no_auto,tests}.rs` after #8337, which landed from a fork branch that could not be amended in place.

--- a/crates/perry/src/commands/compile/optimized_libs/no_auto.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/no_auto.rs
@@ -5,9 +5,7 @@ use std::process::Command;
 
 use crate::OutputFormat;
 
-use super::super::library_search::{
-    android_cross_env, find_harmonyos_sdk, harmonyos_cross_env,
-};
+use super::super::library_search::{android_cross_env, find_harmonyos_sdk, harmonyos_cross_env};
 use super::super::{
     find_perry_workspace_root, is_android_target, is_windows_target, rust_target_triple,
     CompilationContext,
@@ -89,15 +87,15 @@ fn build_wasm_host_runtime(
     }
 
     if matches!(format, OutputFormat::Text) {
-        println!(
-            "  wasm-host (no-auto): rebuilding perry-runtime-static with wasm-host feature"
-        );
+        println!("  wasm-host (no-auto): rebuilding perry-runtime-static with wasm-host feature");
     }
 
     // Use a dedicated target dir so the prebuilt libperry_runtime.a in
     // target/release is not overwritten. Cargo's incremental cache makes
     // repeat builds a no-op.
-    let wasm_host_target_dir = workspace_root.join("target").join("perry-wasm-host-runtime");
+    let wasm_host_target_dir = workspace_root
+        .join("target")
+        .join("perry-wasm-host-runtime");
 
     let mut cargo_cmd = Command::new("cargo");
     cargo_cmd
@@ -134,9 +132,7 @@ fn build_wasm_host_runtime(
     }
     if is_android_target(target) {
         if let Some(ndk) = std::env::var_os("ANDROID_NDK_HOME") {
-            for (k, v) in
-                android_cross_env(std::path::Path::new(&ndk), target)
-            {
+            for (k, v) in android_cross_env(std::path::Path::new(&ndk), target) {
                 cargo_cmd.env(k, v);
             }
         }
@@ -154,9 +150,7 @@ fn build_wasm_host_runtime(
         }
         Err(err) => {
             if matches!(format, OutputFormat::Text) {
-                eprintln!(
-                    "  wasm-host (no-auto): failed to spawn cargo ({err})"
-                );
+                eprintln!("  wasm-host (no-auto): failed to spawn cargo ({err})");
             }
             return None;
         }

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -1299,10 +1299,8 @@ fn wasm_usage_changes_auto_optimize_cache_key() {
         ctx_no_wasm.uses_crypto_builtins,
     );
     let feature_arg = features_to_cargo_arg(&features);
-    let key_no_wasm =
-        auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm);
-    let key_wasm =
-        auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm);
+    let key_no_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm);
+    let key_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm);
     assert_ne!(
         key_no_wasm, key_wasm,
         "wasm usage must change the cache key so the target dirs don't collide"


### PR DESCRIPTION
## Summary

#8337 landed from a fork branch whose `cargo fmt --all -- --check` was failing on
`crates/perry/src/commands/compile/optimized_libs/no_auto.rs` (lines 5, 89, 98, 134,
154) and `optimized_libs/tests.rs:1299`. I could not push to the fork, so this
applies the formatting immediately after the merge rather than bouncing an
otherwise-green PR over whitespace.

Attribution checked before merging #8337: clean `main` was fmt-clean (exit 0),
and #8337 alone on current `main` still failed — including `no_auto.rs`, which
the #8338 merge never touched. So it was the branch, not the auto-merge.

## Validation

- `cargo fmt --all` then `cargo fmt --all -- --check` — exit 0
- Only the two files above changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied code formatting updates to compilation and WebAssembly testing components.
  * Updated the changelog with formatting guidance.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->