### PR TITLE
fix(dgram): support UDP multicast discovery

### DIFF
--- a/changelog.d/8536-udp-multicast.md
+++ b/changelog.d/8536-udp-multicast.md
@@ -1,0 +1,5 @@
+**Runtime: make `node:dgram` multicast usable by Bonjour/mDNS clients.**
+
+UDP sockets now apply Node-compatible `reuseAddr` and `ipv6Only` options before bind, including the BSD/Apple `SO_REUSEPORT` behavior required for multiple mDNS listeners. Multicast membership, interface, TTL, and loopback controls operate on the live socket and report failures instead of silently accepting invalid configuration.
+
+Closing a socket now wakes and joins its receive worker before emitting `close`, releasing shared ports promptly. Datagram callbacks also restore the AsyncLocalStorage context captured when the socket was bound. New host-network fixtures cover shared bind/cleanup, multicast loopback delivery with join/drop membership, and async-context propagation.

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -317,10 +317,10 @@ url = { version = "2", optional = true }
 # style. resolv-conf reads the system nameserver list from /etc/resolv.conf.
 hickory-proto = { version = "0.26", default-features = false, features = ["std"] }
 resolv-conf = "0.7"
-# #4911: real node:dgram UDP sockets. std::net::UdpSocket covers bind/send/recv
-# + the common multicast/broadcast/TTL options; socket2 borrows the same fd
-# (SockRef) for the few std lacks — set_multicast_if and source-specific
-# membership — so those are real rather than silent no-ops.
+# #4911/#8515: real node:dgram UDP sockets. socket2 creates sockets so reuse
+# and IPv6-only options are applied before bind; std::net::UdpSocket then drives
+# send/recv and the common multicast/broadcast/TTL options. SockRef covers the
+# remaining multicast-interface and source-specific membership controls.
 socket2 = { workspace = true, features = ["all"] }
 # mimalloc is declared 64-bit-only below (see the target_pointer_width section) —
 # on arm64_32/ILP32 it is neither used nor compiled.

--- a/crates/perry-runtime/src/dgram.rs
+++ b/crates/perry-runtime/src/dgram.rs
@@ -99,6 +99,8 @@ pub(crate) const KEY_REMOTE_FAMILY: &[u8] = b"__perryDgramRemoteFamily";
 pub(crate) const KEY_REMOTE_PORT: &[u8] = b"__perryDgramRemotePort";
 pub(crate) const KEY_RECV_BUFFER_SIZE: &[u8] = b"__perryDgramRecvBufferSize";
 pub(crate) const KEY_SEND_BUFFER_SIZE: &[u8] = b"__perryDgramSendBufferSize";
+pub(crate) const KEY_REUSE_ADDR: &[u8] = b"__perryDgramReuseAddr";
+pub(crate) const KEY_IPV6_ONLY: &[u8] = b"__perryDgramIpv6Only";
 pub(crate) const KEY_LOOKUP: &[u8] = b"__perryDgramLookup";
 pub(crate) const KEY_SEND_BLOCK_LIST: &[u8] = b"__perryDgramSendBlockList";
 pub(crate) const KEY_BIND_ATTEMPTED: &[u8] = b"__perryDgramBindAttempted";
@@ -472,6 +474,8 @@ pub(crate) fn socket_object(socket_type: &str) -> f64 {
     set_hidden_value(socket, KEY_REMOTE_PORT, 0.0);
     set_hidden_value(socket, KEY_RECV_BUFFER_SIZE, 65536.0);
     set_hidden_value(socket, KEY_SEND_BUFFER_SIZE, 65536.0);
+    set_hidden_value(socket, KEY_REUSE_ADDR, bool_value(false));
+    set_hidden_value(socket, KEY_IPV6_ONLY, bool_value(false));
     for method in SOCKET_METHODS {
         js_object_set_field_by_name(
             obj,

--- a/crates/perry-runtime/src/dgram/net.rs
+++ b/crates/perry-runtime/src/dgram/net.rs
@@ -10,6 +10,8 @@ use super::*;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
 use std::sync::Arc;
 
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+
 use crate::object::{js_object_alloc, js_object_set_field_by_name};
 
 pub(crate) fn allocate_port(registry: &mut DgramRegistry, address: &str) -> u16 {
@@ -273,7 +275,29 @@ pub(crate) fn resolve_send_addr(address: &str, port: u16) -> Result<SocketAddr, 
 /// returns the error value for the caller to emit as `'error'`.
 pub(crate) fn real_bind(socket: f64, port: u16, address: &str) -> Result<(), f64> {
     let address = normalize_address(address, socket);
-    let udp = match UdpSocket::bind((address.as_str(), port)) {
+    let is_v6 = string_eq(
+        get_hidden_value(socket, KEY_TYPE).unwrap_or_else(|| str_value("udp4")),
+        b"udp6",
+    );
+    let socket_addr = match (address.as_str(), port)
+        .to_socket_addrs()
+        .ok()
+        .and_then(|mut addresses| addresses.find(|candidate| candidate.is_ipv6() == is_v6))
+    {
+        Some(address) => address,
+        None => {
+            return Err(socket_error_value(
+                &format!("bind EADDRNOTAVAIL {address}:{port}"),
+                "EADDRNOTAVAIL",
+                "bind",
+            ));
+        }
+    };
+    let udp = match open_udp_socket(
+        socket_addr,
+        is_truthy_hidden(socket, KEY_REUSE_ADDR),
+        is_v6 && is_truthy_hidden(socket, KEY_IPV6_ONLY),
+    ) {
         Ok(udp) => udp,
         Err(err) => {
             return Err(socket_error_value(
@@ -298,6 +322,51 @@ pub(crate) fn real_bind(socket: f64, port: u16, address: &str) -> Result<(), f64
     set_hidden_value(socket, KEY_PORT, actual_port as f64);
     set_hidden_value(socket, KEY_BOUND, bool_value(true));
     Ok(())
+}
+
+fn open_udp_socket(
+    address: SocketAddr,
+    reuse_addr: bool,
+    ipv6_only: bool,
+) -> std::io::Result<UdpSocket> {
+    let domain = if address.is_ipv6() {
+        Domain::IPV6
+    } else {
+        Domain::IPV4
+    };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    if reuse_addr {
+        configure_reuse_addr(&socket)?;
+    }
+    if address.is_ipv6() && ipv6_only {
+        socket.set_only_v6(true)?;
+    }
+    socket.bind(&SockAddr::from(address))?;
+    Ok(socket.into())
+}
+
+// libuv's UV_UDP_REUSEADDR uses SO_REUSEPORT on Apple/BSD because those
+// kernels give it the multicast port-sharing semantics Node expects. Linux
+// uses SO_REUSEADDR; SO_REUSEPORT there load-balances instead.
+fn configure_reuse_addr(socket: &Socket) -> std::io::Result<()> {
+    #[cfg(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    {
+        socket.set_reuse_port(true)
+    }
+    #[cfg(not(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    {
+        socket.set_reuse_address(true)
+    }
 }
 
 /// Real `send()`: transmit over the OS socket. Errors go to the callback when

--- a/crates/perry-runtime/src/dgram/ops.rs
+++ b/crates/perry-runtime/src/dgram/ops.rs
@@ -133,6 +133,20 @@ pub(crate) fn create_socket_impl(args: &[f64]) -> f64 {
                 validate_option_buffer_size(size, "options.sendBufferSize").max(1.0),
             );
         }
+        if let Some(reuse_addr) = get_prop(options, "reuseAddr") {
+            set_hidden_value(
+                socket,
+                KEY_REUSE_ADDR,
+                bool_value(crate::value::js_is_truthy(reuse_addr) != 0),
+            );
+        }
+        if let Some(ipv6_only) = get_prop(options, "ipv6Only") {
+            set_hidden_value(
+                socket,
+                KEY_IPV6_ONLY,
+                bool_value(crate::value::js_is_truthy(ipv6_only) != 0),
+            );
+        }
         if let Some(block_list) = get_prop(options, "sendBlockList") {
             set_hidden_value(socket, KEY_SEND_BLOCK_LIST, block_list);
         }
@@ -503,10 +517,12 @@ pub(crate) fn membership_impl(socket: f64, args: &[f64], syscall: &'static str) 
     let interface = args.get(1).copied().and_then(string_to_rust);
     let dropping = syscall == "dropMembership";
     let result = if let Some(group_v4) = parse_multicast_v4(&group) {
-        let iface = interface
-            .as_deref()
-            .and_then(|s| s.parse::<Ipv4Addr>().ok())
-            .unwrap_or(Ipv4Addr::UNSPECIFIED);
+        let iface = match interface.as_deref() {
+            Some(value) => value
+                .parse::<Ipv4Addr>()
+                .unwrap_or_else(|_| throw_socket_errno(syscall, "EINVAL")),
+            None => Ipv4Addr::UNSPECIFIED,
+        };
         if dropping {
             udp.leave_multicast_v4(&group_v4, &iface)
         } else {
@@ -605,9 +621,12 @@ pub(crate) fn set_multicast_ttl_impl(socket: f64, args: &[f64]) -> f64 {
     }
     ensure_running(socket, "setMulticastTTL");
     if !deterministic() {
-        with_udp(socket, |udp| {
-            let _ = udp.set_multicast_ttl_v4(ttl as u32);
-        });
+        let result = live_udp(socket)
+            .ok_or(())
+            .and_then(|udp| udp.set_multicast_ttl_v4(ttl as u32).map_err(|_| ()));
+        if result.is_err() {
+            throw_socket_errno("setMulticastTTL", "EINVAL");
+        }
     }
     ttl
 }
@@ -617,9 +636,20 @@ pub(crate) fn set_multicast_loopback_impl(socket: f64, args: &[f64]) -> f64 {
     ensure_running(socket, "setMulticastLoopback");
     if !deterministic() {
         let flag = crate::value::js_is_truthy(arg) != 0;
-        with_udp(socket, |udp| {
-            let _ = udp.set_multicast_loop_v4(flag);
+        let is_v6 = string_eq(
+            get_hidden_value(socket, KEY_TYPE).unwrap_or_else(|| str_value("udp4")),
+            b"udp6",
+        );
+        let result = live_udp(socket).ok_or(()).and_then(|udp| {
+            if is_v6 {
+                udp.set_multicast_loop_v6(flag).map_err(|_| ())
+            } else {
+                udp.set_multicast_loop_v4(flag).map_err(|_| ())
+            }
         });
+        if result.is_err() {
+            throw_socket_errno("setMulticastLoopback", "EINVAL");
+        }
     }
     arg
 }
@@ -634,10 +664,16 @@ pub(crate) fn set_multicast_interface_impl(socket: f64, args: &[f64]) -> f64 {
     }
     ensure_running(socket, "setMulticastInterface");
     if !deterministic() {
-        if let Ok(iface) = interface_address.parse::<Ipv4Addr>() {
-            with_udp(socket, |udp| {
-                let _ = socket2::SockRef::from(udp).set_multicast_if_v4(&iface);
-            });
+        let iface = interface_address
+            .parse::<Ipv4Addr>()
+            .unwrap_or_else(|_| throw_socket_errno("setMulticastInterface", "EINVAL"));
+        let result = live_udp(socket).ok_or(()).and_then(|udp| {
+            socket2::SockRef::from(&*udp)
+                .set_multicast_if_v4(&iface)
+                .map_err(|_| ())
+        });
+        if result.is_err() {
+            throw_socket_errno("setMulticastInterface", "EINVAL");
         }
     }
     undefined_value()

--- a/crates/perry-runtime/src/dgram_reactor.rs
+++ b/crates/perry-runtime/src/dgram_reactor.rs
@@ -31,6 +31,9 @@ struct LiveSocket {
     socket_bits: u64,
     udp: Arc<UdpSocket>,
     closing: Arc<AtomicBool>,
+    recv_thread: Option<std::thread::JoinHandle<()>>,
+    /// AsyncLocalStorage context active when the UDP handle was bound.
+    context: crate::async_context::AsyncContextSnapshot,
     /// Whether this socket holds the event loop open (`ref`'d). `unref()`
     /// clears it; `ref()` sets it.
     refed: bool,
@@ -68,6 +71,8 @@ pub(crate) fn register(socket_bits: u64, udp: Arc<UdpSocket>) -> u64 {
     let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
     let closing = Arc::new(AtomicBool::new(false));
     let _ = udp.set_read_timeout(Some(RECV_POLL));
+    let context = crate::async_context::capture_context();
+    let recv_thread = spawn_recv(id, udp.clone(), closing.clone());
     {
         let mut guard = live_lock();
         guard.get_or_insert_with(HashMap::new).insert(
@@ -76,17 +81,22 @@ pub(crate) fn register(socket_bits: u64, udp: Arc<UdpSocket>) -> u64 {
                 socket_bits,
                 udp: udp.clone(),
                 closing: closing.clone(),
+                recv_thread: Some(recv_thread),
+                context,
                 refed: true,
             },
         );
     }
     LIVE_COUNT.fetch_add(1, Ordering::SeqCst);
     REFED_COUNT.fetch_add(1, Ordering::SeqCst);
-    spawn_recv(id, udp, closing);
     id
 }
 
-fn spawn_recv(id: u64, udp: Arc<UdpSocket>, closing: Arc<AtomicBool>) {
+fn spawn_recv(
+    id: u64,
+    udp: Arc<UdpSocket>,
+    closing: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut buf = [0u8; RECV_CAP];
         loop {
@@ -112,7 +122,7 @@ fn spawn_recv(id: u64, udp: Arc<UdpSocket>, closing: Arc<AtomicBool>) {
                 },
             }
         }
-    });
+    })
 }
 
 /// Recover the live `UdpSocket` for `id` (set/used by `dgram.rs` methods).
@@ -129,13 +139,29 @@ pub(crate) fn unregister(id: u64) {
         let mut guard = live_lock();
         guard.as_mut().and_then(|map| map.remove(&id))
     };
-    if let Some(ls) = removed {
+    if let Some(mut ls) = removed {
         ls.closing.store(true, Ordering::Release);
+        wake_receiver(&ls.udp);
+        if let Some(thread) = ls.recv_thread.take() {
+            let _ = thread.join();
+        }
         LIVE_COUNT.fetch_sub(1, Ordering::SeqCst);
         if ls.refed {
             REFED_COUNT.fetch_sub(1, Ordering::SeqCst);
         }
     }
+}
+
+fn wake_receiver(udp: &UdpSocket) {
+    let Ok(local) = udp.local_addr() else {
+        return;
+    };
+    let wake = if local.is_ipv4() {
+        SocketAddr::from(([127, 0, 0, 1], local.port()))
+    } else {
+        SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], local.port()))
+    };
+    let _ = udp.send_to(&[], wake);
 }
 
 /// `socket.ref()` / `socket.unref()` — toggle whether this socket holds the
@@ -163,13 +189,14 @@ pub(crate) fn pump() {
     let datagrams = std::mem::take(&mut *queue_lock());
     for datagram in datagrams {
         // The socket may have been closed between recv and pump; skip if gone.
-        let socket_bits = {
+        let live = {
             let guard = live_lock();
-            guard
-                .as_ref()
-                .and_then(|map| map.get(&datagram.id).map(|ls| ls.socket_bits))
+            guard.as_ref().and_then(|map| {
+                map.get(&datagram.id)
+                    .map(|ls| (ls.socket_bits, ls.context.clone()))
+            })
         };
-        let Some(socket_bits) = socket_bits else {
+        let Some((socket_bits, context)) = live else {
             continue;
         };
         let family = if datagram.src.is_ipv4() {
@@ -177,6 +204,10 @@ pub(crate) fn pump() {
         } else {
             "IPv6"
         };
+        let previous = crate::async_context::enter_context(&context);
+        crate::async_context::push_context_guard(
+            crate::async_context::ContextGuardAction::RestoreSnapshot(previous),
+        );
         crate::dgram::dgram_emit_message(
             socket_bits,
             &datagram.data,
@@ -184,6 +215,9 @@ pub(crate) fn pump() {
             datagram.src.port(),
             family,
         );
+        if let Some(action) = crate::async_context::pop_context_guard() {
+            crate::async_context::apply_context_guard(action);
+        }
     }
 }
 
@@ -202,6 +236,7 @@ pub(crate) fn scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     if let Some(map) = live_lock().as_mut() {
         for ls in map.values_mut() {
             visitor.visit_nanbox_u64_slot(&mut ls.socket_bits);
+            crate::async_context::scan_snapshot_roots_mut(&mut ls.context, visitor);
         }
     }
 }

--- a/test-parity/node-suite/dgram/STATUS.md
+++ b/test-parity/node-suite/dgram/STATUS.md
@@ -171,6 +171,15 @@ These boundaries assign DNS resolver behavior to `dns`, socket distribution to
 
 ## Verification
 
+### #8515 multicast additions
+
+Three host-network fixtures extend the portable floor to 42/57: reusable
+shared-port binds with prompt close/rebind, IPv4 multicast loopback delivery
+with explicit join/drop membership, and AsyncLocalStorage propagation through
+UDP message callbacks. The multicast fixture uses the loopback interface and
+an ephemeral port so it exercises the OS multicast path without depending on
+LAN topology or occupying mDNS port 5353.
+
 ```text
 NODE_BIN=/private/tmp/node-v26.5.0-bin/bin/node \
 python3 scripts/node_suite_run.py "$PWD/target/release/perry" "$PWD" dgram

--- a/test-parity/node-suite/dgram/multicast/loopback-delivery.ts
+++ b/test-parity/node-suite/dgram/multicast/loopback-delivery.ts
@@ -1,0 +1,31 @@
+import * as dgram from "node:dgram";
+
+const group = "224.0.0.114";
+const iface = "127.0.0.1";
+const socket = dgram.createSocket({ type: "udp4", reuseAddr: true });
+
+await new Promise<void>((resolve, reject) => {
+  const timeout = setTimeout(() => reject(new Error("multicast timeout")), 3000);
+  socket.once("error", reject);
+  socket.once("message", (message, rinfo) => {
+    clearTimeout(timeout);
+    console.log(
+      "multicast message:",
+      message.toString(),
+      rinfo.family,
+      rinfo.size,
+    );
+    resolve();
+  });
+  socket.bind(0, "0.0.0.0", () => {
+    socket.addMembership(group, iface);
+    socket.setMulticastInterface(iface);
+    socket.setMulticastTTL(16);
+    socket.setMulticastLoopback(true);
+    socket.send("bonjour", socket.address().port, group);
+  });
+});
+
+socket.dropMembership(group, iface);
+await new Promise<void>((resolve) => socket.close(resolve));
+console.log("membership cleanup: true");

--- a/test-parity/node-suite/dgram/multicast/reuse-address-cleanup.ts
+++ b/test-parity/node-suite/dgram/multicast/reuse-address-cleanup.ts
@@ -1,0 +1,31 @@
+import * as dgram from "node:dgram";
+
+function bind(socket: dgram.Socket, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("error", reject);
+    socket.bind(port, "0.0.0.0", () => {
+      socket.removeListener("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(socket: dgram.Socket): Promise<void> {
+  return new Promise((resolve) => socket.close(resolve));
+}
+
+const first = dgram.createSocket({ type: "udp4", reuseAddr: true });
+const second = dgram.createSocket({ type: "udp4", reuseAddr: true });
+
+await bind(first, 0);
+const port = first.address().port;
+await bind(second, port);
+console.log("shared bind: true");
+
+await close(second);
+await close(first);
+
+const replacement = dgram.createSocket("udp4");
+await bind(replacement, port);
+console.log("released after close: true");
+await close(replacement);

--- a/test-parity/node-suite/dgram/send/async-local-storage.ts
+++ b/test-parity/node-suite/dgram/send/async-local-storage.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as dgram from "node:dgram";
+
+const storage = new AsyncLocalStorage<string>();
+
+await new Promise<void>((resolve, reject) => {
+  storage.run("udp-context", () => {
+    const receiver = dgram.createSocket("udp4");
+    const sender = dgram.createSocket("udp4");
+    receiver.once("error", reject);
+    sender.once("error", reject);
+    receiver.once("message", () => {
+      console.log("message store:", storage.getStore());
+      sender.close(() => receiver.close(resolve));
+    });
+    receiver.bind(0, "127.0.0.1", () => {
+      sender.send("context", receiver.address().port, "127.0.0.1");
+    });
+  });
+});

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -42,8 +42,8 @@
       "total": 242
     },
     "dgram": {
-      "pass": 39,
-      "total": 54
+      "pass": 42,
+      "total": 57
     },
     "diagnostics_channel": {
       "pass": 66,


### PR DESCRIPTION
## Summary

Enable real `node:dgram` multicast discovery for `bonjour-service` and OpenCode by honoring reusable-socket options before bind, tightening multicast socket controls, releasing receive workers promptly on close, and propagating async-local context through UDP message callbacks.

## Changes

- create UDP sockets through `socket2` so `reuseAddr` and `ipv6Only` are applied before bind, with libuv-compatible Apple/BSD reuse semantics
- make multicast membership, interface, TTL, and loopback operations act on the live OS socket and report invalid configuration
- wake and join the receive worker during close so the descriptor and shared port are released before the close event
- preserve bind-time `AsyncLocalStorage` context while dispatching message callbacks and scan those stores as GC roots
- add differential fixtures for shared bind/cleanup, real multicast loopback delivery, and async-context propagation

## Related issue

Closes #8515

## Test plan

- [x] `cargo build --release -p perry`
- [x] `cargo check -p perry-runtime --features mod-dgram`
- [x] `cargo test -p perry-runtime --lib dgram --features mod-dgram`
- [x] `cargo clippy -p perry-runtime --lib --features mod-dgram` (passes with the repository's existing warnings)
- [x] `python3 scripts/check_test_registration.py`
- [x] `python3 scripts/gc_runtime_root_holders.py`
- [x] Node oracle passes all three new fixtures
- [x] Perry executable passes shared bind/rebind, multicast loopback join/drop/delivery, and AsyncLocalStorage message-context checks

## Checklist

- [x] No workspace version bump; `CLAUDE.md` and `CHANGELOG.md` are unchanged
- [x] Added a `changelog.d/` fragment
