### PR TITLE
fix(runtime): root Array.join inputs across coercion

### DIFF
--- a/changelog.d/8482-array-join-gc-safety.md
+++ b/changelog.d/8482-array-join-gc-safety.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Keep `Array.prototype.join` separators, receivers, and coerced elements valid
+  when user `toString` code triggers a moving garbage collection.

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -1077,6 +1077,62 @@ pub(crate) fn throw_reduce_of_empty() -> ! {
     crate::exception::js_throw(f64::from_bits(err_value))
 }
 
+/// Read one exotic join element while keeping the receiver current across a
+/// getter or prototype lookup that can allocate and move it.
+#[cold]
+#[inline(never)]
+fn join_exotic_element(arr: *const ArrayHeader, index: u32) -> (Option<u64>, *const ArrayHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_const_ptr(arr);
+    let present = arr_handle.with_const_ptr(|arr| crate::array::array_spec_has_index(arr, index));
+    if !present {
+        return (
+            None,
+            normalize_array_receiver(arr_handle.get_raw_const_ptr::<ArrayHeader>()),
+        );
+    }
+    let value = arr_handle.with_const_ptr(|arr| crate::array::array_spec_get(arr, index));
+    (
+        Some(value.to_bits()),
+        normalize_array_receiver(arr_handle.get_raw_const_ptr::<ArrayHeader>()),
+    )
+}
+
+/// Run an allocating element conversion with the receiver and value rooted,
+/// then return the receiver's post-collection address.
+#[cold]
+#[inline(never)]
+fn join_element_to_string(
+    arr: *const ArrayHeader,
+    element_bits: u64,
+) -> (*const crate::string::StringHeader, *const ArrayHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_const_ptr(arr);
+    let element_handle = scope.root_nanbox_u64(element_bits);
+    let string = crate::value::js_jsvalue_to_string(element_handle.get_nanbox_f64());
+    (
+        string,
+        normalize_array_receiver(arr_handle.get_raw_const_ptr::<ArrayHeader>()),
+    )
+}
+
+#[cold]
+#[inline(never)]
+fn join_bigint_to_string(
+    arr: *const ArrayHeader,
+    element_bits: u64,
+) -> (*const crate::string::StringHeader, *const ArrayHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_const_ptr(arr);
+    let element_handle = scope.root_nanbox_u64(element_bits);
+    let value = crate::value::JSValue::from_bits(element_handle.get_nanbox_u64());
+    let string = crate::bigint::js_bigint_to_string(value.as_bigint_ptr());
+    (
+        string,
+        normalize_array_receiver(arr_handle.get_raw_const_ptr::<ArrayHeader>()),
+    )
+}
+
 /// join - Join array elements into a string with a separator
 /// Returns pointer to new StringHeader
 #[no_mangle]
@@ -1084,10 +1140,10 @@ pub extern "C" fn js_array_join(
     arr: *const ArrayHeader,
     separator: *const crate::string::StringHeader,
 ) -> *mut crate::string::StringHeader {
-    use crate::string::{js_string_from_bytes, StringHeader};
+    use crate::string::{js_string_from_bytes, OwnedStringBytes, StringHeader};
     use crate::value::JSValue;
 
-    let arr = normalize_array_receiver(arr);
+    let mut arr = normalize_array_receiver(arr);
     if arr.is_null() {
         return crate::string::js_string_from_bytes(b"".as_ptr(), 0);
     }
@@ -1106,35 +1162,38 @@ pub extern "C" fn js_array_join(
             return js_string_from_bytes(ptr::null(), 0);
         }
 
-        let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let mut elements_ptr =
+            (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
-        // Get separator string
-        let sep_str = if separator.is_null() {
-            ","
-        } else {
-            let sep_len = (*separator).byte_len as usize;
-            let sep_data = (separator as *const u8).add(std::mem::size_of::<StringHeader>());
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(sep_data, sep_len))
-        };
+        // Element coercion can run user code and move a heap separator. Keep an
+        // owned snapshot so the hot loop never holds a GC payload borrow across
+        // a collection point.
+        let separator_snapshot =
+            (!separator.is_null()).then(|| OwnedStringBytes::copy_from_header(separator));
+        let separator_str = separator_snapshot
+            .as_ref()
+            .map_or(",", |bytes| std::str::from_utf8_unchecked(bytes.as_bytes()));
 
-        // Separators are an exact lower bound for the result. Reserving them
-        // up front avoids the zero-capacity growth ladder without speculatively
-        // coercing elements (which could run user code or mutate the array).
-        let separator_bytes = sep_str
+        // Separators are an exact lower bound for the result. Element
+        // coercion remains single-pass because it can run user code.
+        let separator_bytes = separator_str
             .len()
             .saturating_mul(length.saturating_sub(1) as usize);
         let mut result = String::with_capacity(separator_bytes);
+
         for i in 0..length as usize {
             if i > 0 {
-                result.push_str(sep_str);
+                result.push_str(separator_str);
             }
             let element_bits = if exotic {
-                if !crate::array::array_spec_has_index(arr, i as u32) {
+                let (element, arr_now) = join_exotic_element(arr, i as u32);
+                arr = arr_now;
+                let Some(bits) = element else {
                     // absent slot (own or inherited) → empty string per spec
                     continue;
-                }
-                crate::array::array_spec_get(arr, i as u32).to_bits()
+                };
+                bits
             } else {
                 let bits = (*elements_ptr.add(i)).to_bits();
                 // Issue #907: `Array(n)` initializes slots to TAG_HOLE; per
@@ -1187,7 +1246,12 @@ pub extern "C" fn js_array_join(
                     let s_ptr = if is_string_obj {
                         ptr_addr as *const StringHeader
                     } else {
-                        crate::value::js_jsvalue_to_string(f64::from_bits(element_bits))
+                        let (s_ptr, arr_now) = join_element_to_string(arr, element_bits);
+                        arr = arr_now;
+                        if !exotic {
+                            elements_ptr = array_elements_ptr(arr);
+                        }
+                        s_ptr
                     };
                     if !s_ptr.is_null() {
                         let str_len = (*s_ptr).byte_len as usize;
@@ -1205,7 +1269,11 @@ pub extern "C" fn js_array_join(
                 // so they bypass the pointer arm above and previously fell through
                 // to the `[object Object]` catch-all. ToString(BigInt) is the plain
                 // decimal digits with NO `n` suffix (`[10n].join() === "10"`).
-                let s_ptr = crate::bigint::js_bigint_to_string(jsvalue.as_bigint_ptr());
+                let (s_ptr, arr_now) = join_bigint_to_string(arr, element_bits);
+                arr = arr_now;
+                if !exotic {
+                    elements_ptr = array_elements_ptr(arr);
+                }
                 if !s_ptr.is_null() {
                     let str_len = (*s_ptr).byte_len as usize;
                     let str_data = (s_ptr as *const u8).add(std::mem::size_of::<StringHeader>());

--- a/scripts/string_payload_access_baseline.txt
+++ b/scripts/string_payload_access_baseline.txt
@@ -12,7 +12,7 @@ inline-offset | perry-ext-nodemailer | 1
 inline-offset | perry-ext-pg | 2
 inline-offset | perry-ext-zlib | 3
 inline-offset | perry-ffi | 3
-inline-offset | perry-runtime | 370
+inline-offset | perry-runtime | 369
 inline-offset | perry-stdlib | 48
 inline-offset | perry-updater | 5
 reader-helper | perry-ext-ethers | 1

--- a/test-files/test_issue_8434_array_join_gc.ts
+++ b/test-files/test_issue_8434_array_join_gc.ts
@@ -1,0 +1,29 @@
+const show = (label: string, value: string): void => {
+  console.log(`${label}:${value}|${value.length}`);
+};
+
+show("holes", new Array(3).join("|"));
+show("empty", ["", "", ""].join(""));
+show("unicode", ["A", "😀", "é"].join("·"));
+
+let calls = 0;
+const values: unknown[] = [];
+const churn = (): number => {
+  const live: unknown[] = [];
+  for (let i = 0; i < 128; i++) {
+    live.push({ i, text: ("allocation-" + i).repeat(32) });
+  }
+  return live.length;
+};
+const allocating = {
+  toString(): string {
+    calls++;
+    churn();
+    values[1] = "after";
+    return "before";
+  },
+};
+values.push(allocating, "original", "tail");
+const movingSeparator = ("x" + "/").slice(1);
+show("coerce", values.join(movingSeparator));
+console.log(`calls:${calls}`);


### PR DESCRIPTION
## Summary

- snapshot the `Array.prototype.join` separator before element coercion so moving GC cannot invalidate its payload view
- root and reload the array receiver and current element across exotic getters, object `toString`, nested joins, and BigInt formatting
- refresh dense element storage after any allocating coercion while preserving the separator-capacity floor from #8460
- add a Node-parity allocation witness that exercises scheduled copying GC

This covers the `Array.join` family investigated for #8434. Direct-write and broader string-builder changes remain out of scope because the prototypes measured slower.

## Validation

- `cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test -p perry-runtime join_ -- --nocapture`
- `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime` (2604 passed, 4 ignored)
- Node output parity for `test_issue_8434_array_join_gc.ts`
- scheduled moving-GC witness: 21 copying minors, 17,426 moved objects
- `python3 scripts/check_test_registration.py`
- `python3 scripts/string_payload_access_inventory.py` (open-coded runtime payload accesses reduced from 370 to 369)
- exact-current-base benchmark, 30 runs: 221.3 ± 0.9 ms vs 221.2 ± 1.8 ms upstream (within noise)

No version bump.