### PR TITLE
ci: give full-tier jobs timeout margin over observed contention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -704,7 +704,12 @@ jobs:
     needs: plan
     if: fromJSON(needs.plan.outputs.plan).jobs.check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 90 (was 60): full-tier runs share the free-plan runner pool with the
+    # coalesced main sweeps; in dispatch run 32298711372 sibling jobs pushed
+    # this past its cap and the cancellation alone failed full-suite-gate
+    # (the gate treats cancelled == failed). The cap is a hang backstop, not
+    # a perf budget — margin costs nothing on healthy runs.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
 
@@ -783,7 +788,9 @@ jobs:
     needs: plan
     if: fromJSON(needs.plan.outputs.plan).jobs.warnings
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 90 (was 60): same contention margin as `check` — cancelled at exactly
+    # 60:26 in full-tier run 32298711372 while doing useful work.
+    timeout-minutes: 90
     env:
       RUSTFLAGS: -D warnings
       RUSTC_WRAPPER: sccache
@@ -2197,7 +2204,12 @@ jobs:
     # heavy shard) while still bounding a genuine hang. Durable fix — raising
     # the shard count 8->12 so no single slice approaches the cap — tracked as
     # a follow-up on #6456.
-    timeout-minutes: 75
+    # 110 (was 75): in full-tier run 32298711372 the auto-optimize shards ran
+    # ~70 min when they finished at all, and shards 2/4/5 were cancelled at
+    # exactly 75:00 under runner contention — each cancellation fails
+    # full-suite-gate on its own. Margin over the observed worst case until
+    # the #6456 reshard lands.
+    timeout-minutes: 110
     steps:
       - uses: actions/checkout@v7
 

--- a/changelog.d/8462-full-tier-timeout-margins.md
+++ b/changelog.d/8462-full-tier-timeout-margins.md
@@ -1,0 +1,1 @@
+ci: `check` (60→90), `warnings` (60→90) and `gap-suite` (75→110) got timeout margin over the contention observed in full-tier run 32298711372, where exact-cap cancellations — not failures — redded `full-suite-gate` (the gate counts cancelled as failed). Windows doc-tests' 6h hard-cap overrun is tracked separately (needs sharding, not margin).


### PR DESCRIPTION
Part of the release-blocker set: `full-suite-gate` fails on *cancelled* jobs, and full-tier run 32298711372 lost three gap-suite shards at exactly 75:00 (siblings finished ~70:00), `warnings` at exactly 60:00, and yesterday's nightly lost `check` the same way — all timeout cancellations under free-plan runner contention with the coalesced main sweeps, none a real failure. Every one of them reds the release gate by itself.

`check` 60→90, `warnings` 60→90, `gap-suite` 75→110 (margin over the observed auto-optimize worst case until the #6456 reshard). The caps are hang backstops, not perf budgets — margin is free on healthy runs.

Not addressed here: the Windows doc-tests leg hit GitHub's 6-hour hard job cap in the same run — that needs sharding or scope reduction, not `timeout-minutes`, and both harnesses already have the `PERRY_NO_AUTO_OPTIMIZE=1` short-circuit (verified). Also worth knowing for the release itself: dispatching the full tier during quiet hours avoids the sweep contention entirely.
