### PR TITLE
fix: preserve deferred Function errors on Linux

### DIFF
--- a/changelog.d/8416-function-apply-linux-unwind.md
+++ b/changelog.d/8416-function-apply-linux-unwind.md
@@ -1,0 +1,1 @@
+Fixed Linux debug/static builds aborting when a dynamically dispatched one-argument closure threw into a surrounding `try`/`catch`. Dynamic `Function.apply` deferrals now reach the generated catch landing pad and report the located ahead-of-time limitation instead of terminating the process.

--- a/crates/perry-runtime/src/closure/dispatch/calln.rs
+++ b/crates/perry-runtime/src/closure/dispatch/calln.rs
@@ -35,7 +35,9 @@ pub extern "C" fn js_closure_call0(closure: *const ClosureHeader) -> f64 {
 
 /// Call a closure with 1 argument, returning f64
 #[no_mangle]
-pub extern "C" fn js_closure_call1(closure: *const ClosureHeader, arg0: f64) -> f64 {
+// The one-argument value-call path can run arbitrary generated code and must
+// let a JS exception unwind to the generated caller's catch landing pad.
+pub extern "C-unwind" fn js_closure_call1(closure: *const ClosureHeader, arg0: f64) -> f64 {
     let func_ptr = get_valid_func_ptr(closure);
     if func_ptr.is_null() {
         return dispatch_proxy_callee_or_throw(closure, &[arg0]);
@@ -50,7 +52,7 @@ pub extern "C" fn js_closure_call1(closure: *const ClosureHeader, arg0: f64) -> 
             dispatch_with_arity(closure, func_ptr, &[arg0], declared)
         },
         _ => {
-            let func: extern "C" fn(*const ClosureHeader, f64) -> f64 =
+            let func: extern "C-unwind" fn(*const ClosureHeader, f64) -> f64 =
                 unsafe { std::mem::transmute(func_ptr) };
             func(closure, arg0)
         }

--- a/crates/perry-runtime/src/closure/dispatch/value_call.rs
+++ b/crates/perry-runtime/src/closure/dispatch/value_call.rs
@@ -14,7 +14,11 @@ use super::*;
 /// NOTE: This function is named js_native_call_value to avoid symbol collision
 /// with js_call_value in perry-jsruntime which handles V8 JavaScript values.
 #[no_mangle]
-pub unsafe extern "C" fn js_native_call_value(
+// A dynamically-dispatched closure can throw into a generated caller's catch
+// landing pad. Keep this value-call bridge unwind-capable just like
+// `js_native_call_method`; otherwise debug/static runtime builds install an
+// abort-on-unwind guard here and Linux aborts before the landing pad is reached.
+pub unsafe extern "C-unwind" fn js_native_call_value(
     func_value: f64,
     args_ptr: *const f64,
     args_len: usize,

--- a/crates/perry/tests/function_apply_dynamic_args_eval_surface.rs
+++ b/crates/perry/tests/function_apply_dynamic_args_eval_surface.rs
@@ -157,7 +157,10 @@ fn function_apply_with_runtime_args_defers_to_a_located_aot_error() {
         .expect("run compiled binary --dynamic");
     assert!(
         run2.status.success(),
-        "the binary must not crash when the dynamic Function site is reached"
+        "the binary must not crash when the dynamic Function site is reached\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        run2.status,
+        String::from_utf8_lossy(&run2.stdout),
+        String::from_utf8_lossy(&run2.stderr),
     );
     let stdout2 = String::from_utf8_lossy(&run2.stdout);
     assert!(


### PR DESCRIPTION
Fixes #8402.\n\n## Summary\n\n- make the generic dynamic value-call bridge unwind-capable\n- make the one-argument closure dispatcher and generated closure call unwind-capable\n- retain process status/stdout/stderr in the regression assertion for actionable failures\n- add a changelog fragment; intentionally no version bump\n\n## Root cause\n\nFunction.apply reaches the deferred AOT-error closure through js_native_call_value and js_closure_call1. Those two Rust boundaries, plus the generated closure function-pointer call, used the non-unwinding C ABI. Linux debug/static runtime builds therefore installed an abort-on-unwind guard and terminated the process before the generated caller catch landing pad could receive the JS exception.\n\n## Validation\n\n- cargo fmt --all -- --check\n- CARGO_INCREMENTAL=0 cargo check -p perry-runtime\n- CARGO_INCREMENTAL=0 cargo build -p perry-runtime-static\n- compiled and ran the regression fixture locally in normal and --dynamic modes; the dynamic path reports CAUGHT with the located AOT limitation\n- scoped Linux CI pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux debug and static builds aborting when dynamically dispatched one-argument closures threw within `try`/`catch` blocks.
  * Errors now reach the appropriate catch handler and report the relevant ahead-of-time compilation limitation instead of terminating the process.

* **Tests**
  * Improved failure diagnostics by including process status, standard output, and error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->