### PR TITLE
perf(codegen): fuse String.concat arguments into concat chain

### DIFF
--- a/changelog.d/8450-string-concat-chain.md
+++ b/changelog.d/8450-string-concat-chain.md
@@ -1,0 +1,13 @@
+### Performance
+
+- Fuse `String.prototype.concat` calls of up to 31 arguments into one
+  `js_string_concat_chain` allocation instead of allocating and copying the
+  growing prefix once per argument. An 8-argument call now emits one chain
+  helper instead of eight pairwise helpers; the 6,000-iteration growing-string
+  fixture measured 0.18 s median on macOS arm64.
+
+### Fixed
+
+- Preserve JavaScript's argument-evaluation-before-coercion order for
+  `String.prototype.concat`, and keep the receiver, raw arguments, and coerced
+  strings rooted across re-entrant user `toString` calls.

--- a/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
+++ b/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
@@ -367,6 +367,37 @@ fn a_self_append_chain_retains_the_accumulator_and_fuses_only_the_suffix() {
 }
 
 #[test]
+fn string_concat_method_fuses_four_arguments_into_one_chain_call() {
+    let ir = ir(
+        Vec::new(),
+        Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::String("head".to_string())),
+                property: "concat".to_string(),
+                byte_offset: 0,
+            }),
+            args: ["a", "b", "c", "d"]
+                .into_iter()
+                .map(|s| Expr::String(s.to_string()))
+                .collect(),
+            type_args: Vec::new(),
+            byte_offset: 0,
+        },
+    );
+
+    assert_eq!(
+        ir.matches("call i64 @js_string_concat_chain(").count(),
+        1,
+        "a four-argument String.concat should allocate one chain result:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("call i64 @js_string_concat(").count(),
+        0,
+        "the fused String.concat must not retain pairwise concat calls:\n{ir}"
+    );
+}
+
+#[test]
 fn a_self_append_chain_keeps_an_opaque_numeric_head_pair_intact() {
     // `s = s + n + "x"` cannot split after `s`: when a lying string slot and
     // `n` both contain numbers, the head pair is numeric addition before the

--- a/crates/perry-codegen/src/lower_string_concat.rs
+++ b/crates/perry-codegen/src/lower_string_concat.rs
@@ -519,7 +519,7 @@ pub(crate) fn lower_string_concat(
 /// Cap the per-call part count for the n-way fold. Must match the
 /// runtime's `MAX_PARTS` in `js_string_concat_chain`. 32 covers every
 /// realistic CSV / log-line / template chain in user code.
-const CONCAT_CHAIN_MAX_PARTS: usize = 32;
+pub(crate) const CONCAT_CHAIN_MAX_PARTS: usize = 32;
 
 /// Try to flatten a left-spine of `Binary { Add }` nodes where every Add
 /// has at least one statically-string operand. Returns the parts in
@@ -606,24 +606,38 @@ pub(crate) fn lower_string_concat_chain(ctx: &mut FnCtx<'_>, parts: &[&Expr]) ->
     // one allocating interpolation was enough to sweep the parts already
     // lowered. Parts that nothing allocating follows emit no rooting calls.
     with_operands_rooted(ctx, parts, |ctx, lowered| {
-        let n = lowered.len();
-        // Hoist the buffer to the function entry block. Issue #167.
-        let buf_reg = ctx.func.alloca_entry_array(DOUBLE, CONCAT_CHAIN_MAX_PARTS);
-        let blk = ctx.block();
-        for (i, val) in lowered.iter().enumerate() {
-            let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
-            blk.store(DOUBLE, val, &slot);
-        }
-        // Pass the array's base pointer as i64 (codegen ABI uses i64 for
-        // raw pointer args matching the existing `js_string_concat` shape).
-        let base_i64 = blk.next_reg();
-        blk.emit_raw(format!("{} = ptrtoint ptr {} to i64", base_i64, buf_reg));
-
-        let result_handle = blk.call(
-            I64,
-            "js_string_concat_chain",
-            &[(I64, &base_i64), (I32, &format!("{}", n))],
-        );
-        Ok(nanbox_string_inline(blk, &result_handle))
+        Ok(emit_string_concat_chain(ctx, lowered))
     })
+}
+
+/// Emit the shared stack-buffer + runtime-call core for values that have
+/// already been lowered, coerced where required, and re-read from their roots.
+///
+/// `String.prototype.concat` needs this lower-level entry point because its
+/// arguments are evaluated first and then `ToString`-coerced left-to-right.
+/// Each coercion needs a fresh root re-read of the raw value, which is more
+/// than `with_operands_rooted`'s single re-read point can provide.
+pub(crate) fn emit_string_concat_chain(ctx: &mut FnCtx<'_>, parts: &[String]) -> String {
+    debug_assert!(parts.len() >= 2);
+    debug_assert!(parts.len() <= CONCAT_CHAIN_MAX_PARTS);
+
+    let n = parts.len();
+    // Hoist the buffer to the function entry block. Issue #167.
+    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, CONCAT_CHAIN_MAX_PARTS);
+    let blk = ctx.block();
+    for (i, val) in parts.iter().enumerate() {
+        let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+        blk.store(DOUBLE, val, &slot);
+    }
+    // Pass the array's base pointer as i64 (codegen ABI uses i64 for
+    // raw pointer args matching the existing `js_string_concat` shape).
+    let base_i64 = blk.next_reg();
+    blk.emit_raw(format!("{} = ptrtoint ptr {} to i64", base_i64, buf_reg));
+
+    let result_handle = blk.call(
+        I64,
+        "js_string_concat_chain",
+        &[(I64, &base_i64), (I32, &format!("{}", n))],
+    );
+    nanbox_string_inline(blk, &result_handle)
 }

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -11,12 +11,14 @@ use crate::expr::{
     i32_bool_to_nanbox, lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_str_handle,
     FnCtx,
 };
-use crate::lower_string_concat::str_operand_handle_tag_dispatched;
-use crate::rooting::{
-    open_rooted_group, operand_may_collect, with_rooted_accumulator, Arg, EmittedValue, Repr,
-    RootedGroup,
+use crate::lower_string_concat::{
+    emit_string_concat_chain, str_operand_handle_tag_dispatched, CONCAT_CHAIN_MAX_PARTS,
 };
-use crate::type_analysis::is_string_expr;
+use crate::rooting::{
+    open_rooted_group, operand_may_collect, with_rooted_accumulator, with_rooted_group, Arg,
+    EmittedValue, Repr, RootedGroup,
+};
+use crate::type_analysis::{is_string_expr, string_value_is_runtime_guaranteed};
 
 mod char_code_at;
 use crate::types::{DOUBLE, I1, I32, I64, PTR};
@@ -158,7 +160,14 @@ fn lower_string_method_from_box(
     // `gc::root_words` bare form covers. Root it across the whole dispatch;
     // the truncate below is the single release point for every one of the
     // match's ~60 return paths.
-    let args_can_collect = args.iter().any(|a| operand_may_collect(ctx, a));
+    let args_can_collect = if property == "concat" {
+        // concat immediately ToString-coerces every argument. A plain object
+        // local is inert to load but can run arbitrary user code while being
+        // coerced, so that coercion must be part of the receiver's window.
+        args.iter().any(|a| concat_arg_may_collect(ctx, a))
+    } else {
+        args.iter().any(|a| operand_may_collect(ctx, a))
+    };
     // #7615 slice 8: the ESCAPING group form. The release has to post-dominate
     // ~60 return paths inside the dispatch, which no closure form can own
     // without swallowing the whole 1,100-line match — the same argument
@@ -168,7 +177,7 @@ fn lower_string_method_from_box(
     // twice: it never sees an index.
     let mut group = open_rooted_group(1);
     let recv = group.adopt_emitted(ctx, Repr::Boxed, &recv_box, args_can_collect);
-    let result = lower_string_method_dispatch(ctx, object, property, args, &recv_box, &group, recv);
+    let result = lower_string_method_dispatch(ctx, object, property, args, &group, recv);
     // Released only after the dispatch's consuming runtime call has run: that
     // call allocates while it reads the receiver.
     //
@@ -211,17 +220,38 @@ fn reread_recv(ctx: &mut FnCtx<'_>, group: &RootedGroup<'_>, recv: EmittedValue)
     group.reread_emitted(ctx, recv)
 }
 
+/// Whether lowering and immediately `ToString`-coercing one concat argument
+/// can collect. A plain object local does not collect when loaded, but its
+/// coercion can call user `toString`, so `operand_may_collect` alone is not
+/// enough for the receiver/previous-part rooting window.
+fn concat_arg_may_collect(ctx: &FnCtx<'_>, arg: &Expr) -> bool {
+    operand_may_collect(ctx, arg) || !string_value_is_runtime_guaranteed(ctx, arg)
+}
+
+/// Perform one `String.prototype.concat` argument's spec-mandated `ToString`
+/// after call-argument evaluation has finished. Proven string values stay
+/// boxed so the chain runtime can consume SSO directly; every other value is
+/// coerced now and returned as a boxed heap string.
+fn coerce_concat_arg_to_box(ctx: &mut FnCtx<'_>, arg: &Expr, raw_box: &str) -> String {
+    if string_value_is_runtime_guaranteed(ctx, arg) {
+        return raw_box.to_string();
+    }
+
+    let handle = ctx
+        .block()
+        .call(I64, "js_string_coerce", &[(DOUBLE, raw_box)]);
+    nanbox_string_inline(ctx.block(), &handle)
+}
+
 #[allow(clippy::too_many_lines)]
 fn lower_string_method_dispatch(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
     property: &str,
     args: &[Expr],
-    recv_box: &str,
     group: &RootedGroup<'_>,
     recv: EmittedValue,
 ) -> Result<String> {
-    let recv_box = recv_box.to_string();
     match property {
         "indexOf" => {
             // No `searchString` → `undefined`, which `js_string_coerce`
@@ -1100,50 +1130,87 @@ fn lower_string_method_dispatch(
             // arg (`undefined`, a boolean, a `{ toString }` object) must render
             // as its string form, not be bit-cast as a string handle (which
             // dropped `undefined`/booleans). A static string arg skips coercion.
-            // #6971: unlike every other arm, `concat` unboxes the receiver
-            // BEFORE it lowers its arguments, then keeps threading the running
-            // accumulator through an SSA register across each one. That
-            // accumulator is a bare `StringHeader*`, so the generic
-            // `reread_recv` above cannot help: it has to be rooted in its own
-            // right and written back after every concat, because each iteration
-            // produces a NEW address.
-            let acc_handle = {
-                let blk = ctx.block();
-                unbox_str_handle(blk, &recv_box)
-            };
-            let args_can_collect = args.iter().any(|a| operand_may_collect(ctx, a));
-            // #7615 slice 8: `RootedAcc::advance` IS the "re-read, call, write
-            // the new address back" triple this arm spelled out by hand, and it
-            // exists for this exact reason (its doc names `js_string_concat`'s
-            // sibling `js_array_push_f64`). The accumulator never becomes a
-            // register the loop holds: `advance` materialises argument 0 from
-            // the slot as part of emitting the call.
-            with_rooted_accumulator(
-                ctx,
-                Repr::Ptr,
-                &acc_handle,
-                args_can_collect,
-                |ctx, acc| {
-                    for a in args {
-                        let a_is_str = is_string_expr(ctx, a);
-                        let s_box = lower_expr(ctx, a)?;
-                        // The ToString coercion allocates too, so re-read only after it.
-                        let s_handle = {
-                            let blk = ctx.block();
-                            if a_is_str {
-                                unbox_str_handle(blk, &s_box)
-                            } else {
-                                blk.call(I64, "js_string_coerce", &[(DOUBLE, &s_box)])
-                            }
-                        };
-                        // Write the new accumulator back, so the NEXT argument's
-                        // lowering keeps *this* string alive rather than its input.
-                        acc.advance(ctx, "js_string_concat", &[Arg::Plain(I64, &s_handle)]);
+            if args.is_empty() {
+                return Ok(reread_recv(ctx, group, recv));
+            }
+
+            // A call evaluates every argument before entering the method. Keep
+            // those raw values rooted, then perform ToString left-to-right;
+            // interleaving `lower(arg); coerce(arg)` would observably differ
+            // for `concat(make("a"), make("b"))`.
+            with_rooted_group(ctx, args.len(), |ctx, raw_group| {
+                let mut raw_args = Vec::with_capacity(args.len());
+                let raw_window_collects = args.iter().any(|arg| concat_arg_may_collect(ctx, arg));
+                for arg in args {
+                    // The window covers both later argument evaluation and the
+                    // subsequent user-code-capable coercion pass.
+                    raw_args.push(raw_group.lower(ctx, arg, raw_window_collects)?);
+                }
+
+                // Fuse the receiver plus the first 31 arguments. The runtime
+                // caps one chain at 32 parts, so a pathological larger call
+                // keeps the existing rooted pairwise lowering only for its tail.
+                let fused_arg_count = args.len().min(CONCAT_CHAIN_MAX_PARTS - 1);
+                let fused = with_rooted_group(ctx, fused_arg_count, |ctx, parts_group| {
+                    let mut part_roots = Vec::with_capacity(fused_arg_count);
+                    for (i, arg) in args[..fused_arg_count].iter().enumerate() {
+                        let raw_box = raw_group.reread(ctx, raw_args[i])?;
+                        let part_box = coerce_concat_arg_to_box(ctx, arg, &raw_box);
+                        let future_can_collect = args[i + 1..fused_arg_count]
+                            .iter()
+                            .any(|later| concat_arg_may_collect(ctx, later));
+                        part_roots.push(parts_group.adopt_emitted(
+                            ctx,
+                            Repr::Boxed,
+                            &part_box,
+                            future_can_collect,
+                        ));
                     }
-                    Ok(())
-                },
-                |ctx, handle| Ok(nanbox_string_inline(ctx.block(), handle)),
-            )
+
+                    // Store only post-coercion, post-collection re-reads in the
+                    // scratch array. A plain alloca is not a GC root.
+                    let mut parts = Vec::with_capacity(fused_arg_count + 1);
+                    parts.push(reread_recv(ctx, group, recv));
+                    for part in part_roots {
+                        parts.push(parts_group.reread_emitted(ctx, part));
+                    }
+                    Ok(emit_string_concat_chain(ctx, &parts))
+                })?;
+
+                if fused_arg_count == args.len() {
+                    return Ok(fused);
+                }
+
+                // Above the cap, the fused prefix becomes the accumulator and
+                // the old pairwise path handles only the remaining arguments.
+                let tail = &args[fused_arg_count..];
+                let acc_handle = unbox_str_handle(ctx.block(), &fused);
+                let tail_can_collect = tail.iter().any(|a| concat_arg_may_collect(ctx, a));
+                with_rooted_accumulator(
+                    ctx,
+                    Repr::Ptr,
+                    &acc_handle,
+                    tail_can_collect,
+                    |ctx, acc| {
+                        for (tail_i, arg) in tail.iter().enumerate() {
+                            let raw_i = fused_arg_count + tail_i;
+                            let raw_box = raw_group.reread(ctx, raw_args[raw_i])?;
+                            let s_box = coerce_concat_arg_to_box(ctx, arg, &raw_box);
+                            // The tail's pointer-only helper needs a heap handle.
+                            // This is inert for a coerced heap string and
+                            // materializes a proven SSO value.
+                            let s_handle =
+                                ctx.block()
+                                    .call(I64, "js_string_coerce", &[(DOUBLE, &s_box)]);
+                            // Write the new accumulator back, so the NEXT
+                            // argument keeps this result alive, not its input.
+                            acc.advance(ctx, "js_string_concat", &[Arg::Plain(I64, &s_handle)]);
+                        }
+                        Ok(())
+                    },
+                    |ctx, handle| Ok(nanbox_string_inline(ctx.block(), handle)),
+                )
+            })
         }
         "substr" => {
             // Legacy substr(start, length) — distinct from substring/slice:

--- a/test-files/test_issue_8433_string_concat_chain.ts
+++ b/test-files/test_issue_8433_string_concat_chain.ts
@@ -1,0 +1,53 @@
+// #8433: String.prototype.concat should coerce arguments left-to-right, keep
+// every coerced part alive across re-entrant coercions, and use the N-way
+// concat helper for the common <=32-part case.
+
+const order: string[] = [];
+
+function ordered(label: string): any {
+  order.push("eval-" + label);
+  return {
+    toString(): string {
+      order.push("coerce-" + label);
+      // Allocate through concat while the outer call's receiver and earlier
+      // coerced arguments are live.
+      let churn = "";
+      for (let i = 0; i < 40; i++) {
+        churn = churn.concat(label, String(i), ":");
+      }
+      return label + churn.length;
+    },
+  };
+}
+
+const mixed = "start:".concat(
+  undefined as any,
+  ":",
+  true as any,
+  ":",
+  false as any,
+  ":",
+  ordered("A"),
+  ":",
+  ordered("B"),
+);
+console.log(mixed);
+console.log(order.join(","));
+
+// The join between these two WTF-8 parts must canonicalize to one scalar.
+const high = String.fromCharCode(0xd83d);
+const low = String.fromCharCode(0xde00);
+const joined = "<".concat(high, low, ">");
+console.log(joined === "<😀>", joined.length, joined.charCodeAt(1), joined.charCodeAt(2));
+
+// Receiver + 35 arguments exceeds the runtime's 32-part chain cap. The first
+// 31 arguments fuse; the rooted pairwise tail must preserve all remaining
+// parts and their order.
+console.log(
+  "many:".concat(
+    "00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+    "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+    "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+    "30", "31", "32", "33", "34",
+  ),
+);


### PR DESCRIPTION
## Summary

- lower all `String.prototype.concat` arguments first, then preserve left-to-right `ToString` coercion with mutable-root re-reads
- emit one `js_string_concat_chain` for the receiver plus up to 31 arguments
- keep the existing rooted pairwise accumulator only for arguments beyond the runtime's 32-part cap
- share the existing entry-block chain scratch-buffer emitter with string `+` lowering

This also preserves JavaScript call ordering: all argument expressions are evaluated before any method-side coercion (`eval-A, eval-B, coerce-A, coerce-B`).

## Measurement

Fixture: an 8-argument direct `s.concat(p, …)` growing accumulator for 6,000 iterations (`p` is 8 bytes), plus a 35-argument case for 1,400 iterations.

- emitted helper calls per 8-argument concat: **8 `js_string_concat` → 1 `js_string_concat_chain`**
- emitted helper calls per 35-argument concat: **35 `js_string_concat` → 1 chain + 4 pairwise tail calls**
- post-fix wall time, median of 3 runs on this macOS arm64 host:
  - 8-argument method: **0.18 s**
  - equivalent 8-part `+` expression: **4.67 s**
  - 35-argument method: **0.18 s**

The chain path removes seven intermediate allocations and seven repeated prefix copies in the common 8-argument case.

## Validation

- `cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test -p perry-codegen string_concat_method_fuses_four_arguments_into_one_chain_call -- --nocapture`
- Node 26.5.1 byte parity for mixed primitives, observable evaluation/coercion order, re-entrant allocating `toString`, split-surrogate canonicalization, and 35 arguments
- forced moving-GC run with `PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_PROTECT_FROMSPACE=1`: output matched Node; 8/8 scheduled copying collections, 16,699 moved objects
- `cargo fmt --check`
- `python3 scripts/check_test_registration.py`

Closes #8433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved `String.prototype.concat` performance by combining multiple arguments into a single allocation.
  * Supports efficient concatenation chains of up to 31 arguments.

* **Bug Fixes**
  * Preserved left-to-right evaluation and string coercion behavior.
  * Improved reliability during re-entrant operations and garbage collection.
  * Corrected surrogate-pair handling and concatenation beyond the optimized argument limit.

* **Tests**
  * Added coverage for evaluation order, coercion, memory retention, Unicode handling, and long concatenation chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->