### PR TITLE
fix(runtime): use across_mut for push_pop's post-call reloads

### DIFF
--- a/changelog.d/8368-push-pop-raw-handle-ratchet.md
+++ b/changelog.d/8368-push-pop-raw-handle-ratchet.md
@@ -1,0 +1,1 @@
+Convert the two post-call receiver reloads in `array/push_pop.rs` from `get_raw_mut_ptr` to `RuntimeHandle::across_mut`, returning the module to its raw-handle ceiling after #8366. Semantics are unchanged — both sites already re-resolved the receiver after an observable operation.

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -815,18 +815,22 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
         // can also run an accessor which allocates, moves `arr`, freezes it,
         // or makes its length non-writable, so keep both values rooted and
         // resolve the receiver again after every observable operation.
-        let value_handle = scope.root_nanbox_f64(crate::array::array_spec_get(arr, new_length));
-        let arr = clean_arr_ptr_mut(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
+        let (value_handle, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+            scope.root_nanbox_f64(crate::array::array_spec_get(arr, new_length))
+        });
+        let arr = clean_arr_ptr_mut(arr);
 
         // DeletePropertyOrThrow only targets an own property. An inherited
         // value is returned without deleting it from Array.prototype.
-        if crate::array::array_has_own_index(arr, new_length)
-            && js_array_delete(arr, new_length) == 0
-        {
-            throw_cannot_delete_array_index(new_length);
-        }
+        let (_, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+            if crate::array::array_has_own_index(arr, new_length)
+                && js_array_delete(arr, new_length) == 0
+            {
+                throw_cannot_delete_array_index(new_length);
+            }
+        });
 
-        let arr = clean_arr_ptr_mut(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
+        let arr = clean_arr_ptr_mut(arr);
         if array_is_frozen(arr) {
             throw_frozen_array_mutation();
         }


### PR DESCRIPTION
## Summary

#8366 landed from a fork branch with `raw_handle_debt` failing:

```
crates/perry-runtime/src/array/push_pop.rs: 6 bare reads exceeds its ceiling of 4
```

Its rooting semantics were already correct — it opens a `RuntimeHandleScope`,
roots the array, and re-resolves the receiver after each observable operation.
The gate counts `handle.get_raw_mut_ptr::<T>()` and wants the #7341 wrappers, so
this is a spelling change, not a behaviour change.

Both sites are **post-call reloads**, so both become `across_mut` (runs the
closure, then reloads):

- after `array_spec_get`, which can run an accessor that allocates and moves `arr`
- after the conditional `js_array_delete`

`clean_arr_ptr_mut(...)` stays at the same two points.

## Validation

- `python3 scripts/raw_handle_debt.py` — **978/978**, every module inside its ceiling
- `cargo test --release -p perry-runtime --lib` — 2590 passed
- `scripts/run_lint_gates.sh` — all 50 gates pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when removing items from JavaScript arrays, including arrays using proxy or custom property behavior.
  - Prevented potential issues caused by array memory moving during pop operations.
  - Preserved existing array behavior and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->