### PR TITLE
fix(gc): root defineProperty operands across exotic probes (#8507)

### DIFF
--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -165,28 +165,33 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
     obj: *mut ObjectHeader,
     descriptor_value: f64,
 ) -> bool {
-    let desc_ptr = extract_obj_ptr(descriptor_value);
-    if desc_ptr.is_null() {
+    // #8507: every descriptor-field name below is allocated in the GC heap,
+    // and the value's ToNumber hooks may run user JS. Keep both the array and
+    // descriptor rooted for the whole algorithm; helper-local roots cannot
+    // refresh raw copies held by this caller between field probes.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let desc_handle = scope.root_nanbox_f64(descriptor_value);
+    let current_desc = || extract_obj_ptr(desc_handle.get_nanbox_f64());
+    if current_desc().is_null() {
         return true;
     }
     // A customized `length` (e.g. writable:false) gates the raw numeric
     // fast paths — see OBJ_FLAG_ARRAY_DESCRIPTORS in define_array_property.
     // Set here too so the `Reflect.defineProperty` entry point is covered.
     {
+        let obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
         let gc = gc_header_for(obj);
         (*gc)._reserved |= crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS;
     }
-    // #7548: `obj` may be a pre-grow forwarding stub. `old_len` below drives
-    // the shrink walk, so it must come from the array's current home.
-    let arr = array_header_mut(obj);
 
     let read_present = |name: &[u8]| -> bool {
         let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        own_key_present(desc_ptr, k)
+        own_key_present(current_desc(), k)
     };
     let read_bool = |name: &[u8]| -> bool {
         let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let v = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k);
+        let v = js_object_get_field_by_name(current_desc() as *const ObjectHeader, k);
         crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0
     };
 
@@ -208,10 +213,16 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
     // mutation (e.g. flipping `writable` to false) is honored.
     let new_len: Option<u32> = if has_value {
         let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-        let value_field = js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
+        let value_field =
+            js_object_get_field_by_name(current_desc() as *const ObjectHeader, value_key);
         let value = f64::from_bits(value_field.bits());
-        let uint = to_uint32(crate::builtins::js_number_coerce(value));
-        let number = crate::builtins::js_number_coerce(value);
+        // ArraySetLength coerces the same value twice. The first conversion can
+        // evacuate an object-valued operand, so the second must re-read it.
+        let value_handle = scope.root_nanbox_f64(value);
+        let uint = to_uint32(crate::builtins::js_number_coerce(
+            value_handle.get_nanbox_f64(),
+        ));
+        let number = crate::builtins::js_number_coerce(value_handle.get_nanbox_f64());
         // SameValueZero(newLen, numberLen): a fractional / out-of-range length
         // is a RangeError.
         if (uint as f64) != number {
@@ -222,10 +233,16 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
         None
     };
 
+    // #7548: `obj` may be a pre-grow forwarding stub. `old_len` below drives
+    // the shrink walk, so it must come from the array's current home. Re-read
+    // after every descriptor allocation and user coercion above (#8507).
+    let obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let arr = array_header_mut(obj);
+    let owner = obj as usize;
     let old_len = (*arr).length;
     // `length` is non-configurable, non-enumerable; writable defaults to true
     // until explicitly set otherwise via the side table.
-    let cur_writable = super::get_property_attrs(obj as usize, "length")
+    let cur_writable = super::get_property_attrs(owner, "length")
         .map(|a| a.writable())
         .unwrap_or(true);
 
@@ -268,7 +285,7 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
             while i > n {
                 i -= 1;
                 let key = i.to_string();
-                let configurable = super::get_property_attrs(obj as usize, &key)
+                let configurable = super::get_property_attrs(owner, &key)
                     .map(|a| a.configurable())
                     .unwrap_or(true);
                 if !configurable {
@@ -282,7 +299,7 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
             let mut j = old_len;
             while j > target {
                 j -= 1;
-                super::clear_property_attrs(obj as usize, &j.to_string());
+                super::clear_property_attrs(owner, &j.to_string());
             }
             crate::array::js_array_set_length(arr, target as f64);
         } else {
@@ -294,13 +311,13 @@ pub(crate) unsafe fn array_set_length_from_descriptor(
         // rejected (the property becomes non-writable; only the truncation
         // partially failed).
         super::set_property_attrs(
-            obj as usize,
+            owner,
             "length".to_string(),
             PropertyAttrs::new(false, false, false),
         );
     } else if has_writable {
         super::set_property_attrs(
-            obj as usize,
+            owner,
             "length".to_string(),
             PropertyAttrs::new(new_writable, false, false),
         );

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -430,15 +430,23 @@ pub extern "C" fn js_object_define_property(
         // handles truncates the outer container's newest entries (see
         // `gc::RootedValues`' module docs), so the arms below share this one.
         let scope = crate::gc::RuntimeHandleScope::new();
+        // #8507: root the three entry operands before descriptor validation and
+        // the TypedArray exotic probe. The latter can coerce an object key and
+        // then return `NotTypedArray`; its private roots keep the operands live
+        // only inside that helper, so the caller must re-read its own roots
+        // before continuing into the expando/closure/ordinary paths.
+        let obj_value_handle = scope.root_heap_word_u64(obj_value.to_bits());
+        let desc_handle = scope.root_nanbox_f64(descriptor_value);
+        let key_handle = scope.root_nanbox_f64(key_value);
         // #6748 follow-up: decode the descriptor's 6 fields in ONE pass when it
         // is a plain default-prototype object (the overwhelming majority) —
         // the per-field `desc_has_field`/`desc_read_field` helpers each cost a
         // key-string alloc plus a HasProperty/[[Get]] walk. `None` keeps the
         // spec-general per-field path everywhere below.
-        let desc_view = try_decode_descriptor(&scope, descriptor_value);
+        let desc_view = try_decode_descriptor(&scope, desc_handle.get_nanbox_f64());
         match &desc_view {
             Some(v) => validate_property_descriptor_view(v),
-            None => validate_property_descriptor(descriptor_value),
+            None => validate_property_descriptor(desc_handle.get_nanbox_f64()),
         }
 
         // TypedArrays are Integer-Indexed exotic objects: a canonical numeric
@@ -446,17 +454,25 @@ pub extern "C" fn js_object_define_property(
         // either write the element or reject with a TypeError).
         if !receiver_plain_object {
             match super::super::typed_array_define_own_property(
-                obj_value,
-                key_value,
-                descriptor_value,
+                f64::from_bits(obj_value_handle.get_heap_word_u64()),
+                key_handle.get_nanbox_f64(),
+                desc_handle.get_nanbox_f64(),
             ) {
-                super::super::TypedArrayDefineOutcome::Defined => return obj_value,
+                super::super::TypedArrayDefineOutcome::Defined => {
+                    return f64::from_bits(obj_value_handle.get_heap_word_u64());
+                }
                 super::super::TypedArrayDefineOutcome::Rejected => {
                     throw_object_type_error(b"Cannot redefine property")
                 }
                 super::super::TypedArrayDefineOutcome::NotTypedArray => {}
             }
         }
+
+        // Everything below must start from the post-probe addresses. The
+        // ordinary arm keeps re-reading these same handles via `across!`.
+        let obj_value = f64::from_bits(obj_value_handle.get_heap_word_u64());
+        let descriptor_value = desc_handle.get_nanbox_f64();
+        let key_value = key_handle.get_nanbox_f64();
 
         // Date / RegExp / Error instances are exotic cells, not
         // `ObjectHeader`s — the ordinary define path below would bit-cast
@@ -1013,13 +1029,6 @@ pub extern "C" fn js_object_define_property(
         // runs the call FIRST and rebinds every one from its root afterwards,
         // so a pre-collection address is never nameable.
         let obj_handle = scope.root_raw_mut_ptr(obj);
-        let obj_value_handle = scope.root_heap_word_u64(obj_value.to_bits());
-        let desc_handle = scope.root_nanbox_f64(descriptor_value);
-        // `key_value` is rooted too: the non-indexable fallback far below
-        // passes it RAW into `obj_value_has_own_key`, which re-coerces it. An
-        // object / BigInt key evacuated by the coercion on the next line would
-        // be dereferenced again there.
-        let key_handle = scope.root_nanbox_f64(key_value);
         let (key_str, mut obj) = obj_handle
             .across_mut::<ObjectHeader, _>(|| crate::builtins::js_string_coerce(key_value));
         let mut obj_value = f64::from_bits(obj_value_handle.get_heap_word_u64());

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -245,11 +245,28 @@ fn reflect_bool(b: bool) -> f64 {
 /// reporting success as a NaN-boxed boolean. Shared by `crate::proxy`'s
 /// `Reflect.defineProperty` entry point (both the no-trap and direct paths).
 pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f64 {
+    // #8507: each exotic probe below may coerce `key`, which can run user JS
+    // and evacuate all three operands. A helper's private handle scope keeps
+    // its arguments current only for that helper; when it returns
+    // `NotTypedArray` / `None`, the copies in this caller would still name
+    // from-space. Keep one caller-owned set of roots and re-read it before
+    // every subsequent operation.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_heap_word_u64(obj.to_bits());
+    let key_handle = scope.root_nanbox_f64(key);
+    let descriptor_handle = scope.root_nanbox_f64(descriptor);
+
     // TypedArrays are Integer-Indexed exotic objects: a canonical numeric index
     // key returns true/false here rather than going through the ordinary object
     // machinery (which would mishandle in-bounds element writes and treats the
     // view as non-extensible).
-    match unsafe { super::typed_array_define_own_property(obj, key, descriptor) } {
+    match unsafe {
+        super::typed_array_define_own_property(
+            f64::from_bits(obj_handle.get_heap_word_u64()),
+            key_handle.get_nanbox_f64(),
+            descriptor_handle.get_nanbox_f64(),
+        )
+    } {
         super::TypedArrayDefineOutcome::Defined => return reflect_bool(true),
         super::TypedArrayDefineOutcome::Rejected => return reflect_bool(false),
         super::TypedArrayDefineOutcome::NotTypedArray => {}
@@ -258,22 +275,38 @@ pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f6
     // reports success/failure as a boolean here rather than throwing — bypass
     // the generic non-configurable pre-check below, which would mishandle the
     // (non-configurable but writable) `length` property.
-    if let Some(ok) = unsafe { super::array_length_reflect_define(obj, key, descriptor) } {
+    if let Some(ok) = unsafe {
+        super::array_length_reflect_define(
+            f64::from_bits(obj_handle.get_heap_word_u64()),
+            key_handle.get_nanbox_f64(),
+            descriptor_handle.get_nanbox_f64(),
+        )
+    } {
         return reflect_bool(ok);
     }
-    let has_own = obj_value_has_own_key(obj, key);
+    let has_own = obj_value_has_own_key(
+        f64::from_bits(obj_handle.get_heap_word_u64()),
+        key_handle.get_nanbox_f64(),
+    );
     // Redefining a non-configurable existing property fails.
     if has_own {
-        if let Some((_writable, configurable)) = obj_value_attrs(obj, key) {
+        if let Some((_writable, configurable)) = obj_value_attrs(
+            f64::from_bits(obj_handle.get_heap_word_u64()),
+            key_handle.get_nanbox_f64(),
+        ) {
             if !configurable {
                 return reflect_bool(false);
             }
         }
-    } else if obj_value_no_extend(obj) {
+    } else if obj_value_no_extend(f64::from_bits(obj_handle.get_heap_word_u64())) {
         // Defining a brand-new property on a non-extensible object fails.
         return reflect_bool(false);
     }
-    super::js_object_define_property(obj, key, descriptor);
+    super::js_object_define_property(
+        f64::from_bits(obj_handle.get_heap_word_u64()),
+        key_handle.get_nanbox_f64(),
+        descriptor_handle.get_nanbox_f64(),
+    );
     reflect_bool(true)
 }
 

--- a/crates/perry-runtime/src/object/typed_array_define.rs
+++ b/crates/perry-runtime/src/object/typed_array_define.rs
@@ -113,7 +113,13 @@ fn is_valid_integer_index(index: f64, length: u32) -> bool {
 
 /// Is the descriptor's `name` field present and falsy (`{ name: false }`)?
 unsafe fn field_present_and_false(desc: *mut ObjectHeader, name: &[u8]) -> bool {
+    // #8507: allocating the field-name string can evacuate the descriptor
+    // before the following keys-array walk. Re-read it from a root after the
+    // allocation rather than dereferencing the incoming raw pointer.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let desc_handle = scope.root_raw_mut_ptr(desc);
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let desc = desc_handle.get_raw_mut_ptr::<ObjectHeader>();
     if !own_key_present(desc, key) {
         return false;
     }
@@ -123,8 +129,10 @@ unsafe fn field_present_and_false(desc: *mut ObjectHeader, name: &[u8]) -> bool 
 
 /// Is the descriptor's `name` field present (regardless of value)?
 unsafe fn field_present(desc: *mut ObjectHeader, name: &[u8]) -> bool {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let desc_handle = scope.root_raw_mut_ptr(desc);
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    own_key_present(desc, key)
+    own_key_present(desc_handle.get_raw_mut_ptr::<ObjectHeader>(), key)
 }
 
 /// If `key_value` is a String key that is a CanonicalNumericIndexString, return
@@ -219,16 +227,18 @@ pub(crate) unsafe fn typed_array_define_own_property(
         // Symbol / non-string / non-canonical key → ordinary define handles it.
         return TypedArrayDefineOutcome::NotTypedArray;
     };
-    let descriptor_value = desc_handle.get_nanbox_f64();
-
     // Canonical numeric index → integer-indexed branch. From here every path
     // returns Rejected or Defined; we never fall back to ordinary define.
     if !is_valid_integer_index(numeric_index, length) {
         return TypedArrayDefineOutcome::Rejected;
     }
 
-    let desc = extract_obj_ptr(descriptor_value);
-    if desc.is_null() {
+    // Every descriptor-field probe below allocates, so derive the raw pointer
+    // from the existing descriptor root at each use. The helper-local roots
+    // keep an individual probe safe; this outer root carries the updated
+    // address from one probe to the next (#8507).
+    let desc = || extract_obj_ptr(desc_handle.get_nanbox_f64());
+    if desc().is_null() {
         // Descriptor isn't ObjectHeader-backed; nothing constrains the index, so
         // accept with no element write (matches an all-default data descriptor).
         return TypedArrayDefineOutcome::Defined;
@@ -236,24 +246,24 @@ pub(crate) unsafe fn typed_array_define_own_property(
 
     // A valid integer index requires a configurable, enumerable, writable data
     // descriptor. Any field that contradicts that rejects the definition.
-    if field_present_and_false(desc, b"configurable") {
+    if field_present_and_false(desc(), b"configurable") {
         return TypedArrayDefineOutcome::Rejected;
     }
-    if field_present_and_false(desc, b"enumerable") {
+    if field_present_and_false(desc(), b"enumerable") {
         return TypedArrayDefineOutcome::Rejected;
     }
-    if field_present(desc, b"get") || field_present(desc, b"set") {
+    if field_present(desc(), b"get") || field_present(desc(), b"set") {
         return TypedArrayDefineOutcome::Rejected; // accessor descriptor
     }
-    if field_present_and_false(desc, b"writable") {
+    if field_present_and_false(desc(), b"writable") {
         return TypedArrayDefineOutcome::Rejected;
     }
 
     // If the descriptor carries a value, perform IntegerIndexedElementSet. The
     // ToNumber coercion may run user `valueOf` (and throw) before the write.
     let value_key = crate::string::js_string_from_bytes(b"value".as_ptr(), 5);
-    if own_key_present(desc, value_key) {
-        let value_field = js_object_get_field_by_name(desc as *const ObjectHeader, value_key);
+    if own_key_present(desc(), value_key) {
+        let value_field = js_object_get_field_by_name(desc() as *const ObjectHeader, value_key);
         let value = f64::from_bits(value_field.bits());
         // Object values coerce via OrdinaryToPrimitive(number) first, running a
         // user `valueOf`/`toString` (which may throw). The resulting primitive is


### PR DESCRIPTION
Closes #8507.

`Reflect.defineProperty` and `Object.defineProperty` called individually-rooted exotic helpers, then reused their own raw receiver/key/descriptor copies when a helper returned `NotTypedArray` or `None`. A key coercion inside the helper could evacuate those operands, leaving the caller to continue with from-space addresses. TypedArray and array-length descriptor processing also retained raw descriptor/array pointers across field-name allocations and user coercions.

This change keeps caller-owned handles across the full define-property sequence, re-reads operands between exotic probes, and roots/re-reads TypedArray and array-length descriptor operands at every allocation boundary.

No version bump or changelog fragment is included.

Validation:
- `PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800 RUST_TEST_THREADS=1 cargo test --release -p perry --test gc_string_coerce_property_key_rooting_6943 -- --nocapture` (3/3)
- `cargo test -p perry-runtime rooted_define_property -- --nocapture` (3/3)
- `cargo check -p perry-runtime`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when defining object, array, and TypedArray properties during garbage collection.
  * Prevented property descriptors, keys, and target objects from becoming stale while operations allocate memory or coerce values.
  * Preserved existing validation, length-restriction, attribute, and element-write behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->