### PR TITLE
perf(codegen): inline runtime-proven integer remainder

### DIFF
--- a/changelog.d/8407-inline-integer-remainder.md
+++ b/changelog.d/8407-inline-integer-remainder.md
@@ -1,0 +1,4 @@
+Inline `%` for runtime-proven i32 operands instead of unconditionally calling
+libm `fmod`, while retaining the floating fallback for fractional, non-finite,
+zero-divisor, and wide-number cases. On `pipeline`, 20-run batches improve wall
+time by 6.7% and retired instructions by 1.6% with unchanged peak RSS.

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -52,6 +52,82 @@ fn lower_rooted_dynamic_binary(
     })
 }
 
+/// Emit JS numeric remainder with an inline fast path for i32-valued operands.
+///
+/// LLVM lowers `frem double` to a libm `fmod` call on AArch64. Most application
+/// remainders use small whole numbers (loop indices, lengths, parsed integer
+/// configuration), so prove that common case at runtime and use integer
+/// remainder instead. The ordered range checks are deliberately in a separate
+/// predecessor from `fptosi`: converting NaN, infinity, or an out-of-range
+/// double is poison in LLVM even when a later select would discard it.
+fn lower_checked_i32_modulo(ctx: &mut FnCtx<'_>, left: &str, right: &str) -> String {
+    let convert_idx = ctx.new_block("mod.i32.convert");
+    let integer_idx = ctx.new_block("mod.i32.integer");
+    let fallback_idx = ctx.new_block("mod.f64.fallback");
+    let merge_idx = ctx.new_block("mod.merge");
+    let convert_label = ctx.block_label(convert_idx);
+    let integer_label = ctx.block_label(integer_idx);
+    let fallback_label = ctx.block_label(fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+
+    let min = crate::nanbox::double_literal(f64::from(i32::MIN));
+    let max = crate::nanbox::double_literal(f64::from(i32::MAX));
+    let l_ge_min = ctx.block().fcmp("oge", left, &min);
+    let l_le_max = ctx.block().fcmp("ole", left, &max);
+    let r_ge_min = ctx.block().fcmp("oge", right, &min);
+    let r_le_max = ctx.block().fcmp("ole", right, &max);
+    let l_in_range = ctx.block().and(I1, &l_ge_min, &l_le_max);
+    let r_in_range = ctx.block().and(I1, &r_ge_min, &r_le_max);
+    let both_in_range = ctx.block().and(I1, &l_in_range, &r_in_range);
+    ctx.block()
+        .cond_br(&both_in_range, &convert_label, &fallback_label);
+
+    ctx.current_block = convert_idx;
+    let li = ctx.block().fptosi(DOUBLE, left, I32);
+    let ri = ctx.block().fptosi(DOUBLE, right, I32);
+    let l_roundtrip = ctx.block().sitofp(I32, &li, DOUBLE);
+    let r_roundtrip = ctx.block().sitofp(I32, &ri, DOUBLE);
+    let l_is_integer = ctx.block().fcmp("oeq", &l_roundtrip, left);
+    let r_is_integer = ctx.block().fcmp("oeq", &r_roundtrip, right);
+    let r_is_nonzero = ctx.block().icmp_ne(I32, &ri, "0");
+    let both_integer = ctx.block().and(I1, &l_is_integer, &r_is_integer);
+    let can_use_integer = ctx.block().and(I1, &both_integer, &r_is_nonzero);
+    ctx.block()
+        .cond_br(&can_use_integer, &integer_label, &fallback_label);
+
+    ctx.current_block = integer_idx;
+    let remainder = ctx.block().srem(I32, &li, &ri);
+    let result = ctx.block().sitofp(I32, &remainder, DOUBLE);
+
+    // Integer remainder loses the sign of a zero result. Test the dividend's
+    // IEEE-754 sign bit rather than `left < 0`, because -0 must also produce
+    // -0. Nonzero results already have the dividend's sign via signed `srem`.
+    let remainder_is_zero = ctx.block().icmp_eq(I32, &remainder, "0");
+    let left_bits = ctx.block().bitcast_double_to_i64(left);
+    let dividend_has_sign = ctx.block().icmp_slt(I64, &left_bits, "0");
+    let needs_negative_zero = ctx.block().and(I1, &remainder_is_zero, &dividend_has_sign);
+    let negative_result = ctx.block().fneg(&result);
+    let integer_value =
+        ctx.block()
+            .select(I1, &needs_negative_zero, DOUBLE, &negative_result, &result);
+    let integer_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = fallback_idx;
+    let fallback_value = ctx.block().frem(left, right);
+    let fallback_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    ctx.block().phi(
+        DOUBLE,
+        &[
+            (&integer_value, &integer_end),
+            (&fallback_value, &fallback_end),
+        ],
+    )
+}
+
 /// `+` where both operands are statically numeric but at least one of them is
 /// numeric only because a DECLARED type said so (#7773, #7776).
 ///
@@ -869,16 +945,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // fptosi, producing the wrong result. `is_integer_valued_expr`
             // only returns true when we can prove the value is a whole
             // number (integer literals, integer loop counters, or nested
-            // integer arithmetic). A zero RHS falls through to `frem`
-            // because srem(x,0) is UB in LLVM (on ARM the CPU silently
-            // gives 0, but JS requires NaN for any x % 0). For everything
-            // else we fall through to the `frem` path.
-            let right_is_known_zero = matches!(**right, Expr::Integer(0))
-                || matches!(**right, Expr::Number(v) if v == 0.0);
+            // integer arithmetic). A zero RHS cannot use this unconditional
+            // path because srem(x,0) is UB in LLVM (on ARM the CPU silently
+            // gives 0, but JS requires NaN for any x % 0). Everything not
+            // proven here reaches the guarded i32 path and its `frem`
+            // fallback below.
             if matches!(op, BinaryOp::Mod)
                 && crate::type_analysis::is_integer_valued_expr(ctx, left)
-                && crate::type_analysis::is_integer_valued_divisor(ctx, right)
-                && !right_is_known_zero
+                && matches!(right.as_ref(), Expr::Integer(divisor) if *divisor != 0)
             {
                 let l_raw = lower_expr(ctx, left)?;
                 let r_raw = lower_expr(ctx, right)?;
@@ -935,10 +1009,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let blk = ctx.block();
                     blk.fdiv(&l, &r)
                 }
-                BinaryOp::Mod => {
-                    let blk = ctx.block();
-                    blk.frem(&l, &r)
-                }
+                BinaryOp::Mod => lower_checked_i32_modulo(ctx, &l, &r),
                 BinaryOp::Pow => {
                     ctx.block()
                         .call(DOUBLE, "js_math_pow", &[(DOUBLE, &l), (DOUBLE, &r)])

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -2706,46 +2706,11 @@ fn lower_numeric_binary_value(
         return Ok(None);
     }
 
-    // Hand this proven shape to `binary::lower`, which owns the existing
-    // integer remainder and negative-zero repair. This must run before operand
-    // lowering so returning `None` emits no dead loads or duplicate records.
-    if matches!(op, BinaryOp::Mod)
-        && matches!(
-            left,
-            Expr::LocalGet(id)
-                if ctx.i32_counter_slots.contains_key(id)
-                    && !ctx.unsigned_i32_locals.contains(id)
-        )
-        && matches!(
-            right,
-            Expr::Integer(value)
-                if i32::try_from(*value).is_ok_and(|divisor| divisor > 0)
-        )
-    {
-        return Ok(None);
-    }
-
-    // #7404: the same hand-off for a remainder whose operands the integer
-    // fast path can prove, but whose dividend has no i32 counter slot — the
-    // `bench_bitwise` shape (`let a = 12345678; … a = a + 1; a % 1000`).
-    //
-    // The condition above only recognises an `i32_counter_slots` dividend, so
-    // an i64-range integer local fell through to the `frem double` below,
-    // which on AArch64 is a `bl _fmod` libm call.
-    //
-    // The DIVISOR is restricted to a non-zero integer literal, exactly like the
-    // hand-off above. That is not incidental tidiness: `binary::lower`'s own
-    // Mod gate accepts any `integer_locals` divisor, and `srem(x, 0)` is UB in
-    // LLVM while JS requires NaN. A decrementing counter that walks through
-    // zero (`for (let d = 10; d >= 0; d--) … x % d`) IS in `integer_locals`,
-    // so widening the hand-off to non-literal divisors would newly route it
-    // into `srem` — main keeps it on `frem` only because this hand-off never
-    // fires for it. Literal divisors cannot be zero here, so the dividend is
-    // the only side this widens.
-    if matches!(op, BinaryOp::Mod)
-        && matches!(right, Expr::Integer(divisor) if *divisor != 0)
-        && crate::type_analysis::is_integer_valued_expr(ctx, left)
-    {
+    // `binary::lower` owns both remainder specializations: the static integer
+    // proof and the runtime-checked i32 path with an `frem` fallback. Keep all
+    // numeric `%` expressions on that one path so native-value lowering cannot
+    // bypass the guard and retain an unconditional libm call.
+    if matches!(op, BinaryOp::Mod) {
         return Ok(None);
     }
 

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -32,8 +32,8 @@ mod refine;
 mod strings;
 
 pub(crate) use numeric::{
-    expr_produces_canonical_raw_f64, is_bigint_expr, is_bool_expr, is_integer_valued_divisor,
-    is_integer_valued_expr, is_numeric_expr, is_provably_not_bigint,
+    expr_produces_canonical_raw_f64, is_bigint_expr, is_bool_expr, is_integer_valued_expr,
+    is_numeric_expr, is_provably_not_bigint,
 };
 pub(crate) use pod::{
     add_operands_have_pod_materialization_hazard,

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -755,26 +755,6 @@ pub(crate) fn is_integer_valued_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     integer_magnitude_bits_inner(ctx, e, true).is_some_and(|bits| bits <= MAX_FPTOSI_I64_BITS)
 }
 
-/// The same judgment for the **divisor** of `%`, with the i64-range local set
-/// deliberately withheld.
-///
-/// `srem(x, 0)` is UB in LLVM while JS requires `NaN`, and the caller's
-/// `right_is_known_zero` guard only recognises a literal `0` — a *local* that
-/// happens to hold `0` slips past it. The i64-range set admits exactly the
-/// counters that walk through zero (`for (let d = 10; d >= 0; d--) … x % d`),
-/// so letting it widen the divisor would introduce a UB window that
-/// `integer_locals` alone does not open. The dividend has no such constraint.
-pub(crate) fn is_integer_valued_divisor(ctx: &FnCtx<'_>, e: &Expr) -> bool {
-    if matches!(
-        e,
-        Expr::LocalGet(id) | Expr::Update { id, .. }
-            if ctx.int_valued_i64_locals.contains_key(id)
-    ) {
-        return false;
-    }
-    integer_magnitude_bits_inner(ctx, e, false).is_some_and(|bits| bits <= MAX_FPTOSI_I64_BITS)
-}
-
 /// Largest magnitude (as `log2`) an expression may have and still convert
 /// exactly and in-range through `fptosi double -> i64`. `i64::MAX` is
 /// `2^63 - 1`, so `2^62` leaves a full bit of headroom.

--- a/crates/perry-codegen/tests/native_proof_regressions/integer_modulo.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/integer_modulo.rs
@@ -45,14 +45,20 @@ fn assert_integer_modulo_with_negative_zero_repair(ir: &str) {
     );
 }
 
-fn assert_floating_modulo(ir: &str) {
+fn assert_checked_modulo(ir: &str) {
     assert!(
         ir.contains("frem double"),
-        "ineligible modulo shape must remain on floating remainder:\n{ir}"
+        "runtime-checked modulo must retain the floating fallback:\n{ir}"
     );
     assert!(
-        !ir.contains("srem i64") && !ir.contains("srem i32"),
-        "ineligible modulo shape must not emit integer remainder:\n{ir}"
+        ir.contains("mod.i32.convert")
+            && ir.contains("srem i32")
+            && ir.contains("fptosi double")
+            && ir.contains("sitofp i32")
+            && ir.contains("icmp ne i32")
+            && ir.contains("bitcast double")
+            && ir.contains("icmp slt i64"),
+        "runtime-checked modulo must guard conversion and preserve negative zero:\n{ir}"
     );
 }
 
@@ -61,7 +67,7 @@ fn i32_counter_mod_positive_literal_reaches_integer_fast_path() {
     assert_integer_modulo_with_negative_zero_repair(&factorial_shaped_ir(int(1000)));
 }
 
-/// #7494 (was `i32_counter_mod_unsafe_or_nonliteral_divisors_keep_frem`):
+/// #7494 (originally `i32_counter_mod_unsafe_or_nonliteral_divisors_keep_frem`):
 /// `negative` and `out_of_i32` used to belong to this "must stay on frem"
 /// bucket. #7404/#7416 (`expr/mod.rs::lower_numeric_binary_value`) added a
 /// SECOND hand-off for a dividend the integer fast path can prove even
@@ -99,29 +105,21 @@ fn i32_counter_mod_any_nonzero_integer_literal_divisor_reaches_integer_fast_path
 }
 
 #[test]
-fn i32_counter_mod_unsafe_or_nonliteral_divisors_keep_frem() {
-    let cases = [
+fn i32_counter_mod_unsafe_or_nonliteral_divisors_use_checked_path() {
+    let divisors = [
         // Not `Expr::Integer` at all — an integral-VALUED `Expr::Number` is
-        // still a float literal syntactically, so neither Mod hand-off in
-        // `lower_numeric_binary_value` (both pattern-match `Expr::Integer`
-        // specifically) fires for it.
-        ("integral_number", number(1000.0)),
-        // `srem(x, 0)` is UB in LLVM; JS `x % 0` is NaN. Excluded by both
-        // hand-offs' explicit non-zero-divisor guard.
-        ("zero", int(0)),
+        // still a float literal syntactically, so the static proof does not
+        // fire and the checked path handles it at runtime.
+        number(1000.0),
+        // `srem(x, 0)` is UB in LLVM; JS `x % 0` is NaN. The static path
+        // excludes it, and the checked path branches to `frem` at runtime.
+        int(0),
         // Fractional — `Expr::Number`, same as `integral_number` above.
-        ("fractional", number(2.5)),
+        number(2.5),
     ];
-    for (case, divisor) in cases {
+    for divisor in divisors {
         let ir = factorial_shaped_ir(divisor);
-        assert!(
-            ir.contains("frem double"),
-            "{case} divisor must remain on floating remainder:\n{ir}"
-        );
-        assert!(
-            !ir.contains("srem i64") && !ir.contains("srem i32"),
-            "{case} divisor must not emit integer remainder:\n{ir}"
-        );
+        assert_checked_modulo(&ir);
     }
 
     let dynamic_ir = compile_ir(
@@ -141,11 +139,11 @@ fn i32_counter_mod_unsafe_or_nonliteral_divisors_keep_frem() {
             Stmt::Return(Some(local(1))),
         ],
     );
-    assert_floating_modulo(&dynamic_ir);
+    assert_checked_modulo(&dynamic_ir);
 }
 
 #[test]
-fn non_i32_left_operands_keep_frem() {
+fn non_i32_left_operands_use_checked_path_with_frem_fallback() {
     let f64_ir = compile_ir(
         "value_first_f64_modulo.ts",
         vec![
@@ -153,7 +151,7 @@ fn non_i32_left_operands_keep_frem() {
             Stmt::Return(Some(modulo(local(1), int(2)))),
         ],
     );
-    assert_floating_modulo(&f64_ir);
+    assert_checked_modulo(&f64_ir);
 
     // A `>>> 0` initializer plus only `>>> 0` writes is the harness's existing
     // way to obtain an unsigned i32 shadow slot. The specialization must not
@@ -182,5 +180,5 @@ fn non_i32_left_operands_keep_frem() {
             Stmt::Return(Some(local(1))),
         ],
     );
-    assert_floating_modulo(&u32_ir);
+    assert_checked_modulo(&u32_ir);
 }

--- a/test-files/test_gap_numeric_remainder_i32.ts
+++ b/test-files/test_gap_numeric_remainder_i32.ts
@@ -25,3 +25,29 @@ console.log("dynamic-zero-divisor:" + (5 % dynamicZero));
 console.log("negative-divisor:" + (5 % -2));
 console.log("min-i32-negative-one:" + Object.is(-2147483648 % -1, -0));
 console.log("wide-safe-integer:" + (9007199254740991 % 97));
+
+function displayRemainder(value: number): string {
+    if (Object.is(value, -0)) return "-0";
+    if (Number.isNaN(value)) return "NaN";
+    return String(value);
+}
+
+// Keep both operands behind array reads so codegen has to exercise the
+// runtime-checked integer path and its floating fallback, rather than folding
+// literal pairs at compile time. This is run differentially against Node by
+// the ordinary test-files harness.
+const dynamicLeft = [
+    7, -7, 7, -7, -0, 0, 5.5, -5.5, NaN, Infinity, 5,
+    2147483647, -2147483648, 4294967296, 9007199254740991,
+    9007199254740992,
+];
+const dynamicRight = [
+    3, 3, -3, -3, 3, -3, 2, 2, 2, 2, Infinity,
+    97, -1, 3, 97, 7,
+];
+let differential = "";
+for (let i = 0; i < dynamicLeft.length; i++) {
+    if (i > 0) differential = differential + ",";
+    differential = differential + displayRemainder(dynamicLeft[i] % dynamicRight[i]);
+}
+console.log("dynamic-differential:" + differential);


### PR DESCRIPTION
## Summary

Inline numeric `%` when runtime checks prove both operands are non-fractional i32 values, avoiding the hot libm `fmod` call while preserving the floating fallback and JavaScript edge-case semantics.

## Changes

- route numeric remainder through one lowering path instead of allowing native-value lowering to emit unconditional `frem`
- guard ordered i32 range, integer round-trips, and a nonzero divisor before `srem`
- preserve negative zero from the dividend sign bit
- extend the Node-differential remainder matrix across negative, fractional, non-finite, zero-divisor, and wide-number operands
- add the required changelog fragment without changing any version metadata

## Related issue

Fixes #8407

## Test plan

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test --release -p perry-runtime --lib` — 2,596 passed, 4 ignored
- `cargo test --release -p perry --bin perry` — 1,005 passed
- `cargo test -p perry-codegen --test native_proof_regressions integer_modulo` — 4 passed
- `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --filter test_gap_numeric_remainder_i32` — PASS against pinned Node 26.5.1
- all 19 issue corpus rows compile and match their Node-oracle stdout byte-for-byte
- `bash scripts/run_lint_gates.sh` — all 50 gates passed

### Performance

Median of five interleaved batches, 20 `pipeline` executions per wall-time sample:

| Runtime | Wall / 20 runs | Instructions / run | Peak RSS |
|---|---:|---:|---:|
| Perry baseline | 2.69 s | 2,298,525,301 | 22,200,320 B |
| Perry fixed | 2.51 s | 2,263,207,126 | 22,200,320 B |
| Node 26.5.1 | 2.23 s | 1,244,482,162 | 89,014,272 B |

That is a 6.7% wall-time improvement and 1.5% fewer retired instructions with unchanged RSS.

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [x] (if CLI / stdlib / runtime API changed) N/A — no API change
- [x] (if touching a platform UI backend) N/A — no UI backend change

## Screenshots / output

Not applicable.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved numeric remainder operations for proven 32-bit integer values, delivering faster execution with unchanged peak memory usage.

* **Bug Fixes**
  * Preserved correct results for negative zero, fractional values, non-finite numbers, zero divisors, and wide integers.
  * Added safeguards for dynamic and unsupported operand types.

* **Tests**
  * Expanded coverage for integer, floating-point, special-value, sign, and wide-number remainder cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->