### PR TITLE
perf(codegen): elide proven element shape checks

### DIFF
--- a/changelog.d/8414-element-shape-locality.md
+++ b/changelog.d/8414-element-shape-locality.md
@@ -1,0 +1,7 @@
+Speed up loops over contained class-instance arrays by carrying their proven
+numeric field layout into direct `array[i].field` reads. Specialized loops now
+skip redundant per-object header and shape checks when runtime parameter guards
+and the complete reachable-store proof establish the exact raw-f64 layout; the
+generic fallback remains guarded. On the `churn` corpus row this reduces retired
+instructions by 8.8% and median wall time by 30%, putting Perry ahead of Node
+without increasing RSS.

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -805,6 +805,16 @@ pub(super) fn compile_function(
                 .collect()
         })
         .unwrap_or_default();
+    let spec_numeric_params: HashSet<u32> = spec_param_proofs
+        .iter()
+        .filter_map(|(id, ty)| {
+            matches!(
+                ty,
+                perry_hir::types::Type::Number | perry_hir::types::Type::Int32
+            )
+            .then_some(*id)
+        })
+        .collect();
     // `--opt-report` (#6952): attribute every representation decision the
     // collectors below make to this function. No-op when the report is off.
     //
@@ -834,6 +844,7 @@ pub(super) fn compile_function(
         &cross_module.module_dispatch,
         &spec_ta_lens,
         &spec_i32_params,
+        &spec_numeric_params,
     );
 
     if let Some(plan) = spec_entry {

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -116,6 +116,9 @@ pub(crate) struct ArrayFacts {
     /// empty, receives only same-class fresh allocations, stays dense, and
     /// never escapes to an unbounded mutator.
     pub exact_element_classes: HashMap<u32, String>,
+    /// Array binding -> fields whose slots remain raw f64 for every element,
+    /// proven from the complete reachable-store set of its E1--E5 group.
+    pub exact_numeric_element_fields: HashMap<u32, HashSet<String>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -291,6 +294,10 @@ impl TypeFacts {
             .map(String::as_str)
     }
 
+    pub(crate) fn exact_numeric_element_fields(&self, local_id: u32) -> Option<&HashSet<String>> {
+        self.arrays.exact_numeric_element_fields.get(&local_id)
+    }
+
     pub(crate) fn array_length_mutation_locals(&self) -> &HashSet<u32> {
         &self.effect.array_length_mutation_locals
     }
@@ -440,6 +447,7 @@ pub(crate) fn collect_type_facts(
     module_dispatch: &super::ModuleDispatchFacts,
     spec_ta_lens: &HashMap<u32, i64>,
     spec_i32_params: &HashSet<u32>,
+    spec_numeric_params: &HashSet<u32>,
 ) -> TypeFacts {
     // #7700: which locals hold a NUMBER, so a `u8[k]` keyed on one is a byte
     // read rather than a property read. Computed once here because
@@ -635,15 +643,18 @@ pub(crate) fn collect_type_facts(
     // Representation-selection Phase 3b: shape-proven pointer locals. Gated
     // on `PERRY_PTR_SHAPE_LOCALS` and the module-wide §5.2 barrier scan
     // inside the collector.
-    let shape_proven_ptr_locals = super::ptr_shape::collect_shape_proven_ptr_locals(
-        stmts,
-        boxed_vars,
-        module_globals,
-        classes,
-        module_dispatch,
-        &not_bigint_locals,
-        &element_shape_facts,
-    );
+    let (shape_proven_ptr_locals, exact_numeric_element_fields) =
+        super::ptr_shape::collect_shape_proven_ptr_locals_and_element_fields(
+            stmts,
+            boxed_vars,
+            module_globals,
+            classes,
+            module_dispatch,
+            &not_bigint_locals,
+            &element_shape_facts,
+            spec_numeric_params,
+        );
+    array_facts.exact_numeric_element_fields = exact_numeric_element_fields;
     // Representation-selection Phase 4a.3: `Ptr<NumArray>` locals. Gated on
     // `PERRY_PTR_NUMARRAY_LOCALS`, the module-wide §5.2 barrier scan, and the
     // array-specific prototype-indexed-write kill inside the collector.
@@ -742,6 +753,7 @@ pub(crate) fn collect_native_region_fact_graph(
         module_dispatch,
         &HashMap::new(),
         &HashSet::new(),
+        &HashSet::new(),
     )
 }
 
@@ -763,6 +775,7 @@ pub(crate) fn collect_native_region_fact_graph_with_spec_params(
     module_dispatch: &super::ModuleDispatchFacts,
     spec_ta_lens: &HashMap<u32, i64>,
     spec_i32_params: &HashSet<u32>,
+    spec_numeric_params: &HashSet<u32>,
 ) -> NativeRegionFactGraph {
     collect_type_facts(
         stmts,
@@ -778,6 +791,7 @@ pub(crate) fn collect_native_region_fact_graph_with_spec_params(
         module_dispatch,
         spec_ta_lens,
         spec_i32_params,
+        spec_numeric_params,
     )
 }
 
@@ -804,6 +818,7 @@ pub(crate) fn collect_hir_facts(
         // conservative default keeps it that way if one ever could.
         &super::ModuleDispatchFacts::default(),
         &HashMap::new(),
+        &HashSet::new(),
         &HashSet::new(),
     )
 }
@@ -1471,6 +1486,7 @@ impl ArrayFactCollector {
                 // Filled in by `collect_type_facts` from the E1--E5 exact
                 // element-shape proof.
                 exact_element_classes: HashMap::new(),
+                exact_numeric_element_fields: HashMap::new(),
             },
             EffectFacts {
                 unknown_call_escape: self.unknown_call_escape,

--- a/crates/perry-codegen/src/collectors/ptr_shape.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape.rs
@@ -300,6 +300,32 @@ pub(crate) fn collect_shape_proven_ptr_locals(
     not_bigint_locals: &HashSet<u32>,
     element_facts: &ElementShapeFacts,
 ) -> HashMap<u32, PtrShapeLocal> {
+    collect_shape_proven_ptr_locals_and_element_fields(
+        stmts,
+        boxed_vars,
+        module_globals,
+        classes,
+        module_dispatch,
+        not_bigint_locals,
+        element_facts,
+        &HashSet::new(),
+    )
+    .0
+}
+
+/// Collect pointer-local facts plus the group-wide numeric layouts of proven
+/// element arrays. The latter includes arrays read only as `A[i].field`, which
+/// have no element local to carry a [`PtrShapeLocal`] of their own.
+pub(crate) fn collect_shape_proven_ptr_locals_and_element_fields(
+    stmts: &[Stmt],
+    boxed_vars: &HashSet<u32>,
+    module_globals: &HashMap<u32, String>,
+    classes: &HashMap<String, &Class>,
+    module_dispatch: &ModuleDispatchFacts,
+    not_bigint_locals: &HashSet<u32>,
+    element_facts: &ElementShapeFacts,
+    numeric_param_seeds: &HashSet<u32>,
+) -> (HashMap<u32, PtrShapeLocal>, HashMap<u32, HashSet<String>>) {
     // #7152: Perry's own `cjs_wrap` preamble, recognised once for this region.
     // One scan of the top-level statement list on anything else, then a
     // `Default` that suppresses nothing. See `cjs_scaffolding.rs`.
@@ -313,7 +339,7 @@ pub(crate) fn collect_shape_proven_ptr_locals(
     };
     if let Some(denial) = bail {
         report_early_bail(stmts, boxed_vars, module_globals, &preamble, denial);
-        return HashMap::new();
+        return (HashMap::new(), HashMap::new());
     }
     // `--opt-report` (#6952): binding names and loop depths for the values
     // this pass is about to accept or deny. Both walks are skipped entirely
@@ -366,8 +392,8 @@ pub(crate) fn collect_shape_proven_ptr_locals(
         candidates.insert(id, class_name.to_owned());
         callback_seeded.insert(id);
     }
-    if candidates.is_empty() {
-        return HashMap::new();
+    if candidates.is_empty() && element_facts.is_empty() {
+        return (HashMap::new(), HashMap::new());
     }
     // Class-level admission BEFORE the use walk so the walk's chain-field
     // membership tests are meaningful.
@@ -380,8 +406,8 @@ pub(crate) fn collect_shape_proven_ptr_locals(
             }
         }
     });
-    if candidates.is_empty() {
-        return HashMap::new();
+    if candidates.is_empty() && element_facts.is_empty() {
+        return (HashMap::new(), HashMap::new());
     }
 
     // Alias pre-pass: `const alias = candidate` (the exact-receiver inliner
@@ -447,13 +473,18 @@ pub(crate) fn collect_shape_proven_ptr_locals(
     } = walk;
     // #7770: locals whose every write is number-producing by construction —
     // they let a provenance `new C(i, i + 1)` resolve its parameters.
-    let numeric_locals = collect_numeric_by_construction_locals(
+    let mut numeric_locals = collect_numeric_by_construction_locals(
         stmts,
         boxed_vars,
         module_globals,
         not_bigint_locals,
         &const_local_inits,
     );
+    // A spec entry has validated these parameters before entering this body.
+    // Unlike a TypeScript annotation, that is runtime evidence, so derived
+    // object-literal values such as `base + i` are numeric by construction in
+    // this clone while the public fallback remains conservative.
+    numeric_locals.extend(numeric_param_seeds.iter().copied());
     // #7770: one numeric-field verdict per element group, computed from the
     // union of every member's stores and the meet over every push's `new`
     // arguments (see `ptr_shape_numeric.rs`). Consulted by the `'cand` loop
@@ -462,7 +493,7 @@ pub(crate) fn collect_shape_proven_ptr_locals(
     // integrity below drops EVERY member's fact when any member fails, and a
     // dropped fact takes its claim with it.
     let groups = element_facts.group_members();
-    let group_numeric = prove_group_numeric_fields(
+    let mut group_numeric = prove_group_numeric_fields(
         classes,
         module_dispatch,
         element_facts,
@@ -675,64 +706,21 @@ pub(crate) fn collect_shape_proven_ptr_locals(
             }
         }
     }
-    out
+    // A group-wide layout claim is usable only when every reference-bearing
+    // member survived the exact-shape proof. Direct `A[i].field` groups have
+    // no members, so their all-inline provenance verdict survives vacuously.
+    group_numeric.retain(|root, _| {
+        groups
+            .get(root)
+            .is_some_and(|members| members.iter().all(|member| out.contains_key(member)))
+    });
+    let element_fields = element_facts.proven_array_numeric_fields(&group_numeric);
+    (out, element_fields)
 }
 
-/// Collect `Let { mutable: false, init: Some(LocalGet(src)) }` edges — the
-/// alias shape the exact-receiver inliner emits for compound assigns.
-pub(super) fn collect_alias_edges(stmts: &[Stmt], out: &mut Vec<(u32, u32)>) {
-    for s in stmts {
-        match s {
-            Stmt::Let {
-                id,
-                mutable: false,
-                init: Some(Expr::LocalGet(src)),
-                ..
-            } => out.push((*id, *src)),
-            Stmt::If {
-                then_branch,
-                else_branch,
-                ..
-            } => {
-                collect_alias_edges(then_branch, out);
-                if let Some(eb) = else_branch {
-                    collect_alias_edges(eb, out);
-                }
-            }
-            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
-                collect_alias_edges(body, out);
-            }
-            Stmt::For { init, body, .. } => {
-                if let Some(init) = init {
-                    collect_alias_edges(std::slice::from_ref(init.as_ref()), out);
-                }
-                collect_alias_edges(body, out);
-            }
-            Stmt::Try {
-                body,
-                catch,
-                finally,
-            } => {
-                collect_alias_edges(body, out);
-                if let Some(c) = catch {
-                    collect_alias_edges(&c.body, out);
-                }
-                if let Some(f) = finally {
-                    collect_alias_edges(f, out);
-                }
-            }
-            Stmt::Switch { cases, .. } => {
-                for case in cases {
-                    collect_alias_edges(&case.body, out);
-                }
-            }
-            Stmt::Labeled { body, .. } => {
-                collect_alias_edges(std::slice::from_ref(body.as_ref()), out);
-            }
-            _ => {}
-        }
-    }
-}
+#[path = "ptr_shape_aliases.rs"]
+mod aliases;
+pub(super) use aliases::collect_alias_edges;
 
 // ── Class-level admission ──────────────────────────────────────────────────
 

--- a/crates/perry-codegen/src/collectors/ptr_shape_aliases.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_aliases.rs
@@ -1,0 +1,59 @@
+//! Alias-edge collection for the `Ptr<Shape>` containment proof.
+
+use super::*;
+
+/// Collect `Let { mutable: false, init: Some(LocalGet(src)) }` edges — the
+/// alias shape the exact-receiver inliner emits for compound assigns.
+pub(in crate::collectors) fn collect_alias_edges(stmts: &[Stmt], out: &mut Vec<(u32, u32)>) {
+    for s in stmts {
+        match s {
+            Stmt::Let {
+                id,
+                mutable: false,
+                init: Some(Expr::LocalGet(src)),
+                ..
+            } => out.push((*id, *src)),
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_alias_edges(then_branch, out);
+                if let Some(eb) = else_branch {
+                    collect_alias_edges(eb, out);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                collect_alias_edges(body, out);
+            }
+            Stmt::For { init, body, .. } => {
+                if let Some(init) = init {
+                    collect_alias_edges(std::slice::from_ref(init.as_ref()), out);
+                }
+                collect_alias_edges(body, out);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                collect_alias_edges(body, out);
+                if let Some(c) = catch {
+                    collect_alias_edges(&c.body, out);
+                }
+                if let Some(f) = finally {
+                    collect_alias_edges(f, out);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    collect_alias_edges(&case.body, out);
+                }
+            }
+            Stmt::Labeled { body, .. } => {
+                collect_alias_edges(std::slice::from_ref(body.as_ref()), out);
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_elements.rs
@@ -210,7 +210,15 @@ impl ElementShapeFacts {
     ///
     /// Group integrity: `ptr_shape.rs` promotes all of these or none of them.
     pub(crate) fn group_members(&self) -> HashMap<u32, Vec<u32>> {
-        let mut out: HashMap<u32, Vec<u32>> = HashMap::new();
+        // Keep roots whose elements are used only through direct `A[i].field`
+        // reads. They have no element locals, but the group-wide reachable-
+        // store proof still needs to inspect their inline `new` push sites.
+        let mut out: HashMap<u32, Vec<u32>> = self
+            .arrays
+            .keys()
+            .copied()
+            .map(|root| (root, Vec::new()))
+            .collect();
         for (id, root) in self
             .pushed
             .iter()
@@ -270,6 +278,17 @@ impl ElementShapeFacts {
                     .get(root)
                     .map(|class_name| (*id, class_name.clone()))
             })
+            .collect()
+    }
+
+    /// Expand root-keyed numeric-field verdicts to every proven array alias.
+    pub(crate) fn proven_array_numeric_fields(
+        &self,
+        root_fields: &HashMap<u32, HashSet<String>>,
+    ) -> HashMap<u32, HashSet<String>> {
+        self.array_roots
+            .iter()
+            .filter_map(|(id, root)| root_fields.get(root).map(|fields| (*id, fields.clone())))
             .collect()
     }
 

--- a/crates/perry-codegen/src/collectors/ptr_shape_group_numeric_tests.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_group_numeric_tests.rs
@@ -261,6 +261,49 @@ fn promote(stmts: &[Stmt], classes: &HashMap<String, &Class>) -> HashMap<u32, Pt
     )
 }
 
+fn promote_with_element_fields(
+    stmts: &[Stmt],
+    classes: &HashMap<String, &Class>,
+) -> (HashMap<u32, PtrShapeLocal>, HashMap<u32, HashSet<String>>) {
+    promote_with_element_fields_and_numeric_params(stmts, classes, &HashSet::new())
+}
+
+fn promote_with_element_fields_and_numeric_params(
+    stmts: &[Stmt],
+    classes: &HashMap<String, &Class>,
+    numeric_param_seeds: &HashSet<u32>,
+) -> (HashMap<u32, PtrShapeLocal>, HashMap<u32, HashSet<String>>) {
+    let facts = facts_for(classes);
+    let els = super::super::ptr_shape_elements::collect_element_shape_facts(
+        stmts,
+        &HashSet::new(),
+        &HashMap::new(),
+        classes,
+        &facts,
+    );
+    collect_shape_proven_ptr_locals_and_element_fields(
+        stmts,
+        &HashSet::new(),
+        &HashMap::new(),
+        classes,
+        &facts,
+        &HashSet::new(),
+        &els,
+        numeric_param_seeds,
+    )
+}
+
+fn read_direct_field(array_id: u32, index_id: u32, property: &str) -> Stmt {
+    Stmt::Expr(Expr::PropertyGet {
+        object: Box::new(Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(array_id)),
+            index: Box::new(Expr::LocalGet(index_id)),
+        }),
+        property: property.to_string(),
+        byte_offset: 0,
+    })
+}
+
 fn names(set: &[&str]) -> HashSet<String> {
     set.iter().map(|s| s.to_string()).collect()
 }
@@ -302,6 +345,94 @@ fn inline_push_loop_counter_args_prove_numeric_fields() {
         names(&["x", "y"]),
         "loop-counter constructor args are numeric by construction"
     );
+}
+
+/// `churn` reads fields directly from `a[i]`, so no element local exists to
+/// carry the group verdict. The root-keyed result must still expose the
+/// complete numeric layout to the versioned-loop matcher.
+#[test]
+fn direct_field_only_group_exports_numeric_element_layout() {
+    let cs = [class_p()];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "P"),
+        counted_loop(
+            2,
+            Expr::Number(10.0),
+            vec![push(
+                1,
+                new_of("P", vec![Expr::LocalGet(2), counter_plus_one(2)]),
+            )],
+        ),
+        counted_loop(5, arr_len(1), vec![read_direct_field(1, 5, "x")]),
+    ];
+
+    let (promoted, fields) = promote_with_element_fields(&stmts, &classes);
+    assert!(
+        promoted.is_empty(),
+        "the direct read creates no element local"
+    );
+    assert_eq!(fields.get(&1), Some(&names(&["x", "y"])));
+}
+
+/// `churn` constructs `new Pair(base + i, i)` inside a specialized clone.
+/// Only that clone's runtime parameter guard may seed `base` as numeric; the
+/// public fallback must not trust the source annotation alone.
+#[test]
+fn guarded_numeric_parameter_proves_derived_constructor_argument() {
+    const BASE: u32 = 9;
+    let cs = [class_p()];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "P"),
+        counted_loop(
+            2,
+            Expr::Number(10.0),
+            vec![push(
+                1,
+                new_of(
+                    "P",
+                    vec![
+                        Expr::Binary {
+                            op: BinaryOp::Add,
+                            left: Box::new(Expr::LocalGet(BASE)),
+                            right: Box::new(Expr::LocalGet(2)),
+                        },
+                        Expr::LocalGet(2),
+                    ],
+                ),
+            )],
+        ),
+        counted_loop(5, arr_len(1), vec![read_direct_field(1, 5, "x")]),
+    ];
+
+    let (_, generic_fields) = promote_with_element_fields(&stmts, &classes);
+    assert_eq!(generic_fields.get(&1), Some(&names(&["y"])));
+
+    let numeric_params = HashSet::from([BASE]);
+    let (_, specialized_fields) =
+        promote_with_element_fields_and_numeric_params(&stmts, &classes, &numeric_params);
+    assert_eq!(specialized_fields.get(&1), Some(&names(&["x", "y"])));
+}
+
+#[test]
+fn non_numeric_constructor_argument_denies_that_element_field_layout() {
+    let cs = [class_p()];
+    let classes = classes_of(&cs);
+    let stmts = vec![
+        let_arr(1, "P"),
+        push(
+            1,
+            new_of(
+                "P",
+                vec![Expr::String("not a number".to_string()), Expr::Number(2.0)],
+            ),
+        ),
+        counted_loop(5, arr_len(1), vec![read_direct_field(1, 5, "x")]),
+    ];
+
+    let (_, fields) = promote_with_element_fields(&stmts, &classes);
+    assert_eq!(fields.get(&1), Some(&names(&["y"])));
 }
 
 /// A producer local with numeric args joins the meet and proves.

--- a/crates/perry-codegen/src/expr/element_shape_guard.rs
+++ b/crates/perry-codegen/src/expr/element_shape_guard.rs
@@ -329,7 +329,7 @@ pub(crate) fn emit_element_shape_loop_preheader_check(
 }
 
 /// Emit one `arr[i].field` read inside the fast clone: bare element load,
-/// residual per-element check with a single side exit, bare raw-f64 slot load.
+/// an optional residual per-element check, then a bare raw-f64 slot load.
 ///
 /// `idx_i32` must be the loop counter's canonical i32 (non-negative, and
 /// `< bound <= length` by the preheader), and `fact` must be the fact the
@@ -343,9 +343,6 @@ pub(crate) fn emit_element_shape_field_load(
     let field_index_str = field_index.to_string();
     let header_skip = crate::target_layout::object_header_size_bytes(ctx.target_triple).to_string();
 
-    let load_idx = ctx.new_block("element_shape.load");
-    let load_label = ctx.block_label(load_idx);
-
     let elem_ptr = {
         let blk = ctx.block();
         // The element-shape invariant proved every slot in the verified prefix
@@ -358,27 +355,32 @@ pub(crate) fn emit_element_shape_field_load(
         let elem_handle = blk.and(I64, &elem_bits, crate::nanbox::POINTER_MASK_I64);
         let elem_ptr = blk.inttoptr(I64, &elem_handle);
 
-        // Residual per-OBJECT facts (see the module docs for why they cannot
-        // come from the array-level invariant).
-        let hdr_ptr = blk.gep(I8, &elem_ptr, &[(I64, "-8")]);
-        let hdr = blk.load(I32, &hdr_ptr);
-        let hdr_masked = blk.and(I32, &hdr, ELEM_HEADER_MASK);
-        let hdr_ok = blk.icmp_eq(I32, &hdr_masked, ELEM_HEADER_EXPECT);
+        if !fact.statically_layout_proven {
+            let load_idx = ctx.new_block("element_shape.load");
+            let load_label = ctx.block_label(load_idx);
+            let blk = ctx.block();
 
-        // #8113: the ShapeId moved from header offset 8 to 4.
-        let sid_ptr = blk.gep(I8, &elem_ptr, &[(I64, "4")]);
-        let shape_id = blk.load(I32, &sid_ptr);
-        let shape_ok = blk.icmp_eq(I32, &shape_id, &fact.expected_shape_id);
+            // Residual per-OBJECT facts (see the module docs for why they
+            // cannot come from the runtime array-level invariant).
+            let hdr_ptr = blk.gep(I8, &elem_ptr, &[(I64, "-8")]);
+            let hdr = blk.load(I32, &hdr_ptr);
+            let hdr_masked = blk.and(I32, &hdr, ELEM_HEADER_MASK);
+            let hdr_ok = blk.icmp_eq(I32, &hdr_masked, ELEM_HEADER_EXPECT);
 
-        let ok = blk.and(I1, &hdr_ok, &shape_ok);
-        // One branch per access. The side exit resumes the CURRENT iteration
-        // in the slow clone; the matcher guarantees no effect of this
-        // iteration has committed yet, so re-executing cannot double-apply.
-        blk.cond_br(&ok, &load_label, &fact.side_exit_label);
+            // #8113: the ShapeId moved from header offset 8 to 4.
+            let sid_ptr = blk.gep(I8, &elem_ptr, &[(I64, "4")]);
+            let shape_id = blk.load(I32, &sid_ptr);
+            let shape_ok = blk.icmp_eq(I32, &shape_id, &fact.expected_shape_id);
+
+            let ok = blk.and(I1, &hdr_ok, &shape_ok);
+            // One branch per access. The side exit resumes the CURRENT
+            // iteration in the slow clone; no effect has committed yet.
+            blk.cond_br(&ok, &load_label, &fact.side_exit_label);
+            ctx.current_block = load_idx;
+        }
         elem_ptr
     };
 
-    ctx.current_block = load_idx;
     let blk = ctx.block();
     let fields_base = blk.gep(I8, &elem_ptr, &[(I64, &header_skip)]);
     let field_ptr = blk.gep(DOUBLE, &fields_base, &[(I64, &field_index_str)]);

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1721,6 +1721,10 @@ pub(crate) struct ElementShapeLoopFact {
     /// re-executes the current iteration, which is safe because the matcher
     /// admits no body that commits an effect before the read.
     pub side_exit_label: String,
+    /// E1--E5 containment plus the group-wide reachable-store proof establish
+    /// the exact ShapeId, descriptor-free state, and raw-f64 layout for every
+    /// field this clone reads. When true, no per-object residual is needed.
+    pub statically_layout_proven: bool,
     /// property name -> packed slot index, every entry a declared raw-f64
     /// candidate validated by the matcher.
     pub fields: std::collections::BTreeMap<String, u32>,

--- a/crates/perry-codegen/src/stmt/element_shape_loop.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop.rs
@@ -139,7 +139,11 @@ struct ElementShapeVersionedLoop {
     /// The native-region E1--E5 proof already establishes every element's
     /// exact class for this array's whole lifetime. When true, the preheader
     /// need not rebuild the weaker runtime invariant by scanning the array.
-    statically_proven: bool,
+    statically_class_proven: bool,
+    /// The same contained group proof also established that every requested
+    /// field remains a raw-f64 slot, so per-object residual checks are
+    /// redundant inside the call-free clone.
+    statically_layout_proven: bool,
     /// property name -> packed slot index.
     fields: std::collections::BTreeMap<String, u32>,
     /// #7771: the body's `const r = arr[counter]` binding in the two-statement
@@ -750,7 +754,7 @@ fn match_element_shape_versioned_loop(
     }
     let expected_class_id = *ctx.class_ids.get(&class_name)?;
     let keys_global_name = ctx.class_keys_globals.get(&class_name)?.clone();
-    let statically_proven = ctx
+    let statically_class_proven = ctx
         .native_facts
         .exact_element_class(array_id)
         .is_some_and(|proven| proven == class_name);
@@ -780,6 +784,11 @@ fn match_element_shape_versioned_loop(
         }
         fields.insert(prop, field_index);
     }
+    let statically_layout_proven = statically_class_proven
+        && ctx
+            .native_facts
+            .exact_numeric_element_fields(array_id)
+            .is_some_and(|proven| fields.keys().all(|field| proven.contains(field)));
 
     Some(ElementShapeVersionedLoop {
         counter_id,
@@ -788,7 +797,8 @@ fn match_element_shape_versioned_loop(
         class_name,
         expected_class_id,
         keys_global_name,
-        statically_proven,
+        statically_class_proven,
+        statically_layout_proven,
         fields,
         element_binding,
         accumulator_id: *acc_id,
@@ -883,7 +893,7 @@ pub(super) fn lower_element_shape_versioned_for(
             &matched.keys_global_name,
             trip_count,
             &slow_pre_label,
-            matched.statically_proven,
+            matched.statically_class_proven,
         )?;
     let accumulator = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.accumulator_id))?;
     let accumulator_is_number = emit_js_value_is_number(ctx, &accumulator);
@@ -904,6 +914,7 @@ pub(super) fn lower_element_shape_versioned_for(
             elements_base,
             expected_shape_id,
             side_exit_label: slow_pre_label.clone(),
+            statically_layout_proven: matched.statically_layout_proven,
             fields: matched.fields.clone(),
             element_binding: matched.element_binding,
             numeric_accumulator: matched.accumulator_id,
@@ -972,7 +983,9 @@ pub(super) fn lower_element_shape_versioned_for(
             Some(format!(
                 "element-shape loop clone ({}): class {}, {} tracked field(s); \
                  element reads in this loop lower to offset loads behind the preheader guard",
-                if matched.statically_proven {
+                if matched.statically_layout_proven {
+                    "statically layout-proven"
+                } else if matched.statically_class_proven {
                     "statically proven"
                 } else {
                     "runtime-guarded"

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -367,8 +367,9 @@ fn assert_fast_clone_is_entered(ir: &str) {
 }
 
 /// The emitted text the fast clone owns: exactly the blocks named
-/// `for.element_shape_fast.*` and the `element_shape.load` blocks its field
-/// reads branch into.
+/// `for.element_shape_fast.*` and any `element_shape.load` blocks its
+/// runtime-guarded field reads branch into. A statically layout-proven clone
+/// keeps the field load directly in its body and owns no such side-exit block.
 ///
 /// #7480 step 3 — ANTI-VACUITY. This used to slice from the first *substring*
 /// occurrence of `for.element_shape_fast.cond`, which is the
@@ -406,8 +407,10 @@ fn fast_clone_slice(ir: &str) -> String {
         }
     }
     assert!(
-        owned.contains("for.element_shape_fast.body") && owned.contains("element_shape.load"),
-        "the fast-clone slice must contain the cloned BODY and its element \
+        owned.contains("for.element_shape_fast.body")
+            && owned.contains("getelementptr double")
+            && owned.contains("load double"),
+        "the fast-clone slice must contain the cloned BODY and a raw field \
          load, otherwise every negative assertion against it is vacuous; \
          sliced:\n{owned}"
     );
@@ -500,6 +503,15 @@ fn exact_local_array_construction_skips_the_runtime_shape_scan() {
     assert!(
         !ir.contains("call i32 @js_array_ensure_element_shape"),
         "an exact E1--E5 construction proof must not rescan the array"
+    );
+    let fast = fast_clone_slice(&ir);
+    assert!(
+        !fast.contains("element_shape.load"),
+        "the group-wide numeric-layout proof must remove per-object residual branches"
+    );
+    assert!(
+        !fast.contains("402686207"),
+        "the statically layout-proven clone must not reload and mask every GC header"
     );
     assert!(
         ir.contains("for.element_shape_slow.cond"),


### PR DESCRIPTION
## Summary

- expose group-wide numeric element layouts for arrays read directly as `A[i].field`
- seed numeric constructor expressions only from parameters validated by the existing specialized-entry runtime guards
- elide per-object GC-header and ShapeId checks when E1-E5 containment proves the exact class and every requested field has a raw-f64 layout
- keep the public generic fallback on the existing guarded path

Closes #8408.

## Mechanism

The earlier exact-element proof removed the runtime array scan, but each field access in the fast loop still loaded the element GC header and ShapeId and branched to a side exit. In `churn`, two fields meant two dependent object-check chains per element.

This change carries the existing group-wide reachable-store proof to direct element reads. In the specialized clone, the already-emitted numeric parameter guard licenses expressions such as `base + i`; together with the E1-E5 exact-class/containment proof, that establishes both the object shape and the raw-f64 layout for all fields read by the loop. Codegen can then emit the element pointer and fixed-offset field loads directly. The unguarded public fallback receives no numeric-parameter seed and retains the residual checks.

## Performance

Median of 9 interleaved macOS `/usr/bin/time -l` runs, using a frozen `origin/main` compiler and Node v26.5.1:

| runner | wall | user | instructions | max RSS |
| --- | ---: | ---: | ---: | ---: |
| Perry `origin/main` | 0.23 s | 0.21 s | 2,659,024,363 | 22,020,096 B |
| Perry this PR | 0.16 s | 0.14 s | 2,425,600,310 | 21,987,328 B |
| Node | 0.25 s | 0.19 s | 2,687,108,017 | 89,735,168 B |

This is a 30% wall-time and 8.8% retired-instruction reduction versus main, with slightly lower RSS. The fixed Perry binary is 36% faster than Node in the interleaved median.

The full 19-program corpus was compiled before and after. Every stdout/stderr pair is byte-exact; non-target rows showed no material retired-instruction or RSS regression. Wall samples for longer rows were host-contended by unrelated release builds, so the headline comparison uses the controlled interleaved churn run above.

## Validation

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test --release -p perry-codegen --lib` (1,106 passed)
- `cargo test --release -p perry-runtime --lib` (2,596 passed, 4 ignored)
- `cargo test --release -p perry --bin perry` (1,005 passed)
- `BASE_SHA=origin/main bash scripts/run_lint_gates.sh` (all 50 gates passed)
- all 19 corpus programs: stdout and stderr byte-exact

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized processing of contained class-instance arrays by using faster numeric field access when layouts can be proven safe.
  * Reduced redundant object-header and shape checks in eligible fast paths, improving performance on representative workloads.
  * Preserved guarded fallback behavior for cases where layouts cannot be proven, maintaining compatibility and safety.
  * Benchmarks show improved performance without increasing memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->