### PR TITLE
fix(test): drop two KNOWN_EXT_GAPS entries #8375 made stale

### DIFF
--- a/changelog.d/8385-zlib-ext-gaps-stale.md
+++ b/changelog.d/8385-zlib-ext-gaps-stale.md
@@ -1,0 +1,1 @@
+Delete `js_zlib_crc32` and `js_zlib_unzip_sync` from `KNOWN_EXT_GAPS`. #8375 implemented both in `perry-ext-zlib`, which made their allowlist entries stale and turned `ext_zlib_covers_every_stdlib_symbol_the_flip_strips` red on `main`.

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -1150,11 +1150,9 @@ fn ext_zlib_covers_every_stdlib_symbol_the_flip_strips() {
         "js_zlib_process_pending",
         // Genuine one-shot gaps. Same shape as the #8005 pair; they have not
         // broken a link only because no gap test links them on this path yet.
-        "js_zlib_crc32",
         "js_zlib_deflate_raw",
         "js_zlib_inflate_raw",
         "js_zlib_unzip",
-        "js_zlib_unzip_sync",
     ];
 
     fn exported_zlib_symbols(dir: &Path) -> std::collections::BTreeSet<String> {


### PR DESCRIPTION
## Summary

`commands::compile::optimized_libs::tests::ext_zlib_covers_every_stdlib_symbol_the_flip_strips`
is **red on `main`** at `1b61941bc`:

```
these KNOWN_EXT_GAPS entries no longer describe reality — the symbol left
perry-stdlib or gained an ext implementation: ["js_zlib_crc32", "js_zlib_unzip_sync"].
Delete them; a list that outlives its entries stops being a ratchet.
```

#8375 ("add missing external zlib exports") implemented both symbols in
`perry-ext-zlib` but left their `KNOWN_EXT_GAPS` entries in place. The ratchet did
exactly what it is built to do — an allowlist entry that matches nothing fails — so
the fix is to delete the two entries, not to weaken the assertion.

Both symbols are now present in `crates/perry-ext-zlib/src/lib.rs` *and*
`crates/perry-stdlib/src/zlib.rs`, so they are covered on the flip path and the
`missing` assertion above stays satisfied. The three remaining entries under the same
comment (`js_zlib_deflate_raw`, `js_zlib_inflate_raw`, `js_zlib_unzip`) are still
genuine gaps and are untouched.

## Validation

Verified against a clean `main` build at `1b61941bc`:

- before: `test result: FAILED. 0 passed; 1 failed`
- after: `test result: ok. 1 passed; 0 failed`

Found while validating #8383 — the failure reproduced identically on unmodified `main`
at the same commit, so it is not that PR's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated zlib compatibility tracking to reflect newly supported compression and decompression functionality.
  * Removed obsolete gap entries while retaining tracking for features that are still unavailable.

* **Documentation**
  * Added a changelog entry documenting the updated zlib support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->