### PR TITLE
perf(codegen): preserve numeric envelope proofs

### DIFF
--- a/changelog.d/8491-numeric-envelope.md
+++ b/changelog.d/8491-numeric-envelope.md
@@ -1,0 +1,5 @@
+### Performance
+
+- Preserve Number proofs across numeric local reassignments and guarded plain-
+  array parameter reads, removing dynamic arithmetic around native typed-array
+  element loads.

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -363,7 +363,8 @@ fn emit_public_spec_function_trampoline(
                 crate::collectors::SpecParamRep::F64 => {
                     Some(emit_typed_arg_guard(blk, TypedParamRep::F64, arg))
                 }
-                crate::collectors::SpecParamRep::Boxed => None,
+                crate::collectors::SpecParamRep::Boxed
+                | crate::collectors::SpecParamRep::NumberArray => None,
                 // Guarded plans never carry TaPtr: its raw pointer contract is
                 // admitted only by construction at a direct call site.
                 crate::collectors::SpecParamRep::TaPtr { .. } => Some("false".to_string()),
@@ -428,7 +429,8 @@ fn emit_public_spec_function_trampoline(
         let blk = wf.block_mut(fast_idx).unwrap();
         for (arg, rep) in arg_names.iter().zip(plan.reps.iter()) {
             match rep {
-                crate::collectors::SpecParamRep::Boxed => {
+                crate::collectors::SpecParamRep::Boxed
+                | crate::collectors::SpecParamRep::NumberArray => {
                     raw_args.push((DOUBLE, arg.clone()));
                 }
                 crate::collectors::SpecParamRep::I32 => {
@@ -714,7 +716,16 @@ pub(super) fn compile_function(
     // plan selection demoted any reassigned/closure-referenced param to
     // `Boxed` — a stamped param provably holds this rep for the whole body.
     if let Some(plan) = spec_entry {
-        for (p, rep) in f.params.iter().zip(plan.reps.iter()) {
+        for ((p, rep), guard) in f
+            .params
+            .iter()
+            .zip(plan.reps.iter())
+            .zip(plan.guards.iter())
+        {
+            if let Some(guard) = guard {
+                local_types.insert(p.id, guard.proof.clone());
+                continue;
+            }
             match rep {
                 crate::collectors::SpecParamRep::I32 => {
                     local_types.insert(p.id, perry_hir::types::Type::Int32);
@@ -724,7 +735,9 @@ pub(super) fn compile_function(
                         local_types.insert(p.id, perry_hir::types::Type::Named(class.to_string()));
                     }
                 }
-                crate::collectors::SpecParamRep::Boxed | crate::collectors::SpecParamRep::F64 => {}
+                crate::collectors::SpecParamRep::Boxed
+                | crate::collectors::SpecParamRep::NumberArray
+                | crate::collectors::SpecParamRep::F64 => {}
             }
         }
     }
@@ -798,7 +811,11 @@ pub(super) fn compile_function(
                                 spec_ta_kind_class_name(*kind)?.to_string(),
                             )
                         }
-                        (None, crate::collectors::SpecParamRep::Boxed) => return None,
+                        (
+                            None,
+                            crate::collectors::SpecParamRep::Boxed
+                            | crate::collectors::SpecParamRep::NumberArray,
+                        ) => return None,
                     };
                     Some((param.id, proof))
                 })

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -226,6 +226,7 @@ pub use opts::{
     AppMetadata, CompileOptions, FpContractMode, ImportedClass, NamespaceEntry, NamespaceEntryKind,
 };
 pub(crate) use opts::{CrossModuleCtx, ImportedCtor};
+pub(crate) use param_guard::scalar_descriptor_rep;
 pub(crate) use spec_abi::{spec_abi_enabled, spec_function_name, SpecDispatch, SpecFnPlan};
 pub(crate) use typed_abi::{
     emit_typed_arg_guard, emit_typed_arg_to_raw, generic_closure_body_name,
@@ -2652,7 +2653,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let plan = match sites
                 .and_then(|sites| spec_abi::select_dominant_tuple(sites, f.params.len(), &demoted))
             {
-                Some((reps, _matching_sites)) => {
+                Some((mut reps, _matching_sites)) => {
                     // Raw slots already carry a by-construction proof. Boxed
                     // slots may additionally recover an ordinary declared
                     // parameter fact, but only through their runtime
@@ -2660,23 +2661,49 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                     // unknown/public caller has no equivalent cheap guard for
                     // the raw pointer + length contract, so mixed TaPtr plans
                     // keep their existing static-only route.
-                    let guards: Vec<_> = if reps
+                    let mut inferred_guards = vec![None; reps.len()];
+                    for (index, (rep, param)) in reps.iter_mut().zip(f.params.iter()).enumerate() {
+                        if !matches!(rep, crate::collectors::SpecParamRep::NumberArray) {
+                            continue;
+                        }
+                        *rep = crate::collectors::SpecParamRep::Boxed;
+                        if crate::collectors::guarded_number_array_param_eligible(&f.body, param.id)
+                        {
+                            inferred_guards[index] = param_guard::inferred_guard(
+                                perry_hir::types::Type::Array(Box::new(
+                                    perry_hir::types::Type::Number,
+                                )),
+                                param_guard::guard_descriptor_name(&module_prefix, f.id, index),
+                                &cross_module.type_aliases,
+                                &cross_module.interfaces,
+                                &class_table,
+                                &class_ids,
+                            );
+                        }
+                    }
+                    let has_ta_ptr = reps
                         .iter()
-                        .any(|rep| matches!(rep, crate::collectors::SpecParamRep::TaPtr { .. }))
-                    {
-                        vec![None; reps.len()]
-                    } else {
-                        declaration_guards
-                            .into_iter()
-                            .zip(reps.iter())
-                            .map(|(guard, rep)| {
-                                matches!(rep, crate::collectors::SpecParamRep::Boxed)
-                                    .then_some(guard)
-                                    .flatten()
-                            })
-                            .collect()
-                    };
-                    let dispatch = if guards.iter().any(Option::is_some) {
+                        .any(|rep| matches!(rep, crate::collectors::SpecParamRep::TaPtr { .. }));
+                    let guards: Vec<_> = declaration_guards
+                        .into_iter()
+                        .zip(inferred_guards)
+                        .zip(reps.iter())
+                        .map(|((declared, inferred), rep)| {
+                            if !matches!(rep, crate::collectors::SpecParamRep::Boxed) {
+                                None
+                            } else if has_ta_ptr {
+                                inferred
+                            } else {
+                                inferred.or(declared)
+                            }
+                        })
+                        .collect();
+                    let dispatch = if has_ta_ptr {
+                        // Raw typed-array pointers remain direct-call-only.
+                        // Any inferred boxed-array descriptor is checked in
+                        // the same call-site diamond as an i32 range check.
+                        SpecDispatch::Static
+                    } else if guards.iter().any(Option::is_some) {
                         SpecDispatch::Guarded
                     } else {
                         SpecDispatch::Static

--- a/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
+++ b/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
@@ -128,6 +128,121 @@ fn public_guard_routes_to_proof_clone_and_conservative_fallback() {
 }
 
 #[test]
+fn mixed_ta_clone_guards_numeric_array_shape_at_the_direct_call() {
+    let lr = Param {
+        id: 10,
+        name: "lr".to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    };
+    let table = Param {
+        id: 11,
+        name: "table".to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    };
+    let loaded = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(10)),
+        index: Box::new(Expr::Integer(0)),
+    };
+    let xor_loaded = || Expr::Binary {
+        op: BinaryOp::BitXor,
+        left: Box::new(Expr::LocalGet(12)),
+        right: Box::new(Expr::Integer(1)),
+    };
+    let encipher = Function {
+        id: 1,
+        name: "encipher".to_string(),
+        type_params: Vec::new(),
+        params: vec![lr, table],
+        return_type: Type::Number,
+        body: vec![
+            Stmt::Let {
+                id: 12,
+                name: "value".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(loaded),
+            },
+            Stmt::While {
+                condition: Expr::Bool(false),
+                body: vec![Stmt::Expr(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(11)),
+                    index: Box::new(Expr::Integer(0)),
+                })],
+            },
+            Stmt::Expr(Expr::IndexSet {
+                object: Box::new(Expr::LocalGet(10)),
+                index: Box::new(Expr::Integer(0)),
+                value: Box::new(xor_loaded()),
+            }),
+            Stmt::Return(Some(xor_loaded())),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+    let mut module = Module::new("number_array_guard.ts");
+    module.functions.push(encipher);
+    module.init.extend([
+        Stmt::Let {
+            id: 20,
+            name: "lr".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Array(vec![Expr::Integer(1), Expr::Integer(2)])),
+        },
+        Stmt::Let {
+            id: 21,
+            name: "table".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::TypedArrayNew {
+                kind: perry_hir::TYPED_ARRAY_KIND_INT32,
+                arg: Some(Box::new(Expr::Integer(4))),
+            }),
+        },
+        Stmt::Expr(Expr::Call {
+            callee: Box::new(Expr::FuncRef(1)),
+            args: vec![Expr::LocalGet(20), Expr::LocalGet(21)],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    ]);
+
+    let opts = CompileOptions {
+        emit_ir_only: true,
+        output_type: "executable".to_string(),
+        ..Default::default()
+    };
+    let ir = String::from_utf8(compile_module(&module, opts).expect("module compiles"))
+        .expect("LLVM IR is UTF-8");
+    let init = function_ir(&ir, "@number_array_guard_ts__init_body(");
+    let specialized = function_ir(&ir, "encipher$spec_b_ta4x4(");
+    let generic = function_ir(&ir, "@perry_fn_number_array_guard_ts__encipher(");
+
+    assert!(
+        init.contains("call i32 @js_param_type_guard("),
+        "direct call must validate the inferred array proof:\n{init}"
+    );
+    assert!(init.contains("encipher$spec_b_ta4x4("), "{init}");
+    assert!(init.contains("@perry_fn_number_array_guard_ts__encipher("));
+    assert!(!specialized.contains("js_dynamic_bitxor"));
+    assert!(generic.contains("js_dynamic_bitxor"));
+}
+
+#[test]
 fn nonsuspending_async_function_needs_no_direct_call_site_for_its_guarded_clone() {
     // An async body with no `await` runs to completion synchronously, so the
     // entry guard still describes the live arguments when the body reads them.

--- a/crates/perry-codegen/src/codegen/param_guard.rs
+++ b/crates/perry-codegen/src/codegen/param_guard.rs
@@ -766,14 +766,35 @@ pub(crate) fn declaration_guards(
             }
             Some(SpecParamGuard {
                 proof: param.ty.clone(),
-                descriptor_name: format!(
-                    "perry_param_guard_{}_{}_{}",
-                    module_prefix, function_id, index
-                ),
+                descriptor_name: guard_descriptor_name(module_prefix, function_id, index),
                 descriptor,
             })
         })
         .collect()
+}
+
+pub(crate) fn guard_descriptor_name(module_prefix: &str, function_id: u32, index: usize) -> String {
+    format!("perry_param_guard_{module_prefix}_{function_id}_{index}")
+}
+
+/// Build a descriptor for a proof inferred from a guarded direct-call shape
+/// rather than from the callee's annotation. The caller owns the eligibility
+/// checks; this helper deliberately only serializes the requested type.
+pub(crate) fn inferred_guard(
+    proof: Type,
+    descriptor_name: String,
+    type_aliases: &HashMap<String, Type>,
+    interfaces: &HashMap<String, perry_hir::Interface>,
+    classes: &HashMap<String, &perry_hir::Class>,
+    class_ids: &HashMap<String, u32>,
+) -> Option<SpecParamGuard> {
+    let (descriptor, _) =
+        descriptor_for_type_with_walk_bound(&proof, type_aliases, interfaces, classes, class_ids)?;
+    Some(SpecParamGuard {
+        proof,
+        descriptor_name,
+        descriptor,
+    })
 }
 
 /// Whether the current function body can suspend after its entry guard.

--- a/crates/perry-codegen/src/codegen/spec_abi.rs
+++ b/crates/perry-codegen/src/codegen/spec_abi.rs
@@ -113,8 +113,9 @@ pub(crate) fn spec_abi_max() -> usize {
 /// How proven call sites reach the specialized entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SpecDispatch {
-    /// Tier A: every non-Boxed slot proven BY CONSTRUCTION at the call site —
-    /// direct `call @{name}$spec_...` with raw args, no guard.
+    /// Tier A: raw slots are proven BY CONSTRUCTION at the direct call site.
+    /// Boxed container facts may additionally be validated in one call-site
+    /// descriptor diamond when the raw `TaPtr` ABI prevents a public wrapper.
     Static,
     /// Tier B: reps proven only by declared types — the call site keeps the
     /// runtime-guarded diamond (guard → spec entry / boxed fallback → phi).
@@ -135,7 +136,7 @@ pub(crate) struct SpecFnPlan {
 /// LLVM parameter type for a rep slot.
 pub(crate) fn spec_rep_llvm_ty(rep: SpecParamRep) -> LlvmType {
     match rep {
-        SpecParamRep::Boxed | SpecParamRep::F64 => DOUBLE,
+        SpecParamRep::Boxed | SpecParamRep::NumberArray | SpecParamRep::F64 => DOUBLE,
         SpecParamRep::I32 => I32,
         SpecParamRep::TaPtr { .. } => I64,
     }

--- a/crates/perry-codegen/src/codegen/spec_return_proof.rs
+++ b/crates/perry-codegen/src/codegen/spec_return_proof.rs
@@ -137,7 +137,7 @@ fn plan_param_proofs(function: &Function, plan: &SpecFnPlan) -> HashMap<u32, Typ
                 (None, SpecParamRep::TaPtr { kind, .. }) => {
                     Type::Named(spec_ta_kind_class_name(*kind)?.to_string())
                 }
-                (None, SpecParamRep::Boxed) => return None,
+                (None, SpecParamRep::Boxed | SpecParamRep::NumberArray) => return None,
             };
             Some((param.id, proof))
         })
@@ -176,7 +176,8 @@ fn call_is_proven(
                 // The verifier currently handles ordinary boxed/scalar plans.
                 // TaPtr's construction proof stays in its existing call-site
                 // machinery and cannot publish a return fact here.
-                (None, SpecParamRep::TaPtr { .. }) | (None, SpecParamRep::Boxed) => return false,
+                (None, SpecParamRep::TaPtr { .. })
+                | (None, SpecParamRep::Boxed | SpecParamRep::NumberArray) => return false,
             };
             expr_proves(ctx, locals, arg, expected, 0)
         })

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -535,8 +535,12 @@ pub(crate) fn collect_type_facts(
     // `PERRY_PTR_SHAPE_LOCALS=0` — `is_numeric_expr` is not a repsel consumer.
     let number_by_construction_locals = super::collect_number_by_construction_locals(
         stmts,
+        params,
         boxed_vars,
         module_globals,
+        binding_types,
+        spec_ta_lens,
+        spec_numeric_params,
         &not_bigint_locals,
     );
     let (mut array_facts, effect_facts, materialization_hazards) =

--- a/crates/perry-codegen/src/collectors/int_valued_ta_locals.rs
+++ b/crates/perry-codegen/src/collectors/int_valued_ta_locals.rs
@@ -271,7 +271,7 @@ fn additive_write_admissible(
 /// Does this RHS provably leave a NUMBER (never `undefined`) in the target?
 /// `numberish` is the flow set at the write site (for `LocalGet` copies and
 /// additive sub-trees).
-fn write_establishes_number(
+pub(super) fn write_establishes_number(
     e: &Expr,
     types: &HashMap<u32, HirType>,
     ta_lens: &HashMap<u32, i64>,

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -100,8 +100,8 @@ pub(crate) use shadow_slots::{
     collect_declared_shadow_slots_in_stmts, collect_shadow_slot_clear_points,
 };
 pub(crate) use spec_abi_sites::{
-    collect_spec_abi_facts, reassigned_locals, reassigned_locals_in_module, SpecParamRep,
-    SpecTaBinding,
+    collect_spec_abi_facts, guarded_number_array_param_eligible, reassigned_locals,
+    reassigned_locals_in_module, SpecParamRep, SpecTaBinding,
 };
 pub(crate) use this_as_value::{
     class_chain_extends_builtin_error, class_chain_has_unmodeled_base, class_uses_this_as_value,

--- a/crates/perry-codegen/src/collectors/number_by_construction.rs
+++ b/crates/perry-codegen/src/collectors/number_by_construction.rs
@@ -54,7 +54,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use perry_hir::Stmt;
+use perry_hir::types::Type as HirType;
+use perry_hir::{Expr, Param, Stmt};
 
 /// `PERRY_NUMBER_BY_CONSTRUCTION` gate. Enabled by default; `=0`/`off`/`false`
 /// empties the fact, reverting every reassigned numeric accumulator to the
@@ -80,18 +81,468 @@ pub(crate) fn enabled() -> bool {
 /// verdict without it.
 pub(crate) fn collect_number_by_construction_locals(
     stmts: &[Stmt],
+    params: &[Param],
     boxed_vars: &HashSet<u32>,
     module_globals: &HashMap<u32, String>,
+    binding_types: &HashMap<u32, HirType>,
+    spec_ta_lens: &HashMap<u32, i64>,
+    spec_numeric_params: &HashSet<u32>,
     not_bigint_locals: &HashSet<u32>,
 ) -> HashSet<u32> {
     if !enabled() {
         return HashSet::new();
     }
-    super::ptr_shape::collect_numeric_by_construction_locals_for_type_analysis(
+    let mut numeric = super::ptr_shape::collect_numeric_by_construction_locals_for_type_analysis(
         stmts,
         boxed_vars,
         module_globals,
         not_bigint_locals,
         &HashMap::new(),
-    )
+    );
+    numeric.extend(collect_number_at_read_after_undefined(
+        stmts,
+        params,
+        boxed_vars,
+        module_globals,
+        binding_types,
+        spec_ta_lens,
+        spec_numeric_params,
+    ));
+    numeric
+}
+
+/// Locals whose only non-Number state is `undefined`, and whose every read is
+/// dominated by a write that establishes a genuine Number.
+///
+/// TypeScript lowers `let n: number;` to an explicit `Undefined` seed.  The
+/// whole-write proof above must reject that seed, but rejecting the local at
+/// every later read is unnecessarily strong when control flow overwrites it
+/// first on every path.  This pass supplies the missing flow leg without
+/// trusting the declaration: writes qualify only through runtime-established
+/// facts (literals, Number-producing operations, or an in-bounds int typed-
+/// array read backed by a specialized-entry/constructor length proof).
+///
+/// A non-Number write other than `undefined` poisons the candidate even when
+/// it is overwritten before a read.  That keeps the broader consumers of
+/// `number_by_construction_locals` sound: between reads they may also use the
+/// fact to omit pointer rooting, and `undefined` is non-pointer while a string
+/// or object is not.
+fn collect_number_at_read_after_undefined(
+    stmts: &[Stmt],
+    params: &[Param],
+    boxed_vars: &HashSet<u32>,
+    module_globals: &HashMap<u32, String>,
+    binding_types: &HashMap<u32, HirType>,
+    spec_ta_lens: &HashMap<u32, i64>,
+    spec_numeric_params: &HashSet<u32>,
+) -> HashSet<u32> {
+    let mut writes: HashMap<u32, Vec<Option<&Expr>>> = HashMap::new();
+    let mut let_bound = HashSet::new();
+    super::not_bigint_locals::collect_writes(stmts, &mut writes, &mut let_bound);
+
+    let candidates: HashSet<u32> = let_bound
+        .into_iter()
+        .filter(|id| !boxed_vars.contains(id) && !module_globals.contains_key(id))
+        .filter(|id| {
+            writes.get(id).is_some_and(|local_writes| {
+                local_writes
+                    .iter()
+                    .any(|write| matches!(write, None | Some(Expr::Undefined)))
+            })
+        })
+        .collect();
+    if candidates.is_empty() {
+        return candidates;
+    }
+
+    let mut types = binding_types.clone();
+    for param in params {
+        types.entry(param.id).or_insert_with(|| param.ty.clone());
+    }
+    let mut ta_lens = super::integer_locals::collect_const_int_ta_views(stmts);
+    for (id, len) in spec_ta_lens {
+        ta_lens.entry(*id).or_insert(*len);
+    }
+
+    // Only raw numeric parameters proven by the specialized entry seed the
+    // initial flow state.  Declared `number` parameters remain untrusted in a
+    // generic body.  The same set is the conservative numeric-key evidence
+    // passed to the shared typed-array write predicate.
+    let mut numberish = spec_numeric_params.clone();
+    let invalid = {
+        let mut flow = NumberAtReadFlow {
+            candidates: &candidates,
+            types: &types,
+            ta_lens: &ta_lens,
+            numeric_index_locals: spec_numeric_params,
+            invalid: HashSet::new(),
+        };
+        flow.stmts(stmts, &mut numberish);
+        flow.invalid
+    };
+
+    candidates
+        .into_iter()
+        .filter(|id| !invalid.contains(id))
+        .collect()
+}
+
+struct NumberAtReadFlow<'a> {
+    candidates: &'a HashSet<u32>,
+    types: &'a HashMap<u32, HirType>,
+    ta_lens: &'a HashMap<u32, i64>,
+    numeric_index_locals: &'a HashSet<u32>,
+    invalid: HashSet<u32>,
+}
+
+impl NumberAtReadFlow<'_> {
+    fn stmts(&mut self, stmts: &[Stmt], numberish: &mut HashSet<u32>) {
+        for stmt in stmts {
+            self.stmt(stmt, numberish);
+        }
+    }
+
+    fn stmt(&mut self, stmt: &Stmt, numberish: &mut HashSet<u32>) {
+        match stmt {
+            Stmt::Let { id, init, .. } => match init {
+                Some(rhs) => self.write(*id, rhs, numberish),
+                None => {
+                    numberish.remove(id);
+                }
+            },
+            Stmt::Expr(expr) | Stmt::Throw(expr) => self.expr(expr, numberish, true),
+            Stmt::Return(Some(expr)) => self.expr(expr, numberish, false),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.expr(condition, numberish, false);
+                let mut then_state = numberish.clone();
+                self.stmts(then_branch, &mut then_state);
+                let mut else_state = numberish.clone();
+                if let Some(else_branch) = else_branch {
+                    self.stmts(else_branch, &mut else_state);
+                }
+                *numberish = then_state.intersection(&else_state).copied().collect();
+            }
+            Stmt::While { condition, body } => {
+                let entry = numberish.clone();
+                self.expr(condition, numberish, false);
+                let mut backedge = numberish.clone();
+                self.stmts(body, &mut backedge);
+                // Re-check the condition under the back-edge state.  This is
+                // what prevents a body write from invalidating a value read
+                // by the next iteration's condition without being noticed.
+                self.expr(condition, &mut backedge, false);
+                *numberish = entry.intersection(&backedge).copied().collect();
+            }
+            Stmt::DoWhile { body, condition } => {
+                let entry = numberish.clone();
+                let mut backedge = numberish.clone();
+                self.stmts(body, &mut backedge);
+                self.expr(condition, &mut backedge, false);
+                // A second conservative body walk covers later iterations
+                // whose entry state is the meet of the first entry/back-edge.
+                let mut loop_entry: HashSet<u32> = entry.intersection(&backedge).copied().collect();
+                self.stmts(body, &mut loop_entry);
+                self.expr(condition, &mut loop_entry, false);
+                *numberish = backedge.intersection(&loop_entry).copied().collect();
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    self.stmt(init, numberish);
+                }
+                let entry = numberish.clone();
+                if let Some(condition) = condition {
+                    self.expr(condition, numberish, false);
+                }
+                let mut backedge = numberish.clone();
+                self.stmts(body, &mut backedge);
+                if let Some(update) = update {
+                    self.expr(update, &mut backedge, false);
+                }
+                if let Some(condition) = condition {
+                    self.expr(condition, &mut backedge, false);
+                }
+                let mut loop_entry: HashSet<u32> = entry.intersection(&backedge).copied().collect();
+                self.stmts(body, &mut loop_entry);
+                if let Some(update) = update {
+                    self.expr(update, &mut loop_entry, false);
+                }
+                *numberish = entry.intersection(&loop_entry).copied().collect();
+            }
+            Stmt::Labeled { body, .. } => self.stmt(body, numberish),
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                let entry = numberish.clone();
+                let mut try_state = numberish.clone();
+                self.stmts(body, &mut try_state);
+                let mut merged: HashSet<u32> = entry.intersection(&try_state).copied().collect();
+                if let Some(catch) = catch {
+                    let mut catch_state = entry.clone();
+                    self.stmts(&catch.body, &mut catch_state);
+                    merged.retain(|id| catch_state.contains(id));
+                }
+                if let Some(finally) = finally {
+                    self.stmts(finally, &mut merged);
+                }
+                *numberish = merged;
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                self.expr(discriminant, numberish, false);
+                let entry = numberish.clone();
+                let mut merged = entry.clone();
+                for case in cases {
+                    if let Some(test) = &case.test {
+                        let mut test_state = entry.clone();
+                        self.expr(test, &mut test_state, false);
+                        merged.retain(|id| test_state.contains(id));
+                    }
+                    let mut case_state = entry.clone();
+                    self.stmts(&case.body, &mut case_state);
+                    merged.retain(|id| case_state.contains(id));
+                }
+                *numberish = merged;
+            }
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::Return(None)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+
+    fn write(&mut self, target: u32, rhs: &Expr, numberish: &mut HashSet<u32>) {
+        self.expr(rhs, numberish, false);
+        if matches!(rhs, Expr::Undefined) {
+            numberish.remove(&target);
+            return;
+        }
+        if super::int_valued_ta_locals::write_establishes_number(
+            rhs,
+            self.types,
+            self.ta_lens,
+            numberish,
+            self.numeric_index_locals,
+        ) {
+            numberish.insert(target);
+        } else {
+            numberish.remove(&target);
+            if self.candidates.contains(&target) {
+                self.invalid.insert(target);
+            }
+        }
+    }
+
+    fn expr(&mut self, expr: &Expr, numberish: &mut HashSet<u32>, root_store: bool) {
+        match expr {
+            Expr::LocalGet(id) => {
+                if self.candidates.contains(id) && !numberish.contains(id) {
+                    self.invalid.insert(*id);
+                }
+            }
+            Expr::LocalSet(id, rhs) if root_store => self.write(*id, rhs, numberish),
+            Expr::LocalSet(id, rhs) => {
+                // Conditional/short-circuit expression writes need their own
+                // CFG before they can establish dominance.  Decline them.
+                self.expr(rhs, numberish, false);
+                numberish.remove(id);
+                if self.candidates.contains(id) {
+                    self.invalid.insert(*id);
+                }
+            }
+            Expr::Update { id, .. } => {
+                if self.candidates.contains(id) && !numberish.contains(id) {
+                    self.invalid.insert(*id);
+                }
+                if !numberish.contains(id) {
+                    numberish.remove(id);
+                }
+            }
+            Expr::Closure { .. } => {
+                // Captured mutable locals are excluded through `boxed_vars`.
+                // The HIR walker intentionally keeps closure bodies separate.
+            }
+            _ => perry_hir::walker::walk_expr_children(expr, &mut |child| {
+                self.expr(child, numberish, false)
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perry_hir::{BinaryOp, CompareOp};
+
+    const N: u32 = 1;
+    const S: u32 = 2;
+    const L: u32 = 3;
+
+    fn let_n() -> Stmt {
+        Stmt::Let {
+            id: N,
+            name: "n".to_string(),
+            ty: HirType::Number,
+            mutable: true,
+            init: Some(Expr::Undefined),
+        }
+    }
+
+    fn set_n(rhs: Expr) -> Stmt {
+        Stmt::Expr(Expr::LocalSet(N, Box::new(rhs)))
+    }
+
+    fn s_read(index: Expr) -> Expr {
+        Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(S)),
+            index: Box::new(index),
+        }
+    }
+
+    fn add(left: Expr, right: Expr) -> Expr {
+        Expr::Binary {
+            op: BinaryOp::Add,
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    fn run(stmts: &[Stmt]) -> HashSet<u32> {
+        let params = [Param {
+            id: S,
+            name: "S".to_string(),
+            ty: HirType::Named("Int32Array".to_string()),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }];
+        collect_number_at_read_after_undefined(
+            stmts,
+            &params,
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::from([(S, 1024)]),
+            &HashSet::new(),
+        )
+    }
+
+    fn masked_s_read() -> Expr {
+        s_read(Expr::Binary {
+            op: BinaryOp::UShr,
+            left: Box::new(Expr::LocalGet(L)),
+            right: Box::new(Expr::Integer(24)),
+        })
+    }
+
+    #[test]
+    fn undefined_seed_reset_before_each_loop_read_is_number_at_reads() {
+        let stmts = vec![
+            let_n(),
+            Stmt::While {
+                condition: Expr::Compare {
+                    op: CompareOp::Lt,
+                    left: Box::new(Expr::Integer(0)),
+                    right: Box::new(Expr::Integer(1)),
+                },
+                body: vec![
+                    set_n(masked_s_read()),
+                    set_n(add(Expr::LocalGet(N), s_read(Expr::Integer(256)))),
+                    Stmt::Expr(Expr::Binary {
+                        op: BinaryOp::BitXor,
+                        left: Box::new(Expr::LocalGet(N)),
+                        right: Box::new(Expr::Integer(7)),
+                    }),
+                ],
+            },
+        ];
+
+        assert!(run(&stmts).contains(&N));
+    }
+
+    #[test]
+    fn read_before_first_numeric_write_keeps_dynamic_type() {
+        let stmts = vec![
+            let_n(),
+            Stmt::While {
+                condition: Expr::Bool(true),
+                body: vec![set_n(add(Expr::LocalGet(N), Expr::Integer(1)))],
+            },
+        ];
+
+        assert!(!run(&stmts).contains(&N));
+    }
+
+    #[test]
+    fn zero_trip_loop_does_not_dominate_a_later_read() {
+        let stmts = vec![
+            let_n(),
+            Stmt::While {
+                condition: Expr::Bool(false),
+                body: vec![set_n(Expr::Integer(1))],
+            },
+            Stmt::Return(Some(Expr::LocalGet(N))),
+        ];
+
+        assert!(!run(&stmts).contains(&N));
+    }
+
+    #[test]
+    fn both_branch_writes_dominate_the_join_read() {
+        let stmts = vec![
+            let_n(),
+            Stmt::If {
+                condition: Expr::LocalGet(99),
+                then_branch: vec![set_n(Expr::Integer(1))],
+                else_branch: Some(vec![set_n(Expr::Number(2.5))]),
+            },
+            Stmt::Return(Some(Expr::LocalGet(N))),
+        ];
+
+        assert!(run(&stmts).contains(&N));
+    }
+
+    #[test]
+    fn missing_branch_write_keeps_join_read_dynamic() {
+        let stmts = vec![
+            let_n(),
+            Stmt::If {
+                condition: Expr::LocalGet(99),
+                then_branch: vec![set_n(Expr::Integer(1))],
+                else_branch: None,
+            },
+            Stmt::Return(Some(Expr::LocalGet(N))),
+        ];
+
+        assert!(!run(&stmts).contains(&N));
+    }
+
+    #[test]
+    fn pointer_write_poisons_rooting_fact_even_when_overwritten() {
+        let stmts = vec![
+            let_n(),
+            set_n(Expr::String("temporary".to_string())),
+            set_n(Expr::Integer(1)),
+            Stmt::Return(Some(Expr::LocalGet(N))),
+        ];
+
+        assert!(!run(&stmts).contains(&N));
+    }
 }

--- a/crates/perry-codegen/src/collectors/spec_abi_sites.rs
+++ b/crates/perry-codegen/src/collectors/spec_abi_sites.rs
@@ -54,6 +54,10 @@ pub enum SpecParamRep {
     I32,
     /// Raw double (bit-identical to the boxed form for numbers).
     F64,
+    /// NaN-boxed plain array whose elements are expected to be Numbers. The
+    /// call site still validates that expectation with a descriptor guard;
+    /// this marker only carries the profitable shape through tuple selection.
+    NumberArray,
     /// Raw `TypedArrayHeader*` of a proven non-view typed array.
     TaPtr {
         /// `perry_hir::TYPED_ARRAY_KIND_*` element kind.
@@ -71,6 +75,7 @@ impl SpecParamRep {
             Self::Boxed => "b".to_string(),
             Self::I32 => "i32".to_string(),
             Self::F64 => "f64".to_string(),
+            Self::NumberArray => "narr".to_string(),
             Self::TaPtr { kind, const_len } => match const_len {
                 Some(len) => format!("ta{kind}x{len}"),
                 None => format!("ta{kind}"),
@@ -515,6 +520,16 @@ fn array_literal_len(e: &Expr) -> Option<i64> {
     }
 }
 
+fn is_number_array_literal(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::Array(elements)
+            if elements
+                .iter()
+                .all(|element| matches!(element, Expr::Integer(_) | Expr::Number(_)))
+    )
+}
+
 /// A typed-array constructor length literal. Keep this deliberately aligned
 /// with the direct-literal arm of [`judge_ctor_arg`].
 fn typed_array_length_literal(e: &Expr) -> Option<i64> {
@@ -559,6 +574,7 @@ fn judge_sites_in_body(
     stmts: &[Stmt],
     params: &[perry_hir::Param],
     ta_bindings: &HashMap<u32, SpecTaBinding>,
+    number_array_bindings: &HashSet<u32>,
     out: &mut HashMap<u32, Vec<Vec<SpecParamRep>>>,
 ) {
     // Use the same transitive, all-writes range proof as canonical i32 slots.
@@ -576,9 +592,16 @@ fn judge_sites_in_body(
     );
     let mut ready: HashSet<u32> = HashSet::new();
     for s in stmts {
-        judge_stmt(s, ta_bindings, &integer_locals, &ready, out);
+        judge_stmt(
+            s,
+            ta_bindings,
+            number_array_bindings,
+            &integer_locals,
+            &ready,
+            out,
+        );
         if let Stmt::Let { id, .. } = s {
-            if ta_bindings.contains_key(id) {
+            if ta_bindings.contains_key(id) || number_array_bindings.contains(id) {
                 ready.insert(*id);
             }
         }
@@ -588,17 +611,22 @@ fn judge_sites_in_body(
 fn judge_stmt(
     s: &Stmt,
     ta: &HashMap<u32, SpecTaBinding>,
+    number_arrays: &HashSet<u32>,
     integer_locals: &HashSet<u32>,
     ready: &HashSet<u32>,
     out: &mut HashMap<u32, Vec<Vec<SpecParamRep>>>,
 ) {
     match s {
-        Stmt::Let { init: Some(e), .. } => judge_expr(e, ta, integer_locals, ready, out),
+        Stmt::Let { init: Some(e), .. } => {
+            judge_expr(e, ta, number_arrays, integer_locals, ready, out)
+        }
         Stmt::Let { init: None, .. } => {}
-        Stmt::Expr(e) | Stmt::Throw(e) => judge_expr(e, ta, integer_locals, ready, out),
+        Stmt::Expr(e) | Stmt::Throw(e) => {
+            judge_expr(e, ta, number_arrays, integer_locals, ready, out)
+        }
         Stmt::Return(opt) => {
             if let Some(e) = opt {
-                judge_expr(e, ta, integer_locals, ready, out);
+                judge_expr(e, ta, number_arrays, integer_locals, ready, out);
             }
         }
         Stmt::If {
@@ -606,20 +634,20 @@ fn judge_stmt(
             then_branch,
             else_branch,
         } => {
-            judge_expr(condition, ta, integer_locals, ready, out);
+            judge_expr(condition, ta, number_arrays, integer_locals, ready, out);
             for st in then_branch {
-                judge_stmt(st, ta, integer_locals, ready, out);
+                judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
             }
             if let Some(eb) = else_branch {
                 for st in eb {
-                    judge_stmt(st, ta, integer_locals, ready, out);
+                    judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
                 }
             }
         }
         Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
-            judge_expr(condition, ta, integer_locals, ready, out);
+            judge_expr(condition, ta, number_arrays, integer_locals, ready, out);
             for st in body {
-                judge_stmt(st, ta, integer_locals, ready, out);
+                judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
             }
         }
         Stmt::For {
@@ -629,35 +657,37 @@ fn judge_stmt(
             body,
         } => {
             if let Some(i) = init {
-                judge_stmt(i, ta, integer_locals, ready, out);
+                judge_stmt(i, ta, number_arrays, integer_locals, ready, out);
             }
             if let Some(c) = condition {
-                judge_expr(c, ta, integer_locals, ready, out);
+                judge_expr(c, ta, number_arrays, integer_locals, ready, out);
             }
             if let Some(u) = update {
-                judge_expr(u, ta, integer_locals, ready, out);
+                judge_expr(u, ta, number_arrays, integer_locals, ready, out);
             }
             for st in body {
-                judge_stmt(st, ta, integer_locals, ready, out);
+                judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
             }
         }
-        Stmt::Labeled { body, .. } => judge_stmt(body, ta, integer_locals, ready, out),
+        Stmt::Labeled { body, .. } => {
+            judge_stmt(body, ta, number_arrays, integer_locals, ready, out)
+        }
         Stmt::Try {
             body,
             catch,
             finally,
         } => {
             for st in body {
-                judge_stmt(st, ta, integer_locals, ready, out);
+                judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
             }
             if let Some(c) = catch {
                 for st in &c.body {
-                    judge_stmt(st, ta, integer_locals, ready, out);
+                    judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
                 }
             }
             if let Some(f) = finally {
                 for st in f {
-                    judge_stmt(st, ta, integer_locals, ready, out);
+                    judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
                 }
             }
         }
@@ -665,13 +695,13 @@ fn judge_stmt(
             discriminant,
             cases,
         } => {
-            judge_expr(discriminant, ta, integer_locals, ready, out);
+            judge_expr(discriminant, ta, number_arrays, integer_locals, ready, out);
             for case in cases {
                 if let Some(t) = &case.test {
-                    judge_expr(t, ta, integer_locals, ready, out);
+                    judge_expr(t, ta, number_arrays, integer_locals, ready, out);
                 }
                 for st in &case.body {
-                    judge_stmt(st, ta, integer_locals, ready, out);
+                    judge_stmt(st, ta, number_arrays, integer_locals, ready, out);
                 }
             }
         }
@@ -686,6 +716,7 @@ fn judge_stmt(
 pub(crate) fn judge_arg(
     arg: &Expr,
     ta: &HashMap<u32, SpecTaBinding>,
+    number_arrays: &HashSet<u32>,
     integer_locals: &HashSet<u32>,
     ready: &HashSet<u32>,
 ) -> SpecParamRep {
@@ -699,6 +730,8 @@ pub(crate) fn judge_arg(
                     kind: binding.kind,
                     const_len: binding.const_len,
                 }
+            } else if number_arrays.contains(id) && ready.contains(id) {
+                SpecParamRep::NumberArray
             } else if integer_locals.contains(id) {
                 SpecParamRep::I32
             } else {
@@ -712,6 +745,7 @@ pub(crate) fn judge_arg(
 fn judge_expr(
     e: &Expr,
     ta: &HashMap<u32, SpecTaBinding>,
+    number_arrays: &HashSet<u32>,
     integer_locals: &HashSet<u32>,
     ready: &HashSet<u32>,
     out: &mut HashMap<u32, Vec<Vec<SpecParamRep>>>,
@@ -720,7 +754,7 @@ fn judge_expr(
         if let Expr::FuncRef(fid) = callee.as_ref() {
             let judged: Vec<SpecParamRep> = args
                 .iter()
-                .map(|a| judge_arg(a, ta, integer_locals, ready))
+                .map(|a| judge_arg(a, ta, number_arrays, integer_locals, ready))
                 .collect();
             out.entry(*fid).or_default().push(judged);
         }
@@ -731,7 +765,7 @@ fn judge_expr(
         return;
     }
     perry_hir::walker::walk_expr_children(e, &mut |c| {
-        judge_expr(c, ta, integer_locals, ready, out)
+        judge_expr(c, ta, number_arrays, integer_locals, ready, out)
     });
 }
 
@@ -745,6 +779,7 @@ pub fn collect_spec_abi_facts(hir: &Module) -> SpecAbiModuleFacts {
     // local has NO uses outside element-access-receiver / TA-ctor-arg
     // positions — `len_unsafe_uses` records everything else).
     let mut array_literal_locals: HashMap<u32, Option<i64>> = HashMap::new();
+    let mut number_array_bindings: HashSet<u32> = HashSet::new();
     let mut collect_array_literals = |stmts: &[Stmt]| {
         for s in stmts {
             if let Stmt::Let {
@@ -758,6 +793,9 @@ pub fn collect_spec_abi_facts(hir: &Module) -> SpecAbiModuleFacts {
                     if let Some(len) = array_literal_len(e) {
                         let exact = !scan.len_unsafe_uses.contains(id);
                         array_literal_locals.insert(*id, exact.then_some(len));
+                        if is_number_array_literal(e) {
+                            number_array_bindings.insert(*id);
+                        }
                     }
                 }
             }
@@ -842,15 +880,196 @@ pub fn collect_spec_abi_facts(hir: &Module) -> SpecAbiModuleFacts {
 
     // Judge every direct call site in init + function bodies.
     let mut call_sites: HashMap<u32, Vec<Vec<SpecParamRep>>> = HashMap::new();
-    judge_sites_in_body(&hir.init, &[], &ta_bindings, &mut call_sites);
+    judge_sites_in_body(
+        &hir.init,
+        &[],
+        &ta_bindings,
+        &number_array_bindings,
+        &mut call_sites,
+    );
     for f in &hir.functions {
-        judge_sites_in_body(&f.body, &f.params, &ta_bindings, &mut call_sites);
+        judge_sites_in_body(
+            &f.body,
+            &f.params,
+            &ta_bindings,
+            &number_array_bindings,
+            &mut call_sites,
+        );
     }
 
     SpecAbiModuleFacts {
         ta_bindings,
         call_sites,
     }
+}
+
+/// Whether an entry guard may lend `Array<Number>` to reads from `param_id`.
+/// The descriptor proves the initial contents. Keep that proof only when the
+/// body has enough work to amortize the walk, cannot call aliasing code, and
+/// performs all reads before its first element write. Later writes therefore
+/// cannot invalidate any read that consumed the proof.
+pub(crate) fn guarded_number_array_param_eligible(stmts: &[Stmt], param_id: u32) -> bool {
+    #[derive(Default)]
+    struct Uses {
+        read: bool,
+        write: bool,
+        call: bool,
+    }
+
+    fn scan_expr(expr: &Expr, param_id: u32, uses: &mut Uses) {
+        match expr {
+            Expr::Call { .. } | Expr::New { .. } => {
+                uses.call = true;
+                perry_hir::walker::walk_expr_children(expr, &mut |child| {
+                    scan_expr(child, param_id, uses)
+                });
+            }
+            Expr::IndexGet { object, index } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == param_id) =>
+            {
+                uses.read = true;
+                scan_expr(index, param_id, uses);
+            }
+            Expr::IndexSet {
+                object,
+                index,
+                value,
+            } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == param_id) => {
+                uses.write = true;
+                scan_expr(index, param_id, uses);
+                scan_expr(value, param_id, uses);
+            }
+            Expr::LocalGet(id) if *id == param_id => uses.read = true,
+            Expr::Closure { .. } => {}
+            _ => perry_hir::walker::walk_expr_children(expr, &mut |child| {
+                scan_expr(child, param_id, uses)
+            }),
+        }
+    }
+
+    fn scan_stmts(stmts: &[Stmt], param_id: u32, uses: &mut Uses) {
+        for stmt in stmts {
+            scan_stmt(stmt, param_id, uses);
+        }
+    }
+
+    fn scan_stmt(stmt: &Stmt, param_id: u32, uses: &mut Uses) {
+        match stmt {
+            Stmt::Let {
+                init: Some(expr), ..
+            }
+            | Stmt::Expr(expr)
+            | Stmt::Throw(expr) => scan_expr(expr, param_id, uses),
+            Stmt::Return(Some(expr)) => scan_expr(expr, param_id, uses),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                scan_expr(condition, param_id, uses);
+                scan_stmts(then_branch, param_id, uses);
+                if let Some(branch) = else_branch {
+                    scan_stmts(branch, param_id, uses);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                scan_expr(condition, param_id, uses);
+                scan_stmts(body, param_id, uses);
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    scan_stmt(init, param_id, uses);
+                }
+                if let Some(condition) = condition {
+                    scan_expr(condition, param_id, uses);
+                }
+                if let Some(update) = update {
+                    scan_expr(update, param_id, uses);
+                }
+                scan_stmts(body, param_id, uses);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                scan_stmts(body, param_id, uses);
+                if let Some(catch) = catch {
+                    scan_stmts(&catch.body, param_id, uses);
+                }
+                if let Some(finally) = finally {
+                    scan_stmts(finally, param_id, uses);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                scan_expr(discriminant, param_id, uses);
+                for case in cases {
+                    if let Some(test) = &case.test {
+                        scan_expr(test, param_id, uses);
+                    }
+                    scan_stmts(&case.body, param_id, uses);
+                }
+            }
+            Stmt::Labeled { body, .. } => scan_stmt(body, param_id, uses),
+            Stmt::Let { init: None, .. }
+            | Stmt::Return(None)
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+
+    fn contains_loop(stmts: &[Stmt]) -> bool {
+        stmts.iter().any(|stmt| match stmt {
+            Stmt::While { .. } | Stmt::DoWhile { .. } | Stmt::For { .. } => true,
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => contains_loop(then_branch) || else_branch.as_deref().is_some_and(contains_loop),
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                contains_loop(body)
+                    || catch
+                        .as_ref()
+                        .is_some_and(|catch| contains_loop(&catch.body))
+                    || finally.as_deref().is_some_and(contains_loop)
+            }
+            Stmt::Switch { cases, .. } => cases.iter().any(|case| contains_loop(&case.body)),
+            Stmt::Labeled { body, .. } => contains_loop(std::slice::from_ref(body.as_ref())),
+            _ => false,
+        })
+    }
+
+    if !contains_loop(stmts) {
+        return false;
+    }
+    let mut after_write = false;
+    let mut saw_read = false;
+    for stmt in stmts {
+        let mut uses = Uses::default();
+        scan_stmt(stmt, param_id, &mut uses);
+        if uses.call || (uses.read && (after_write || uses.write)) {
+            return false;
+        }
+        saw_read |= uses.read;
+        after_write |= uses.write;
+    }
+    saw_read
 }
 
 #[cfg(test)]

--- a/crates/perry-codegen/src/collectors/spec_abi_sites/tests.rs
+++ b/crates/perry-codegen/src/collectors/spec_abi_sites/tests.rs
@@ -455,3 +455,39 @@ fn local_is_reassigned_sees_closure_writes() {
     assert!(local_is_reassigned(&stmts, 5));
     assert!(!local_is_reassigned(&stmts, 6));
 }
+
+#[test]
+fn guarded_number_array_rejects_stale_or_aliasable_reads() {
+    let read = || Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(5)),
+        index: Box::new(Expr::Integer(0)),
+    };
+    let write = || {
+        Stmt::Expr(Expr::IndexSet {
+            object: Box::new(Expr::LocalGet(5)),
+            index: Box::new(Expr::Integer(0)),
+            value: Box::new(Expr::Integer(1)),
+        })
+    };
+    let loop_stmt = || Stmt::While {
+        condition: Expr::Bool(false),
+        body: Vec::new(),
+    };
+
+    assert!(guarded_number_array_param_eligible(
+        &[let_stmt(6, false, read()), loop_stmt(), write(),],
+        5,
+    ));
+    assert!(!guarded_number_array_param_eligible(
+        &[write(), loop_stmt(), Stmt::Return(Some(read()))],
+        5,
+    ));
+    assert!(!guarded_number_array_param_eligible(
+        &[
+            let_stmt(6, false, read()),
+            loop_stmt(),
+            Stmt::Expr(call(9, Vec::new())),
+        ],
+        5,
+    ));
+}

--- a/crates/perry-codegen/src/lower_call/func_ref.rs
+++ b/crates/perry-codegen/src/lower_call/func_ref.rs
@@ -19,11 +19,10 @@ fn typed_i1_signature_note(reps: &[crate::codegen::TypedParamRep]) -> String {
     }
 }
 
-/// Representation-selection Phase 2, Tier A: statically-proven dispatch to a
-/// specialized entry — direct call with raw args, no guard, no diamond, no
-/// phi. Every non-`Boxed` slot must be proven BY CONSTRUCTION at this exact
-/// call site (this check, not the collector, is the load-bearing soundness
-/// gate — a mismatch silently keeps today's boxed path):
+/// Representation-selection Phase 2, Tier A: direct dispatch to a specialized
+/// entry. Raw slots are proven by construction at this exact call site. A
+/// boxed container proof may add one descriptor diamond for the whole call;
+/// a mismatch keeps the permanent boxed fallback.
 ///
 /// - `I32` — integer literal in i32 range.
 /// - `F64` — numeric literal (bit-identical raw double).
@@ -60,6 +59,9 @@ fn try_emit_spec_static_call(
     for (i, (rep, arg)) in plan.reps.iter().zip(args.iter()).enumerate() {
         match rep {
             SpecParamRep::Boxed => raw_plan.push(RawArg::Double(i)),
+            // Plan construction normalizes this call-site-only marker to a
+            // boxed slot plus a descriptor before lowering.
+            SpecParamRep::NumberArray => return None,
             SpecParamRep::F64 => match arg {
                 Expr::Number(_) | Expr::Integer(_) => raw_plan.push(RawArg::Double(i)),
                 _ => return None,
@@ -143,7 +145,8 @@ fn try_emit_spec_static_call(
         raw_args_storage
     }
 
-    if !range_checked.is_empty() {
+    let check_descriptors = matches!(plan.dispatch, crate::codegen::SpecDispatch::Static);
+    if !range_checked.is_empty() || (check_descriptors && plan.guards.iter().any(Option::is_some)) {
         // One diamond for the whole call: every range-checked slot's test is
         // ANDed, so the fast arm is entered only when EVERY raw slot's
         // contract holds. The fallback is the permanent boxed ABI, which is
@@ -160,10 +163,37 @@ fn try_emit_spec_static_call(
                 None => ok,
             });
         }
+        if check_descriptors {
+            for (i, descriptor) in plan.guards.iter().enumerate() {
+                let Some(descriptor) = descriptor else {
+                    continue;
+                };
+                let ok = if let Some(rep) =
+                    crate::codegen::scalar_descriptor_rep(&descriptor.descriptor)
+                {
+                    crate::codegen::emit_typed_arg_guard(ctx.block(), rep, &lowered[i])
+                } else {
+                    let raw = ctx.block().call(
+                        I32,
+                        "js_param_type_guard",
+                        &[
+                            (DOUBLE, lowered[i].as_str()),
+                            (PTR, &format!("@{}", descriptor.descriptor_name)),
+                            (I32, &descriptor.descriptor.len().to_string()),
+                        ],
+                    );
+                    ctx.block().icmp_ne(I32, &raw, "0")
+                };
+                guard = Some(match guard {
+                    Some(prev) => ctx.block().and(I1, &prev, &ok),
+                    None => ok,
+                });
+            }
+        }
         let guard = guard?;
-        let fast_idx = ctx.new_block("spec_i32_call.fast");
-        let fallback_idx = ctx.new_block("spec_i32_call.fallback");
-        let merge_idx = ctx.new_block("spec_i32_call.merge");
+        let fast_idx = ctx.new_block("spec_checked_call.fast");
+        let fallback_idx = ctx.new_block("spec_checked_call.fallback");
+        let merge_idx = ctx.new_block("spec_checked_call.merge");
         let fast_label = ctx.block_label(fast_idx);
         let fallback_label = ctx.block_label(fallback_idx);
         let merge_label = ctx.block_label(merge_idx);
@@ -201,7 +231,7 @@ fn try_emit_spec_static_call(
         ctx.record_lowered_value(
             "Call",
             None,
-            "spec_abi_range_checked_call",
+            "spec_abi_checked_call",
             &LoweredValue::js_value(result.clone()),
             None,
             None,
@@ -209,9 +239,19 @@ fn try_emit_spec_static_call(
             false,
             false,
             vec![
-                format!("spec_call=range_checked; symbol={spec_name}; boxed_fallback={fname}"),
+                format!("spec_call=checked; symbol={spec_name}; boxed_fallback={fname}"),
                 format!("tuple={}", tuple_note.join(",")),
                 format!("range_checked_slots={range_checked:?}"),
+                format!(
+                    "descriptor_checked_slots={:?}",
+                    plan.guards
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, guard)| {
+                            (check_descriptors && guard.is_some()).then_some(i)
+                        })
+                        .collect::<Vec<_>>()
+                ),
             ],
         );
         return Some(result);

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -589,7 +589,17 @@ pub(crate) fn numeric_proof_is_declared_only(ctx: &FnCtx<'_>, expr: &Expr) -> bo
         // `const sum = o.x + o.y`). Without this bit, a later `v * 2` or
         // `sum * scale` becomes a bare `fmul` on whatever boxed value the slot
         // holds, and a NaN-boxed string passes straight through it.
-        Expr::LocalGet(id) => ctx.declared_only_numeric_locals.contains(id),
+        Expr::LocalGet(id) => {
+            ctx.declared_only_numeric_locals.contains(id)
+                // A declaration-only marker is seeded when the `Let` lowers,
+                // before later assignments are seen.  The whole-region
+                // write/flow proof can subsequently establish the stronger
+                // fact that every observable read is a Number (including an
+                // `undefined` seed overwritten on every path before use).
+                // Keep the historical marker for generic/unproven bodies,
+                // but do not let it mask that runtime-derived proof.
+                && !ctx.number_by_construction_locals.contains(id)
+        }
         // `a + b` is numeric only when both sides are, so it is violable when
         // either side is; `a || b` / `a && b` / `a ?? b` pass one operand
         // VALUE through, so the same holds. Both mirror `is_numeric_expr`.


### PR DESCRIPTION
Fixes #8485.

## What changed

- preserve a runtime-derived Number fact for `undefined`-seeded locals when every observable read is dominated by a Number-producing write
- carry numeric plain-array call-site evidence into mixed specialized-ABI plans and validate it once per direct call
- propagate successful descriptor proofs into the specialized body's local type map, allowing numeric element reads to feed native bitwise/add lowering
- keep a boxed generic fallback whenever the numeric-array descriptor does not match

This removes the dynamic `+` and `^` envelope from both `encipherUntyped` and `encipherTyped`. The S/P typed-array loads remain on their existing native path.

## Benchmark

Five runs of `benchmarks/suite/bench_typed_array_untyped_access.ts`, using a fresh release build of `perry`, `perry-runtime-static`, and `perry-stdlib-static`. Instructions retired are the primary signal.

| median (5 runs) | before | after | delta |
|---|---:|---:|---:|
| wall | 6.30 s | 3.52 s | -44.1% |
| instructions retired | 86,740,343,839 | 56,612,344,138 | -34.73% |
| peak RSS | 11,714,560 B | 5,554,176 B | -52.6% |
| untyped / typed | 1.0438 | 1.0017 | improved |

Wall ranges were disjoint despite host contention: 6.30–6.93 s before and 3.49–3.89 s after. The checksum remained `-821955270` in every run.

The numeric/dynamic-heavy sweep rows stayed instruction-neutral:

| median (5 runs) | before | after | instruction delta |
|---|---:|---:|---:|
| `interp` | 0.61 s / 8,996,431,485 inst / 33,030,144 B RSS | 0.67 s / 9,002,446,227 inst / 32,980,992 B RSS | +0.067% |
| `iso_miss` | 0.93 s / 14,788,875,174 inst / 32,817,152 B RSS | 1.15 s / 14,797,545,801 inst / 32,833,536 B RSS | +0.059% |

Their wall ranges overlapped (`interp`: 0.59–0.68 s both; `iso_miss`: 0.91–1.66 s before, 1.06–1.27 s after), so the wall movement is contention noise.

## Validation

- all 19 programs in `sweep-artifacts-0820/sources` byte-exact against expected stdout/stderr
- `cargo test --release -p perry-runtime --lib` (2,605 passed, 4 ignored)
- `cargo test --release -p perry --bin perry` (1,008 passed)
- `cargo test --release -p perry-codegen --lib` (1,121 passed)
- `bash scripts/run_lint_gates.sh` (all 52 gates passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved numeric operation performance by preserving number guarantees across local reassignments and eligible array reads.
  * Reduced dynamic arithmetic overhead for native typed-array element access.

* **Bug Fixes**
  * Improved handling of uninitialized numeric locals when all reads follow valid numeric assignments.
  * Added safer guarded dispatch for numeric array parameters, including runtime validation when required.

* **Tests**
  * Added regression coverage for loops, conditional assignments, mixed typed-array arguments, and invalidating writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->