### PR TITLE
perf(codegen): inline generic string key equality

### DIFF
--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -786,14 +786,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // the wrapper first. Strict `=== "lit"` is unaffected (both sides are
                 // real strings at runtime). #boxed-loose-eq.
                 if one_side_string && matches!(op, CompareOp::Eq | CompareOp::Ne) {
+                    // Reuse the no-literal string prefix instead of sending
+                    // every comparison through two unified-unbox calls. This
+                    // is the hot shape of a specialized generic container:
+                    // `this.keys[i]` has a concrete string type while `k`
+                    // retains its `K` spelling. Identical pooled strings now
+                    // leave after one bit compare; distinct heap strings call
+                    // only `js_string_equals`. The boxed arm is byte-for-byte
+                    // the old helper composition, so a lying annotation keeps
+                    // its existing behaviour.
+                    let i32_eq = lower_string_strict_eq_inline(ctx, &l, &r, true);
                     let blk = ctx.block();
-                    let l_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &l)]);
-                    let r_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &r)]);
-                    let i32_eq = blk.call(
-                        I32,
-                        "js_string_equals",
-                        &[(I64, &l_handle), (I64, &r_handle)],
-                    );
                     let bit = blk.icmp_ne(I32, &i32_eq, "0");
                     let bit_final = if matches!(op, CompareOp::Ne | CompareOp::LooseNe) {
                         blk.xor(crate::types::I1, &bit, "true")

--- a/crates/perry-codegen/src/expr/compare_tests.rs
+++ b/crates/perry-codegen/src/expr/compare_tests.rs
@@ -250,6 +250,45 @@ fn strict_eq_between_two_any_locals_does_not_use_the_literal_dispatch() {
     );
 }
 
+#[test]
+fn string_vs_generic_key_uses_the_identity_first_dispatch() {
+    let ir = ir_for(
+        "streq_generic_key",
+        vec![
+            Stmt::Let {
+                id: X,
+                name: "stored".to_string(),
+                ty: Type::String,
+                mutable: false,
+                init: Some(Expr::String("stored".to_string())),
+            },
+            Stmt::Let {
+                id: Y,
+                name: "key".to_string(),
+                ty: Type::TypeVar("K".to_string()),
+                mutable: false,
+                init: Some(Expr::Undefined),
+            },
+            Stmt::Let {
+                id: R,
+                name: "same".to_string(),
+                ty: Type::Boolean,
+                mutable: false,
+                init: Some(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(X)),
+                    right: Box::new(Expr::LocalGet(Y)),
+                }),
+            },
+        ],
+    );
+
+    assert!(
+        ir.contains("streq.tag"),
+        "string-vs-generic comparison did not enter the identity-first dispatch:\n{ir}"
+    );
+}
+
 /// The SSO immediate is hand-built here but consumed by `perry-runtime`'s
 /// canonical encoding (`JSValue::try_short_string`): tag `0x7FF9` in bits
 /// 48..=63, byte length in bits 40..=47, bytes little-endian in bits 0..=39,


### PR DESCRIPTION
## Summary

Progresses the `pipeline` row of #8289 by inlining generic string-key equality.

Authored by a codex agent working the issue; it could not reach the GitHub API
from its sandbox, so I am opening the PR from its pushed branch and auditing it
as I would any other.

## Measurement

| | retired instructions |
|---|---:|
| before | 3,180,075,117 |
| after | **2,299,626,226** |
| delta | **−27.69 %** |
| vs Node | 1.84× (was 2.15× in the issue table) |

Outputs unchanged across seven runs.

For context on why this row needed more work: #8351's four-entry polymorphic
closure-dispatch cache took only −3.23 %, so the bulk of the gap was still
unexplained. This is a second, larger bite; `pipeline` remains the widest
remaining gap of the four rows, so #8289 should stay open.

## Validation

Claimed by the agent and being independently re-run before merge: full codegen
test suite, and `scripts/run_lint_gates.sh` (50 gates, including the compile
tier).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict string equality checks for faster and more reliable comparisons.
  * Preserved compatibility for fallback string comparison scenarios.

* **Tests**
  * Added regression coverage for strict equality checks involving strings and generic keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->