### PR TITLE
runtime: instantiate compiled WebAssembly modules synchronously

### DIFF
--- a/changelog.d/8508-wasm-instance-constructor.md
+++ b/changelog.d/8508-wasm-instance-constructor.md
@@ -1,0 +1,6 @@
+### runtime: instantiate compiled WebAssembly modules synchronously
+
+`new WebAssembly.Instance(module, imports)` now routes through Perry's wasmi
+host and returns live exports. This supports the synchronous, file-packaged
+constructor shape used by wasm-bindgen Node loaders for Perry's existing
+numeric function/import subset.

--- a/crates/perry-runtime/src/object/global_this_webassembly.rs
+++ b/crates/perry-runtime/src/object/global_this_webassembly.rs
@@ -31,9 +31,10 @@
 //!
 //! When the runtime is built with the `wasm-host` cargo feature (the opt-in
 //! `--enable-wasm-runtime` wasmi path, issue #76), `validate` / `compile` /
-//! `instantiate` and the `Module` constructor + metadata statics route to the
-//! real host shims in `crate::webassembly` instead. The streaming entry
-//! points still reject (no `Response`-driven compile in the host MVP).
+//! `instantiate`, the `Module` constructor + metadata statics, and the
+//! synchronous `Instance(module, imports)` constructor route to the real host
+//! shims in `crate::webassembly` instead. The streaming entry points still
+//! reject (no `Response`-driven compile in the host MVP).
 //!
 //! NOTE: the statically-recognized spellings (`WebAssembly.compile(bytes)`
 //! etc. written literally against the global) lower to dedicated HIR
@@ -494,12 +495,25 @@ extern "C" fn webassembly_module_ctor_thunk(
 
 extern "C" fn webassembly_instance_ctor_thunk(
     closure: *const crate::closure::ClosureHeader,
-    _module: f64,
+    module: f64,
+    imports: f64,
 ) -> f64 {
     if !invoked_as_constructor(closure) {
         throw_requires_new("WebAssembly.Instance");
     }
-    crate::exception::js_throw(wasm_unsupported_error(b"LinkError", "WebAssembly.Instance"));
+    #[cfg(feature = "wasm-host")]
+    {
+        crate::webassembly::js_webassembly_instance_new(
+            module,
+            imports,
+            crate::object::js_implicit_this_get(),
+        )
+    }
+    #[cfg(not(feature = "wasm-host"))]
+    {
+        let _ = (module, imports);
+        crate::exception::js_throw(wasm_unsupported_error(b"LinkError", "WebAssembly.Instance"));
+    }
 }
 
 extern "C" fn webassembly_table_ctor_thunk(
@@ -821,6 +835,10 @@ pub(super) fn create_webassembly_namespace() -> f64 {
         "Instance",
         webassembly_instance_ctor_thunk as *const u8,
     );
+    // The optional imports object is a real second call argument, while the
+    // standard constructor metadata remains `WebAssembly.Instance.length ===
+    // 1`. Keep the dispatch arity separate from the public length.
+    crate::closure::js_register_closure_arity(webassembly_instance_ctor_thunk as *const u8, 2);
     install_webassembly_proto_data(instance_ctor, "exports", undefined());
 
     let memory_ctor = install_webassembly_constructor(

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -817,7 +817,7 @@ fn make_export_function(
     crate::value::js_nanbox_pointer(closure_ptr as i64)
 }
 
-fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) -> f64 {
+fn make_instance_value(module: *mut c_void, inst: *mut c_void, imports: f64, receiver: f64) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let imports = scope.root_nanbox_f64(imports);
     let memory_len = unsafe { perry_wasm_host_instance_memory_len(inst) };
@@ -829,7 +829,18 @@ fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) ->
         copy_instance_memory(inst, value);
         value
     });
-    let instance = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
+    // `new WebAssembly.Instance(...)` arrives with a receiver whose
+    // [[Prototype]] was already linked to `WebAssembly.Instance.prototype` by
+    // the generic construct path. Populate that object in place so
+    // `instanceof WebAssembly.Instance` keeps working. The static
+    // `WebAssembly.instantiate(...)` path passes `undefined` and gets a fresh
+    // ordinary wrapper instead.
+    let receiver_value = JSValue::from_bits(receiver.to_bits());
+    let instance = scope.root_nanbox_f64(if receiver_value.is_pointer() {
+        receiver
+    } else {
+        object_value(crate::object::js_object_alloc(0, 0))
+    });
     let exports = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
     let exports_len = unsafe { perry_wasm_host_module_exports_len(module) };
     for index in 0..exports_len {
@@ -850,7 +861,7 @@ fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) ->
                 name,
                 unsafe { perry_wasm_host_module_export_func_arity(module, index) },
                 memory_buffer.get_nanbox_f64(),
-                object_value(instance.get_raw_mut_ptr::<crate::object::ObjectHeader>()),
+                instance.get_nanbox_f64(),
                 imports.get_nanbox_f64(),
             ),
             WASM_EXTERN_KIND_MEMORY => {
@@ -870,12 +881,27 @@ fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) ->
         );
         exports.set_raw_mut_ptr(exports_ptr);
     }
+    let instance_ptr = JSValue::from_bits(instance.get_nanbox_f64().to_bits())
+        .as_pointer::<crate::object::ObjectHeader>()
+        as *mut crate::object::ObjectHeader;
     let instance_ptr = object_set(
-        instance.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        instance_ptr,
         b"exports",
         object_value(exports.get_raw_mut_ptr::<crate::object::ObjectHeader>()),
     );
-    instance.set_raw_mut_ptr(instance_ptr);
+    instance.set_nanbox_f64(object_value(instance_ptr));
+
+    instance.get_nanbox_f64()
+}
+
+fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let instance = scope.root_nanbox_f64(make_instance_value(
+        module,
+        inst,
+        imports,
+        nanbox_undefined(),
+    ));
 
     let result = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
     let module_value = scope.root_nanbox_f64(make_module_object(module));
@@ -886,10 +912,56 @@ fn make_instance_result(module: *mut c_void, inst: *mut c_void, imports: f64) ->
     let result_ptr = object_set(
         result.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
         b"instance",
-        object_value(instance.get_raw_mut_ptr::<crate::object::ObjectHeader>()),
+        instance.get_nanbox_f64(),
     );
     result.set_raw_mut_ptr(result_ptr);
     result.with_mut_ptr(|r: *mut crate::object::ObjectHeader| object_value(r))
+}
+
+/// `new WebAssembly.Instance(module, imports?)` — synchronously instantiate a
+/// previously compiled module. This is the shape emitted by wasm-bindgen's
+/// Node glue (including `@silvia-odwyer/photon-node`). Unlike the async
+/// `WebAssembly.instantiate(bytes, imports)` API, constructor failures throw a
+/// `TypeError`/`LinkError` directly.
+#[no_mangle]
+pub extern "C" fn js_webassembly_instance_new(
+    module_jsval: f64,
+    imports_jsval: f64,
+    receiver_jsval: f64,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let module_value = scope.root_nanbox_f64(module_jsval);
+    let imports = scope.root_nanbox_f64(imports_jsval);
+    let receiver = scope.root_nanbox_f64(receiver_jsval);
+    let Some(module) = extract_module_handle(module_value.get_nanbox_f64()) else {
+        crate::exception::js_throw(wasm_type_error_value(
+            "WebAssembly.Instance(): first argument must be a WebAssembly.Module",
+        ));
+    };
+
+    let mut err: *mut c_char = std::ptr::null_mut();
+    let inst = unsafe {
+        perry_wasm_host_instance_new(
+            module,
+            Some(call_wasm_import),
+            imports.get_nanbox_f64().to_bits(),
+            &mut err,
+        )
+    };
+    if inst.is_null() {
+        crate::exception::js_throw(wasm_error_value_from_host(
+            b"LinkError",
+            err,
+            "WebAssembly.Instance(): instantiation failed",
+        ));
+    }
+
+    make_instance_value(
+        module,
+        inst,
+        imports.get_nanbox_f64(),
+        receiver.get_nanbox_f64(),
+    )
 }
 
 /// `WebAssembly.instantiate(bytes, imports?)` returns the standard instance

--- a/crates/perry/tests/issue_5234_wasm_esm_import.rs
+++ b/crates/perry/tests/issue_5234_wasm_esm_import.rs
@@ -77,6 +77,9 @@ import * as wasmNamespace from "./add.wasm";
 import { call as importedCall } from "./imported.wasm";
 import { throughGlue } from "./glue";
 import memoryDefault, { memory } from "./memory.wasm";
+import addWasmPath from "./file-add.wasm" with { type: "file" };
+import importedWasmPath from "./file-imported.wasm" with { type: "file" };
+import { readFileSync } from "node:fs";
 
 console.log("namespace=" + wasmNamespace.add(2, 3));
 console.log("named=" + add(7, 8));
@@ -85,6 +88,19 @@ console.log("imported=" + importedCall(41));
 console.log("circular=" + throughGlue(8));
 console.log("memory=" + memory.buffer.byteLength);
 console.log("defaultMemory=" + memoryDefault.memory.buffer.byteLength);
+
+// #8508: wasm-bindgen's Node loader compiles file-backed bytes first, then
+// synchronously constructs an Instance with its glue imports object.
+const fileModule = new WebAssembly.Module(readFileSync(addWasmPath));
+const fileInstance = new WebAssembly.Instance(fileModule);
+console.log("fileInstance=" + fileInstance.exports.add(9, 12));
+
+const importedModule = new WebAssembly.Module(readFileSync(importedWasmPath));
+const importedInstance = new WebAssembly.Instance(importedModule, {
+    "./glue": { inc: (value: number) => value + 1 },
+});
+console.log("fileImported=" + importedInstance.exports.call(20));
+console.log("instanceLength=" + WebAssembly.Instance.length);
 "#;
 
 const GLUE_FIXTURE: &str = r#"
@@ -105,8 +121,11 @@ fn write_fixture(root: &std::path::Path) {
         .decode(ADD_WASM_BASE64)
         .expect("decode add.wasm");
     assert_eq!(bytes.len(), 41);
-    std::fs::write(root.join("add.wasm"), bytes).expect("write add.wasm");
+    std::fs::write(root.join("add.wasm"), &bytes).expect("write add.wasm");
     std::fs::write(root.join("imported.wasm"), IMPORTED_WASM).expect("write imported.wasm");
+    std::fs::write(root.join("file-add.wasm"), bytes).expect("write file add.wasm");
+    std::fs::write(root.join("file-imported.wasm"), IMPORTED_WASM)
+        .expect("write file imported.wasm");
     std::fs::write(root.join("memory.wasm"), MEMORY_WASM).expect("write memory.wasm");
     std::fs::write(root.join("glue.ts"), GLUE_FIXTURE).expect("write glue.ts");
     std::fs::write(root.join("main.ts"), MAIN_FIXTURE).expect("write main.ts");
@@ -162,4 +181,7 @@ fn wasm_esm_import_instantiates_and_exposes_exports() {
     assert!(stdout.contains("circular=9"), "stdout:\n{stdout}");
     assert!(stdout.contains("memory=65536"), "stdout:\n{stdout}");
     assert!(stdout.contains("defaultMemory=65536"), "stdout:\n{stdout}");
+    assert!(stdout.contains("fileInstance=21"), "stdout:\n{stdout}");
+    assert!(stdout.contains("fileImported=21"), "stdout:\n{stdout}");
+    assert!(stdout.contains("instanceLength=1"), "stdout:\n{stdout}");
 }

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -264,6 +264,13 @@ In practice this means lazy wasm consumers — wasm-bindgen loaders like
 probe — hit their own catch/fallback paths and the app keeps running with
 that feature degraded.
 
+When the wasmi host is linked, `new WebAssembly.Module(bytes)` and the
+synchronous `new WebAssembly.Instance(module, imports)` constructor execute
+real modules in Perry's numeric function/import subset. This includes WASM
+bytes exposed through the embedded `import ... with { type: "file" }` loader;
+tables, globals, non-function imports, reference values, and streaming remain
+outside that subset.
+
 Two spellings, two paths:
 
 - **Namespace access** (`const WA = globalThis.WebAssembly; WA.compile(...)`,

--- a/types/perry/webassembly/index.d.ts
+++ b/types/perry/webassembly/index.d.ts
@@ -12,11 +12,15 @@
 // programs that load the runtime via dlopen / FFI without a static
 // reference, but the common case needs nothing.
 //
-// **Two call shapes work, identically.** Pick whichever reads better:
+// Supported instantiation shapes include:
 //
 //   const inst = WebAssembly.instantiate(bytes);
 //   inst.exports.add(2, 3);                       // standard JS shape
 //   WebAssembly.callExport(inst, "add", 2, 3);    // Perry helper
+//
+//   const module = new WebAssembly.Module(bytes);
+//   const syncInst = new WebAssembly.Instance(module, imports);
+//   syncInst.exports.add(2, 3);                    // wasm-bindgen Node shape
 //
 // The standard `inst.exports.<method>(...)` shape is recognised
 // syntactically — the local must be tagged at compile time as a wasm


### PR DESCRIPTION
## Summary

- route `new WebAssembly.Instance(module, imports)` through the existing wasmi host
- preserve the constructor receiver/prototype while exposing live exports
- cover the wasm-bindgen Node loader shape using WASM bytes packaged via `with { type: "file" }`
- keep synchronous TypeError/LinkError behavior and the standard `Instance.length === 1`

## Scope

This is a scoped step toward #8508. It unblocks the Module → Instance path used by Photon-style Node glue for Perry's existing numeric/function-import subset. Tree-sitter's memory/table/global imports and streaming/reference-value support remain follow-up work, so this PR intentionally does not close the umbrella issue.

## Testing

- `cargo check -p perry-runtime --features wasm-host`
- `cargo test -p perry-wasm-host`
- `cargo test -p perry --test issue_5234_wasm_esm_import -- --nocapture`
- `./scripts/pre-tag-check.sh --quick`

Refs #8508
