### PR TITLE
fix(tls): unblock server handshake fixtures

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/tls_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/tls_events.rs
@@ -41,7 +41,7 @@ pub(super) const TLS_EVENTS_ROWS: &[NativeModSig] = &[
         method: "listen",
         class_filter: Some("Server"),
         runtime: "js_tls_server_listen",
-        args: &[NA_F64, NA_JSV],
+        args: &[NA_F64, NA_JSV, NA_JSV],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -252,6 +252,13 @@ mod tests {
 
         let resolved = resolve_url("..", "file:///Users/test/lib/file.ts");
         assert_eq!(resolved, "file:/Users/test");
+
+        let fixture = resolve_url("../fixtures/", "file:///Users/test/tls/handshake/test.ts");
+        assert_eq!(fixture, "file:/Users/test/tls/fixtures/");
+        assert_eq!(
+            resolve_url("localhost-key.pem", &fixture),
+            "file:/Users/test/tls/fixtures/localhost-key.pem"
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/url/parse.rs
+++ b/crates/perry-runtime/src/url/parse.rs
@@ -246,7 +246,14 @@ pub(crate) fn resolve_url(url_str: &str, base_str: &str) -> String {
         }
     }
 
-    let resolved_path = format!("/{}", segments.join("/"));
+    let mut resolved_path = format!("/{}", segments.join("/"));
+    // A trailing slash is semantically significant for URL resolution: the
+    // result remains a directory base for a subsequent `new URL(...)` call.
+    // Dropping it made `new URL("cert.pem", new URL("../fixtures/", base))`
+    // resolve next to `fixtures` instead of inside it (#6765).
+    if url_str.ends_with('/') && !resolved_path.ends_with('/') {
+        resolved_path.push('/');
+    }
 
     if base_protocol == "file:" {
         format!("{}{}", base_protocol, resolved_path)

--- a/crates/perry-stdlib/src/tls.rs
+++ b/crates/perry-stdlib/src/tls.rs
@@ -671,11 +671,31 @@ pub unsafe extern "C" fn js_tls_tlssocket_constructor(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn js_tls_server_listen(handle: i64, port: f64, callback_bits: i64) -> i64 {
+pub unsafe extern "C" fn js_tls_server_listen(
+    handle: i64,
+    port: f64,
+    host_or_callback_bits: i64,
+    callback_bits: i64,
+) -> i64 {
     crate::common::async_bridge::ensure_pump_registered();
     ensure_tls_gc_scanner_registered();
     let port = port as u16;
-    let host = "0.0.0.0".to_string();
+    let host_or_callback = f64_from_raw_bits(host_or_callback_bits);
+    let callback = f64_from_raw_bits(callback_bits);
+    let host = if JSValue::from_bits(host_or_callback.to_bits()).is_any_string() {
+        value_to_string(host_or_callback).unwrap_or_else(|| "0.0.0.0".to_string())
+    } else {
+        "0.0.0.0".to_string()
+    };
+    let callback_bits = if pointer_addr(callback).is_some() {
+        callback_bits
+    } else if pointer_addr(host_or_callback).is_some()
+        && !JSValue::from_bits(host_or_callback.to_bits()).is_any_string()
+    {
+        host_or_callback_bits
+    } else {
+        TAG_UNDEFINED_BITS as i64
+    };
     let config = {
         let mut all = servers().lock().unwrap();
         let Some(server) = all.get_mut(&handle) else {
@@ -1029,7 +1049,7 @@ pub unsafe extern "C" fn js_tls_process_pending() -> i32 {
                 drain_once_listeners(server_id, "listening");
             }
             PendingTlsEvent::ServerSecureConnection(server_id, socket_id) => {
-                let socket = raw_handle_value(socket_id);
+                let socket = nanbox_handle(socket_id);
                 for event_name in ["secureConnection", "connection"] {
                     for cb in listeners_for(server_id, event_name) {
                         if cb != 0 {

--- a/crates/perry-stdlib/src/tls/dispatch.rs
+++ b/crates/perry-stdlib/src/tls/dispatch.rs
@@ -125,8 +125,9 @@ pub unsafe fn dispatch_tls_handle(handle: i64, method: &str, args: &[f64]) -> f6
         match method {
             "listen" => {
                 let port = args.first().copied().unwrap_or(0.0);
-                let cb = callback_bits(args, 1);
-                js_tls_server_listen(handle, port, cb);
+                let host_or_cb = callback_bits(args, 1);
+                let cb = callback_bits(args, 2);
+                js_tls_server_listen(handle, port, host_or_cb, cb);
                 return nanbox_handle(handle);
             }
             "close" => {


### PR DESCRIPTION
## Summary

- preserve trailing slashes when resolving relative file URLs so nested TLS fixture URLs resolve inside their directory
- normalize Server.listen(port[, host][, callback]) to a fixed native ABI and honor the requested bind host
- pass accepted TLS sockets to callbacks as boxed native handles

This removes the bootstrap blockers behind the TLS server handshake cluster. Remaining getter, ALPN, and event-order parity gaps continue to be tracked in #6765.

## Validation

- cargo test --release -p perry-runtime test_resolve_relative_url --lib
- cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static
- PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --suite node-suite --module tls --filter node-suite/tls/handshake/basic-loopback (100% parity)
- BASE_SHA=origin/main ./scripts/run_lint_gates.sh (all 50 gates passed)

No version bump included.

Progress on #6765.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TLS servers can now listen on a specified host and port, while retaining support for the existing callback-only format.
  * Secure connection events now provide TLS socket handles in a consistent format.

* **Bug Fixes**
  * Relative file URL resolution now preserves trailing directory separators, enabling correct resolution of files within directories.
  * Added coverage for resolving certificate files from fixture directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->