### PR TITLE
perf(codegen): elide proven churn array scans

### DIFF
--- a/benchmarks/issue-8289/churn.ts
+++ b/benchmarks/issue-8289/churn.ts
@@ -1,0 +1,23 @@
+type Node = { v: number; w: number };
+
+function chunk(base: number): number {
+  const keep: Node[] = [];
+  for (let j = 0; j < 1000; j++) {
+    keep.push({ v: base + j, w: j });
+  }
+  let acc = 0;
+  for (let j = 0; j < keep.length; j++) {
+    acc += keep[j].v + keep[j].w;
+  }
+  return acc;
+}
+
+function main(): void {
+  let total = 0;
+  for (let c = 0; c < 20000; c++) {
+    total += chunk(c * 1000);
+  }
+  console.log(total);
+}
+
+main();

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -111,6 +111,11 @@ pub(crate) struct ArrayFacts {
     /// why this fact governs *profitability* rather than the soundness of the
     /// elided per-store note (which the emitted header test owns).
     pub all_pointer_element_locals: HashSet<u32>,
+    /// Array binding -> exact element class from the E1--E5 containment
+    /// proof. Unlike a TypeScript annotation, this proves the array was born
+    /// empty, receives only same-class fresh allocations, stays dense, and
+    /// never escapes to an unbounded mutator.
+    pub exact_element_classes: HashMap<u32, String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -277,6 +282,13 @@ impl TypeFacts {
     /// `collectors/all_pointer_arrays.rs`.
     pub(crate) fn declares_all_pointer_elements(&self, local_id: u32) -> bool {
         self.arrays.all_pointer_element_locals.contains(&local_id)
+    }
+
+    pub(crate) fn exact_element_class(&self, local_id: u32) -> Option<&str> {
+        self.arrays
+            .exact_element_classes
+            .get(&local_id)
+            .map(String::as_str)
     }
 
     pub(crate) fn array_length_mutation_locals(&self) -> &HashSet<u32> {
@@ -619,6 +631,7 @@ pub(crate) fn collect_type_facts(
         classes,
         module_dispatch,
     );
+    array_facts.exact_element_classes = element_shape_facts.proven_array_classes();
     // Representation-selection Phase 3b: shape-proven pointer locals. Gated
     // on `PERRY_PTR_SHAPE_LOCALS` and the module-wide §5.2 barrier scan
     // inside the collector.
@@ -1455,6 +1468,9 @@ impl ArrayFactCollector {
                 // Filled in by `collect_type_facts` — its own walk, with its
                 // own admission terms, over the same statements.
                 all_pointer_element_locals: HashSet::new(),
+                // Filled in by `collect_type_facts` from the E1--E5 exact
+                // element-shape proof.
+                exact_element_classes: HashMap::new(),
             },
             EffectFacts {
                 unknown_call_escape: self.unknown_call_escape,

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
@@ -40,12 +40,13 @@
 //!   `copyWithin`, not `IndexSet`, not a `length` write — which is what makes
 //!   `A` **dense** and monomorphic for its whole lifetime.
 //! * **E3 — array containment.** Every *other* use of `A` is an in-bounds
-//!   element read (E5), a `.length` read, or `return A`. The return exemption
-//!   is #7034 §4's, unchanged and for the same reason. The one conditional
-//!   escape is the compiler-generated `ArrayIterationPatched` guard described
-//!   below. Anything else — call argument, closure capture, reassignment,
-//!   `IndexSet`, an unrecognised array method, being an element of another
-//!   container — disqualifies `A`.
+//!   element read (E5), a direct declared-field read from such an element, a
+//!   `.length` read, or `return A`. The return exemption is #7034 §4's,
+//!   unchanged and for the same reason. The one conditional escape is the
+//!   compiler-generated `ArrayIterationPatched` guard described below.
+//!   Anything else — call argument, closure capture, reassignment, `IndexSet`,
+//!   an unrecognised array method, being an element of another container —
+//!   disqualifies `A`.
 //! * **E4 — class admissibility.** `C` passes the same `chain_admissible`
 //!   gate rule 1 applies to a `new C(...)` local, and the module-wide rule-5
 //!   barrier scan is clear.
@@ -58,7 +59,11 @@
 //!   `A[i]` is an own element, hence an instance of `C`. **This conjunct is
 //!   the whole difference between this pass and a wrong one**: without it
 //!   `A[i]` can be `undefined`, and a guard-free fixed-offset load masks a
-//!   NaN-boxed `undefined` into a wild pointer.
+//!   NaN-boxed `undefined` into a wild pointer. A direct `A[i].field` read is
+//!   licensed under the same bound only when `field` is a declared instance
+//!   data field on `C`'s admissible, accessor-free chain. It does not hand out
+//!   the element reference, so it contributes array exactness without creating
+//!   a promoted element local.
 //!
 //! `for (const r of A)` has an E5 index arm
 //! (`lower/stmt_loops.rs::lazy_or_index_elem` — a `__idx` local, `__idx <
@@ -250,6 +255,24 @@ impl ElementShapeFacts {
         self.arrays.contains_key(root).then_some(*root)
     }
 
+    /// Exact element classes for every proven array binding, aliases included.
+    ///
+    /// This exports the E1--E5 verdict into the native-region fact graph so
+    /// later lowering does not have to reconstruct the same whole-region
+    /// proof. The class is exact, not merely declared: E2 admits only
+    /// same-class `new C(...)` pushes, while E3 rejects every other write,
+    /// escape, and mutator.
+    pub(crate) fn proven_array_classes(&self) -> HashMap<u32, String> {
+        self.array_roots
+            .iter()
+            .filter_map(|(id, root)| {
+                self.arrays
+                    .get(root)
+                    .map(|class_name| (*id, class_name.clone()))
+            })
+            .collect()
+    }
+
     /// Callback element parameters licensed by this region, paired with the
     /// closure body that owns them. Callers still intersect these sites with
     /// the full Ptr<Shape> containment/use proof.
@@ -361,6 +384,7 @@ pub(crate) fn collect_element_shape_facts(
         disqualified: HashSet::new(),
         pushes: HashMap::new(),
         reads: Vec::new(),
+        direct_reads: Vec::new(),
         callbacks: Vec::new(),
         idx_writes: HashMap::new(),
         bounded: Vec::new(),
@@ -371,6 +395,7 @@ pub(crate) fn collect_element_shape_facts(
         mut disqualified,
         pushes,
         reads,
+        direct_reads,
         callbacks,
         idx_writes,
         ..
@@ -448,6 +473,28 @@ pub(crate) fn collect_element_shape_facts(
             pushed.insert(m, (*root, class_name.to_string()));
         }
     }
+    if arrays.is_empty() {
+        return ElementShapeFacts::default();
+    }
+
+    // E5's direct `A[i].field` form does not create an element local, but it
+    // still has to discharge the identical in-bounds obligation and must name
+    // a plain field on the exact class. `chain_admissible` above has already
+    // rejected accessors and computed members, so a declared chain field is a
+    // side-effect-free value read and cannot leak the element reference.
+    for read in &direct_reads {
+        let valid_index = idx_writes.get(&read.index).copied().unwrap_or(0) == 2
+            && !boxed_vars.contains(&read.index)
+            && !module_globals.contains_key(&read.index);
+        let valid_field = arrays.get(&read.root).is_some_and(|class_name| {
+            let chain = super::ptr_shape::chain_classes(classes, class_name);
+            super::ptr_shape::chain_field_names(&chain).contains(&read.property)
+        });
+        if !valid_index || !valid_field {
+            disqualified.insert(read.root);
+        }
+    }
+    arrays.retain(|root, _| !disqualified.contains(root));
     if arrays.is_empty() {
         return ElementShapeFacts::default();
     }
@@ -554,6 +601,15 @@ struct ReadSite {
     local: u32,
 }
 
+struct DirectReadSite {
+    /// The array root read from.
+    root: u32,
+    /// The proven-bounded induction variable.
+    index: u32,
+    /// The data field read directly from the element.
+    property: String,
+}
+
 struct CallbackReadSite {
     root: u32,
     func_id: u32,
@@ -567,6 +623,7 @@ struct ArrayWalk<'a> {
     disqualified: HashSet<u32>,
     pushes: HashMap<u32, Vec<PushValue>>,
     reads: Vec<ReadSite>,
+    direct_reads: Vec<DirectReadSite>,
     callbacks: Vec<CallbackReadSite>,
     /// local id -> number of writes (`Let` / `LocalSet` / `Update`) anywhere
     /// in the region, closures included.
@@ -920,10 +977,38 @@ impl<'a> ArrayWalk<'a> {
                     self.walk_expr(callback);
                 }
             }
-            // `A.length` — the only property read admitted on the array.
+            // E5, direct spelling: `A[i].field`. Unlike a bare `A[i]`, this
+            // does not hand the element reference to an untracked consumer.
+            // Defer the declared-field check until E2 has resolved the exact
+            // element class; the bound itself is known here.
             Expr::PropertyGet {
                 object, property, ..
             } => {
+                if let Expr::IndexGet {
+                    object: array,
+                    index,
+                } = object.as_ref()
+                {
+                    if let (Expr::LocalGet(array_id), Expr::LocalGet(index_id)) =
+                        (array.as_ref(), index.as_ref())
+                    {
+                        if let Some(root) = self.root_of(*array_id) {
+                            if !self.in_closure
+                                && self.bounded.iter().any(|(bounded_id, bounded_root)| {
+                                    bounded_id == index_id && *bounded_root == root
+                                })
+                            {
+                                self.direct_reads.push(DirectReadSite {
+                                    root,
+                                    index: *index_id,
+                                    property: property.clone(),
+                                });
+                                return;
+                            }
+                        }
+                    }
+                }
+                // `A.length` — the only property read admitted on the array.
                 if let Expr::LocalGet(id) = object.as_ref() {
                     if self.root_of(*id).is_some() {
                         if property != "length" {
@@ -1030,10 +1115,9 @@ impl<'a> ArrayWalk<'a> {
             // never sees, and `r.extra = 1` reshapes it. All three would make
             // the OTHER members' fixed-offset loads wrong.
             //
-            // So every unlicensed element read disqualifies the array. Direct
-            // `A[i].field` access is therefore not covered at all today, and
-            // widening to it needs the element class in this walk (which is
-            // only known after the push scan) — tracked in #7151.
+            // So every unlicensed element read disqualifies the array. The
+            // direct bounded declared-field form was consumed by the
+            // `PropertyGet` arm above; every other form still reaches here.
             Expr::IndexGet { object, index } => {
                 if let Expr::LocalGet(id) = object.as_ref() {
                     self.disq(*id);

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements_tests.rs
@@ -382,6 +382,62 @@ fn inline_reduce_promotes_the_element_not_the_accumulator() {
 }
 
 #[test]
+fn bounded_direct_field_read_preserves_the_arrays_exact_class() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        push(1, new_c()),
+        bounded_loop(
+            5,
+            1,
+            vec![Stmt::Expr(Expr::PropertyGet {
+                object: Box::new(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    index: Box::new(Expr::LocalGet(5)),
+                }),
+                property: "x".to_string(),
+                byte_offset: 0,
+            })],
+        ),
+    ];
+
+    assert_eq!(
+        elements(&stmts, &classes)
+            .proven_array_classes()
+            .get(&1)
+            .map(String::as_str),
+        Some("C")
+    );
+}
+
+#[test]
+fn bounded_direct_non_field_read_denies_exactness() {
+    let c = class_c();
+    let cs = [c];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "rows"),
+        push(1, new_c()),
+        bounded_loop(
+            5,
+            1,
+            vec![Stmt::Expr(Expr::PropertyGet {
+                object: Box::new(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    index: Box::new(Expr::LocalGet(5)),
+                }),
+                property: "missing".to_string(),
+                byte_offset: 0,
+            })],
+        ),
+    ];
+
+    assert!(elements(&stmts, &classes).is_empty());
+}
+
+#[test]
 fn escaping_array_callback_element_denies_the_whole_group() {
     let c = class_c();
     let cs = [c];

--- a/crates/perry-codegen/src/expr/element_shape_guard.rs
+++ b/crates/perry-codegen/src/expr/element_shape_guard.rs
@@ -4,12 +4,12 @@
 //! Two emitters live here.
 //!
 //! * [`emit_element_shape_loop_preheader_check`] — run ONCE, before the fast
-//!   clone. It brands the receiver as a genuine array, asks the runtime
-//!   whether the per-array homogeneous element-shape invariant
-//!   (`array/element_shape.rs`, #7496) holds at a specific class id, checks
-//!   that the verified prefix covers the whole index range, and caches the
-//!   elements base pointer plus the two loop-invariant words the residual
-//!   check needs.
+//!   clone. It brands the receiver as a genuine array, establishes the exact
+//!   element class either from the native-region construction proof or from
+//!   the runtime's per-array homogeneous element-shape invariant
+//!   (`array/element_shape.rs`, #7496), checks that the covered range includes
+//!   the whole loop, and caches the elements base pointer plus the two
+//!   loop-invariant words the residual check needs.
 //! * [`emit_element_shape_field_load`] — run per access inside the fast clone.
 //!   It is a bare element load followed by the *residual* facts the
 //!   element-shape invariant does NOT cover, AND-reduced into one predicate
@@ -123,10 +123,11 @@ pub(crate) enum ElementShapeLoopTripCount<'a> {
 ///    pointer, where a forwarding stub is not merely wrong but *plausibly*
 ///    wrong (see the block comment). It goes before the guard call, not after,
 ///    because the refresh can itself allocate;
-/// 4. the guard call, and only THEN the elements base — derived from a fresh
-///    load of the array's rooted slot, because the guard call can allocate and
-///    an allocation can move the array, so a base derived before it could be a
-///    from-space address.
+/// 4. the runtime guard call when static construction did not already prove
+///    the class, and only THEN the elements base — derived from a fresh load of
+///    the array's rooted slot, because either preceding helper can allocate
+///    and an allocation can move the array, so a base derived before it could
+///    be a from-space address.
 ///
 /// Returns `(elements_base, expected_shape_id, shape_ok, bound_i32)`.
 pub(crate) fn emit_element_shape_loop_preheader_check(
@@ -136,15 +137,18 @@ pub(crate) fn emit_element_shape_loop_preheader_check(
     keys_global_name: &str,
     trip_count: ElementShapeLoopTripCount<'_>,
     slow_label: &str,
+    statically_proven: bool,
 ) -> anyhow::Result<(String, String, String, String)> {
     let brand_idx = ctx.new_block("element_shape.loop.preheader.brand");
     let repair_idx = ctx.new_block("element_shape.loop.preheader.repair");
-    let query_idx = ctx.new_block("element_shape.loop.preheader.query");
+    let query_idx =
+        (!statically_proven).then(|| ctx.new_block("element_shape.loop.preheader.query"));
     let deref_idx = ctx.new_block("element_shape.loop.preheader.deref");
     let brand_label = ctx.block_label(brand_idx);
     let repair_label = ctx.block_label(repair_idx);
-    let query_label = ctx.block_label(query_idx);
+    let query_label = query_idx.map(|idx| ctx.block_label(idx));
     let deref_label = ctx.block_label(deref_idx);
+    let post_repair_label = query_label.as_deref().unwrap_or(&deref_label);
 
     // (1) Receiver is a heap pointer at all. A basic block has no
     // short-circuit, so nothing may be dereferenced until this branch is taken.
@@ -229,30 +233,35 @@ pub(crate) fn emit_element_shape_loop_preheader_check(
         let handler = blk.and(I64, &bitsr, crate::nanbox::POINTER_MASK_I64);
         let abover = blk.icmp_ugt(I64, &handler, HANDLE_BAND_TOP);
         let okr = blk.and(I1, &is_ptrr, &abover);
-        blk.cond_br(&okr, &query_label, slow_label);
+        blk.cond_br(&okr, post_repair_label, slow_label);
     }
 
-    // (3) The live-header query. `js_array_ensure_element_shape` establishes
-    // the invariant by scan on first visit and confirms it in O(1) afterwards;
-    // either way it reads the array's CURRENT `GcHeader` bit and its record,
-    // and self-heals (clearing the bit) when the record went stale. Static
-    // declarations are never consulted — #7501's lesson.
+    // (3) The live-header query for arrays whose construction is not statically
+    // contained. `js_array_ensure_element_shape` establishes the invariant by
+    // scan on first visit and confirms it in O(1) afterwards; either way it
+    // reads the array's CURRENT `GcHeader` bit and its record, and self-heals
+    // (clearing the bit) when the record went stale. Type declarations are
+    // never sufficient — #7501's lesson. The static arm is stronger: E1--E5
+    // proves every dense slot is a fresh exact-class allocation for the whole
+    // native region.
     //
     // Deliberately re-loads the (now repaired) binding rather than reusing the
     // repair block's handle: `js_array_refresh_local_head` can allocate, so a
     // handle derived before it is a pre-move address.
-    ctx.current_block = query_idx;
-    let arrq = super::lower_expr(ctx, &perry_hir::Expr::LocalGet(array_local_id))?;
-    {
-        let blk = ctx.block();
-        let bitsq = blk.bitcast_double_to_i64(&arrq);
-        let handleq = blk.and(I64, &bitsq, crate::nanbox::POINTER_MASK_I64);
-        let class_id = blk.call(I32, "js_array_ensure_element_shape", &[(I64, &handleq)]);
-        let cid_ok = blk.icmp_eq(I32, &class_id, expected_class_id);
-        blk.cond_br(&cid_ok, &deref_label, slow_label);
+    if let Some(query_idx) = query_idx {
+        ctx.current_block = query_idx;
+        let arrq = super::lower_expr(ctx, &perry_hir::Expr::LocalGet(array_local_id))?;
+        {
+            let blk = ctx.block();
+            let bitsq = blk.bitcast_double_to_i64(&arrq);
+            let handleq = blk.and(I64, &bitsq, crate::nanbox::POINTER_MASK_I64);
+            let class_id = blk.call(I32, "js_array_ensure_element_shape", &[(I64, &handleq)]);
+            let cid_ok = blk.icmp_eq(I32, &class_id, expected_class_id);
+            blk.cond_br(&cid_ok, &deref_label, slow_label);
+        }
     }
 
-    // (4) Post-call re-derivation. Everything from here to the end of the fast
+    // (4) Post-proof re-derivation. Everything from here to the end of the fast
     // clone is call-free, so THIS pointer is the pointer the clone uses.
     ctx.current_block = deref_idx;
     let arr1 = super::lower_expr(ctx, &perry_hir::Expr::LocalGet(array_local_id))?;

--- a/crates/perry-codegen/src/stmt/element_shape_loop.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop.rs
@@ -136,6 +136,10 @@ struct ElementShapeVersionedLoop {
     class_name: String,
     expected_class_id: u32,
     keys_global_name: String,
+    /// The native-region E1--E5 proof already establishes every element's
+    /// exact class for this array's whole lifetime. When true, the preheader
+    /// need not rebuild the weaker runtime invariant by scanning the array.
+    statically_proven: bool,
     /// property name -> packed slot index.
     fields: std::collections::BTreeMap<String, u32>,
     /// #7771: the body's `const r = arr[counter]` binding in the two-statement
@@ -746,6 +750,10 @@ fn match_element_shape_versioned_loop(
     }
     let expected_class_id = *ctx.class_ids.get(&class_name)?;
     let keys_global_name = ctx.class_keys_globals.get(&class_name)?.clone();
+    let statically_proven = ctx
+        .native_facts
+        .exact_element_class(array_id)
+        .is_some_and(|proven| proven == class_name);
 
     let mut fields = std::collections::BTreeMap::new();
     for prop in props {
@@ -780,6 +788,7 @@ fn match_element_shape_versioned_loop(
         class_name,
         expected_class_id,
         keys_global_name,
+        statically_proven,
         fields,
         element_binding,
         accumulator_id: *acc_id,
@@ -874,6 +883,7 @@ pub(super) fn lower_element_shape_versioned_for(
             &matched.keys_global_name,
             trip_count,
             &slow_pre_label,
+            matched.statically_proven,
         )?;
     let accumulator = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.accumulator_id))?;
     let accumulator_is_number = emit_js_value_is_number(ctx, &accumulator);
@@ -960,8 +970,13 @@ pub(super) fn lower_element_shape_versioned_for(
             "Ptr<Shape>",
             1,
             Some(format!(
-                "element-shape loop clone (runtime-guarded): class {}, {} tracked field(s); \
+                "element-shape loop clone ({}): class {}, {} tracked field(s); \
                  element reads in this loop lower to offset loads behind the preheader guard",
+                if matched.statically_proven {
+                    "statically proven"
+                } else {
+                    "runtime-guarded"
+                },
                 matched.class_name,
                 matched.fields.len()
             )),

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -462,6 +462,51 @@ fn element_shape_versioned_loop_fires_for_the_7480_access_shape() {
     );
 }
 
+/// The composite `churn` shape differs from `churn_read` in one decisive way:
+/// it builds a fresh exact-shape array immediately before reading it. The
+/// native-region E1--E5 proof already establishes every element as exactly
+/// `Node`, so rescanning the whole array in the preheader is redundant work.
+#[test]
+fn exact_local_array_construction_skips_the_runtime_shape_scan() {
+    let mut m = element_shape_module(
+        vec![accumulate_stmt(
+            SUM_ID,
+            ARRAY_ID,
+            Expr::LocalGet(COUNTER_ID),
+        )],
+        None,
+    );
+    with_bound(&mut m, length_of(ARRAY_ID));
+    m.init.insert(
+        1,
+        Stmt::Expr(Expr::ArrayPush {
+            array_id: ARRAY_ID,
+            value: Box::new(Expr::New {
+                class_name: "Node".to_string(),
+                args: Vec::new(),
+                type_args: Vec::new(),
+                byte_offset: 0,
+                cap_args_appended: 0,
+            }),
+        }),
+    );
+
+    let ir = emit(&m);
+    assert_fast_clone_is_entered(&ir);
+    assert!(
+        !ir.contains("element_shape.loop.preheader.query"),
+        "an exact E1--E5 construction proof must bypass the runtime query block"
+    );
+    assert!(
+        !ir.contains("call i32 @js_array_ensure_element_shape"),
+        "an exact E1--E5 construction proof must not rescan the array"
+    );
+    assert!(
+        ir.contains("for.element_shape_slow.cond"),
+        "the ordinary slow clone remains the residual-check side exit"
+    );
+}
+
 /// SABOTAGE (clone selection): a body that STORES cannot be cloned — a store
 /// is the primary way to revoke the invariant mid-loop, and admitting one
 /// would be a miscompile rather than a slow path.


### PR DESCRIPTION
## Summary

Closes the `churn` row of #8289. Elides provably-redundant array scans in the
element-shape loop.

Authored by a codex agent working the issue; it could not reach the GitHub API
from its sandbox, so I am opening the PR from its pushed branch and auditing it
as I would any other.

## Measurement

Re-measured on current `main` rather than against the issue's table, because the
issue explicitly sequenced #8288 first — its allocation-bitmap regression
contaminated this row — and **#8288 closed on 2026-08-17**. The tabulated
1.98× / 5.006 B figures therefore predate that fix and would have been the wrong
baseline to optimise against.

| | retired instructions |
|---|---:|
| before | 4,645,492,850 |
| after | **2,656,776,895** |
| delta | **−42.81 %** |
| vs Node | **0.987×** — now marginally faster |

Outputs unchanged across seven runs.

## Validation

Claimed by the agent and being independently re-run before merge: full codegen
test suite, and `scripts/run_lint_gates.sh` (50 gates, including the compile
tier).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved optimization of loops processing arrays with statically known element types.
  * Reduced unnecessary runtime type checks for safely proven array contents.
  * Preserved fallback behavior when array contents cannot be verified.

* **Bug Fixes**
  * Improved handling of direct field reads from array elements.
  * Invalid property accesses now correctly prevent unsafe optimizations.

* **Tests**
  * Added regression coverage for optimized array loops and field access validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->