### PR TITLE
chore(fmt): format arithmetic.rs after #8395

### DIFF
--- a/changelog.d/8398-fmt-after-8395.md
+++ b/changelog.d/8398-fmt-after-8395.md
@@ -1,0 +1,1 @@
+Apply `cargo fmt` to `perry-runtime/src/builtins/arithmetic.rs`. #8395 appended its regression-test module after its last gate run, leaving `main` failing `cargo fmt --all -- --check`.

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -810,7 +810,6 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
     }
 }
 
-
 #[cfg(test)]
 mod rel_numeric_fastpath_tests {
     use super::*;


### PR DESCRIPTION
## Summary

`main` is failing `cargo fmt --all -- --check` at
`crates/perry-runtime/src/builtins/arithmetic.rs:810` — a stray double blank line before
the `rel_numeric_fastpath_tests` module.

This is my own breakage from #8395. I ran the 50-gate check on that branch *before*
appending the regression-test module, then pushed without re-running it, so the added code
was never fmt-checked. The lesson is the obvious one: re-run the gates after the last edit,
not after the last edit you happened to think was interesting.

Found while validating #8397, whose only gate failure was this inherited one — that PR
does not touch this file.

## Validation

- `cargo fmt --all -- --check` — exit 0
- Only `arithmetic.rs` changed, whitespace only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence in numeric comparisons, including edge cases such as `NaN`, signed zero, infinities, and integer-tagged values.
* **Tests**
  * Added regression coverage for supported numeric operand types and ordinary relational comparisons.
* **Documentation**
  * Updated the changelog with a note about maintaining consistent code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->