### PR TITLE
fix: compile large TypeScript source graphs natively

### DIFF
--- a/changelog.d/8383-opencode-source-graphs.md
+++ b/changelog.d/8383-opencode-source-graphs.md
@@ -1,0 +1,3 @@
+Compile large TypeScript package graphs directly, preserving nested namespace,
+barrel-export, class-origin, asset, WebAssembly, and CommonJS linkage while
+keeping native-addon dependencies on explicit compatibility paths.

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -2,7 +2,7 @@
 //! globals, the module entry function, and string-pool initialization.
 //! Split from `codegen/mod.rs` to keep the compiler pipeline navigable.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -26,6 +26,7 @@ use super::method::{
     compile_typed_f64_receiver_method, compile_typed_i1_method, compile_typed_i32_method,
     compile_typed_string_method,
 };
+use super::native_namespace_exports::emit_native_namespace_reexport_getters;
 use super::opts::CrossModuleCtx;
 use super::spec_function_length;
 use super::typed_abi::TypedFunctionTrampolineKind;
@@ -765,6 +766,52 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         blk.ret(DOUBLE, &result);
     }
 
+    // Exported function names use a stable, plain-sanitized cross-module ABI,
+    // while local function bodies use the injective `sanitize_member` mangling
+    // so hostile-but-valid identifiers cannot collide inside one module. The
+    // direct-call aliases bridge those schemes above; closure values need the
+    // identical bridge for their `__perry_wrap_*` symbols.
+    {
+        let func_by_id: HashMap<u32, &perry_hir::Function> =
+            hir.functions.iter().map(|f| (f.id, f)).collect();
+        let mut emitted_aliases: HashSet<String> = HashSet::new();
+        for (exported_name, func_id) in &hir.exported_functions {
+            let Some(f) = func_by_id.get(func_id) else {
+                continue;
+            };
+            let Some(target_name) = func_names.get(func_id) else {
+                continue;
+            };
+            let target_wrap = format!("__perry_wrap_{}", target_name);
+            let alias_wrap = format!(
+                "__perry_wrap_perry_fn_{}__{}",
+                module_prefix,
+                sanitize(exported_name)
+            );
+            if alias_wrap == target_wrap
+                || llmod.has_function(&alias_wrap)
+                || !emitted_aliases.insert(alias_wrap.clone())
+            {
+                continue;
+            }
+
+            let arity = f.params.len().min(16);
+            let mut params: Vec<(LlvmType, String)> = vec![(I64, "%this_closure".to_string())];
+            params.extend((0..arity).map(|i| (DOUBLE, format!("%a{}", i))));
+            let alias = llmod.define_function(&alias_wrap, DOUBLE, params);
+            let _ = alias.create_block("entry");
+            let blk = alias.block_mut(0).unwrap();
+            let mut args: Vec<(LlvmType, String)> = vec![(I64, "%this_closure".to_string())];
+            args.extend((0..arity).map(|i| (DOUBLE, format!("%a{}", i))));
+            let arg_refs: Vec<(LlvmType, &str)> = args
+                .iter()
+                .map(|(ty, value)| (*ty, value.as_str()))
+                .collect();
+            let result = blk.call(DOUBLE, &target_wrap, &arg_refs);
+            blk.ret(DOUBLE, &result);
+        }
+    }
+
     // Closes #837 / refs #836: emit `__perry_wrap_perry_fn_<src>__<exported>`
     // closure wrappers for every `Export::Named { local, exported }` rename
     // where `exported != local`. The regular wrapper loop above keys
@@ -836,7 +883,10 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                 let wf = llmod.define_function(&exported_wrap, DOUBLE, wrap_params);
                 let _ = wf.create_block("entry");
                 let blk = wf.block_mut(0).unwrap();
-                let target = scoped_fn_name(module_prefix, &f.name);
+                let target = func_names
+                    .get(&f.id)
+                    .cloned()
+                    .unwrap_or_else(|| scoped_fn_name(module_prefix, &f.name));
                 let call_args: Vec<(LlvmType, String)> =
                     (0..arity).map(|i| (DOUBLE, format!("%a{}", i))).collect();
                 let call_args_ref: Vec<(LlvmType, &str)> =
@@ -1017,6 +1067,25 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                 }
             }
 
+            // Namespace initialization reads renamed values through the local
+            // getter name. Forward that name to the public getter when this is
+            // not a real function alias.
+            if local != exported && !func_by_local_name.contains_key(local.as_str()) {
+                let local_target = format!("perry_fn_{}__{}", module_prefix, sanitize(local));
+                let exported_target = format!("perry_fn_{}__{}", module_prefix, sanitize(exported));
+                if local_target != exported_target
+                    && !llmod.has_function(&local_target)
+                    && llmod.has_function(&exported_target)
+                    && emitted_aliases.insert(local_target.clone())
+                {
+                    let getter = llmod.define_function(&local_target, DOUBLE, vec![]);
+                    let _ = getter.create_block("entry");
+                    let blk = getter.block_mut(0).unwrap();
+                    let value = blk.call(DOUBLE, &exported_target, &[]);
+                    blk.ret(DOUBLE, &value);
+                }
+            }
+
             // Sub-bug B: emit no-op wrapper for `local==exported` named
             // exports where local isn't a HIR function and no wrapper
             // is yet defined. Catches `import * as z; export { z };`
@@ -1067,7 +1136,10 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                         let wf = llmod.define_function(&exported_wrap, DOUBLE, wrap_params);
                         let _ = wf.create_block("entry");
                         let blk = wf.block_mut(0).unwrap();
-                        let target = scoped_fn_name(module_prefix, &f.name);
+                        let target = func_names
+                            .get(&f.id)
+                            .cloned()
+                            .unwrap_or_else(|| scoped_fn_name(module_prefix, &f.name));
                         let call_args: Vec<(LlvmType, String)> =
                             (0..arity).map(|i| (DOUBLE, format!("%a{}", i))).collect();
                         let call_args_ref: Vec<(LlvmType, &str)> =
@@ -1199,152 +1271,13 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         blk.ret(DOUBLE, "0x7FFC000000000001");
     }
 
-    // Emit ExternFuncRef-as-value wrappers for every imported function in
-    // `opts.import_function_prefixes`. Each gets a thin wrapper plus a
-    // static `ClosureHeader` so the value can be passed as a callback,
-    // stored in a variable, or used in a truthiness / equality check —
-    // all the things you can do with a regular closure pointer.
-    //
-    // The wrappers are `internal` linkage so multiple modules can each
-    // emit their own copy without colliding at link time. Dead-code
-    // elimination strips wrappers for externs that are never referenced
-    // as values.
-    //
-    // Why this exists: when an imported function appears as a STANDALONE
-    // value (`if (this.ffi.setCursors)` capability check, `arr.forEach(
-    // importedFn)` callback, or `someFn === otherFn` reference equality),
-    // the lowering needs *some* JSValue to thread through. The previous
-    // pragmatic fix returned `TAG_TRUE` — correct for truthiness but it
-    // would crash at runtime the moment anything called the value via
-    // `js_closure_callN` (the runtime would dereference garbage from
-    // the function pointer's prefix bytes looking for a `ClosureHeader`).
-    // The static-ClosureHeader approach makes those calls actually work:
-    // `get_valid_func_ptr` reads `type_tag` at offset 12, sees
-    // `CLOSURE_MAGIC = 0x434C4F53 ("CLOS")`, and dispatches to the
-    // wrapper, which forwards the args to `perry_fn_<src>__<name>`.
-    {
-        use std::collections::HashSet;
-        let mut emitted_wrappers: HashSet<String> = HashSet::new();
-        // Build a quick lookup of imported class names (and their local aliases).
-        // Classes have no `perry_fn_<src>__<Class>` symbol — method/constructor/
-        // static dispatch happens via separate tables. For these we still need
-        // the `__perry_extern_closure_*` global (other code may load it as a
-        // value), but the wrapper body must NOT call a missing function: emit
-        // a no-op that returns `undefined` so any indirect call through the
-        // closure header fails closed instead of failing at link time.
-        let mut imported_class_names: HashSet<String> = HashSet::new();
-        for ic in opts.imported_classes {
-            imported_class_names.insert(ic.name.clone());
-            if let Some(alias) = &ic.local_alias {
-                imported_class_names.insert(alias.clone());
-            }
-        }
-        // Stable iteration order for deterministic IR output.
-        let mut imports: Vec<(&String, &String)> = opts.import_function_prefixes.iter().collect();
-        imports.sort_by(|a, b| a.0.cmp(b.0));
-        for (name, source_prefix) in imports {
-            let is_class = imported_class_names.contains(name);
-            // Issue #678 followup: V8-fallback imports have no native target
-            // — the wrapper body cannot call `perry_fn_<src>__<name>` because
-            // that symbol doesn't exist. Emit the same no-op wrapper +
-            // ClosureHeader as the imported-class branch so direct calls of
-            // the function-reference-as-value still link (and fail closed at
-            // runtime). Actual call sites — Call/PropertyGet-Call/namespace
-            // member call — route through `emit_v8_export_call` and do NOT
-            // touch this wrapper.
-            let is_v8_import = cross_module
-                .import_function_v8_specifiers
-                .contains_key(name);
-            let wrapper_name = format!("__perry_wrap_extern_{}__{}", source_prefix, name);
-            if !emitted_wrappers.insert(wrapper_name.clone()) {
-                continue;
-            }
-            if is_class || is_v8_import {
-                // No-op wrapper + a closure header that points at it. The
-                // wrapper returns NaN-tagged `undefined` so any indirect call
-                // (`MyClass.somethingThatIsActuallyAFn()`) returns undefined.
-                // Match the regular wrapper's calling convention — `%this_closure`
-                // followed by 6 double params — so direct calls in the IR don't
-                // tear off into garbage stack slots.
-                let mut wrap_params: Vec<(LlvmType, String)> = Vec::with_capacity(7);
-                wrap_params.push((I64, "%this_closure".to_string()));
-                for i in 0..6 {
-                    wrap_params.push((DOUBLE, format!("%a{}", i)));
-                }
-                let wf = llmod.define_function(&wrapper_name, DOUBLE, wrap_params);
-                wf.linkage = "internal".to_string();
-                let _ = wf.create_block("entry");
-                let blk = wf.block_mut(0).unwrap();
-                let undef =
-                    crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                blk.ret(DOUBLE, &undef);
-                let global_name = format!("__perry_extern_closure_{}__{}", source_prefix, name);
-                let init = format!("{{ ptr @{}, i32 0, i32 1129074515 }}", wrapper_name);
-                llmod.add_internal_constant(&global_name, "{ ptr, i32, i32 }", &init);
-                continue;
-            }
-            // Issue #678: when a re-export rename routes this name to an
-            // origin export with a different suffix (`export { default as
-            // render }`), call into the origin's real symbol — `perry_fn_<
-            // src>__default`, not `perry_fn_<src>__render`. The local
-            // wrapper still uses the consumer-visible name so this
-            // module's own callers can find it.
-            let origin_suffix =
-                crate::expr::import_origin_suffix(&cross_module.import_function_origin_names, name);
-            let target_name = format!("perry_fn_{}__{}", source_prefix, origin_suffix);
-            // Look up the param count from the import metadata. Fall back
-            // to 0 if missing — emits a no-arg wrapper, which is wrong
-            // for nonzero-arity functions but won't break compilation.
-            // (Read from `cross_module.imported_func_param_counts` rather
-            // than `opts.imported_func_param_counts` because the latter
-            // was moved into `cross_module` earlier in this function.)
-            let param_count = cross_module
-                .imported_func_param_counts
-                .get(name)
-                .copied()
-                .unwrap_or(0);
-            // Make sure the target is declared. The lazy-declares path
-            // in `lower_call.rs::ExternFuncRef` only fires when the
-            // function is actually CALLED — if it's only referenced as
-            // a value, the declare would be missing without this.
-            let param_types: Vec<crate::types::LlvmType> =
-                std::iter::repeat_n(DOUBLE, param_count).collect();
-            llmod.declare_function(&target_name, DOUBLE, &param_types);
-            // Wrapper: `define internal double @__perry_wrap_extern_<src>__<name>(
-            //              i64 %this_closure, double %a0, …, double %aN-1)`
-            // discards the closure pointer and forwards the doubles to
-            // `perry_fn_<src>__<name>`.
-            let mut wrap_params: Vec<(LlvmType, String)> = Vec::with_capacity(param_count + 1);
-            wrap_params.push((I64, "%this_closure".to_string()));
-            for i in 0..param_count {
-                wrap_params.push((DOUBLE, format!("%a{}", i)));
-            }
-            let wf = llmod.define_function(&wrapper_name, DOUBLE, wrap_params);
-            wf.linkage = "internal".to_string();
-            let _ = wf.create_block("entry");
-            let blk = wf.block_mut(0).unwrap();
-            let arg_names: Vec<String> = (0..param_count).map(|i| format!("%a{}", i)).collect();
-            let call_args: Vec<(LlvmType, &str)> =
-                arg_names.iter().map(|s| (DOUBLE, s.as_str())).collect();
-            let result = blk.call(DOUBLE, &target_name, &call_args);
-            blk.ret(DOUBLE, &result);
-            // Static `ClosureHeader` global pointing at the wrapper.
-            // Layout matches `crates/perry-runtime/src/closure.rs`:
-            //   { *const u8 func_ptr (8 bytes),
-            //     u32 capture_count (4 bytes),
-            //     u32 type_tag      (4 bytes) }
-            // The runtime's `get_valid_func_ptr` reads `type_tag` at
-            // offset 12 and validates against `CLOSURE_MAGIC = 0x434C4F53`
-            // ("CLOS" in ASCII = 1129074515 decimal). If the magic doesn't
-            // match, the call fast-paths to `undefined` instead of
-            // dispatching, so any non-closure value passed where a closure
-            // is expected fails closed rather than crashing.
-            let global_name = format!("__perry_extern_closure_{}__{}", source_prefix, name);
-            let init = format!("{{ ptr @{}, i32 0, i32 1129074515 }}", wrapper_name);
-            llmod.add_internal_constant(&global_name, "{ ptr, i32, i32 }", &init);
-        }
-    }
+    emit_native_namespace_reexport_getters(llmod, hir, module_prefix);
 
+    // Imported function values now materialize the source module's canonical
+    // wrapper through `js_closure_alloc_singleton` in ExternFuncRef lowering.
+    // The former consumer-local `__perry_wrap_extern_*` globals are no longer
+    // referenced; omitting them also avoids creating undefined runtime symbols
+    // for imports that survive only as cross-module TypeScript metadata.
     progress.checkpoint("method, fallback, and imported function wrappers");
 
     // Issue #100: emit the per-module `@__perry_ns_<prefix>` global iff

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -1622,6 +1622,21 @@ pub(super) fn emit_namespace_populator(
                 NamespaceEntryKind::NestedNamespace { source_prefix } => ctx
                     .block()
                     .load(DOUBLE, &format!("@__perry_ns_{}", source_prefix)),
+                NamespaceEntryKind::NativeNamespace { specifier } => {
+                    let name = specifier.strip_prefix("node:").unwrap_or(specifier);
+                    let name_idx = ctx.strings.intern(name);
+                    let name_global = format!("@{}", ctx.strings.entry(name_idx).bytes_global);
+                    let name_len = name.len().to_string();
+                    let blk = ctx.block();
+                    if let Some(install) = crate::nm_install::nm_install_symbol(name) {
+                        blk.call_void(install, &[]);
+                    }
+                    blk.call(
+                        DOUBLE,
+                        "js_create_native_module_namespace",
+                        &[(PTR, &name_global), (I64, &name_len)],
+                    )
+                }
             };
 
             handles.push(group.adopt_emitted(ctx, crate::rooting::Repr::Boxed, &val_str, true));

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -195,6 +195,7 @@ pub(crate) mod helpers;
 mod method;
 mod method_registry;
 mod module_globals_emit;
+mod native_namespace_exports;
 #[cfg(test)]
 mod number_exactness_tests;
 mod opts;

--- a/crates/perry-codegen/src/codegen/module_globals_emit.rs
+++ b/crates/perry-codegen/src/codegen/module_globals_emit.rs
@@ -287,10 +287,24 @@ pub(crate) fn emit_module_globals(
     // dispatch instead of the class method registry.
     let mut module_global_types: HashMap<u32, perry_hir::types::Type> = HashMap::new();
     let mut module_global_proven_types: HashMap<u32, perry_hir::types::Type> = HashMap::new();
-    // Collect exported variable names so we can create external
-    // globals + getter functions for cross-module access.
-    let exported_var_names: std::collections::HashSet<String> =
-        hir.exported_objects.iter().cloned().collect();
+    // `exported_objects` contains both sides of renamed exports. Storage is
+    // owned by the local binding; deriving this set from the flat list can
+    // globalize an unrelated local that happens to have the public name.
+    let exported_object_names: std::collections::HashSet<&str> =
+        hir.exported_objects.iter().map(String::as_str).collect();
+    let exported_var_names: std::collections::HashSet<String> = hir
+        .exports
+        .iter()
+        .filter_map(|export| match export {
+            perry_hir::Export::Named { local, exported }
+                if exported_object_names.contains(local.as_str())
+                    || exported_object_names.contains(exported.as_str()) =>
+            {
+                Some(local.clone())
+            }
+            _ => None,
+        })
+        .collect();
     // #6649: module-level array-destructuring declarations (`var [Prime, Size]
     // = [BigInt(...), BigInt(...)]` — TypeBox's FNV-1a table in the pi bundle)
     // lower their leaf `Stmt::Let`s inside the iterator-protocol `Stmt::Try`
@@ -415,14 +429,25 @@ pub(crate) fn emit_module_globals(
                 // emitting a getter here on top would be a redef and is
                 // semantically wrong (it'd return the closure value instead
                 // of invoking it).
-                let is_function_alias = hir.exported_functions.iter().any(|(exp, _)| exp == name);
+                let is_function_alias = hir.exported_functions.iter().any(|(exp, _)| exp == name)
+                    || hir.exports.iter().any(|export| match export {
+                        perry_hir::Export::Named { local, exported } if local == name => hir
+                            .exported_functions
+                            .iter()
+                            .any(|(function_export, _)| function_export == exported),
+                        _ => false,
+                    });
                 if is_exported && !is_also_function && !is_function_alias {
-                    let fn_name = format!("perry_fn_{}__{}", module_prefix, sanitize(name),);
-                    let getter = llmod.define_function(&fn_name, DOUBLE, vec![]);
-                    let _ = getter.create_block("entry");
-                    let blk = getter.block_mut(0).unwrap();
-                    let val = blk.load(DOUBLE, &format!("@{}", global_name));
-                    blk.ret(DOUBLE, &val);
+                    let public_names: std::collections::BTreeSet<&str> = hir
+                        .exports
+                        .iter()
+                        .filter_map(|export| match export {
+                            perry_hir::Export::Named { local, exported } if local == name => {
+                                Some(exported.as_str())
+                            }
+                            _ => None,
+                        })
+                        .collect();
 
                     // #460: also emit a duplicate getter under any renamed
                     // export targeting this local. `export { _await as await }`
@@ -433,20 +458,46 @@ pub(crate) fn emit_module_globals(
                     // returns; callers that invoke it as a function get the
                     // closure handle (matching status quo for non-renamed
                     // `export const f = aFunctionRef` exports).
-                    for export in &hir.exports {
-                        if let perry_hir::Export::Named { local, exported } = export {
-                            if local == name && exported != name {
-                                let alias_fn =
-                                    format!("perry_fn_{}__{}", module_prefix, sanitize(exported));
-                                if alias_fn == fn_name {
-                                    continue;
-                                }
-                                let g = llmod.define_function(&alias_fn, DOUBLE, vec![]);
-                                let _ = g.create_block("entry");
-                                let b = g.block_mut(0).unwrap();
-                                let v = b.load(DOUBLE, &format!("@{}", global_name));
-                                b.ret(DOUBLE, &v);
-                            }
+                    for public_name in public_names {
+                        let getter_name =
+                            format!("perry_fn_{}__{}", module_prefix, sanitize(public_name));
+                        if !llmod.has_function(&getter_name) {
+                            let getter = llmod.define_function(&getter_name, DOUBLE, vec![]);
+                            let _ = getter.create_block("entry");
+                            let blk = getter.block_mut(0).unwrap();
+                            let val = blk.load(DOUBLE, &format!("@{}", global_name));
+                            blk.ret(DOUBLE, &val);
+                        }
+
+                        // Import-origin metadata preserves the raw exported
+                        // spelling. For identifiers such as `$i`, consumers
+                        // therefore reference `perry_fn_<mod>__$i`, while the
+                        // historical getter above uses the plain sanitizer
+                        // (`_i`). Mirror the function-export alias rule and
+                        // forward the raw spelling to the canonical getter.
+                        let raw_getter_name =
+                            format!("perry_fn_{}__{}", module_prefix, public_name);
+                        if raw_getter_name != getter_name && !llmod.has_function(&raw_getter_name) {
+                            let alias = llmod.define_function(&raw_getter_name, DOUBLE, vec![]);
+                            let _ = alias.create_block("entry");
+                            let blk = alias.block_mut(0).unwrap();
+                            let val = blk.call(DOUBLE, &getter_name, &[]);
+                            blk.ret(DOUBLE, &val);
+                        }
+
+                        // Re-export origin metadata can instead preserve the
+                        // raw LOCAL spelling (`export { $i as filesFilter }`).
+                        // Forward that spelling to the same public getter too.
+                        let raw_local_getter_name = format!("perry_fn_{}__{}", module_prefix, name);
+                        if raw_local_getter_name != getter_name
+                            && !llmod.has_function(&raw_local_getter_name)
+                        {
+                            let alias =
+                                llmod.define_function(&raw_local_getter_name, DOUBLE, vec![]);
+                            let _ = alias.create_block("entry");
+                            let blk = alias.block_mut(0).unwrap();
+                            let val = blk.call(DOUBLE, &getter_name, &[]);
+                            blk.ret(DOUBLE, &val);
                         }
                     }
                 }

--- a/crates/perry-codegen/src/codegen/native_namespace_exports.rs
+++ b/crates/perry-codegen/src/codegen/native_namespace_exports.rs
@@ -1,0 +1,52 @@
+//! Runtime getters for namespace re-exports of Perry-native modules.
+
+use perry_hir::Module as HirModule;
+
+use crate::module::LlModule;
+use crate::types::{DOUBLE, I64, PTR};
+
+pub(super) fn emit_native_namespace_reexport_getters(
+    llmod: &mut LlModule,
+    hir: &HirModule,
+    module_prefix: &str,
+) {
+    // A namespace re-export of a compiler-native module has no compiled
+    // source module (and therefore no `@__perry_ns_<prefix>` global) behind
+    // it. Expose it as a zero-argument value getter on the re-exporting module
+    // so ordinary named imports can materialize the runtime-native namespace:
+    //
+    //   export * as NodeWS from "ws"
+    //   import { NodeWS } from "./NodeSocket"
+    //
+    // The driver classifies the consumer binding as `imported_vars`, so its
+    // ExternFuncRef value path calls this getter rather than creating a closure
+    // around a nonexistent function export.
+    for export in &hir.exports {
+        let perry_hir::Export::NamespaceReExport { source, name } = export else {
+            continue;
+        };
+        if !perry_hir::NATIVE_MODULES.contains(&source.strip_prefix("node:").unwrap_or(source)) {
+            continue;
+        }
+        let getter_name = format!("perry_fn_{}__{}", module_prefix, name);
+        if llmod.has_function(&getter_name) {
+            continue;
+        }
+        let (source_global, source_len) = llmod.add_string_constant(source);
+        let getter = llmod.define_function(&getter_name, DOUBLE, vec![]);
+        let _ = getter.create_block("entry");
+        let blk = getter.block_mut(0).unwrap();
+        if let Some(install) = crate::nm_install::nm_install_symbol(source) {
+            blk.call_void(install, &[]);
+        }
+        let value = blk.call(
+            DOUBLE,
+            "js_create_native_module_namespace",
+            &[
+                (PTR, &format!("@{}", source_global)),
+                (I64, &source_len.to_string()),
+            ],
+        );
+        blk.ret(DOUBLE, &value);
+    }
+}

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -460,11 +460,10 @@ pub enum NamespaceEntryKind {
         source_prefix: String,
         source_local: String,
     },
-    /// Re-exported function from another module. Codegen declares the
-    /// target's `perry_fn_*` as extern, emits a per-callsite
-    /// `__perry_wrap_extern_*` thin wrapper (if not already emitted by
-    /// the import-wrapper pass), and calls
-    /// `js_closure_alloc_singleton` against that wrapper.
+    /// Re-exported function from another module. The namespace populator
+    /// declares the target's `perry_fn_*`, emits its own
+    /// `__perry_wrap_extern_*` thunk, and calls `js_closure_alloc_singleton`
+    /// against that wrapper.
     ForeignFunction {
         source_prefix: String,
         source_local: String,
@@ -474,6 +473,10 @@ pub enum NamespaceEntryKind {
     /// nested value IS the target module's `@__perry_ns_<source_prefix>`
     /// global, populated by the target's own `__init`.
     NestedNamespace { source_prefix: String },
+    /// `export * as Name from "node:..."` (or another Perry-native module).
+    /// Native modules have no compiled `@__perry_ns_*` global, so codegen asks
+    /// the runtime to materialize their namespace directly.
+    NativeNamespace { specifier: String },
 }
 
 /// A class imported from another native module.

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -763,14 +763,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // an imported function appears as a STANDALONE value — `if
         // (this.ffi.setCursors)` truthiness check, `someFn === otherFn`
         // equality comparison, or being passed as a callback — we route
-        // to the static `__perry_extern_closure_<src>__<name>` global
-        // emitted by `compile_module` for every imported function (see the
-        // wrapper-emit block right after the user-function `__perry_wrap_*`
-        // loop). The global is a `ClosureHeader` with `func_ptr` pointing
-        // at a thin `__perry_wrap_extern_<src>__<name>` thunk and
-        // `type_tag = CLOSURE_MAGIC`, so the runtime's `js_closure_callN`
-        // sees a valid closure and dispatches correctly. We just take the
-        // address and NaN-box it as POINTER.
+        // to the source module's canonical `__perry_wrap_perry_fn_*` symbol
+        // and ask `js_closure_alloc_singleton` for its shared ClosureHeader.
+        // This preserves reference identity across consumers without emitting
+        // a second consumer-local wrapper for every imported binding.
         //
         // For namespaces / built-ins that aren't in `import_function_prefixes`
         // (e.g. setTimeout / clearTimeout / Math / Date), we still don't

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1827,6 +1827,45 @@ pub(crate) fn class_field_loop_fact_lookup<'f>(
     })
 }
 
+/// Build a linker-unique inline-cache global name.
+///
+/// `ic_site_counter` is only module-wide. LLVM codegen-unit splitting can
+/// promote a private global for cross-unit use, so the source-module prefix is
+/// also required to keep separately compiled modules from defining the same
+/// `perry_ic_N` symbol at the final application link.
+pub(crate) fn inline_cache_global_name(ctx: &FnCtx<'_>, site_id: u32) -> String {
+    inline_cache_global_name_for_prefix(ctx.strings.module_prefix(), site_id)
+}
+
+fn inline_cache_global_name_for_prefix(module_prefix: &str, site_id: u32) -> String {
+    if module_prefix.is_empty() {
+        format!("perry_ic_{site_id}")
+    } else {
+        format!("perry_ic_{module_prefix}__{site_id}")
+    }
+}
+
+#[cfg(test)]
+mod inline_cache_name_tests {
+    use super::inline_cache_global_name_for_prefix;
+
+    #[test]
+    fn cache_symbols_are_unique_across_source_modules() {
+        assert_eq!(
+            inline_cache_global_name_for_prefix("packages_a_ts", 7),
+            "perry_ic_packages_a_ts__7"
+        );
+        assert_eq!(
+            inline_cache_global_name_for_prefix("packages_b_ts", 7),
+            "perry_ic_packages_b_ts__7"
+        );
+        assert_ne!(
+            inline_cache_global_name_for_prefix("packages_a_ts", 7),
+            inline_cache_global_name_for_prefix("packages_b_ts", 7)
+        );
+    }
+}
+
 impl<'a> FnCtx<'a> {
     /// Return runtime-derived initializer evidence only when no write anywhere
     /// in this region can have invalidated it.

--- a/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
+++ b/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
@@ -86,7 +86,7 @@ pub(crate) fn lower_generic_property_get(
         // unchanged.
         let cache_site = ctx.ic_site_counter;
         ctx.ic_site_counter += 1;
-        let cache_name = format!("perry_ic_{}", cache_site);
+        let cache_name = super::super::inline_cache_global_name(ctx, cache_site);
         ctx.pending_declares
             .push((format!("__ic_decl_{}", cache_site), DOUBLE, vec![]));
         ctx.ic_globals.push(cache_name.clone());
@@ -262,7 +262,7 @@ pub(crate) fn lower_generic_property_get(
     // full lookup and primes the cache for next time.
     let site_id = ctx.ic_site_counter;
     ctx.ic_site_counter += 1;
-    let cache_name = format!("perry_ic_{}", site_id);
+    let cache_name = super::super::inline_cache_global_name(ctx, site_id);
     ctx.pending_declares
         .push((format!("__ic_decl_{}", site_id), DOUBLE, vec![]));
     ctx.ic_globals.push(cache_name.clone());

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -480,7 +480,7 @@ fn lower_put_value_static_write_ic(
 
     let site_id = ctx.ic_site_counter;
     ctx.ic_site_counter += 1;
-    let cache_name = format!("perry_ic_{}", site_id);
+    let cache_name = super::inline_cache_global_name(ctx, site_id);
     ctx.pending_declares
         .push((format!("__ic_decl_{}", site_id), DOUBLE, vec![]));
     ctx.ic_globals.push(cache_name.clone());
@@ -488,7 +488,7 @@ fn lower_put_value_static_write_ic(
     // Keep the first four ways inline. Shapes 5–8 use a separate cache in a
     // compact outlined helper, avoiding four more copies of the generated
     // receiver guards while preventing the fourth inline way from thrashing.
-    let tail_cache_name = format!("perry_ic_{}_poly_tail", site_id);
+    let tail_cache_name = format!("{}_poly_tail", cache_name);
     ctx.ic_globals.push(tail_cache_name.clone());
     let tail_cache_ref = format!("@{}", tail_cache_name);
 
@@ -884,7 +884,7 @@ fn lower_put_value_dyn_ic_inline(
 ) -> Result<String> {
     let site_id = ctx.ic_site_counter;
     ctx.ic_site_counter += 1;
-    let cache_name = format!("perry_ic_{}", site_id);
+    let cache_name = super::inline_cache_global_name(ctx, site_id);
     ctx.ic_globals.push(cache_name.clone());
     let cache_ref = format!("@{}", cache_name);
 
@@ -1653,7 +1653,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let t = g.reread(ctx, recv_slot)?;
                     let site_id = ctx.ic_site_counter;
                     ctx.ic_site_counter += 1;
-                    let cache_name = format!("perry_ic_{}", site_id);
+                    let cache_name = super::inline_cache_global_name(ctx, site_id);
                     ctx.ic_globals.push(cache_name.clone());
                     let cache_ref = format!("@{}", cache_name);
                     Ok(ctx.block().call(

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -4,7 +4,7 @@
 //! Pure mechanical move — match arm bodies are verbatim copies, called from
 //! `lower_expr`'s outer dispatch.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use perry_hir::types::Type as HirType;
 use perry_hir::Expr;
 
@@ -279,39 +279,110 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     // Both wildcard imports and namespaces reached through a
                     // re-export use the same getter ABI.
                     if ctx.imported_vars.contains(method_name) {
-                        let mut lowered: Vec<String> = Vec::with_capacity(args.len());
-                        for a in args {
-                            lowered.push(lower_expr(ctx, a)?);
-                        }
-                        if lowered.len() > 16 {
-                            bail!(
-                                "perry-codegen: namespace static-method closure call with {} args (max 16)",
-                                lowered.len()
-                            );
-                        }
                         ctx.pending_declares.push((fn_name.clone(), DOUBLE, vec![]));
+                        // Preserve JavaScript evaluation order: fetch the
+                        // callable namespace member before evaluating any
+                        // argument, then root it across that argument window.
                         let closure_box = ctx.block().call(DOUBLE, &fn_name, &[]);
-                        let blk = ctx.block();
-                        let closure_handle = unbox_to_i64(blk, &closure_box);
-                        let runtime_fn = format!("js_closure_call{}", lowered.len());
-                        let mut call_args: Vec<(crate::types::LlvmType, &str)> =
-                            vec![(I64, &closure_handle)];
-                        for v in &lowered {
-                            call_args.push((DOUBLE, v.as_str()));
-                        }
-                        return Ok(blk.call(DOUBLE, &runtime_fn, &call_args));
+                        let arg_refs: Vec<&Expr> = args.iter().collect();
+                        let lowered_args = std::cell::RefCell::new(Vec::<String>::new());
+                        let result = crate::rooting::with_rooted_accumulator(
+                            ctx,
+                            crate::rooting::Repr::Boxed,
+                            &closure_box,
+                            crate::rooting::any_operand_may_collect(ctx, args.iter()),
+                            |ctx, _closure| {
+                                crate::rooting::with_operands_rooted(
+                                    ctx,
+                                    &arg_refs,
+                                    |_ctx, vals| {
+                                        *lowered_args.borrow_mut() = vals.to_vec();
+                                        Ok(())
+                                    },
+                                )
+                            },
+                            |ctx, closure_box| {
+                                let lowered = lowered_args.borrow();
+                                let closure_handle = {
+                                    let blk = ctx.block();
+                                    unbox_to_i64(blk, closure_box)
+                                };
+                                if lowered.len() <= 16 {
+                                    let runtime_fn = format!("js_closure_call{}", lowered.len());
+                                    let mut call_args: Vec<(crate::types::LlvmType, &str)> =
+                                        vec![(I64, &closure_handle)];
+                                    for value in lowered.iter() {
+                                        call_args.push((DOUBLE, value.as_str()));
+                                    }
+                                    return Ok(ctx.block().call(DOUBLE, &runtime_fn, &call_args));
+                                }
+
+                                // #3527: namespace members backed by exported
+                                // closure getters need the same arbitrary-arity
+                                // array dispatch as ordinary closure values.
+                                // Effect's `Layer.mergeAll` is a rest closure
+                                // and OpenCode passes 18 layers here.
+                                let n = lowered.len();
+                                let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+                                let blk = ctx.block();
+                                for (i, value) in lowered.iter().enumerate() {
+                                    let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                                    blk.store(DOUBLE, value, &slot);
+                                }
+                                let argc = n.to_string();
+                                Ok(blk.call(
+                                    DOUBLE,
+                                    "js_closure_call_array",
+                                    &[(I64, &closure_handle), (PTR, &buf), (I64, &argc)],
+                                ))
+                            },
+                        )?;
+                        return Ok(result);
                     }
-                    let mut lowered: Vec<String> = Vec::with_capacity(args.len());
-                    for a in args {
-                        lowered.push(lower_expr(ctx, a)?);
+                    // Function-declaration namespace members need the same ABI
+                    // adaptation as the lowercase namespace-call path. In
+                    // particular, a rest declaration receives its trailing
+                    // arguments as one array parameter; passing the source
+                    // arguments directly makes `Event.inventory(...defs)` read
+                    // a scalar as an array and return `undefined`.
+                    let declared_count = ctx
+                        .imported_func_param_counts
+                        .get(method_name)
+                        .copied()
+                        .unwrap_or(args.len());
+                    if ctx.imported_func_has_rest.contains(method_name) {
+                        let fixed_count = declared_count.saturating_sub(1);
+                        let (lowered, guard) = crate::lower_call::lower_rest_call_args_rooted(
+                            ctx,
+                            args,
+                            fixed_count,
+                            &[crate::lower_call::RestBundle {
+                                from: fixed_count,
+                                mark_arguments_object: false,
+                            }],
+                        )?;
+                        let arg_kinds: Vec<crate::types::LlvmType> =
+                            std::iter::repeat_n(DOUBLE, lowered.len()).collect();
+                        ctx.pending_declares
+                            .push((fn_name.clone(), DOUBLE, arg_kinds));
+                        return Ok(crate::lower_call::emit_rooted_call(
+                            ctx, &fn_name, &lowered, guard,
+                        ));
                     }
+
+                    let (mut lowered, guard) =
+                        crate::lower_call::lower_call_args_rooted(ctx, args)?;
+                    lowered.resize(
+                        lowered.len().max(declared_count),
+                        double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
+                    );
                     let arg_kinds: Vec<crate::types::LlvmType> =
-                        std::iter::repeat_n(DOUBLE, args.len()).collect();
+                        std::iter::repeat_n(DOUBLE, lowered.len()).collect();
                     ctx.pending_declares
                         .push((fn_name.clone(), DOUBLE, arg_kinds));
-                    let arg_slices: Vec<(crate::types::LlvmType, &str)> =
-                        lowered.iter().map(|s| (DOUBLE, s.as_str())).collect();
-                    return Ok(ctx.block().call(DOUBLE, &fn_name, &arg_slices));
+                    return Ok(crate::lower_call::emit_rooted_call(
+                        ctx, &fn_name, &lowered, guard,
+                    ));
                 }
             }
             // Issue #818 (Effect.succeed pattern): the receiver is a NAMED

--- a/crates/perry-codegen/src/lower_call/namespace_call.rs
+++ b/crates/perry-codegen/src/lower_call/namespace_call.rs
@@ -50,7 +50,7 @@
 //! is a gap in the API, filed with the slice, not a decision this file makes.
 //! Delegating to an audited helper is the same posture as calling `lower_expr`.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use perry_hir::Expr;
 
 use super::extern_timers::fill_arg_buffer;
@@ -305,12 +305,6 @@ pub fn try_lower_namespace_member_call(
     if ctx.imported_vars.contains(property) {
         // Var-shaped export: fetch closure via zero-arg
         // getter, then closure-call with the user args.
-        if args.len() > 16 {
-            bail!(
-                "perry-codegen: namespace closure call with {} args (max 16)",
-                args.len()
-            );
-        }
         ctx.pending_declares.push((symbol.clone(), DOUBLE, vec![]));
         // The getter runs FIRST and must keep running first: it is the callee
         // reference, and the spec evaluates that before the arguments. Sinking
@@ -348,15 +342,37 @@ pub fn try_lower_namespace_member_call(
                 // Below every collection point: the inner group's re-reads, then
                 // the accumulator's own re-read, then nothing that allocates.
                 let lowered = lowered_args.borrow();
-                let blk = ctx.block();
-                let closure_handle = unbox_to_i64(blk, closure_box);
-                let runtime_fn = format!("js_closure_call{}", lowered.len());
-                let mut call_args: Vec<(crate::types::LlvmType, &str)> =
-                    vec![(I64, &closure_handle)];
-                for v in lowered.iter() {
-                    call_args.push((DOUBLE, v.as_str()));
+                let closure_handle = {
+                    let blk = ctx.block();
+                    unbox_to_i64(blk, closure_box)
+                };
+                if lowered.len() <= 16 {
+                    let runtime_fn = format!("js_closure_call{}", lowered.len());
+                    let mut call_args: Vec<(crate::types::LlvmType, &str)> =
+                        vec![(I64, &closure_handle)];
+                    for v in lowered.iter() {
+                        call_args.push((DOUBLE, v.as_str()));
+                    }
+                    return Ok(ctx.block().call(DOUBLE, &runtime_fn, &call_args));
                 }
-                Ok(blk.call(DOUBLE, &runtime_fn, &call_args))
+
+                // #3527: the runtime's array dispatcher owns arbitrary-arity
+                // closure calls (including rest bundling). Keep the fixed-N
+                // entry points as the small fast path and marshal wider calls
+                // into a stack buffer after all rooted operand re-reads.
+                let n = lowered.len();
+                let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+                let blk = ctx.block();
+                for (i, value) in lowered.iter().enumerate() {
+                    let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                    blk.store(DOUBLE, value, &slot);
+                }
+                let argc = n.to_string();
+                Ok(blk.call(
+                    DOUBLE,
+                    "js_closure_call_array",
+                    &[(I64, &closure_handle), (PTR, &buf), (I64, &argc)],
+                ))
             },
         )?;
         return Ok(Some(result));

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -85,10 +85,10 @@ impl LoweringContext {
             func_defaults: Vec::new(),
             classes: Vec::new(),
             class_statics: Vec::new(),
-            class_field_names: Vec::new(),
-            class_accessor_names: Vec::new(),
+            class_field_names: HashMap::new(),
+            class_accessor_names: HashMap::new(),
             class_native_extends: Vec::new(),
-            class_field_types: Vec::new(),
+            class_field_types: HashMap::new(),
             enums: Vec::new(),
             pending_body_enums: Vec::new(),
             interfaces: Vec::new(),
@@ -524,24 +524,14 @@ impl LoweringContext {
         class_name: String,
         field_names: Vec<String>,
     ) {
-        // Replace existing entry if present; otherwise append.
-        if let Some(entry) = self
-            .class_field_names
-            .iter_mut()
-            .find(|(n, _)| *n == class_name)
-        {
-            entry.1 = field_names;
-        } else {
-            self.class_field_names.push((class_name, field_names));
-        }
+        self.class_field_names.insert(class_name, field_names);
     }
 
     /// Look up the list of instance field names declared on a class (NOT including inherited).
     pub(crate) fn lookup_class_field_names(&self, class_name: &str) -> Option<&[String]> {
         self.class_field_names
-            .iter()
-            .find(|(n, _)| n == class_name)
-            .map(|(_, f)| f.as_slice())
+            .get(class_name)
+            .map(|fields| fields.as_slice())
     }
 
     /// Issue #665: register getter and setter property names for a class.
@@ -553,15 +543,7 @@ impl LoweringContext {
         class_name: String,
         accessor_names: crate::ClassAccessorNames,
     ) {
-        if let Some(entry) = self
-            .class_accessor_names
-            .iter_mut()
-            .find(|(n, _)| *n == class_name)
-        {
-            entry.1 = accessor_names;
-        } else {
-            self.class_accessor_names.push((class_name, accessor_names));
-        }
+        self.class_accessor_names.insert(class_name, accessor_names);
     }
 
     /// Look up the accessor property names registered for a
@@ -572,10 +554,7 @@ impl LoweringContext {
         &self,
         class_name: &str,
     ) -> Option<&crate::ClassAccessorNames> {
-        self.class_accessor_names
-            .iter()
-            .find(|(n, _)| n == class_name)
-            .map(|(_, f)| f)
+        self.class_accessor_names.get(class_name)
     }
 
     /// Issue #302: register declared field types for a class (parallel to
@@ -587,15 +566,7 @@ impl LoweringContext {
         class_name: String,
         field_types: Vec<(String, Type)>,
     ) {
-        if let Some(entry) = self
-            .class_field_types
-            .iter_mut()
-            .find(|(n, _)| *n == class_name)
-        {
-            entry.1 = field_types;
-        } else {
-            self.class_field_types.push((class_name, field_types));
-        }
+        self.class_field_types.insert(class_name, field_types);
     }
 
     /// Pre-seed `class_field_types` (and `class_field_names`) with cross-module
@@ -614,13 +585,12 @@ impl LoweringContext {
         seeds: &std::collections::HashMap<String, Vec<(String, Type)>>,
     ) {
         for (name, fields) in seeds {
-            if !self.class_field_types.iter().any(|(n, _)| n == name) {
-                self.class_field_types.push((name.clone(), fields.clone()));
-            }
-            if !self.class_field_names.iter().any(|(n, _)| n == name) {
-                let names: Vec<String> = fields.iter().map(|(n, _)| n.clone()).collect();
-                self.class_field_names.push((name.clone(), names));
-            }
+            self.class_field_types
+                .entry(name.clone())
+                .or_insert_with(|| fields.clone());
+            self.class_field_names
+                .entry(name.clone())
+                .or_insert_with(|| fields.iter().map(|(field, _)| field.clone()).collect());
         }
     }
 
@@ -632,10 +602,9 @@ impl LoweringContext {
         seeds: &std::collections::HashMap<String, crate::ClassAccessorNames>,
     ) {
         for (name, accessors) in seeds {
-            if !self.class_accessor_names.iter().any(|(n, _)| n == name) {
-                self.class_accessor_names
-                    .push((name.clone(), accessors.clone()));
-            }
+            self.class_accessor_names
+                .entry(name.clone())
+                .or_insert_with(|| accessors.clone());
         }
     }
 
@@ -648,9 +617,9 @@ impl LoweringContext {
         field_name: &str,
     ) -> Option<&Type> {
         self.class_field_types
-            .iter()
-            .find(|(n, _)| n == class_name)
-            .and_then(|(_, fs)| fs.iter().find(|(n, _)| n == field_name).map(|(_, ty)| ty))
+            .get(class_name)
+            .and_then(|fields| fields.iter().find(|(name, _)| name == field_name))
+            .map(|(_, ty)| ty)
     }
 
     /// Issue #212: register the outer-scope LocalIds that a nested class

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -131,7 +131,7 @@ pub struct LoweringContext {
     /// Used by the "infer fields from ctor body" pass to skip fields inherited from parents,
     /// avoiding the creation of shadow fields that cause later index shift bugs after
     /// inheritance resolution in codegen.
-    pub(crate) class_field_names: Vec<(String, Vec<String>)>,
+    pub(crate) class_field_names: HashMap<String, Vec<String>>,
     /// Issue #665 (sixth pass): per-class set of getter and setter property names.
     /// Used by the "infer fields from ctor body `this.x = ...`" pass to avoid
     /// mis-categorising a setter assignment as an own data field — the
@@ -142,7 +142,7 @@ pub struct LoweringContext {
     /// Populated alongside `register_class_field_names`; looked up via
     /// `lookup_class_accessor_names` and walked across the parent chain when
     /// processing a subclass's ctor body.
-    pub(crate) class_accessor_names: Vec<(String, ClassAccessorNames)>,
+    pub(crate) class_accessor_names: HashMap<String, ClassAccessorNames>,
     /// Issue #562: class name → `(module, class)` tuple from
     /// `native_extends`. Populated when lowering each class, consumed by
     /// `destructuring.rs` to register `let x = new SubclassOfStream()`
@@ -157,7 +157,7 @@ pub struct LoweringContext {
     /// path doesn't apply. Parallel to `class_field_names` but stores
     /// `(field_name, declared_type)` pairs. Populated by
     /// `register_class_field_types` next to `register_class_field_names`.
-    pub(crate) class_field_types: Vec<(String, Vec<(String, Type)>)>,
+    pub(crate) class_field_types: HashMap<String, Vec<(String, Type)>>,
     /// Enums: name -> (id, members with values)
     pub(crate) enums: Vec<(String, EnumId, Vec<(String, EnumValue)>)>,
     /// Enums declared inside a FUNCTION BODY, awaiting attachment to the

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -110,9 +110,8 @@ use resolve::{
 use strip_dedup::{
     dedup_native_lib_for_tier3, dedup_runtime_for_tier3, dedup_stdlib_for_tier3,
     dedup_ui_lib_against_linked_libs, localize_stdlib_stub_symbols,
-    localize_stdlib_stub_symbols_for_windows, strip_bundled_runtime_from_well_known_lib,
-    strip_bundled_shared_deps_from_well_known_lib, strip_duplicate_objects_from_lib,
-    strip_duplicate_objects_from_well_known_lib,
+    strip_bundled_runtime_from_well_known_lib, strip_bundled_shared_deps_from_well_known_lib,
+    strip_duplicate_objects_from_lib, strip_duplicate_objects_from_well_known_lib,
 };
 use targets::{
     apple_sdk_version, find_visionos_swift_runtime, find_watchos_swift_runtime,
@@ -169,7 +168,11 @@ pub fn run(
     use_color: bool,
     verbose: u8,
 ) -> Result<CompileResult> {
-    run_with_parse_cache(args, None, format, use_color, verbose)
+    // Cross-module metadata can require a complete second lowering pass.
+    // Retain parsed ASTs for the lifetime of this build so large source-first
+    // graphs do not reread and reparse every module during that pass.
+    let mut parse_cache = ParseCache::with_capacity(usize::MAX);
+    run_with_parse_cache(args, Some(&mut parse_cache), format, use_color, verbose)
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
@@ -395,6 +395,10 @@ pub fn extract_object_literal_exports_from_require(source: &str) -> Vec<(String,
 ///      output occasionally falls back to) was unsupported, so the consumer
 ///      `import { X } from "pkg"` link-failed because no named export was
 ///      ever extracted.
+///
+/// esbuild's `__export(target, { X: () => value })` helper form is also
+/// recognized. The helper installs getters on `target`, which is later passed
+/// through `__toCommonJS` into `module.exports`.
 pub fn extract_exports_from_source(source: &str) -> Vec<String> {
     let mut names = Vec::new();
     let push_unique = |names: &mut Vec<String>, name: &str| {
@@ -556,6 +560,79 @@ pub fn extract_exports_from_source(source: &str) -> Vec<String> {
         let body = &source[body_start..body_end];
         extract_object_literal_keys(body, &mut |name| push_unique(&mut names, name));
         search_from = q;
+    }
+
+    // Shape 3: esbuild's generated export table:
+    //
+    //     __export(src_exports, {
+    //       getContext: () => import_get_context.getContext,
+    //       refreshToken: () => refreshToken
+    //     });
+    //
+    // The helper definition itself has a non-object second parameter and is
+    // therefore not matched. Accept numeric suffixes (`__export2`) used when
+    // a bundle has to avoid colliding with an existing binding.
+    let esbuild_export_re = regex::Regex::new(
+        r"(?:^|[^A-Za-z0-9_$])__export[0-9]*\s*\(\s*[A-Za-z_$][A-Za-z0-9_$]*\s*,\s*\{",
+    )
+    .unwrap();
+    for export_call in esbuild_export_re.find_iter(source) {
+        let Some(open_rel) = source[export_call.start()..export_call.end()].rfind('{') else {
+            continue;
+        };
+        let open = export_call.start() + open_rel;
+        let mut depth: i32 = 1;
+        let mut q = open + 1;
+        while q < bytes.len() && depth > 0 {
+            match bytes[q] {
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                b'"' | b'\'' => {
+                    let quote = bytes[q];
+                    q += 1;
+                    while q < bytes.len() && bytes[q] != quote {
+                        if bytes[q] == b'\\' && q + 1 < bytes.len() {
+                            q += 2;
+                            continue;
+                        }
+                        q += 1;
+                    }
+                }
+                b'`' => {
+                    q += 1;
+                    while q < bytes.len() && bytes[q] != b'`' {
+                        if bytes[q] == b'\\' && q + 1 < bytes.len() {
+                            q += 2;
+                            continue;
+                        }
+                        q += 1;
+                    }
+                }
+                b'/' if q + 1 < bytes.len() && bytes[q + 1] == b'/' => {
+                    q += 2;
+                    while q < bytes.len() && bytes[q] != b'\n' {
+                        q += 1;
+                    }
+                    continue;
+                }
+                b'/' if q + 1 < bytes.len() && bytes[q + 1] == b'*' => {
+                    q += 2;
+                    while q + 1 < bytes.len() && !(bytes[q] == b'*' && bytes[q + 1] == b'/') {
+                        q += 1;
+                    }
+                    if q + 1 < bytes.len() {
+                        q += 2;
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+            q += 1;
+        }
+        if depth == 0 {
+            let body = &source[open + 1..q - 1];
+            extract_object_literal_keys(body, &mut |name| push_unique(&mut names, name));
+        }
     }
 
     names

--- a/crates/perry/src/commands/compile/cjs_wrap/tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/tests.rs
@@ -14,6 +14,8 @@ use super::wrap::{wrap_commonjs, wrap_commonjs_for_target, wrap_commonjs_with_bo
 use std::fs;
 use std::path::PathBuf;
 
+mod source_graph;
+
 // #5247: the wrapped output must report where the ORIGINAL body begins, and
 // because blanking/hoisting preserve newlines, the prefix line count lets a
 // wrapped body line map back to its original-source line. This is the unit

--- a/crates/perry/src/commands/compile/cjs_wrap/tests/source_graph.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/tests/source_graph.rs
@@ -1,0 +1,40 @@
+use super::{extract_exports_from_source, wrap_commonjs, PathBuf};
+
+#[test]
+fn extracts_esbuild_export_helper_keys() {
+    let src = r#"
+var __export = (target, all) => {
+  for (var name in all) Object.defineProperty(target, name, { get: all[name] });
+};
+var src_exports = {};
+__export(src_exports, {
+  getContext: () => import_get_context.getContext,
+  refreshToken: () => refreshToken,
+  default: () => src_default
+});
+module.exports = __toCommonJS(src_exports);
+0 && (module.exports = { getContext, refreshToken });
+"#;
+    let names = extract_exports_from_source(src);
+    assert_eq!(
+        names,
+        vec!["getContext".to_string(), "refreshToken".to_string()]
+    );
+}
+
+#[test]
+fn wraps_esbuild_export_helper_as_named_esm_exports() {
+    let src = r#"
+var src_exports = {};
+__export(src_exports, { getContext: () => getContext });
+function getContext() { return {}; }
+module.exports = __toCommonJS(src_exports);
+"#;
+    let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/vercel-oidc/index.js"));
+    assert!(
+        wrapped.contains("export const getContext = _cjs.getContext;"),
+        "expected esbuild named export, got:\n{}",
+        wrapped
+    );
+    assert!(perry_parser::parse_typescript(&wrapped, "index.js").is_ok());
+}

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -11,7 +11,7 @@ use perry_transform::{
     gather_cross_module_methods_with_extern_imports, inline_finally_into_returns, inline_functions,
     transform_async_to_generator, transform_generators, MethodCandidate,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -39,6 +39,7 @@ mod script_string;
 mod static_require_transform;
 #[cfg(test)]
 mod tests;
+mod walk;
 mod wasm_asset;
 
 use binding_faithfulness::audit_native_binding_choice;
@@ -50,116 +51,14 @@ pub(super) use import_helpers::known_node_submodule_key;
 use import_helpers::{
     cached_resolve_import_with_lexical_base, collect_js_module_imports, env_defines_for_lowering,
 };
+pub(super) use native_addon::package_has_unsupported_node_addon;
 use native_addon::{refuse_compile_package_native_addon, refuse_node_addon_binary};
 use parse_error::annotate_parse_error;
 use static_require_transform::transform_static_literal_requires;
+pub(super) use walk::collect_modules;
 use wasm_asset::{is_wasm_asset, synthesize_wasm_module};
 
 const MAX_CROSS_MODULE_INLINE_PRIOR_MODULES: usize = 128;
-
-/// Collect all modules to compile (transitive closure of imports)
-pub(super) fn collect_modules(
-    entry_path: &PathBuf,
-    ctx: &mut CompilationContext,
-    visited: &mut HashSet<PathBuf>,
-    format: OutputFormat,
-    target: Option<&str>,
-    next_class_id: &mut perry_hir::ClassId,
-    skip_transforms: bool,
-    progress: &VerboseProgress,
-    mut parse_cache: Option<&mut ParseCache>,
-) -> Result<()> {
-    let mut states: HashMap<PathBuf, VisitState> = HashMap::new();
-    let mut stack = vec![WorkFrame::Enter(entry_path.clone())];
-    // Next.js wall 54 (part 2): a standalone `server.js` loads its page, route,
-    // and turbopack chunk modules from `<entry_dir>/.next/server/**` by a path
-    // computed at request time (`require(getPagePath(...))`, turbopack
-    // `R.c("chunkpath")`) — never via a static `import`/`require` literal — so
-    // the import walk below never reaches them and they would not be AOT
-    // compiled. Seed every `.next/server/**/*.js` file as an additional root so
-    // each compiles natively and self-registers under its absolute path (see
-    // cjs_wrap `__perry_register_path_module`), letting the runtime
-    // `require(absolutePath)` resolve it. Detected only when the entry sits next
-    // to a `.next/server` directory (a Next.js standalone bundle).
-    if let Some(entry_dir) = entry_path.parent() {
-        let next_server_dir = entry_dir.join(".next").join("server");
-        if next_server_dir.is_dir() {
-            let mut next_js_files = Vec::new();
-            collect_js_files_recursive(&next_server_dir, &mut next_js_files);
-            if !next_js_files.is_empty() {
-                if matches!(format, OutputFormat::Text) {
-                    println!(
-                        "Next.js standalone: discovered {} runtime module(s) under {}",
-                        next_js_files.len(),
-                        next_server_dir.display()
-                    );
-                }
-                // Push after the entry so the entry is processed first; order
-                // among the discovered files does not matter (the walk dedups).
-                for f in next_js_files {
-                    stack.push(WorkFrame::Enter(f));
-                }
-            }
-        }
-    }
-    while let Some(frame) = stack.pop() {
-        match frame {
-            WorkFrame::Enter(next_path) => {
-                let canonical = next_path.canonicalize().map_err(|e| {
-                    anyhow!("Failed to canonicalize {}: {}", next_path.display(), e)
-                })?;
-
-                if matches!(
-                    states.get(&canonical),
-                    Some(VisitState::InProgress | VisitState::Done)
-                ) {
-                    continue;
-                }
-                if visited.contains(&canonical) {
-                    states.insert(canonical, VisitState::Done);
-                    continue;
-                }
-
-                states.insert(canonical.clone(), VisitState::InProgress);
-                visited.insert(canonical.clone());
-                progress.record(ProgressSnapshot {
-                    stage: "collect-module",
-                    module_path: Some(&canonical),
-                    visited: Some(visited.len()),
-                    collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
-                    ..Default::default()
-                });
-
-                let discovered = collect_module_one(
-                    &next_path,
-                    canonical.clone(),
-                    ctx,
-                    visited,
-                    format,
-                    target,
-                    next_class_id,
-                    progress,
-                    parse_cache.as_deref_mut(),
-                )?;
-
-                if let Some(prepared) = discovered.finish {
-                    stack.push(WorkFrame::Finish(prepared));
-                } else {
-                    states.insert(canonical, VisitState::Done);
-                }
-                for child in discovered.children.into_iter().rev() {
-                    stack.push(WorkFrame::Enter(child));
-                }
-            }
-            WorkFrame::Finish(prepared) => {
-                let canonical = prepared.canonical.clone();
-                collect_module_finish(prepared, ctx, visited, target, skip_transforms, progress)?;
-                states.insert(canonical, VisitState::Done);
-            }
-        }
-    }
-    Ok(())
-}
 
 enum VisitState {
     InProgress,
@@ -180,6 +79,57 @@ struct PreparedModule {
     canonical: PathBuf,
     module_name: String,
     hir_module: perry_hir::Module,
+}
+
+/// Return imports that request Bun's file loader:
+/// `import path from "./asset.bin" with { type: "file" }`.
+fn file_loader_import_sources(module: &swc_ecma_ast::Module) -> HashSet<String> {
+    use swc_ecma_ast::{Expr, Lit, ModuleDecl, ModuleItem, Prop, PropName, PropOrSpread};
+
+    module
+        .body
+        .iter()
+        .filter_map(|item| {
+            let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+                return None;
+            };
+            let attributes = import.with.as_deref()?;
+            let uses_file_loader = attributes.props.iter().any(|prop| {
+                let PropOrSpread::Prop(prop) = prop else {
+                    return false;
+                };
+                let Prop::KeyValue(property) = prop.as_ref() else {
+                    return false;
+                };
+                let is_type = match &property.key {
+                    PropName::Ident(name) => name.sym == *"type",
+                    PropName::Str(name) => name.value == *"type",
+                    _ => false,
+                };
+                is_type
+                    && matches!(
+                        property.value.as_ref(),
+                        Expr::Lit(Lit::Str(value)) if value.value == *"file"
+                    )
+            });
+            uses_file_loader.then(|| import.src.value.as_str().unwrap_or("").to_string())
+        })
+        .collect()
+}
+
+/// Produce a stable virtual asset name without leaking an absolute source path.
+fn imported_file_asset_name(path: &Path) -> String {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in normalized.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("asset.bin");
+    format!("__perry_imports/{hash:016x}/{filename}")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -204,6 +154,18 @@ fn collect_module_one(
     // default export is the file contents as a JS string (see the text branch
     // below, mirroring the JSON-module path).
     let is_text_asset = is_recognized_text_asset(&canonical);
+    // Bun's `{ type: "file" }` loader exposes a virtual path string while
+    // keeping the imported bytes out of the TypeScript parser. The importer
+    // registers this canonical path before the child frame is visited.
+    let imported_file_asset = ctx
+        .file_loader_asset_paths
+        .contains(&canonical)
+        .then(|| {
+            ctx.embedded_assets
+                .iter()
+                .find_map(|(name, path)| (path == &canonical).then(|| name.clone()))
+        })
+        .flatten();
     // #5234: `.wasm` is binary, so collect it through an executable synthetic
     // module instead of the UTF-8 source reader.
     let is_wasm = is_wasm_asset(&canonical);
@@ -353,14 +315,30 @@ fn collect_module_one(
     // #5234: synthesize a TypeScript adapter that embeds and instantiates the
     // binary at module initialization, then feed it through the normal native
     // module pipeline used by JSON and text assets.
-    let raw_source = if is_wasm {
-        let display_name = canonical
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("module.wasm");
+    let raw_source = if let Some(asset_name) = &imported_file_asset {
+        let virtual_path = format!("$perryfs/{asset_name}");
+        let literal = serde_json::to_string(&virtual_path).map_err(|e| {
+            anyhow!(
+                "Failed to encode imported file asset path {}: {}",
+                canonical.display(),
+                e
+            )
+        })?;
+        format!("export default {literal};\n")
+    } else if is_wasm {
         let bytes = fs::read(&canonical)
             .map_err(|e| anyhow!("Failed to read {}: {}", canonical.display(), e))?;
-        synthesize_wasm_module(&bytes, display_name).source
+        let asset_name = imported_file_asset_name(&canonical);
+        if !ctx
+            .embedded_assets
+            .iter()
+            .any(|(_, path)| path == &canonical)
+        {
+            ctx.embedded_assets
+                .push((asset_name.clone(), canonical.clone()));
+        }
+        let virtual_path = format!("$perryfs/{asset_name}");
+        synthesize_wasm_module(&bytes, &virtual_path).source
     } else {
         // It's a TypeScript (or synthetic JSON/text) file to compile natively.
         refuse_node_addon_binary(&canonical)?;
@@ -404,7 +382,7 @@ fn collect_module_one(
     } else {
         raw_source
     };
-    if is_in_compiled_pkg {
+    if is_in_compiled_pkg && !ctx.aot_discovered_modules.contains(&canonical) {
         refuse_compile_package_native_addon(ctx, &canonical)?;
     }
 
@@ -534,6 +512,7 @@ fn collect_module_one(
             }
         },
     };
+    let file_loader_sources = file_loader_import_sources(ast_module);
     let source_file_path = canonical.to_string_lossy().to_string();
 
     // If type checking is enabled, resolve types from tsgo before lowering
@@ -1067,6 +1046,7 @@ fn collect_module_one(
         if import.type_only {
             continue;
         }
+        let uses_file_loader = file_loader_sources.contains(&import.source);
         progress.record(ProgressSnapshot {
             stage: "resolve-import",
             module_path: Some(&canonical),
@@ -1258,6 +1238,17 @@ fn collect_module_one(
         {
             let resolved_path = resolved.canonical_path;
             let source_path = resolved.source_path;
+            if uses_file_loader {
+                let name = imported_file_asset_name(&resolved_path);
+                ctx.file_loader_asset_paths.insert(resolved_path.clone());
+                if !ctx
+                    .embedded_assets
+                    .iter()
+                    .any(|(_, path)| path == &resolved_path)
+                {
+                    ctx.embedded_assets.push((name, resolved_path.clone()));
+                }
+            }
             let kind = if resolved.kind == ModuleKind::Interpreted
                 && !is_in_perry_native_package(&resolved_path)
                 && !is_declaration_file(&resolved_path)

--- a/crates/perry/src/commands/compile/collect_modules/discovery.rs
+++ b/crates/perry/src/commands/compile/collect_modules/discovery.rs
@@ -49,7 +49,13 @@ pub(crate) fn is_nextjs_runtime_module(path: &Path) -> bool {
 pub(super) fn aot_promotion_is_authorized(resolved_path: &Path, ctx: &CompilationContext) -> bool {
     super::super::audit_manifest::package_name_for_path(&resolved_path.to_string_lossy())
         .is_none_or(|package| {
-            ctx.compile_packages.contains(&package)
-                && super::super::allowlist_matches(&package, &ctx.allow_compile_packages)
+            (ctx.compile_packages.contains(&package)
+                && super::super::allowlist_matches(&package, &ctx.allow_compile_packages))
+                // Automatic whole-package routing deliberately omits Node
+                // native addons, but a package can expose a pure JS/TS helper
+                // subpath. A static edge to that exact file is safe to
+                // AOT-promote; collection still rejects any `.node` file it
+                // actually reaches.
+                || ctx.auto_skipped_node_addon_packages.contains(&package)
         })
 }

--- a/crates/perry/src/commands/compile/collect_modules/native_addon.rs
+++ b/crates/perry/src/commands/compile/collect_modules/native_addon.rs
@@ -76,6 +76,22 @@ fn find_node_addon_file(dir: &std::path::Path, max_depth: usize) -> Option<PathB
 }
 
 fn node_addon_marker(package_root: &std::path::Path) -> Option<(&'static str, String)> {
+    if let Some(marker) = wildcard_node_addon_marker(package_root) {
+        return Some(marker);
+    }
+    if let Some(node_file) = find_node_addon_file(package_root, 5) {
+        return Some(("*.node", node_file.display().to_string()));
+    }
+    None
+}
+
+/// Cheap preflight used while expanding a wildcard across an entire install.
+/// Reading package-level markers is bounded; recursively walking every file in
+/// thousands of pure JS/TS packages would make source-first startup needlessly
+/// expensive. A sidecar package containing a root-level `.node` file is still
+/// detected, while the full guard retains its depth-five scan for packages
+/// that are actually selected explicitly.
+fn wildcard_node_addon_marker(package_root: &std::path::Path) -> Option<(&'static str, String)> {
     let binding_gyp = package_root.join("binding.gyp");
     if binding_gyp.exists() {
         return Some(("binding.gyp", binding_gyp.display().to_string()));
@@ -107,10 +123,21 @@ fn node_addon_marker(package_root: &std::path::Path) -> Option<(&'static str, St
             }
         }
     }
-    if let Some(node_file) = find_node_addon_file(package_root, 5) {
+    if let Some(node_file) = find_node_addon_file(package_root, 1) {
         return Some(("*.node", node_file.display().to_string()));
     }
     None
+}
+
+/// Whether wildcard/auto `compilePackages` routing should leave this package
+/// off the AOT path. Exact package opt-ins are still checked by
+/// `refuse_compile_package_native_addon` and remain hard errors; this helper is
+/// for broad automatic selection, where a package may be an optional
+/// try/catch-guarded accelerator such as `msgpackr-extract`.
+pub(in crate::commands::compile) fn package_has_unsupported_node_addon(
+    package_root: &std::path::Path,
+) -> bool {
+    !has_perry_native_library(package_root) && wildcard_node_addon_marker(package_root).is_some()
 }
 
 fn package_json_dependency_uses_native_addon_loader(

--- a/crates/perry/src/commands/compile/collect_modules/tests.rs
+++ b/crates/perry/src/commands/compile/collect_modules/tests.rs
@@ -3,7 +3,8 @@
 
 use super::{
     collect_js_module_imports, collect_modules, env_defines_for_lowering,
-    expand_dynamic_import_glob, refuse_compile_package_native_addon,
+    expand_dynamic_import_glob, package_has_unsupported_node_addon,
+    refuse_compile_package_native_addon,
 };
 use crate::commands::compile::{CompilationContext, DefineValue};
 use crate::commands::progress::VerboseProgress;
@@ -544,6 +545,120 @@ fn compile_package_with_binding_gyp_is_rejected() {
         },
         "binding.gyp",
     );
+}
+
+#[test]
+fn file_loader_import_registers_binary_asset_without_utf8_decoding() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let asset = root.join("tone.mp3");
+    let entry = root.join("entry.ts");
+    std::fs::write(&asset, [0xff, 0xfb, 0x90, 0x64, 0x00]).expect("write binary asset");
+    std::fs::write(
+        &entry,
+        r#"
+import tone from "./tone.mp3" with { type: "file" };
+console.log(tone);
+"#,
+    )
+    .expect("write entry");
+
+    let mut ctx = CompilationContext::new(root.to_path_buf());
+    ctx.entry_canonical = Some(entry.canonicalize().unwrap());
+    let mut visited = HashSet::new();
+    let mut next_class_id: perry_hir::ClassId = 1;
+    let progress = VerboseProgress::new(OutputFormat::Text, 0);
+
+    collect_modules(
+        &entry,
+        &mut ctx,
+        &mut visited,
+        OutputFormat::Text,
+        None,
+        &mut next_class_id,
+        false,
+        &progress,
+        None,
+    )
+    .expect("collect modules");
+
+    let canonical_asset = asset.canonicalize().unwrap();
+    let (name, path) = ctx.embedded_assets.first().expect("registered file asset");
+    assert_eq!(path, &canonical_asset);
+    assert!(name.starts_with("__perry_imports/"));
+    assert!(name.ends_with("/tone.mp3"));
+    assert!(ctx.native_modules.contains_key(&canonical_asset));
+}
+
+#[test]
+fn wildcard_preflight_skips_node_native_addon_package() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_compile_package_fixture(root, "optional-accelerator", "");
+    let package = root.join("node_modules/optional-accelerator");
+    std::fs::write(package.join("binding.gyp"), "{}\n").expect("write binding.gyp");
+
+    assert!(package_has_unsupported_node_addon(&package));
+}
+
+#[test]
+fn static_pure_js_subpath_of_auto_skipped_native_addon_is_aot_compiled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let package = root.join("node_modules/native-with-wrapper");
+    std::fs::create_dir_all(&package).expect("create package");
+    std::fs::write(
+        package.join("package.json"),
+        r#"{
+  "name": "native-with-wrapper",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": { "./wrapper": "./wrapper.js" }
+}"#,
+    )
+    .expect("write package json");
+    std::fs::write(package.join("binding.gyp"), "{}\n").expect("write binding.gyp");
+    let wrapper = package.join("wrapper.js");
+    std::fs::write(
+        &wrapper,
+        "export function createWrapper(binding) { return binding; }\n",
+    )
+    .expect("write wrapper");
+    let entry = root.join("entry.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { createWrapper } from "native-with-wrapper/wrapper";
+console.log(createWrapper({ ok: true }).ok);
+"#,
+    )
+    .expect("write entry");
+
+    let mut ctx = CompilationContext::new(root.to_path_buf());
+    ctx.auto_skipped_node_addon_packages
+        .insert("native-with-wrapper".to_string());
+    ctx.entry_canonical = Some(entry.canonicalize().unwrap());
+    let mut visited = HashSet::new();
+    let mut next_class_id: perry_hir::ClassId = 1;
+    let progress = VerboseProgress::new(OutputFormat::Text, 0);
+
+    collect_modules(
+        &entry,
+        &mut ctx,
+        &mut visited,
+        OutputFormat::Text,
+        None,
+        &mut next_class_id,
+        false,
+        &progress,
+        None,
+    )
+    .expect("collect pure wrapper subpath");
+
+    let canonical_wrapper = wrapper.canonicalize().unwrap();
+    assert!(ctx.aot_discovered_modules.contains(&canonical_wrapper));
+    assert!(ctx.native_modules.contains_key(&canonical_wrapper));
+    assert!(ctx.js_modules.is_empty());
 }
 
 #[test]

--- a/crates/perry/src/commands/compile/collect_modules/walk.rs
+++ b/crates/perry/src/commands/compile/collect_modules/walk.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+
+use super::*;
+
+/// Collect all modules to compile (transitive closure of imports).
+pub(crate) fn collect_modules(
+    entry_path: &PathBuf,
+    ctx: &mut CompilationContext,
+    visited: &mut HashSet<PathBuf>,
+    format: OutputFormat,
+    target: Option<&str>,
+    next_class_id: &mut perry_hir::ClassId,
+    skip_transforms: bool,
+    progress: &VerboseProgress,
+    mut parse_cache: Option<&mut ParseCache>,
+) -> Result<()> {
+    let mut states: HashMap<PathBuf, VisitState> = HashMap::new();
+    let mut stack = vec![WorkFrame::Enter(entry_path.clone())];
+    // Next.js wall 54 (part 2): a standalone `server.js` loads its page, route,
+    // and turbopack chunk modules from `<entry_dir>/.next/server/**` by a path
+    // computed at request time (`require(getPagePath(...))`, turbopack
+    // `R.c("chunkpath")`) — never via a static `import`/`require` literal — so
+    // the import walk below never reaches them and they would not be AOT
+    // compiled. Seed every `.next/server/**/*.js` file as an additional root so
+    // each compiles natively and self-registers under its absolute path (see
+    // cjs_wrap `__perry_register_path_module`), letting the runtime
+    // `require(absolutePath)` resolve it. Detected only when the entry sits next
+    // to a `.next/server` directory (a Next.js standalone bundle).
+    if let Some(entry_dir) = entry_path.parent() {
+        let next_server_dir = entry_dir.join(".next").join("server");
+        if next_server_dir.is_dir() {
+            let mut next_js_files = Vec::new();
+            collect_js_files_recursive(&next_server_dir, &mut next_js_files);
+            if !next_js_files.is_empty() {
+                if matches!(format, OutputFormat::Text) {
+                    println!(
+                        "Next.js standalone: discovered {} runtime module(s) under {}",
+                        next_js_files.len(),
+                        next_server_dir.display()
+                    );
+                }
+                // Push after the entry so the entry is processed first; order
+                // among the discovered files does not matter (the walk dedups).
+                for f in next_js_files {
+                    stack.push(WorkFrame::Enter(f));
+                }
+            }
+        }
+    }
+    while let Some(frame) = stack.pop() {
+        match frame {
+            WorkFrame::Enter(next_path) => {
+                let canonical = next_path.canonicalize().map_err(|e| {
+                    anyhow!("Failed to canonicalize {}: {}", next_path.display(), e)
+                })?;
+
+                if matches!(
+                    states.get(&canonical),
+                    Some(VisitState::InProgress | VisitState::Done)
+                ) {
+                    continue;
+                }
+                if visited.contains(&canonical) {
+                    states.insert(canonical, VisitState::Done);
+                    continue;
+                }
+
+                states.insert(canonical.clone(), VisitState::InProgress);
+                visited.insert(canonical.clone());
+                progress.record(ProgressSnapshot {
+                    stage: "collect-module",
+                    module_path: Some(&canonical),
+                    visited: Some(visited.len()),
+                    collected: Some(ctx.native_modules.len() + ctx.js_modules.len()),
+                    ..Default::default()
+                });
+
+                let discovered = collect_module_one(
+                    &next_path,
+                    canonical.clone(),
+                    ctx,
+                    visited,
+                    format,
+                    target,
+                    next_class_id,
+                    progress,
+                    parse_cache.as_deref_mut(),
+                )?;
+
+                if let Some(prepared) = discovered.finish {
+                    stack.push(WorkFrame::Finish(prepared));
+                } else {
+                    states.insert(canonical, VisitState::Done);
+                }
+                for child in discovered.children.into_iter().rev() {
+                    stack.push(WorkFrame::Enter(child));
+                }
+            }
+            WorkFrame::Finish(prepared) => {
+                let canonical = prepared.canonical.clone();
+                collect_module_finish(prepared, ctx, visited, target, skip_transforms, progress)?;
+                states.insert(canonical, VisitState::Done);
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/perry/src/commands/compile/collect_modules/wasm_asset.rs
+++ b/crates/perry/src/commands/compile/collect_modules/wasm_asset.rs
@@ -2,9 +2,9 @@
 //!
 //! A wasm file is binary, so it cannot enter the normal TypeScript source
 //! reader. We parse its export names and synthesize a small TypeScript adapter
-//! that embeds the bytes, instantiates the module during module initialization,
-//! and re-exports the live instance exports through Perry's normal module
-//! pipeline.
+//! that reads bytes from Perry's native embedded-asset registry, instantiates
+//! the module during module initialization, and re-exports the live instance
+//! exports through Perry's normal module pipeline.
 
 /// True when `path` is a `.wasm` file (case-insensitive extension).
 pub(crate) fn is_wasm_asset(path: &std::path::Path) -> bool {
@@ -160,20 +160,23 @@ pub(crate) struct WasmModuleSource {
 
 /// Build an executable TypeScript adapter for a `.wasm` import.
 ///
-/// The generated module uses Perry's compile-time `embedWasm` intrinsic, so
-/// the produced executable does not need the source wasm file at runtime. The
-/// instance exports object is also the default export. Wasm names that cannot
-/// be represented as static ESM names remain available through bracket access
-/// on that default object.
-pub(crate) fn synthesize_wasm_module(bytes: &[u8], display_name: &str) -> WasmModuleSource {
+/// The caller registers the wasm file in Perry's embedded-asset table and
+/// passes its `$perryfs/...` path here. Keeping the bytes out of HIR avoids a
+/// million-element array literal (and an enormous LLVM function) for parser
+/// wasm files. The instance exports object is also the default export. Wasm
+/// names that cannot be represented as static ESM names remain available
+/// through bracket access on that default object.
+pub(crate) fn synthesize_wasm_module(bytes: &[u8], embedded_path: &str) -> WasmModuleSource {
     let names = parse_wasm_exports(bytes)
         .map(|exports| exports.names)
         .unwrap_or_default();
     let imports = parse_wasm_imports(bytes).unwrap_or_default();
-    let path_lit = serde_json::to_string(display_name).unwrap_or_else(|_| "\"module.wasm\"".into());
+    let path_lit =
+        serde_json::to_string(embedded_path).unwrap_or_else(|_| "\"$perryfs/module.wasm\"".into());
 
     let mut source = String::new();
     source.push_str("// #5234: synthesized executable adapter for a .wasm import.\n");
+    source.push_str("import { readEmbedded as __perry_read_embedded } from \"perry\";\n");
     let mut import_groups: std::collections::BTreeMap<String, Vec<(String, String)>> =
         std::collections::BTreeMap::new();
     for (index, import) in imports.iter().enumerate() {
@@ -193,7 +196,7 @@ pub(crate) fn synthesize_wasm_module(bytes: &[u8], display_name: &str) -> WasmMo
     }
     if import_groups.is_empty() {
         source.push_str(&format!(
-            "const __perry_wasm_result = WebAssembly.instantiate(embedWasm({path_lit}));\n"
+            "const __perry_wasm_result = WebAssembly.instantiate(__perry_read_embedded({path_lit}));\n"
         ));
     } else {
         source.push_str("const __perry_wasm_imports = {\n");
@@ -208,7 +211,7 @@ pub(crate) fn synthesize_wasm_module(bytes: &[u8], display_name: &str) -> WasmMo
         }
         source.push_str("};\n");
         source.push_str(&format!(
-            "const __perry_wasm_result = WebAssembly.instantiate(embedWasm({path_lit}), __perry_wasm_imports);\n"
+            "const __perry_wasm_result = WebAssembly.instantiate(__perry_read_embedded({path_lit}), __perry_wasm_imports);\n"
         ));
     }
     source.push_str("const __perry_wasm_exports = __perry_wasm_result.instance.exports;\n");
@@ -266,8 +269,10 @@ mod tests {
 
     #[test]
     fn synthesizes_instantiated_named_and_default_exports() {
-        let source = synthesize_wasm_module(&add_wasm(), "add.wasm").source;
-        assert!(source.contains("WebAssembly.instantiate(embedWasm(\"add.wasm\"))"));
+        let source = synthesize_wasm_module(&add_wasm(), "$perryfs/add.wasm").source;
+        assert!(source.contains("readEmbedded as __perry_read_embedded"));
+        assert!(source
+            .contains("WebAssembly.instantiate(__perry_read_embedded(\"$perryfs/add.wasm\"))"));
         assert!(source.contains("as add"));
         assert!(source.contains("export default __perry_wasm_exports"));
     }
@@ -282,12 +287,12 @@ mod tests {
                 name: "inc".to_string(),
             }])
         );
-        let source = synthesize_wasm_module(&bytes, "imported.wasm").source;
+        let source = synthesize_wasm_module(&bytes, "$perryfs/imported.wasm").source;
         assert!(source.contains("import { inc as __perry_wasm_import_0 } from \"./glue\""));
         assert!(source.contains("\"./glue\": {"));
         assert!(source.contains("\"inc\": __perry_wasm_import_0"));
         assert!(source.contains(
-            "WebAssembly.instantiate(embedWasm(\"imported.wasm\"), __perry_wasm_imports)"
+            "WebAssembly.instantiate(__perry_read_embedded(\"$perryfs/imported.wasm\"), __perry_wasm_imports)"
         ));
         assert!(source.contains("as call"));
     }
@@ -295,10 +300,10 @@ mod tests {
     #[test]
     fn malformed_header_still_instantiates_for_a_host_compile_error() {
         assert!(parse_wasm_exports(b"not a wasm file at all").is_none());
-        let source = synthesize_wasm_module(b"garbage", "bad.wasm").source;
+        let source = synthesize_wasm_module(b"garbage", "$perryfs/bad.wasm").source;
         assert!(source.contains("WebAssembly.instantiate"));
         assert!(source.contains("export default __perry_wasm_exports"));
-        assert!(!source.contains(" as "));
+        assert!(!source.contains("__perry_wasm_export_"));
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/embed.rs
+++ b/crates/perry/src/commands/compile/embed.rs
@@ -20,13 +20,10 @@
 //! and it keeps binary assets byte-exact. The runtime keeps `&'static` slices
 //! into the resulting `.rodata` (no copy).
 //!
-//! Embedding runs the host `cc` over the generated translation unit and links
-//! its `.o` into the executable, so it is supported only on Unix-like hosts
-//! (macOS/Linux). On Windows Perry links with MSVC `link.exe`, which neither
-//! consumes a `cc`-produced object nor supports `__attribute__((constructor))`
-//! / `.incbin`; [`generate_embedded_asset_object`] fails loudly there rather
-//! than emitting an object that silently won't link. Cross-target / Windows
-//! embedding is a tracked follow-up to #5731.
+//! Embedding runs the host C compiler over the generated translation unit and
+//! links its object into the executable. Unix-like hosts use `cc` plus a GNU
+//! constructor; Windows uses Perry's discovered LLVM clang to emit native COFF
+//! and registers through MSVC's `.CRT$XCU` initializer section.
 
 use anyhow::{anyhow, Result};
 use std::fmt::Write as _;
@@ -250,21 +247,15 @@ pub(super) fn generate_embedded_asset_object(
     if assets.is_empty() {
         return Ok(None);
     }
-    // The generated object is compiled with `cc` and linked into the executable.
-    // On a Windows host Perry links with MSVC `link.exe`, which is ABI-
-    // incompatible with a `cc`-produced object (and `cl.exe` supports neither
-    // `__attribute__((constructor))` nor `.incbin`). Fail loudly here rather
-    // than emit an object that silently won't link — Windows / cross-target
-    // embedding is a tracked follow-up to #5731.
-    if cfg!(windows) {
-        return Err(anyhow!(
-            "`--embed` is currently supported only on Unix-like hosts (macOS/Linux); \
-             Windows embedding is a follow-up to #5731"
-        ));
-    }
-
+    // Match the host linker: `cc` emits Mach-O/ELF, while LLVM clang emits
+    // MSVC-compatible COFF on Windows. Both integrated assemblers support the
+    // `.incbin` payload used below.
     let c_path = output_dir.join("__perry_embedded_assets.c");
-    let obj_path = output_dir.join("__perry_embedded_assets.o");
+    let obj_path = output_dir.join(if cfg!(windows) {
+        "__perry_embedded_assets.obj"
+    } else {
+        "__perry_embedded_assets.o"
+    });
 
     // Mach-O prefixes C symbols with `_` and names its read-only-const section
     // `__TEXT,__const`; ELF uses the bare symbol and `.rodata`. Perry runs on
@@ -273,6 +264,8 @@ pub(super) fn generate_embedded_asset_object(
     let sym_prefix = if cfg!(target_os = "macos") { "_" } else { "" };
     let rodata_section = if cfg!(target_os = "macos") {
         "__TEXT,__const"
+    } else if cfg!(windows) {
+        ".rdata,\"dr\""
     } else {
         ".rodata"
     };
@@ -328,10 +321,19 @@ pub(super) fn generate_embedded_asset_object(
         writeln!(c, "extern const char PERRY_ASSET_END_{idx}[];").ok();
     }
 
-    // Constructor priority 101: runs before `main`'s `js_runtime_init`, so the
-    // registry is populated by the time any user code or fs read consults it.
-    c.push_str("__attribute__((constructor(101)))\n");
-    c.push_str("static void perry_register_embedded_assets(void) {\n");
+    // Register before `main`'s `js_runtime_init`. Unix hosts use a priority
+    // constructor; Windows uses the CRT's user-initializer range.
+    if cfg!(windows) {
+        c.push_str("static void __cdecl perry_register_embedded_assets(void);\n");
+        c.push_str("typedef void (__cdecl *perry_embedded_ctor_fn)(void);\n");
+        c.push_str("#pragma section(\".CRT$XCU\", read)\n");
+        c.push_str("#pragma comment(linker, \"/include:PERRY_EMBEDDED_ASSETS_CTOR\")\n");
+        c.push_str("__declspec(allocate(\".CRT$XCU\")) perry_embedded_ctor_fn PERRY_EMBEDDED_ASSETS_CTOR = perry_register_embedded_assets;\n");
+        c.push_str("static void __cdecl perry_register_embedded_assets(void) {\n");
+    } else {
+        c.push_str("__attribute__((constructor(101)))\n");
+        c.push_str("static void perry_register_embedded_assets(void) {\n");
+    }
     for idx in 0..assets.len() {
         writeln!(
             c,
@@ -343,17 +345,34 @@ pub(super) fn generate_embedded_asset_object(
 
     fs::write(&c_path, &c)?;
 
-    let status = Command::new("cc")
+    let compiler = if cfg!(windows) {
+        perry_codegen::linker::find_clang().ok_or_else(|| {
+            anyhow!(
+                "clang is required to embed assets on Windows; install LLVM or set \
+                 PERRY_LLVM_CLANG to a clang 22 executable"
+            )
+        })?
+    } else {
+        PathBuf::from("cc")
+    };
+    let status = Command::new(&compiler)
         .arg("-c")
         .arg(&c_path)
         .arg("-O0")
         .arg("-o")
         .arg(&obj_path)
         .status()
-        .map_err(|e| anyhow!("failed to invoke cc for embedded assets: {}", e))?;
+        .map_err(|e| {
+            anyhow!(
+                "failed to invoke {} for embedded assets: {}",
+                compiler.display(),
+                e
+            )
+        })?;
     if !status.success() {
         return Err(anyhow!(
-            "cc failed to compile embedded asset table ({})",
+            "{} failed to compile embedded asset table ({})",
+            compiler.display(),
             c_path.display()
         ));
     }

--- a/crates/perry/src/commands/compile/helpers.rs
+++ b/crates/perry/src/commands/compile/helpers.rs
@@ -98,20 +98,17 @@ pub(crate) fn is_windows_reserved_file_stem(stem: &str) -> bool {
 
 pub(crate) fn canonical_class_source_prefix(
     class: &perry_hir::Class,
-    class_canonical_path: &HashMap<perry_hir::ClassId, (String, String)>,
+    class_canonical_path: &HashMap<usize, String>,
     project_root: &Path,
     fallback_prefix: &str,
 ) -> String {
-    // Issue #5987: `ClassId` is meant to be globally unique, but a large
-    // multi-module compile can still produce a collision (two unrelated
-    // classes assigned the same id). Only trust the recorded path if its
-    // class NAME also matches this class — a mismatch means the id
-    // collided with some other class, and `fallback_prefix` (derived from
-    // the caller's own already-verified origin lookup) is reliable.
+    // Large cached/parallel source graphs can reuse a ClassId. Key canonical
+    // provenance by the stable address of the HIR class stored in
+    // `native_modules` instead: even two platform variants with the same id
+    // AND name (OpenTUI's node/bun BoxRenderable classes) remain distinct.
     class_canonical_path
-        .get(&class.id)
-        .filter(|(_, name)| name == &class.name)
-        .map(|(path, _)| compute_module_prefix(path, project_root))
+        .get(&(class as *const perry_hir::Class as usize))
+        .map(|path| compute_module_prefix(path, project_root))
         .unwrap_or_else(|| fallback_prefix.to_string())
 }
 
@@ -297,11 +294,8 @@ mod tests {
         let project_root = PathBuf::from("/repo");
         let mut class_canonical_path = HashMap::new();
         class_canonical_path.insert(
-            class.id,
-            (
-                "/repo/node_modules/rxjs/src/internal/Observable.ts".to_string(),
-                "Observable".to_string(),
-            ),
+            &class as *const perry_hir::Class as usize,
+            "/repo/node_modules/rxjs/src/internal/Observable.ts".to_string(),
         );
 
         assert_eq!(
@@ -316,12 +310,9 @@ mod tests {
     }
 
     #[test]
-    fn canonical_class_source_prefix_falls_back_on_id_collision() {
-        // Issue #5987: a `ClassId` collision (two unrelated classes assigned
-        // the same id) must not silently misattribute the wrong module —
-        // the recorded entry's name has to match this class's own name, or
-        // the caller's fallback (already verified correct by the caller)
-        // wins instead.
+    fn canonical_class_source_prefix_falls_back_on_identity_collision() {
+        // A cached ClassId collision must not silently misattribute the class,
+        // even when both platform variants also share the same class name.
         let class = perry_hir::Class {
             id: 7,
             name: "ClientAbort".to_string(),
@@ -350,14 +341,15 @@ mod tests {
         };
         let project_root = PathBuf::from("/repo");
         let mut class_canonical_path = HashMap::new();
-        // Same id (7), but recorded for a DIFFERENT class ("SchemaAST") —
-        // simulates an id collision from an unrelated module.
+        let colliding_class = perry_hir::Class {
+            name: "ClientAbort".to_string(),
+            ..class.clone()
+        };
+        // Same id AND name, but a distinct HIR class object. This is the
+        // platform-sibling collision that an id/name key cannot distinguish.
         class_canonical_path.insert(
-            class.id,
-            (
-                "/repo/node_modules/effect/src/SchemaAST.ts".to_string(),
-                "SchemaAST".to_string(),
-            ),
+            &colliding_class as *const perry_hir::Class as usize,
+            "/repo/node_modules/opentui/chunk-bun.js".to_string(),
         );
 
         assert_eq!(
@@ -368,8 +360,7 @@ mod tests {
                 "node_modules_effect_src_unstable_rpc_RpcSchema_ts",
             ),
             "node_modules_effect_src_unstable_rpc_RpcSchema_ts",
-            "name mismatch on the ClassId entry must fall back to the caller's \
-             already-verified prefix, not the colliding entry's path"
+            "a same-id, same-name class must not steal this class's provenance"
         );
     }
 

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -766,10 +766,21 @@ pub(super) fn apply_pkg_and_toml_config(
         .filter_map(|p| p.strip_suffix("/*").map(|s| s.to_string()))
         .collect();
     if has_universal || !scope_wildcards.is_empty() {
-        let installed = super::resolve::enumerate_installed_packages(project_root);
+        // Preserve exact entries when they are combined with a wildcard. An
+        // exact opt-in must still receive the native-addon hard error; only
+        // packages selected by broad automatic routing are eligible for the
+        // safe skip below.
+        let exact_compile_packages: std::collections::HashSet<String> = ctx
+            .compile_packages
+            .iter()
+            .filter(|name| *name != "*" && !name.ends_with("/*"))
+            .cloned()
+            .collect();
+        let installed = super::resolve::enumerate_installed_package_roots(project_root);
         let mut added = 0usize;
         let mut skipped_native = 0usize;
-        for name in installed {
+        let mut skipped_node_addons = 0usize;
+        for (name, roots) in installed {
             let matches = has_universal
                 || scope_wildcards.iter().any(|scope| {
                     name.strip_prefix(scope.as_str())
@@ -797,6 +808,20 @@ pub(super) fn apply_pkg_and_toml_config(
                 skipped_native += 1;
                 continue;
             }
+            // A wildcard means "compile all usable JS/TS source", not "force
+            // Node native addons through a compiler that cannot host N-API".
+            // Optional guarded accelerators stay off whole-package routing;
+            // statically imported pure source subpaths may still be promoted,
+            // while an actual `.node` edge remains a hard error.
+            if !exact_compile_packages.contains(&name)
+                && roots
+                    .iter()
+                    .any(|root| super::collect_modules::package_has_unsupported_node_addon(root))
+            {
+                ctx.auto_skipped_node_addon_packages.insert(name);
+                skipped_node_addons += 1;
+                continue;
+            }
             if ctx.compile_packages.insert(name) {
                 added += 1;
             }
@@ -814,8 +839,11 @@ pub(super) fn apply_pkg_and_toml_config(
         // package(s)" line purely because the default now injects `"*"`
         // internally, making an additive default non-additive for the stdout
         // of every existing build.
-        let report_expansion =
-            should_report_wildcard_expansion(compile_packages_auto_default, added, skipped_native);
+        let report_expansion = should_report_wildcard_expansion(
+            compile_packages_auto_default,
+            added,
+            skipped_native + skipped_node_addons,
+        );
         if matches!(format, OutputFormat::Text) && report_expansion {
             println!(
                 "  Compile package wildcard: expanded to {} installed package(s)",
@@ -826,6 +854,12 @@ pub(super) fn apply_pkg_and_toml_config(
                     "  Compile package wildcard: kept {} package(s) on Perry's \
                      native shim (list explicitly to compile the real source)",
                     skipped_native
+                );
+            }
+            if skipped_node_addons > 0 {
+                println!(
+                    "  Compile package wildcard: left {} Node native-addon package(s) out of whole-package AOT routing (static pure-source subpaths can still compile; list explicitly for a hard error)",
+                    skipped_node_addons
                 );
             }
         }

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -330,7 +330,7 @@ pub(crate) fn build_and_run_link(
     let skip_runtime = (is_android || is_watchos || is_visionos)
         && (ctx.needs_ui || is_watchos)
         && find_ui_library(target).is_some();
-    let well_known_libs: Vec<PathBuf> = if prefer_well_known_before_stdlib {
+    let mut well_known_libs: Vec<PathBuf> = if prefer_well_known_before_stdlib {
         well_known_libs
             .iter()
             .map(|wk| {
@@ -389,46 +389,21 @@ pub(crate) fn build_and_run_link(
     } else {
         well_known_libs.to_vec()
     };
+    // Multiple specifiers can route to the same native archive (`http` and
+    // `https` both select perry_ext_http). Repeating it adds no symbols and on
+    // COFF can make lld-link choose a different duplicate COMDAT provider.
+    let mut seen_well_known = std::collections::HashSet::new();
+    well_known_libs.retain(|path| seen_well_known.insert(path.clone()));
     if !skip_runtime {
         if ctx.needs_stdlib || is_windows {
             // On Windows/MSVC, always try to link stdlib because codegen unconditionally
             // declares all stdlib extern functions, creating import references that MSVC
             // won't dead-strip. On macOS/Linux, the linker ignores unreferenced archives.
             if let Some(ref stdlib) = stdlib_lib {
-                // Windows: link the standalone perry_runtime.lib FIRST so
-                // its symbols win lld-link's /FORCE:MULTIPLE "first
-                // definition wins" rule over the perry-runtime copies
-                // *bundled* inside perry_stdlib.lib and the
-                // /WHOLEARCHIVE'd perry_ui_windows.lib. Auto-optimize
-                // refreshes perry-runtime + perry-stdlib but NOT
-                // perry-ui-windows, so the UI lib's bundled runtime is
-                // perpetually stale; the /WHOLEARCHIVE force-includes its
-                // js_* symbols, and without this the stale copy shadows a
-                // genuine runtime fix (e.g. the js_shadow_frame_pop bounds
-                // guard, #880) — the crash it fixes still fires because the
-                // guarded function never gets linked. The standalone
-                // runtime_lib is the canonical / auto-optimize-fresh
-                // source; making it authoritative on Windows matches every
-                // other platform (all of which already link runtime_lib).
-                //
-                // #5000: but the standalone runtime is built WITHOUT the
-                // `stdlib` feature, so it also defines the no-op
-                // `stdlib_stubs` symbols (js_fetch_with_options,
-                // js_stdlib_init_dispatch, js_ws_*, js_readline_*). Linked
-                // first, those stubs shadow perry-stdlib's REAL fetch /
-                // WebSocket / readline implementations — `fetch()` then
-                // silently no-ops and `response.json()` fails with "Invalid
-                // response handle". Localize exactly those stub symbols in a
-                // copy of the runtime archive so they no longer satisfy
-                // user-code references; lld-link resolves them from
-                // perry_stdlib.lib instead, while every other runtime symbol
-                // keeps its first-definition win. Non-fatal: falls back to the
-                // untouched runtime_lib if the LLVM archive tools are missing.
-                if is_windows {
-                    let runtime_for_link =
-                        localize_stdlib_stub_symbols_for_windows(runtime_lib, stdlib);
-                    cmd.arg(&runtime_for_link);
-                }
+                // COFF archives must have one authoritative Rust dependency
+                // graph. Put selected wrappers first, then let stdlib fill the
+                // unresolved surface. The stdlib staticlib already bundles
+                // perry-runtime, so Windows must not add it again.
                 if prefer_well_known_before_stdlib {
                     for wk in &well_known_libs {
                         cmd.arg(wk);
@@ -441,19 +416,25 @@ pub(crate) fn build_and_run_link(
                 // `_js_*` symbol gap that was just opened by stripping the
                 // corresponding feature from the perry-stdlib rebuild.
                 //
-                // In no-auto/fallback mode the full prebuilt stdlib may still
-                // contain method-value bridge objects that reference wrapper
-                // symbols (for example external net Socket helpers). Archives
-                // are scanned left-to-right, so repeat the well-known libs
-                // after stdlib as well: the first occurrence lets wrapper
-                // definitions win over duplicate bundled stdlib functions,
-                // and the second resolves stdlib bridge references.
-                for wk in &well_known_libs {
-                    cmd.arg(wk);
+                // Non-Windows archive linkers retain the historical repeat for
+                // stdlib bridge references. On Windows each wrapper appears
+                // exactly once; if there was no wrapper-first pass, put it here.
+                if !is_windows || !prefer_well_known_before_stdlib {
+                    for wk in &well_known_libs {
+                        cmd.arg(wk);
+                    }
                 }
                 // Also link runtime for symbols DCE'd from stdlib's bundled
                 // perry-runtime; on tier-3 it's first stripped of stdlib's objects.
-                if !is_android && !is_windows {
+                if !is_android && is_windows && ctx.needs_wasm_runtime {
+                    // The normal Windows link deliberately lets stdlib's
+                    // bundled runtime be authoritative. A wasm program's
+                    // on-demand runtime archive is the one exception: stdlib
+                    // is built without `wasm-host`, so append the feature-
+                    // augmented archive after stdlib to fill only the still-
+                    // unresolved `js_webassembly_*` surface.
+                    cmd.arg(runtime_lib);
+                } else if !is_android && !is_windows {
                     // #5000 (macOS/Linux): the standalone runtime archive is built
                     // WITHOUT the `stdlib` feature, so it also defines the no-op
                     // stdlib_stubs (js_fetch_with_options, js_headers_new,

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -37,11 +37,10 @@ use super::{
     find_geisterhand_ui, find_lld_link, find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe,
     find_perry_windows_sdk, find_stdlib_library, find_ui_library, find_visionos_swift_runtime,
     find_watchos_swift_runtime, is_android_target, is_native_windows_target, is_windows_target,
-    localize_stdlib_stub_symbols, localize_stdlib_stub_symbols_for_windows, rust_target_triple,
-    strip_bundled_runtime_from_well_known_lib, strip_bundled_shared_deps_from_well_known_lib,
-    strip_duplicate_objects_from_lib, strip_duplicate_objects_from_well_known_lib,
-    windows_pe_subsystem_flag, windows_subsystem_needs_ui, windows_target_arch, CompilationContext,
-    WindowsTargetArch,
+    localize_stdlib_stub_symbols, rust_target_triple, strip_bundled_runtime_from_well_known_lib,
+    strip_bundled_shared_deps_from_well_known_lib, strip_duplicate_objects_from_lib,
+    strip_duplicate_objects_from_well_known_lib, windows_pe_subsystem_flag,
+    windows_subsystem_needs_ui, windows_target_arch, CompilationContext, WindowsTargetArch,
 };
 
 mod build_and_run;

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -1148,6 +1148,10 @@ fn serialize_namespace_entry_kind(kind: &perry_codegen::NamespaceEntryKind, out:
             out.push_str("nested_ns:");
             out.push_str(source_prefix);
         }
+        perry_codegen::NamespaceEntryKind::NativeNamespace { specifier } => {
+            out.push_str("native_ns:");
+            out.push_str(specifier);
+        }
     }
 }
 /// On-disk per-module object cache at `<cache_dir>/objects/<target>/<hash:016x>.o`,

--- a/crates/perry/src/commands/compile/optimized_libs/no_auto.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/no_auto.rs
@@ -26,11 +26,13 @@ use super::super::{
 /// `libperry_runtime.a` is insufficient: `wasm-host` is deliberately kept out
 /// of perry-runtime's `default` feature set so non-wasm programs don't pay for
 /// wasmi. The no-auto path can't enable a cargo feature on an already-built
-/// archive, so it does a targeted rebuild of just `perry-runtime-static` with
-/// default features + `perry-runtime/wasm-host` into a dedicated target dir.
+/// archive, so it does a targeted rebuild with
+/// `perry-runtime/wasm-host` into a dedicated target dir.
 /// This is the same on-demand build pattern `build_missing_prebuilt_ext_lib`
-/// uses for CPU-only ext wrappers. `perry-wasm-host` has no tokio dep, so
-/// there is no #507 shared-tokio concern with the prebuilt stdlib.
+/// uses for CPU-only ext wrappers. On Windows the rebuilt runtime and stdlib
+/// must come from one Cargo graph: mixing a feature-augmented standalone
+/// runtime with the prebuilt stdlib splits process-global registries such as
+/// Buffer ownership across two runtime copies.
 pub(crate) fn resolve_no_auto_optimized_libs(
     ctx: &CompilationContext,
     target: Option<&str>,
@@ -47,16 +49,21 @@ pub(crate) fn resolve_no_auto_optimized_libs(
     };
     // Issue #76 — the prebuilt runtime is built WITHOUT `wasm-host` (kept
     // out of `default` to avoid wasmi bloat on non-wasm programs). When the
-    // program uses `WebAssembly.*`, rebuild just the runtime with the
-    // feature on so `js_webassembly_*` symbols are defined. The prebuilt
-    // stdlib is unaffected (wasm-host only adds a module to perry-runtime).
-    let runtime = if ctx.needs_wasm_runtime {
-        build_wasm_host_runtime(target, format, verbose)
+    // program uses `WebAssembly.*`, rebuild the runtime with the feature on so
+    // `js_webassembly_*` symbols are defined. Windows also rebuilds stdlib in
+    // that Cargo invocation so its bundled runtime shares the same global
+    // registries as the wasm-enabled runtime.
+    let (runtime, stdlib) = if ctx.needs_wasm_runtime {
+        match build_wasm_host_runtime(target, format, verbose) {
+            Some((runtime, stdlib)) => (Some(runtime), stdlib),
+            None => (None, None),
+        }
     } else {
-        None
+        (None, None)
     };
     OptimizedLibs {
         runtime,
+        stdlib,
         prefer_well_known_before_stdlib: !well_known_libs.is_empty(),
         well_known_libs,
         ..OptimizedLibs::empty()
@@ -65,16 +72,20 @@ pub(crate) fn resolve_no_auto_optimized_libs(
 
 /// Build `perry-runtime-static` with default features + `perry-runtime/wasm-host`
 /// into a dedicated target dir so the prebuilt `libperry_runtime.a` is not
-/// clobbered. Returns the path to the rebuilt archive, or `None` when there's
-/// no workspace source or the build fails (the caller falls back to the
-/// prebuilt runtime, which will fail to link with `_js_webassembly_*`
-/// undefined — the error message points the user at the cause).
+/// clobbered. Windows also builds `perry-stdlib-static` in the same graph and
+/// returns it as the authoritative archive. Returns `(runtime, stdlib)` or
+/// `None` when there's no workspace source or the build fails.
 fn build_wasm_host_runtime(
     target: Option<&str>,
     format: OutputFormat,
     verbose: u8,
-) -> Option<PathBuf> {
-    let workspace_root = find_perry_workspace_root()?;
+) -> Option<(PathBuf, Option<PathBuf>)> {
+    // Canonical Windows paths can carry a `\\?\` prefix. Cargo forwards an
+    // absolute verbatim `CARGO_TARGET_DIR` to cc-rs, where MSVC interprets the
+    // generated `\\?\...\mimalloc-static.cc` argument as `\mimalloc-static.cc`.
+    // Match the auto-optimize path: normalize the workspace and use a relative
+    // target-dir env value on Windows.
+    let workspace_root = cargo_target_dir_path(find_perry_workspace_root()?);
     let crate_dir = workspace_root.join("crates").join("perry-runtime-static");
     if !crate_dir.is_dir() {
         if matches!(format, OutputFormat::Text) && verbose > 0 {
@@ -87,26 +98,33 @@ fn build_wasm_host_runtime(
     }
 
     if matches!(format, OutputFormat::Text) {
-        println!("  wasm-host (no-auto): rebuilding perry-runtime-static with wasm-host feature");
+        println!("  wasm-host (no-auto): rebuilding runtime with wasm-host feature");
     }
 
     // Use a dedicated target dir so the prebuilt libperry_runtime.a in
     // target/release is not overwritten. Cargo's incremental cache makes
     // repeat builds a no-op.
-    let wasm_host_target_dir = workspace_root
-        .join("target")
-        .join("perry-wasm-host-runtime");
+    let relative_target_dir = PathBuf::from("target").join("perry-wasm-host-runtime");
+    let wasm_host_target_dir = cargo_target_dir_path(workspace_root.join(&relative_target_dir));
+    let cargo_target_dir = if cfg!(windows) {
+        relative_target_dir
+    } else {
+        wasm_host_target_dir.clone()
+    };
 
     let mut cargo_cmd = Command::new("cargo");
     cargo_cmd
         .current_dir(&workspace_root)
-        .env("CARGO_TARGET_DIR", &wasm_host_target_dir)
+        .env("CARGO_TARGET_DIR", &cargo_target_dir)
         .arg("build")
         .arg("--release")
         .arg("-p")
         .arg("perry-runtime-static")
         .arg("--features")
         .arg("perry-runtime/wasm-host");
+    if is_windows_target(target) {
+        cargo_cmd.arg("-p").arg("perry-stdlib-static");
+    }
     if let Some(triple) = rust_target_triple(target) {
         cargo_cmd.arg("--target").arg(triple);
     }
@@ -143,7 +161,7 @@ fn build_wasm_host_runtime(
         Ok(status) => {
             if matches!(format, OutputFormat::Text) {
                 eprintln!(
-                    "  wasm-host (no-auto): cargo build for perry-runtime-static failed ({status})"
+                    "  wasm-host (no-auto): cargo build for wasm-enabled archives failed ({status})"
                 );
             }
             return None;
@@ -165,18 +183,33 @@ fn build_wasm_host_runtime(
     if let Some(triple) = rust_target_triple(target) {
         release_dir = release_dir.join(triple);
     }
-    let built = release_dir.join("release").join(lib_name);
-    if built.exists() {
-        return Some(built);
+    let release_dir = release_dir.join("release");
+    let runtime = release_dir.join(lib_name);
+    if !runtime.exists() {
+        if matches!(format, OutputFormat::Text) && verbose > 0 {
+            eprintln!(
+                "  wasm-host (no-auto): cargo finished but {lib_name} was not produced at {}",
+                runtime.display()
+            );
+        }
+        return None;
     }
-
-    if matches!(format, OutputFormat::Text) && verbose > 0 {
-        eprintln!(
-            "  wasm-host (no-auto): cargo finished but {lib_name} was not produced at {}",
-            built.display()
-        );
-    }
-    None
+    let stdlib = if is_windows_target(target) {
+        let path = release_dir.join("perry_stdlib.lib");
+        if !path.exists() {
+            if matches!(format, OutputFormat::Text) && verbose > 0 {
+                eprintln!(
+                    "  wasm-host (no-auto): cargo finished but perry_stdlib.lib was not produced at {}",
+                    path.display()
+                );
+            }
+            return None;
+        }
+        Some(path)
+    } else {
+        None
+    };
+    Some((runtime, stdlib))
 }
 
 /// #2532 / #3954 — resolve the `perry-ext-*` staticlibs a program needs

--- a/crates/perry/src/commands/compile/parse_cache.rs
+++ b/crates/perry/src/commands/compile/parse_cache.rs
@@ -5,8 +5,9 @@
 //! re-parse is skipped when the source bytes haven't changed since the
 //! last call. Counters track hit / miss for diagnostics.
 //!
-//! Scope is strictly per-process: the cache lives for the duration of
-//! one `perry dev` invocation. `perry compile` never sees it.
+//! Scope is strictly per-process: `perry dev` retains one across rebuilds,
+//! while `perry compile` uses a build-scoped instance so its intentional
+//! cross-module metadata re-lowering pass can reuse the first pass's ASTs.
 
 use anyhow::{anyhow, Result};
 use std::collections::{HashMap, VecDeque};

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -313,8 +313,21 @@ fn is_compile_package_dir(candidate: &Path, package_name: &str) -> bool {
 /// and the many `compile_packages.contains(name)` sites) all match exact
 /// package names, so the wildcard has to be expanded before routing or it is a
 /// silent no-op. Returns scoped names as `@scope/name`.
+#[cfg(test)]
 pub(super) fn enumerate_installed_packages(project_root: &Path) -> HashSet<String> {
-    let mut out = HashSet::new();
+    enumerate_installed_package_roots(project_root)
+        .into_keys()
+        .collect()
+}
+
+/// Enumerate installed package names together with every directory that
+/// supplied that name. Wildcard compile routing normally needs only the names,
+/// but policy checks such as the Node native-addon guard must inspect package
+/// roots before deciding whether the wildcard may select them.
+pub(super) fn enumerate_installed_package_roots(
+    project_root: &Path,
+) -> HashMap<String, Vec<PathBuf>> {
+    let mut out = HashMap::new();
     if let Some(nm) = find_node_modules(project_root) {
         collect_packages_in_node_modules(&nm, &mut out);
     }
@@ -351,7 +364,7 @@ pub(super) fn enumerate_installed_packages(project_root: &Path) -> HashSet<Strin
 /// ordinary `node_modules` directory, so walk it with the same collector.
 /// `node_modules` need not exist (`fs::read_dir` on the derived `.bun` path
 /// simply fails and returns).
-fn collect_packages_in_bun_store(node_modules: &Path, out: &mut HashSet<String>) {
+fn collect_packages_in_bun_store(node_modules: &Path, out: &mut HashMap<String, Vec<PathBuf>>) {
     let bun_dir = node_modules.join(".bun");
     let entries = match fs::read_dir(&bun_dir) {
         Ok(e) => e,
@@ -367,7 +380,7 @@ fn collect_packages_in_bun_store(node_modules: &Path, out: &mut HashSet<String>)
 
 /// Walk a single `node_modules` directory, recording each package name and
 /// recursing into any nested `node_modules` it contains.
-fn collect_packages_in_node_modules(node_modules: &Path, out: &mut HashSet<String>) {
+fn collect_packages_in_node_modules(node_modules: &Path, out: &mut HashMap<String, Vec<PathBuf>>) {
     let entries = match fs::read_dir(node_modules) {
         Ok(e) => e,
         Err(_) => return,
@@ -396,7 +409,9 @@ fn collect_packages_in_node_modules(node_modules: &Path, out: &mut HashSet<Strin
                     if !sub_path.is_dir() {
                         continue;
                     }
-                    out.insert(format!("{}/{}", name, sub_name));
+                    out.entry(format!("{}/{}", name, sub_name))
+                        .or_default()
+                        .push(sub_path.clone());
                     let nested = sub_path.join("node_modules");
                     if nested.is_dir() {
                         collect_packages_in_node_modules(&nested, out);
@@ -405,7 +420,7 @@ fn collect_packages_in_node_modules(node_modules: &Path, out: &mut HashSet<Strin
             }
             continue;
         }
-        out.insert(name.to_string());
+        out.entry(name.to_string()).or_default().push(path.clone());
         let nested = path.join("node_modules");
         if nested.is_dir() {
             collect_packages_in_node_modules(&nested, out);

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -911,7 +911,8 @@ pub fn run_with_parse_cache(
     // Build a map of all exported classes from all modules
     // Key: (resolved_path, class_name) -> Class reference
     let mut exported_classes: BTreeMap<(String, String), &perry_hir::Class> = BTreeMap::new();
-    // Issue #489 followup: canonical defining path keyed by class id. The
+    // Issue #489 followup: canonical defining path keyed by HIR class object
+    // identity. The
     // re-export propagation loop below adds extra `(re_export_path,
     // class_name)` entries pointing at the same class, and the transitive
     // parent-class closure later picks `exported_classes`'s first BTreeMap
@@ -927,27 +928,27 @@ pub fn run_with_parse_cache(
     // closure (`MySqlPreparedQuery extends QueryPromise`), but the
     // canonical path is `query-promise.js`, not `index.js` which
     // re-exports it via `export *`.
-    // Issue #5987: `ClassId` is meant to be unique across the whole program
-    // (module lowering threads a `next_class_id` counter forward precisely
-    // to guarantee this), but a real multi-thousand-module compile can still
-    // produce two unrelated classes with the same id (e.g. via parallel
-    // lowering or object-cache reuse of a previously-lowered module) — this
-    // showed up for `effect`'s two distinct `ClientAbort` classes (in
-    // `RpcSchema.ts` and `HttpServerError.ts`) resolving to a third,
-    // unrelated module (`SchemaAST.ts`) that doesn't define either. Store
-    // the class's own name alongside its path so a lookup can detect an id
-    // collision (name mismatch) and refuse the entry rather than silently
-    // trusting it — every caller already has a reliable fallback for this
-    // case (the compound `(path, name)` key that found `class` in the first
-    // place already proves the origin is correct).
-    let mut class_canonical_path: std::collections::HashMap<perry_hir::ClassId, (String, String)> =
+    // Cached/parallel lowering can reuse a ClassId. An id/name key is still
+    // ambiguous for platform siblings with identical class names (OpenTUI's
+    // node/bun BoxRenderable variants), while the references stored in
+    // `exported_classes` point directly into `native_modules` and therefore
+    // have unambiguous addresses for this pipeline run. Keep a second legacy
+    // id map only for transitive-parent lookup, whose ImportedClass record
+    // currently retains the id but not the HIR reference.
+    let mut class_canonical_path: std::collections::HashMap<usize, String> =
         std::collections::HashMap::new();
+    let mut class_canonical_path_by_id: std::collections::HashMap<
+        perry_hir::ClassId,
+        (String, String),
+    > = std::collections::HashMap::new();
     for (path, hir_module) in &ctx.native_modules {
         let path_str = path.to_string_lossy().to_string();
         for class in &hir_module.classes {
             if class.is_exported {
                 exported_classes.insert((path_str.clone(), class.name.clone()), class);
                 class_canonical_path
+                    .insert(class as *const perry_hir::Class as usize, path_str.clone());
+                class_canonical_path_by_id
                     .entry(class.id)
                     .or_insert_with(|| (path_str.clone(), class.name.clone()));
             }
@@ -1264,20 +1265,31 @@ pub fn run_with_parse_cache(
                 // `class_ids["Number"]` (the export alias) — a miss — and
                 // `S.Number` falls back to the global `Number`, losing all
                 // inherited statics (effect's `S.Number.ast` → undefined →
-                // Schema decode crash). Scoped to classes: renamed var/func
-                // exports route through wrapper-symbol emission that keys on the
-                // export name, and feeding the origin name there breaks linking.
-                if local != exported
-                    && hir_module
-                        .classes
-                        .iter()
-                        .any(|c| c.name == *local && c.is_exported)
-                {
+                // Schema decode crash). Declared functions need the same origin
+                // mapping when a public alias collides with another local body
+                // (`Record3 as Record` beside an unrelated local `Record`).
+                // Variable/closure exports remain on the public getter ABI.
+                let is_renamed_class = hir_module
+                    .classes
+                    .iter()
+                    .any(|c| c.name == *local && c.is_exported);
+                let is_renamed_declared_function = hir_module
+                    .functions
+                    .iter()
+                    .any(|f| f.name == *local && f.is_exported);
+                if local != exported && (is_renamed_class || is_renamed_declared_function) {
                     all_module_export_origin_names
                         .entry(path_str.clone())
                         .or_default()
                         .insert(exported.clone(), local.clone());
                 }
+            }
+            // A namespace re-export is itself a runtime value export. Record
+            // the declaring module as its origin so `export *` barrels carry
+            // the namespace name forward and named-import analysis can walk
+            // back to the `NamespaceReExport` that defines its shape.
+            if let perry_hir::Export::NamespaceReExport { name, .. } = export {
+                exports.insert(name.clone(), path_str.clone());
             }
             // ReExport is handled in the propagation loop below (avoids borrow issues)
         }
@@ -2160,30 +2172,35 @@ pub fn run_with_parse_cache(
     //
     // Keyed by re-exporting module path → exported alias → target module path.
     let mut namespace_reexport_targets: HashMap<String, BTreeMap<String, PathBuf>> = HashMap::new();
+    let lookup = |name: &str| module_name_to_module.get(name);
     for (path, hir_module) in &ctx.native_modules {
-        for export in &hir_module.exports {
-            let perry_hir::Export::NamespaceReExport { source, name } = export else {
+        // Do not stop at declarations written directly in this module. A
+        // namespace value retains its identity through ordinary named and
+        // export-all barrels too:
+        //
+        //   export * as util from "./util.js";  // core/index
+        //   export { util } from "./core/index.js"; // external
+        //   export * from "./external.js";      // public entry
+        //
+        // `flatten_exports` already follows those chains (and imported local
+        // aliases) cycle-safely. Reusing its `nested_namespace_of` provenance
+        // keeps the member pointed at the defining module's namespace instead
+        // of inventing a callable/getter symbol in whichever barrel happened
+        // to expose it last.
+        for flat in perry_hir::flatten_exports(&hir_module.name, &lookup) {
+            let Some(nested_name) = flat.nested_namespace_of else {
                 continue;
             };
-            // `source` was rewritten to `Module::name` on `module_name_to_module`
-            // above, but `hir_module` here is the ORIGINAL, so this is still the
-            // specifier as written.
-            let Some((target_path, _)) = resolve_import(
-                source,
-                path,
-                &ctx.project_root,
-                &ctx.compile_packages,
-                &ctx.compile_package_dirs,
-            ) else {
+            let Some(target_path) = module_name_to_path.get(&nested_name).cloned() else {
+                // Native namespaces (`node:path`, etc.) are classified by the
+                // namespace-populator path and do not have a native-module
+                // object/global to register here.
                 continue;
             };
-            if !ctx.native_modules.contains_key(&target_path) {
-                continue;
-            }
             namespace_reexport_targets
                 .entry(path.to_string_lossy().to_string())
                 .or_default()
-                .insert(name.clone(), target_path.clone());
+                .insert(flat.name, target_path.clone());
             // The target needs its own `@__perry_ns_` global emitted and
             // populated, which is what being in this set means.
             dyn_target_paths.insert(target_path);
@@ -2209,12 +2226,21 @@ pub fn run_with_parse_cache(
                 .map(|m| sanitize_module_name(&m.name))
                 .unwrap_or_else(|| sanitize_module_name(&fe.source_module));
             let kind = if let Some(nested) = &fe.nested_namespace_of {
-                let nested_prefix = module_name_to_module
-                    .get(nested)
-                    .map(|m| sanitize_module_name(&m.name))
-                    .unwrap_or_else(|| sanitize_module_name(nested));
-                perry_codegen::NamespaceEntryKind::NestedNamespace {
-                    source_prefix: nested_prefix,
+                let native_name = nested.strip_prefix("node:").unwrap_or(nested);
+                if !module_name_to_module.contains_key(nested)
+                    && perry_hir::NATIVE_MODULES.contains(&native_name)
+                {
+                    perry_codegen::NamespaceEntryKind::NativeNamespace {
+                        specifier: nested.clone(),
+                    }
+                } else {
+                    let nested_prefix = module_name_to_module
+                        .get(nested)
+                        .map(|m| sanitize_module_name(&m.name))
+                        .unwrap_or_else(|| sanitize_module_name(nested));
+                    perry_codegen::NamespaceEntryKind::NestedNamespace {
+                        source_prefix: nested_prefix,
+                    }
                 }
             } else if fe.source_module == target_name {
                 // Local binding — find what kind it is in target_hir.
@@ -2493,8 +2519,11 @@ pub fn run_with_parse_cache(
                 started: codegen_started,
                 enabled: codegen_progress_enabled,
             };
-            // Compile this module to LLVM IR (or .ll text in bitcode-link mode)
-            // and return the object bytes for the linker to consume.
+            // Compile this module to LLVM IR (or .ll text in bitcode-link mode).
+            // Linking builds return an artifact for the linker. `--no-link`
+            // writes each cold object in this worker as soon as it is ready so
+            // a large graph does not retain every object byte until all module
+            // jobs finish.
             let codegen_index = codegen_modules_started.fetch_add(1, Ordering::Relaxed) + 1;
             progress.record(ProgressSnapshot {
                 stage: "codegen",
@@ -3054,24 +3083,6 @@ pub fn run_with_parse_cache(
                                 }
                             }
                         }
-                        // #7189: the source module's `export * as ns` aliases.
-                        // These are NOT in `all_module_exports` — that map holds
-                        // name → module-that-declares-the-binding, and a
-                        // namespace alias has no declaring binding to point at.
-                        // Registering the alias here is what puts it in
-                        // `Object.keys(ns)`, since the whole-value materializer
-                        // enumerates `namespace_member_prefixes`.
-                        if let Some(nested) = namespace_reexport_targets.get(&resolved_path_str) {
-                            for (alias, target_path) in nested {
-                                let target_prefix =
-                                    compute_module_prefix(&target_path.to_string_lossy(), &ctx.project_root);
-                                namespace_member_prefixes.insert(
-                                    (local.clone(), alias.clone()),
-                                    target_prefix,
-                                );
-                                namespace_member_nested.insert((local.clone(), alias.clone()));
-                            }
-                        }
                         // Register all exports from the source module
                         if let Some(exports) = all_module_exports.get(&resolved_path_str) {
                             for (export_name, origin_path) in exports {
@@ -3224,6 +3235,21 @@ pub fn run_with_parse_cache(
                                 if let Some(members) = exported_enums.get(&key) {
                                     imported_enums.push((export_name.clone(), members.clone()));
                                 }
+                            }
+                        }
+                        // Namespace aliases also participate in
+                        // `all_module_exports`, so repeat this after the
+                        // ordinary walk and let the TARGET prefix win over the
+                        // declaring barrel's prefix.
+                        if let Some(nested) = namespace_reexport_targets.get(&resolved_path_str) {
+                            for (alias, target_path) in nested {
+                                let target_prefix = compute_module_prefix(
+                                    &target_path.to_string_lossy(),
+                                    &ctx.project_root,
+                                );
+                                namespace_member_prefixes
+                                    .insert((local.clone(), alias.clone()), target_prefix);
+                                namespace_member_nested.insert((local.clone(), alias.clone()));
                             }
                         }
                         if source_module.is_some_and(|module| is_wrapped_cjs(module)) {
@@ -3402,19 +3428,40 @@ pub fn run_with_parse_cache(
                         }) {
                             break;
                         }
-                        // Follow `export { <ns_scan_name> } from "<src>"`.
-                        let Some((hop_src, hop_imported)) =
-                            hir.exports.iter().find_map(|e| match e {
-                                perry_hir::Export::ReExport {
+                        // Follow either an explicit named re-export or an
+                        // `export *` barrel whose target owns this name. The
+                        // latter is how Effect and OpenCode expose namespace
+                        // values through public entry points.
+                        let named_hop = hir.exports.iter().find_map(|e| match e {
+                            perry_hir::Export::ReExport {
+                                source,
+                                imported,
+                                exported,
+                            } if *exported == ns_scan_name => {
+                                Some((source.clone(), imported.clone()))
+                            }
+                            _ => None,
+                        });
+                        let export_all_hop = || {
+                            hir.exports.iter().find_map(|e| {
+                                let perry_hir::Export::ExportAll { source } = e else {
+                                    return None;
+                                };
+                                let (target_path, _) = resolve_import(
                                     source,
-                                    imported,
-                                    exported,
-                                } if *exported == ns_scan_name => {
-                                    Some((source.clone(), imported.clone()))
-                                }
-                                _ => None,
+                                    std::path::Path::new(&ns_scan_path),
+                                    &ctx.project_root,
+                                    &ctx.compile_packages,
+                                    &ctx.compile_package_dirs,
+                                )?;
+                                let target = target_path.to_string_lossy().to_string();
+                                all_module_exports
+                                    .get(&target)
+                                    .is_some_and(|exports| exports.contains_key(&ns_scan_name))
+                                    .then(|| (source.clone(), ns_scan_name.clone()))
                             })
-                        else {
+                        };
+                        let Some((hop_src, hop_imported)) = named_hop.or_else(export_all_hop) else {
                             break;
                         };
                         let Some((hop_path, _)) = resolve_import(
@@ -3453,6 +3500,29 @@ pub fn run_with_parse_cache(
                             {
                                 if name != &ns_scan_name {
                                     continue;
+                                }
+                                // Native namespace targets (for example
+                                // `export * as NodeWS from "ws"`) have no HIR
+                                // module and no `@__perry_ns_ws` global. The
+                                // declaring module emits a zero-arg namespace
+                                // getter; classify this named import as a var so
+                                // consumer code calls that getter.
+                                if perry_hir::NATIVE_MODULES.contains(
+                                    &ns_src.strip_prefix("node:").unwrap_or(ns_src),
+                                ) {
+                                    let declaring_prefix = compute_module_prefix(
+                                        &ns_scan_path,
+                                        &ctx.project_root,
+                                    );
+                                    import_function_prefixes
+                                        .insert(local_name.clone(), declaring_prefix);
+                                    if local_name != ns_scan_name {
+                                        import_function_origin_names
+                                            .insert(local_name.clone(), ns_scan_name.clone());
+                                    }
+                                    imported_vars.insert(local_name.clone());
+                                    handled_as_namespace_reexport = true;
+                                    break;
                                 }
                                 let importer = std::path::Path::new(&ns_scan_path);
                                 let Some((ns_target, _)) = resolve_import(
@@ -3616,6 +3686,29 @@ pub fn run_with_parse_cache(
                                     }
                                     if let Some(members) = exported_enums.get(&key) {
                                         imported_enums.push((export_name.clone(), members.clone()));
+                                    }
+                                }
+                                // A named namespace re-export can itself expose
+                                // nested namespace aliases (Zod's `z.core`,
+                                // `z.locales`, `z.iso`, and `z.coerce` shape).
+                                // Mark those members explicitly and overwrite
+                                // the declaring-barrel prefixes registered by
+                                // the ordinary export walk above with the
+                                // namespace TARGET prefixes.
+                                if let Some(nested) =
+                                    namespace_reexport_targets.get(&ns_target_str)
+                                {
+                                    for (alias, target_path) in nested {
+                                        let target_prefix = compute_module_prefix(
+                                            &target_path.to_string_lossy(),
+                                            &ctx.project_root,
+                                        );
+                                        namespace_member_prefixes.insert(
+                                            (local_name.clone(), alias.clone()),
+                                            target_prefix,
+                                        );
+                                        namespace_member_nested
+                                            .insert((local_name.clone(), alias.clone()));
                                     }
                                 }
                                 handled_as_namespace_reexport = true;
@@ -4472,14 +4565,13 @@ pub fn run_with_parse_cache(
                 let field_types_clone = imported_classes[idx].field_types.clone();
                 let parent_name_clone = imported_classes[idx].parent_name.clone();
                 // The child's own canonical source path, used to resolve its
-                // `extends` parent in the child's module scope. Issue #5987:
-                // guard against a `ClassId` collision the same way
-                // `canonical_class_source_prefix` does — only trust the
-                // recorded path if its name matches this child's own name.
+                // `extends` parent in the child's module scope. This legacy
+                // ImportedClass path only retains a ClassId, so keep the name
+                // guard here; direct class provenance above uses identity.
                 let child_name_clone = imported_classes[idx].name.clone();
                 let child_src_path: Option<String> = imported_classes[idx]
                     .source_class_id
-                    .and_then(|cid| class_canonical_path.get(&cid).cloned())
+                    .and_then(|cid| class_canonical_path_by_id.get(&cid).cloned())
                     .filter(|(_, name)| name == &child_name_clone)
                     .map(|(path, _)| path);
                 // Issue #485: include the class's parent in the transitive
@@ -4533,8 +4625,8 @@ pub fn run_with_parse_cache(
                             exported_classes.iter().find(|((path, cname), class)| {
                                 cname == &ref_name
                                     && class_canonical_path
-                                        .get(&class.id)
-                                        .map(|(cp, cid_name)| cp == path && cid_name == cname)
+                                        .get(&(**class as *const perry_hir::Class as usize))
+                                        .map(|cp| cp == path)
                                         .unwrap_or(true)
                             })
                         })
@@ -4543,12 +4635,50 @@ pub fn run_with_parse_cache(
                                 .iter()
                                 .find(|((_, cname), _)| cname == &ref_name)
                         })
-                        .map(|((path, _), class)| (path.clone(), *class));
+                        .map(|((path, _), class)| {
+                            // `exported_classes` deliberately carries alias
+                            // entries stamped under barrel paths. Selecting an
+                            // alias in the child's module is correct for scope
+                            // resolution, but constructor/method symbols still
+                            // live in the HIR class's defining module.
+                            let canonical_path = class_canonical_path
+                                .get(&(*class as *const perry_hir::Class as usize))
+                                .cloned()
+                                .unwrap_or_else(|| path.clone());
+                            (canonical_path, *class)
+                        });
                     // Dedup: parent refs key on (resolved_path, name) so a
                     // distinct same-named parent in another module is still
                     // imported; all other refs key on name only (legacy).
                     if is_parent_ref {
-                        if let Some((src_path, _)) = &found {
+                        if let Some((src_path, class)) = &found {
+                            let source_prefix =
+                                compute_module_prefix(src_path, &ctx.project_root);
+                            let effective_name = if ref_name != class.name {
+                                ref_name.as_str()
+                            } else {
+                                class.name.as_str()
+                            };
+                            // The initial import walk may already contain this
+                            // exact canonical class. A barrel-local child
+                            // extending a re-exported parent must not append a
+                            // second copy under the barrel path: the later
+                            // duplicate would overwrite the correct ctor in
+                            // codegen's name-keyed map (OpenTUI's index.node.js
+                            // / chunk-node BoxRenderable shape).
+                            if imported_classes.iter().any(|imported| {
+                                imported.source_prefix == source_prefix
+                                    && imported.name == class.name
+                                    && imported
+                                        .local_alias
+                                        .as_deref()
+                                        .unwrap_or(&imported.name)
+                                        == effective_name
+                            }) {
+                                visited_parent_paths
+                                    .insert((src_path.clone(), ref_name.clone()));
+                                continue;
+                            }
                             if !visited_parent_paths
                                 .insert((src_path.clone(), ref_name.clone()))
                             {
@@ -4915,15 +5045,35 @@ pub fn run_with_parse_cache(
                     });
                 }
             }
+            // A no-link build's object is the final product. Flush it from the
+            // module worker instead of collecting its bytes in
+            // `compile_results`: multi-thousand-module graphs otherwise hold
+            // gigabytes of completed objects at once and can exhaust host
+            // commit before the deferred parallel-write phase begins. Module
+            // destinations are unique, so the existing codegen pool already
+            // provides safe parallel I/O here.
+            if args.no_link {
+                fs::write(&obj_path, &object_code).map_err(|e| {
+                    format!(
+                        "failed to write object file {}: {}",
+                        obj_path.display(),
+                        e
+                    )
+                })?;
+                return Ok(NativeObjectArtifact {
+                    path: obj_path,
+                    bytes: None,
+                    fingerprint: object_fingerprint,
+                    cleanup_after_link: false,
+                    reused_cache_path: false,
+                    stored_cache_path: false,
+                });
+            }
             Ok(NativeObjectArtifact {
                 path: obj_path,
                 bytes: Some(object_code),
                 fingerprint: object_fingerprint,
-                // #7167: a staged object is an intermediate; a `--no-link`
-                // object is the product and must never be listed for cleanup.
-                // Nothing consults this before the `--no-link` return today —
-                // it is set correctly so that stays true if cleanup ever moves.
-                cleanup_after_link: !args.no_link,
+                cleanup_after_link: true,
                 reused_cache_path: false,
                 stored_cache_path: false,
             })
@@ -4931,14 +5081,12 @@ pub fn run_with_parse_cache(
         .collect()
     });
 
-    // Tier 4.4 (v0.5.336): partition compile results, then write object
-    // files in parallel via rayon. The OS handles concurrent writes to
-    // distinct paths, and codegen typically finishes producing bytes
-    // faster than a single thread can drain them to disk for projects
-    // with many modules. Pre-fix this was a single sequential
-    // `for ... fs::write(...)`. Errors from compilation print in source
-    // order (preserved); successful writes' "Wrote ..." messages print
-    // after all writes complete.
+    // Tier 4.4 (v0.5.336): partition compile results, then write any retained
+    // object files in parallel via rayon. No-link workers have already flushed
+    // cold objects above to keep memory bounded; linking builds without an
+    // object-cache path still arrive here as bytes. Errors from compilation
+    // print in source order (preserved); successful writes' "Wrote ..."
+    // messages print after all writes complete.
     let mut failed_modules: Vec<String> = Vec::new();
     let mut artifacts: Vec<NativeObjectArtifact> = Vec::new();
     for result in compile_results {
@@ -5880,7 +6028,21 @@ pub fn run_with_parse_cache(
     // config are package/project-root-relative, so use the same walked-up root
     // as package.json, perry.toml, and the on-disk caches. Otherwise an entry
     // at `src/main.ts` makes `--embed ./dist/**` silently search `src/dist`.
-    let embedded_assets = embed::resolve_embedded_assets(&args.embed, &ctx.cache_root)?;
+    let mut embedded_assets = embed::resolve_embedded_assets(&args.embed, &ctx.cache_root)?;
+    // `{ type: "file" }` imports are discovered while walking the module graph
+    // and already carry their virtual registry names. Merge those automatic
+    // assets with explicit `--embed`/config matches before generating the one
+    // registration object. A path can be named explicitly and imported; keep
+    // both names because user code may address either virtual path.
+    for (name, path) in &ctx.embedded_assets {
+        if !embedded_assets
+            .iter()
+            .any(|(existing_name, _)| existing_name == name)
+        {
+            embedded_assets.push((name.clone(), path.clone()));
+        }
+    }
+    embedded_assets.sort_by(|a, b| a.0.cmp(&b.0));
     if !embedded_assets.is_empty() {
         if let Some(obj) =
             embed::generate_embedded_asset_object(&embedded_assets, &object_output_dir)?

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -1606,10 +1606,8 @@ pub(super) fn strip_bundled_shared_deps_from_well_known_lib(
 }
 
 mod stub_symbols;
+pub(super) use stub_symbols::localize_stdlib_stub_symbols;
 use stub_symbols::strip_members_present_in_reference;
-pub(super) use stub_symbols::{
-    localize_stdlib_stub_symbols, localize_stdlib_stub_symbols_for_windows,
-};
 
 /// Tier-3 (tvOS/watchOS, no prebuilt std): perry-stdlib is built with
 /// `-Zbuild-std` and bundles its own copy of std's allocator/panic runtime

--- a/crates/perry/src/commands/compile/strip_dedup/stub_symbols.rs
+++ b/crates/perry/src/commands/compile/strip_dedup/stub_symbols.rs
@@ -81,6 +81,7 @@ const STDLIB_STUB_SYMBOLS: &[&str] = &[
 /// Best-effort: a missing LLVM tool or any failed sub-step returns the
 /// original `runtime_lib` path unchanged, preserving the pre-fix behavior
 /// rather than failing the build.
+#[allow(dead_code)]
 pub(crate) fn localize_stdlib_stub_symbols_for_windows(
     runtime_lib: &Path,
     stdlib_lib: &Path,

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -614,6 +614,12 @@ pub struct CompilationContext {
     pub package_aliases: HashMap<String, String>,
     /// Packages to compile natively instead of routing to V8 (from perry.compilePackages)
     pub compile_packages: HashSet<String>,
+    /// Node native-addon packages omitted from wildcard/automatic whole-package
+    /// AOT routing. A statically imported pure JS/TS subpath may still be
+    /// promoted file-by-file; reaching an actual `.node` binary remains a hard
+    /// error, while exact `compilePackages` opt-ins keep the package-level
+    /// diagnostic.
+    pub auto_skipped_node_addon_packages: HashSet<String>,
     /// JavaScript package entry files reached through a statically resolved
     /// import edge. Perry has no runtime JavaScript engine, so these exact
     /// graph members must re-enter the native AOT collector even when their
@@ -628,6 +634,11 @@ pub struct CompilationContext {
     #[allow(dead_code)]
     // #5731 embed-assets context contract; pub field populated on the embed path, not read here
     pub embedded_assets: Vec<(String, PathBuf)>,
+    /// Canonical paths whose import attributes explicitly requested Bun's
+    /// `{ type: "file" }` loader. Kept separate from `embedded_assets` because
+    /// automatic wasm imports also register bytes there but must still lower
+    /// their executable adapter on a later metadata pass.
+    pub file_loader_asset_paths: HashSet<PathBuf>,
     /// #1681 (Phase 3 of #1677): true when this is the build-time capture
     /// stage (the `current_exe` subprocess), so `precompile(EXPR)` sites
     /// emit their build-time value instead of substituting. Re-installed on
@@ -1111,8 +1122,10 @@ impl CompilationContext {
             native_libraries: Vec::new(),
             package_aliases: HashMap::new(),
             compile_packages: HashSet::new(),
+            auto_skipped_node_addon_packages: HashSet::new(),
             aot_discovered_modules: HashSet::new(),
             embedded_assets: Vec::new(),
+            file_loader_asset_paths: HashSet::new(),
             precompile_capture: false,
             precompile_results: HashMap::new(),
             fast_math: false,

--- a/crates/perry/tests/issue_5731_embedded_assets.rs
+++ b/crates/perry/tests/issue_5731_embedded_assets.rs
@@ -7,10 +7,8 @@
 //!   * `node:fs` (`readFileSync` / `existsSync`) via the `$perryfs/<path>` path
 //! plus `isStandaloneExecutable` (always `true` in a compiled binary).
 //!
-//! Asset embedding is host-only (Unix-like): it compiles a `cc` object that
-//! MSVC `link.exe` can't consume, so the feature errors on a Windows host and
-//! this end-to-end test is skipped there.
-#![cfg(not(windows))]
+//! Asset embedding is host-targeted: Unix-like systems compile a `cc` object;
+//! Windows uses clang's COFF output and a `.CRT$XCU` startup initializer.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -61,16 +59,19 @@ catch (e) { console.log("throwMissing: yes"); }
     .expect("write entry");
 
     let output = root.join("app");
-    let compile = Command::new(perry_bin())
+    let mut compile_command = Command::new(perry_bin());
+    compile_command
         .current_dir(root)
         .arg("compile")
         .arg(&entry)
         .arg("--embed")
         .arg("./dist/**")
         .arg("-o")
-        .arg(&output)
-        .output()
-        .expect("run perry compile");
+        .arg(&output);
+    if cfg!(windows) {
+        compile_command.env("PERRY_RS4GC", "0");
+    }
+    let compile = compile_command.output().expect("run perry compile");
     assert!(
         compile.status.success(),
         "perry compile failed\nstdout:\n{}\nstderr:\n{}",

--- a/crates/perry/tests/source_graph_export_regressions.rs
+++ b/crates/perry/tests/source_graph_export_regressions.rs
@@ -1,0 +1,355 @@
+//! Cross-module export shapes found while compiling OpenCode's TypeScript
+//! source graph. Each regression previously produced an undefined native
+//! linker symbol despite all source modules lowering successfully.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    if cfg!(windows) {
+        target.join("x86_64-pc-windows-msvc").join("debug")
+    } else {
+        target.join("debug")
+    }
+}
+
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let mut command = Command::new(cargo);
+        command
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static");
+        if cfg!(windows) {
+            command.arg("--target").arg("x86_64-pc-windows-msvc");
+        }
+        let build = command
+            .output()
+            .expect("run cargo build of static runtime archives");
+        assert!(
+            build.status.success(),
+            "cargo build of static runtime archives failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
+}
+
+fn write(dir: &Path, name: &str, source: &str) {
+    std::fs::write(dir.join(name), source).expect("write fixture");
+}
+
+fn compile_and_run(dir: &Path, entry: &str) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("--no-cache")
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn namespace_reexport_survives_export_all_barrels() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "value.ts", "export const answer = 42;\n");
+    write(
+        dir.path(),
+        "namespace.ts",
+        "export * as Values from './value';\n",
+    );
+    write(dir.path(), "barrel.ts", "export * from './namespace';\n");
+    write(
+        dir.path(),
+        "main.ts",
+        "import { Values } from './barrel'; console.log(Values.answer);\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42\n");
+}
+
+#[test]
+fn whole_type_only_import_does_not_wrap_same_named_runtime_builtin() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "types.ts",
+        "const Array_ = 123; export { Array_ as Array };\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import type { Array } from './types'; console.log(Array.isArray([1]));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "true\n");
+}
+
+#[test]
+fn renamed_export_exposes_raw_local_getter_spelling() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "filter.js",
+        "var $i = (value) => value + 1; export { $i as filesFilter };\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import { filesFilter } from './filter.js'; console.log(filesFilter(41));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42\n");
+}
+
+#[test]
+fn native_namespace_reexport_survives_export_all_barrels() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "namespace.ts",
+        "export * as Path from 'node:path';\n",
+    );
+    write(dir.path(), "barrel.ts", "export * from './namespace';\n");
+    write(
+        dir.path(),
+        "main.ts",
+        "import { Path } from './barrel'; console.log(Path.join('a', 'b').replace('\\\\', '/'));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "a/b\n");
+}
+
+#[test]
+fn namespace_exported_rest_closure_accepts_more_than_sixteen_args() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "layer.ts",
+        "export const mergeAll = (...values: number[]) => values.length;\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import * as Layer from './layer';\n\
+         console.log(Layer.mergeAll(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "18\n");
+}
+
+#[test]
+fn named_namespace_reexport_rest_closure_accepts_more_than_sixteen_args() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "layer.ts",
+        "export const mergeAll = (...values: number[]) => values.length;\n",
+    );
+    write(
+        dir.path(),
+        "barrel.ts",
+        "export * as Layer from './layer';\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import { Layer } from './barrel';\n\
+         console.log(Layer.mergeAll(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "18\n");
+}
+
+#[test]
+fn self_namespace_reexport_is_not_treated_as_a_function() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "event.ts",
+        "export * as Event from './event';\n\
+         export const answer = 42;\n\
+         export function add(left: number, right: number) { return left + right; }\n\
+         export function inventory(...values: number[]) { return values.length; }\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import { Event } from './event';\n\
+         console.log(Event.answer, Event.add(1, 2), Event.inventory(1, 2, 3));\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42 3 3\n");
+}
+
+#[test]
+fn materialized_namespace_keeps_nested_namespace_exports() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "core.ts", "export const answer = 42;\n");
+    write(
+        dir.path(),
+        "external.ts",
+        "export * as core from './core';\n",
+    );
+    write(
+        dir.path(),
+        "index.ts",
+        "export * as schema from './external';\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import { schema } from './index';\n\
+         const assigned = schema;\n\
+         console.log(assigned.core.answer);\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42\n");
+}
+
+#[test]
+fn nested_namespaces_survive_named_and_export_all_barrels() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(dir.path(), "util.ts", "export const name = 'util';\n");
+    write(dir.path(), "regexes.ts", "export const name = 'regexes';\n");
+    write(dir.path(), "coerce.ts", "export const name = 'coerce';\n");
+    write(dir.path(), "iso.ts", "export const name = 'iso';\n");
+    write(
+        dir.path(),
+        "core.ts",
+        "export * as util from './util';\nexport * as regexes from './regexes';\n",
+    );
+    write(
+        dir.path(),
+        "external.ts",
+        "export { util, regexes } from './core';\n\
+         export * as coerce from './coerce';\n\
+         export * as iso from './iso';\n",
+    );
+    write(dir.path(), "index.ts", "export * from './external';\n");
+    write(
+        dir.path(),
+        "main.ts",
+        "import * as z from './index';\n\
+         const assigned = z;\n\
+         console.log(assigned.util.name, assigned.regexes.name, assigned.coerce.name, assigned.iso.name);\n",
+    );
+
+    assert_eq!(
+        compile_and_run(dir.path(), "main.ts"),
+        "util regexes coerce iso\n"
+    );
+}
+
+#[test]
+fn self_namespace_can_be_aliased_as_an_exported_const() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "event.ts",
+        "export * as Event from './event';\n\
+         export function define(value: number) { return value; }\n",
+    );
+    write(
+        dir.path(),
+        "session-event.ts",
+        "export * as SessionEvent from './session-event';\n\
+         import { Event } from './event';\n\
+         export const Started = Event.define(42);\n",
+    );
+    write(
+        dir.path(),
+        "session.ts",
+        "export * as Session from './session';\n\
+         import { SessionEvent } from './session-event';\n\
+         export const Event = SessionEvent;\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import { Session } from './session';\n\
+         console.log(Session.Event.Started);\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42\n");
+}
+
+#[test]
+fn imported_class_reexport_uses_the_defining_constructor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(
+        dir.path(),
+        "chunk-node.js",
+        "class Box { constructor(value) { this.value = value; } }\nexport { Box };\n",
+    );
+    write(
+        dir.path(),
+        "chunk-bun.js",
+        "class Box { constructor(value) { this.value = value + 100; } }\nexport { Box };\n",
+    );
+    write(
+        dir.path(),
+        "index.node.js",
+        "import { Box } from './chunk-node.js';\n\
+         class Child extends Box {}\n\
+         export { Box, Child };\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "import './chunk-bun.js';\n\
+         import { Box } from './index.node.js';\n\
+         function build<T>(value: T) { return new Box(value); }\n\
+         console.log(build(42).value);\n",
+    );
+
+    assert_eq!(compile_and_run(dir.path(), "main.ts"), "42\n");
+}

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -83,6 +83,13 @@ const html = readFileSync("$perryfs/dist/index.html", "utf8");
 that array methods dispatch on its result. `readEmbedded(path)` and `node:fs`
 accept either the `$perryfs/<path>` virtual path or the embed-relative key.
 
+Bun-compatible file-loader imports embed the referenced binary automatically
+and bind the default import to its `$perryfs` path:
+
+```typescript,no-test
+import sound from "./sound.mp3" with { type: "file" };
+```
+
 > **Note**
 > `node:fs` consults the embedded registry *before* disk, and a bare
 > embed-relative key matches too — so `readFileSync("dist/index.html")` returns
@@ -90,9 +97,10 @@ accept either the `$perryfs/<path>` virtual path or the embed-relative key.
 > binary. Read a real on-disk file by absolute path, and use the explicit
 > `$perryfs/<path>` form when you specifically mean the embedded copy.
 >
-> Embedding currently requires a Unix-like host toolchain (macOS/Linux); on a
-> Windows host `--embed` errors out. Cross-target / Windows embedding is a
-> tracked follow-up.
+> Embedding supports host builds on macOS, Linux, and Windows. Windows uses
+> LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when
+> the matching clang is not first on `PATH`. Cross-target embedding is not
+> currently supported.
 
 ## Debug Flags
 

--- a/docs/src/getting-started/project-config.md
+++ b/docs/src/getting-started/project-config.md
@@ -73,6 +73,14 @@ When a package is listed here, Perry:
 
 This is useful for pure TypeScript/JavaScript packages that don't rely on Node.js APIs. Packages that use native bindings, `eval()`, or dynamic `require()` won't work.
 
+Universal forms (`"auto"`, `"all"`, `true`, or a `"*"` wildcard) skip packages
+identified as Node native addons instead of trying to compile N-API binaries as
+source. This lets a dependency's guarded optional native accelerator fall back
+to its JavaScript implementation. A statically imported pure-source subpath of
+such a package can still be compiled, but an actual `.node` edge fails. Naming
+the addon package exactly still fails immediately with the native-addon
+diagnostic.
+
 #### `codegen`
 
 Perry is an ahead-of-time compiler: it never runs a code string at runtime. Many libraries that would normally JIT a function from a schema or a config (`ajv`, `fast-json-stringify`, Prisma, Drizzle, …) ship a **build-time** mode that emits plain, eval-free source instead. The `codegen` field declares the commands that produce that source. Perry runs them **before** compiling, then compiles the generated output natively — so the shipped binary links no JavaScript engine.

--- a/docs/src/native-libraries/zero-config-and-faithfulness.md
+++ b/docs/src/native-libraries/zero-config-and-faithfulness.md
@@ -12,8 +12,13 @@ file resolution does not walk into the installed package source.
 
 Other reachable packages are AOT-compiled by default. When the host
 `package.json` omits `perry.compilePackages`, Perry enumerates installed
-packages, skips natively shimmed packages, and routes the remaining package
-source through the compiler. This is equivalent to:
+packages, skips natively shimmed packages, and routes the remaining usable
+TypeScript/JavaScript source through the compiler. Packages marked as Node
+native addons are excluded from wildcard selection: this preserves guarded
+optional acceleration such as `msgpackr-extract`, while a statically imported
+pure source subpath can still be promoted into the AOT graph. Reaching an
+actual `.node` binary still fails, and listing the addon by exact name retains
+the actionable whole-package hard error. This is equivalent to:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Compile large real-world TypeScript source graphs natively instead of feeding Perry a bundled/minified artifact. The motivating OpenCode source graph now completes on Windows with all 4,743 discovered modules native-compiled and zero JavaScript fallback modules.

## Changes

- Preserve source-module identity through named exports, `export *` barrels, nested namespaces, class aliases, and declared functions so large package graphs link to their defining symbols.
- Route eligible TypeScript/JavaScript package sources through native compilation while refusing native-addon packages and retaining shims only where host/platform dependencies require them.
- Support Bun file-loader assets, compact embedded WASM adapters, esbuild CommonJS `__export` shapes, high-arity/rest namespace calls, and Windows COFF asset/link ordering.
- Reduce large-graph memory and object pressure with build-scoped parse caches, streamed module objects, split LLVM units, compact registries, and embedded-asset merging.
- Add focused source-graph, asset, CJS, addon, namespace, class-origin, and linker regressions; split touched modules to stay below the 2,000-line policy cap.

## Related issue

n/a

## Test plan

- [x] `cargo build --release -p perry`
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run; Perry requires per-crate feature isolation)
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [x] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform (n/a)

Focused verification:

- `cargo test -p perry --test source_graph_export_regressions -- --nocapture`: 11 passed
- `cargo test -p perry --bin perry cjs_wrap::tests::source_graph -- --nocapture`: 2 passed
- `cargo test -p perry canonical_class_source_prefix -- --nocapture`: 2 passed
- `cargo check -p perry-codegen -p perry-hir -p perry`: passed
- `cargo fmt -p perry -p perry-codegen --check`: passed
- HIR suite: 315 passed, 1 ignored
- focused WASM E2E: passed
- `cargo test -p perry-codegen --lib`: 1,092/1,095 passed; the three failures are existing Windows/LLVM-sensitive assertions (one shrink-wrap prologue expectation and two COFF temp-filename byte expectations)
- The repository file-size rule passes when evaluated with native PowerShell. Git Bash's full quick gate is not usable on this checkout because Python is not available in that shell and Windows path length error 206 prevents `cargo fmt --all`; affected-package formatting passes.

## Screenshots / output

Real OpenCode validation (`packages/opencode/src/index.ts`, OpenCode commit `d041eee`):

- Exit code: 0
- Modules: 4,743 native / 0 JS fallback
- End-to-end compile and link: 6,423.5 seconds (1h47m03.5s)
- Output: 1,699,019,264-byte Windows executable
- SHA-256: `AB1A68AF5F12E4EAB6D337B9A472D9F4CD41DA4980A1AB18DEBC1D900BA23D58`
- The executable was not launched because that would start the application; this PR validates source collection, native compilation, and final linking.

The remaining inventory is dependency/runtime work rather than TypeScript parse blockers: four unresolved optional/generated/platform imports (`msgpackr-extract`, Axios' Node distribution subpath, generated `opencode-web-ui.gen.ts`, and `bun:sqlite`), 19 native-addon package exclusions, 25 compatibility shims, plus package-version/browser-global/generic-constraint warnings. Runtime feature smoke testing remains follow-up work. Archive strip/dedup is also the largest remaining compile-time hotspot at roughly 19 minutes; the linked binary is about 1.62 GiB.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compile large TypeScript/JavaScript dependency graphs with improved cross-module exports, aliases, namespaces, and native-module re-exports.
  * Support Bun file-loader imports and embedded binary assets, including WebAssembly and Windows builds.
  * Support function calls with more than 16 arguments.
  * Automatically compile pure-source subpaths while handling packages containing unsupported native addons more safely.

* **Bug Fixes**
  * Improved handling of renamed exports, imported classes, nested namespaces, and CommonJS wrappers.
  * Prevented collisions in cross-module property caches and export resolution.

* **Documentation**
  * Added guidance for file-loader embedding, Windows support, and native-addon package behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->