### PR TITLE
chore(fmt): format cjs_wrap_builtin_require after #8343

### DIFF
--- a/changelog.d/8356-fmt-after-8343.md
+++ b/changelog.d/8356-fmt-after-8343.md
@@ -1,0 +1,1 @@
+Apply `cargo fmt` to `crates/perry/tests/cjs_wrap_builtin_require.rs` after #8343, which landed from a fork branch that could not be amended in place.

--- a/crates/perry/tests/cjs_wrap_builtin_require.rs
+++ b/crates/perry/tests/cjs_wrap_builtin_require.rs
@@ -89,9 +89,7 @@ console.log("join:", typeof path.join, path.join("a", "b"));
     };
     assert_eq!(
         stdout,
-        format!(
-            "platform: {expected_platform}\ncpus: function\njoin: function a/b\n"
-        )
+        format!("platform: {expected_platform}\ncpus: function\njoin: function a/b\n")
     );
 }
 
@@ -130,9 +128,7 @@ module.exports = { platform: node_process.platform };
     };
     assert_eq!(
         stdout,
-        format!(
-            "node_process.platform: {expected_platform}\nnode_os.cpus: function\n"
-        )
+        format!("node_process.platform: {expected_platform}\nnode_os.cpus: function\n")
     );
 }
 
@@ -163,8 +159,6 @@ console.log("join:", join("a", "b"));
     };
     assert_eq!(
         stdout,
-        format!(
-            "platform: {expected_platform}\narch: string\njoin: a/b\n"
-        )
+        format!("platform: {expected_platform}\narch: string\njoin: a/b\n")
     );
 }


### PR DESCRIPTION
## Summary

#8343 landed from a fork branch with `cargo fmt --all -- --check` failing on
`crates/perry/tests/cjs_wrap_builtin_require.rs` (lines 89, 130, 163). Applying
the formatting here since the fork branch could not be amended in place.

## Validation

- `cargo fmt --all` then `cargo fmt --all -- --check` — exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Applied consistent formatting to test assertions.
  - Added a changelog entry documenting the formatting update.
  - No user-facing behavior or expected test results changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->