### PR TITLE
test(codegen): pin inline-asm leaf emission for #8121

### DIFF
--- a/changelog.d/8358-inline-asm-leaf-emission-regression.md
+++ b/changelog.d/8358-inline-asm-leaf-emission-regression.md
@@ -1,0 +1,7 @@
+### Tests
+
+- Pin the `gc-leaf-function` marker on Perry's inline-assembly loop barrier in
+  both text and native LLVM emission. This closes the remaining regression gap
+  for #8121: the existing hand-written IR tests covered the LLVM behavior but
+  could not detect either Perry emitter dropping the marker and reintroducing
+  the `rewrite-statepoints-for-gc` SIGBUS.

--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -906,7 +906,7 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
             .map_err(be)?;
         // Perry-emitted inline asm never calls back into the runtime, so it
         // can never reach a safepoint. Without this, RS4GC statepoint-wraps
-        // the call and produces IR the verifier rejects (#8082).
+        // the call and produces IR the verifier rejects (#8121).
         site.add_attribute(
             inkwell::attributes::AttributeLoc::Function,
             self.ctx.create_string_attribute("gc-leaf-function", ""),
@@ -1613,7 +1613,7 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
                     .map_err(be)?;
                 // The empty barrier can never reach a safepoint; the
                 // exemption keeps RS4GC from statepoint-wrapping inline asm
-                // into invalid IR (#8082).
+                // into invalid IR (#8121).
                 site.add_attribute(
                     inkwell::attributes::AttributeLoc::Function,
                     self.ctx.create_string_attribute("gc-leaf-function", ""),

--- a/crates/perry-codegen/src/inprocess.rs
+++ b/crates/perry-codegen/src/inprocess.rs
@@ -480,7 +480,7 @@ fn optimize_and_emit(
                 )
             })?;
         // Verify the rewritten module before it reaches the backend. RS4GC
-        // has produced verifier-invalid IR in the wild (#8082: it wrapped an
+        // has produced verifier-invalid IR in the wild (#8121: it wrapped an
         // inline-asm barrier into a gc.statepoint), and unlike the external
         // `opt` path — whose verifier aborts with the broken instruction —
         // the in-process pipeline would feed the broken module straight to
@@ -580,7 +580,7 @@ mod tests {
     fn unattributed_asm_barrier_is_rejected_not_miscompiled() {
         // Sabotage arm: without the attribute RS4GC wraps the asm into a
         // gc.statepoint whose callee is inline asm — invalid IR. The
-        // pipeline must fail verification loudly (#8082's SIGBUS shape),
+        // pipeline must fail verification loudly (#8121's SIGBUS shape),
         // proving the leaf test above can actually fail.
         let result = statepoint_rewritten_ir(
             &asm_barrier_fixture(""),

--- a/crates/perry-codegen/src/native_emit.rs
+++ b/crates/perry-codegen/src/native_emit.rs
@@ -695,6 +695,44 @@ mod tests {
         }
     }
 
+    /// #8121, emission half. The sibling pair in `inprocess::tests` proves the
+    /// LLVM mechanism (RS4GC breaks an unmarked inline-asm barrier, and
+    /// `gc-leaf-function` stops it) using hand-written IR, so it would still
+    /// pass if Perry stopped emitting the attribute. This asserts the emission
+    /// itself, on both paths.
+    #[test]
+    fn perry_emits_the_loop_barrier_as_a_gc_leaf() {
+        let mut module = LlModule::new(crate::codegen::default_target_triple());
+        let function = module.define_function("barrier_emission_fixture", VOID, vec![]);
+        let entry = function.create_block("entry");
+        entry.asm_sideeffect_barrier();
+        entry.ret_void();
+
+        let text_ir = module.to_ir();
+        assert!(
+            text_ir.contains("asm sideeffect"),
+            "fixture emitted no barrier, so this proves nothing:\n{text_ir}"
+        );
+        assert!(
+            text_ir.contains(r#"call void asm sideeffect "", ""() "gc-leaf-function""#),
+            "text path barrier lost its gc-leaf callsite attribute (#8121):\n{text_ir}"
+        );
+
+        let context = Context::create();
+        let native_ir = build_native_module(&context, &module)
+            .expect("barrier emission fixture constructs")
+            .print_to_string()
+            .to_string();
+        assert!(
+            native_ir.contains("asm sideeffect"),
+            "native arm emitted no barrier, so this proves nothing:\n{native_ir}"
+        );
+        assert!(
+            native_ir.contains("gc-leaf-function"),
+            "native path lost the gc-leaf attribute on the barrier (#8121):\n{native_ir}"
+        );
+    }
+
     fn compact_gc_map_section_name() -> &'static [u8] {
         if cfg!(target_os = "macos") {
             b"__perry_gcmap"


### PR DESCRIPTION
## Summary

- restore direct regression coverage that Perry marks its loop-preservation inline assembly as `gc-leaf-function` in both text and native LLVM emission
- keep the existing LLVM mechanism and sabotage tests tied to the actual SIGBUS report
- correct stale code comments that attributed the crash shape to the broader Next.js PR

The production fix itself landed in #8128 and the full Next.js App Route dylib gate landed in #8082. This PR restores the emitter-level assertion from the superseded #8123 so a future emitter regression cannot leave the hand-written LLVM tests green while reintroducing the crash.

Closes #8121.

## Validation

- `cargo test -p perry-codegen --lib`: 1096 passed
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `python3 scripts/addr_class_inventory.py`
- `git diff --check`

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added regression coverage to ensure inline-assembly loop barriers retain required garbage-collection safety markers.
  - Verified consistent behavior across textual and native LLVM emission paths, reducing risks such as SIGBUS failures.

- **Tests**
  - Added coverage for the `gc-leaf-function` attribute during loop-barrier emission.

- **Documentation**
  - Updated regression references and safety comments to reflect the correct issue tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->