### PR TITLE
fix(gc): root the displaced receiver in direct IMPLICIT_THIS save/restore pairs (#8495)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1513
+**Current Version:** 0.5.1514
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,7 +5528,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "cc",
  "libc",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5704,14 +5704,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "serde",
  "serde_json",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1513"
+version = "0.5.1514"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "clap",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "block2",
  "objc2",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "chrono",
  "cron",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5855,14 +5855,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "bson",
  "futures-util",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6019,7 +6019,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6064,14 +6064,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "brotli",
  "flate2",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6211,14 +6211,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6313,14 +6313,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6329,14 +6329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.0",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1513"
+version = "0.5.1514"
 
 [[package]]
 name = "perry-ui-test"
@@ -6431,11 +6431,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1513"
+version = "0.5.1514"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6469,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "block2",
  "libc",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6502,14 +6502,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1513"
+version = "0.5.1514"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1513"
+version = "0.5.1514"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/8500-implicit-this-direct-access-rooting.md
+++ b/changelog.d/8500-implicit-this-direct-access-rooting.md
@@ -1,0 +1,19 @@
+**GC: `this` could become a stale from-space pointer after a moving collection inside a method body (#8495).**
+
+A method whose body triggered an evacuating collection saw `this` become a dangling from-space pointer. Reads through it returned garbage — `Object.keys(this)` came back `[]` and `Object.getPrototypeOf(this) === Object.prototype` was `false` — so a method that collected before touching `this` silently observed an empty object:
+
+```ts
+const recv: any = { n: "RECV" };
+recv.f = function (): string { churnGc(); return JSON.stringify(Object.keys(this)); };
+recv.f();   // was: []   now: ["n","f"]
+```
+
+**Cause.** Twenty-two receiver save/restore pairs manipulated the `IMPLICIT_THIS` cell *directly* — `let prev = IMPLICIT_THIS.with(|c| c.replace(recv))` … call … `IMPLICIT_THIS.with(|c| c.set(prev))` — instead of going through `js_implicit_this_set`. The `replace` has already overwritten the cell, so the displaced receiver lives only in that local across the user call. An evacuating collection inside the callee moves the object and rewrites the cell (its scanner works correctly), and the restore then publishes the pre-move address back *into* the scanned cell. This is the same defect #7211 fixed on the codegen side with the `implicit_this_save`/`implicit_this_restore` combinator, and the rooted form already existed in-tree at `native_call_method/common_methods.rs`; these twenty-two sites had not been converted.
+
+Each now roots the displaced receiver in a `RuntimeHandleScope` and restores by re-reading the handle.
+
+**Why it hid.** Three things mask it, all worth knowing when auditing this area. `===` reports `true` for a moved-away pointer because equality resolves forwarding while ordinary reads do not, so identity checks look healthy. Reading any property of `this` *before* the collection makes later reads succeed. And because these sites bypass `js_implicit_this_set`, instrumenting that function shows no write at all — the cell appears to change on its own.
+
+Found with `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, which faults at the stale use and names the retiring minor.
+
+Closes #8495. `gc_property_key_operand_rooting_6935` goes 1/3 → 3/3.

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -727,9 +727,13 @@ pub unsafe extern "C" fn js_super_method_call_dynamic(
     // walks the parent chain and drops its read lock before returning, so the
     // invoked body may re-take the registry lock without deadlocking (wall-37).
     if let Some(method_value) = super::class_registry::lookup_prototype_method(parent_cid, name) {
-        let prev_this = super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits()));
+        // #8495: root the displaced receiver across the call below — the
+        // replace has already overwritten the cell, so this is the frame's only
+        // copy and the restore would otherwise publish a pre-move address.
+        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+        let prev_this_h = prev_this_scope.root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
         let result = crate::closure::js_native_call_value(method_value, args_ptr, args_len);
-        super::IMPLICIT_THIS.with(|c| c.set(prev_this));
+        super::IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
         return result;
     }
     // #6316: the parent chain is real (an intermediate user class) but bottoms
@@ -774,9 +778,13 @@ unsafe fn call_displaced_native_base_method(
     // IMPLICIT_THIS too: the shared emitter/stream stubs read their receiver
     // through `this_value(closure)`, which falls back to IMPLICIT_THIS when the
     // capture is undefined (the prototype-installed form).
-    let prev_this = super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits()));
+    // #8495: root the displaced receiver across the call below — the
+    // replace has already overwritten the cell, so this is the frame's only
+    // copy and the restore would otherwise publish a pre-move address.
+    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+    let prev_this_h = prev_this_scope.root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
     let result = crate::closure::js_native_call_value(method_value, args_ptr, args_len);
-    super::IMPLICIT_THIS.with(|c| c.set(prev_this));
+    super::IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
     result
 }
 

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -731,7 +731,8 @@ pub unsafe extern "C" fn js_super_method_call_dynamic(
         // replace has already overwritten the cell, so this is the frame's only
         // copy and the restore would otherwise publish a pre-move address.
         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-        let prev_this_h = prev_this_scope.root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
+        let prev_this_h = prev_this_scope
+            .root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
         let result = crate::closure::js_native_call_value(method_value, args_ptr, args_len);
         super::IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
         return result;
@@ -782,7 +783,8 @@ unsafe fn call_displaced_native_base_method(
     // replace has already overwritten the cell, so this is the frame's only
     // copy and the restore would otherwise publish a pre-move address.
     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-    let prev_this_h = prev_this_scope.root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
+    let prev_this_h = prev_this_scope
+        .root_nanbox_u64(super::IMPLICIT_THIS.with(|c| c.replace(this_value.to_bits())));
     let result = crate::closure::js_native_call_value(method_value, args_ptr, args_len);
     super::IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
     result

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -31,9 +31,13 @@ pub(crate) extern "C" fn function_prototype_call_thunk(
     // Concise/object-literal methods read `this` from a baked capture slot, not
     // IMPLICIT_THIS; rebind so the explicit `.call(thisArg)` receiver is honored.
     let target = crate::closure::rebind_explicit_this(target, this_arg);
-    let prev_this = IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits()));
+    // #8495: root the displaced receiver across the call below — the
+    // replace has already overwritten the cell, so this is the frame's only
+    // copy and the restore would otherwise publish a pre-move address.
+    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
     let result = unsafe { crate::closure::js_native_call_value(target, args_ptr, args_len) };
-    IMPLICIT_THIS.with(|c| c.set(prev_this));
+    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
     result
 }
 
@@ -512,9 +516,13 @@ pub(crate) extern "C" fn function_prototype_apply_thunk(
         // Rebind a concise/object-literal method's baked `this` slot to the
         // explicit `.apply(thisArg)` receiver (no-op for arrows / plain fns).
         let target = crate::closure::rebind_explicit_this(target, this_arg);
-        let prev_this = IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits()));
+        // #8495: root the displaced receiver across the call below — the
+        // replace has already overwritten the cell, so this is the frame's only
+        // copy and the restore would otherwise publish a pre-move address.
+        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
         let result = crate::closure::js_native_call_value(target, args.as_ptr(), args.len());
-        IMPLICIT_THIS.with(|c| c.set(prev_this));
+        IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
         result
     }
 }

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -35,7 +35,8 @@ pub(crate) extern "C" fn function_prototype_call_thunk(
     // replace has already overwritten the cell, so this is the frame's only
     // copy and the restore would otherwise publish a pre-move address.
     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
+    let prev_this_h =
+        prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
     let result = unsafe { crate::closure::js_native_call_value(target, args_ptr, args_len) };
     IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
     result
@@ -520,7 +521,8 @@ pub(crate) extern "C" fn function_prototype_apply_thunk(
         // replace has already overwritten the cell, so this is the frame's only
         // copy and the restore would otherwise publish a pre-move address.
         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
+        let prev_this_h =
+            prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(this_arg.to_bits())));
         let result = crate::closure::js_native_call_value(target, args.as_ptr(), args.len());
         IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
         result

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -695,7 +695,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method_value(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
+                let prev_this_h = prev_this_scope
+                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
                 let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return result;
@@ -1484,7 +1485,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
+                let prev_this_h = prev_this_scope
+                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
                 // #7803: `clone_closure_rebind_this` above ALLOCATES, so the
                 // caller's raw `args_ptr` buffer holds pre-move addresses from
                 // here on. `arg_handles` is what the collector rewrites; the
@@ -1636,7 +1638,9 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
         // replace has already overwritten the cell, so this is the frame's only
         // copy and the restore would otherwise publish a pre-move address.
         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits())));
+        let prev_this_h = prev_this_scope.root_nanbox_u64(
+            IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits())),
+        );
         let result = crate::closure::js_native_call_value(
             method_handle.get_nanbox_f64(),
             args.as_ptr(),
@@ -1817,7 +1821,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
+                let prev_this_h =
+                    prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                 let result =
                     crate::closure::js_native_call_value(f64::from_bits(bound), args_ptr, args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
@@ -1960,7 +1965,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     // replace has already overwritten the cell, so this is the frame's only
                     // copy and the restore would otherwise publish a pre-move address.
                     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
+                    let prev_this_h = prev_this_scope
+                        .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
                     let result = crate::closure::js_native_call_value(
                         f64::from_bits(bound),
                         args_ptr,
@@ -1987,7 +1993,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     // replace has already overwritten the cell, so this is the frame's only
                     // copy and the restore would otherwise publish a pre-move address.
                     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
+                    let prev_this_h = prev_this_scope
+                        .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
                     let result = crate::closure::js_native_call_value(
                         f64::from_bits(bound),
                         args_ptr,
@@ -2319,7 +2326,8 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     // replace has already overwritten the cell, so this is the frame's only
                     // copy and the restore would otherwise publish a pre-move address.
                     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
+                    let prev_this_h = prev_this_scope
+                        .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
                     let result =
                         crate::closure::js_native_call_value(candidate, args_ptr, args_len);
                     IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -691,9 +691,13 @@ pub unsafe extern "C-unwind" fn js_native_call_method_value(
                 crate::object::js_object_get_index_polymorphic(object.to_bits() as i64, index);
             let fv = JSValue::from_bits(field.to_bits());
             if !fv.is_undefined() && !fv.is_null() {
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
                 let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return result;
             }
         }
@@ -812,9 +816,15 @@ pub unsafe extern "C-unwind" fn js_native_call_method_value(
         field
     };
 
-    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+    // #8495: the displaced receiver must be ROOTED across the call. The
+    // `replace` has already overwritten the cell, so this is the only copy the
+    // frame holds; an evacuating collection inside the callee moves it and the
+    // restore would publish a pre-move address back INTO the scanned cell.
+    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+    let prev_this_h =
+        prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
     let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
-    IMPLICIT_THIS.with(|c| c.set(prev_this));
+    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
     result
 }
 
@@ -1470,7 +1480,11 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     dyn_val.to_bits(),
                     f64::from_bits(object().to_bits()),
                 );
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(object().to_bits()));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
                 // #7803: `clone_closure_rebind_this` above ALLOCATES, so the
                 // caller's raw `args_ptr` buffer holds pre-move addresses from
                 // here on. `arg_handles` is what the collector rewrites; the
@@ -1483,7 +1497,7 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     call_args.as_ptr(),
                     call_args.len(),
                 );
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return result;
             }
             // `fn.length()` / `fn.name()` — the own slots hold a number /
@@ -1618,13 +1632,17 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
         // canonical class-method value reads its receiver from IMPLICIT_THIS via
         // `canonical_bound_method_receiver` (#6699 routes a proxy receiver
         // through there).
-        let prev_this = IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+        // #8495: root the displaced receiver across the call below — the
+        // replace has already overwritten the cell, so this is the frame's only
+        // copy and the restore would otherwise publish a pre-move address.
+        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits())));
         let result = crate::closure::js_native_call_value(
             method_handle.get_nanbox_f64(),
             args.as_ptr(),
             args.len(),
         );
-        IMPLICIT_THIS.with(|c| c.set(prev_this));
+        IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
         return result;
     }
 
@@ -1795,10 +1813,14 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     dyn_val.to_bits(),
                     f64::from_bits(recv_bits),
                 );
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv_bits));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                 let result =
                     crate::closure::js_native_call_value(f64::from_bits(bound), args_ptr, args_len);
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return result;
             }
             let null_obj_ptr = &NULL_OBJECT_BYTES as *const NullObjectBytes as *mut u8;
@@ -1934,13 +1956,17 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                         field_val.bits(),
                         f64::from_bits(jsval().bits()),
                     );
-                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval().bits()));
+                    // #8495: root the displaced receiver across the call below — the
+                    // replace has already overwritten the cell, so this is the frame's only
+                    // copy and the restore would otherwise publish a pre-move address.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
                     let result = crate::closure::js_native_call_value(
                         f64::from_bits(bound),
                         args_ptr,
                         args_len,
                     );
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return result;
                 }
             }
@@ -1957,13 +1983,17 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                         field_val.bits(),
                         f64::from_bits(jsval().bits()),
                     );
-                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval().bits()));
+                    // #8495: root the displaced receiver across the call below — the
+                    // replace has already overwritten the cell, so this is the frame's only
+                    // copy and the restore would otherwise publish a pre-move address.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval().bits())));
                     let result = crate::closure::js_native_call_value(
                         f64::from_bits(bound),
                         args_ptr,
                         args_len,
                     );
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return result;
                 }
             }
@@ -2285,10 +2315,14 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
             if let Some(bits) = super::exotic_expando::value_lookup(kind, addr, method_name) {
                 let candidate = f64::from_bits(bits);
                 if crate::collection_iter::is_callable(candidate) {
-                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object().to_bits()));
+                    // #8495: root the displaced receiver across the call below — the
+                    // replace has already overwritten the cell, so this is the frame's only
+                    // copy and the restore would otherwise publish a pre-move address.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
                     let result =
                         crate::closure::js_native_call_value(candidate, args_ptr, args_len);
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return result;
                 }
             }

--- a/crates/perry-runtime/src/object/native_call_method/disposal.rs
+++ b/crates/perry-runtime/src/object/native_call_method/disposal.rs
@@ -33,7 +33,8 @@ pub(super) unsafe fn try_symbol_dispose_dispatch(
             // replace has already overwritten the cell, so this is the frame's only
             // copy and the restore would otherwise publish a pre-move address.
             let prev_scope = crate::gc::RuntimeHandleScope::new();
-            let prev_h = prev_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
+            let prev_h =
+                prev_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
             let result = crate::closure::js_native_call_value(method, args_ptr, args_len);
             IMPLICIT_THIS.with(|c| c.set(prev_h.get_nanbox_u64()));
             return Some(result);

--- a/crates/perry-runtime/src/object/native_call_method/disposal.rs
+++ b/crates/perry-runtime/src/object/native_call_method/disposal.rs
@@ -29,9 +29,13 @@ pub(super) unsafe fn try_symbol_dispose_dispatch(
         let method = crate::symbol::js_object_get_symbol_property(object, sym_f64);
         let mjsv = JSValue::from_bits(method.to_bits());
         if method.to_bits() != crate::value::TAG_UNDEFINED && !mjsv.is_null() && mjsv.is_pointer() {
-            let prev = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+            // #8495: root the displaced receiver across the call below — the
+            // replace has already overwritten the cell, so this is the frame's only
+            // copy and the restore would otherwise publish a pre-move address.
+            let prev_scope = crate::gc::RuntimeHandleScope::new();
+            let prev_h = prev_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
             let result = crate::closure::js_native_call_value(method, args_ptr, args_len);
-            IMPLICIT_THIS.with(|c| c.set(prev));
+            IMPLICIT_THIS.with(|c| c.set(prev_h.get_nanbox_u64()));
             return Some(result);
         }
     }

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -219,7 +219,8 @@ pub(super) unsafe fn dispatch_handle(
                         // replace has already overwritten the cell, so this is the frame's only
                         // copy and the restore would otherwise publish a pre-move address.
                         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
+                        let prev_this_h = prev_this_scope
+                            .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                         let result =
                             crate::closure::js_native_call_value(stored, args_ptr, args_len);
                         IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
@@ -945,7 +946,8 @@ pub(super) unsafe fn dispatch_handle(
                                 // replace has already overwritten the cell, so this is the frame's only
                                 // copy and the restore would otherwise publish a pre-move address.
                                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
+                                let prev_this_h = prev_this_scope
+                                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                                 let result = crate::closure::js_native_call_value(
                                     f64::from_bits(field_val.bits()),
                                     args_ptr,
@@ -1142,7 +1144,8 @@ pub(super) unsafe fn dispatch_handle(
                         // replace has already overwritten the cell, so this is the frame's only
                         // copy and the restore would otherwise publish a pre-move address.
                         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
+                        let prev_this_h = prev_this_scope
+                            .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                         let result = crate::closure::js_native_call_value(
                             f64::from_bits(bound),
                             args_ptr,
@@ -1208,7 +1211,8 @@ pub(super) unsafe fn dispatch_handle(
                         // replace has already overwritten the cell, so this is the frame's only
                         // copy and the restore would otherwise publish a pre-move address.
                         let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
+                        let prev_this_h = prev_this_scope
+                            .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                         let result = crate::closure::js_native_call_value(
                             f64::from_bits(bound),
                             args_ptr,
@@ -1230,7 +1234,8 @@ pub(super) unsafe fn dispatch_handle(
                     // replace has already overwritten the cell, so this is the frame's only
                     // copy and the restore would otherwise publish a pre-move address.
                     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
+                    let prev_this_h = prev_this_scope
+                        .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                     let result =
                         crate::closure::js_native_call_value(method_value, args_ptr, args_len);
                     IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -215,10 +215,14 @@ pub(super) unsafe fn dispatch_handle(
                     let stored_ptr = crate::value::js_nanbox_get_pointer(stored) as usize;
                     if crate::closure::is_closure_ptr(stored_ptr) {
                         let recv_bits = jsval.bits();
-                        let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv_bits));
+                        // #8495: root the displaced receiver across the call below — the
+                        // replace has already overwritten the cell, so this is the frame's only
+                        // copy and the restore would otherwise publish a pre-move address.
+                        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                         let result =
                             crate::closure::js_native_call_value(stored, args_ptr, args_len);
-                        IMPLICIT_THIS.with(|c| c.set(prev_this));
+                        IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                         return Some(result);
                     }
                 }
@@ -937,13 +941,17 @@ pub(super) unsafe fn dispatch_handle(
                                 // RegExpRouter.match (imported function
                                 // assigned as a class field) hit this.
                                 let recv_bits = jsval.bits();
-                                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv_bits));
+                                // #8495: root the displaced receiver across the call below — the
+                                // replace has already overwritten the cell, so this is the frame's only
+                                // copy and the restore would otherwise publish a pre-move address.
+                                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                                 let result = crate::closure::js_native_call_value(
                                     f64::from_bits(field_val.bits()),
                                     args_ptr,
                                     args_len,
                                 );
-                                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                                 return Some(result);
                             }
                         }
@@ -1130,13 +1138,17 @@ pub(super) unsafe fn dispatch_handle(
                             field_bits,
                             f64::from_bits(jsval.bits()),
                         );
-                        let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                        // #8495: root the displaced receiver across the call below — the
+                        // replace has already overwritten the cell, so this is the frame's only
+                        // copy and the restore would otherwise publish a pre-move address.
+                        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                         let result = crate::closure::js_native_call_value(
                             f64::from_bits(bound),
                             args_ptr,
                             args_len,
                         );
-                        IMPLICIT_THIS.with(|c| c.set(prev_this));
+                        IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                         return Some(result);
                     }
                     None => {}
@@ -1192,13 +1204,17 @@ pub(super) unsafe fn dispatch_handle(
                             field_val.bits(),
                             f64::from_bits(jsval.bits()),
                         );
-                        let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                        // #8495: root the displaced receiver across the call below — the
+                        // replace has already overwritten the cell, so this is the frame's only
+                        // copy and the restore would otherwise publish a pre-move address.
+                        let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                        let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                         let result = crate::closure::js_native_call_value(
                             f64::from_bits(bound),
                             args_ptr,
                             args_len,
                         );
-                        IMPLICIT_THIS.with(|c| c.set(prev_this));
+                        IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                         return Some(result);
                     }
                 }
@@ -1210,10 +1226,14 @@ pub(super) unsafe fn dispatch_handle(
                 // only exists in `CLASS_PROTOTYPE_METHODS`. Bind `this`
                 // to the receiver and call the stored closure.
                 if let Some(method_value) = lookup_prototype_method(class_id, method_name) {
-                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(jsval.bits()));
+                    // #8495: root the displaced receiver across the call below — the
+                    // replace has already overwritten the cell, so this is the frame's only
+                    // copy and the restore would otherwise publish a pre-move address.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(jsval.bits())));
                     let result =
                         crate::closure::js_native_call_value(method_value, args_ptr, args_len);
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return Some(result);
                 }
             }

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -327,7 +327,8 @@ pub(super) unsafe fn dispatch_primitive(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv.to_bits())));
+                let prev_this_h = prev_this_scope
+                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv.to_bits())));
                 let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
@@ -390,7 +391,8 @@ pub(super) unsafe fn dispatch_primitive(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
+                let prev_this_h = prev_this_scope
+                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
                 let result = unsafe {
                     crate::closure::js_native_call_value(own_then, args.as_ptr(), args.len())
                 };
@@ -406,7 +408,8 @@ pub(super) unsafe fn dispatch_primitive(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
+                let prev_this_h = prev_this_scope
+                    .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
                 let result = unsafe {
                     crate::closure::js_native_call_value(proto_method, args.as_ptr(), args.len())
                 };
@@ -669,7 +672,8 @@ pub(super) unsafe fn dispatch_primitive(
                 // replace has already overwritten the cell, so this is the frame's only
                 // copy and the restore would otherwise publish a pre-move address.
                 let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
+                let prev_this_h =
+                    prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                 let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
                 IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
@@ -691,7 +695,8 @@ pub(super) unsafe fn dispatch_primitive(
                     // replace has already overwritten the cell, so this is the frame's only
                     // copy and the restore would otherwise publish a pre-move address.
                     let prev_this_scope = crate::gc::RuntimeHandleScope::new();
-                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
+                    let prev_this_h = prev_this_scope
+                        .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
                     let result =
                         crate::closure::js_native_call_value(value_f64, args_ptr, args_len);
                     IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -323,9 +323,13 @@ pub(super) unsafe fn dispatch_primitive(
             if (v.to_bits() & crate::value::TAG_MASK) == crate::value::POINTER_TAG
                 && crate::closure::is_closure_ptr(cand)
             {
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv.to_bits()));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv.to_bits())));
                 let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
             }
         }
@@ -382,11 +386,15 @@ pub(super) unsafe fn dispatch_primitive(
                     ));
                 }
                 let args = refreshed_args();
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits()));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
                 let result = unsafe {
                     crate::closure::js_native_call_value(own_then, args.as_ptr(), args.len())
                 };
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
             }
             // For "catch"/"finally" with own "then", or "then" with own "constructor":
@@ -394,11 +402,15 @@ pub(super) unsafe fn dispatch_primitive(
             // read the receiver and invoke call_receiver_then / SpeciesConstructor.
             if let Some(proto_method) = crate::promise::promise_proto_method(method_name) {
                 let args = refreshed_args();
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits()));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(promise_val.to_bits())));
                 let result = unsafe {
                     crate::closure::js_native_call_value(proto_method, args.as_ptr(), args.len())
                 };
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
             }
             // Fallthrough to fast path if prototype method lookup fails.
@@ -653,9 +665,13 @@ pub(super) unsafe fn dispatch_primitive(
             if (v.to_bits() & crate::value::TAG_MASK) == crate::value::POINTER_TAG
                 && crate::closure::is_closure_ptr((v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize)
             {
-                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv_bits));
+                // #8495: root the displaced receiver across the call below — the
+                // replace has already overwritten the cell, so this is the frame's only
+                // copy and the restore would otherwise publish a pre-move address.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(recv_bits)));
                 let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
             }
         }
@@ -671,10 +687,14 @@ pub(super) unsafe fn dispatch_primitive(
                 let value = crate::object::js_object_get_field_by_name(proto_ptr, key);
                 if !value.is_undefined() {
                     let value_f64 = f64::from_bits(value.bits());
-                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                    // #8495: root the displaced receiver across the call below — the
+                    // replace has already overwritten the cell, so this is the frame's only
+                    // copy and the restore would otherwise publish a pre-move address.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object.to_bits())));
                     let result =
                         crate::closure::js_native_call_value(value_f64, args_ptr, args_len);
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return Some(result);
                 }
             }


### PR DESCRIPTION
Closes #8495.

A method whose body triggered an evacuating collection saw `this` become a stale from-space pointer. Reads through it returned garbage — `Object.keys(this)` came back `[]` and `Object.getPrototypeOf(this) === Object.prototype` was `false` — so a method that collected before touching `this` silently observed an empty object:

```ts
const recv: any = { n: "RECV" };
recv.f = function (): string { churnGc(); return JSON.stringify(Object.keys(this)); };
recv.f();   // was: []   now: ["n","f"]
```

### Cause

Twenty-two receiver save/restore pairs manipulated the `IMPLICIT_THIS` cell **directly** rather than through `js_implicit_this_set`:

```rust
let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
let result = crate::closure::js_native_call_value(field, args_ptr, args_len);  // user code; can collect
IMPLICIT_THIS.with(|c| c.set(prev_this));                                      // publishes a pre-move address
```

The `replace` has already overwritten the cell, so the displaced receiver lives only in that local across the user call. An evacuating collection inside the callee moves the object and rewrites the cell — its scanner (`scan_implicit_this_roots_mut`) works correctly — and the restore then publishes the **pre-move** address back *into* the scanned cell.

This is the same defect #7211 fixed on the codegen side with the `implicit_this_save`/`implicit_this_restore` combinator. The rooted form already existed in-tree at `native_call_method/common_methods.rs:542`; these twenty-two sites had never been converted. Each now roots the displaced receiver in a `RuntimeHandleScope` and restores by re-reading the handle.

### Why it stayed hidden

Three separate maskings, all worth knowing when auditing this area:

- **`===` lies.** `this === recv` reports `true` for a moved-away pointer, because equality resolves forwarding while ordinary reads do not. Identity checks look healthy while every read is garbage.
- **An early read masks it.** Touching any property of `this` *before* the collection makes later reads succeed, so a probe that reads early proves nothing.
- **Instrumenting `js_implicit_this_set` shows nothing.** These sites bypass it, so the cell appears to change with no write at all — which is what made this look impossible for a long stretch.

Found with `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`, which faults at the stale use and names the retiring minor:

```
FAULT: signal 10 — RETIRED FROM-SPACE ... retired_by_minor=#0
last-known object: obj_type=2 size=40
The faulting instruction IS the stale use.
```

### Validation

- `gc_property_key_operand_rooting_6935`: **1/3 → 3/3** (was the last `cargo-test` blocker for the release).
- `gc_dynamic_arith_operand_rooting_6655` (4/4) and `gc_side_table_roots_evacuation` (1/1): green.
- `gc_string_coerce_property_key_rooting_6943`: 1/3, with `define_property_operands_survive_forced_evacuation` and `reflect_and_own_key_paths_survive_forced_evacuation` failing. **Verified pre-existing** — the same two fail identically on a pristine `origin/main` runtime built in this worktree, so they are not introduced here. Worth its own issue.
- Five standalone repro programs covering receiver identity, prototype, `Object.keys`, `JSON.stringify` and `getOwnPropertyNames` all match Node under `PERRY_GC_FORCE_EVACUATE=1`.
- `cargo fmt --all -- --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rare runtime stability issues during dynamic method calls and function invocations when garbage collection occurs.
  - Preserved correct `this` values across calls involving built-in methods, proxies, closures, class methods, disposal handlers, and prototype methods.
  - Prevented stale object references from being restored after memory movement.

- **Documentation**
  - Added a changelog entry describing the garbage-collection issue, affected scenarios, and resolution.

- **Chores**
  - Updated the documented and workspace version to 0.5.1514.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->