### PR TITLE
perf(codegen): inline mixed-layout constructor stores

### DIFF
--- a/benchmarks/issue-8289/tree_wide.ts
+++ b/benchmarks/issue-8289/tree_wide.ts
@@ -1,0 +1,32 @@
+class Tree {
+  left: Tree | null;
+  right: Tree | null;
+  a: number; b: number; c: number; d: number;
+  e: number; f: number; g: number; h: number;
+  constructor(left: Tree | null, right: Tree | null, s: number) {
+    this.left = left;
+    this.right = right;
+    this.a = s; this.b = s + 1; this.c = s + 2; this.d = s + 3;
+    this.e = s + 4; this.f = s + 5; this.g = s + 6; this.h = s + 7;
+  }
+}
+
+function build(depth: number, s: number): Tree {
+  if (depth === 0) return new Tree(null, null, s);
+  return new Tree(build(depth - 1, s), build(depth - 1, s + 1), s);
+}
+
+function count(t: Tree): number {
+  if (t.left === null) return 1;
+  return 1 + count(t.left) + count(t.right as Tree);
+}
+
+function main(): void {
+  let total = 0;
+  for (let i = 0; i < 40; i++) {
+    const t = build(18, i);
+    total += count(t);
+  }
+  console.log(total);
+}
+main();

--- a/changelog.d/8363-mixed-layout-constructor-stores.md
+++ b/changelog.d/8363-mixed-layout-constructor-stores.md
@@ -1,0 +1,6 @@
+### Performance
+
+- Skip prologue-only constructors for mixed pointer/raw-f64 layouts, including
+  typed `numberParam + finiteLiteral` field initialization, while retaining
+  pointer write barriers. On issue #8289's `tree_wide` fixture this reduces
+  retired instructions by 67.4% (23.41B to 7.62B) with unchanged output.

--- a/crates/perry-codegen/src/lower_call/ctor_prologue_store_tests.rs
+++ b/crates/perry-codegen/src/lower_call/ctor_prologue_store_tests.rs
@@ -7,17 +7,16 @@
 //! is merely as slow as it was before. `js_gc_declare_typed_shape_layout` was
 //! 30% of `churn_alloc` and nothing but a profile said so — the same shape of
 //! mistake is available here, so the positive test asserts the fast arm exists
-//! AND that it carries the stores, and the negatives assert it is absent for
-//! each shape that must keep the call.
+//! AND that it carries the stores, while the negative fixtures assert it is
+//! absent for each shape that must keep the call.
 //!
 //! The module reuses the `#7834` bake tests' fixtures verbatim
-//! (`typed_shape_bake_tests`), because the qualifying population is a subset of
-//! that ticket's: `typed_layout_baked` is the first thing
-//! `prologue_store_plan` tests.
+//! (`typed_shape_bake_tests`) so the pointer-free baked path and the
+//! pointer-bearing runtime-declared path differ by one field type only.
 
-use super::typed_shape_bake_tests::{emit, loop_new_module};
+use super::typed_shape_bake_tests::{emit, loop_new_module, outlined_new_module};
 use perry_hir::types::Type;
-use perry_hir::Expr;
+use perry_hir::{BinaryOp, Expr, Stmt};
 
 /// The label the fast arm's basic block carries.
 const FAST_BLOCK: &str = "ctor_prologue.fast";
@@ -56,21 +55,85 @@ fn a_prologue_only_ctor_stores_its_fields_at_the_new_site() {
     );
 }
 
-/// The control. `class Link { a: number; b: Link | null }` has a non-empty
-/// pointer mask, so `typed_layout_baked` is false, so none of the header
-/// constants this change reads as proof were written — and the arm must not be
-/// emitted at all.
+/// `class Link { a: number; b: Link | null }` has a non-empty pointer mask.
+/// Its declaration stays runtime-installed, but once INTACT is observed the
+/// new site can store both fields directly and skip the constructor call.
 #[test]
-fn a_pointer_bearing_shape_keeps_the_constructor_call() {
+fn a_pointer_bearing_shape_checks_intact_then_stores_at_the_new_site() {
     let ir = emit(&loop_new_module(
         "Link",
         Type::Union(vec![Type::Named("Link".to_string()), Type::Null]),
         Expr::Null,
     ));
     assert!(
-        !ir.contains(FAST_BLOCK),
-        "a pointer-bearing shape took the constructor-free arm. Its header is \
-         GC_LAYOUT_SIDE_MASK with no INTACT bit, so the precheck conditions \
-         this arm skips are NOT statically true for it:\n{ir}"
+        ir.contains(FAST_BLOCK),
+        "a declared pointer-bearing shape did not get a constructor-free arm:\n{ir}"
+    );
+    assert_eq!(
+        fast_arm_double_stores(&ir),
+        2,
+        "the mixed-layout fast arm must store both the raw-f64 and pointer fields:\n{ir}"
+    );
+    assert!(
+        ir.contains("and i16") && ir.contains(", 4096"),
+        "the mixed-layout arm must test GC_OBJ_TYPED_LAYOUT_INTACT after the runtime declaration:\n{ir}"
+    );
+}
+
+/// Wide records commonly initialize adjacent numeric fields as `seed + k`.
+/// Keep that pure typed arithmetic at the construction site instead of making
+/// those otherwise-trivial constructors ineligible as a group.
+#[test]
+fn a_finite_numeric_param_offset_is_stored_at_the_new_site() {
+    let mut module = loop_new_module("Pair", Type::Number, Expr::Integer(2));
+    let ctor = module.classes[0].constructor.as_mut().unwrap();
+    let seed = match &ctor.body[0] {
+        Stmt::Expr(Expr::PropertySet { value, .. }) => value.clone(),
+        other => panic!("unexpected first constructor statement: {other:?}"),
+    };
+    match &mut ctor.body[1] {
+        Stmt::Expr(Expr::PropertySet { value, .. }) => {
+            *value = Box::new(Expr::Binary {
+                op: BinaryOp::Add,
+                left: seed,
+                right: Box::new(Expr::Integer(1)),
+            });
+        }
+        other => panic!("unexpected second constructor statement: {other:?}"),
+    }
+    let ir = emit(&module);
+    assert!(ir.contains(FAST_BLOCK), "{ir}");
+    assert_eq!(fast_arm_double_stores(&ir), 2, "{ir}");
+    assert!(
+        ir.contains("fadd double"),
+        "the derived numeric field was not rebuilt at the new site:\n{ir}"
+    );
+}
+
+/// A pointer-bearing shape on the stamped outlined allocator must retain the
+/// constructor's pointer-barrier semantics, including the incremental-marking
+/// gate.
+#[test]
+fn an_outlined_pointer_bearing_shape_keeps_its_write_barrier() {
+    let ir = emit(&outlined_new_module(
+        "Link",
+        Type::Union(vec![Type::Named("Link".to_string()), Type::Null]),
+        Expr::Null,
+    ));
+    assert!(
+        ir.contains(FAST_BLOCK),
+        "a stamped outlined allocation did not get a constructor-free arm:\n{ir}"
+    );
+    assert_eq!(fast_arm_double_stores(&ir), 2, "{ir}");
+    assert!(
+        ir.contains("and i8")
+            && ir.contains(", 32")
+            && ir.contains("@PERRY_INCREMENTAL_MARK_BARRIER_ACTIVE_COUNT"),
+        "the outlined mixed-layout arm must retain every required pointer barrier:\n{ir}"
+    );
+    assert!(
+        ir.contains("ctor_prologue.barrier.maybe")
+            && ir.contains("call void @js_write_barrier_slot("),
+        "the direct pointer store must reach the ordinary write-barrier call:\n{ir}"
     );
 }

--- a/crates/perry-codegen/src/lower_call/ctor_prologue_stores.rs
+++ b/crates/perry-codegen/src/lower_call/ctor_prologue_stores.rs
@@ -1,5 +1,5 @@
 //! Constructor-free construction for a class whose entire constructor is a run
-//! of `this.<field> = <parameter>` stores.
+//! of `this.<field> = <parameter>` stores and typed finite-offset variants.
 //!
 //! ## What this is for
 //!
@@ -23,17 +23,16 @@
 //! (4 fields, **identical object bytes**) 0.3707 s → `churn_alloc8` 0.6143 s.
 //! The step is field *stores*, not bytes.
 //!
-//! Every one of those conditions is statically true three instructions earlier,
-//! at the allocation. This module recognizes that case and stores the fields
-//! straight into their packed slots at the `new` site, with no call and no
-//! per-field guard.
+//! The allocation establishes the structural conditions, and the pre-constructor
+//! layout declaration establishes the representation condition. This module
+//! recognizes that case and stores the fields straight into their packed slots
+//! at the `new` site, with no call and no per-field guard.
 //!
 //! ## Where the proof comes from
 //!
-//! Almost all of it from one bit: `InstanceAlloc::typed_layout_baked` (#7834).
-//! It is set only on the inline-bump arm of `new_alloc.rs`, and only when
-//! `layout_pointer_free_at_allocation` holds, so it certifies that the
-//! allocation wrote these header constants itself:
+//! Almost all of it comes from allocation with the class's canonical stamped
+//! shape. The inline bump writes these facts directly; the stamped outlined
+//! allocator establishes the same contract:
 //!
 //! | precheck condition | why it holds |
 //! |---|---|
@@ -43,16 +42,16 @@
 //! | `class_id == <this class>` | same word, `cid` is this site's class |
 //! | live-slot bound > slot | the bound is the class's own field count (the ShapeId descriptor's `live_inline_slot_count` since #8113), and every slot in the plan indexes a declared field |
 //! | `keys_array == @perry_class_keys_<C>` | the header store loads the same global the precheck compares against |
-//! | no per-object descriptors | `_reserved` is the constant `GC_LAYOUT_POINTER_FREE \| INTACT` |
-//! | not frozen | same constant |
-//! | typed layout INTACT | same constant — this is exactly what #7834 baked |
+//! | no property descriptors | the instance is freshly allocated and unpublished |
+//! | not frozen | same fresh-instance proof |
+//! | typed layout INTACT | baked by #7834 for pointer-free shapes; checked after the runtime declaration otherwise |
 //!
 //! Nothing can invalidate any of it in between: the instance has not escaped,
 //! and the arguments were lowered *before* the allocation (they are re-read from
 //! their roots by `refresh_rooted_args`, so a collection during the allocation
 //! is already handled).
 //!
-//! Two conditions are **not** static, and both are still emitted — once for the
+//! Three conditions are **not** static, and all are still emitted — once for the
 //! whole construction rather than once per field:
 //!
 //! * **The policy latch** `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED`. It is
@@ -60,6 +59,10 @@
 //!   or typed-feedback tracing arms. Honouring it keeps the escape hatch real —
 //!   a knob whose off-state is not on the path it claims to gate is the failure
 //!   mode `CLAUDE.md`'s kill-policy section is about.
+//! * **The typed-layout result** for pointer-bearing shapes. The declaration
+//!   can reject an ambiguous layout, so the fast arm reads the authoritative
+//!   INTACT header bit after the call. Pointer-free shapes retain #7834's
+//!   compile-time bake and pay no extra check.
 //! * **The values.** A raw slot may hold only a plain finite double. The
 //!   conjunction of the per-value finite tests decides the whole construction,
 //!   so a single non-number sends *all* fields to the constructor call, which is
@@ -74,10 +77,16 @@
 //! `js_array_numeric_value_to_raw_f64` canonicalization (the only inputs that
 //! helper rewrites are exactly the ones the finite test rejects).
 //!
-//! GC: a plain finite double is provably not a heap pointer, the shape is
-//! `GC_LAYOUT_POINTER_FREE`, and the instance is a fresh nursery object — so no
-//! write barrier and no per-slot layout note are due. Same reasoning, same
-//! audit tag, as the #5093 loop-clone store in `expr/property_set.rs`.
+//! Pointer-bearing typed layouts are also eligible once
+//! `js_gc_declare_typed_shape_layout` has established the descriptor. The fast
+//! arm checks `GC_OBJ_TYPED_LAYOUT_INTACT` after that call, so an ambiguous or
+//! rejected layout stays on the constructor path. Only raw-f64 fields need the
+//! finite-value check; pointer/boxed slots keep their NaN-boxed bits.
+//!
+//! GC: the instance is fresh and unpublished. Pointer stores are already
+//! covered by the declared shape mask, so no per-slot layout note is due; each
+//! pointer/boxed field still emits the ordinary value-and-generation-tested
+//! write barrier for old-generation and incremental-marking correctness.
 
 use crate::expr::FnCtx;
 
@@ -87,6 +96,13 @@ pub(super) struct PrologueStore {
     pub(super) slot: u32,
     /// Index into the `new` site's lowered argument vector.
     pub(super) arg_index: usize,
+    /// For a numeric field initialized as `<number param> + <finite literal>`,
+    /// the literal to add at the construction site. `None` is a direct
+    /// parameter store.
+    pub(super) numeric_addend: Option<f64>,
+    /// The slot is read as a raw `f64`, so its argument must be a plain finite
+    /// number before the direct store is allowed.
+    pub(super) requires_raw_f64: bool,
 }
 
 /// Can `new <class_name>(…)` skip its constructor call and store the fields
@@ -110,24 +126,26 @@ pub(super) struct PrologueStore {
 ///   parameters `undefined`. Requiring exact positional correspondence is what
 ///   makes `lowered_args[i]` the value of parameter `i`.
 /// * **A body that is anything other than the full run** — every statement must
-///   be `this.<f> = <param>`, and the assigned set must cover *every* declared
-///   field exactly once. Partial coverage would leave a declared raw-f64 slot
-///   holding the allocator's `undefined` fill under an INTACT header, which is
-///   precisely the state `layout_pointer_free_at_allocation` exists to prevent.
+///   be `this.<f> = <param>` or the finite typed-number offset documented below,
+///   and the assigned set must cover *every* declared field exactly once.
+///   Partial coverage would leave a declared raw-f64 slot holding the
+///   allocator's `undefined` fill under an INTACT header, which is precisely the
+///   state the at-allocation declaration exists to prevent.
 ///
-/// A literal or a pure operator tree on the right-hand side is admissible to
-/// `field_init::ctor_prologue_param_assigned_fields` but NOT here: those values
-/// have no corresponding entry in the call site's argument vector. Widening to
-/// them means lowering the expression at the `new` site, which is a different
-/// change.
+/// A general literal or pure operator tree on the right-hand side is admissible
+/// to `field_init::ctor_prologue_param_assigned_fields` but NOT here: those
+/// values have no corresponding entry in the call site's argument vector. The
+/// one derived form admitted is `<number param> + <finite numeric literal>`;
+/// it lowers to one `fadd`, exactly as the typed constructor body does, and is
+/// the wide-record initialization pattern in issue #8289's `tree_wide` case.
 pub(super) fn prologue_store_plan(
     ctx: &FnCtx<'_>,
     class_name: &str,
     class: &perry_hir::Class,
     lowered_arg_count: usize,
-    typed_layout_baked: bool,
+    constructor_layout_ready: bool,
 ) -> Option<Vec<PrologueStore>> {
-    if !typed_layout_baked {
+    if !constructor_layout_ready {
         return None;
     }
     if class.extends.is_some()
@@ -173,11 +191,16 @@ pub(super) fn prologue_store_plan(
     let mut plan: Vec<PrologueStore> = Vec::with_capacity(ctor.body.len());
     let mut assigned: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for stmt in &ctor.body {
-        let (property, param_id) = param_store(stmt)?;
+        let (property, param_id, numeric_addend) = param_store(stmt)?;
         if !assigned.insert(property) {
             return None;
         }
         let arg_index = *param_slot.get(&param_id)?;
+        if numeric_addend.is_some()
+            && !matches!(ctor.params[arg_index].ty, perry_hir::types::Type::Number)
+        {
+            return None;
+        }
         // A compiled setter owns the name — never store into the slot behind it.
         if ctx
             .methods
@@ -186,7 +209,18 @@ pub(super) fn prologue_store_plan(
             return None;
         }
         let slot = crate::type_analysis::class_field_global_index(ctx, class_name, property)?;
-        plan.push(PrologueStore { slot, arg_index });
+        // Refuse an unresolved field type rather than guessing boxed: missing
+        // a raw-f64 slot here would store NaN-box bits into a slot readers
+        // reinterpret as a plain double.
+        let field_type =
+            crate::type_analysis::class_field_declared_type(ctx, class_name, property)?;
+        let requires_raw_f64 = crate::typed_shape::type_is_raw_f64_candidate(&field_type);
+        plan.push(PrologueStore {
+            slot,
+            arg_index,
+            numeric_addend,
+            requires_raw_f64,
+        });
     }
     // Every declared field written, exactly once — see the doc comment.
     if !class
@@ -199,24 +233,46 @@ pub(super) fn prologue_store_plan(
     Some(plan)
 }
 
-/// `Some((field, param_id))` when `stmt` is exactly `this.<field> = <param>`.
+/// `Some((field, param_id, addend))` when `stmt` is exactly
+/// `this.<field> = <param>` or `this.<field> = <param> + <finite number>`.
 ///
 /// Both HIR spellings, for the same reason `field_init::prologue_assigned_field`
 /// matches both: `Expr::PropertySet` is what the anon-shape lowering
 /// synthesizes, `Expr::PutValueSet` is what user source produces. Matching one
 /// of them covers exactly half the population — #7512 is the bug that shape
 /// caused.
-fn param_store(stmt: &perry_hir::Stmt) -> Option<(&str, u32)> {
-    use perry_hir::{Expr, Stmt};
+fn param_store(stmt: &perry_hir::Stmt) -> Option<(&str, u32, Option<f64>)> {
+    use perry_hir::{BinaryOp, Expr, Stmt};
+    fn value_spec(expr: &Expr) -> Option<(u32, Option<f64>)> {
+        match expr {
+            Expr::LocalGet(id) => Some((*id, None)),
+            Expr::Binary {
+                op: BinaryOp::Add,
+                left,
+                right,
+            } => {
+                let Expr::LocalGet(id) = left.as_ref() else {
+                    return None;
+                };
+                let addend = match right.as_ref() {
+                    Expr::Integer(value) => *value as f64,
+                    Expr::Number(value) => *value,
+                    _ => return None,
+                };
+                addend.is_finite().then_some((*id, Some(addend)))
+            }
+            _ => None,
+        }
+    }
     match stmt {
         Stmt::Expr(Expr::PropertySet {
             object,
             property,
             value,
-        }) if matches!(object.as_ref(), Expr::This) => match value.as_ref() {
-            Expr::LocalGet(id) => Some((property.as_str(), *id)),
-            _ => None,
-        },
+        }) if matches!(object.as_ref(), Expr::This) => {
+            let (id, addend) = value_spec(value.as_ref())?;
+            Some((property.as_str(), id, addend))
+        }
         Stmt::Expr(Expr::PutValueSet {
             target,
             key,
@@ -224,10 +280,11 @@ fn param_store(stmt: &perry_hir::Stmt) -> Option<(&str, u32)> {
             receiver,
             strict: _,
         }) if matches!(target.as_ref(), Expr::This) && matches!(receiver.as_ref(), Expr::This) => {
-            match (key.as_ref(), value.as_ref()) {
-                (Expr::String(property), Expr::LocalGet(id)) => Some((property.as_str(), *id)),
-                _ => None,
-            }
+            let Expr::String(property) = key.as_ref() else {
+                return None;
+            };
+            let (id, addend) = value_spec(value.as_ref())?;
+            Some((property.as_str(), id, addend))
         }
         _ => None,
     }

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -23,7 +23,7 @@ use super::new_helpers::{
 use crate::expr::{lower_expr, lower_js_args_array, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::rooting::{self, open_rooted_group, EmittedValue, Repr, RootedGroup};
-use crate::types::{DOUBLE, I32, I64, PTR};
+use crate::types::{DOUBLE, I16, I32, I64, I8, PTR};
 
 /// Does `new <class_name>(…)` run user code — an own or inherited constructor
 /// body, or field initializers — between the instance allocation and the value
@@ -534,6 +534,8 @@ fn lower_new_impl_inner<'a>(
     // Before the instance root's push, so the handle this names is the one the
     // allocator returned: nothing between here and there can collect.
     let typed_layout_baked = alloc.typed_layout_baked;
+    let constructor_layout_ready = alloc.constructor_stores_ready
+        && super::typed_shape_init::layout_declared_at_allocation(ctx, class_name);
     emit_typed_shape_layout_declare(ctx, class_name, &obj_handle, typed_layout_baked);
     let instance = {
         let protected = construction_runs_user_code(ctx, class_name);
@@ -635,9 +637,10 @@ fn lower_new_impl_inner<'a>(
         // `ctor_prologue_stores` for the proof — the short version is that every
         // condition the per-field precheck tests is a compile-time constant this
         // very site wrote three instructions ago, so the only things left to
-        // decide at runtime are the policy latch and whether the values are
-        // plain finite numbers, and both are decided ONCE for the construction
-        // instead of once per field.
+        // decide at runtime are the policy latch, the INTACT result for a
+        // runtime-declared pointer layout, and whether raw-f64 values are plain
+        // finite numbers. All are decided ONCE for the construction instead of
+        // once per field.
         //
         // Emitted only when `saved_new_target` is absent: a `new.target`-reading
         // chain needs the runtime cell the call path sets, and a class whose
@@ -654,7 +657,7 @@ fn lower_new_impl_inner<'a>(
                     class_name,
                     class,
                     lowered_args.len(),
-                    typed_layout_baked,
+                    constructor_layout_ready,
                 )
             } else {
                 None
@@ -663,6 +666,19 @@ fn lower_new_impl_inner<'a>(
         // emitted; the slow arm is the current block from here on.
         let mut prologue_merge: Option<(usize, String)> = None;
         if let Some(plan) = prologue_plan.as_ref() {
+            // Pure derived values are safe to compute before the diamond. A
+            // non-finite result selects the ordinary constructor below, which
+            // recomputes the same `fadd` before taking its guarded slow store.
+            let prologue_values: Vec<String> = plan
+                .iter()
+                .map(|store| {
+                    let arg = &lowered_args[store.arg_index];
+                    store.numeric_addend.map_or_else(
+                        || arg.clone(),
+                        |addend| ctx.block().fadd(arg, &double_literal(addend)),
+                    )
+                })
+                .collect();
             let fast_idx = ctx.new_block("ctor_prologue.fast");
             let slow_idx = ctx.new_block("ctor_prologue.slow");
             let merge_idx = ctx.new_block("ctor_prologue.merge");
@@ -677,8 +693,27 @@ fn lower_new_impl_inner<'a>(
                 let flag =
                     blk.load_volatile(crate::types::I8, "@PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED");
                 let mut acc = blk.icmp_eq(crate::types::I8, &flag, "0");
-                for store in plan {
-                    let bits = blk.bitcast_double_to_i64(&lowered_args[store.arg_index]);
+                // A pointer-bearing layout is installed by the declaration
+                // immediately above. Unlike the pointer-free baked case, its
+                // success is dynamic: an ambiguous ShapeId falls back to a
+                // per-object descriptor, while a rejected declaration clears
+                // INTACT. Test the authoritative header bit before bypassing
+                // the constructor's per-field guards.
+                if !typed_layout_baked {
+                    let obj_ptr = blk.inttoptr(I64, &obj_handle);
+                    // `obj_handle` points just past the 8-byte GcHeader;
+                    // `_reserved: u16` starts two bytes into that header.
+                    let reserved_ptr = blk.gep(I8, &obj_ptr, &[(I64, "-6")]);
+                    let reserved = blk.load(I16, &reserved_ptr);
+                    let intact_bits = blk.and(I16, &reserved, "4096");
+                    let intact = blk.icmp_ne(I16, &intact_bits, "0");
+                    acc = blk.and(crate::types::I1, &acc, &intact);
+                }
+                for (store_index, store) in plan.iter().enumerate() {
+                    if !store.requires_raw_f64 {
+                        continue;
+                    }
+                    let bits = blk.bitcast_double_to_i64(&prologue_values[store_index]);
                     let finite =
                         crate::expr::class_field_inline_guard::emit_plain_finite_number_check(
                             blk, &bits,
@@ -688,28 +723,47 @@ fn lower_new_impl_inner<'a>(
                 blk.cond_br(&acc, &fast_label, &slow_label);
             }
             ctx.current_block = fast_idx;
-            {
-                // arm64_32 watchOS: the fields region starts at
-                // `size_of::<ObjectHeader>()` past the user pointer (16 on
-                // both LP64 and ILP32 since #8047) — same derivation as every
-                // other packed slot access.
-                let header_skip =
-                    crate::target_layout::object_header_size_bytes(ctx.target_triple).to_string();
+            // arm64_32 watchOS: the fields region starts at
+            // `size_of::<ObjectHeader>()` past the user pointer (16 on both
+            // LP64 and ILP32 since #8047) — same derivation as every other
+            // packed slot access.
+            let header_skip =
+                crate::target_layout::object_header_size_bytes(ctx.target_triple).to_string();
+            let fields_base = {
                 let blk = ctx.block();
                 let obj_ptr = blk.inttoptr(I64, &obj_handle);
-                let fields_base = blk.gep(crate::types::I8, &obj_ptr, &[(I64, &header_skip)]);
-                for store in plan {
+                blk.gep(crate::types::I8, &obj_ptr, &[(I64, &header_skip)])
+            };
+            let parent_bits = ctx.block().bitcast_double_to_i64(&obj_box);
+            for (store_index, store) in plan.iter().enumerate() {
+                let (field_addr, child_bits) = {
+                    let blk = ctx.block();
                     let field_ptr =
                         blk.gep(DOUBLE, &fields_base, &[(I64, &store.slot.to_string())]);
-                    // GC_STORE_AUDIT(POINTER_FREE): the finite check above
-                    // proved every value is a genuine unboxed double, never a
-                    // heap pointer, and the shape is GC_LAYOUT_POINTER_FREE —
-                    // no edge, no write barrier, no layout note.
-                    blk.store(DOUBLE, &lowered_args[store.arg_index], &field_ptr);
+                    // GC_STORE_AUDIT(FRESH_TYPED): raw-f64 values passed the
+                    // finite check above; boxed/pointer values are covered by
+                    // the declared typed mask. The unpublished object needs no
+                    // layout note; pointer fields issue the ordinary barrier
+                    // below when generation or incremental marking requires it.
+                    blk.store(DOUBLE, &prologue_values[store_index], &field_ptr);
+                    let field_addr = blk.ptrtoint(&field_ptr, I64);
+                    let child_bits = blk.bitcast_double_to_i64(&prologue_values[store_index]);
+                    (field_addr, child_bits)
+                };
+                if !store.requires_raw_f64 {
+                    crate::expr::emit_write_barrier_slot_value_and_generation_tested(
+                        ctx,
+                        &obj_handle,
+                        &parent_bits,
+                        &field_addr,
+                        &child_bits,
+                        "ctor_prologue",
+                    );
                 }
-                blk.br(&merge_label);
             }
-            prologue_merge = Some((merge_idx, ctx.block_label(fast_idx)));
+            let fast_pred_label = ctx.block().label.clone();
+            ctx.block().br(&merge_label);
+            prologue_merge = Some((merge_idx, fast_pred_label));
             ctx.current_block = slow_idx;
         }
         if let Some(ctor_ret) = call_local_constructor_symbol(

--- a/crates/perry-codegen/src/lower_call/new_alloc.rs
+++ b/crates/perry-codegen/src/lower_call/new_alloc.rs
@@ -130,6 +130,11 @@ fn inline_shape_descriptor_facts_exact(
 /// layout into the object's `GcHeader` constant (#7834).
 pub(super) struct InstanceAlloc {
     pub(super) handle: String,
+    /// `true` when the allocator publishes this class's canonical keys and
+    /// ShapeId at birth. Both the inline bump and the stamped outlined
+    /// allocator provide the structural proof needed by constructor-free
+    /// field initialization.
+    pub(super) constructor_stores_ready: bool,
     /// `true` ⟹ the header already reads `GC_LAYOUT_POINTER_FREE |
     /// GC_OBJ_TYPED_LAYOUT_INTACT`, so the construction site owes the runtime
     /// only the address-dependent half of `js_gc_declare_typed_shape_layout`
@@ -143,9 +148,17 @@ pub(super) fn emit_instance_alloc(
     class: &Class,
 ) -> InstanceAlloc {
     let mut typed_layout_baked = false;
-    let handle = emit_instance_alloc_inner(ctx, class_name, class, &mut typed_layout_baked);
+    let mut constructor_stores_ready = false;
+    let handle = emit_instance_alloc_inner(
+        ctx,
+        class_name,
+        class,
+        &mut typed_layout_baked,
+        &mut constructor_stores_ready,
+    );
     InstanceAlloc {
         handle,
+        constructor_stores_ready,
         typed_layout_baked,
     }
 }
@@ -155,6 +168,7 @@ fn emit_instance_alloc_inner(
     class_name: &str,
     class: &Class,
     typed_layout_baked: &mut bool,
+    constructor_stores_ready: &mut bool,
 ) -> String {
     // Compute total field count including inherited parent fields.
     // The runtime allocates at least 8 inline slots regardless, so this
@@ -311,6 +325,11 @@ fn emit_instance_alloc_inner(
             ],
         )
     } else if let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() {
+        // Both arms below stamp the canonical class keys and ShapeId. The
+        // outlined arm may allocate an old-generation object when a learned
+        // width crosses the large-object threshold; constructor-free pointer
+        // stores retain the ordinary generation-tested write barrier.
+        *constructor_stores_ready = true;
         // [#bloat] Outline the per-`new`-site allocator EXCEPT inside a loop.
         //
         // Outlining collapses ~145 lines of per-class-constant IR per site into

--- a/crates/perry-codegen/src/lower_call/typed_shape_bake_tests.rs
+++ b/crates/perry-codegen/src/lower_call/typed_shape_bake_tests.rs
@@ -342,6 +342,35 @@ pub(super) fn loop_new_module(name: &str, f1_ty: Type, second: Expr) -> Module {
     m
 }
 
+/// One escaping `new <name>(1, <second>)` outside a loop. This selects the
+/// stamped outlined allocator and covers specialized/cold entries that do not
+/// inherit a caller's loop or allocation-hot classification.
+pub(super) fn outlined_new_module(name: &str, f1_ty: Type, second: Expr) -> Module {
+    let mut module = loop_new_module(name, f1_ty, second.clone());
+    module.init = vec![
+        Stmt::Let {
+            id: 20,
+            name: "x".to_string(),
+            ty: Type::Named(name.to_string()),
+            mutable: false,
+            init: Some(Expr::New {
+                class_name: name.to_string(),
+                args: vec![Expr::Integer(1), second],
+                type_args: Vec::new(),
+                byte_offset: 0,
+                cap_args_appended: 0,
+            }),
+        },
+        Stmt::Expr(Expr::Call {
+            callee: Box::new(Expr::FuncRef(10)),
+            args: vec![Expr::LocalGet(20)],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    ];
+    module
+}
+
 pub(super) fn emit(m: &Module) -> String {
     String::from_utf8(compile_module(m, ir_opts()).unwrap()).expect("LLVM IR should be UTF-8")
 }


### PR DESCRIPTION
## Summary

- extend constructor-free construction to runtime-declared mixed layouts and stamped outlined allocations
- recognize typed `numberParam + finiteLiteral` field initializers, covering the eight derived numeric fields in `tree_wide`
- preserve pointer-store generation and incremental-mark barriers on the direct-store arm
- add the exact issue benchmark fixture and IR regression coverage

Refs #8289.

## Performance

Five interleaved runs of `benchmarks/issue-8289/tree_wide.ts` on macOS arm64, comparing `origin/main` with this branch (median):

| Metric | main | PR | Change |
|---|---:|---:|---:|
| Retired instructions | 23,412,462,462 | 7,622,290,049 | -67.44% (3.07x) |
| Wall time | 6.39 s | 1.80 s | -71.83% (3.55x) |
| Peak RSS | 63,504,384 B | 63,537,152 B | +0.052% |

The fixture output remains `20971480`. The `churn` comparison remains instruction-neutral within measurement noise (4,651,981,862 to 4,648,010,989 instructions, -0.09%).

## Validation

- `cargo test --profile perry-dev -p perry-codegen --lib` (1,097 passed)
- `cargo check --profile perry-dev -p perry-codegen --lib`
- `cargo fmt --all -- --check`
- `python3 scripts/check_test_registration.py`
- `bash scripts/check_file_size.sh`
- exact fixture output under forced evacuation, evacuation verification, and protected/poisoned from-space

No version bump is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved object construction performance for mixed pointer and numeric field layouts.
  * Reduced unnecessary constructor work when allocation metadata is ready, with measured instruction reductions on wide-tree workloads.
* **Reliability**
  * Added support for numeric fields initialized with finite offsets.
  * Preserved pointer write barriers and validated layout readiness before applying optimized field stores.
* **Testing**
  * Expanded coverage for outlined allocations, pointer-bearing layouts, numeric offsets, and wide-tree benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->