### PR TITLE
chore(fmt): format ir/mod.rs and cjs_wrap/wrap.rs after #8380

### DIFF
--- a/changelog.d/8382-fmt-after-8380.md
+++ b/changelog.d/8382-fmt-after-8380.md
@@ -1,0 +1,1 @@
+Apply `cargo fmt` to `perry-hir/src/ir/mod.rs` and `cjs_wrap/wrap.rs` after #8380, which landed from a fork branch that could not be amended in place.

--- a/crates/perry-hir/src/ir/mod.rs
+++ b/crates/perry-hir/src/ir/mod.rs
@@ -24,17 +24,17 @@ pub use constants::{
     current_module_has_allow_dynamic_at, current_module_line_at,
     current_module_source_mentions_global_this, current_module_source_slice, determine_module_kind,
     dynamic_stdlib_allowed_for_package, env_define_lookup, is_compile_package_override,
-    is_native_module, is_native_module_with_externals, is_node_builtin_module, NODE_BUILTIN_MODULES,
+    is_native_module, is_native_module_with_externals, is_node_builtin_module,
     package_name_for_source_path, precompile_capture_enabled, precompile_result_at,
     refuse_dynamic_stdlib_dispatch_enabled, requires_stdlib, set_allow_dynamic_stdlib_packages,
     set_compile_packages_override, set_current_module_source, set_env_defines,
     set_precompile_capture, set_precompile_results, set_refuse_dynamic_stdlib_dispatch,
     typed_array_kind_for_name, ClassId, EnumId, EnvDefine, InterfaceId, ModuleInitKind, ModuleKind,
-    PosixCredentialKind, TypeAliasId, NATIVE_MODULES, TYPED_ARRAY_KIND_BIGINT64,
-    TYPED_ARRAY_KIND_BIGUINT64, TYPED_ARRAY_KIND_FLOAT16, TYPED_ARRAY_KIND_FLOAT32,
-    TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16, TYPED_ARRAY_KIND_INT32,
-    TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_UINT32,
-    TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
+    PosixCredentialKind, TypeAliasId, NATIVE_MODULES, NODE_BUILTIN_MODULES,
+    TYPED_ARRAY_KIND_BIGINT64, TYPED_ARRAY_KIND_BIGUINT64, TYPED_ARRAY_KIND_FLOAT16,
+    TYPED_ARRAY_KIND_FLOAT32, TYPED_ARRAY_KIND_FLOAT64, TYPED_ARRAY_KIND_INT16,
+    TYPED_ARRAY_KIND_INT32, TYPED_ARRAY_KIND_INT8, TYPED_ARRAY_KIND_UINT16,
+    TYPED_ARRAY_KIND_UINT32, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED,
 };
 
 // ---- module.rs ----

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -680,7 +680,10 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
                     // surface `named_export_decls` uses below.
                     Some(format!("export const {name} = _cjs.{name};"))
                 } else {
-                    Some(format!("export {{ {} as {} }};", import_local_names[n], name))
+                    Some(format!(
+                        "export {{ {} as {} }};",
+                        import_local_names[n], name
+                    ))
                 }
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

#8380 landed from a fork branch with `cargo fmt --all -- --check` failing on
`crates/perry-hir/src/ir/mod.rs` (lines 24, 31) and
`crates/perry/src/commands/compile/cjs_wrap/wrap.rs:680`. I could not push to the
fork, so this applies the formatting immediately after the merge.

Attribution checked before merging: #8379 was validated in the same worktree and
is fmt-clean on its own, so both offenders belong to #8380.

## Validation

- `cargo fmt --all` then `cargo fmt --all -- --check` — exit 0
- Only the two files above changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for formatting updates.

* **Refactor**
  * Exposed additional module-related constants for internal tooling.
  * Reformatted generated named re-export output without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->