### PR TITLE
fix(test): register two dark GC string tests in the repsel corpus

### DIFF
--- a/changelog.d/8461-register-dark-gc-tests.md
+++ b/changelog.d/8461-register-dark-gc-tests.md
@@ -1,0 +1,1 @@
+Register `test_gap_gc_string_copy_source_rooting` and `test_gap_gc_string_repeat_reentrant_count` in `test-parity/gc_repsel_corpus.txt`. #8439 and #8443 added them to `test-files/` without registering them, so `scripts/gc_repsel_matrix.sh` never executed either — a GC regression test that never runs is not a gate. `check_test_registration` was red on `main`.

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -816,3 +816,11 @@ test_gap_gc_http2_pending_event_callback_rooting
 # `Object.getPrototypeOf(undefined)` throws. Pre-fix `bad > 0` under seeded
 # GC; post-fix `bad 0`. Clean under `PERRY_GEN_GC=0`.
 test_gap_gc_interp_global_this_rooting
+
+# #8439: `js_string_copy` borrowed its source's bytes across an allocation that
+# can trigger a moving minor. Registered so gc-stress / gc-moving-witnesses
+# actually execute it instead of leaving it dark on disk.
+test_gap_gc_string_copy_source_rooting
+# #8443: `String.prototype.repeat` held its receiver unrooted across a
+# re-entrant count coercion. Same reason.
+test_gap_gc_string_repeat_reentrant_count


### PR DESCRIPTION
## Summary

`check_test_registration` is **red on `main`**: #8439 and #8443 each added a
`test_gap_gc_*` fixture to `test-files/` without registering it in
`test-parity/gc_repsel_corpus.txt`, so `scripts/gc_repsel_matrix.sh` (gc-stress,
gc-moving-witnesses, gc-ptr-shape-off-witness) never executed either.

```
- DARK TEST test-files/test_gap_gc_string_copy_source_rooting.ts
- DARK TEST test-files/test_gap_gc_string_repeat_reentrant_count.ts
```

A GC regression test that exists on disk but never runs is worse than no test: it reads as
coverage in review and provides none. That is the exact failure mode CLAUDE.md calls out —
"the gate runs but its subject never did".

I caught this while batch-validating the string series and fixed it locally, but the fix
lived in my stack rather than in the PRs, so it did not travel through the squash merges.

## Validation

- `python3 scripts/check_test_registration.py` — exit 0
- `python3 scripts/check_test_registration.py --self-test` — exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added two previously omitted garbage-collection stress tests to the representation-selection test suite.
  * These tests are now included in the automated GC test matrix.

* **Documentation**
  * Added a changelog entry documenting the newly registered tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->