### PR TITLE
perf: cache prepared native archives for incremental links

### DIFF
--- a/changelog.d/8396-prepared-archive-cache.md
+++ b/changelog.d/8396-prepared-archive-cache.md
@@ -1,0 +1,12 @@
+Closes #8396: incremental native builds now cache the prepared well-known
+binding archives used by the linker. A one-file edit still relinks against its
+new object, but it no longer repeats unchanged archive extraction, symbol-table
+analysis, symbol localization, and rebuilding for every native shim.
+
+The prepared-archive key fingerprints the exact runtime, stdlib, wrapper,
+compiler, target/feature profile, and archive-tool bytes. Cached outputs carry
+their own size and SHA-256 checks and are rejected if missing or corrupted.
+Application objects and linker flags remain covered independently by the final
+link cache, so changes to either still invoke the linker. Set
+`PERRY_NO_ARCHIVE_CACHE=1` to bypass only the prepared-archive cache for
+diagnosis.

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -810,7 +810,6 @@ pub extern "C" fn js_value_typeof(value: f64) -> *mut StringHeader {
     }
 }
 
-
 #[cfg(test)]
 mod rel_numeric_fastpath_tests {
     use super::*;

--- a/crates/perry/src/commands/compile/link/archive_cache.rs
+++ b/crates/perry/src/commands/compile/link/archive_cache.rs
@@ -1,0 +1,373 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use super::super::strip_dedup::{find_nightly_llvm_tool, find_path_tool};
+use super::find_llvm_tool;
+
+const PREPARED_ARCHIVE_CACHE_VERSION: u32 = 1;
+const PREPARED_ARCHIVE_CACHE_SCHEMA: &str = "perry-prepared-archives-v1";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PreparedArchiveManifest {
+    version: u32,
+    key: String,
+    outputs: Vec<CachedOutput>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedOutput {
+    hash: String,
+    size: u64,
+}
+
+pub(super) struct PreparedArchiveInputs<'a> {
+    pub cache_dir: &'a Path,
+    pub target: Option<&'a str>,
+    pub target_triple: Option<&'a str>,
+    pub compiled_features: &'a [String],
+    pub runtime_lib: &'a Path,
+    pub stdlib_lib: Option<&'a Path>,
+    pub well_known_libs: &'a [PathBuf],
+}
+
+/// Cache the expensive, deterministic strip/dedup pass over well-known native
+/// archives. This is an intermediate-artifact cache: application objects and
+/// linker flags remain covered by the final-link cache and are deliberately
+/// absent here because they cannot affect the bytes produced by archive
+/// preparation.
+pub(super) fn prepare_well_known_archives<F>(
+    inputs: PreparedArchiveInputs<'_>,
+    prepare: F,
+) -> Vec<PathBuf>
+where
+    F: FnOnce() -> (Vec<PathBuf>, bool),
+{
+    if std::env::var_os("PERRY_NO_ARCHIVE_CACHE").is_some()
+        || std::env::var("PERRY_NO_CACHE").as_deref() == Ok("1")
+    {
+        debug_cache("MISS", "disabled");
+        return prepare().0;
+    }
+
+    let compiler = std::env::current_exe().ok();
+    let tools = vec![
+        find_llvm_tool("llvm-ar").or_else(|| find_path_tool("ar")),
+        find_nightly_llvm_tool("llvm-nm")
+            .or_else(|| find_llvm_tool("llvm-nm"))
+            .or_else(|| find_path_tool("nm")),
+        find_nightly_llvm_tool("llvm-objcopy")
+            .or_else(|| find_llvm_tool("llvm-objcopy"))
+            .or_else(|| find_path_tool("objcopy")),
+    ];
+    let key = match derive_prepared_archive_key(&inputs, compiler.as_deref(), &tools) {
+        Ok(key) => key,
+        Err(error) => {
+            debug_cache("MISS", &format!("could not fingerprint inputs: {error}"));
+            return prepare().0;
+        }
+    };
+    let entry_dir = inputs
+        .cache_dir
+        .join("prepared-archives")
+        .join(inputs.target.unwrap_or("native"))
+        .join(&key);
+
+    if let Some(paths) = load_cached_archives(&entry_dir, &key, inputs.well_known_libs) {
+        debug_cache("HIT", &key);
+        return paths;
+    }
+
+    debug_cache("MISS", &key);
+    let (prepared, cacheable) = prepare();
+    if !cacheable {
+        debug_cache("MISS", "archive preparation used a non-fatal fallback");
+        return prepared;
+    }
+    match store_cached_archives(&entry_dir, &key, inputs.well_known_libs, &prepared) {
+        Some(paths) => paths,
+        None => prepared,
+    }
+}
+
+fn derive_prepared_archive_key(
+    inputs: &PreparedArchiveInputs<'_>,
+    compiler: Option<&Path>,
+    tools: &[Option<PathBuf>],
+) -> std::io::Result<String> {
+    let mut hasher = Sha256::new();
+    hash_field(&mut hasher, "schema", PREPARED_ARCHIVE_CACHE_SCHEMA);
+    hash_field(&mut hasher, "perry-version", env!("CARGO_PKG_VERSION"));
+    hash_field(&mut hasher, "target", inputs.target.unwrap_or("native"));
+    hash_field(
+        &mut hasher,
+        "target-triple",
+        inputs.target_triple.unwrap_or("native-host"),
+    );
+    if inputs.target_triple.is_none() {
+        hash_field(&mut hasher, "host-arch", std::env::consts::ARCH);
+        hash_field(&mut hasher, "host-os", std::env::consts::OS);
+    }
+
+    let mut features = inputs.compiled_features.to_vec();
+    features.sort();
+    features.dedup();
+    for feature in features {
+        hash_field(&mut hasher, "feature", &feature);
+    }
+
+    hash_optional_file(&mut hasher, "compiler", compiler)?;
+    for (index, tool) in tools.iter().enumerate() {
+        hash_field(&mut hasher, "tool-index", &index.to_string());
+        hash_optional_file(&mut hasher, "tool", tool.as_deref())?;
+    }
+    hash_file(&mut hasher, "runtime", inputs.runtime_lib)?;
+    hash_optional_file(&mut hasher, "stdlib", inputs.stdlib_lib)?;
+    for (index, archive) in inputs.well_known_libs.iter().enumerate() {
+        hash_field(&mut hasher, "archive-index", &index.to_string());
+        hash_file(&mut hasher, "well-known", archive)?;
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn load_cached_archives(
+    entry_dir: &Path,
+    key: &str,
+    source_archives: &[PathBuf],
+) -> Option<Vec<PathBuf>> {
+    let raw = fs::read(entry_dir.join("manifest.json")).ok()?;
+    let manifest: PreparedArchiveManifest = serde_json::from_slice(&raw).ok()?;
+    if manifest.version != PREPARED_ARCHIVE_CACHE_VERSION
+        || manifest.key != key
+        || manifest.outputs.len() != source_archives.len()
+    {
+        return None;
+    }
+
+    let mut paths = Vec::with_capacity(source_archives.len());
+    for (index, (source, expected)) in source_archives.iter().zip(&manifest.outputs).enumerate() {
+        let path = entry_dir.join(cached_archive_name(index, source));
+        let (hash, size) = hash_file_value(&path).ok()?;
+        if hash != expected.hash || size != expected.size {
+            return None;
+        }
+        paths.push(path);
+    }
+    Some(paths)
+}
+
+fn store_cached_archives(
+    entry_dir: &Path,
+    key: &str,
+    source_archives: &[PathBuf],
+    prepared: &[PathBuf],
+) -> Option<Vec<PathBuf>> {
+    if prepared.len() != source_archives.len() || fs::create_dir_all(entry_dir).is_err() {
+        return None;
+    }
+
+    let nonce = format!("{}-{}", std::process::id(), monotonic_nonce());
+    let mut outputs = Vec::with_capacity(prepared.len());
+    let mut cached_paths = Vec::with_capacity(prepared.len());
+    for (index, (source, generated)) in source_archives.iter().zip(prepared).enumerate() {
+        let destination = entry_dir.join(cached_archive_name(index, source));
+        let temporary = destination.with_extension(format!("tmp-{nonce}"));
+        if fs::copy(generated, &temporary).is_err() {
+            let _ = fs::remove_file(&temporary);
+            return None;
+        }
+        let (hash, size) = match hash_file_value(&temporary) {
+            Ok(value) => value,
+            Err(_) => {
+                let _ = fs::remove_file(&temporary);
+                return None;
+            }
+        };
+        if destination.exists() {
+            let _ = fs::remove_file(&destination);
+        }
+        if fs::rename(&temporary, &destination).is_err() {
+            let _ = fs::remove_file(&temporary);
+            return None;
+        }
+        outputs.push(CachedOutput { hash, size });
+        cached_paths.push(destination);
+    }
+
+    let manifest = PreparedArchiveManifest {
+        version: PREPARED_ARCHIVE_CACHE_VERSION,
+        key: key.to_string(),
+        outputs,
+    };
+    let bytes = serde_json::to_vec_pretty(&manifest).ok()?;
+    let manifest_path = entry_dir.join("manifest.json");
+    let temporary = entry_dir.join(format!("manifest.json.tmp-{nonce}"));
+    if fs::write(&temporary, bytes).is_err() {
+        return None;
+    }
+    if manifest_path.exists() {
+        let _ = fs::remove_file(&manifest_path);
+    }
+    if fs::rename(&temporary, &manifest_path).is_err() {
+        let _ = fs::remove_file(&temporary);
+        return None;
+    }
+    Some(cached_paths)
+}
+
+fn cached_archive_name(index: usize, source: &Path) -> String {
+    let extension = source
+        .extension()
+        .and_then(|value| value.to_str())
+        .filter(|value| *value == "lib")
+        .unwrap_or("a");
+    format!("{index}.{extension}")
+}
+
+fn monotonic_nonce() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
+}
+
+fn debug_cache(result: &str, detail: &str) {
+    if std::env::var("PERRY_CACHE_DEBUG_KEY").as_deref() == Ok("1") {
+        eprintln!("[archive-cache] {result}: {detail}");
+    }
+}
+
+fn hash_optional_file(
+    hasher: &mut Sha256,
+    label: &str,
+    path: Option<&Path>,
+) -> std::io::Result<()> {
+    match path {
+        Some(path) => hash_file(hasher, label, path),
+        None => {
+            hash_field(hasher, label, "<missing>");
+            Ok(())
+        }
+    }
+}
+
+fn hash_file(hasher: &mut Sha256, label: &str, path: &Path) -> std::io::Result<()> {
+    hash_field(hasher, &format!("{label}-name"), &path.to_string_lossy());
+    let (hash, size) = hash_file_value(path)?;
+    hash_field(hasher, &format!("{label}-size"), &size.to_string());
+    hash_field(hasher, &format!("{label}-sha256"), &hash);
+    Ok(())
+}
+
+fn hash_file_value(path: &Path) -> std::io::Result<(String, u64)> {
+    let file = fs::File::open(path)?;
+    let size = file.metadata()?.len();
+    let mut reader = BufReader::with_capacity(256 * 1024, file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 256 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok((hex::encode(hasher.finalize()), size))
+}
+
+fn hash_field(hasher: &mut Sha256, name: &str, value: &str) {
+    hasher.update((name.len() as u64).to_le_bytes());
+    hasher.update(name.as_bytes());
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(root: &Path, features: &[String], archives: &[PathBuf], target: &str) -> String {
+        let runtime = root.join("runtime.a");
+        let stdlib = root.join("stdlib.a");
+        let inputs = PreparedArchiveInputs {
+            cache_dir: root,
+            target: Some(target),
+            target_triple: Some(target),
+            compiled_features: features,
+            runtime_lib: &runtime,
+            stdlib_lib: Some(&stdlib),
+            well_known_libs: archives,
+        };
+        derive_prepared_archive_key(
+            &inputs,
+            Some(&root.join("perry")),
+            &[
+                Some(root.join("llvm-ar")),
+                Some(root.join("llvm-nm")),
+                Some(root.join("llvm-objcopy")),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn prepared_archive_key_covers_every_output_affecting_input() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for (name, bytes) in [
+            ("runtime.a", b"runtime-v1".as_slice()),
+            ("stdlib.a", b"stdlib-v1".as_slice()),
+            ("wrapper.a", b"wrapper-v1".as_slice()),
+            ("perry", b"perry-v1".as_slice()),
+            ("llvm-ar", b"ar-v1".as_slice()),
+            ("llvm-nm", b"nm-v1".as_slice()),
+            ("llvm-objcopy", b"objcopy-v1".as_slice()),
+        ] {
+            fs::write(root.join(name), bytes).unwrap();
+        }
+        let features = vec!["crypto".to_string(), "async-runtime".to_string()];
+        let archives = vec![root.join("wrapper.a")];
+        let baseline = key(root, &features, &archives, "macos");
+
+        for (name, replacement) in [
+            ("runtime.a", b"runtime-v2".as_slice()),
+            ("stdlib.a", b"stdlib-v2".as_slice()),
+            ("wrapper.a", b"wrapper-v2".as_slice()),
+            ("perry", b"perry-v2".as_slice()),
+            ("llvm-ar", b"ar-v2".as_slice()),
+            ("llvm-nm", b"nm-v2".as_slice()),
+            ("llvm-objcopy", b"objcopy-v2".as_slice()),
+        ] {
+            let path = root.join(name);
+            let original = fs::read(&path).unwrap();
+            fs::write(&path, replacement).unwrap();
+            assert_ne!(baseline, key(root, &features, &archives, "macos"));
+            fs::write(path, original).unwrap();
+        }
+
+        let changed_features = vec!["crypto".to_string(), "web-fetch".to_string()];
+        assert_ne!(baseline, key(root, &changed_features, &archives, "macos"));
+        assert_ne!(baseline, key(root, &features, &archives, "linux"));
+    }
+
+    #[test]
+    fn prepared_archive_cache_rejects_corrupt_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for name in ["runtime.a", "stdlib.a", "wrapper.a"] {
+            fs::write(root.join(name), name).unwrap();
+        }
+        let archives = vec![root.join("wrapper.a")];
+        let entry = root.join("entry");
+        let key = "test-key";
+        let prepared = root.join("prepared.a");
+        fs::write(&prepared, b"prepared-v1").unwrap();
+        let stored =
+            store_cached_archives(&entry, key, &archives, std::slice::from_ref(&prepared)).unwrap();
+        assert!(load_cached_archives(&entry, key, &archives).is_some());
+        fs::write(&stored[0], b"corrupt").unwrap();
+        assert!(load_cached_archives(&entry, key, &archives).is_none());
+    }
+}

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -330,8 +330,12 @@ pub(crate) fn build_and_run_link(
     let skip_runtime = (is_android || is_watchos || is_visionos)
         && (ctx.needs_ui || is_watchos)
         && find_ui_library(target).is_some();
-    let mut well_known_libs: Vec<PathBuf> = if prefer_well_known_before_stdlib {
-        well_known_libs
+    let mut source_well_known_libs = well_known_libs.to_vec();
+    let mut seen_well_known = std::collections::HashSet::new();
+    source_well_known_libs.retain(|path| seen_well_known.insert(path.clone()));
+    let prepare_well_known = || {
+        let cacheable = std::cell::Cell::new(true);
+        let paths = source_well_known_libs
             .iter()
             .map(|wk| {
                 // Wrappers precede stdlib here, so a wrapper's bundled
@@ -346,6 +350,7 @@ pub(crate) fn build_and_run_link(
                 let wk = match stdlib_lib {
                     Some(stdlib) => strip_bundled_runtime_from_well_known_lib(wk, stdlib)
                         .unwrap_or_else(|e| {
+                            cacheable.set(false);
                             eprintln!(
                                 "[strip-dedup] bundled-runtime drop skipped for {} (non-fatal): {e}",
                                 wk.display()
@@ -375,6 +380,7 @@ pub(crate) fn build_and_run_link(
                 let wk = match stdlib_lib {
                     Some(stdlib) => strip_bundled_shared_deps_from_well_known_lib(&wk, stdlib)
                         .unwrap_or_else(|e| {
+                            cacheable.set(false);
                             eprintln!(
                                 "[strip-dedup] shared-deps drop skipped for {} (non-fatal): {e}",
                                 wk.display()
@@ -383,17 +389,34 @@ pub(crate) fn build_and_run_link(
                         }),
                     None => wk.clone(),
                 };
-                strip_duplicate_objects_from_well_known_lib(&wk).unwrap_or(wk)
+                strip_duplicate_objects_from_well_known_lib(&wk).unwrap_or_else(|_| {
+                    cacheable.set(false);
+                    wk
+                })
             })
-            .collect()
-    } else {
-        well_known_libs.to_vec()
+            .collect();
+        (paths, cacheable.get())
     };
+    let well_known_libs: Vec<PathBuf> =
+        if prefer_well_known_before_stdlib && !source_well_known_libs.is_empty() {
+            prepare_well_known_archives(
+                PreparedArchiveInputs {
+                    cache_dir: &ctx.cache_dir,
+                    target,
+                    target_triple: rust_target_triple(target),
+                    compiled_features,
+                    runtime_lib,
+                    stdlib_lib: stdlib_lib.as_deref(),
+                    well_known_libs: &source_well_known_libs,
+                },
+                prepare_well_known,
+            )
+        } else {
+            source_well_known_libs
+        };
     // Multiple specifiers can route to the same native archive (`http` and
-    // `https` both select perry_ext_http). Repeating it adds no symbols and on
-    // COFF can make lld-link choose a different duplicate COMDAT provider.
-    let mut seen_well_known = std::collections::HashSet::new();
-    well_known_libs.retain(|path| seen_well_known.insert(path.clone()));
+    // `https` both select perry_ext_http). They were de-duplicated before the
+    // archive-preparation pass so the expensive transform also runs once.
     if !skip_runtime {
         if ctx.needs_stdlib || is_windows {
             // On Windows/MSVC, always try to link stdlib because codegen unconditionally

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -43,6 +43,7 @@ use super::{
     windows_subsystem_needs_ui, windows_target_arch, CompilationContext, WindowsTargetArch,
 };
 
+mod archive_cache;
 mod build_and_run;
 mod link_cache;
 mod linux_ui_libs;
@@ -51,6 +52,7 @@ mod pkg_config;
 mod platform_cmd;
 mod windows_link;
 
+use archive_cache::{prepare_well_known_archives, PreparedArchiveInputs};
 pub(super) use build_and_run::build_and_run_link;
 use link_cache::prepare_link_cache_status;
 pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -164,7 +164,7 @@ fn object_is_elf(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn find_path_tool(name: &str) -> Option<PathBuf> {
+pub(super) fn find_path_tool(name: &str) -> Option<PathBuf> {
     let paths = std::env::var_os("PATH")?;
     std::env::split_paths(&paths)
         .map(|dir| dir.join(name))
@@ -200,7 +200,7 @@ fn find_llvm_tool_or_beside_lld(tool: &str) -> Option<PathBuf> {
 /// `perry compile` as a systemd subprocess whose environment carries only
 /// `PATH`), so the rustup home is also derived from the `rustup`/`cargo` binary
 /// on `PATH` and from well-known absolute locations.
-fn find_nightly_llvm_tool(tool: &str) -> Option<PathBuf> {
+pub(super) fn find_nightly_llvm_tool(tool: &str) -> Option<PathBuf> {
     let exe_suffix = std::env::consts::EXE_SUFFIX;
     let mut rustup_homes: Vec<PathBuf> = Vec::new();
     if let Some(rustup_home) = std::env::var_os("RUSTUP_HOME") {


### PR DESCRIPTION
Closes #8396.

## Profile first

I instrumented the warm forced-link path before changing it. In a 10.13 s compile with all 44 object files reused and `PERRY_NO_LINK_CACHE=1`, the post-object work broke down as follows:

| sub-stage | wall |
|---|---:|
| well-known archive strip/dedup | 8.474 s |
| other archive/command preparation | 0.269 s |
| `clang`/`ld64` invocation | 0.193 s |
| post-link strip + cache manifest | 0.043 s |
| measured post-object subtotal | 8.979 s |

Strip/dedup was 94.4% of the directly instrumented post-object subtotal. The existing final-link cache probe happens after that work; it can skip a wholly unchanged final binary, but it is both too late to avoid archive preparation and correctly misses when one application object changes.

## Change

Cache the prepared well-known native archives under `PERRY_CACHE_DIR/prepared-archives`. A one-file edit still reaches the linker with its changed object, but unchanged wrapper archives no longer repeat extraction, symbol inspection, localization, and rebuilding.

The intermediate key includes the schema and Perry version, exact Perry executable bytes, target selector and effective target triple (or native host architecture/OS), sorted feature set, exact runtime and stdlib archive bytes, every ordered wrapper archive, and the exact resolved `ar`, `nm`, and `objcopy` executable bytes. Paths, sizes, and SHA-256 digests are framed into the key. Cached outputs have a manifest with their own sizes and SHA-256 digests and are rejected when missing or corrupt. A non-fatal strip/dedup fallback is deliberately not cached.

Application objects and linker flags cannot affect the prepared archive bytes, so they remain in the existing final-link cache key rather than this intermediate key. Either change still forces the final executable to relink. Empty wrapper sets bypass this cache entirely. `PERRY_NO_ARCHIVE_CACHE=1` bypasses only this layer for diagnosis; `--no-cache`/`PERRY_NO_CACHE=1` bypasses it too.

## Fixture results

The before column is the #8396 audit's repeated baseline. The after column is this branch on the same copied `rung4-api` fixture and dedicated cache, with the required runtime/stdlib wrapper build and `PERRY_RUNTIME_DIR` pin.

| case | before | after | cache evidence |
|---|---:|---:|---|
| unchanged rebuild | 0.28–0.29 s | 0.28–0.29 s | whole-build hit |
| edit leaf `plans.ts` | 10.56–11.31 s | 2.66, 2.73, 3.92 s | 43 reused, 1 stored; archive HIT (third run was machine-contended) |
| edit `db.ts` | 10.16–10.65 s | 2.84–2.90 s | 43 reused, 1 stored; archive HIT |
| all 44 hit, `--no-link` | 1.47 s | 1.01 s | all objects came from the populated cache |
| all 44 hit, forced link | 9.59 s | 1.83–1.92 s | 44 reused; archive HIT; linker ran |

The isolated archive/link increment falls from 8.12 s to 0.82–0.91 s, an 88.8–89.9% reduction. A final-build verification printed `[archive-cache] MISS` while populating key `969c7d…`, then `[archive-cache] HIT` for the same key; the hit took 1.83 s with all 44 objects reused.

Compiler peak RSS on the profiled baseline forced link was 312.5 MB. Warm cache-hit forced links used 254.6–266.8 MB (266.3 MB in the final verification), so the cache does not add to the existing ~300 MB peak.

## Hit/miss and correctness evidence

- Input object change: a temporary leaf edit produced 43 object hits + 1 miss/store, the archive cache hit, and the final-link report said `linked: true`, `skipped: false`.
- Linker flag change: `PERRY_EXTRA_LINK_ARGS=-Wl,-no_uuid` produced 44 object hits, an archive hit, and a real final relink; `dwarfdump --uuid` confirmed the flag affected the output.
- Runtime archive change: inserting a valid, unreferenced C object into the active runtime archive changed its SHA-256, produced an archive-cache MISS with a different key, and relinked. The original archive was restored and byte-verified afterward.
- Corrupt prepared output: the unit test populates an entry, corrupts its cached archive, and proves the next load rejects it.
- Key-test negative control: I temporarily removed the runtime archive hash from derivation and the key-coverage test failed at the runtime mutation assertion. Restoring the field made it pass.

The five prepared wrapper archives from the cache were byte-identical to freshly regenerated archives (SHA-256 matched individually). The final Mach-O files have the same 23,386,152-byte size and section layout, but not the same whole-file SHA-256: `ld64` derived a different Mach-O UUID (and therefore ad-hoc signature) when identical archive bytes came from persistent cache paths instead of per-process strip-temp paths. Clean and cached programs had byte-identical stdout and stderr and the same exit status.

Because that metadata difference changes the emitted file, I also measured seven runs of each executable. Median instructions were 145,214,016 clean vs 145,316,582 cached (+0.071%); median peak RSS was 40,386,560 vs 40,419,328 bytes (+0.081%). Both are within run noise, with no runtime-cost trade.

## Validation

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`: pass
- `cargo test --release -p perry --bin perry`: 1005 passed
- `cargo test --release -p perry-runtime --lib`: 2595 passed, 4 ignored
- `bash scripts/run_lint_gates.sh`: all 50 passed
- 19-program sweep: 19/19 compiled and byte-exact against every expected stdout
- Empty-wrapper regression guard: no archive-cache hashing/logging and byte-exact output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for prepared native library archives during compilation.
  * Cache entries are validated automatically and safely discarded if corrupted or outdated.
  * Cache keys account for compiler, target, features, libraries, and archive tools.

* **Documentation**
  * Documented the prepared-archive cache and how to disable it with environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->