### PR TITLE
fix(runtime): honor Array.prototype.pop side effects

### DIFF
--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -35,6 +35,13 @@ fn throw_non_writable_length() -> ! {
     );
 }
 
+#[cold]
+fn throw_cannot_delete_array_index(index: u32) -> ! {
+    crate::collection_iter::throw_type_error(&format!(
+        "Cannot delete property '{index}' of [object Array]"
+    ));
+}
+
 /// Install an array-growth forwarding stub after `tracked_header_for` proves
 /// allocator ownership of `old_user_addr`. Keeping the classifier injectable
 /// makes the below-2-TiB macOS case deterministic without mapping a fixed low
@@ -795,10 +802,37 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
         }
 
         let new_length = length - 1;
-        let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-        let value = *elements_ptr.add(new_length as usize);
+        if !crate::array::array_iteration_is_exotic(arr) {
+            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            let value = *elements_ptr.add(new_length as usize);
+            (*arr).length = new_length;
+            return value;
+        }
+
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let arr_handle = scope.root_raw_mut_ptr(arr);
+        // `Get(O, ToString(newLength))` must consult the prototype chain. It
+        // can also run an accessor which allocates, moves `arr`, freezes it,
+        // or makes its length non-writable, so keep both values rooted and
+        // resolve the receiver again after every observable operation.
+        let value_handle = scope.root_nanbox_f64(crate::array::array_spec_get(arr, new_length));
+        let arr = clean_arr_ptr_mut(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
+
+        // DeletePropertyOrThrow only targets an own property. An inherited
+        // value is returned without deleting it from Array.prototype.
+        if crate::array::array_has_own_index(arr, new_length)
+            && js_array_delete(arr, new_length) == 0
+        {
+            throw_cannot_delete_array_index(new_length);
+        }
+
+        let arr = clean_arr_ptr_mut(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
+        if array_is_frozen(arr) {
+            throw_frozen_array_mutation();
+        }
+        guard_writable_length(arr);
         (*arr).length = new_length;
-        value
+        value_handle.get_nanbox_f64()
     }
 }
 

--- a/crates/perry/tests/issue_5898_array_pop_prototype.rs
+++ b/crates/perry/tests/issue_5898_array_pop_prototype.rs
@@ -1,0 +1,90 @@
+//! Regression coverage for the Array.prototype.pop subcluster in #5898.
+//! Pop must use ordinary property access for the last index, then re-check
+//! receiver state after an inherited getter has run.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn pop_reads_inherited_last_index_and_observes_getter_side_effects() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+(Array.prototype as any)[1] = 1;
+const inherited = [0];
+inherited.length = 2;
+console.log("inherited", inherited.pop(), inherited.length, (Array.prototype as any)[1]);
+delete (Array.prototype as any)[1];
+
+const frozen: any[] = [];
+frozen.length = 1;
+Object.defineProperty(Array.prototype, "0", {
+  configurable: true,
+  get() { Object.freeze(frozen); return 7; }
+});
+try {
+  frozen.pop();
+  console.log("frozen no throw");
+} catch (error) {
+  console.log("frozen", error instanceof TypeError, frozen.length);
+}
+delete (Array.prototype as any)[0];
+
+const readonlyLength: any[] = [];
+readonlyLength.length = 1;
+Object.defineProperty(Array.prototype, "0", {
+  configurable: true,
+  get() {
+    Object.defineProperty(readonlyLength, "length", { writable: false });
+    return 8;
+  }
+});
+try {
+  readonlyLength.pop();
+  console.log("readonly no throw");
+} catch (error) {
+  console.log("readonly", error instanceof TypeError, readonlyLength.length);
+}
+delete (Array.prototype as any)[0];
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "inherited 1 1 1\nfrozen true 1\nreadonly true 1\n"
+    );
+}


### PR DESCRIPTION
## Summary

- preserve the allocation-free dense `Array.prototype.pop` fast path
- use ordinary indexed `Get`/`DeletePropertyOrThrow` semantics when descriptors, sparse storage, or indexed prototypes make the receiver exotic
- root the receiver and returned value across accessors, then revalidate frozen/non-writable length state after getter side effects
- add end-to-end regression coverage for the three selected Test262 cases

## Test262

Pinned corpus: `4249661388e5d3f92a85186213da140a6481490f`

- exact worklist: 3 pass, 0 runtime failures, 0 compile failures
- full `built-ins/Array` base: 2488 pass, 39 runtime failures, 0 compile failures
- full `built-ins/Array` patched: 2491 pass, 36 runtime failures, 0 compile failures
- only removed failures:
  - `prototype/pop/S15.4.4.6_A4_T1.js`
  - `prototype/pop/set-length-array-is-frozen.js`
  - `prototype/pop/set-length-array-length-is-non-writable.js`
- no new failures

## Validation

- `cargo test -p perry --test issue_5898_array_pop_prototype -- --nocapture`
- `cargo check -p perry-runtime`
- `cargo fmt --all -- --check`
- `bash scripts/check_file_size.sh`
- no version, lockfile, CLAUDE, or changelog changes

Refs #5898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Array.prototype.pop` behavior for arrays with inherited properties and accessor side effects.
  - Correctly reports errors when indexed deletion fails or when array length becomes frozen or read-only during the operation.
  - Preserved optimized behavior for ordinary arrays.

- **Tests**
  - Added regression coverage for prototype lookups, getter-triggered mutations, and expected `TypeError` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->