### PR TITLE
tooling: harden the string payload-access ratchet

### DIFF
--- a/changelog.d/8502-string-payload-ratchet.md
+++ b/changelog.d/8502-string-payload-ratchet.md
@@ -1,0 +1,1 @@
+Tooling: harden the `StringHeader` payload-access ratchet against `byte_add` and signed-offset pointer arithmetic, and make its self-test exercise crate discovery, per-crate attribution, and stale-baseline failure end to end (#8429).

--- a/scripts/string_payload_access_inventory.py
+++ b/scripts/string_payload_access_inventory.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tempfile
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,9 +34,11 @@ DEFAULT_BASELINE = REPO_ROOT / "scripts" / "string_payload_access_baseline.txt"
 RULES = ("inline-offset", "reader-helper")
 
 INLINE_OFFSET_RE = re.compile(
-    r"(?:\.(?:add|wrapping_add)\s*\(\s*|\+\s*)"
+    r"(?:\.(?:add|wrapping_add|byte_add|wrapping_byte_add|offset|wrapping_offset)"
+    r"\s*\(\s*|\+\s*)"
     r"(?:(?:std|core)::mem::)?size_of\s*::\s*<\s*"
-    r"(?:[A-Za-z_][A-Za-z0-9_]*::)*StringHeader\s*>\s*\(\s*\)",
+    r"(?:[A-Za-z_][A-Za-z0-9_]*::)*StringHeader\s*>\s*\(\s*\)"
+    r"(?:\s+as\s+(?:usize|isize))?",
     re.MULTILINE,
 )
 FUNCTION_RE = re.compile(r"\bfn\s+([A-Za-z_][A-Za-z0-9_]*)[^;{]*\{", re.MULTILINE)
@@ -311,6 +314,22 @@ unsafe fn copied_reader(ptr: *const perry_runtime::StringHeader) -> &'static str
         "synthetic copy-pasted reader helper was not detected exactly once",
     )
 
+    alternate_offsets = r'''
+unsafe fn alternate_offsets(ptr: *const u8) {
+    let _ = ptr.byte_add(core::mem::size_of::<StringHeader>());
+    let _ = ptr.wrapping_byte_add(size_of::<crate::StringHeader>());
+    let _ = ptr.offset(std::mem::size_of::<perry_runtime::StringHeader>() as isize);
+    let _ = ptr.wrapping_offset(size_of::<StringHeader>() as isize);
+}
+'''
+    alternate_findings = scan_text(
+        "synthetic-crate", "crates/synthetic-crate/src/alternate.rs", alternate_offsets
+    )
+    expect(
+        sum(f.rule == "inline-offset" for f in alternate_findings) == 4,
+        "alternate raw-pointer payload offsets were not all detected",
+    )
+
     clean = r'''
 fn sanctioned(ptr: *const perry_runtime::StringHeader) -> Vec<u8> {
     unsafe { perry_runtime::string::OwnedStringBytes::copy_from_header(ptr) }
@@ -324,6 +343,35 @@ const EXAMPLE: &str = ".add(std::mem::size_of::<StringHeader>())";
         not scan_text("synthetic-crate", "crates/synthetic-crate/src/lib.rs", clean),
         "sanctioned access, comments, or strings produced a finding",
     )
+
+    # Exercise crate discovery and the ratchet end to end. This prevents the
+    # scanner's regex unit tests from staying green if workspace traversal or
+    # per-crate attribution is accidentally broken.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        crate_dir = temp_root / "crates" / "synthetic-crate"
+        source = crate_dir / "src" / "lib.rs"
+        source.parent.mkdir(parents=True)
+        (crate_dir / "Cargo.toml").write_text(
+            '[package]\nname = "synthetic-crate"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        source.write_text(planted, encoding="utf-8")
+        discovered, files_scanned = collect_inventory(temp_root)
+        expect(files_scanned == 1, "synthetic crate source was not scanned exactly once")
+        expect(
+            counts_for(discovered) == counts_for(findings),
+            "filesystem inventory disagreed with direct source scanning",
+        )
+
+        planted_baseline = dict(counts_for(discovered))
+        source.write_text(clean, encoding="utf-8")
+        removed, _ = collect_inventory(temp_root)
+        regressions, stale = compare_counts(counts_for(removed), planted_baseline)
+        expect(
+            not regressions and bool(stale),
+            "removing a planted offender did not make its baseline fail stale",
+        )
 
     actual = counts_for(findings)
     regressions, stale = compare_counts(actual, {})


### PR DESCRIPTION
## Summary

- recognize `byte_add`, `wrapping_byte_add`, `offset`, and `wrapping_offset` StringHeader payload arithmetic in the existing ratchet
- exercise actual temporary-crate discovery and per-crate attribution in `--self-test`
- prove end to end that removing a planted offender leaves a stale baseline and fails the ratchet

The main chokepoint API and baseline gate landed in #8481. This follow-up closes the remaining issue by hardening the gate against valid raw-pointer spellings and making its non-vacuity test cover filesystem traversal, not only regex helpers.

## Census and manual spot-check

Current-tree scanner census: **440 inline offsets and 14 reader helpers** (versus the issue original approximate 729 / 325 before the migration PRs).

- `perry-runtime`: scanner 369 inline offsets; raw grep 374 textual matches, with the 5 extras manually confirmed as comments/docs. Scanner 13 reader helpers, matching manual inspection.
- `perry-ext-fastify`: scanner 3 inline offsets; raw grep 3.
- `perry-ui-macos`: scanner 0; raw grep 0 after the UI reader migration.

The expanded spellings add no current-tree findings, so the committed baseline remains unchanged.

## Validation

- `python3 scripts/string_payload_access_inventory.py --self-test`
- `python3 scripts/string_payload_access_inventory.py`
- `scripts/run_lint_gates.sh` — all 52 gates passed, including warning-denied workspace check and Clippy

No version bump.

Closes #8429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of additional raw-pointer offset patterns during payload access checks.
  - Enhanced validation for crate discovery, attribution, baseline comparisons, and stale-baseline failures.

- **Tests**
  - Expanded self-tests to cover temporary-directory workflows and additional pointer arithmetic patterns.

- **Documentation**
  - Added a changelog entry documenting the strengthened payload-access checks and expanded testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->