### PR TITLE
perf(codegen): retain string accumulators in concat chains

### DIFF
--- a/changelog.d/8417-string-accumulator-chains.md
+++ b/changelog.d/8417-string-accumulator-chains.md
@@ -1,0 +1,6 @@
+### Performance
+
+- Keep the growing prefix of loop-local string accumulator chains on Perry's
+  amortized append path while fusing only the fixed-size suffix. The reported
+  16,000-iteration forced-read benchmark drops from 124 ms to 1 ms and no
+  longer exhibits quadratic growth.

--- a/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
+++ b/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
@@ -42,13 +42,17 @@ fn param(id: u32, name: &str, ty: Type) -> Param {
 }
 
 fn probe_fn(params: Vec<Param>, body: Expr) -> Function {
+    probe_fn_with_body(params, vec![Stmt::Return(Some(body))])
+}
+
+fn probe_fn_with_body(params: Vec<Param>, body: Vec<Stmt>) -> Function {
     Function {
         id: 1,
         name: "probe".to_string(),
         type_params: Vec::new(),
         params,
         return_type: Type::Any,
-        body: vec![Stmt::Return(Some(body))],
+        body,
         is_async: false,
         is_generator: false,
         is_strict: true,
@@ -98,6 +102,10 @@ fn module_with(function: Function) -> Module {
 
 fn ir(params: Vec<Param>, body: Expr) -> String {
     let module = module_with(probe_fn(params, body));
+    function_ir(module)
+}
+
+fn function_ir(module: Module) -> String {
     let ir =
         String::from_utf8(compile_module(&module, ir_opts()).unwrap()).expect("LLVM IR is UTF-8");
     // An ordinary typed parameter may now produce a public guard wrapper plus
@@ -318,6 +326,71 @@ fn a_chain_whose_second_part_is_proven_still_folds() {
     assert!(
         ir.contains("call i64 @js_string_concat_chain("),
         "`s + \",\" + t` concatenates at every node whatever `s` holds:\n{ir}"
+    );
+}
+
+#[test]
+fn a_self_append_chain_retains_the_accumulator_and_fuses_only_the_suffix() {
+    // `s = s + "[" + name + "]"` is the #8394 accumulator shape. Folding
+    // all four parts into `js_string_concat_chain` copies the growing `s`
+    // prefix on every iteration. The self-append lowering must instead build
+    // the three-part suffix once and hand it to `js_string_append`, whose
+    // unique-owner path grows the accumulator geometrically.
+    let value = add(
+        add(
+            add(Expr::LocalGet(1), Expr::String("[".to_string())),
+            Expr::LocalGet(2),
+        ),
+        Expr::String("]".to_string()),
+    );
+    let module = module_with(probe_fn_with_body(
+        vec![str_param(), param(2, "name", Type::String)],
+        vec![
+            Stmt::While {
+                condition: Expr::Bool(false),
+                body: vec![Stmt::Expr(Expr::LocalSet(1, Box::new(value)))],
+            },
+            Stmt::Return(Some(Expr::LocalGet(1))),
+        ],
+    ));
+    let ir = function_ir(module);
+
+    assert!(
+        ir.contains("call i64 @js_string_append("),
+        "the growing prefix must reach the amortized append path:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("call i64 @js_string_concat_chain(").count(),
+        1,
+        "only the fixed-size suffix should use the n-way concat fold:\n{ir}"
+    );
+}
+
+#[test]
+fn a_self_append_chain_keeps_an_opaque_numeric_head_pair_intact() {
+    // `s = s + n + "x"` cannot split after `s`: when a lying string slot and
+    // `n` both contain numbers, the head pair is numeric addition before the
+    // trailing literal forces concatenation. `flatten_string_add_chain`
+    // preserves that pair as one opaque part, so this must not select append.
+    let value = add(
+        add(Expr::LocalGet(1), Expr::LocalGet(2)),
+        Expr::String("x".to_string()),
+    );
+    let module = module_with(probe_fn_with_body(
+        vec![str_param(), param(2, "n", Type::Number)],
+        vec![
+            Stmt::While {
+                condition: Expr::Bool(false),
+                body: vec![Stmt::Expr(Expr::LocalSet(1, Box::new(value)))],
+            },
+            Stmt::Return(Some(Expr::LocalGet(1))),
+        ],
+    ));
+    let ir = function_ir(module);
+
+    assert!(
+        !ir.contains("call i64 @js_string_append("),
+        "an opaque numeric-capable head pair must remain in source-tree order:\n{ir}"
     );
 }
 

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use perry_hir::types::Type as HirType;
 use perry_hir::{BinaryOp, Expr, UpdateOp};
 
-use crate::lower_string_concat::lower_string_self_append;
+use crate::lower_string_concat::{flatten_string_add_chain, lower_string_self_append};
 use crate::nanbox::double_literal;
 use crate::native_value::MaterializationReason;
 use crate::type_analysis::{is_map_expr, is_set_expr, receiver_class_name};
@@ -491,7 +491,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 super::record_native_arena_owner_assignment(ctx, *id, value.as_ref());
                 return Ok(v);
             }
-            // Detect the `x = x + y` self-append pattern.
+            // Detect the `x = x + y` self-append pattern. For a longer
+            // left-associated concat (`x = x + a + b + c`), retain `x` as
+            // the accumulator and rebuild only `a + b + c` as the append
+            // operand. Lowering the whole expression through
+            // `js_string_concat_chain` would copy the growing `x` prefix on
+            // every loop iteration, turning the otherwise-amortized append
+            // path back into O(n^2) work (#8394).
             // The fast path requires a plain alloca slot in `ctx.locals` —
             // module globals (use `@global` loads), closure captures (use
             // `js_closure_{get,set}_capture_bits`), and boxed vars (use
@@ -526,6 +532,38 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             super::record_native_arena_owner_assignment(ctx, *id, value.as_ref());
                             return Ok(v);
                         }
+                    }
+
+                    // `flatten_string_add_chain` applies the same soundness
+                    // rules as the ordinary n-way fold. In particular, it
+                    // stops before an Add whose operands do not guarantee
+                    // string semantics, so splitting after the leading local
+                    // cannot change a numeric `+` into concatenation.
+                    let in_loop = ctx
+                        .loop_targets
+                        .iter()
+                        .any(|(continue_label, _, _)| !continue_label.is_empty());
+                    let accumulator_parts = if in_loop {
+                        flatten_string_add_chain(ctx, left, right).filter(|parts| {
+                            parts.len() >= 3
+                                && matches!(parts[0], Expr::LocalGet(left_id) if left_id == id)
+                        })
+                    } else {
+                        None
+                    };
+                    if let Some(parts) = accumulator_parts {
+                        let mut suffix = parts[1].clone();
+                        for part in &parts[2..] {
+                            suffix = Expr::Binary {
+                                op: BinaryOp::Add,
+                                left: Box::new(suffix),
+                                right: Box::new((*part).clone()),
+                            };
+                        }
+                        let v = lower_string_self_append(ctx, *id, &suffix)?;
+                        emit_shadow_slot_update_for_expr(ctx, *id, &v, value);
+                        super::record_native_arena_owner_assignment(ctx, *id, value.as_ref());
+                        return Ok(v);
                     }
                 }
             }

--- a/test-files/test_issue_8394_string_accumulator_chain.ts
+++ b/test-files/test_issue_8394_string_accumulator_chain.ts
@@ -1,0 +1,28 @@
+// #8394: an n-way concat fold must retain the growing local prefix and fuse
+// only the fixed-size suffix. Folding the prefix into js_string_concat_chain
+// copies it on every iteration and makes this standard builder pattern O(n²).
+
+function build(n: number): string {
+  let seen = "";
+  for (let i = 0; i < n; i++) {
+    seen = seen + "[" + "abc" + "]";
+  }
+  return seen;
+}
+
+const built = build(2_000);
+console.log("built", built.length, built.slice(0, 5), built.slice(-5));
+
+// The existing unique-owner hint must still preserve immutable aliases. The
+// first append after aliasing allocates a new accumulator before later growth
+// can happen in place.
+let current = "prefix";
+const alias = current;
+current = current + "[" + "next" + "]";
+console.log("alias", alias, current);
+
+// Type annotations are erased. This head pair is numeric at runtime and must
+// remain opaque: (42 + 8) + "x" is "50x", not "428x".
+let lied: string = 42 as any;
+lied = lied + (8 as any) + "x";
+console.log("lie", lied);


### PR DESCRIPTION
## Summary

- recognize loop-local `s = s + a + b + c` as the existing safe self-append shape
- retain the growing accumulator and fuse only the fixed-size suffix
- preserve numeric `+` semantics for opaque head pairs and immutable string aliases

Perry already has a unique-owner `js_string_append` path with geometric capacity growth. The n-way concat fold bypassed it by materializing the accumulator together with every suffix piece. Keeping the prefix out of that fold removes the quadratic copy without adding a new string representation or exposing cons nodes to raw-byte readers. The new selection is limited to loop bodies, where the repeated-copy cost exists.

Closes #8394.

## Measured

Forced-materialization benchmark (including indexed `charCodeAt` reads), one build per size:

| iterations | main | patched |
|---:|---:|---:|
| 2,000 | 1 ms | 0 ms |
| 4,000 | 15 ms | 1 ms |
| 8,000 | 35 ms | 0 ms |
| 16,000 | 124 ms | 1 ms |

The patched executable used the less-optimized `perry-dev` profile; the main executable used release, so the result is conservative. Output/checksums matched. A 20-repetition version of the issue workload completed in 2/4/14/15 ms across 2k/4k/8k/16k.

## Validation

- `cargo test -p perry-codegen --lib`: 1,105 passed
- focused IR regressions: accumulator suffix fusion and numeric-capable head pair
- compiled regression fixture matched Node 26.5.1 byte-for-byte
- optimized `perry` + runtime/stdlib static-wrapper build succeeded
- `cargo check -p perry-codegen`
- `python3 scripts/check_test_registration.py`
- `./scripts/pre-tag-check.sh --quick`

The broader `cargo test -p perry --bin perry` build was attempted but the separate test-profile dependency graph exhausted the host disk before linking (`errno=28`); no test in that command ran or failed.

No version bump or central changelog edit is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated string concatenation in loops, reducing quadratic growth and significantly speeding up large string builds.
  * Optimized accumulator patterns while preserving efficient handling of fixed suffixes.

* **Bug Fixes**
  * Preserved aliases correctly after string appends.
  * Ensured string-typed values retain correct runtime behavior even when backed by numeric values.

* **Tests**
  * Added coverage for self-appending strings, large repeated builds, and mixed numeric/string scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->