### PR TITLE
perf(runtime): instrument async event paths

### DIFF
--- a/changelog.d/8409-async-event-path.md
+++ b/changelog.d/8409-async-event-path.md
@@ -1,0 +1,8 @@
+## Add async event-loop counters
+
+The generated executable loop no longer ticks the three timer queues twice per
+checkpoint.
+
+`PERRY_MT_PROFILE=1` now reports microtask-drain, timer registration/tick/fire,
+event notification, and event-wait counters so scheduler investigations can
+distinguish active work from time spent parked.

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -1062,9 +1062,13 @@ pub(super) fn compile_module_entry(
                 let body_label = ctx.block_label(body_idx);
                 let exit_label = ctx.block_label(exit_idx);
 
-                // Initial microtask flush (4 rounds) before entering the
-                // event loop — handles fire-and-forget .then() chains that
-                // don't need the full event loop.
+                // Initial event-loop flush (4 rounds) before entering the
+                // main loop — handles fire-and-forget .then() chains that
+                // don't need the full event loop. The event-loop microtask
+                // entry drains the three timer queues after its promise jobs;
+                // do not tick those queues a second time here. Apart from the
+                // wasted queue scans, a second tick can run a zero-delay timer
+                // scheduled by another timer in the same turn.
                 //
                 // #6077: `js_promise_run_microtasks_event_loop` is
                 // `js_promise_run_microtasks` plus the unhandled-rejection
@@ -1079,9 +1083,6 @@ pub(super) fn compile_module_entry(
                     let _ = ctx
                         .block()
                         .call(I32, "js_promise_run_microtasks_event_loop", &[]);
-                    let _ = ctx.block().call(I32, "js_timer_tick_if_refed", &[]);
-                    let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
-                    let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 }
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
                 ctx.block().br(&header_label);
@@ -1146,14 +1147,13 @@ pub(super) fn compile_module_entry(
                 let cmp = ctx.block().icmp_ne(I32, &any, &zero);
                 ctx.block().cond_br(&cmp, &body_label, &exit_label);
 
-                // loop_body: tick everything, sleep, loop
+                // loop_body: the event-loop microtask drain also owns the
+                // promise/callback/interval timer phases. Cron remains an
+                // explicit stdlib queue, then the pump sleeps and loops.
                 ctx.current_block = body_idx;
                 let _ = ctx
                     .block()
                     .call(I32, "js_promise_run_microtasks_event_loop", &[]);
-                let _ = ctx.block().call(I32, "js_timer_tick", &[]);
-                let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
-                let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 if cross_module.needs_stdlib {
                     let _ = ctx.block().call(I32, "js_cron_timer_tick", &[]);
                 }
@@ -1183,9 +1183,6 @@ pub(super) fn compile_module_entry(
                 let _ = ctx
                     .block()
                     .call(I32, "js_promise_run_microtasks_event_loop", &[]);
-                let _ = ctx.block().call(I32, "js_timer_tick_if_refed", &[]);
-                let _ = ctx.block().call(I32, "js_callback_timer_tick", &[]);
-                let _ = ctx.block().call(I32, "js_interval_timer_tick", &[]);
                 ctx.block()
                     .call_void("js_process_run_finalization_exit", &[]);
                 ctx.block().call_void("js_trace_events_flush_output", &[]);

--- a/crates/perry-codegen/src/codegen/entry/tests.rs
+++ b/crates/perry-codegen/src/codegen/entry/tests.rs
@@ -171,6 +171,26 @@ fn executable_exit_releases_collection_side_allocations_last() {
 }
 
 #[test]
+fn event_loop_microtask_pump_is_the_single_timer_phase_owner() {
+    let ir = emitted_ir("executable");
+    assert!(
+        ir.contains("call i32 @js_promise_run_microtasks_event_loop()"),
+        "the executable entry must retain its event-loop checkpoint\n{ir}"
+    );
+    for redundant_call in [
+        "call i32 @js_timer_tick()",
+        "call i32 @js_timer_tick_if_refed()",
+        "call i32 @js_callback_timer_tick()",
+        "call i32 @js_interval_timer_tick()",
+    ] {
+        assert!(
+            !ir.contains(redundant_call),
+            "{redundant_call} duplicates the timer phases already owned by the event-loop checkpoint\n{ir}"
+        );
+    }
+}
+
+#[test]
 fn dylib_entry_does_not_release_process_owned_collection_storage() {
     let ir = emitted_ir("dylib");
     assert!(

--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -229,6 +229,13 @@ static PUMP: Pump = Pump {
 /// an actual `cvar.wait_timeout` sleep counts as progress.
 static NOTIFIED: AtomicBool = AtomicBool::new(false);
 static WAITER_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_NOTIFY_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_NOTIFY_DURING_DRAIN_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_WAIT_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_WAIT_FAST_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_WAIT_ZERO_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_WAIT_DRIVER_COUNT: AtomicI64 = AtomicI64::new(0);
+pub static PROFILE_WAIT_CONDVAR_COUNT: AtomicI64 = AtomicI64::new(0);
 #[cfg(test)]
 static TEST_FORCE_ZERO_BUDGET: AtomicBool = AtomicBool::new(false);
 
@@ -313,6 +320,12 @@ pub extern "C" fn js_main_thread_notified() -> i32 {
 /// consumer drains the entire queue each pass anyway.
 #[no_mangle]
 pub extern "C" fn js_notify_main_thread() {
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_NOTIFY_COUNT.fetch_add(1, Ordering::Relaxed);
+        if crate::promise::microtasks::microtask_drain_active() {
+            PROFILE_NOTIFY_DURING_DRAIN_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
+    }
     // Mark notification visible to the consumer regardless of which
     // path it took (Release so subsequent producer side-effects are
     // visible).
@@ -480,6 +493,9 @@ pub extern "C" fn js_event_loop_host_driven() -> i32 {
 /// and `await` busy-wait.
 #[no_mangle]
 pub extern "C" fn js_wait_for_event() {
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_WAIT_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
     // FAST PATH: a notify was already issued since the last wait. The
     // hot async/await steady-state hits this every iteration.
     //
@@ -507,6 +523,9 @@ pub extern "C" fn js_wait_for_event() {
     // #1114: do NOT reset the spin streak on this path.
     let was_notified = NOTIFIED.swap(false, Ordering::Acquire);
     if was_notified || unsafe { js_microtasks_pending() } > 0 {
+        if crate::promise::mt_profile_enabled() {
+            PROFILE_WAIT_FAST_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
         invoke_wait_driver_fast();
         return;
     }
@@ -530,6 +549,9 @@ pub extern "C" fn js_wait_for_event() {
     }
 
     if budget_ms == 0 {
+        if crate::promise::mt_profile_enabled() {
+            PROFILE_WAIT_ZERO_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
         // A timer reads as due now — don't block. Transient hits stay
         // zero-latency; only a *sustained* budget-0 spin (the #1114
         // wedge) gets throttled so it can't peg a core and starve the
@@ -562,6 +584,9 @@ pub extern "C" fn js_wait_for_event() {
     // lose; `perry_poll` drains it on the next loop turn. A real tick yielded
     // the core, so it counts as progress for the #1114 spin throttle.
     if wait_driver_sleep(budget_ms) {
+        if crate::promise::mt_profile_enabled() {
+            PROFILE_WAIT_DRIVER_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
         spin_streak_reset();
         return;
     }
@@ -573,6 +598,9 @@ pub extern "C" fn js_wait_for_event() {
     // they checked WAITER_COUNT and we'd miss the wake). The
     // mutex-protected `flag` covers the lost-wakeup window.
     WAITER_COUNT.fetch_add(1, Ordering::Release);
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_WAIT_CONDVAR_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
     let mut flag = PUMP.flag.lock().unwrap();
     // Re-check NOTIFIED under the lock — a producer may have set it
     // between our atomic-load above and the WAITER_COUNT increment.

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -39,6 +39,17 @@ crate::perry_thread_local! {
     static ESM_EVAL_CHECKPOINT_PENDING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+/// Whether this thread is already executing a microtask checkpoint.
+///
+/// A same-thread enqueue during a checkpoint does not need to wake the event
+/// loop: the runner drains the queue to quiescence before returning. Producers
+/// on other threads observe their own depth (zero) and still take the normal
+/// cross-thread wake path.
+#[inline(always)]
+pub(crate) fn microtask_drain_active() -> bool {
+    MICROTASK_RUN_DEPTH.with(|depth| depth.get() != 0)
+}
+
 /// Called once from the compiled entry (before top-level statements) when the
 /// entry module uses import/export syntax — i.e. Node would load it as ESM.
 #[no_mangle]
@@ -172,6 +183,7 @@ fn rooted_closure(h: &crate::gc::RuntimeHandle<'_>) -> ClosurePtr {
 
 fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
     mt_profile_register();
+    bump(&MT_DRAIN_COUNT);
     let async_box_ref_depth = async_box_execution_ref_depth();
     let reentrant = MICROTASK_RUN_DEPTH.with(|depth| {
         let current = depth.get();

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -147,6 +147,7 @@ pub(crate) fn is_definitely_primitive(value: f64) -> bool {
 
 // Instrumentation counters (set PERRY_MT_PROFILE=1 to print at exit).
 pub static MT_RUN_COUNT: AtomicU64 = AtomicU64::new(0);
+pub static MT_DRAIN_COUNT: AtomicU64 = AtomicU64::new(0);
 pub static MT_THENABLE_PROBE_COUNT: AtomicU64 = AtomicU64::new(0);
 pub static MT_PROMISE_NEW_COUNT: AtomicU64 = AtomicU64::new(0);
 pub static MT_PROMISE_THEN_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -216,6 +217,29 @@ extern "C" fn mt_profile_atexit() {
         // fired measured nothing about it — this counter is what tells an A/B
         // its subject was live.
         then_probe::MT_THENABLE_FAST_NEGATIVE.load(Ordering::Relaxed),
+    );
+    eprintln!(
+        "[mt-profile] drains={} timer_reg={{promise:{},callback:{},interval:{}}} timer_tick={{promise:{},callback:{},interval:{}}} timer_fired={{promise:{},callback:{},interval:{}}}",
+        MT_DRAIN_COUNT.load(Ordering::Relaxed),
+        crate::timer::PROFILE_PROMISE_TIMER_REGISTRATIONS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_CALLBACK_TIMER_REGISTRATIONS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_INTERVAL_TIMER_REGISTRATIONS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_PROMISE_TIMER_TICKS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_CALLBACK_TIMER_TICKS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_INTERVAL_TIMER_TICKS.load(Ordering::Relaxed),
+        crate::timer::PROFILE_PROMISE_TIMERS_FIRED.load(Ordering::Relaxed),
+        crate::timer::PROFILE_CALLBACK_TIMERS_FIRED.load(Ordering::Relaxed),
+        crate::timer::PROFILE_INTERVAL_TIMERS_FIRED.load(Ordering::Relaxed),
+    );
+    eprintln!(
+        "[mt-profile] event_notify={{sent:{},during_drain:{}}} event_wait={{total:{},fast:{},zero:{},driver:{},condvar:{}}}",
+        crate::event_pump::PROFILE_NOTIFY_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_NOTIFY_DURING_DRAIN_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_WAIT_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_WAIT_FAST_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_WAIT_ZERO_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_WAIT_DRIVER_COUNT.load(Ordering::Relaxed),
+        crate::event_pump::PROFILE_WAIT_CONDVAR_COUNT.load(Ordering::Relaxed),
     );
     let q = MT_TIME_NS_QUEUE.load(Ordering::Relaxed);
     let cb = MT_TIME_NS_CALLBACK.load(Ordering::Relaxed);
@@ -1120,9 +1144,7 @@ pub(crate) fn cleanup_copied_minor_promise_contexts_for_gc() {
 
 pub(crate) fn enter_microtask_context(snapshot: &AsyncContextSnapshot) {
     let previous = enter_context(snapshot);
-    MICROTASK_PREV_CONTEXTS.with(|stack| {
-        stack.borrow_mut().push(previous);
-    });
+    MICROTASK_PREV_CONTEXTS.with(|stack| stack.borrow_mut().push(previous));
 }
 
 pub(crate) fn restore_microtask_context() {

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -14,7 +14,7 @@ use async_lifecycle::{enqueue_destroy_ids, IntervalCallback};
 use std::any::Any;
 use std::os::raw::c_int;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Mutex,
 };
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -47,6 +47,19 @@ unsafe impl Send for Timer {}
 // Global timer queues (Mutex-protected for cross-thread access)
 per_test_global!(static TIMER_QUEUE: Mutex<Vec<Timer>> = Mutex::new(Vec::new()));
 static START_TIME: Mutex<Option<Instant>> = Mutex::new(None);
+
+// Opt-in event-path counters printed with `PERRY_MT_PROFILE=1`. Keeping these
+// beside the queues makes registrations, scans, and firings independently
+// visible instead of asking a sampling profiler to catch sub-microsecond work.
+pub static PROFILE_PROMISE_TIMER_REGISTRATIONS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_CALLBACK_TIMER_REGISTRATIONS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_INTERVAL_TIMER_REGISTRATIONS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_PROMISE_TIMER_TICKS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_CALLBACK_TIMER_TICKS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_INTERVAL_TIMER_TICKS: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_PROMISE_TIMERS_FIRED: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_CALLBACK_TIMERS_FIRED: AtomicU64 = AtomicU64::new(0);
+pub static PROFILE_INTERVAL_TIMERS_FIRED: AtomicU64 = AtomicU64::new(0);
 
 /// Initialize the timer system (called once at startup)
 fn ensure_initialized() {
@@ -89,6 +102,7 @@ pub extern "C" fn js_set_timeout_value_ref(
 }
 
 fn schedule_promise_timer(delay_ms: f64, value: f64, has_ref: bool) -> *mut Promise {
+    crate::promise::bump(&PROFILE_PROMISE_TIMER_REGISTRATIONS);
     ensure_initialized();
 
     let promise = js_promise_new();
@@ -191,6 +205,7 @@ fn order_expired_callback_batch(expired: &mut [CallbackTimer]) {
 /// Returns the number of timers that fired
 #[no_mangle]
 pub extern "C" fn js_timer_tick() -> i32 {
+    crate::promise::bump(&PROFILE_PROMISE_TIMER_TICKS);
     let now = Instant::now();
     let allow_unref = should_run_unref_promise_timers();
     let mut fired = 0;
@@ -230,6 +245,9 @@ pub extern "C" fn js_timer_tick() -> i32 {
         fired += 1;
     }
 
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_PROMISE_TIMERS_FIRED.fetch_add(fired as u64, Ordering::Relaxed);
+    }
     fired
 }
 
@@ -991,6 +1009,7 @@ fn schedule_callback_timer(
     type_name: &str,
     kind: CallbackTimerKind,
 ) -> i64 {
+    crate::promise::bump(&PROFILE_CALLBACK_TIMER_REGISTRATIONS);
     if let Some(id) = schedule_mock_callback_timer(callback, delay_ms, args.clone(), kind) {
         return id;
     }
@@ -1086,6 +1105,7 @@ pub unsafe extern "C" fn js_set_immediate_callback_args(
 /// Returns the number of callbacks that were called
 #[no_mangle]
 pub extern "C" fn js_callback_timer_tick() -> i32 {
+    crate::promise::bump(&PROFILE_CALLBACK_TIMER_TICKS);
     // First turn of the codegen event loop — `nodeTiming.loopStart` stops being
     // the "not started" sentinel here.
     crate::perf_hooks::note_event_loop_start();
@@ -1234,6 +1254,9 @@ pub extern "C" fn js_callback_timer_tick() -> i32 {
     // this is a cheap empty-buffer check when there's no input.
     crate::os::pump_process_stdin();
 
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_CALLBACK_TIMERS_FIRED.fetch_add(fired as u64, Ordering::Relaxed);
+    }
     fired
 }
 
@@ -1438,6 +1461,7 @@ pub extern "C" fn setInterval(callback: i64, interval_ms: f64) -> i64 {
 }
 
 fn schedule_interval_timer(callback: i64, interval_ms: f64, args: Vec<f64>) -> i64 {
+    crate::promise::bump(&PROFILE_INTERVAL_TIMER_REGISTRATIONS);
     if let Some(id) = schedule_mock_interval_timer(callback, interval_ms, args.clone()) {
         return id;
     }
@@ -1522,6 +1546,7 @@ pub extern "C" fn clearInterval(interval_id: i64) {
 /// Returns the number of callbacks that were called
 #[no_mangle]
 pub extern "C" fn js_interval_timer_tick() -> i32 {
+    crate::promise::bump(&PROFILE_INTERVAL_TIMER_TICKS);
     use crate::closure::{
         js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3, js_closure_call4,
         js_closure_call5, js_closure_call6, js_closure_call7, js_closure_call8, js_closure_call9,
@@ -1609,6 +1634,9 @@ pub extern "C" fn js_interval_timer_tick() -> i32 {
     // count threshold check, which fire during allocation when values are
     // guaranteed to be stored.
 
+    if crate::promise::mt_profile_enabled() {
+        PROFILE_INTERVAL_TIMERS_FIRED.fetch_add(fired as u64, Ordering::Relaxed);
+    }
     fired
 }
 


### PR DESCRIPTION
## Summary

- extend `PERRY_MT_PROFILE=1` with microtask-drain, timer registration/tick/fire, notification, and event-wait counters
- make the event-loop microtask checkpoint the single owner of promise/callback/interval timer phases, removing duplicate scans and preventing nested zero-delay timers from running in the same turn
- add a codegen regression test for the single-owner invariant

## asyncpipe result

30-run release measurements using the issue corpus and full static wrappers:

| Metric | `origin/main` | This PR | Node |
| --- | ---: | ---: | ---: |
| Wall time | 94.5 ms | 94.3 ms | 82.0 ms |
| Instructions retired | 1.369B | 1.370B | — |
| Max RSS | 40.73 MB | 40.69 MB | — |

The wall result is flat within noise. The new counters explain why changing timer delays or event-loop parking cannot close the remaining ~1.15x gap:

```text
runs=72243 drains=8
timer_reg={promise:0,callback:3,interval:0}
timer_tick={promise:5,callback:5,interval:5}
timer_fired={promise:0,callback:3,interval:0}
event_notify={sent:119844,during_drain:119844}
event_wait={total:0,fast:0,zero:0,driver:0,condvar:0}
```

asyncpipe never enters an event wait and registers only three timers. Its remaining gap is in executing 72k microtask jobs/runtime work, not timer latency or a parked event loop. The duplicate timer-phase calls were real overhead and a turn-order hazard, so this PR removes them, but does not claim a benchmark win that the measurements do not show.

## Validation

- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test --release -p perry-runtime --lib`: 2,596 passed, 4 ignored
- `cargo test --release -p perry --bin perry`: 1,005 passed
- focused codegen timer-owner regression test
- `BASE_SHA=origin/main bash scripts/run_lint_gates.sh`: all 50 gates passed
- all 19 issue corpus programs match Node oracle stdout and stderr byte-for-byte
- no version bump

Closes #8409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event-loop processing to prevent timer queues from being advanced twice during a single checkpoint.
  * Improved timer and callback handling across event-loop phases.

* **Diagnostics**
  * Added optional `PERRY_MT_PROFILE=1` metrics for microtask processing, timer activity, event notifications, and event-wait behavior.
  * Added coverage to verify correct event-loop generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->