### PR TITLE
fix(diagnostics): identify missing relative namespace imports

### DIFF
--- a/changelog.d/8348-missing-relative-namespace-diagnostic.md
+++ b/changelog.d/8348-missing-relative-namespace-diagnostic.md
@@ -1,0 +1,1 @@
+**Fix missing relative namespace import diagnostics (#8348):** Perry now reports the absolute path it tried when a relative `import * as ...` target is absent and recommends checking the import or build/staging step. Bare package imports with no native bindings retain the existing `perry.compilePackages` guidance.

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -1532,6 +1532,20 @@ fn collect_module_one(
             // compile.rs registration loop can wire the namespace local
             // through to that runtime helper.
             if has_namespace_specifier && known_node_submodule_key(&import.source).is_none() {
+                if let Some(attempted_path) =
+                    super::resolve::attempted_relative_import_path(&import.source, entry_path)
+                {
+                    return Err(anyhow::anyhow!(
+                        "Could not resolve relative namespace import `import * as ... from \"{source}\"` in {filename} ({path}).\n\
+                         The module file was not found at the path Perry tried:\n  \
+                           {attempted_path}\n\
+                         Check the import path, or ensure the build step that generates or stages this file runs before compiling.",
+                        source = import.source,
+                        filename = filename,
+                        path = canonical.display(),
+                        attempted_path = attempted_path.display(),
+                    ));
+                }
                 return Err(anyhow::anyhow!(
                     "Could not resolve namespace import `import * as ... from \"{source}\"` in {filename} ({path}).\n\
                      Perry has no stdlib bindings for this module path, so the namespace would compile to an empty object \

--- a/crates/perry/src/commands/compile/collect_modules/tests.rs
+++ b/crates/perry/src/commands/compile/collect_modules/tests.rs
@@ -10,6 +10,83 @@ use crate::commands::progress::VerboseProgress;
 use crate::OutputFormat;
 use std::collections::HashSet;
 
+fn collect_entry(root: &std::path::Path, entry: &std::path::Path) -> anyhow::Result<()> {
+    let mut ctx = CompilationContext::new(root.to_path_buf());
+    ctx.entry_canonical = Some(entry.canonicalize().unwrap());
+    let mut visited = HashSet::new();
+    let mut next_class_id: perry_hir::ClassId = 1;
+    let progress = VerboseProgress::new(OutputFormat::Text, 0);
+
+    collect_modules(
+        &entry.to_path_buf(),
+        &mut ctx,
+        &mut visited,
+        OutputFormat::Text,
+        None,
+        &mut next_class_id,
+        false,
+        &progress,
+        None,
+    )
+    .map(|_| ())
+}
+
+#[test]
+fn missing_relative_namespace_import_reports_attempted_file_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("missing.ts");
+    std::fs::write(
+        &entry,
+        "import * as bundle from \"./sub/absent.js\";\nconsole.log(bundle);\n",
+    )
+    .expect("write entry");
+
+    let err = collect_entry(dir.path(), &entry)
+        .expect_err("a namespace import of a missing relative module must fail");
+    let message = err.to_string();
+    let attempted = dir.path().join("sub/absent.js");
+
+    assert!(
+        message.contains("relative namespace import"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains(&attempted.display().to_string()),
+        "diagnostic must include the attempted absolute path; got: {message}"
+    );
+    assert!(
+        message.contains("module file was not found"),
+        "got: {message}"
+    );
+    assert!(message.contains("build step"), "got: {message}");
+    assert!(!message.contains("compilePackages"), "got: {message}");
+    assert!(!message.contains("stdlib bindings"), "got: {message}");
+    assert!(!message.contains("named imports"), "got: {message}");
+}
+
+#[test]
+fn missing_bare_namespace_import_keeps_binding_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("missing.ts");
+    std::fs::write(
+        &entry,
+        "import * as bundle from \"package-that-does-not-exist\";\nconsole.log(bundle);\n",
+    )
+    .expect("write entry");
+
+    let err = collect_entry(dir.path(), &entry)
+        .expect_err("a namespace import of a missing bare package must fail");
+    let message = err.to_string();
+
+    assert!(message.contains("no stdlib bindings"), "got: {message}");
+    assert!(message.contains("named imports"), "got: {message}");
+    assert!(message.contains("perry.compilePackages"), "got: {message}");
+    assert!(
+        !message.contains("module file was not found"),
+        "got: {message}"
+    );
+}
+
 #[test]
 fn env_defines_for_lowering_strips_prefix_and_maps_kinds() {
     // #5009: only `process.env.*` define keys are honored, the prefix is

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -1374,6 +1374,28 @@ fn normalize_path_lexically(path: &Path) -> PathBuf {
     normalized
 }
 
+/// Return the absolute filesystem path that a relative import is resolved
+/// from. This is intentionally available even when resolution fails so
+/// diagnostics can distinguish a missing local file from a bare package with
+/// no Perry bindings.
+pub(super) fn attempted_relative_import_path(
+    import_source: &str,
+    importer_path: &Path,
+) -> Option<PathBuf> {
+    if !is_relative_specifier(import_source) {
+        return None;
+    }
+
+    let parent = importer_path.parent().unwrap_or_else(|| Path::new(""));
+    let joined = parent.join(import_source);
+    let absolute = if joined.is_absolute() {
+        joined
+    } else {
+        std::env::current_dir().ok()?.join(joined)
+    };
+    Some(normalize_path_lexically(&absolute))
+}
+
 /// True for ECMAScript relative-import specifiers. Besides the obvious `./x`
 /// and `../x`, the bare `"."` and `".."` are also relative — they resolve to
 /// the current / parent **directory**'s `index` file. `@tanstack/table-core`'s


### PR DESCRIPTION
## Summary

Distinguishes a missing relative namespace-import target from a bare module with no Perry bindings. Relative failures now report the absolute filesystem path Perry tried and point users toward the import path or generating/staging build step.

## Changes

- Detect unresolved relative specifiers before emitting the missing-stdlib diagnostic.
- Print the attempted absolute path and actionable local-file guidance.
- Preserve the existing named-import / `perry.compilePackages` guidance for unresolved bare specifiers.
- Add regression coverage for both diagnostic branches and a changelog fragment.

## Related issue

Fixes #8348

## Test plan

- `cargo test -p perry --bin perry --no-default-features --features compile-cli commands::compile::collect_modules::tests::` (21 passed)
- `./scripts/pre-tag-check.sh --quick` (passed)

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — not applicable; this corrects an existing diagnostic
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — not applicable

## Screenshots / output

The relative-path branch now reports:

```text
The module file was not found at the path Perry tried:
  /tmp/nsrepro/sub/absent.js
Check the import path, or ensure the build step that generates or stages this file runs before compiling.
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read `CONTRIBUTING.md` and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for missing relative namespace imports by showing the attempted file path.
  * Added guidance to verify the import or build/staging process.
  * Preserved package-binding guidance for unresolved bare package imports.

* **Documentation**
  * Added changelog coverage for the improved import diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->