### PR TITLE
fix(test): make Next dylib provider build cwd-independent

### DIFF
--- a/changelog.d/8377-next-app-route-dylib-cwd.md
+++ b/changelog.d/8377-next-app-route-dylib-cwd.md
@@ -1,0 +1,3 @@
+The Next App Route dylib gate now builds its provider runtime from the
+repository root, so Cargo discovers Perry's required unwind-table configuration
+even when the gate is invoked from outside the checkout.

--- a/tests/test_next_app_route_dylib.sh
+++ b/tests/test_next_app_route_dylib.sh
@@ -236,15 +236,22 @@ perl -0pi -e 's/("crates\/perry-runtime",\n)/$1    "crates\/next-app-route-provi
 
 runtime_build_library="$provider_target_dir/$profile/libperry_runtime.$library_extension"
 provider_linker="$fixture/provider-linker.sh"
-env \
-    CARGO_TARGET_DIR="$provider_target_dir" \
-    PERRY_NEXT_RUNTIME_LIBRARY="$runtime_build_library" \
-    PERRY_NEXT_REQUIRED_SYMBOLS="$required_symbols" \
-    PERRY_NEXT_REAL_CC="$real_cc" \
-    "$cargo_linker_env=$provider_linker" \
-    cargo build --manifest-path "$runtime_source/Cargo.toml" \
-        --profile "$profile" --jobs "$cargo_jobs" \
-        -p perry-runtime -p next-app-route-provider
+(
+    # Cargo discovers .cargo/config.toml from the invocation directory, not
+    # from --manifest-path. Build from the repository root so the provider
+    # runtime always inherits the required force-unwind-tables rustflag, even
+    # when this gate is invoked from another directory.
+    cd "$repo_root"
+    env \
+        CARGO_TARGET_DIR="$provider_target_dir" \
+        PERRY_NEXT_RUNTIME_LIBRARY="$runtime_build_library" \
+        PERRY_NEXT_REQUIRED_SYMBOLS="$required_symbols" \
+        PERRY_NEXT_REAL_CC="$real_cc" \
+        "$cargo_linker_env=$provider_linker" \
+        cargo build --manifest-path "$runtime_source/Cargo.toml" \
+            --profile "$profile" --jobs "$cargo_jobs" \
+            -p perry-runtime -p next-app-route-provider
+)
 
 runtime_library="$providers/$runtime_filename"
 cp "$runtime_build_library" "$runtime_library"


### PR DESCRIPTION
## Summary

- run the Next App Route provider Cargo build from the repository root
- ensure `.cargo/config.toml` is discovered when the gate is invoked outside the checkout
- preserve the fixture-root working directory used later by the production route host

Closes #8258

## Validation

- `bash -n tests/test_next_app_route_dylib.sh`
- `shellcheck tests/test_next_app_route_dylib.sh`
- invoked a Cargo check from `/tmp` through the repository-root boundary and confirmed rustc receives `-C force-unwind-tables=yes`
- `BASE_SHA=origin/main ./scripts/run_lint_gates.sh` (all 50 gates passed)

## Checklist

- [x] No workspace version bump
- [x] No `CLAUDE.md` or `CHANGELOG.md` edit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Next App Route dylib builds so repository-level Cargo configuration is found reliably.
  - Improved build consistency when invoked from outside the project checkout.

- **Documentation**
  - Added a changelog entry describing the corrected build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->