### PR TITLE
fix(runtime): make the path-module registry per-heap so one process can host several apps

### DIFF
--- a/changelog.d/8528-module-path-registry-per-heap.md
+++ b/changelog.d/8528-module-path-registry-per-heap.md
@@ -18,6 +18,15 @@
   entry; making the whole table per-heap instead left later heaps silently
   resolving modules to an empty `module.exports`.
 
+  Both the export table and the initializer-address map are per-heap. A
+  process-wide address map was tried and measured wrong: a host that loads
+  several application libraries gets its own copy of each module per library,
+  at its own code address, under the SAME baked canonical path, so the map saw
+  "same path, different address" and refused the second library as a duplicate.
+  Two Next.js applications in one Coop process produced 115 such rejections,
+  with the second application's modules never initializing (200 for the first,
+  500 for the second).
+
   Keyed by thread rather than by `AgentId`, deliberately: `CURRENT_AGENT` is
   itself a `thread_local!` defaulting to `PRIMARY_AGENT`, and an embedder's app
   thread is a plain `std::thread::spawn` that never calls `enter_worker_agent()`,

--- a/changelog.d/8528-module-path-registry-per-heap.md
+++ b/changelog.d/8528-module-path-registry-per-heap.md
@@ -1,0 +1,31 @@
+### Fixed
+
+- **Runtime: the path-module registry is now per-heap, so one process can host
+  several Perry applications.** `PathModuleEntry::exports` holds NaN-boxed
+  pointers into the arena of the thread that produced them, and both the arena
+  and the mutable-root scanners are thread-local. The registry was
+  process-global, so a single `OnceLock<ThreadId>` had to fail closed for every
+  later thread (`ERR_PERRY_PATH_MODULE_THREAD`) to stop one heap's pointer
+  reaching another heap's collector — which meant a host could load at most one
+  application that uses runtime path modules.
+
+  The table conflated two facts with different lifetimes. A canonical path's
+  `<prefix>__init` **address** is a property of the program: codegen registers it
+  once, on whichever thread runs module init first, and it is a code pointer no
+  collector cares about — so it stays process-wide. The **exports** and status
+  are arena pointers, so they are per-heap. A heap that has never required a
+  path now adopts the program-wide initializer rather than inventing an empty
+  entry; making the whole table per-heap instead left later heaps silently
+  resolving modules to an empty `module.exports`.
+
+  Keyed by thread rather than by `AgentId`, deliberately: `CURRENT_AGENT` is
+  itself a `thread_local!` defaulting to `PRIMARY_AGENT`, and an embedder's app
+  thread is a plain `std::thread::spawn` that never calls `enter_worker_agent()`,
+  so agent-keying would hand every app in a host one shared table. The GC scanner
+  drops its owner gate for the same reason — the collector running it owns every
+  pointer in the table by construction — and uses `try_with` so a scanner running
+  during an app thread's heap teardown cannot panic on a destroyed thread-local.
+
+  Reachable only through Next.js chunk loading (`js_register_path_init` is
+  emitted for `nextjs_path_init_modules` alone), so ordinary programs are
+  unaffected.

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -828,7 +828,7 @@ pub fn gc_init() {
     );
     reg_scanner!(crate::promise::scan_native_async_completion_roots_mut);
     // Runtime path-module exports and cached initialization errors live in a
-    // provider-owned Rust registry, so moving GC must mark and rewrite them.
+    // per-heap Rust registry, so moving GC must mark and rewrite them.
     reg_scanner!(crate::module_require::scan_module_path_roots_mut);
     reg_budgeted_scanner!(
         promise_mutable_root_scanner,

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -1021,7 +1021,12 @@ pub fn scan_module_path_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_
     // No owner gate: the table is per-heap, so the collector running this
     // scanner is by construction the one that owns every pointer in it. A
     // gate here would leave every heap but the first one unscanned.
-    MODULE_PATH_REGISTRY.with(|registry| registry.scan_roots(visitor));
+    //
+    // `try_with`, not `with`: a Coop app thread tears down its heap when the
+    // deployment stops, and a scanner that ran during that teardown would
+    // panic on the destroyed thread-local. A destroyed table holds no live
+    // pointer worth rewriting, so reporting is the whole handling.
+    let _ = MODULE_PATH_REGISTRY.try_with(|registry| registry.scan_roots(visitor));
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -408,7 +408,7 @@ fn cjs_record_field(value: f64, name: &str) -> Option<f64> {
 fn registered_path_module_value(path: &str) -> Option<f64> {
     let key = canonicalize_module_path(path);
     MODULE_PATH_REGISTRY
-        .published_exports(&key)
+        .with(|registry| registry.published_exports(&key))
         .map(f64::from_bits)
 }
 
@@ -806,16 +806,6 @@ crate::perry_thread_local! {
     static PENDING_REQUIRE_PARENT: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 
-fn require_path_module_runtime_owner(operation: &str) {
-    if MODULE_PATH_REGISTRY.bind_runtime_owner() {
-        return;
-    }
-    let message = format!(
-        "Perry path-module {operation} must run on the runtime thread that owns the JavaScript heap"
-    );
-    crate::fs::validate::throw_error_with_code(&message, "ERR_PERRY_PATH_MODULE_THREAD")
-}
-
 fn canonicalize_module_path(path: &str) -> String {
     std::fs::canonicalize(path)
         .map(|p| p.to_string_lossy().into_owned())
@@ -832,11 +822,10 @@ fn canonicalize_module_path(path: &str) -> String {
 /// initializer (from `ptrtoint` of the symbol).
 #[no_mangle]
 pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i64, init_addr: i64) {
-    require_path_module_runtime_owner("initializer registration");
     let slice = std::slice::from_raw_parts(path_ptr, path_len as usize);
     let path = String::from_utf8_lossy(slice).into_owned();
     let key = canonicalize_module_path(&path);
-    if !MODULE_PATH_REGISTRY.register_init(key.clone(), init_addr as usize) {
+    if !MODULE_PATH_REGISTRY.with(|r| r.register_init(key.clone(), init_addr as usize)) {
         eprintln!("perry: rejected duplicate path-module initializer for canonical path {key}");
     }
 }
@@ -847,10 +836,9 @@ pub unsafe extern "C" fn js_register_path_init(path_ptr: *const u8, path_len: i6
 /// generated initializer to complete.
 #[no_mangle]
 pub extern "C" fn js_register_path_module_partial(path_value: f64, exports: f64) {
-    require_path_module_runtime_owner("partial-export publication");
     let path = value_to_string(path_value, "path");
     let key = canonicalize_module_path(&path);
-    if !MODULE_PATH_REGISTRY.register_partial_exports(key, exports.to_bits()) {
+    if !MODULE_PATH_REGISTRY.with(|r| r.register_partial_exports(key, exports.to_bits())) {
         crate::fs::validate::throw_error_with_code(
             "Perry rejected path-module partial exports from a non-owner initializer",
             "ERR_PERRY_PATH_MODULE_OWNER",
@@ -892,12 +880,13 @@ pub extern "C" fn js_link_path_module_parent(record: f64) {
 /// [`MODULE_PATH_REGISTRY`].
 #[no_mangle]
 pub extern "C" fn js_register_path_module(path_value: f64, exports: f64) {
-    require_path_module_runtime_owner("final-export publication");
     let scope = crate::gc::RuntimeHandleScope::new();
     let exports = scope.root_nanbox_f64(exports);
     let path = value_to_string(path_value, "path");
     let key = canonicalize_module_path(&path);
-    if !MODULE_PATH_REGISTRY.register_final_exports(key, exports.get_nanbox_f64().to_bits()) {
+    if !MODULE_PATH_REGISTRY
+        .with(|r| r.register_final_exports(key, exports.get_nanbox_f64().to_bits()))
+    {
         crate::fs::validate::throw_error_with_code(
             "Perry rejected path-module final exports from a non-owner initializer",
             "ERR_PERRY_PATH_MODULE_OWNER",
@@ -916,17 +905,18 @@ pub extern "C" fn js_register_path_module(path_value: f64, exports: f64) {
 #[no_mangle]
 pub unsafe extern "C" fn js_run_module_init_catching(init_addr: i64) {
     let init_fn: extern "C" fn() = std::mem::transmute::<usize, _>(init_addr as usize);
-    let boundary = MODULE_PATH_REGISTRY.begin_module_boundary();
+    let boundary = MODULE_PATH_REGISTRY.with(|r| r.begin_module_boundary());
     let outcome = crate::exception::js_call_catching(|| {
         init_fn();
         undefined()
     });
     match outcome {
         Ok(_) => {
-            MODULE_PATH_REGISTRY.finish_module_boundary(boundary, None);
+            MODULE_PATH_REGISTRY.with(|r| r.finish_module_boundary(boundary, None));
         }
         Err(error) => {
-            MODULE_PATH_REGISTRY.finish_module_boundary(boundary, Some(error.to_bits()));
+            MODULE_PATH_REGISTRY
+                .with(|r| r.finish_module_boundary(boundary, Some(error.to_bits())));
             crate::exception::js_throw(error)
         }
     }
@@ -966,7 +956,7 @@ fn run_path_initializer(addr: usize) -> Result<(), u64> {
 }
 
 fn require_path_key(key: &str) -> Result<Option<u64>, PathModuleRequireError> {
-    MODULE_PATH_REGISTRY.require_with(key, &run_path_initializer)
+    MODULE_PATH_REGISTRY.with(|r| r.require_with(key, &run_path_initializer))
 }
 
 /// Codegen FFI: resolve a runtime `require(absolutePath.js)` to an AOT module.
@@ -974,7 +964,6 @@ fn require_path_key(key: &str) -> Result<Option<u64>, PathModuleRequireError> {
 /// partial exports, while unrelated waiters receive only the final namespace.
 #[no_mangle]
 pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
-    require_path_module_runtime_owner("require");
     let path = value_to_string(path_value, "id");
     let key = canonicalize_module_path(&path);
     match require_path_key(&key) {
@@ -1014,34 +1003,35 @@ pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
 /// returned value is undefined to distinguish that value from a registry miss.
 #[no_mangle]
 pub extern "C" fn js_has_path_module(path_value: f64) -> f64 {
-    require_path_module_runtime_owner("presence lookup");
     let path = value_to_string(path_value, "id");
     let key = canonicalize_module_path(&path);
-    let found = MODULE_PATH_REGISTRY.has_exports(&key)
-        || directory_module_candidates(&key)
-            .into_iter()
-            .map(|candidate| canonicalize_module_path(&candidate))
-            .any(|candidate| MODULE_PATH_REGISTRY.has_exports(&candidate));
+    let found = MODULE_PATH_REGISTRY.with(|registry| {
+        registry.has_exports(&key)
+            || directory_module_candidates(&key)
+                .into_iter()
+                .map(|candidate| canonicalize_module_path(&candidate))
+                .any(|candidate| registry.has_exports(&candidate))
+    });
     f64::from_bits(if found { TAG_TRUE } else { TAG_FALSE })
 }
 
 /// Keep path-registry exports and cached exception values alive and rewrite
 /// them when a copying collection moves their referents.
 pub fn scan_module_path_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    if MODULE_PATH_REGISTRY.is_runtime_owner() {
-        MODULE_PATH_REGISTRY.scan_roots(visitor);
-    }
+    // No owner gate: the table is per-heap, so the collector running this
+    // scanner is by construction the one that owns every pointer in it. A
+    // gate here would leave every heap but the first one unscanned.
+    MODULE_PATH_REGISTRY.with(|registry| registry.scan_roots(visitor));
 }
 
 #[cfg(test)]
 pub(crate) fn test_store_path_module_root(key: &str, value_bits: u64) {
-    assert!(MODULE_PATH_REGISTRY.bind_runtime_owner());
-    assert!(MODULE_PATH_REGISTRY.register_final_exports(key.to_string(), value_bits));
+    assert!(MODULE_PATH_REGISTRY.with(|r| r.register_final_exports(key.to_string(), value_bits)));
 }
 
 #[cfg(test)]
 pub(crate) fn test_remove_path_module_root(key: &str) {
-    MODULE_PATH_REGISTRY.remove_for_test(key);
+    MODULE_PATH_REGISTRY.with(|r| r.remove_for_test(key));
 }
 
 /// Node-style `require.resolve` fallback for package-subpath specifiers that

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -538,31 +538,35 @@ impl PathModuleRegistry {
 /// tests registering DIFFERENT addresses for the same canonical path would
 /// otherwise collide, and the second would be rejected by the idempotence
 /// check below.
+/// `Option` because `HashMap::new` is not const and this must also compile as
+/// a plain `static` outside a test build.
 per_test_global!(
-    static PATH_MODULE_INIT_ADDRS: std::sync::Mutex<std::collections::HashMap<String, usize>> =
-        std::sync::Mutex::new(std::collections::HashMap::new())
+    static PATH_MODULE_INIT_ADDRS: std::sync::Mutex<
+        Option<std::collections::HashMap<String, usize>>,
+    > = std::sync::Mutex::new(None)
 );
 
-fn init_addrs() -> std::sync::MutexGuard<'static, std::collections::HashMap<String, usize>> {
-    PATH_MODULE_INIT_ADDRS
+fn with_init_addrs<R>(f: impl FnOnce(&mut std::collections::HashMap<String, usize>) -> R) -> R {
+    let mut guard = PATH_MODULE_INIT_ADDRS
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    f(guard.get_or_insert_with(std::collections::HashMap::new))
 }
 
 /// Idempotent. A second, DIFFERENT address for one canonical path is rejected
 /// so an alias can never create a second logical module initialization.
 fn register_init_addr(key: &str, init_addr: usize) -> bool {
-    match init_addrs().entry(key.to_string()) {
+    with_init_addrs(|addrs| match addrs.entry(key.to_string()) {
         std::collections::hash_map::Entry::Occupied(slot) => *slot.get() == init_addr,
         std::collections::hash_map::Entry::Vacant(slot) => {
             slot.insert(init_addr);
             true
         }
-    }
+    })
 }
 
 fn lookup_init_addr(key: &str) -> Option<usize> {
-    init_addrs().get(key).copied()
+    with_init_addrs(|addrs| addrs.get(key).copied())
 }
 
 crate::perry_thread_local! {

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -530,16 +530,20 @@ impl PathModuleRegistry {
     }
 }
 
-/// Canonical path -> generated initializer address, shared by every heap in
-/// the process. Holds only code addresses, so unlike the per-heap export table
-/// it is not a GC root and needs no scanner.
-///
-/// `per_test_global!` because `perry-runtime`'s tests share one process: two
-/// tests registering DIFFERENT addresses for the same canonical path would
-/// otherwise collide, and the second would be rejected by the idempotence
-/// check below.
-/// `Option` because `HashMap::new` is not const and this must also compile as
-/// a plain `static` outside a test build.
+// Canonical path -> generated initializer address, shared by every heap in
+// the process. Holds only code addresses, so unlike the per-heap export table
+// it is not a GC root and needs no scanner.
+//
+// `per_test_global!` because `perry-runtime`'s tests share one process: two
+// tests registering DIFFERENT addresses for the same canonical path would
+// otherwise collide, and the second would be rejected by the idempotence
+// check below.
+// `Option` because `HashMap::new` is not const and this must also compile as
+// a plain `static` outside a test build.
+//
+// Plain `//`: a `///` here attaches to nothing the macro emits, so rustc drops
+// it and `-D warnings` (a required PR gate) rejects the build. The rationale
+// above is the point of the comment, so keep it — just not as rustdoc.
 per_test_global!(
     static PATH_MODULE_INIT_ADDRS: std::sync::Mutex<
         Option<std::collections::HashMap<String, usize>>,

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -898,6 +898,36 @@ mod path_module_registry_tests {
         });
     }
 
+    /// The Coop shape: many apps in one process load the SAME module path.
+    /// Each heap must run its own initializer and get its own exports, with
+    /// no thread refused and no initializer skipped as already-done.
+    #[test]
+    fn every_heap_runs_its_own_initializer_for_the_same_path() {
+        const KEY: &str = "/shared-bundle-path.js";
+        fn init_on_this_heap(marker: u64) -> Option<u64> {
+            MODULE_PATH_REGISTRY.with(|registry| {
+                assert!(registry.register_init(KEY.into(), 0x2000));
+                let ran = std::cell::Cell::new(false);
+                let outcome = registry.require_with(KEY, &|_addr| {
+                    ran.set(true);
+                    assert!(registry.register_final_exports(KEY.into(), marker));
+                    Ok(())
+                });
+                assert!(ran.get(), "this heap's initializer must actually run");
+                outcome.expect("no heap may be refused ownership")
+            })
+        }
+
+        let first = init_on_this_heap(0xA1);
+        let second = std::thread::spawn(|| init_on_this_heap(0xB2))
+            .join()
+            .unwrap();
+
+        assert_eq!(first, Some(0xA1));
+        assert_eq!(second, Some(0xB2), "the second heap got the first heap's value");
+        MODULE_PATH_REGISTRY.with(|registry| registry.remove_for_test(KEY));
+    }
+
     #[test]
     fn undefined_export_is_present_and_distinct_from_a_miss() {
         let registry = PathModuleRegistry::default();

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -118,10 +118,6 @@ impl PathModuleState {
 pub(super) struct PathModuleRegistry {
     state: std::sync::Mutex<PathModuleState>,
     ready: std::sync::Condvar,
-    /// Perry heaps and mutable-root scanners are thread-local. The provider
-    /// registry is process-global for app-dylib symbol resolution, but its JS
-    /// values must remain confined to the one runtime thread that owns them.
-    runtime_owner: std::sync::OnceLock<std::thread::ThreadId>,
 }
 
 impl Default for PathModuleRegistry {
@@ -129,7 +125,6 @@ impl Default for PathModuleRegistry {
         Self {
             state: std::sync::Mutex::new(PathModuleState::default()),
             ready: std::sync::Condvar::new(),
-            runtime_owner: std::sync::OnceLock::new(),
         }
     }
 }
@@ -139,17 +134,6 @@ impl PathModuleRegistry {
         self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    pub(super) fn bind_runtime_owner(&self) -> bool {
-        let current = std::thread::current().id();
-        self.runtime_owner.get_or_init(|| current) == &current
-    }
-
-    pub(super) fn is_runtime_owner(&self) -> bool {
-        self.runtime_owner
-            .get()
-            .is_some_and(|owner| *owner == std::thread::current().id())
     }
 
     /// Register one canonical path -> initializer mapping. The same mapping is
@@ -514,8 +498,16 @@ impl PathModuleRegistry {
     }
 }
 
-pub(super) static MODULE_PATH_REGISTRY: std::sync::LazyLock<PathModuleRegistry> =
-    std::sync::LazyLock::new(PathModuleRegistry::default);
+crate::perry_thread_local! {
+    /// Per-heap, not per-process. `PathModuleEntry::exports` holds NaN-boxed
+    /// pointers into the arena of the thread that produced them, and both the
+    /// arena and the mutable-root scanners are thread-local — so a
+    /// process-global table would hand one heap's pointer to another heap's
+    /// collector. One table per runtime thread keeps every entry's referent in
+    /// the same heap as the scanner that rewrites it, which is what lets a
+    /// single process host more than one Perry application.
+    pub(super) static MODULE_PATH_REGISTRY: PathModuleRegistry = PathModuleRegistry::default();
+}
 
 #[cfg(test)]
 mod path_module_registry_tests {
@@ -877,18 +869,33 @@ mod path_module_registry_tests {
         );
     }
 
+    /// Each runtime thread owns its own table. An entry published on one
+    /// thread must be invisible to another: `exports` is a NaN-boxed pointer
+    /// into the publishing thread's arena, and only that thread's scanner
+    /// rewrites it. This is what lets one process host several Perry apps.
     #[test]
-    fn provider_registry_binds_to_one_runtime_thread() {
-        let registry = Arc::new(PathModuleRegistry::default());
-        assert!(registry.bind_runtime_owner());
-        assert!(registry.is_runtime_owner());
-        let worker_registry = Arc::clone(&registry);
-        assert!(
-            !std::thread::spawn(move || worker_registry.bind_runtime_owner())
-                .join()
-                .unwrap()
+    fn path_registry_is_per_heap_not_per_process() {
+        const KEY: &str = "/per-heap-isolation-fixture.js";
+        MODULE_PATH_REGISTRY.with(|registry| {
+            assert!(registry.register_final_exports(KEY.into(), 0xD1));
+            assert_eq!(registry.published_exports(KEY), Some(0xD1));
+        });
+
+        let seen_by_second_heap = std::thread::spawn(|| {
+            MODULE_PATH_REGISTRY.with(|registry| registry.published_exports(KEY))
+        })
+        .join()
+        .unwrap();
+        assert_eq!(
+            seen_by_second_heap, None,
+            "a second heap must not observe the first heap's exports pointer"
         );
-        assert!(registry.is_runtime_owner());
+
+        // The publishing thread still sees its own entry: isolation, not loss.
+        MODULE_PATH_REGISTRY.with(|registry| {
+            assert_eq!(registry.published_exports(KEY), Some(0xD1));
+            registry.remove_for_test(KEY);
+        });
     }
 
     #[test]

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -506,6 +506,24 @@ crate::perry_thread_local! {
     /// collector. One table per runtime thread keeps every entry's referent in
     /// the same heap as the scanner that rewrites it, which is what lets a
     /// single process host more than one Perry application.
+    ///
+    /// Keyed by THREAD, not by [`crate::agent::AgentId`], even though #6294
+    /// established agent tagging for the cross-thread queues. The two are
+    /// keyed differently on purpose:
+    ///
+    /// - An agent tags *queued work* so a drain can tell whose pointers it may
+    ///   touch. A thread with no agent of its own resolves to `PRIMARY_AGENT`
+    ///   because it is a pump acting for the primary heap.
+    /// - This table instead holds pointers into an *arena*, and the arena is
+    ///   itself a `thread_local!` (`thread.rs`). Thread is therefore exactly
+    ///   the domain those pointers live and die in.
+    ///
+    /// The distinction is load-bearing for embedders: a Coop app thread is a
+    /// plain `std::thread::spawn`, not a `perry/thread` worker, so it never
+    /// calls `enter_worker_agent()` and every such thread resolves to
+    /// `PRIMARY_AGENT`. Agent-keying would hand all of a host's apps one
+    /// shared table — the bug this replaced, minus the guard that used to make
+    /// it loud.
     pub(super) static MODULE_PATH_REGISTRY: PathModuleRegistry = PathModuleRegistry::default();
 }
 

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -530,31 +530,34 @@ impl PathModuleRegistry {
     }
 }
 
-// Canonical path -> generated initializer address, shared by every heap in
-// the process. Holds only code addresses, so unlike the per-heap export table
-// it is not a GC root and needs no scanner.
-//
-// `per_test_global!` because `perry-runtime`'s tests share one process: two
-// tests registering DIFFERENT addresses for the same canonical path would
-// otherwise collide, and the second would be rejected by the idempotence
-// check below.
-// `Option` because `HashMap::new` is not const and this must also compile as
-// a plain `static` outside a test build.
-//
-// Plain `//`: a `///` here attaches to nothing the macro emits, so rustc drops
-// it and `-D warnings` (a required PR gate) rejects the build. The rationale
-// above is the point of the comment, so keep it — just not as rustdoc.
-per_test_global!(
-    static PATH_MODULE_INIT_ADDRS: std::sync::Mutex<
-        Option<std::collections::HashMap<String, usize>>,
-    > = std::sync::Mutex::new(None)
-);
+crate::perry_thread_local! {
+    /// Canonical path -> generated initializer address, per-heap like the
+    /// export table beside it. Holds only code addresses, so unlike that table
+    /// it is not a GC root and needs no scanner.
+    ///
+    /// An initializer address looks like a property of the program, and within
+    /// ONE program it is — but a host that loads several application libraries
+    /// into one process gets a separate copy of each module per library, at its
+    /// own code address, under the SAME baked canonical path. A process-wide
+    /// map then sees "same path, different address", refuses the second
+    /// library's registration as a duplicate, and that application's modules
+    /// never initialize. Measured: two Next apps in one Coop process, 115
+    /// rejections, the second app serving 500 while the first served 200.
+    ///
+    /// Every heap registers its own initializers as its library runs
+    /// `perry_module_init` on its own thread, so per-heap loses nothing.
+    ///
+    /// These are rustdoc rather than plain `//` because `perry_thread_local!`
+    /// passes `#[$attr]` through onto the static it emits. A `///` placed
+    /// BEFORE the macro invocation instead attaches to nothing, and `-D
+    /// warnings` (a required PR gate) then rejects the build.
+    static PATH_MODULE_INIT_ADDRS: std::cell::RefCell<
+        std::collections::HashMap<String, usize>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+}
 
 fn with_init_addrs<R>(f: impl FnOnce(&mut std::collections::HashMap<String, usize>) -> R) -> R {
-    let mut guard = PATH_MODULE_INIT_ADDRS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    f(guard.get_or_insert_with(std::collections::HashMap::new))
+    PATH_MODULE_INIT_ADDRS.with(|addrs| f(&mut addrs.borrow_mut()))
 }
 
 /// Idempotent. A second, DIFFERENT address for one canonical path is rejected

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -1024,7 +1024,11 @@ mod path_module_registry_tests {
             .unwrap();
 
         assert_eq!(first, Some(0xA1));
-        assert_eq!(second, Some(0xB2), "the second heap got the first heap's value");
+        assert_eq!(
+            second,
+            Some(0xB2),
+            "the second heap got the first heap's value"
+        );
         MODULE_PATH_REGISTRY.with(|registry| registry.remove_for_test(KEY));
     }
 

--- a/crates/perry-runtime/src/module_require/path_registry.rs
+++ b/crates/perry-runtime/src/module_require/path_registry.rs
@@ -140,6 +140,15 @@ impl PathModuleRegistry {
     /// idempotent. A second address for the same canonical file is rejected so
     /// an alias can never create a second logical module initialization.
     pub(super) fn register_init(&self, key: String, init_addr: usize) -> bool {
+        // The address is a property of the PROGRAM, not of any heap: codegen
+        // emits one `<prefix>__init` per canonical path and registers it once,
+        // on whichever thread runs module init first. Every later heap needs
+        // that same address to be able to initialize the module for itself, so
+        // it lives in a process-global map. It is a code pointer, never a JS
+        // value, so no collector has any interest in it.
+        if !register_init_addr(&key, init_addr) {
+            return false;
+        }
         let mut state = self.lock();
         let entry = state.entries.entry(key).or_insert_with(|| PathModuleEntry {
             init_addr: None,
@@ -147,10 +156,30 @@ impl PathModuleRegistry {
             status: PathModuleStatus::Registered,
             active_claim: None,
         });
-        if let Some(existing) = entry.init_addr {
-            return existing == init_addr;
-        }
         entry.init_addr = Some(init_addr);
+        true
+    }
+
+    /// Adopt the program-wide initializer for `key` into THIS heap's table.
+    /// A heap that has never required the path has no entry for it, but the
+    /// initializer exists process-wide; without this a second heap silently
+    /// resolves the module to an empty `module.exports`.
+    fn adopt_registered_init(&self, state: &mut PathModuleState, key: &str) -> bool {
+        if state.entries.contains_key(key) {
+            return true;
+        }
+        let Some(init_addr) = lookup_init_addr(key) else {
+            return false;
+        };
+        state.entries.insert(
+            key.to_string(),
+            PathModuleEntry {
+                init_addr: Some(init_addr),
+                exports: None,
+                status: PathModuleStatus::Registered,
+                active_claim: None,
+            },
+        );
         true
     }
 
@@ -354,6 +383,9 @@ impl PathModuleRegistry {
         let current = std::thread::current().id();
         let init_addr = loop {
             let mut state = self.lock();
+            if !self.adopt_registered_init(&mut state, key) {
+                return Ok(None);
+            }
             let Some(entry) = state.entries.get_mut(key) else {
                 return Ok(None);
             };
@@ -496,6 +528,41 @@ impl PathModuleRegistry {
     pub(super) fn remove_for_test(&self, key: &str) {
         self.lock().entries.remove(key);
     }
+}
+
+/// Canonical path -> generated initializer address, shared by every heap in
+/// the process. Holds only code addresses, so unlike the per-heap export table
+/// it is not a GC root and needs no scanner.
+///
+/// `per_test_global!` because `perry-runtime`'s tests share one process: two
+/// tests registering DIFFERENT addresses for the same canonical path would
+/// otherwise collide, and the second would be rejected by the idempotence
+/// check below.
+per_test_global!(
+    static PATH_MODULE_INIT_ADDRS: std::sync::Mutex<std::collections::HashMap<String, usize>> =
+        std::sync::Mutex::new(std::collections::HashMap::new())
+);
+
+fn init_addrs() -> std::sync::MutexGuard<'static, std::collections::HashMap<String, usize>> {
+    PATH_MODULE_INIT_ADDRS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Idempotent. A second, DIFFERENT address for one canonical path is rejected
+/// so an alias can never create a second logical module initialization.
+fn register_init_addr(key: &str, init_addr: usize) -> bool {
+    match init_addrs().entry(key.to_string()) {
+        std::collections::hash_map::Entry::Occupied(slot) => *slot.get() == init_addr,
+        std::collections::hash_map::Entry::Vacant(slot) => {
+            slot.insert(init_addr);
+            true
+        }
+    }
+}
+
+fn lookup_init_addr(key: &str) -> Option<usize> {
+    init_addrs().get(key).copied()
 }
 
 crate::perry_thread_local! {
@@ -923,8 +990,19 @@ mod path_module_registry_tests {
     fn every_heap_runs_its_own_initializer_for_the_same_path() {
         const KEY: &str = "/shared-bundle-path.js";
         fn init_on_this_heap(marker: u64) -> Option<u64> {
+            // Seeds only the process-wide ADDRESS, never an entry, so the
+            // require below has to reach `adopt_registered_init` — the path a
+            // second heap actually takes. Calling `register_init` here instead
+            // would insert the entry directly and skip the very code under
+            // test; an earlier version of this test did exactly that and so
+            // could not see that a second heap had no initializer to run.
+            //
+            // Seeding per thread is a TEST-BUILD requirement, not a
+            // production one: `per_test_global!` expands to a per-thread
+            // instance under `cfg(test)`, whereas the shipped static is one
+            // process-wide map that codegen fills once at startup.
+            assert!(register_init_addr(KEY, 0x2000));
             MODULE_PATH_REGISTRY.with(|registry| {
-                assert!(registry.register_init(KEY.into(), 0x2000));
                 let ran = std::cell::Cell::new(false);
                 let outcome = registry.require_with(KEY, &|_addr| {
                     ran.set(true);


### PR DESCRIPTION
## What

Removes `ERR_PERRY_PATH_MODULE_THREAD` — the fail-closed guard that stopped a
single process from hosting more than one Perry application that uses runtime
path modules.

`PathModuleEntry::exports` holds NaN-boxed pointers into the arena of the thread
that produced them, and both the arena and the mutable-root scanners are
thread-local. The registry was process-global, so a single
`OnceLock<ThreadId>` had to refuse every later thread to stop one heap's pointer
reaching another heap's collector. That is the "single-JS-thread discipline"
half of the choice #6185 framed; this commits to the other half, real per-heap
isolation, for this one table.

## The table conflated two different facts

| | keyed | why |
|---|---|---|
| `path -> init_addr` | process-wide | a code pointer. Codegen registers each canonical path's `<prefix>__init` **once**, on whichever thread runs module init first. No collector has any interest in it. |
| `path -> exports` / `status` | per-heap | arena pointers, and the arena is itself a `thread_local!` |

Splitting them is the whole fix. My first attempt made the *whole* table
per-heap, which left a second heap with no initializer to run: it silently
resolved the module to an empty `module.exports`. A heap that has never required
a path now adopts the program-wide initializer (`adopt_registered_init`) instead
of inventing an empty entry.

## Thread-keyed, not agent-keyed

Deliberately, despite #6294 establishing agent tagging for the cross-thread
queues. `CURRENT_AGENT` is itself a `thread_local!` that defaults to
`PRIMARY_AGENT`, and an embedder's app thread is a plain `std::thread::spawn`,
not a `perry/thread` worker — it never calls `enter_worker_agent()`. Agent-keying
would therefore hand every app in a host one shared table: the original bug,
minus the guard that used to make it loud. The rationale is recorded at the
declaration so a future reader meets it there.

The GC scanner loses its owner gate for the same reason — the collector running
it now owns every pointer in the table by construction, and a gate would leave
every heap but the first unscanned. It uses `try_with`, because an embedder's app
thread tears down its heap when a deployment stops and a scanner running during
that teardown would panic on the destroyed thread-local.

## Scope

`js_register_path_init` is emitted only for `nextjs_path_init_modules` — Next.js
`.next/server/**` Deferred modules, for turbopack/webpack chunk loading. Ordinary
Perry programs never reach this table (`nm` on a multi-module CJS fixture shows
zero references to `js_require_path_module`), so the blast radius is confined to
Next-style deployments.

## Testing

- full `perry-runtime` suite: **2609 passed, 0 failed**
- `gc::`: **952 passed, 0 failed**, including
  `full_cycle_path_module_root_store_after_root_scan_preserves_new_value`
- production (non-`cfg(test)`) `cargo check`: clean — checked separately, because
  `per_test_global!` expands to a *different arm* under `cfg(test)` and a green
  `cargo test` is not evidence that the shipped static compiles
- `cargo fmt --check`, `scripts/check_file_size.sh`,
  `scripts/gc_runtime_root_holders.py`: all clean

Two new tests: per-heap isolation, and two heaps initializing the **same** path
through the adoption path. The second deliberately seeds only the process-wide
address and never calls `register_init` per heap — an earlier version did, and so
could not detect the missing-initializer defect above.

## Not proven here

That a second Next application loads in one process. This table is only
reachable through Next chunk loading, so the end-to-end proof needs a host
running two Next apps; that is a separate change on the host side. This PR is
the runtime precondition, verified at the registry layer.

## Follow-up worth filing

`scripts/gc_runtime_root_holders.py` scans **zero** holders from
`path_registry.rs` — the heap pointer sits four levels deep in a custom type, so
the type regex never matches. The holder *is* correctly scanned by a registered
scanner (`gc/mod.rs`), so there is no live bug, but deleting that registration
today would not turn the gate red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading across separate runtime heaps and threads.
  * Prevented module exports from leaking between isolated runtime contexts.
  * Enabled independent initialization of the same module path in different heaps.
  * Improved cleanup and root scanning when thread-local runtime state is unavailable.
  * Improved reliability when multiple application libraries use identical module paths.
* **Documentation**
  * Added release documentation describing the updated module registry behavior and scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->