### PR TITLE
runtime: add bun:ffi JSCallback support (#6562)

### DIFF
--- a/changelog.d/8522-bun-ffi-callbacks.md
+++ b/changelog.d/8522-bun-ffi-callbacks.md
@@ -1,0 +1,6 @@
+- **Complete `bun:ffi` callbacks (#6562).** `JSCallback` now exposes GC-rooted,
+  same-thread C-ABI trampolines for scalar arguments and returns, and
+  `FFIType.function` is accepted by `dlopen` symbol signatures. Callback
+  wrappers provide Bun-compatible `ptr`, `threadsafe`, and idempotent `close()`
+  members; cross-thread/threadsafe calls and uncaught callback exceptions fail
+  closed without unwinding through native frames.

--- a/crates/perry-api-manifest/src/entries/part_1.rs
+++ b/crates/perry-api-manifest/src/entries/part_1.rs
@@ -203,10 +203,10 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
     method("better-sqlite3", "pluck", true, None),
     method("better-sqlite3", "columns", true, None),
     method("better-sqlite3", "transaction", true, None),
-    // bun:ffi (#6562) — stage-1/2 surface. `FFIType` and `suffix` are
+    // bun:ffi (#6562). `FFIType` and `suffix` are
     // constants; symbol-table call stubs live on the object `dlopen`
     // returns, so the module surface itself is small. The later-stage
-    // exports (JSCallback / linkSymbols / CFunction / viewSource / read) are
+    // exports (linkSymbols / CFunction / viewSource / read) are
     // declared and throw a descriptive
     // ERR_NOT_IMPLEMENTED at runtime.
     method("bun:ffi", "dlopen", false, None),
@@ -216,12 +216,11 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
     property("bun:ffi", "suffix"),
     method("bun:ffi", "toArrayBuffer", false, None),
     method("bun:ffi", "toBuffer", false, None),
-    // Stage ≥3 surface: declared so feature-probes get a clear error rather
+    method("bun:ffi", "JSCallback", false, None),
+    // Remaining surface: declared so feature-probes get a clear error rather
     // than `undefined is not a function`, but NOT implemented yet — each
     // throws at runtime. Marked `.stub_note` so the generated `.d.ts` /
     // `reference.md` say so instead of reading as usable APIs (#6562).
-    method("bun:ffi", "JSCallback", false, None)
-        .stub_note("stage 3 — not yet implemented, throws at runtime (#6562)"),
     method("bun:ffi", "CFunction", false, None)
         .stub_note("stage 3 — not yet implemented, throws at runtime (#6562)"),
     method("bun:ffi", "linkSymbols", false, None)

--- a/crates/perry-api-manifest/tests/stub_inventory.rs
+++ b/crates/perry-api-manifest/tests/stub_inventory.rs
@@ -93,11 +93,10 @@ fn stub_inventory_matches_known_clusters() {
         // event-loop refcount), mongodb.findOne (parsed document),
         // exponential-backoff options (honored, incl. retry predicate).
         ("#4917", 9),
-        // #6562 (bun:ffi stages 1-2) — the later FFI surface is declared so
+        // #6562 (bun:ffi) — the remaining FFI surface is declared so
         // feature probes get a clear error, but throws at runtime until the
-        // later stages land: JSCallback, CFunction, linkSymbols, viewSource,
-        // read.
-        ("#6562", 5),
+        // later stages land: CFunction, linkSymbols, viewSource, read.
+        ("#6562", 4),
     ];
     let expected_map: BTreeMap<String, usize> =
         expected.iter().map(|(k, v)| (k.to_string(), *v)).collect();

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -568,6 +568,21 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             }
 
             if let Some((module_name, method_name)) = ctx.lookup_native_module(&class_name) {
+                // #6562: Bun exposes JSCallback as a constructor, but Perry's
+                // native-module export returns the already-built
+                // `{ ptr, threadsafe, close }` object. Route the named import
+                // through the module call directly so `new JSCallback(...)`
+                // observes that explicit object return instead of generic
+                // `Expr::New` manufacturing and retaining a blank instance.
+                if module_name == "bun:ffi" && method_name == Some("JSCallback") {
+                    return Ok(Expr::NativeMethodCall {
+                        module: "bun:ffi".to_string(),
+                        class_name: None,
+                        object: None,
+                        method: "JSCallback".to_string(),
+                        args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                    });
+                }
                 if module_name == "module"
                     && matches!(method_name, Some("Module") | Some("SourceMap"))
                 {

--- a/crates/perry-hir/src/lower/expr_new/member.rs
+++ b/crates/perry-hir/src/lower/expr_new/member.rs
@@ -71,6 +71,26 @@ pub(crate) fn lower_new_member_native(
                 }));
             }
 
+            // #6562: namespace/default/CommonJS `bun:ffi` access uses the
+            // same explicit-return constructor route as a named
+            // `JSCallback` import. OpenTUI's runtime-selected backend calls
+            // exactly `new bun.JSCallback(...)`.
+            let is_bun_ffi_module = ctx.lookup_builtin_module_alias(obj_name) == Some("bun:ffi")
+                || ctx
+                    .lookup_native_module(obj_name)
+                    .is_some_and(|(module, export)| {
+                        module == "bun:ffi" && (export.is_none() || export == Some("default"))
+                    });
+            if is_bun_ffi_module && prop_ident.sym.as_ref() == "JSCallback" {
+                return Ok(Some(Expr::NativeMethodCall {
+                    module: "bun:ffi".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "JSCallback".to_string(),
+                    args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                }));
+            }
+
             let is_net_module =
                 obj_name == "net" || ctx.lookup_builtin_module_alias(obj_name) == Some("net");
             if is_net_module

--- a/crates/perry-runtime/src/bun_ffi/call.rs
+++ b/crates/perry-runtime/src/bun_ffi/call.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Why not libffi
 //!
-//! Every stage-1 `FFIType` is a scalar (integer, float, or pointer), so the
+//! Every supported `FFIType` is a scalar (integer, float, or pointer), so the
 //! full generality of libffi (struct classification, closures) buys nothing
 //! here, while costing a new native library on every final link (perry's
 //! driver links user binaries with `cc`; libffi would have to be added to
@@ -241,7 +241,7 @@ unsafe fn bigint_low_u64(v: JSValue) -> u64 {
 /// float→int cast (NaN → 0); BigInts wrap mod 2^64 like C; booleans are
 /// 0/1; null/undefined are 0. Objects/strings do NOT go through JS ToNumber
 /// here — Bun requires numeric-ish args for integer slots too.
-unsafe fn value_to_u64_int(v: f64) -> u64 {
+pub(crate) unsafe fn value_to_u64_int(v: f64) -> u64 {
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_int32() {
         return jv.as_int32() as i64 as u64;
@@ -259,7 +259,7 @@ unsafe fn value_to_u64_int(v: f64) -> u64 {
 }
 
 /// Numeric coercion for float-typed args.
-unsafe fn value_to_f64_num(v: f64) -> f64 {
+pub(crate) unsafe fn value_to_f64_num(v: f64) -> f64 {
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_int32() {
         return jv.as_int32() as f64;
@@ -333,7 +333,7 @@ fn describe_value_for_error(jv: JSValue) -> &'static str {
 /// through as addresses, buffer-ish objects hand over their (non-moving)
 /// data pointer, null/undefined/0 become NULL, strings are rejected with
 /// Bun's exact hint.
-unsafe fn value_to_pointer_arg(v: f64) -> usize {
+pub(crate) unsafe fn value_to_pointer_arg(v: f64) -> usize {
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_undefined() || jv.is_null() {
         return 0;
@@ -417,7 +417,7 @@ pub(crate) unsafe fn marshal_args(arg_types: &[u8], js_args: &[f64]) -> ArgImage
                 image.ints[ii] = crate::value::js_is_truthy(v) as usize;
                 ii += 1;
             }
-            T_PTR => {
+            T_PTR | T_FUNCTION => {
                 image.ints[ii] = value_to_pointer_arg(v);
                 ii += 1;
             }
@@ -503,7 +503,7 @@ pub(crate) unsafe fn call_and_convert(fn_ptr: usize, ret_type: u8, image: &ArgIm
     result
 }
 
-fn convert_int_return(ret_type: u8, r: u64) -> f64 {
+pub(crate) fn convert_int_return(ret_type: u8, r: u64) -> f64 {
     match ret_type {
         T_VOID => super::undefined(),
         T_BOOL => bool_value((r as u8) != 0),
@@ -533,7 +533,7 @@ fn convert_int_return(ret_type: u8, r: u64) -> f64 {
                 bigint_value_u64(r)
             }
         }
-        T_PTR => {
+        T_PTR | T_FUNCTION => {
             if r == 0 {
                 super::null()
             } else {

--- a/crates/perry-runtime/src/bun_ffi/callback.rs
+++ b/crates/perry-runtime/src/bun_ffi/callback.rs
@@ -1,0 +1,446 @@
+//! Same-thread native-to-JS callback trampolines for `bun:ffi`.
+//!
+//! A callback pointer must carry both an arbitrary C scalar signature and a
+//! Perry callback identity. The hosted ABIs already split scalar arguments
+//! into integer and floating-point register files, so each static trampoline
+//! places its slot number in a scratch register and branches to one assembly
+//! entry point. That entry saves both register files, calls the Rust dispatcher,
+//! and places the returned bits in both the integer and FP return registers.
+//!
+//! The pool is intentionally finite and never reuses a closed slot. Reusing a
+//! pointer after `close()` could silently invoke an unrelated later callback;
+//! retaining a poisoned slot instead makes such a stale native call return zero.
+
+use super::call::{self, MAX_ARGS, MAX_FLOAT_ARGS};
+use super::types::*;
+use crate::closure::ClosureHeader;
+use crate::value::JSValue;
+use std::sync::Mutex;
+use std::thread::ThreadId;
+
+const MAX_CALLBACKS: usize = 128;
+#[cfg(target_arch = "x86_64")]
+const MAX_CALLBACK_INT_ARGS: usize = 6;
+#[cfg(target_arch = "aarch64")]
+const MAX_CALLBACK_INT_ARGS: usize = 8;
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+const MAX_CALLBACK_INT_ARGS: usize = 0;
+
+#[derive(Clone)]
+struct CallbackRecord {
+    callback_bits: u64,
+    owner: ThreadId,
+    ret: u8,
+    argc: u8,
+    args: [u8; MAX_ARGS],
+    open: bool,
+}
+
+static CALLBACKS: Mutex<Vec<CallbackRecord>> = Mutex::new(Vec::new());
+
+#[cfg(target_vendor = "apple")]
+macro_rules! callback_symbol {
+    ($name:literal) => {
+        concat!("_", $name)
+    };
+}
+#[cfg(not(target_vendor = "apple"))]
+macro_rules! callback_symbol {
+    ($name:literal) => {
+        $name
+    };
+}
+
+#[cfg(all(unix, target_arch = "aarch64"))]
+const CALLBACK_TRAMPOLINE_SIZE: usize = 8;
+#[cfg(all(unix, target_arch = "x86_64"))]
+const CALLBACK_TRAMPOLINE_SIZE: usize = 11;
+
+#[cfg(all(unix, target_arch = "aarch64"))]
+core::arch::global_asm!(
+    ".text",
+    ".p2align 2",
+    concat!(
+        ".globl ",
+        callback_symbol!("perry_ffi_callback_trampoline_base")
+    ),
+    concat!(callback_symbol!("perry_ffi_callback_trampoline_base"), ":"),
+    ".set Lperry_ffi_callback_index, 0",
+    ".rept 128",
+    // Every AArch64 instruction is four bytes: mov-immediate + branch gives
+    // one fixed eight-byte slot whose address can be derived from the base.
+    "    mov x16, #Lperry_ffi_callback_index",
+    "    b Lperry_ffi_callback_entry",
+    ".set Lperry_ffi_callback_index, Lperry_ffi_callback_index + 1",
+    ".endr",
+    "Lperry_ffi_callback_entry:",
+    // 8 GPR slots, 8 FP slots, and the link register. Keep SP 16-aligned.
+    "    sub sp, sp, #144",
+    "    stp x0, x1, [sp, #0]",
+    "    stp x2, x3, [sp, #16]",
+    "    stp x4, x5, [sp, #32]",
+    "    stp x6, x7, [sp, #48]",
+    "    stp d0, d1, [sp, #64]",
+    "    stp d2, d3, [sp, #80]",
+    "    stp d4, d5, [sp, #96]",
+    "    stp d6, d7, [sp, #112]",
+    "    str x30, [sp, #128]",
+    "    mov x0, x16",
+    "    mov x1, sp",
+    "    add x2, sp, #64",
+    concat!("    bl ", callback_symbol!("perry_ffi_callback_dispatch")),
+    // Publish the same raw bits in x0 and d0; the declared return type decides
+    // which register the native caller observes (s0 reads d0's low 32 bits).
+    "    fmov d0, x0",
+    "    ldr x30, [sp, #128]",
+    "    add sp, sp, #144",
+    "    ret",
+);
+
+#[cfg(all(unix, target_arch = "x86_64"))]
+core::arch::global_asm!(
+    ".text",
+    ".p2align 4, 0x90",
+    concat!(
+        ".globl ",
+        callback_symbol!("perry_ffi_callback_trampoline_base")
+    ),
+    concat!(callback_symbol!("perry_ffi_callback_trampoline_base"), ":"),
+    ".set Lperry_ffi_callback_index, 0",
+    ".rept 128",
+    // Encode a fixed-width `mov r10d, imm32; jmp rel32` slot explicitly.
+    // An assembler-selected short jump would make pointer arithmetic invalid.
+    "    .byte 0x41, 0xba",
+    "    .long Lperry_ffi_callback_index",
+    "    .byte 0xe9",
+    "    .long Lperry_ffi_callback_entry - . - 4",
+    ".set Lperry_ffi_callback_index, Lperry_ffi_callback_index + 1",
+    ".endr",
+    "Lperry_ffi_callback_entry:",
+    // SysV has 6 integer and 8 FP argument registers. Entry RSP is 8 mod 16;
+    // a 120-byte frame restores 16-byte alignment before the Rust call.
+    "    sub rsp, 120",
+    "    mov qword ptr [rsp + 0], rdi",
+    "    mov qword ptr [rsp + 8], rsi",
+    "    mov qword ptr [rsp + 16], rdx",
+    "    mov qword ptr [rsp + 24], rcx",
+    "    mov qword ptr [rsp + 32], r8",
+    "    mov qword ptr [rsp + 40], r9",
+    "    movsd qword ptr [rsp + 48], xmm0",
+    "    movsd qword ptr [rsp + 56], xmm1",
+    "    movsd qword ptr [rsp + 64], xmm2",
+    "    movsd qword ptr [rsp + 72], xmm3",
+    "    movsd qword ptr [rsp + 80], xmm4",
+    "    movsd qword ptr [rsp + 88], xmm5",
+    "    movsd qword ptr [rsp + 96], xmm6",
+    "    movsd qword ptr [rsp + 104], xmm7",
+    "    mov rdi, r10",
+    "    lea rsi, [rsp]",
+    "    lea rdx, [rsp + 48]",
+    concat!("    call ", callback_symbol!("perry_ffi_callback_dispatch")),
+    "    movq xmm0, rax",
+    "    add rsp, 120",
+    "    ret",
+);
+
+#[cfg(all(unix, any(target_arch = "x86_64", target_arch = "aarch64")))]
+extern "C" {
+    static perry_ffi_callback_trampoline_base: u8;
+}
+
+fn trampoline_ptr(index: usize) -> Option<usize> {
+    #[cfg(all(unix, any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        if index < MAX_CALLBACKS {
+            // Each assembly slot has a fixed width, so no relocated pointer
+            // table (and no text relocations) is needed.
+            let base = core::ptr::addr_of!(perry_ffi_callback_trampoline_base) as usize;
+            return Some(base + index * CALLBACK_TRAMPOLINE_SIZE);
+        }
+    }
+    let _ = index;
+    None
+}
+
+unsafe fn object_ptr(value: f64) -> Option<*mut crate::object::ObjectHeader> {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let address = crate::value::js_nanbox_get_pointer(value) as usize;
+    (address != 0).then_some(address as *mut crate::object::ObjectHeader)
+}
+
+unsafe fn get_field(object: *mut crate::object::ObjectHeader, name: &str) -> f64 {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    f64::from_bits(crate::object::js_object_get_field_by_name(object, key).bits())
+}
+
+fn set_field(object: *mut crate::object::ObjectHeader, name: &str, value: f64) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::object::js_object_set_field_by_name(object, key, value);
+}
+
+fn throw_type(message: &str) -> ! {
+    crate::fs::validate::throw_type_error_with_code(message, "ERR_INVALID_ARG_TYPE")
+}
+
+fn parse_signature(definition: f64) -> (u8, u8, [u8; MAX_ARGS]) {
+    let Some(object) = (unsafe { object_ptr(definition) }) else {
+        throw_type("JSCallback callback definition must be an object");
+    };
+
+    let threadsafe = unsafe { get_field(object, "threadsafe") };
+    if !JSValue::from_bits(threadsafe.to_bits()).is_undefined()
+        && crate::value::js_is_truthy(threadsafe) != 0
+    {
+        crate::fs::validate::throw_error_with_code(
+            "bun:ffi: threadsafe JSCallback is not supported; callbacks must be invoked on their creating thread",
+            "ERR_NOT_IMPLEMENTED",
+        );
+    }
+
+    let mut args = [T_VOID; MAX_ARGS];
+    let args_value = unsafe { get_field(object, "args") };
+    let args_jv = JSValue::from_bits(args_value.to_bits());
+    let mut argc = 0usize;
+    if !args_jv.is_undefined() && !args_jv.is_null() {
+        if !JSValue::from_bits(crate::array::js_array_is_array(args_value).to_bits()).as_bool() {
+            throw_type("JSCallback definition.args must be an array");
+        }
+        let array = crate::value::js_nanbox_get_pointer(args_value) as usize
+            as *const crate::array::ArrayHeader;
+        let len = crate::array::js_array_length(array) as usize;
+        if len > MAX_ARGS {
+            throw_type(&format!("JSCallback supports at most {MAX_ARGS} arguments"));
+        }
+        for (index, slot) in args.iter_mut().take(len).enumerate() {
+            let value = crate::array::js_array_get(array, index as u32);
+            *slot = unsafe { super::types::parse_ffi_type_checked(f64::from_bits(value.bits())) }
+                .unwrap_or_else(|message| throw_type(&format!("JSCallback: {message}")));
+        }
+        argc = len;
+    }
+
+    let returns = unsafe { get_field(object, "returns") };
+    let returns_jv = JSValue::from_bits(returns.to_bits());
+    let ret = if returns_jv.is_undefined() || returns_jv.is_null() {
+        T_VOID
+    } else {
+        unsafe { super::types::parse_ffi_type_checked(returns) }
+            .unwrap_or_else(|message| throw_type(&format!("JSCallback: {message}")))
+    };
+
+    let mut ints = 0usize;
+    let mut floats = 0usize;
+    for &ty in &args[..argc] {
+        match ty {
+            T_VOID => throw_type("JSCallback: void is not a valid argument type"),
+            T_NAPI_ENV | T_NAPI_VALUE | T_BUFFER => {
+                throw_type("JSCallback: napi and buffer argument types are not supported")
+            }
+            ty if super::types::is_float_class(ty) => floats += 1,
+            _ => ints += 1,
+        }
+    }
+    if ints > MAX_CALLBACK_INT_ARGS {
+        throw_type(&format!(
+            "JSCallback supports at most {MAX_CALLBACK_INT_ARGS} integer/pointer register arguments on this target"
+        ));
+    }
+    if floats > MAX_FLOAT_ARGS {
+        throw_type(&format!(
+            "JSCallback supports at most {MAX_FLOAT_ARGS} floating-point register arguments"
+        ));
+    }
+    match ret {
+        T_NAPI_ENV | T_NAPI_VALUE | T_BUFFER => {
+            throw_type("JSCallback: napi and buffer return types are not supported")
+        }
+        T_CSTRING => {
+            throw_type("JSCallback: cstring returns are not supported; return ptr instead")
+        }
+        _ => {}
+    }
+
+    (ret, argc as u8, args)
+}
+
+extern "C" fn callback_close_thunk(closure: *const ClosureHeader) -> f64 {
+    let index = crate::closure::js_closure_get_capture_bits(closure, 0) as usize;
+    if let Some(record) = CALLBACKS.lock().unwrap().get_mut(index) {
+        record.open = false;
+        record.callback_bits = crate::value::TAG_UNDEFINED;
+    }
+    super::undefined()
+}
+
+fn close_closure(index: usize) -> f64 {
+    let function = callback_close_thunk as *const u8;
+    crate::closure::js_register_closure_arity(function, 0);
+    crate::closure::js_register_closure_length(function, 0);
+    let closure = crate::closure::js_closure_alloc(function, 1);
+    crate::closure::js_closure_set_capture_bits(closure, 0, index as u64);
+    crate::object::set_bound_native_closure_name(closure, "close");
+    crate::object::set_builtin_closure_length(closure as usize, 0);
+    crate::value::js_nanbox_pointer(closure as i64)
+}
+
+/// Construct a Bun-shaped `{ ptr, threadsafe, close }` callback wrapper.
+pub(crate) fn js_callback_value(callback: f64, definition: f64) -> f64 {
+    if !call::platform_supported() {
+        crate::fs::validate::throw_error_with_code(
+            "bun:ffi JSCallback is supported only on unix x86_64 / aarch64",
+            "ERR_NOT_IMPLEMENTED",
+        );
+    }
+    if !crate::object::value_is_callable(callback) {
+        throw_type("JSCallback expects a function as its first argument");
+    }
+    let (ret, argc, args) = parse_signature(definition);
+
+    let index = {
+        let mut callbacks = CALLBACKS.lock().unwrap();
+        if callbacks.len() >= MAX_CALLBACKS {
+            crate::fs::validate::throw_error_with_code(
+                &format!("bun:ffi JSCallback exhausted its {MAX_CALLBACKS}-slot process pool"),
+                "ERR_OUT_OF_RANGE",
+            );
+        }
+        let index = callbacks.len();
+        callbacks.push(CallbackRecord {
+            callback_bits: callback.to_bits(),
+            owner: std::thread::current().id(),
+            ret,
+            argc,
+            args,
+            open: true,
+        });
+        index
+    };
+    let pointer = trampoline_ptr(index).expect("supported callback target has trampoline table");
+
+    // The registry roots callback before any of the following JS allocations.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let object = crate::object::js_object_alloc(0, 3);
+    let object = scope.root_raw_mut_ptr(object);
+    set_field(
+        object.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        "ptr",
+        super::number_value(pointer as f64),
+    );
+    set_field(
+        object.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        "threadsafe",
+        f64::from_bits(crate::value::TAG_FALSE),
+    );
+    let close = scope.root_nanbox_f64(close_closure(index));
+    set_field(
+        object.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        "close",
+        close.get_nanbox_f64(),
+    );
+    f64::from_bits(
+        JSValue::object_ptr(object.get_raw_mut_ptr::<crate::object::ObjectHeader>() as *mut u8)
+            .bits(),
+    )
+}
+
+unsafe fn native_arg_value(ty: u8, bits: u64) -> f64 {
+    match ty {
+        T_F64 => super::number_value(f64::from_bits(bits)),
+        T_F32 => super::number_value(f32::from_bits(bits as u32) as f64),
+        _ => call::convert_int_return(ty, bits),
+    }
+}
+
+unsafe fn native_return_bits(ty: u8, value: f64) -> u64 {
+    match ty {
+        T_VOID => 0,
+        T_F64 => call::value_to_f64_num(value).to_bits(),
+        T_F32 => (call::value_to_f64_num(value) as f32).to_bits() as u64,
+        T_BOOL => crate::value::js_is_truthy(value) as u64,
+        T_PTR | T_FUNCTION => call::value_to_pointer_arg(value) as u64,
+        _ => call::value_to_u64_int(value),
+    }
+}
+
+/// Assembly callback target. Never unwinds across native code: an uncaught JS
+/// exception is trapped and converted to the declared ABI's zero value. This
+/// matches the module's fail-closed same-thread contract and, critically,
+/// never sends a Perry unwind through an arbitrary third-party C frame.
+#[no_mangle]
+pub unsafe extern "C" fn perry_ffi_callback_dispatch(
+    index: usize,
+    integer_registers: *const usize,
+    float_registers: *const u64,
+) -> u64 {
+    let record = {
+        let callbacks = CALLBACKS.lock().unwrap();
+        let Some(record) = callbacks.get(index) else {
+            return 0;
+        };
+        if !record.open || record.owner != std::thread::current().id() {
+            return 0;
+        }
+        record.clone()
+    };
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = scope.root_nanbox_f64(f64::from_bits(record.callback_bits));
+    let mut argument_roots = Vec::with_capacity(record.argc as usize);
+    let mut integer_index = 0usize;
+    let mut float_index = 0usize;
+    for &ty in &record.args[..record.argc as usize] {
+        let bits = if super::types::is_float_class(ty) {
+            let bits = *float_registers.add(float_index);
+            float_index += 1;
+            bits
+        } else {
+            let bits = *integer_registers.add(integer_index) as u64;
+            integer_index += 1;
+            bits
+        };
+        argument_roots.push(scope.root_nanbox_f64(native_arg_value(ty, bits)));
+    }
+    let arguments: Vec<f64> = argument_roots
+        .iter()
+        .map(|handle| handle.get_nanbox_f64())
+        .collect();
+
+    match crate::exception::js_call_catching(|| {
+        crate::closure::js_native_call_value(
+            callback.get_nanbox_f64(),
+            arguments.as_ptr(),
+            arguments.len(),
+        )
+    }) {
+        Ok(value) => native_return_bits(record.ret, value),
+        Err(_error) => 0,
+    }
+}
+
+pub(crate) fn scan_callback_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let owner = std::thread::current().id();
+    for record in CALLBACKS.lock().unwrap().iter_mut() {
+        if record.open && record.owner == owner {
+            visitor.visit_nanbox_u64_slot(&mut record.callback_bits);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_pool_has_stable_nonzero_trampolines() {
+        if call::platform_supported() {
+            let first = trampoline_ptr(0).unwrap();
+            let last = trampoline_ptr(MAX_CALLBACKS - 1).unwrap();
+            assert_ne!(first, 0);
+            assert_ne!(last, 0);
+            assert_ne!(first, last);
+        }
+    }
+}

--- a/crates/perry-runtime/src/bun_ffi/dlopen.rs
+++ b/crates/perry-runtime/src/bun_ffi/dlopen.rs
@@ -12,7 +12,7 @@
 //! deliberately stricter than Bun (which leaves use-after-close as UB).
 
 use super::call::{self, MAX_ARGS, MAX_FLOAT_ARGS, MAX_INT_ARGS};
-use super::types::{self, T_BUFFER, T_FUNCTION, T_NAPI_ENV, T_NAPI_VALUE, T_VOID};
+use super::types::{self, T_BUFFER, T_NAPI_ENV, T_NAPI_VALUE, T_VOID};
 use crate::closure::ClosureHeader;
 use crate::value::JSValue;
 use std::sync::Mutex;
@@ -345,12 +345,6 @@ fn validate_signature_checked(sym: &str, args: &[u8], ret: u8) -> Result<(), Str
     let mut floats = 0usize;
     for &t in args {
         match t {
-            T_FUNCTION => {
-                return Err(reject(
-                    "FFIType.function / JSCallback arguments are not yet supported \
-                     in perry (bun:ffi stage 1, #6562)",
-                ))
-            }
             T_NAPI_ENV | T_NAPI_VALUE => return Err(reject("napi types are not supported")),
             T_BUFFER => return Err(reject("FFIType.buffer is not yet supported (use ptr)")),
             T_VOID => return Err(reject("void is not a valid argument type")),
@@ -359,12 +353,6 @@ fn validate_signature_checked(sym: &str, args: &[u8], ret: u8) -> Result<(), Str
         }
     }
     match ret {
-        T_FUNCTION => {
-            return Err(reject(
-                "FFIType.function / JSCallback returns are not yet supported \
-                 in perry (bun:ffi stage 1, #6562)",
-            ))
-        }
         T_NAPI_ENV | T_NAPI_VALUE => return Err(reject("napi types are not supported")),
         T_BUFFER => {
             return Err(reject(
@@ -750,10 +738,10 @@ pub(crate) unsafe fn cstring_value(ptr_arg: f64, offset_arg: f64, length_arg: f6
 
 #[cfg(test)]
 mod tests {
-    // T_BUFFER / T_FUNCTION / T_NAPI_* / T_VOID come in via `use super::*`
+    // T_BUFFER / T_NAPI_* / T_VOID come in via `use super::*`
     // (re-exported from the module-level `use super::types::{...}`); pull the
     // remaining constants the tests need directly.
-    use super::super::types::{T_CSTRING, T_F64, T_I32, T_PTR, T_U64};
+    use super::super::types::{T_CSTRING, T_F64, T_FUNCTION, T_I32, T_PTR, T_U64};
     use super::*;
 
     #[test]
@@ -768,11 +756,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_callback_types_with_a_stage1_message() {
-        let e = validate_signature_checked("f", &[T_FUNCTION], T_VOID).unwrap_err();
-        assert!(e.contains("not yet supported"), "{e}");
-        let e = validate_signature_checked("f", &[T_I32], T_FUNCTION).unwrap_err();
-        assert!(e.contains("not yet supported"), "{e}");
+    fn accepts_function_pointer_types() {
+        assert!(validate_signature_checked("f", &[T_FUNCTION], T_VOID).is_ok());
+        assert!(validate_signature_checked("f", &[T_I32], T_FUNCTION).is_ok());
     }
 
     #[test]
@@ -805,7 +791,7 @@ mod tests {
 
     #[test]
     fn error_messages_name_the_symbol() {
-        let e = validate_signature_checked("my_symbol", &[T_FUNCTION], T_VOID).unwrap_err();
+        let e = validate_signature_checked("my_symbol", &[T_VOID], T_VOID).unwrap_err();
         assert!(e.contains("my_symbol"), "{e}");
     }
 }

--- a/crates/perry-runtime/src/bun_ffi/mod.rs
+++ b/crates/perry-runtime/src/bun_ffi/mod.rs
@@ -1,4 +1,4 @@
-//! `bun:ffi` — C-ABI foreign-function interface, stages 1-2 (#6562).
+//! `bun:ffi` — C-ABI foreign-function interface (#6562).
 //!
 //! Implements the Bun FFI API shape for perry-compiled programs:
 //!
@@ -12,14 +12,11 @@
 //!   (or length-bounded) UTF-8 string from a native pointer.
 //! - `toArrayBuffer` / `toBuffer` — zero-copy JS views over native-owned
 //!   memory. The native allocation remains caller-owned.
+//! - `JSCallback` / `FFIType.function` — same-thread native→JS callbacks.
 //! - `suffix` — platform dylib suffix ("dylib" / "so" / "dll").
 //!
-//! Remaining scope: `JSCallback` / `FFIType.function` (native→JS
-//! trampolines), `linkSymbols`, `CFunction`,
-//! `viewSource` and `read` are declared but throw a clear "not yet
-//! supported" error. The dispatch/type plumbing here is shaped so those can
-//! be added without reworking stage 1 (see `types::` for the reserved
-//! numeric slots and `dlopen::` for the per-symbol signature records).
+//! `linkSymbols`, `CFunction`, `viewSource` and `read` remain declared but
+//! throw a clear "not yet supported" error.
 //!
 //! ## Pointer lifetime / pinning contract (the part that must not be wrong)
 //!
@@ -51,11 +48,10 @@
 //!    through the view's codegen fast path can be stale. Pass base
 //!    (non-view) Buffers/TypedArrays to native code that writes — which is
 //!    what real `bun:ffi` consumers (bun-pty, opentui) do.
-//! 3. During a synchronous FFI call no GC can run on the calling thread
-//!    (stage 1 has no native→JS callbacks), and argument marshalling that
-//!    allocates (temporary NUL-terminated copies of string args) cannot
-//!    invalidate buffer arguments because buffers are non-moving and are
-//!    kept alive by the caller's frame.
+//! 3. A synchronous native call may invoke a same-thread `JSCallback` and
+//!    trigger GC. Buffer addresses remain valid because their storage is
+//!    non-moving, while the caller's frame keeps buffer arguments alive.
+//!    Callback functions are held in a runtime root registry until closed.
 //!
 //! ## Call-stub mechanism
 //!
@@ -73,6 +69,7 @@
 //! time rather than corrupting registers at call time.
 
 pub mod call;
+pub mod callback;
 pub mod dlopen;
 pub mod memory;
 pub mod types;
@@ -118,6 +115,7 @@ pub(crate) fn suffix_str() -> &'static str {
 /// side-table scanners.
 pub fn scan_bun_ffi_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     types::scan_ffi_type_cache_mut(visitor);
+    callback::scan_callback_roots_mut(visitor);
 }
 
 /// Later-stage boundary: named exports that exist in `bun:ffi` but are not yet
@@ -127,7 +125,8 @@ fn throw_unsupported(what: &str) -> ! {
     crate::fs::validate::throw_error_with_code(
         &format!(
             "bun:ffi: {what} is not supported yet in perry (#6562). \
-             Available: dlopen, FFIType, ptr, CString, toArrayBuffer, toBuffer, suffix."
+             Available: dlopen, FFIType, ptr, CString, JSCallback, \
+             toArrayBuffer, toBuffer, suffix."
         ),
         "ERR_NOT_IMPLEMENTED",
     )
@@ -161,7 +160,7 @@ pub(crate) unsafe fn dispatch(
         "FFIType" => Some(types::ffi_type_object_value()),
         "suffix" => Some(string_value(suffix_str())),
         "toArrayBuffer" => Some(memory::view_value(arg(0), arg(1), arg(2), true)),
-        "JSCallback" => throw_unsupported("JSCallback (native-to-JS callbacks)"),
+        "JSCallback" => Some(callback::js_callback_value(arg(0), arg(1))),
         "CFunction" => throw_unsupported("CFunction"),
         "linkSymbols" => throw_unsupported("linkSymbols"),
         "viewSource" => throw_unsupported("viewSource"),

--- a/crates/perry-runtime/src/bun_ffi/types.rs
+++ b/crates/perry-runtime/src/bun_ffi/types.rs
@@ -10,10 +10,8 @@
 //! buffer=20
 //! ```
 //!
-//! Stage 1 implements 0–16; `function` (17) parses but `dlopen` rejects it
-//! with a "not yet supported" error (JSCallback is stage 3), and the napi /
-//! buffer slots (18–20) are rejected as unsupported. The slots stay
-//! reserved so later stages only need to lift the rejection.
+//! Perry implements 0–17; the napi / buffer slots (18–20) are rejected as
+//! unsupported.
 
 use super::{number_value, string_value};
 use crate::value::JSValue;

--- a/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
@@ -4,7 +4,8 @@ fn native_callable_export_arity_reference(module: &str, prop: &str) -> Option<u3
     match (module, prop) {
         // bun:ffi (#6562).
         ("bun:ffi", "dlopen") => Some(2),
-        ("bun:ffi", "ptr" | "CString" | "JSCallback" | "CFunction" | "linkSymbols") => Some(1),
+        ("bun:ffi", "ptr" | "CString" | "CFunction" | "linkSymbols") => Some(1),
+        ("bun:ffi", "JSCallback") => Some(2),
         ("bun:ffi", "toArrayBuffer" | "toBuffer") => Some(3),
         ("bun:ffi", "viewSource") => Some(2),
         ("bun:ffi", "read") => Some(0),
@@ -280,7 +281,7 @@ static CALLABLE_EXPORT_ARITY_TABLE: &[(&str, &[(&str, u32)])] = &[
         &[
             ("CFunction", 1),
             ("CString", 1),
-            ("JSCallback", 1),
+            ("JSCallback", 2),
             ("dlopen", 2),
             ("linkSymbols", 1),
             ("ptr", 1),

--- a/crates/perry/tests/bun_ffi_stage1.rs
+++ b/crates/perry/tests/bun_ffi_stage1.rs
@@ -8,7 +8,7 @@
 // only verdict that counts — naming this file in a runtime diff is what
 // opts the suite into that job, and a candidate fix must not be merged
 // before that job has reported green.
-//! bun:ffi stages 1-2 (#6562) — e2e: compile TS that dlopens real C-ABI
+//! bun:ffi (#6562) — e2e: compile TS that dlopens real C-ABI
 //! dylibs and drive them through the typed call stubs.
 //!
 //! Two tiers:
@@ -61,10 +61,14 @@ fn compile_and_run(dir: &Path, entry: &Path, envs: &[(&str, &str)]) -> (bool, St
         run.env(k, v);
     }
     let run = run.output().expect("run compiled binary");
+    let mut stderr = String::from_utf8_lossy(&run.stderr).to_string();
+    if !run.status.success() {
+        stderr.push_str(&format!("\nprocess status: {}", run.status));
+    }
     (
         run.status.success(),
         String::from_utf8_lossy(&run.stdout).to_string(),
-        String::from_utf8_lossy(&run.stderr).to_string(),
+        stderr,
     )
 }
 
@@ -176,10 +180,34 @@ EXPORT uint8_t ffi_external_get(int32_t index) { return g_external_bytes[index];
 EXPORT void ffi_external_set(int32_t index, uint8_t value) {
     g_external_bytes[index] = value;
 }
+
+EXPORT int32_t ffi_call_callback(
+    int32_t (*callback)(int32_t, double, float),
+    int32_t a, double b, float c
+) {
+    return callback(a, b, c);
+}
+EXPORT void ffi_call_void_callback(
+    void (*callback)(uint8_t, void *, uint32_t), void *pointer
+) {
+    callback(7, pointer, 3);
+}
+EXPORT uint64_t ffi_call_u64_callback(
+    uint64_t (*callback)(uint64_t), uint64_t value
+) {
+    return callback(value);
+}
+EXPORT int32_t ffi_call_cstring_callback(
+    int32_t (*callback)(const char *)
+) {
+    return callback("native callback");
+}
+EXPORT void *ffi_echo_callback(void *callback) { return callback; }
 "#;
 
 const TIER1_TS: &str = r#"
-import { dlopen, FFIType, ptr, CString, suffix, toArrayBuffer, toBuffer } from "bun:ffi";
+import { dlopen, FFIType, ptr, CString, JSCallback, suffix, toArrayBuffer, toBuffer } from "bun:ffi";
+import * as ffiNamespace from "bun:ffi";
 
 console.log("suffix-ok:", suffix === "dylib" || suffix === "so");
 console.log("ffitype:", FFIType.i32, FFIType.cstring, FFIType.ptr, FFIType.void, FFIType.u64);
@@ -230,6 +258,26 @@ const lib = dlopen(process.env.FFI_TEST_LIB!, {
   ffi_external_ptr: { args: [], returns: FFIType.ptr },
   ffi_external_get: { args: [FFIType.i32], returns: FFIType.u8 },
   ffi_external_set: { args: [FFIType.i32, FFIType.u8], returns: FFIType.void },
+  ffi_call_callback: {
+    args: [FFIType.function, FFIType.i32, FFIType.f64, FFIType.f32],
+    returns: FFIType.i32,
+  },
+  ffi_call_void_callback: {
+    args: [FFIType.function, FFIType.ptr],
+    returns: FFIType.void,
+  },
+  ffi_call_u64_callback: {
+    args: [FFIType.function, FFIType.u64],
+    returns: FFIType.u64,
+  },
+  ffi_call_cstring_callback: {
+    args: [FFIType.function],
+    returns: FFIType.i32,
+  },
+  ffi_echo_callback: {
+    args: [FFIType.function],
+    returns: FFIType.function,
+  },
 });
 const s = lib.symbols;
 
@@ -318,6 +366,52 @@ s.ffi_external_set(2, 0);
 const terminated = toArrayBuffer(externalPtr);
 console.log("external-terminated:", terminated.byteLength);
 
+// Stage 3: same-thread native -> JS callbacks, including mixed register
+// classes, pointer/cstring conversion, BigInt, return conversion, close(),
+// and exception handoff to the enclosing FFI call.
+const mixedCallback = new JSCallback((a: number, b: number, c: number) => {
+  console.log("callback-mixed-args:", a, b, c);
+  return a + b + c;
+}, { args: [FFIType.i32, FFIType.f64, FFIType.f32], returns: FFIType.i32 });
+console.log("callback-shape:", typeof mixedCallback.ptr, mixedCallback.threadsafe, typeof mixedCallback.close);
+console.log("callback-mixed-return:", s.ffi_call_callback(mixedCallback.ptr, 10, 20.5, 11.5));
+console.log("callback-function-return:", s.ffi_echo_callback(mixedCallback.ptr) === mixedCallback.ptr);
+
+const pointerCallback = new JSCallback((value: number, pointer: number, length: number) => {
+  console.log("callback-pointer-args:", value, pointer === p, length);
+}, { args: [FFIType.u8, FFIType.ptr, FFIType.u32], returns: FFIType.void });
+s.ffi_call_void_callback(pointerCallback.ptr, p);
+
+const bigintCallback = new JSCallback((value: bigint) => value + 1n, {
+  args: [FFIType.u64], returns: FFIType.u64,
+});
+console.log("callback-bigint:", s.ffi_call_u64_callback(bigintCallback.ptr, 41n));
+
+const namespaceCallback = new ffiNamespace.JSCallback((value: bigint) => value + 2n, {
+  args: [FFIType.u64], returns: FFIType.u64,
+});
+console.log("callback-namespace-new:", s.ffi_call_u64_callback(namespaceCallback.ptr, 40n));
+
+const stringCallback = new JSCallback((value: string) => {
+  console.log("callback-cstring:", value);
+  return value.length;
+}, { args: [FFIType.cstring], returns: FFIType.i32 });
+console.log("callback-cstring-return:", s.ffi_call_cstring_callback(stringCallback.ptr));
+
+const throwingCallback = new JSCallback(() => { throw new Error("callback boom"); }, {
+  args: [], returns: FFIType.i32,
+});
+console.log("callback-throw-zero:", s.ffi_call_cstring_callback(throwingCallback.ptr));
+
+mixedCallback.close();
+mixedCallback.close();
+console.log("callback-closed-zero:", s.ffi_call_callback(mixedCallback.ptr, 1, 2, 3));
+pointerCallback.close();
+bigintCallback.close();
+namespaceCallback.close();
+stringCallback.close();
+throwingCallback.close();
+
 lib.close();
 
 // use-after-close throws a descriptive error instead of crashing
@@ -401,6 +495,17 @@ fn tier1_every_ffi_type_against_test_dylib() {
         "external-buffer: true 2 65",
         "external-buffer-write: 81",
         "external-terminated: 2",
+        "callback-shape: number false function",
+        "callback-mixed-args: 10 20.5 11.5",
+        "callback-mixed-return: 42",
+        "callback-function-return: true",
+        "callback-pointer-args: 7 true 3",
+        "callback-bigint: 42n",
+        "callback-namespace-new: 42n",
+        "callback-cstring: native callback",
+        "callback-cstring-return: 15",
+        "callback-throw-zero: 0",
+        "callback-closed-zero: 0",
         "closed-throws: true",
         "TIER1-DONE",
     ] {
@@ -432,20 +537,29 @@ try {
   console.log("missing-symbol:", String(e.message).includes('Symbol "not_a_real_symbol" not found'));
 }
 
-// FFIType.function -> clear stage-1 rejection at dlopen time
+// FFIType.function is accepted in symbol signatures.
 try {
-  dlopen(process.env.FFI_TEST_LIB!, { ffi_hello: { args: [FFIType.function], returns: FFIType.void } });
-  console.log("function-type: no-throw");
+  const functionLib = dlopen(process.env.FFI_TEST_LIB!, {
+    ffi_echo_callback: { args: [FFIType.function], returns: FFIType.function },
+  });
+  console.log("function-type:", typeof functionLib.symbols.ffi_echo_callback === "function");
+  functionLib.close();
 } catch (e: any) {
-  console.log("function-type:", String(e.message).includes("not yet supported"));
+  console.log("function-type: false");
 }
 
-// JSCallback export exists but throws the stage-1 error when used
+// Constructor validation is explicit, including the same-thread contract.
 try {
-  JSCallback(() => {}, {});
-  console.log("jscallback: no-throw");
+  JSCallback(1 as any, {});
+  console.log("jscallback-type: false");
 } catch (e: any) {
-  console.log("jscallback:", String(e.message).includes("not supported yet"));
+  console.log("jscallback-type:", String(e.message).includes("expects a function"));
+}
+try {
+  JSCallback(() => {}, { threadsafe: true });
+  console.log("jscallback-threadsafe: false");
+} catch (e: any) {
+  console.log("jscallback-threadsafe:", String(e.message).includes("creating thread"));
 }
 
 // strings are not pointers (Bun-compatible hint)
@@ -476,7 +590,8 @@ fn tier1b_error_surfaces() {
         "open-missing: true",
         "missing-symbol: true",
         "function-type: true",
-        "jscallback: true",
+        "jscallback-type: true",
+        "jscallback-threadsafe: true",
         "string-ptr: true",
         "ERRORS-DONE",
     ] {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -318,7 +318,7 @@ declare module "bun:ffi" {
   export function CFunction(...args: any[]): any;
   /** stdlib */
   export function CString(...args: any[]): any;
-  /** stdlib @perryStub stage 3 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function JSCallback(...args: any[]): any;
   /** stdlib */
   export function dlopen(...args: any[]): any;

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -368,7 +368,7 @@ Total: 2951 entries across 125 modules.
 
 - `CFunction` — module ⚠ **stub** — stage 3 — not yet implemented, throws at runtime (#6562)
 - `CString` — module
-- `JSCallback` — module ⚠ **stub** — stage 3 — not yet implemented, throws at runtime (#6562)
+- `JSCallback` — module
 - `dlopen` — module
 - `linkSymbols` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
 - `ptr` — module


### PR DESCRIPTION
## Summary

Implements the remaining native-to-JavaScript callback primitive for `bun:ffi`: `JSCallback` now exposes same-thread C-ABI trampolines with rooted closures, and `FFIType.function` works in `dlopen` signatures.

## Changes

- Add a fixed, non-reused callback trampoline pool for macOS/Linux on arm64 and x86-64, preserving the integer and floating-point ABI register classes.
- Root callback closures until `close()`, poison closed pointers, reject `threadsafe: true`, and convert uncaught callback exceptions to the declared ABI zero value instead of unwinding through C.
- Support Bun's `new JSCallback(...)` named-import and namespace-import forms, including the `{ ptr, threadsafe, close }` wrapper shape.
- Marshal `FFIType.function` as a pointer in arguments and returns.
- Add native-fixture coverage for mixed numeric arguments, pointers, C strings, BigInts, returned function pointers, GC-visible closures, closing, and exception behavior.
- Update the API manifest, generated API docs, and changelog fragment. No version files were changed.

## Related issue

Refs #6562 — completes the `JSCallback` / `FFIType.function` stage. The separately declared `CFunction`, `linkSymbols`, `viewSource`, and `read` exports remain out of scope and continue to report `ERR_NOT_IMPLEMENTED`.

## Test plan

- [ ] `cargo build --release` clean (not run; platform-specific builds below were used)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (project guidance uses affected-crate and scoped tests instead)
- [x] `cargo test -p perry-runtime bun_ffi --lib`
- [x] `cargo test -p perry-api-manifest`
- [x] `cargo check -p perry-hir`
- [x] `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR="$PWD/target/debug" cargo test -p perry --test bun_ffi_stage1 tier1_every_ffi_type_against_test_dylib -- --nocapture`
- [x] `PERRY_NO_AUTO_OPTIMIZE=1 PERRY_RUNTIME_DIR="$PWD/target/debug" cargo test -p perry --test bun_ffi_stage1 tier1b_error_surfaces -- --nocapture`
- [x] `cargo build -p perry-runtime --target x86_64-unknown-linux-gnu --no-default-features --features full`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [x] Updated `docs/src/`
- [x] No platform UI backend changed

## Screenshots / output

Not applicable; this is a runtime API change.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added same-thread `bun:ffi` callback support through `JSCallback`.
  - Supports callback arguments and return values, including pointers, numeric types, strings, and function pointers.
  - Added safe callback lifecycle handling, including closing, invalid usage, exceptions, and unsupported cross-thread calls.
  - `FFIType.function` is now accepted in FFI signatures.

- **Documentation**
  - Updated API documentation to reflect implemented `JSCallback` support and expanded FFI type coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->