### PR TITLE
runtime: add native @parcel/watcher compatibility facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "perry-ext-parcel-watcher"
+version = "0.5.1514"
+dependencies = [
+ "fancy-regex",
+ "notify",
+ "perry-ffi",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "perry-ext-pdf"
 version = "0.5.1516"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "crates/perry-ext-pdf",
     "crates/perry-ext-ads",
     "crates/perry-ext-node-forge",
+    "crates/perry-ext-parcel-watcher",
     "crates/perry-wasm-host",
     "crates/perry-container-compose",
     "crates/perry-container-e2e",
@@ -489,6 +490,7 @@ perry-ext-fastify = { path = "crates/perry-ext-fastify" }
 perry-ext-pdf = { path = "crates/perry-ext-pdf" }
 perry-ext-ads = { path = "crates/perry-ext-ads" }
 perry-ext-node-forge = { path = "crates/perry-ext-node-forge" }
+perry-ext-parcel-watcher = { path = "crates/perry-ext-parcel-watcher" }
 perry-stdlib = { path = "crates/perry-stdlib" }
 perry-diagnostics = { path = "crates/perry-diagnostics" }
 perry-ui-model = { path = "crates/perry-ui-model" }

--- a/changelog.d/8532-parcel-watcher.md
+++ b/changelog.d/8532-parcel-watcher.md
@@ -1,0 +1,6 @@
+feat(runtime): add a native `@parcel/watcher` 2.5.x compatibility facade backed
+by OS filesystem events. OpenCode's platform-selected watcher packages now route
+to one GC-rooted native implementation with coalescing, rename, ignore,
+snapshot, overflow-rescan, and safe-unsubscribe semantics instead of falling
+back to a no-op when its Node-API addon cannot load. A 20,000-file idle tree
+used about 1.3 ms of process CPU over five seconds on macOS.

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -187,6 +187,17 @@ pub const NATIVE_MODULES: &[&str] = &[
     // for Socket Firewall's TLS-MITM CA so forge's pure-JS crypto isn't
     // AOT-compiled.
     "node-forge",
+    // @parcel/watcher's root binding and the eight published Node-API
+    // sidecars. HIR canonicalizes sidecars to the root dispatch table.
+    "@parcel/watcher",
+    "@parcel/watcher-darwin-x64",
+    "@parcel/watcher-darwin-arm64",
+    "@parcel/watcher-linux-x64-glibc",
+    "@parcel/watcher-linux-x64-musl",
+    "@parcel/watcher-linux-arm64-glibc",
+    "@parcel/watcher-linux-arm64-musl",
+    "@parcel/watcher-win32-x64",
+    "@parcel/watcher-win32-arm64",
 ];
 
 /// Node built-in submodules that Perry routes through the

--- a/crates/perry-api-manifest/src/entries/part_2.rs
+++ b/crates/perry-api-manifest/src/entries/part_2.rs
@@ -9,6 +9,62 @@ use super::*;
 
 pub(crate) const API_MANIFEST_PART_2: &[ApiEntry] = &[
     method_sig(
+        "@parcel/watcher",
+        "subscribe",
+        false,
+        None,
+        &[p_str("dir"), p_any("callback"), p_any("options")],
+        TypeSpec::Promise,
+    ),
+    method_sig(
+        "@parcel/watcher",
+        "unsubscribe",
+        false,
+        None,
+        &[p_str("dir"), p_any("callback"), p_any("options")],
+        TypeSpec::Promise,
+    ),
+    method_sig(
+        "@parcel/watcher",
+        "writeSnapshot",
+        false,
+        None,
+        &[p_str("dir"), p_str("snapshot"), p_any("options")],
+        TypeSpec::Promise,
+    ),
+    method_sig(
+        "@parcel/watcher",
+        "getEventsSince",
+        false,
+        None,
+        &[p_str("dir"), p_str("snapshot"), p_any("options")],
+        TypeSpec::Promise,
+    ),
+    method_sig(
+        "@parcel/watcher",
+        "__nativeEventCount",
+        false,
+        None,
+        &[],
+        TypeSpec::Number,
+    ),
+    // Platform sidecars canonicalize to the root dispatch table during HIR
+    // lowering. One manifest row per alias keeps resolver/manifest coverage
+    // explicit without duplicating the full surface eight times.
+    method("@parcel/watcher-darwin-x64", "subscribe", false, None),
+    method("@parcel/watcher-darwin-arm64", "subscribe", false, None),
+    method("@parcel/watcher-linux-x64-glibc", "subscribe", false, None),
+    method("@parcel/watcher-linux-x64-musl", "subscribe", false, None),
+    method(
+        "@parcel/watcher-linux-arm64-glibc",
+        "subscribe",
+        false,
+        None,
+    ),
+    method("@parcel/watcher-linux-arm64-musl", "subscribe", false, None),
+    method("@parcel/watcher-win32-x64", "subscribe", false, None),
+    method("@parcel/watcher-win32-arm64", "subscribe", false, None),
+    method_sig(
         "lodash",
         "drop",
         false,

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -613,6 +613,8 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
 /// wants bespoke routing can always override its family by adding an exact row.
 #[rustfmt::skip]
 const EXT_PREFIX_REGISTRY: &[(&str, &str)] = &[
+    // @parcel/watcher's notify-backed native-addon facade.
+    ("js_parcel_watcher_", "@parcel/watcher"),
     // Redis / Valkey RESP client (perry-ext-ioredis). `ioredis`, `iovalkey`,
     // and `valkey` all share this wrapper + the `js_ioredis_*` surface, so the
     // single `ioredis` binding key covers every RESP package that lowers here.
@@ -1139,9 +1141,9 @@ mod tests {
     /// The measured `_js_ioredis_new` link gap: an AOT-compiled `iovalkey`
     /// (a `perry.compilePackages` member, so never in `native_module_imports`
     /// and never in the well-known iteration set) lowers its client usage to
-    /// `js_ioredis_new`. The prefix net must route the WHOLE `js_ioredis_*` /
-    /// `js_undici_*` / `js_node_forge_*` family to its well-known wrapper off
-    /// codegen provenance alone — no exact-table row per symbol required.
+    /// `js_ioredis_new`. The prefix net must route each registered ext family
+    /// to its well-known wrapper off codegen provenance alone — no exact-table
+    /// row per symbol required.
     #[test]
     fn emitted_ext_prefix_symbols_route_to_well_known_binding() {
         let _guard = ProviderTestGuard::new();
@@ -1153,6 +1155,8 @@ mod tests {
             ("js_undici_proxy_agent_new", "undici"),
             ("js_node_forge_generate_key_pair", "node-forge"),
             ("js_node_forge_create_certificate", "node-forge"),
+            ("js_parcel_watcher_subscribe", "@parcel/watcher"),
+            ("js_parcel_watcher_get_events_since", "@parcel/watcher"),
         ] {
             assert_symbol_routes_to(symbol, OwnerKind::WellKnown(binding));
         }

--- a/crates/perry-codegen/src/lower_call/native_table/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/mod.rs
@@ -32,6 +32,7 @@ mod node_core_util;
 mod node_dns;
 mod node_domain;
 mod node_misc;
+mod parcel_watcher;
 mod thread_lodash;
 mod tls_events;
 mod tui;
@@ -175,6 +176,7 @@ pub(super) static NATIVE_MODULE_TABLE: LazyLock<Vec<NativeModSig>> = LazyLock::n
     v.extend_from_slice(dates::DATES_ROWS);
     v.extend_from_slice(media::MEDIA_ROWS);
     v.extend_from_slice(native_profile::NATIVE_PROFILE_ROWS);
+    v.extend_from_slice(parcel_watcher::PARCEL_WATCHER_ROWS);
     v.extend_from_slice(tui::TUI_ROWS);
     v.extend_from_slice(yoga::YOGA_ROWS);
     v.extend_from_slice(extras::EXTRAS_ROWS);

--- a/crates/perry-codegen/src/lower_call/native_table/parcel_watcher.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/parcel_watcher.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+/// The low-level binding object consumed by `@parcel/watcher/wrapper`.
+/// Platform package names are canonicalized to `@parcel/watcher` by HIR
+/// lowering, so one table covers the root plus every native-addon sidecar.
+pub(super) const PARCEL_WATCHER_ROWS: &[NativeModSig] = &[
+    NativeModSig {
+        module: "@parcel/watcher",
+        has_receiver: false,
+        method: "subscribe",
+        class_filter: None,
+        runtime: "js_parcel_watcher_subscribe",
+        args: &[NA_STR, NA_PTR, NA_F64],
+        ret: NR_PROMISE,
+    },
+    NativeModSig {
+        module: "@parcel/watcher",
+        has_receiver: false,
+        method: "unsubscribe",
+        class_filter: None,
+        runtime: "js_parcel_watcher_unsubscribe",
+        args: &[NA_STR, NA_PTR, NA_F64],
+        ret: NR_PROMISE,
+    },
+    NativeModSig {
+        module: "@parcel/watcher",
+        has_receiver: false,
+        method: "writeSnapshot",
+        class_filter: None,
+        runtime: "js_parcel_watcher_write_snapshot",
+        args: &[NA_STR, NA_STR, NA_F64],
+        ret: NR_PROMISE,
+    },
+    NativeModSig {
+        module: "@parcel/watcher",
+        has_receiver: false,
+        method: "getEventsSince",
+        class_filter: None,
+        runtime: "js_parcel_watcher_get_events_since",
+        args: &[NA_STR, NA_STR, NA_F64],
+        ret: NR_PROMISE,
+    },
+    NativeModSig {
+        module: "@parcel/watcher",
+        has_receiver: false,
+        method: "__nativeEventCount",
+        class_filter: None,
+        runtime: "js_parcel_watcher_native_event_count",
+        args: &[],
+        ret: NR_F64,
+    },
+];

--- a/crates/perry-ext-parcel-watcher/Cargo.toml
+++ b/crates/perry-ext-parcel-watcher/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "perry-ext-parcel-watcher"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Native @parcel/watcher 2.5 compatibility facade backed by notify"
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+perry-ffi.workspace = true
+notify.workspace = true
+fancy-regex = "0.18"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+perry-ffi = { workspace = true, features = ["runtime-link"] }
+tempfile.workspace = true

--- a/crates/perry-ext-parcel-watcher/src/lib.rs
+++ b/crates/perry-ext-parcel-watcher/src/lib.rs
@@ -1,0 +1,1024 @@
+//! Native compatibility facade for `@parcel/watcher` 2.5.x.
+//!
+//! The npm package's JavaScript `wrapper.js` normalizes user-facing ignore
+//! globs and paths before calling this binding object. This crate implements
+//! that binding directly with `notify`, so platform packages whose `main` is a
+//! `.node` addon remain usable in a single static Perry binary.
+
+use fancy_regex::Regex;
+use notify::event::{ModifyKind, RenameMode};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use perry_ffi::{
+    alloc_string, build_object_shape, drop_handle, error_value_with_code,
+    gc_register_mutable_root_scanner_named, get_handle, iter_handles_of_mut, js_array_alloc,
+    js_array_get, js_array_length, js_array_push, js_object_alloc_with_shape, js_object_set_field,
+    notify_main_thread, object_field_by_name, read_string, register_aux_event_pump,
+    register_handle, ErrorKind, GcRootVisitor, Handle, JsClosure, JsPromise, JsString, JsValue,
+    Promise, RawClosureHeader, StringHeader, TransientRootScope,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, Once};
+use std::time::{Duration, Instant, UNIX_EPOCH};
+
+extern "C" {
+    fn js_get_string_pointer_unified(value: f64) -> i64;
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct WatchOptionsKey {
+    backend: Option<String>,
+    ignore_paths: Vec<PathBuf>,
+    ignore_globs: Vec<String>,
+}
+
+#[derive(Clone)]
+struct IgnoreMatcher {
+    paths: Vec<PathBuf>,
+    globs: Vec<Regex>,
+}
+
+impl IgnoreMatcher {
+    fn compile(key: &WatchOptionsKey) -> Result<Self, String> {
+        let mut globs = Vec::with_capacity(key.ignore_globs.len());
+        for source in &key.ignore_globs {
+            globs.push(
+                Regex::new(source)
+                    .map_err(|error| format!("Invalid @parcel/watcher ignore regex: {error}"))?,
+            );
+        }
+        Ok(Self {
+            paths: key.ignore_paths.clone(),
+            globs,
+        })
+    }
+
+    fn ignores(&self, root: &Path, path: &Path) -> bool {
+        if self.paths.iter().any(|ignored| path.starts_with(ignored)) {
+            return true;
+        }
+        let relative = path.strip_prefix(root).unwrap_or(path);
+        let relative = relative
+            .components()
+            .filter_map(|component| match component {
+                Component::Normal(value) => Some(value.to_string_lossy()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/");
+        self.globs
+            .iter()
+            .any(|regex| regex.is_match(&relative).unwrap_or(false))
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Change {
+    Create(PathBuf),
+    Update(PathBuf),
+    Delete(PathBuf),
+    Rescan,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CoalescedKind {
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParcelEvent {
+    path: PathBuf,
+    kind: CoalescedKind,
+}
+
+#[derive(Clone, Debug)]
+enum Pending {
+    Changes(u64, Vec<Change>),
+    Error(u64, String),
+}
+
+#[derive(Clone, Debug)]
+struct PendingItem {
+    queued_at: Instant,
+    event: Pending,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SnapshotEntry {
+    is_dir: bool,
+    len: u64,
+    modified_ns: u64,
+}
+
+type Snapshot = BTreeMap<String, SnapshotEntry>;
+
+struct Subscription {
+    // Dropping notify's watcher stops its OS resource and joins its worker.
+    _watcher: RecommendedWatcher,
+    root: PathBuf,
+    callback_handle: Handle,
+    options: WatchOptionsKey,
+    matcher: IgnoreMatcher,
+    active: Arc<AtomicBool>,
+    snapshot: Snapshot,
+}
+
+/// A stable registry identity for a moving-GC closure.
+///
+/// `unsubscribe` receives the closure's current address, which may differ from
+/// the address passed to `subscribe` after a copying collection. The handle is
+/// stable while this slot is rewritten by the registered root scanner.
+struct CallbackRoot {
+    callback: i64,
+}
+
+static SUBSCRIPTIONS: LazyLock<Mutex<HashMap<u64, Subscription>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static PENDING: LazyLock<Mutex<Vec<PendingItem>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static NATIVE_EVENT_COUNT: AtomicU64 = AtomicU64::new(0);
+static BATCH_WAKE_SCHEDULED: AtomicBool = AtomicBool::new(false);
+static REGISTERED: Once = Once::new();
+const BATCH_WINDOW: Duration = Duration::from_millis(10);
+
+fn ensure_registered() {
+    REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ext-parcel-watcher", scan_subscription_roots);
+        register_aux_event_pump(
+            js_parcel_watcher_process_pending,
+            js_parcel_watcher_has_active,
+        );
+    });
+}
+
+fn scan_subscription_roots(visitor: &mut GcRootVisitor<'_>) {
+    iter_handles_of_mut::<CallbackRoot, _>(|root| {
+        visitor.visit_i64_slot(&mut root.callback);
+    });
+}
+
+fn schedule_batch_wake() {
+    if BATCH_WAKE_SCHEDULED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    std::thread::spawn(|| {
+        std::thread::sleep(BATCH_WINDOW);
+        BATCH_WAKE_SCHEDULED.store(false, Ordering::Release);
+        notify_main_thread();
+    });
+}
+
+fn queue_pending(event: Pending) {
+    PENDING.lock().unwrap().push(PendingItem {
+        queued_at: Instant::now(),
+        event,
+    });
+    schedule_batch_wake();
+}
+
+fn normalize_root(path: PathBuf) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    fs::canonicalize(&absolute).unwrap_or(absolute)
+}
+
+unsafe fn read_ptr_string(ptr: *const StringHeader) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    read_string(JsString::from_raw(ptr as *mut StringHeader)).map(str::to_owned)
+}
+
+unsafe fn string_from_value(value: JsValue) -> Option<String> {
+    if !value.is_any_string() {
+        return None;
+    }
+    let ptr = js_get_string_pointer_unified(f64::from_bits(value.bits())) as *const StringHeader;
+    read_ptr_string(ptr)
+}
+
+unsafe fn string_array_field(options: JsValue, name: &str) -> Vec<String> {
+    let value = object_field_by_name(options, name);
+    if !value.is_pointer() {
+        return Vec::new();
+    }
+    let scope = TransientRootScope::enter();
+    let array = scope.root_nanbox(f64::from_bits(value.bits()));
+    let len = js_array_length(JsValue::from_bits(array.get().to_bits()).as_pointer());
+    (0..len)
+        .filter_map(|index| {
+            let current = JsValue::from_bits(array.get().to_bits()).as_pointer();
+            string_from_value(js_array_get(current, index))
+        })
+        .collect()
+}
+
+unsafe fn parse_options(options_bits: f64) -> WatchOptionsKey {
+    let options = JsValue::from_bits(options_bits.to_bits());
+    if !options.is_pointer_or_raw() {
+        return WatchOptionsKey::default();
+    }
+    let scope = TransientRootScope::enter();
+    let options = scope.root_nanbox(options_bits);
+    let current = || JsValue::from_bits(options.get().to_bits());
+    let backend = string_from_value(object_field_by_name(current(), "backend"));
+    // Unknown and platform-unavailable backends deliberately fall through to
+    // notify's recommended watcher, matching Parcel's documented fallback.
+    let backend = backend.filter(|value| {
+        matches!(
+            value.as_str(),
+            "fs-events" | "watchman" | "inotify" | "kqueue" | "windows" | "brute-force"
+        )
+    });
+    WatchOptionsKey {
+        backend,
+        ignore_paths: string_array_field(current(), "ignorePaths")
+            .into_iter()
+            .map(|path| normalize_root(PathBuf::from(path)))
+            .collect(),
+        ignore_globs: string_array_field(current(), "ignoreGlobs"),
+    }
+}
+
+fn changes_from_notify(event: Event) -> Vec<Change> {
+    if event.need_rescan() {
+        return vec![Change::Rescan];
+    }
+    match event.kind {
+        EventKind::Create(_) => event.paths.into_iter().map(Change::Create).collect(),
+        EventKind::Remove(_) => event.paths.into_iter().map(Change::Delete).collect(),
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) if event.paths.len() >= 2 => {
+            vec![
+                Change::Delete(event.paths[0].clone()),
+                Change::Create(event.paths[1].clone()),
+            ]
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+            event.paths.into_iter().map(Change::Delete).collect()
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+            event.paths.into_iter().map(Change::Create).collect()
+        }
+        // FSEvents and several fallback backends can report a rename without
+        // paired paths. A fresh snapshot is the only reliable way to recover
+        // Parcel's required `delete old` + `create new` semantics (and the
+        // descendants of renamed directories).
+        EventKind::Modify(ModifyKind::Name(_)) => vec![Change::Rescan],
+        EventKind::Modify(_) | EventKind::Any | EventKind::Other => {
+            event.paths.into_iter().map(Change::Update).collect()
+        }
+        EventKind::Access(_) => Vec::new(),
+    }
+}
+
+fn snapshot_entry(path: &Path) -> Option<SnapshotEntry> {
+    let metadata = fs::symlink_metadata(path).ok()?;
+    let modified_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().min(u64::MAX as u128) as u64)
+        .unwrap_or(0);
+    Some(SnapshotEntry {
+        is_dir: metadata.is_dir(),
+        len: metadata.len(),
+        modified_ns,
+    })
+}
+
+fn snapshot_tree(root: &Path, matcher: &IgnoreMatcher) -> Result<Snapshot, String> {
+    fn visit(
+        root: &Path,
+        current: &Path,
+        matcher: &IgnoreMatcher,
+        out: &mut Snapshot,
+    ) -> Result<(), String> {
+        let entries = fs::read_dir(current)
+            .map_err(|error| format!("Unable to read {}: {error}", current.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| error.to_string())?;
+            let path = entry.path();
+            if matcher.ignores(root, &path) {
+                continue;
+            }
+            let Some(metadata) = snapshot_entry(&path) else {
+                continue;
+            };
+            let relative = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let is_dir = metadata.is_dir;
+            out.insert(relative, metadata);
+            if is_dir {
+                visit(root, &path, matcher, out)?;
+            }
+        }
+        Ok(())
+    }
+
+    let mut snapshot = Snapshot::new();
+    visit(root, root, matcher, &mut snapshot)?;
+    Ok(snapshot)
+}
+
+fn diff_snapshots(root: &Path, old: &Snapshot, new: &Snapshot) -> Vec<ParcelEvent> {
+    let mut events = Vec::new();
+    // Parcel specifies rename as delete-old followed by create-new. Snapshot
+    // recovery cannot know which paths were paired, so emit every deletion
+    // before creations while retaining deterministic path order within each
+    // group.
+    for path in old.keys() {
+        if !new.contains_key(path) {
+            events.push(ParcelEvent {
+                path: root.join(path),
+                kind: CoalescedKind::Delete,
+            });
+        }
+    }
+    for (path, entry) in new {
+        let kind = match old.get(path) {
+            None => Some(CoalescedKind::Create),
+            Some(previous) if previous != entry => Some(CoalescedKind::Update),
+            _ => None,
+        };
+        if let Some(kind) = kind {
+            events.push(ParcelEvent {
+                path: root.join(path),
+                kind,
+            });
+        }
+    }
+    events
+}
+
+fn snapshot_key(root: &Path, path: &Path) -> Option<String> {
+    path.strip_prefix(root)
+        .ok()
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn coalesce(
+    root: &Path,
+    matcher: &IgnoreMatcher,
+    snapshot: &Snapshot,
+    changes: &[Change],
+) -> Vec<ParcelEvent> {
+    let mut touched = BTreeSet::<PathBuf>::new();
+    for change in changes {
+        let path = match change {
+            Change::Create(path) | Change::Update(path) | Change::Delete(path) => path,
+            Change::Rescan => continue,
+        };
+        let path = normalize_root(path.clone());
+        if matcher.ignores(root, &path) {
+            continue;
+        }
+        touched.insert(path);
+    }
+
+    // A directory removal may be reported only for the parent. Include its
+    // previously known descendants so Parcel receives one delete per entry.
+    let removed_dirs: Vec<String> = touched
+        .iter()
+        .filter(|path| snapshot_entry(path).is_none())
+        .filter_map(|path| snapshot_key(root, path))
+        .filter(|key| snapshot.get(key).is_some_and(|entry| entry.is_dir))
+        .collect();
+    for dir in removed_dirs {
+        let prefix = format!("{dir}/");
+        touched.extend(
+            snapshot
+                .keys()
+                .filter(|key| key.starts_with(&prefix))
+                .map(|key| root.join(key)),
+        );
+    }
+
+    let mut events = touched
+        .into_iter()
+        .filter_map(|path| {
+            let existed = path == root
+                || snapshot_key(root, &path).is_some_and(|key| snapshot.contains_key(&key));
+            let exists = snapshot_entry(&path).is_some();
+            let kind = match (existed, exists) {
+                (false, true) => CoalescedKind::Create,
+                (true, false) => CoalescedKind::Delete,
+                (true, true) if path != root => CoalescedKind::Update,
+                // Created and deleted within the batch, or a backend's
+                // metadata-only notification for the still-live watch root.
+                _ => return None,
+            };
+            Some(ParcelEvent { path, kind })
+        })
+        .collect::<Vec<_>>();
+    // A rename must always expose delete-old before create-new, regardless
+    // of the two path names' lexical order.
+    events.sort_by(|left, right| {
+        let rank = |kind| i32::from(kind != CoalescedKind::Delete);
+        rank(left.kind)
+            .cmp(&rank(right.kind))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    events
+}
+
+fn update_subscription_snapshot(subscription: &mut Subscription, events: &[ParcelEvent]) {
+    for event in events {
+        let Some(key) = snapshot_key(&subscription.root, &event.path) else {
+            continue;
+        };
+        match event.kind {
+            CoalescedKind::Delete => {
+                subscription.snapshot.remove(&key);
+            }
+            CoalescedKind::Create | CoalescedKind::Update => {
+                if let Some(entry) = snapshot_entry(&event.path) {
+                    subscription.snapshot.insert(key, entry);
+                }
+            }
+        }
+    }
+}
+
+fn event_array(events: &[ParcelEvent]) -> f64 {
+    let scope = TransientRootScope::enter();
+    let array = unsafe { js_array_alloc(events.len() as u32) };
+    let rooted_array = scope.root_nanbox(f64::from_bits(JsValue::from_object_ptr(array).bits()));
+    let (packed, shape) = build_object_shape(&["path", "type"]);
+    for event in events {
+        let path = alloc_string(&event.path.to_string_lossy());
+        let path = scope.root_nanbox(f64::from_bits(
+            JsValue::from_string_ptr(path.as_raw()).bits(),
+        ));
+        let kind = alloc_string(match event.kind {
+            CoalescedKind::Create => "create",
+            CoalescedKind::Update => "update",
+            CoalescedKind::Delete => "delete",
+        });
+        let kind = scope.root_nanbox(f64::from_bits(
+            JsValue::from_string_ptr(kind.as_raw()).bits(),
+        ));
+        let object =
+            unsafe { js_object_alloc_with_shape(shape, 2, packed.as_ptr(), packed.len() as u32) };
+        unsafe {
+            js_object_set_field(object, 0, JsValue::from_bits(path.get().to_bits()));
+            js_object_set_field(object, 1, JsValue::from_bits(kind.get().to_bits()));
+            let current = JsValue::from_bits(rooted_array.get().to_bits()).as_pointer();
+            let _ = js_array_push(current, JsValue::from_object_ptr(object));
+        }
+    }
+    rooted_array.get()
+}
+
+fn fire_events(id: u64, events: Vec<ParcelEvent>) -> bool {
+    if events.is_empty() {
+        return false;
+    }
+    let scope = TransientRootScope::enter();
+    let events_value = scope.root_nanbox(event_array(&events));
+    let callback = SUBSCRIPTIONS
+        .lock()
+        .ok()
+        .and_then(|subscriptions| subscriptions.get(&id).map(|entry| entry.callback_handle))
+        .and_then(|handle| get_handle::<CallbackRoot>(handle).map(|root| root.callback));
+    let Some(callback) = callback else {
+        return false;
+    };
+    let callback = scope.root_addr(callback);
+    let closure = unsafe { JsClosure::from_raw(callback.get() as *const RawClosureHeader) };
+    unsafe {
+        closure.call2(f64::from_bits(JsValue::NULL.bits()), events_value.get());
+    }
+    true
+}
+
+fn fire_error(id: u64, message: &str) -> bool {
+    let scope = TransientRootScope::enter();
+    let error = error_value_with_code(message, "ERR_PARCEL_WATCHER", ErrorKind::Error);
+    let error = scope.root_nanbox(f64::from_bits(error.bits()));
+    let empty = unsafe { js_array_alloc(0) };
+    let events = scope.root_nanbox(f64::from_bits(JsValue::from_object_ptr(empty).bits()));
+    let callback = SUBSCRIPTIONS
+        .lock()
+        .ok()
+        .and_then(|subscriptions| subscriptions.get(&id).map(|entry| entry.callback_handle))
+        .and_then(|handle| get_handle::<CallbackRoot>(handle).map(|root| root.callback));
+    let Some(callback) = callback else {
+        return false;
+    };
+    let callback = scope.root_addr(callback);
+    let closure = unsafe { JsClosure::from_raw(callback.get() as *const RawClosureHeader) };
+    unsafe {
+        closure.call2(error.get(), events.get());
+    }
+    true
+}
+
+/// Drain OS watcher events and invoke subscription callbacks on the JS thread.
+#[no_mangle]
+pub extern "C" fn js_parcel_watcher_process_pending() -> i32 {
+    let now = Instant::now();
+    let ready = {
+        let mut queue = PENDING.lock().unwrap();
+        let mut ready = Vec::new();
+        let mut waiting = Vec::new();
+        for item in std::mem::take(&mut *queue) {
+            if now.duration_since(item.queued_at) >= BATCH_WINDOW {
+                ready.push(item.event);
+            } else {
+                waiting.push(item);
+            }
+        }
+        *queue = waiting;
+        ready
+    };
+    if !PENDING.lock().unwrap().is_empty() {
+        schedule_batch_wake();
+    }
+    let mut changes_by_id = BTreeMap::<u64, Vec<Change>>::new();
+    let mut errors = Vec::new();
+    for item in ready {
+        match item {
+            Pending::Changes(id, changes) => changes_by_id.entry(id).or_default().extend(changes),
+            Pending::Error(id, message) => errors.push((id, message)),
+        }
+    }
+
+    let mut fired = 0;
+    for (id, changes) in changes_by_id {
+        let events = {
+            let mut subscriptions = SUBSCRIPTIONS.lock().unwrap();
+            let Some(subscription) = subscriptions.get_mut(&id) else {
+                continue;
+            };
+            if changes
+                .iter()
+                .any(|change| matches!(change, Change::Rescan))
+            {
+                match snapshot_tree(&subscription.root, &subscription.matcher) {
+                    Ok(next) => {
+                        let events =
+                            diff_snapshots(&subscription.root, &subscription.snapshot, &next);
+                        subscription.snapshot = next;
+                        events
+                    }
+                    Err(error) => {
+                        errors.push((id, error));
+                        Vec::new()
+                    }
+                }
+            } else {
+                let events = coalesce(
+                    &subscription.root,
+                    &subscription.matcher,
+                    &subscription.snapshot,
+                    &changes,
+                );
+                update_subscription_snapshot(subscription, &events);
+                events
+            }
+        };
+        if fire_events(id, events) {
+            fired += 1;
+        }
+    }
+    for (id, error) in errors {
+        if fire_error(id, &error) {
+            fired += 1;
+        }
+    }
+    fired
+}
+
+/// Return non-zero while a live subscription owns an OS watcher.
+#[no_mangle]
+pub extern "C" fn js_parcel_watcher_has_active() -> i32 {
+    SUBSCRIPTIONS
+        .lock()
+        .map(|subscriptions| i32::from(!subscriptions.is_empty()))
+        .unwrap_or(0)
+}
+
+/// Test/gate probe proving events came from notify's native backend.
+#[no_mangle]
+pub extern "C" fn js_parcel_watcher_native_event_count() -> f64 {
+    NATIVE_EVENT_COUNT.load(Ordering::Relaxed) as f64
+}
+
+/// `binding.subscribe(dir, callback, options) -> Promise<void>`.
+///
+/// # Safety
+///
+/// `dir` must be null or point to a live Perry string header, and `callback`
+/// and `options` must be values produced by the Perry runtime.
+#[no_mangle]
+pub unsafe extern "C" fn js_parcel_watcher_subscribe(
+    dir: *const StringHeader,
+    callback: i64,
+    options: f64,
+) -> *mut Promise {
+    ensure_registered();
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    if callback == 0 {
+        promise.reject_string("@parcel/watcher subscribe callback must be a function");
+        return raw;
+    }
+    let Some(dir) = read_ptr_string(dir) else {
+        promise.reject_string("@parcel/watcher directory must be a string");
+        return raw;
+    };
+    let root = normalize_root(PathBuf::from(dir));
+    if !root.is_dir() {
+        promise.reject_string(&format!(
+            "Unable to watch {}: not a directory",
+            root.display()
+        ));
+        return raw;
+    }
+    let options = parse_options(options);
+    let matcher = match IgnoreMatcher::compile(&options) {
+        Ok(matcher) => matcher,
+        Err(error) => {
+            promise.reject_string(&error);
+            return raw;
+        }
+    };
+    let snapshot = match snapshot_tree(&root, &matcher) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            promise.reject_string(&error);
+            return raw;
+        }
+    };
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let active = Arc::new(AtomicBool::new(true));
+    let callback_active = active.clone();
+    let mut watcher = match notify::recommended_watcher(move |result: notify::Result<Event>| {
+        if !callback_active.load(Ordering::Acquire) {
+            return;
+        }
+        match result {
+            Ok(event) => {
+                NATIVE_EVENT_COUNT.fetch_add(1, Ordering::Relaxed);
+                let changes = changes_from_notify(event);
+                if !changes.is_empty() {
+                    queue_pending(Pending::Changes(id, changes));
+                }
+            }
+            Err(error) => queue_pending(Pending::Error(id, error.to_string())),
+        }
+    }) {
+        Ok(watcher) => watcher,
+        Err(error) => {
+            promise.reject_string(&format!("Unable to create watcher: {error}"));
+            return raw;
+        }
+    };
+    if let Err(error) = watcher.watch(&root, RecursiveMode::Recursive) {
+        promise.reject_string(&format!("Unable to watch {}: {error}", root.display()));
+        return raw;
+    }
+    let callback_handle = register_handle(CallbackRoot { callback });
+    SUBSCRIPTIONS.lock().unwrap().insert(
+        id,
+        Subscription {
+            _watcher: watcher,
+            root,
+            callback_handle,
+            options,
+            matcher,
+            active,
+            snapshot,
+        },
+    );
+    promise.resolve_undefined();
+    raw
+}
+
+/// `binding.unsubscribe(dir, callback, options) -> Promise<void>`.
+///
+/// # Safety
+///
+/// `dir` must be null or point to a live Perry string header, and `callback`
+/// and `options` must be values produced by the Perry runtime.
+#[no_mangle]
+pub unsafe extern "C" fn js_parcel_watcher_unsubscribe(
+    dir: *const StringHeader,
+    callback: i64,
+    options: f64,
+) -> *mut Promise {
+    ensure_registered();
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    let Some(dir) = read_ptr_string(dir) else {
+        promise.reject_string("@parcel/watcher directory must be a string");
+        return raw;
+    };
+    let root = normalize_root(PathBuf::from(dir));
+    let options = parse_options(options);
+    let id = SUBSCRIPTIONS.lock().ok().and_then(|subscriptions| {
+        subscriptions.iter().find_map(|(id, subscription)| {
+            let same_callback = get_handle::<CallbackRoot>(subscription.callback_handle)
+                .is_some_and(|root| root.callback == callback);
+            (subscription.root == root && same_callback && subscription.options == options)
+                .then_some(*id)
+        })
+    });
+    if let Some(id) = id {
+        let removed = SUBSCRIPTIONS.lock().unwrap().remove(&id);
+        if let Some(subscription) = removed {
+            let callback_handle = subscription.callback_handle;
+            subscription.active.store(false, Ordering::Release);
+            // Drop synchronously: notify stops and joins before the callback
+            // root is released. Then discard anything already queued.
+            drop(subscription);
+            PENDING.lock().unwrap().retain(|pending| match pending {
+                PendingItem {
+                    event: Pending::Changes(pending_id, _) | Pending::Error(pending_id, _),
+                    ..
+                } => *pending_id != id,
+            });
+            drop_handle(callback_handle);
+        }
+    }
+    promise.resolve_undefined();
+    raw
+}
+
+fn snapshot_options(options: f64) -> Result<(WatchOptionsKey, IgnoreMatcher), String> {
+    let key = unsafe { parse_options(options) };
+    let matcher = IgnoreMatcher::compile(&key)?;
+    Ok((key, matcher))
+}
+
+/// `binding.writeSnapshot(dir, snapshotPath, options) -> Promise<void>`.
+///
+/// # Safety
+///
+/// Both string pointers must be null or point to live Perry string headers,
+/// and `options` must be a value produced by the Perry runtime.
+#[no_mangle]
+pub unsafe extern "C" fn js_parcel_watcher_write_snapshot(
+    dir: *const StringHeader,
+    snapshot_path: *const StringHeader,
+    options: f64,
+) -> *mut Promise {
+    ensure_registered();
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    let Some(dir) = read_ptr_string(dir) else {
+        promise.reject_string("@parcel/watcher directory must be a string");
+        return raw;
+    };
+    let Some(snapshot_path) = read_ptr_string(snapshot_path) else {
+        promise.reject_string("@parcel/watcher snapshot path must be a string");
+        return raw;
+    };
+    let (_, matcher) = match snapshot_options(options) {
+        Ok(options) => options,
+        Err(error) => {
+            promise.reject_string(&error);
+            return raw;
+        }
+    };
+    let root = normalize_root(PathBuf::from(dir));
+    match snapshot_tree(&root, &matcher)
+        .and_then(|snapshot| serde_json::to_vec(&snapshot).map_err(|error| error.to_string()))
+        .and_then(|bytes| fs::write(&snapshot_path, bytes).map_err(|error| error.to_string()))
+    {
+        Ok(()) => promise.resolve_undefined(),
+        Err(error) => promise.reject_string(&error),
+    }
+    raw
+}
+
+/// `binding.getEventsSince(dir, snapshotPath, options) -> Promise<Event[]>`.
+///
+/// # Safety
+///
+/// Both string pointers must be null or point to live Perry string headers,
+/// and `options` must be a value produced by the Perry runtime.
+#[no_mangle]
+pub unsafe extern "C" fn js_parcel_watcher_get_events_since(
+    dir: *const StringHeader,
+    snapshot_path: *const StringHeader,
+    options: f64,
+) -> *mut Promise {
+    ensure_registered();
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    let Some(dir) = read_ptr_string(dir) else {
+        promise.reject_string("@parcel/watcher directory must be a string");
+        return raw;
+    };
+    let Some(snapshot_path) = read_ptr_string(snapshot_path) else {
+        promise.reject_string("@parcel/watcher snapshot path must be a string");
+        return raw;
+    };
+    let (_, matcher) = match snapshot_options(options) {
+        Ok(options) => options,
+        Err(error) => {
+            promise.reject_string(&error);
+            return raw;
+        }
+    };
+    let root = normalize_root(PathBuf::from(dir));
+    let result = fs::read(&snapshot_path)
+        .map_err(|error| error.to_string())
+        .and_then(|bytes| {
+            serde_json::from_slice::<Snapshot>(&bytes).map_err(|error| error.to_string())
+        })
+        .and_then(|old| {
+            snapshot_tree(&root, &matcher).map(|new| diff_snapshots(&root, &old, &new))
+        });
+    match result {
+        Ok(events) => {
+            let scope = TransientRootScope::enter();
+            let value = scope.root_nanbox(event_array(&events));
+            promise.resolve(JsValue::from_bits(value.get().to_bits()));
+        }
+        Err(error) => promise.reject_string(&error),
+    }
+    raw
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalescing_matches_parcel_batch_semantics() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(temp.path()).unwrap();
+        let matcher = IgnoreMatcher {
+            paths: Vec::new(),
+            globs: Vec::new(),
+        };
+        let created = root.join("created.ts");
+        let transient = root.join("transient.ts");
+        fs::write(&created, "updated").unwrap();
+        let events = coalesce(
+            &root,
+            &matcher,
+            &Snapshot::new(),
+            &[
+                Change::Create(created.clone()),
+                Change::Update(created.clone()),
+                Change::Create(transient.clone()),
+                Change::Delete(transient),
+            ],
+        );
+        assert_eq!(
+            events,
+            vec![ParcelEvent {
+                path: created,
+                kind: CoalescedKind::Create,
+            }]
+        );
+    }
+
+    #[test]
+    fn backend_create_for_existing_path_normalizes_to_update() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(temp.path()).unwrap();
+        let path = root.join("existing.ts");
+        fs::write(&path, "one").unwrap();
+        let matcher = IgnoreMatcher {
+            paths: Vec::new(),
+            globs: Vec::new(),
+        };
+        let snapshot = snapshot_tree(&root, &matcher).unwrap();
+        fs::write(&path, "two-two").unwrap();
+        assert_eq!(
+            coalesce(&root, &matcher, &snapshot, &[Change::Create(path.clone())],),
+            vec![ParcelEvent {
+                path,
+                kind: CoalescedKind::Update,
+            }]
+        );
+    }
+
+    #[test]
+    fn coalesced_rename_deletes_before_lexically_earlier_create() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(temp.path()).unwrap();
+        let old = root.join("z-old.ts");
+        let new = root.join("a-new.ts");
+        fs::write(&old, "one").unwrap();
+        let matcher = IgnoreMatcher {
+            paths: Vec::new(),
+            globs: Vec::new(),
+        };
+        let snapshot = snapshot_tree(&root, &matcher).unwrap();
+        fs::rename(&old, &new).unwrap();
+        assert_eq!(
+            coalesce(
+                &root,
+                &matcher,
+                &snapshot,
+                &[Change::Delete(old.clone()), Change::Create(new.clone())],
+            ),
+            vec![
+                ParcelEvent {
+                    path: old,
+                    kind: CoalescedKind::Delete,
+                },
+                ParcelEvent {
+                    path: new,
+                    kind: CoalescedKind::Create,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rename_is_delete_then_create() {
+        let event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+            .add_path(PathBuf::from("old"))
+            .add_path(PathBuf::from("new"));
+        assert!(matches!(
+            changes_from_notify(event).as_slice(),
+            [Change::Delete(old), Change::Create(new)] if old == Path::new("old") && new == Path::new("new")
+        ));
+    }
+
+    #[test]
+    fn snapshots_round_trip_and_honor_ignores() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir(temp.path().join("nested")).unwrap();
+        fs::write(temp.path().join("nested/kept.txt"), "one").unwrap();
+        fs::write(temp.path().join("ignored.txt"), "one").unwrap();
+        let matcher = IgnoreMatcher {
+            paths: vec![temp.path().join("ignored.txt")],
+            globs: Vec::new(),
+        };
+        let old = snapshot_tree(temp.path(), &matcher).unwrap();
+        let encoded = serde_json::to_vec(&old).unwrap();
+        let decoded: Snapshot = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(old, decoded);
+        assert!(!decoded.contains_key("ignored.txt"));
+
+        fs::write(temp.path().join("nested/kept.txt"), "two-two").unwrap();
+        fs::write(temp.path().join("nested/new.txt"), "new").unwrap();
+        let new = snapshot_tree(temp.path(), &matcher).unwrap();
+        let events = diff_snapshots(temp.path(), &old, &new);
+        assert!(events.iter().any(|event| {
+            event.path.ends_with("nested/kept.txt") && event.kind == CoalescedKind::Update
+        }));
+        assert!(events.iter().any(|event| {
+            event.path.ends_with("nested/new.txt") && event.kind == CoalescedKind::Create
+        }));
+    }
+
+    #[test]
+    fn snapshot_rename_is_delete_then_create() {
+        let root = Path::new("/tmp/project");
+        let entry = SnapshotEntry {
+            is_dir: false,
+            len: 3,
+            modified_ns: 1,
+        };
+        let old = BTreeMap::from([("old.ts".to_string(), entry.clone())]);
+        let new = BTreeMap::from([("new.ts".to_string(), entry)]);
+        assert_eq!(
+            diff_snapshots(root, &old, &new),
+            vec![
+                ParcelEvent {
+                    path: root.join("old.ts"),
+                    kind: CoalescedKind::Delete,
+                },
+                ParcelEvent {
+                    path: root.join("new.ts"),
+                    kind: CoalescedKind::Create,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_sources_match_root_relative_dotfiles() {
+        let root = Path::new("/tmp/project");
+        let matcher = IgnoreMatcher {
+            paths: Vec::new(),
+            globs: vec![Regex::new(r"^(?:.*\.log)$").unwrap()],
+        };
+        assert!(matcher.ignores(root, &root.join(".cache/debug.log")));
+        assert!(!matcher.ignores(root, &root.join("src/main.ts")));
+    }
+}

--- a/crates/perry-hir/src/ir/constants.rs
+++ b/crates/perry-hir/src/ir/constants.rs
@@ -441,6 +441,13 @@ pub fn is_native_module(path: &str) -> bool {
     if !NATIVE_MODULES.contains(&normalized) {
         return false;
     }
+    // #8513: @parcel/watcher's root and platform packages are native facade
+    // entry points even when a broad compilePackages wildcard selected their
+    // package roots. The pure-JS `@parcel/watcher/wrapper` subpath is not in
+    // NATIVE_MODULES, so it still compiles normally.
+    if normalized == "@parcel/watcher" || normalized.starts_with("@parcel/watcher-") {
+        return true;
+    }
     let pkg = package_name_of(path);
     let overridden = COMPILE_PACKAGES_OVERRIDE.with(|cell| cell.borrow().contains(pkg));
     !overridden

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -21,7 +21,8 @@ pub(super) mod native_profile_import;
 // resolving. `lower_namespace_as_class` is also called from `lower/stmt.rs`.
 pub(crate) use namespace::lower_namespace_as_class;
 use native_default_import::{
-    is_cjs_style_native_default_import, node_submodule_default_export_key,
+    canonicalize_native_import_source, is_cjs_style_native_default_import,
+    node_submodule_default_export_key,
 };
 
 pub(crate) fn lower_module_decl(
@@ -34,15 +35,7 @@ pub(crate) fn lower_module_decl(
             // Get the source module path
             let raw_source = import_decl.src.value.as_str().unwrap_or("").to_string();
             // Normalize "node:" prefix (e.g., "node:async_hooks" -> "async_hooks")
-            let source = raw_source
-                .strip_prefix("node:")
-                .unwrap_or(&raw_source)
-                .to_string();
-            let source = if source.starts_with("@parcel/watcher-") {
-                "@parcel/watcher".to_string()
-            } else {
-                source
-            };
+            let source = canonicalize_native_import_source(&raw_source);
 
             if raw_source.starts_with("node:") && source == "punycode.ucs2" {
                 crate::lower_bail!(

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -38,6 +38,11 @@ pub(crate) fn lower_module_decl(
                 .strip_prefix("node:")
                 .unwrap_or(&raw_source)
                 .to_string();
+            let source = if source.starts_with("@parcel/watcher-") {
+                "@parcel/watcher".to_string()
+            } else {
+                source
+            };
 
             if raw_source.starts_with("node:") && source == "punycode.ucs2" {
                 crate::lower_bail!(

--- a/crates/perry-hir/src/lower/module_decl/native_default_import.rs
+++ b/crates/perry-hir/src/lower/module_decl/native_default_import.rs
@@ -1,6 +1,15 @@
 //! Native/CJS-style default-import classification helpers — extracted from
 //! `lower/module_decl.rs` (pure mechanical split, no logic changes).
 
+pub(crate) fn canonicalize_native_import_source(raw_source: &str) -> String {
+    let source = raw_source.strip_prefix("node:").unwrap_or(raw_source);
+    if source.starts_with("@parcel/watcher-") {
+        "@parcel/watcher".to_string()
+    } else {
+        source.to_string()
+    }
+}
+
 pub(crate) fn is_cjs_style_native_default_import(module_name: &str) -> bool {
     matches!(
         module_name,

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -5,7 +5,9 @@
 /// `require(someVar)` is unrepresentable as ESM and the bound `require`
 /// inside the IIFE will throw at runtime if hit.
 pub fn extract_require_specifiers(source: &str) -> Vec<String> {
-    let re = regex::Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap();
+    // A trailing comma is valid in calls and is emitted by formatters for
+    // multiline require expressions (including OpenCode's watcher selector).
+    let re = regex::Regex::new(r#"require\s*\(\s*['"]([^'"]+)['"]\s*,?\s*\)"#).unwrap();
     let masked = super::detect::strip_comments_and_strings(source);
     let mut specs = Vec::new();
     for cap in re.captures_iter(source) {

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -45,6 +45,8 @@ mod wrap;
 #[cfg(test)]
 mod issue_6585_tests;
 #[cfg(test)]
+mod parcel_watcher_tests;
+#[cfg(test)]
 mod preamble_canary_tests;
 
 // Cross-sibling helpers — siblings reach for these via `use super::*;`.

--- a/crates/perry/src/commands/compile/cjs_wrap/parcel_watcher_tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/parcel_watcher_tests.rs
@@ -1,0 +1,24 @@
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn wrap_folds_opencode_parcel_watcher_template_require_for_target() {
+    let src = r#"
+const libc = typeof OPENCODE_LIBC === "undefined" ? undefined : OPENCODE_LIBC
+const binding = require(
+  `@parcel/watcher-${process.platform}-${process.arch}${process.platform === "linux" ? `-${libc || "glibc"}` : ""}`,
+)
+module.exports = binding
+"#;
+    let wrapped = wrap_commonjs_for_target(
+        src,
+        &PathBuf::from("/tmp/node_modules/opencode/watcher.js"),
+        Some("linux-x86_64-musl"),
+    );
+    assert!(
+        wrapped.contains("from '@parcel/watcher-linux-x64-musl'")
+            || wrapped.contains("from \"@parcel/watcher-linux-x64-musl\""),
+        "target-specific sidecar must become a static import:\n{wrapped}"
+    );
+    assert!(!wrapped.contains("require(\n  `@parcel/watcher-"));
+}

--- a/crates/perry/src/commands/compile/cjs_wrap/tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/tests.rs
@@ -793,6 +793,28 @@ exports.spawn = function spawn() { return terminalCtor; };
 }
 
 #[test]
+fn wrap_folds_opencode_parcel_watcher_template_require_for_target() {
+    let src = r#"
+const libc = typeof OPENCODE_LIBC === "undefined" ? undefined : OPENCODE_LIBC
+const binding = require(
+  `@parcel/watcher-${process.platform}-${process.arch}${process.platform === "linux" ? `-${libc || "glibc"}` : ""}`,
+)
+module.exports = binding
+"#;
+    let wrapped = wrap_commonjs_for_target(
+        src,
+        &PathBuf::from("/tmp/node_modules/opencode/watcher.js"),
+        Some("linux-x86_64-musl"),
+    );
+    assert!(
+        wrapped.contains("from '@parcel/watcher-linux-x64-musl'")
+            || wrapped.contains("from \"@parcel/watcher-linux-x64-musl\""),
+        "target-specific sidecar must become a static import:\n{wrapped}"
+    );
+    assert!(!wrapped.contains("require(\n  `@parcel/watcher-"));
+}
+
+#[test]
 fn wrap_rewrites_depd_dynamic_deprecation_wrapper() {
     let src = r#"function wrapfunction (fn, message) {
   var args = createArgumentsString(fn.length)

--- a/crates/perry/src/commands/compile/cjs_wrap/tests.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/tests.rs
@@ -793,28 +793,6 @@ exports.spawn = function spawn() { return terminalCtor; };
 }
 
 #[test]
-fn wrap_folds_opencode_parcel_watcher_template_require_for_target() {
-    let src = r#"
-const libc = typeof OPENCODE_LIBC === "undefined" ? undefined : OPENCODE_LIBC
-const binding = require(
-  `@parcel/watcher-${process.platform}-${process.arch}${process.platform === "linux" ? `-${libc || "glibc"}` : ""}`,
-)
-module.exports = binding
-"#;
-    let wrapped = wrap_commonjs_for_target(
-        src,
-        &PathBuf::from("/tmp/node_modules/opencode/watcher.js"),
-        Some("linux-x86_64-musl"),
-    );
-    assert!(
-        wrapped.contains("from '@parcel/watcher-linux-x64-musl'")
-            || wrapped.contains("from \"@parcel/watcher-linux-x64-musl\""),
-        "target-specific sidecar must become a static import:\n{wrapped}"
-    );
-    assert!(!wrapped.contains("require(\n  `@parcel/watcher-"));
-}
-
-#[test]
 fn wrap_rewrites_depd_dynamic_deprecation_wrapper() {
     let src = r#"function wrapfunction (fn, message) {
   var args = createArgumentsString(fn.length)

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -132,6 +132,9 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
             source_cow = Cow::Owned(rewritten);
         }
     }
+    if let Some(rewritten) = fold_parcel_watcher_template_require(source_cow.as_ref(), target) {
+        source_cow = Cow::Owned(rewritten);
+    }
 
     // Issue #665 (fifth pass): rewrite `module.exports = class X { ... };`
     // expressions into declaration form + bare-identifier assignment so the
@@ -1175,6 +1178,62 @@ fn target_node_platform(target: Option<&str>) -> Option<&'static str> {
             }
         }
     }
+}
+
+fn target_node_arch(target: Option<&str>) -> Option<&'static str> {
+    match target {
+        Some(value) if value.contains("x86_64") || value.contains("x64") => Some("x64"),
+        Some(value) if value.contains("aarch64") || value.contains("arm64") => Some("arm64"),
+        Some("windows") | Some("linux") | Some("linux-musl") | Some("macos") => host_node_arch(),
+        Some(_) => None,
+        None => host_node_arch(),
+    }
+}
+
+fn host_node_arch() -> Option<&'static str> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        return Some("x64");
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        return Some("arm64");
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        None
+    }
+}
+
+/// Fold OpenCode's target-dependent @parcel/watcher sidecar require before
+/// the ordinary literal-require extractor runs. Native build targets make
+/// process.platform/process.arch/libc constants, so this is the same branch
+/// selection Node's package loader would perform at startup.
+fn fold_parcel_watcher_template_require(source: &str, target: Option<&str>) -> Option<String> {
+    let platform = target_node_platform(target)?;
+    let arch = target_node_arch(target)?;
+    let suffix = if platform == "linux" {
+        if target.is_some_and(|value| value.contains("musl")) {
+            "-musl"
+        } else {
+            "-glibc"
+        }
+    } else {
+        ""
+    };
+    let specifier = format!("@parcel/watcher-{platform}-{arch}{suffix}");
+    let template = regex::Regex::new(
+        r#"`@parcel/watcher-\$\{process\.platform\}-\$\{process\.arch\}\$\{process\.platform\s*===\s*[\"']linux[\"']\s*\?\s*`-\$\{libc\s*\|\|\s*[\"']glibc[\"']\}`\s*:\s*[\"'][\"']\}`"#,
+    )
+    .expect("parcel watcher template regex");
+    if !template.is_match(source) {
+        return None;
+    }
+    Some(
+        template
+            .replace_all(source, format!("\"{specifier}\"").as_str())
+            .into_owned(),
+    )
 }
 
 fn cyclic_require_specs(source: &str, source_path: &Path) -> std::collections::HashSet<String> {

--- a/crates/perry/src/commands/compile/collect_modules/native_addon.rs
+++ b/crates/perry/src/commands/compile/collect_modules/native_addon.rs
@@ -49,6 +49,11 @@ fn package_name_from_package_json(package_root: &std::path::Path) -> Option<Stri
         .map(str::to_string)
 }
 
+fn package_is_parcel_watcher_facade(package_root: &std::path::Path) -> bool {
+    package_name_from_package_json(package_root)
+        .is_some_and(|name| name == "@parcel/watcher" || name.starts_with("@parcel/watcher-"))
+}
+
 fn find_node_addon_file(dir: &std::path::Path, max_depth: usize) -> Option<PathBuf> {
     if max_depth == 0 {
         return None;
@@ -137,7 +142,9 @@ fn wildcard_node_addon_marker(package_root: &std::path::Path) -> Option<(&'stati
 pub(in crate::commands::compile) fn package_has_unsupported_node_addon(
     package_root: &std::path::Path,
 ) -> bool {
-    !has_perry_native_library(package_root) && wildcard_node_addon_marker(package_root).is_some()
+    !has_perry_native_library(package_root)
+        && !package_is_parcel_watcher_facade(package_root)
+        && wildcard_node_addon_marker(package_root).is_some()
 }
 
 fn package_json_dependency_uses_native_addon_loader(
@@ -170,7 +177,14 @@ pub(super) fn refuse_node_addon_binary(canonical: &std::path::Path) -> Result<()
     if canonical.extension().and_then(|ext| ext.to_str()) != Some("node") {
         return Ok(());
     }
-    let package_name = nearest_package_root(canonical)
+    let package_root = nearest_package_root(canonical);
+    if package_root
+        .as_deref()
+        .is_some_and(package_is_parcel_watcher_facade)
+    {
+        return Ok(());
+    }
+    let package_name = package_root
         .and_then(|root| package_name_from_package_json(&root))
         .unwrap_or_else(|| canonical.display().to_string());
     anyhow::bail!(
@@ -199,6 +213,9 @@ pub(super) fn refuse_compile_package_native_addon(
         return Ok(());
     }
     if has_perry_native_library(&package_root) {
+        return Ok(());
+    }
+    if package_is_parcel_watcher_facade(&package_root) {
         return Ok(());
     }
     let Some((marker, marker_path)) = node_addon_marker(&package_root) else {

--- a/crates/perry/src/commands/compile/collect_modules/tests.rs
+++ b/crates/perry/src/commands/compile/collect_modules/tests.rs
@@ -740,6 +740,20 @@ fn wildcard_preflight_skips_node_native_addon_package() {
 }
 
 #[test]
+fn parcel_watcher_sidecar_is_served_by_facade_not_rejected_as_addon() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let package_name = "@parcel/watcher-darwin-arm64";
+    let entry = write_compile_package_fixture(root, package_name, "");
+    let package = root.join("node_modules").join(package_name);
+    std::fs::write(package.join("watcher.node"), b"not a real addon").expect("write addon marker");
+
+    assert!(!package_has_unsupported_node_addon(&package));
+    guard_compile_package(root, package_name, &entry)
+        .expect("the registered @parcel/watcher sidecar must route to its native facade");
+}
+
+#[test]
 fn static_pure_js_subpath_of_auto_skipped_native_addon_is_aot_compiled() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -963,6 +963,19 @@ pub(crate) fn build_and_run_link(
                 .arg("-lresolv")
                 .arg("-lobjc");
         }
+        // #8513: notify's macOS backend references FSEventStream*. Cargo
+        // normally propagates fsevent-sys's CoreServices link metadata to a
+        // final Rust binary, but a perry-ext static archive crosses Perry's
+        // custom linker boundary, where that metadata is no longer present.
+        // Restore it only for binaries that selected the watcher facade.
+        if (cfg!(target_os = "macos") || is_cross_macos)
+            && ctx
+                .native_module_imports
+                .iter()
+                .any(|module| module == "@parcel/watcher" || module.starts_with("@parcel/watcher-"))
+        {
+            cmd.arg("-framework").arg("CoreServices");
+        }
 
         // On Linux (native, not cross-compiling to macOS), link against system libraries
         if cfg!(target_os = "linux") && !is_cross_macos {

--- a/crates/perry/well_known_bindings.toml
+++ b/crates/perry/well_known_bindings.toml
@@ -651,3 +651,69 @@ repo = "https://github.com/nodejs/undici"
 ref = "21a8e1ed1843e74c3004a2926c12bb0ceaca6b71"
 ported-at = "8.9.0"
 date = "2026-07-30"
+
+# `@parcel/watcher` 2.5.1 ships a pure-JS option wrapper plus one platform
+# package whose `main` is a Node-API `.node` file. Perry serves the binding
+# object natively from one notify-backed static archive; all published sidecar
+# names are aliases so a target-folded dynamic require reaches the same facade.
+[bindings."@parcel/watcher"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+compat = "partial"
+
+[bindings."@parcel/watcher".upstream]
+version = "2.5.1"
+sha256 = "bf7a6b5577a287153c9a6bf7be953556b998f2a57706eb7a5371ec7eb0088d41"
+repo = "https://github.com/parcel-bundler/watcher"
+ref = "119f1ff04bb41c2369929e37274900c61b0a9f49"
+ported-at = "2.5.1"
+date = "2026-08-21"
+
+[bindings."@parcel/watcher-darwin-x64"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-darwin-arm64"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-linux-x64-glibc"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-linux-x64-musl"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-linux-arm64-glibc"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-linux-arm64-musl"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-win32-x64"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"
+
+[bindings."@parcel/watcher-win32-arm64"]
+crate = "perry-ext-parcel-watcher"
+lib = "perry_ext_parcel_watcher"
+tracking = "#8513"
+alias-of = "@parcel/watcher"

--- a/docs/src/stdlib/other.md
+++ b/docs/src/stdlib/other.md
@@ -265,6 +265,31 @@ term.kill("SIGTERM");   // no argument = SIGHUP
 sub.dispose();          // unsubscribe onData
 ```
 
+## @parcel/watcher
+
+Perry provides the low-level `@parcel/watcher` binding object and all eight
+published platform-package names through one `notify`-backed native facade.
+The pure-JavaScript `@parcel/watcher/wrapper` continues to compile normally;
+its target-dependent platform `require` is folded to the native facade at
+compile time. The behavior was checked against `@parcel/watcher` 2.5.1.
+
+Subscriptions use FSEvents on macOS, inotify on Linux,
+ReadDirectoryChangesW on Windows, and notify's native backend on other
+supported systems. An unknown or unavailable requested backend falls back to
+the platform default. Events are delivered on Perry's main thread in
+coalesced batches: create followed by update remains one `create`, create
+followed by delete disappears, and rename is `delete` for the old path plus
+`create` for the new path. Backend overflow/rescan notifications trigger a
+fresh tree snapshot and emit its diff.
+
+`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex sources
+produced by the package's JS wrapper and match root-relative paths, including
+dot-files. `unsubscribe` matches directory, callback identity, and normalized
+options; it stops the native watcher and drains queued events before its
+promise resolves, so no callback fires afterward. Live subscriptions keep the
+event loop active. `writeSnapshot` and `getEventsSince` use the same snapshot
+diff semantics as overflow recovery.
+
 ## External native bindings
 
 Two packages live in their own GitHub repos with their own semver — they're

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -437,6 +437,12 @@
       "why": "Declared in lib.rs, scanned from the gc.rs submodule (split out for the 2,000-line gate): every RequestRecord.signal slot is visited and rewritten."
     },
     {
+      "file": "crates/perry-ext-parcel-watcher/src/lib.rs",
+      "name": "PENDING",
+      "verdict": "not_a_gc_pointer",
+      "why": "Pending watcher events carry only a subscription u64 id plus Rust-owned PathBuf/String payloads and enum tags. Callback closures live in perry-ffi CallbackRoot handles, which scan_subscription_roots visits and rewrites."
+    },
+    {
       "file": "crates/perry-runtime/src/perf_hooks.rs",
       "name": "LOOP_START_MS",
       "verdict": "not_a_gc_pointer",

--- a/test-files/test_parcel_watcher_facade.ts
+++ b/test-files/test_parcel_watcher_facade.ts
@@ -1,0 +1,142 @@
+import {
+  __nativeEventCount,
+  getEventsSince,
+  subscribe,
+  unsubscribe,
+  writeSnapshot,
+} from "@parcel/watcher";
+import { subscribe as sidecarSubscribe } from "@parcel/watcher-darwin-arm64";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+declare function gc(): void;
+
+type WatchEvent = { path: string; type: "create" | "update" | "delete" };
+
+const root = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "perry-parcel-watcher-")),
+);
+const snapshot = path.join(os.tmpdir(), `perry-parcel-watcher-${Date.now()}.json`);
+const ignoredDir = path.join(root, "ignored-dir");
+const options = {
+  // Deliberately unavailable on Linux/Windows: the facade must fall back to
+  // the platform default instead of rejecting the subscription.
+  backend: "fs-events",
+  ignorePaths: [ignoredDir],
+  ignoreGlobs: [String.raw`^(?:.*\.ignored)$`],
+};
+const receivedA: WatchEvent[] = [];
+const receivedB: WatchEvent[] = [];
+const errors: string[] = [];
+
+const callbackA = (error: Error | null, events: WatchEvent[]) => {
+  if (error) errors.push(error.message);
+  for (const event of events) receivedA.push(event);
+};
+const callbackB = (error: Error | null, events: WatchEvent[]) => {
+  if (error) errors.push(error.message);
+  for (const event of events) receivedB.push(event);
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+async function waitFor(predicate: () => boolean, message: string) {
+  const deadline = Date.now() + 4000;
+  while (!predicate() && Date.now() < deadline) await delay(10);
+  if (!predicate()) {
+    throw new Error(
+      `timed out waiting for ${message} (native events: ${__nativeEventCount()})`,
+    );
+  }
+}
+const has = (events: WatchEvent[], type: WatchEvent["type"], file: string) =>
+  events.some((event) => event.type === type && event.path === file);
+
+await writeSnapshot(root, snapshot, options);
+await subscribe(root, callbackA, options);
+await subscribe(root, callbackB, options);
+
+// create+update must coalesce to one create in one throttled batch.
+const created = path.join(root, "created.txt");
+fs.writeFileSync(created, "one");
+fs.writeFileSync(created, "two");
+await waitFor(() => has(receivedA, "create", created), "create event");
+await delay(50);
+const createdEvents = receivedA.filter((event) => event.path === created);
+
+// create+delete in one batch must disappear.
+const transient = path.join(root, "transient.txt");
+fs.writeFileSync(transient, "short-lived");
+fs.rmSync(transient);
+await delay(100);
+
+// Exercise nested creation, modification, rename ordering, and deletion.
+const nestedDir = path.join(root, "nested");
+const nested = path.join(nestedDir, "nested.txt");
+fs.mkdirSync(nestedDir);
+fs.writeFileSync(nested, "nested");
+await waitFor(() => has(receivedA, "create", nested), "nested create event");
+
+fs.writeFileSync(created, "three");
+await waitFor(() => has(receivedA, "update", created), "update event");
+
+const renamed = path.join(root, "renamed.txt");
+fs.renameSync(created, renamed);
+await waitFor(
+  () => has(receivedA, "delete", created) && has(receivedA, "create", renamed),
+  "rename events",
+);
+const renameDelete = receivedA.findIndex(
+  (event) => event.type === "delete" && event.path === created,
+);
+const renameCreate = receivedA.findIndex(
+  (event) => event.type === "create" && event.path === renamed,
+);
+
+fs.rmSync(renamed);
+await waitFor(() => has(receivedA, "delete", renamed), "delete event");
+
+fs.mkdirSync(ignoredDir);
+fs.writeFileSync(path.join(ignoredDir, "ignored.txt"), "ignored");
+const ignoredGlob = path.join(root, ".dot.ignored");
+fs.writeFileSync(ignoredGlob, "ignored");
+await delay(100);
+
+// Queue an event immediately before unsubscribe, then force a collection.
+// Once the promise resolves neither that in-flight event nor a later event may
+// reach callback A, while callback B must remain independently subscribed.
+const inFlight = path.join(root, "in-flight.txt");
+fs.writeFileSync(inFlight, "queued");
+await unsubscribe(root, callbackA, options);
+if (typeof gc === "function") gc();
+const countAfterUnsubscribe = receivedA.length;
+const late = path.join(root, "late.txt");
+fs.writeFileSync(late, "late");
+await waitFor(() => has(receivedB, "create", late), "second subscription event");
+await delay(100);
+await unsubscribe(root, callbackB, options);
+
+const diff = await getEventsSince(root, snapshot, options);
+const checks = [
+  typeof sidecarSubscribe === "function",
+  errors.length === 0,
+  createdEvents.length === 1 && createdEvents[0].type === "create",
+  !receivedA.some((event) => event.path === transient),
+  has(receivedA, "create", nested),
+  renameDelete >= 0 && renameDelete < renameCreate,
+  has(receivedA, "delete", renamed),
+  !receivedA.some((event) => event.path.startsWith(ignoredDir)),
+  !receivedA.some((event) => event.path === ignoredGlob),
+  receivedA.length === countAfterUnsubscribe,
+  has(receivedB, "create", late),
+  diff.some((event) => event.path === nested),
+  receivedA.every((event) => path.isAbsolute(event.path)),
+  __nativeEventCount() > 0,
+];
+for (const check of checks) console.log(check);
+if (checks.some((check) => !check)) {
+  throw new Error("@parcel/watcher facade integration check failed");
+}
+
+fs.rmSync(root, { recursive: true, force: true });
+fs.rmSync(snapshot, { force: true });

--- a/test-files/test_parcel_watcher_idle.ts
+++ b/test-files/test_parcel_watcher_idle.ts
@@ -1,0 +1,35 @@
+import { subscribe, unsubscribe } from "@parcel/watcher";
+import fs from "fs";
+import path from "path";
+
+const configuredRoot = process.env.PERRY_WATCH_ROOT;
+const readyPath = process.env.PERRY_WATCH_READY;
+if (!configuredRoot || !readyPath) {
+  throw new Error(
+    "PERRY_WATCH_ROOT and PERRY_WATCH_READY are required for the idle benchmark",
+  );
+}
+const root = fs.realpathSync(configuredRoot);
+const wakePath = path.join(root, "wake.txt");
+
+const options = {};
+let callbacks = 0;
+let finish: () => void = () => {};
+const wake = new Promise<void>((resolve) => {
+  finish = resolve;
+});
+const callback = (_error: Error | null, events: { path: string }[]) => {
+  callbacks++;
+  if (events.some((event) => event.path === wakePath)) finish();
+};
+await subscribe(root, callback, options);
+fs.writeFileSync(readyPath, "ready");
+const before = process.cpuUsage();
+const started = Date.now();
+await wake;
+const idle = process.cpuUsage(before);
+const elapsed = Date.now() - started;
+await unsubscribe(root, callback, options);
+
+console.log(callbacks === 1);
+console.log(`idle CPU: ${(idle.user + idle.system) / 1000} ms / ${elapsed} ms`);

--- a/workspace-architecture.json
+++ b/workspace-architecture.json
@@ -25,7 +25,7 @@
     ]
   },
   "baseline": {
-    "workspace_members": 78,
+    "workspace_members": 79,
     "default_dependency_closure": [
       "perry",
       "perry-api-manifest",
@@ -66,7 +66,7 @@
       "perry-updater"
     ],
     "decision_counts": {
-      "externalize": 31,
+      "externalize": 32,
       "keep": 42,
       "merge": 1,
       "remove": 1,
@@ -203,6 +203,10 @@
       "decision": "externalize"
     },
     "perry-ext-node-forge": {
+      "category": "binding",
+      "decision": "externalize"
+    },
+    "perry-ext-parcel-watcher": {
       "category": "binding",
       "decision": "externalize"
     },


### PR DESCRIPTION
## Summary

- add a notify 6.1-backed @parcel/watcher 2.5.1 binding facade for the root and all eight platform aliases
- deliver main-thread, GC-rooted callbacks with stable coalescing, rename, ignore, snapshot, liveness, and safe-unsubscribe semantics
- fold OpenCode's target-dependent sidecar require, bypass facade-served Node addon rejection, and restore macOS CoreServices linkage at the custom linker boundary

## Verification

- cargo check -p perry -p perry-codegen -p perry-hir -p perry-api-manifest -p perry-ext-parcel-watcher
- cargo test -p perry-ext-parcel-watcher --lib (7 passed)
- cargo test -p perry --bin perry parcel_watcher (2 passed)
- cargo test -p perry-codegen --test manifest_consistency (5 passed)
- node scripts/binding_pins.mjs --check
- python3 scripts/gc_runtime_root_holders.py
- python3 scripts/workspace_architecture.py
- python3 scripts/ci_ext_link_scope.py
- standalone facade fixture: 14/14 assertions true, including native backend engagement, two subscribers, ignores, rename ordering, snapshots, forced-GC unsubscribe, and no late callbacks
- 20,000-file idle fixture: 1.253 ms process CPU over 5.080 s (about 0.025% of one core)

No version bump is included.

Closes #8513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native support for `@parcel/watcher` and platform-specific watcher packages.
  * Added filesystem event subscriptions, event coalescing, filtering, snapshots, rename handling, and overflow recovery.
  * Added support for native watcher operation across macOS, Linux, and Windows.

* **Bug Fixes**
  * Improved handling of platform-specific watcher imports and dynamic package resolution.
  * Allowed trailing commas in static CommonJS `require` calls.

* **Documentation**
  * Added usage and behavior documentation for the native watcher facade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->