### PR TITLE
fix(node:test): honor finite mock implementations

### DIFF
--- a/changelog.d/8360-node-test-mock-times.md
+++ b/changelog.d/8360-node-test-mock-times.md
@@ -1,0 +1,7 @@
+### fix(node:test): honor finite mock implementations
+
+`mock.fn()` and `mock.method()` now validate and honor the `times` option,
+falling back to the original implementation after the configured number of
+calls while preserving indexed one-shot overrides. Mocking a missing or
+non-callable target method now also reports Node-compatible validation errors.
+Advances #6767.

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -17,6 +17,8 @@ use crate::object::{js_object_alloc, js_object_set_field_by_name};
 use crate::string::js_string_from_bytes;
 use crate::value::{JSValue, POINTER_MASK, TAG_UNDEFINED};
 
+#[path = "test_mock_options.rs"]
+mod mock_options;
 #[path = "test_property.rs"]
 mod property_mock;
 #[path = "test_reporters.rs"]
@@ -25,6 +27,7 @@ mod reporters;
 mod snapshot;
 
 // Re-exported / imported so the pre-split `test::<item>` paths keep resolving.
+use mock_options::{mock_option_times, parse_mock_fn_options};
 pub(crate) use reporters::{
     thunk_reporter_dot, thunk_reporter_junit, thunk_reporter_lcov, thunk_reporter_spec,
     thunk_reporter_tap,
@@ -210,6 +213,16 @@ fn assert_callable_arg(arg: &str, value: f64) {
     }
 }
 
+fn assert_mock_target_method(value: f64) {
+    if !is_callable_value(value) {
+        crate::validators::throw_invalid_arg_value(
+            "methodName",
+            "must be a method",
+            &crate::fs::validate::describe_received(value),
+        );
+    }
+}
+
 extern "C" fn mock_timers_enable(_closure: *const ClosureHeader, options: f64) -> f64 {
     let (apis, now) = parse_mock_timer_options(options);
     crate::timer::js_mock_timers_enable(apis, now);
@@ -327,6 +340,7 @@ struct MockState {
     tracked: bool,
     original: f64,
     implementation: f64,
+    implementation_limit: Option<u64>,
     once: Vec<(usize, f64)>,
     calls: f64,
     context: f64,
@@ -376,6 +390,10 @@ fn property_name(value: f64) -> String {
 }
 
 fn object_target_addr(target: f64) -> usize {
+    let js = JSValue::from_bits(target.to_bits());
+    if !js.is_pointer() || unsafe { crate::symbol::js_is_symbol(target) } != 0 {
+        throw_invalid_arg_type("object", "object", target);
+    }
     let raw = raw_ptr_from_value(target);
     if raw < 0x10000 {
         throw_invalid_arg_type("object", "object", target);
@@ -395,6 +413,7 @@ fn accessor_function_value(bits: u64) -> f64 {
 struct MockMethodOptions {
     getter: bool,
     setter: bool,
+    times: Option<u64>,
 }
 
 fn is_non_null_object(value: f64) -> bool {
@@ -423,16 +442,20 @@ fn parse_mock_method_options(
         return MockMethodOptions {
             getter: default_getter,
             setter: default_setter,
+            times: None,
         };
     }
-    if !is_non_null_object(options) {
-        throw_invalid_arg_type("options", "object", options);
-    }
+    crate::validators::validate_object(options, "options");
     let scope = crate::gc::RuntimeHandleScope::new();
     let options = scope.root_nanbox_f64(options);
     let getter = mock_option_bool(options.get_nanbox_f64(), "getter", default_getter);
     let setter = mock_option_bool(options.get_nanbox_f64(), "setter", default_setter);
-    MockMethodOptions { getter, setter }
+    let times = mock_option_times(options.get_nanbox_f64());
+    MockMethodOptions {
+        getter,
+        setter,
+        times,
+    }
 }
 
 fn normalize_mock_method_args(implementation: f64, options: f64) -> (f64, f64) {
@@ -558,7 +581,12 @@ fn mock_function_metadata(original: f64) -> (String, u32) {
     (name, length)
 }
 
-fn create_mock_function(original: f64, implementation: f64, restore: MockRestoreTarget) -> f64 {
+fn create_mock_function(
+    original: f64,
+    implementation: f64,
+    implementation_limit: Option<u64>,
+    restore: MockRestoreTarget,
+) -> f64 {
     if !JSValue::from_bits(original.to_bits()).is_undefined() {
         assert_callable_arg("original", original);
     }
@@ -597,6 +625,7 @@ fn create_mock_function(original: f64, implementation: f64, restore: MockRestore
             tracked: true,
             original: original.get_nanbox_f64(),
             implementation: implementation.get_nanbox_f64(),
+            implementation_limit,
             once: Vec::new(),
             calls: calls.get_nanbox_f64(),
             context: context.get_nanbox_f64(),
@@ -634,6 +663,11 @@ fn take_mock_implementation(state: &mut MockState) -> f64 {
     let call = mock_state_call_count(state);
     if let Some(position) = state.once.iter().position(|(index, _)| *index == call) {
         state.once.remove(position).1
+    } else if state
+        .implementation_limit
+        .is_some_and(|limit| call as u64 >= limit)
+    {
+        state.original
     } else {
         state.implementation
     }
@@ -896,20 +930,34 @@ extern "C" fn mock_fn_thunk(
     _closure: *const ClosureHeader,
     original: f64,
     implementation_or_options: f64,
-    _options: f64,
+    options: f64,
 ) -> f64 {
-    let implementation = if is_undefined_value(original) {
-        if is_callable_value(implementation_or_options) {
-            implementation_or_options
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let original = scope.root_nanbox_f64(original);
+    let implementation_or_options = scope.root_nanbox_f64(implementation_or_options);
+    let options = scope.root_nanbox_f64(options);
+    let (implementation, options) =
+        if is_non_null_object(implementation_or_options.get_nanbox_f64()) {
+            (
+                original.get_nanbox_f64(),
+                implementation_or_options.get_nanbox_f64(),
+            )
+        } else if is_undefined_value(implementation_or_options.get_nanbox_f64()) {
+            (original.get_nanbox_f64(), options.get_nanbox_f64())
         } else {
-            undefined_value()
-        }
-    } else if is_callable_value(implementation_or_options) {
-        implementation_or_options
-    } else {
-        original
-    };
-    create_mock_function(original, implementation, MockRestoreTarget::None)
+            assert_callable_arg("implementation", implementation_or_options.get_nanbox_f64());
+            (
+                implementation_or_options.get_nanbox_f64(),
+                options.get_nanbox_f64(),
+            )
+        };
+    let times = parse_mock_fn_options(options);
+    create_mock_function(
+        original.get_nanbox_f64(),
+        implementation,
+        times,
+        MockRestoreTarget::None,
+    )
 }
 
 extern "C" fn mock_method_thunk(
@@ -924,6 +972,7 @@ extern "C" fn mock_method_thunk(
     let property = scope.root_nanbox_f64(property);
     let implementation = scope.root_nanbox_f64(implementation);
     let options = scope.root_nanbox_f64(options);
+    object_target_addr(target.get_nanbox_f64());
     let (implementation, options) =
         normalize_mock_method_args(implementation.get_nanbox_f64(), options.get_nanbox_f64());
     let implementation = scope.root_nanbox_f64(implementation);
@@ -934,6 +983,7 @@ extern "C" fn mock_method_thunk(
             target.get_nanbox_f64(),
             property.get_nanbox_f64(),
             implementation.get_nanbox_f64(),
+            options.times,
         );
     }
     if options.setter {
@@ -941,6 +991,7 @@ extern "C" fn mock_method_thunk(
             target.get_nanbox_f64(),
             property.get_nanbox_f64(),
             implementation.get_nanbox_f64(),
+            options.times,
         );
     }
     if unsafe { crate::symbol::js_is_symbol(property.get_nanbox_f64()) } != 0 {
@@ -951,6 +1002,7 @@ extern "C" fn mock_method_thunk(
                 property.get_nanbox_f64(),
             )
         };
+        assert_mock_target_method(original);
         let implementation = if is_undefined_value(implementation.get_nanbox_f64()) {
             original
         } else {
@@ -960,6 +1012,7 @@ extern "C" fn mock_method_thunk(
         let function = scope.root_nanbox_f64(create_mock_function(
             original,
             implementation,
+            options.times,
             MockRestoreTarget::ObjectSymbolMethod,
         ));
         unsafe {
@@ -974,6 +1027,7 @@ extern "C" fn mock_method_thunk(
 
     let property_name = property_name(property.get_nanbox_f64());
     let original = get_property_value(target.get_nanbox_f64(), &property_name);
+    assert_mock_target_method(original);
     let implementation = if is_undefined_value(implementation.get_nanbox_f64()) {
         original
     } else {
@@ -983,6 +1037,7 @@ extern "C" fn mock_method_thunk(
     let function = create_mock_function(
         original,
         implementation,
+        options.times,
         MockRestoreTarget::ObjectProperty {
             target: target.get_nanbox_f64(),
             property: property_name.clone(),
@@ -993,7 +1048,7 @@ extern "C" fn mock_method_thunk(
     function
 }
 
-fn create_getter_mock(target: f64, property: f64, implementation: f64) -> f64 {
+fn create_getter_mock(target: f64, property: f64, implementation: f64, times: Option<u64>) -> f64 {
     let property = property_name(property);
     let raw = object_target_addr(target);
     let original_accessor = crate::object::get_accessor_descriptor(raw, &property);
@@ -1005,6 +1060,7 @@ fn create_getter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     };
     let existing = original_accessor.unwrap_or_default();
     let original = accessor_function_value(existing.get);
+    assert_mock_target_method(original);
     let implementation = if is_undefined_value(implementation) {
         original
     } else {
@@ -1014,6 +1070,7 @@ fn create_getter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     let function = create_mock_function(
         original,
         implementation,
+        times,
         MockRestoreTarget::ObjectAccessor {
             target,
             property: property.clone(),
@@ -1054,10 +1111,11 @@ extern "C" fn mock_getter_thunk(
         target.get_nanbox_f64(),
         property.get_nanbox_f64(),
         implementation.get_nanbox_f64(),
+        options.times,
     )
 }
 
-fn create_setter_mock(target: f64, property: f64, implementation: f64) -> f64 {
+fn create_setter_mock(target: f64, property: f64, implementation: f64, times: Option<u64>) -> f64 {
     let property = property_name(property);
     let raw = object_target_addr(target);
     let original_accessor = crate::object::get_accessor_descriptor(raw, &property);
@@ -1069,6 +1127,7 @@ fn create_setter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     };
     let existing = original_accessor.unwrap_or_default();
     let original = accessor_function_value(existing.set);
+    assert_mock_target_method(original);
     let implementation = if is_undefined_value(implementation) {
         original
     } else {
@@ -1078,6 +1137,7 @@ fn create_setter_mock(target: f64, property: f64, implementation: f64) -> f64 {
     let function = create_mock_function(
         original,
         implementation,
+        times,
         MockRestoreTarget::ObjectAccessor {
             target,
             property: property.clone(),
@@ -1118,6 +1178,7 @@ extern "C" fn mock_setter_thunk(
         target.get_nanbox_f64(),
         property.get_nanbox_f64(),
         implementation.get_nanbox_f64(),
+        options.times,
     )
 }
 

--- a/crates/perry-runtime/src/node_submodules/test_metadata_unit_tests.rs
+++ b/crates/perry-runtime/src/node_submodules/test_metadata_unit_tests.rs
@@ -10,7 +10,7 @@ fn mock_function_preserves_original_name_length_and_descriptors() {
     crate::object::set_bound_native_closure_name(original, "original");
     let original = boxed_ptr(original);
 
-    let mock = create_mock_function(original, original, MockRestoreTarget::None);
+    let mock = create_mock_function(original, original, None, MockRestoreTarget::None);
     let mock_ptr = raw_ptr_from_value(mock);
 
     let name = crate::closure::closure_get_dynamic_prop(mock_ptr, "name");

--- a/crates/perry-runtime/src/node_submodules/test_mock_options.rs
+++ b/crates/perry-runtime/src/node_submodules/test_mock_options.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub(super) fn mock_option_times(options: f64) -> Option<u64> {
+    let Some(value) = object_property(options, b"times") else {
+        return None;
+    };
+    if is_undefined_value(value) {
+        return None;
+    }
+    if crate::fs::validate::is_numeric(JSValue::from_bits(value.to_bits())) {
+        let number = crate::validators::number_value(value);
+        if number == f64::INFINITY {
+            return None;
+        }
+    }
+    Some(crate::validators::validate_integer(
+        value,
+        "options.times",
+        1.0,
+        crate::validators::MAX_SAFE_INTEGER,
+    ) as u64)
+}
+
+pub(super) fn parse_mock_fn_options(options: f64) -> Option<u64> {
+    if is_undefined_value(options) {
+        return None;
+    }
+    crate::validators::validate_object(options, "options");
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let options = scope.root_nanbox_f64(options);
+    mock_option_times(options.get_nanbox_f64())
+}

--- a/crates/perry-runtime/src/node_submodules/test_once_unit_tests.rs
+++ b/crates/perry-runtime/src/node_submodules/test_once_unit_tests.rs
@@ -33,6 +33,7 @@ fn mock_state_with_calls(call_count: usize, implementation: f64) -> MockState {
         tracked: true,
         original: implementation,
         implementation,
+        implementation_limit: None,
         once: Vec::new(),
         calls: boxed_ptr(calls),
         context: undefined_value(),
@@ -78,6 +79,20 @@ fn indexed_once_scheduling_uses_absolute_call_indices() {
 }
 
 #[test]
+fn finite_implementation_limit_falls_back_to_the_original() {
+    let mut state = mock_state_with_calls(0, 20.0);
+    state.original = 10.0;
+    state.implementation_limit = Some(2);
+
+    assert_eq!(take_mock_implementation(&mut state), 20.0);
+    set_call_count(&mut state, 2);
+    assert_eq!(take_mock_implementation(&mut state), 10.0);
+
+    schedule_mock_implementation_once(&mut state, 2, 30.0);
+    assert_eq!(take_mock_implementation(&mut state), 30.0);
+}
+
+#[test]
 fn restoring_a_mock_preserves_calls_and_scheduled_implementations() {
     let mut state = mock_state_with_calls(2, 10.0);
     state.implementation = 20.0;
@@ -96,7 +111,7 @@ fn reentrant_dispatch_uses_completed_call_indices_like_node() {
     let outer = closure_value(reentrant_implementation as *const u8, 0);
     let explicit_once = closure_value(return_twenty as *const u8, 0);
     let scheduled_inside = closure_value(return_thirty as *const u8, 0);
-    let mock = create_mock_function(outer, outer, MockRestoreTarget::None);
+    let mock = create_mock_function(outer, outer, None, MockRestoreTarget::None);
     let mock_ptr = raw_ptr_from_value(mock) as *const ClosureHeader;
     let id = closure_id(mock_ptr);
     REENTRANT_MOCK.with(|slot| slot.set(mock));

--- a/crates/perry-runtime/src/node_submodules/test_unit_tests.rs
+++ b/crates/perry-runtime/src/node_submodules/test_unit_tests.rs
@@ -54,6 +54,52 @@ fn mock_getter_and_setter_defaults_preserve_the_accessor_kind() {
 }
 
 #[test]
+fn mock_times_accepts_positive_integers_and_infinity() {
+    let finite = options_with_value("times", 2.0);
+    assert_eq!(parse_mock_fn_options(finite), Some(2));
+
+    let unlimited = options_with_value("times", f64::INFINITY);
+    assert_eq!(parse_mock_fn_options(unlimited), None);
+}
+
+#[test]
+fn mock_times_rejects_zero_and_fractional_values() {
+    for value in [0.0, 1.5] {
+        let options = options_with_value("times", value);
+        assert_eq!(
+            caught_error_code(|| {
+                let _ = parse_mock_fn_options(options);
+                undefined_value()
+            }),
+            "ERR_OUT_OF_RANGE"
+        );
+    }
+}
+
+#[test]
+fn mock_options_reject_arrays() {
+    let array = boxed_ptr(crate::array::js_array_alloc(0));
+    assert_eq!(
+        caught_error_code(|| {
+            let _ = parse_mock_fn_options(array);
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_TYPE"
+    );
+}
+
+#[test]
+fn mock_method_requires_an_existing_callable_target() {
+    assert_eq!(
+        caught_error_code(|| {
+            assert_mock_target_method(undefined_value());
+            undefined_value()
+        }),
+        "ERR_INVALID_ARG_VALUE"
+    );
+}
+
+#[test]
 fn mock_method_options_survive_an_allocating_getter() {
     let options = js_object_alloc(0, 2);
     install_accessor_mock(


### PR DESCRIPTION
## Summary

Aligns `node:test` mock implementation limits and target-method validation with Node 26.5.1. This closes the `mock-fn/times-options` and `mock-fn/validation` failures from the #6767 parity tracker.

## Changes

- Parse and validate `mock.fn` / `mock.method` `times` options, including Infinity and overload handling.
- Fall back to the original implementation after the configured call limit while preserving indexed one-shot overrides.
- Report Node-compatible invalid-value errors for missing/non-callable target methods.
- Add focused runtime unit coverage and keep the main test module below the 2,000-line cap.

## Related issue

Advances #6767

## Test plan

- [x] `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release -p perry-runtime-static`
- [x] `cargo check --release -p perry-runtime`
- [x] `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime node_submodules::test::tests -- --test-threads=1` (8 passed)
- [x] `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --suite node-suite --module test --filter mock-fn/times-options` (1/1, 100%)
- [x] `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --suite node-suite --module test --filter mock-fn/validation` (1/1, 100%)
- [x] `./scripts/pre-tag-check.sh --quick` (all checks green after the file-size split and dedicated rerun)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the repository convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mock functions, methods, getters, and setters now support limiting implementations to a specified number of calls.
  * After the limit is reached, calls automatically use the original implementation.
  * One-time implementation overrides continue to work with limited mocks.

* **Bug Fixes**
  * Improved validation and Node-compatible errors for invalid options, targets, and non-callable methods.
  * Added support for symbol-based targets and stricter option validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->