### PR TITLE
fix(bun): complete OpenCode compatibility coverage

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/bun.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/bun.rs
@@ -48,6 +48,24 @@ pub(crate) const BUN_ROWS: &[NativeModSig] = &[
         args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
+    NativeModSig {
+        module: "bun",
+        has_receiver: false,
+        method: "Glob",
+        class_filter: None,
+        runtime: "js_bun_glob_new",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "bun",
+        has_receiver: false,
+        method: "unsupported",
+        class_filter: None,
+        runtime: "js_bun_unsupported",
+        args: &[NA_F64],
+        ret: NR_F64,
+    },
     // Module-level aliases with node:url semantics (issue table:
     // `import { pathToFileURL, fileURLToPath } from "bun"`).
     NativeModSig {

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -72,7 +72,8 @@ pub(super) fn try_module_static_methods(
                 if obj_ident.sym.as_ref() == "Bun"
                     && ctx.lookup_local("Bun").is_none()
                     && ctx.lookup_native_module("Bun").is_none()
-                    && matches!(
+                {
+                    if matches!(
                         method_ident.sym.as_ref(),
                         "stringWidth"
                             | "hash"
@@ -80,15 +81,25 @@ pub(super) fn try_module_static_methods(
                             | "write"
                             | "pathToFileURL"
                             | "fileURLToPath"
-                    )
-                {
-                    return Ok(Ok(Expr::NativeMethodCall {
+                    ) {
+                        return Ok(Ok(Expr::NativeMethodCall {
+                            module: "bun".to_string(),
+                            class_name: None,
+                            object: None,
+                            method: method_ident.sym.as_ref().to_string(),
+                            args,
+                        }));
+                    }
+
+                    let mut sequence = args;
+                    sequence.push(Expr::NativeMethodCall {
                         module: "bun".to_string(),
                         class_name: None,
                         object: None,
-                        method: method_ident.sym.as_ref().to_string(),
-                        args,
-                    }));
+                        method: "unsupported".to_string(),
+                        args: vec![Expr::String(method_ident.sym.as_ref().to_string())],
+                    });
+                    return Ok(Ok(Expr::Sequence(sequence)));
                 }
             }
         }

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -325,6 +325,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         | "hash"
                         | "file"
                         | "write"
+                        | "Glob"
                         | "pathToFileURL"
                         | "fileURLToPath"
                 ) {

--- a/crates/perry-hir/src/lower/expr_new/member.rs
+++ b/crates/perry-hir/src/lower/expr_new/member.rs
@@ -29,6 +29,19 @@ pub(crate) fn lower_new_member_native(
             (peel_new_callee(member.obj.as_ref()), &member.prop)
         {
             let obj_name = obj_ident.sym.as_ref();
+            if obj_name == "Bun"
+                && prop_ident.sym.as_ref() == "Glob"
+                && !ctx.shadows_unqualified_global("Bun")
+                && ctx.lookup_native_module("Bun").is_none()
+            {
+                return Ok(Some(Expr::NativeMethodCall {
+                    module: "bun".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "Glob".to_string(),
+                    args: lower_optional_args(ctx, new_expr.args.as_deref())?,
+                }));
+            }
             if let Some(class_name) =
                 global_member_constructor_name(ctx, obj_name, prop_ident.sym.as_ref())
             {

--- a/crates/perry-runtime/src/bun_compat/glob.rs
+++ b/crates/perry-runtime/src/bun_compat/glob.rs
@@ -1,0 +1,50 @@
+//! `Bun.Glob` backed by Perry's native `node:fs` glob walker.
+
+use super::*;
+
+extern "C" fn bun_glob_scan(closure: *const ClosureHeader, options: f64) -> f64 {
+    crate::fs::js_bun_glob_async_iterator(captured(closure), options)
+}
+
+extern "C" fn bun_glob_scan_sync(closure: *const ClosureHeader, options: f64) -> f64 {
+    crate::fs::js_bun_glob_sync_iterator(captured(closure), options)
+}
+
+extern "C" fn bun_glob_match(closure: *const ClosureHeader, path: f64) -> f64 {
+    match crate::fs::bun_glob_matches(captured(closure), path) {
+        Ok(matches) => bool_value(matches),
+        Err(error) => crate::exception::js_throw(error),
+    }
+}
+
+/// `new Bun.Glob(pattern)`. The returned object owns the pattern through each
+/// method closure, so it remains valid across arbitrary intervening GC.
+#[no_mangle]
+pub extern "C-unwind" fn js_bun_glob_new(pattern: f64) -> f64 {
+    if !is_string_value(pattern) {
+        let message = b"Bun.Glob constructor requires a string pattern";
+        let message = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+        let error = crate::error::js_error_new_with_message(message);
+        crate::exception::js_throw(f64::from_bits(JSValue::pointer(error as *const u8).bits()));
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let pattern = scope.root_nanbox_f64(pattern);
+    let obj = js_object_alloc(0, 4);
+    set_field(
+        obj,
+        b"scan",
+        bound_method1(bun_glob_scan, pattern.get_nanbox_f64()),
+    );
+    set_field(
+        obj,
+        b"scanSync",
+        bound_method1(bun_glob_scan_sync, pattern.get_nanbox_f64()),
+    );
+    set_field(
+        obj,
+        b"match",
+        bound_method1(bun_glob_match, pattern.get_nanbox_f64()),
+    );
+    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+}

--- a/crates/perry-runtime/src/bun_compat/mod.rs
+++ b/crates/perry-runtime/src/bun_compat/mod.rs
@@ -20,6 +20,7 @@
 //! - `Bun.hash` is Zig-std Wyhash (see `wyhash.rs`) returning a BigInt, so
 //!   `.toString(16)` cache keys match bun-run installs.
 
+mod glob;
 mod string_width;
 mod width_tables;
 mod wyhash;
@@ -35,6 +36,7 @@ use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::{js_jsvalue_to_string, JSValue};
 use std::io::{Read, Write};
 
+pub use glob::js_bun_glob_new;
 pub use string_width::bun_string_width;
 pub use wyhash::wyhash;
 
@@ -98,6 +100,16 @@ fn is_string_value(value: f64) -> bool {
     js.is_string() || js.is_short_string()
 }
 
+fn bun_path_from_value(value: f64) -> Result<String, f64> {
+    if let Some(path) = unsafe { crate::fs::decode_path_value(value) } {
+        return Ok(path);
+    }
+    let message = b"Expected file path string, Uint8Array, or file: URL";
+    let message = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_typeerror_new(message);
+    Err(f64::from_bits(JSValue::pointer(error as *const u8).bits()))
+}
+
 fn heap_ptr_from_value(value: f64) -> Option<usize> {
     let js = JSValue::from_bits(value.to_bits());
     if !js.is_pointer() {
@@ -135,6 +147,13 @@ fn bound_method0(func: extern "C" fn(*const ClosureHeader) -> f64, capture: f64)
     f64::from_bits(JSValue::pointer(closure as *const u8).bits())
 }
 
+fn bound_method1(func: extern "C" fn(*const ClosureHeader, f64) -> f64, capture: f64) -> f64 {
+    js_register_closure_arity(func as *const u8, 1);
+    let closure = js_closure_alloc(func as *const u8, 1);
+    js_closure_set_capture_f64(closure, 0, capture);
+    f64::from_bits(JSValue::pointer(closure as *const u8).bits())
+}
+
 fn captured(closure: *const ClosureHeader) -> f64 {
     js_closure_get_capture_f64(closure, 0)
 }
@@ -147,22 +166,14 @@ fn payload_bytes(value: f64) -> Result<Vec<u8>, f64> {
     if is_string_value(value) {
         return Ok(value_to_string(value).into_bytes());
     }
-    if let Some(addr) = heap_ptr_from_value(value) {
-        if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
-            let ta = addr as *const crate::typedarray::TypedArrayHeader;
-            if let Some(bytes) = unsafe { crate::typedarray::typed_array_bytes(ta) } {
-                return Ok(bytes.to_vec());
-            }
-        }
-        if crate::buffer::is_array_buffer(addr) {
-            let buf = addr as *const crate::buffer::BufferHeader;
-            unsafe {
-                let len = (*buf).length as usize;
-                let data =
-                    (buf as *const u8).add(std::mem::size_of::<crate::buffer::BufferHeader>());
-                return Ok(std::slice::from_raw_parts(data, len).to_vec());
-            }
-        }
+    let mut binary_len = 0u32;
+    let binary_ptr = unsafe {
+        crate::buffer::js_value_buffer_or_typedarray_data(value, &mut binary_len as *mut u32)
+    };
+    if !binary_ptr.is_null() {
+        return Ok(unsafe { std::slice::from_raw_parts(binary_ptr, binary_len as usize) }.to_vec());
+    }
+    if heap_ptr_from_value(value).is_some() {
         if let Some(path_value) = object_field(value, BUN_FILE_PATH_KEY) {
             let path = value_to_string(path_value);
             return std::fs::read(&path)
@@ -298,6 +309,14 @@ extern "C" fn bun_file_array_buffer(closure: *const ClosureHeader) -> f64 {
     }
 }
 
+extern "C" fn bun_file_bytes(closure: *const ClosureHeader) -> f64 {
+    let path = value_to_string(captured(closure));
+    match read_file_or_reject(&path) {
+        Ok(bytes) => promise_value(uint8_array_from_bytes(&bytes)),
+        Err(err) => promise_rejected(err),
+    }
+}
+
 extern "C" fn bun_file_exists(closure: *const ClosureHeader) -> f64 {
     let path = value_to_string(captured(closure));
     promise_value(bool_value(
@@ -325,13 +344,28 @@ fn array_buffer_from_bytes(bytes: &[u8]) -> f64 {
     f64::from_bits(JSValue::pointer(buf as *const u8).bits())
 }
 
+fn uint8_array_from_bytes(bytes: &[u8]) -> f64 {
+    let buffer = crate::buffer::js_uint8array_alloc(bytes.len() as i32);
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            crate::buffer::buffer_data_mut(buffer),
+            bytes.len(),
+        );
+    }
+    f64::from_bits(JSValue::pointer(buffer as *const u8).bits())
+}
+
 /// `Bun.file(path)` — BunFile-like lazy handle.
 #[no_mangle]
 pub extern "C" fn js_bun_file(path: f64) -> f64 {
-    let path_string = value_to_string(path);
+    let path_string = match bun_path_from_value(path) {
+        Ok(path) => path,
+        Err(error) => crate::exception::js_throw(error),
+    };
     let path_value = boxed_str(path_string.as_bytes());
 
-    let obj = js_object_alloc(0, 8);
+    let obj = js_object_alloc(0, 9);
     set_field(obj, BUN_FILE_PATH_KEY, path_value);
     set_field(obj, b"name", path_value);
     let size = std::fs::metadata(&path_string)
@@ -350,6 +384,7 @@ pub extern "C" fn js_bun_file(path: f64) -> f64 {
         b"arrayBuffer",
         bound_method0(bun_file_array_buffer, path_value),
     );
+    set_field(obj, b"bytes", bound_method0(bun_file_bytes, path_value));
     set_field(obj, b"exists", bound_method0(bun_file_exists, path_value));
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
@@ -387,10 +422,10 @@ pub extern "C" fn js_bun_write(dest: f64, data: f64) -> f64 {
     }
 
     // Path (string) or BunFile destination.
-    let path = if is_string_value(dest) {
-        value_to_string(dest)
-    } else if let Some(path_value) = object_field(dest, BUN_FILE_PATH_KEY) {
+    let path = if let Some(path_value) = object_field(dest, BUN_FILE_PATH_KEY) {
         value_to_string(path_value)
+    } else if let Ok(path) = bun_path_from_value(dest) {
+        path
     } else {
         let msg = b"Bun.write: destination must be a path, BunFile, or Bun.stdout/stderr";
         let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
@@ -473,4 +508,36 @@ pub extern "C" fn js_bun_stdout() -> f64 {
 #[no_mangle]
 pub extern "C" fn js_bun_stderr() -> f64 {
     bun_std_out_like(2.0)
+}
+
+/// Explicit failure for Bun surfaces outside Perry's maintained compatibility
+/// target. Direct `Bun.<member>(...)` calls lower here instead of degrading to
+/// an opaque "value is not a function" error.
+#[no_mangle]
+pub extern "C-unwind" fn js_bun_unsupported(member: f64) -> f64 {
+    let member = value_to_string(member);
+    let message = format!("Bun.{member} is not supported by Perry");
+    let message = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_error_new_with_message(message);
+    crate::exception::js_throw(f64::from_bits(JSValue::pointer(error as *const u8).bits()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_bytes_preserves_uint8array_binary_data() {
+        let expected = [0, 127, 128, 255];
+        let buffer = crate::buffer::js_uint8array_alloc(expected.len() as i32);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                expected.as_ptr(),
+                crate::buffer::buffer_data_mut(buffer),
+                expected.len(),
+            );
+        }
+        let value = f64::from_bits(JSValue::pointer(buffer as *const u8).bits());
+        assert_eq!(payload_bytes(value).unwrap(), expected);
+    }
 }

--- a/crates/perry-runtime/src/fs/dir_glob_watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch.rs
@@ -19,14 +19,16 @@ pub(crate) use opendir::js_fs_opendir_value_with_path;
 // Re-export the glob machinery: the `#[no_mangle]` FFI sync symbols are `pub`,
 // while the run/value helpers and match types are consumed by the `watch`
 // sibling (glob iterator) and stay `pub(crate)`.
-pub(crate) use glob::{glob_entry_value, run_fs_glob_result, FsGlobMatch};
+pub(crate) use glob::{
+    bun_glob_matches, glob_entry_value, run_bun_glob_result, run_fs_glob_result, FsGlobMatch,
+};
 pub use glob::{js_fs_glob_sync, js_fs_glob_sync_options};
 
 // Re-export the watch/watchFile entry points + GC scanner + the shared promise
 // helpers used across the `fs` module (fd_ops.rs, filehandle.rs, etc.).
 pub(crate) use watch::{
-    js_fs_promises_glob_iterator, promise_rejected_fs, promise_undefined_fs, promise_value_fs,
-    scan_fs_watcher_roots_mut,
+    js_bun_glob_async_iterator, js_bun_glob_sync_iterator, js_fs_promises_glob_iterator,
+    promise_rejected_fs, promise_undefined_fs, promise_value_fs, scan_fs_watcher_roots_mut,
 };
 pub use watch::{js_fs_promises_watch, js_fs_unwatch_file, js_fs_watch, js_fs_watch_file};
 

--- a/crates/perry-runtime/src/fs/dir_glob_watch/glob.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch/glob.rs
@@ -53,6 +53,16 @@ struct FsGlobOptions {
 }
 
 #[cfg(feature = "regex-engine")]
+struct BunGlobOptions {
+    cwd_actual: String,
+    only_files: bool,
+    dot: bool,
+    absolute: bool,
+    follow_symlinks: bool,
+    ignore_patterns: Vec<GlobExcludeRegex>,
+}
+
+#[cfg(feature = "regex-engine")]
 struct GlobCandidate {
     actual_path: String,
     kind: DirentKind,
@@ -332,6 +342,84 @@ fn glob_options_from_value_result(options_value: f64) -> Result<FsGlobOptions, f
         follow_symlinks,
         exclude_patterns,
         exclude_fn,
+    })
+}
+
+#[cfg(feature = "regex-engine")]
+fn bun_glob_cwd_result(options_value: f64) -> Result<String, f64> {
+    if is_nullish(options_value) {
+        return Ok(current_dir_slashes());
+    }
+    if let Some(cwd) = decode_string_value(options_value) {
+        return Ok(absolutize_slash(&cwd));
+    }
+    if let Some(err) = validate::object_options_type_error_value("options", options_value) {
+        return Err(err);
+    }
+    unsafe {
+        let Some(cwd) = options_field_value(options_value, b"cwd") else {
+            return Ok(current_dir_slashes());
+        };
+        let cwd = f64::from_bits(cwd.bits());
+        if is_nullish(cwd) {
+            return Ok(current_dir_slashes());
+        }
+        let Some(cwd) = decode_string_value(cwd) else {
+            return Err(glob_pattern_string_error("options.cwd", cwd));
+        };
+        Ok(absolutize_slash(&cwd))
+    }
+}
+
+#[cfg(feature = "regex-engine")]
+fn bun_ignore_patterns_result(options_value: f64) -> Result<Vec<GlobExcludeRegex>, f64> {
+    if is_nullish(options_value) || decode_string_value(options_value).is_some() {
+        return Ok(Vec::new());
+    }
+    let ignore_value = unsafe {
+        options_field_value(options_value, b"ignore")
+            .or_else(|| options_field_value(options_value, b"exclude"))
+    };
+    let Some(ignore_value) = ignore_value else {
+        return Ok(Vec::new());
+    };
+    let ignore_value = f64::from_bits(ignore_value.bits());
+    if is_nullish(ignore_value) {
+        return Ok(Vec::new());
+    }
+    let patterns = glob_patterns_from_value_result(ignore_value)?;
+    Ok(patterns
+        .into_iter()
+        .filter_map(|pattern| glob_regex_from_pattern(&pattern))
+        .collect())
+}
+
+#[cfg(feature = "regex-engine")]
+fn bun_glob_options_from_value_result(options_value: f64) -> Result<BunGlobOptions, f64> {
+    let cwd_actual = bun_glob_cwd_result(options_value)?;
+    let is_object = !is_nullish(options_value) && decode_string_value(options_value).is_none();
+    let (only_files, dot, absolute, follow_symlinks) = if is_object {
+        unsafe {
+            let only_files = options_field_value(options_value, b"onlyFiles")
+                .map(|v| crate::value::js_is_truthy(f64::from_bits(v.bits())) != 0)
+                .unwrap_or(true);
+            (
+                only_files,
+                options_bool_field(options_value, b"dot"),
+                options_bool_field(options_value, b"absolute"),
+                options_bool_field(options_value, b"followSymlinks"),
+            )
+        }
+    } else {
+        (true, false, false, false)
+    };
+    Ok(BunGlobOptions {
+        cwd_actual,
+        only_files,
+        dot,
+        absolute,
+        follow_symlinks,
+        ignore_patterns: bun_ignore_patterns_result(options_value)?,
     })
 }
 
@@ -678,6 +766,130 @@ pub(crate) fn run_fs_glob_result(pattern_value: f64, options_value: f64) -> Resu
         matches: matches.into_values().collect(),
         with_file_types: options.with_file_types,
     })
+}
+
+#[cfg(feature = "regex-engine")]
+fn bun_path_is_hidden(path: &str) -> bool {
+    path.split('/')
+        .any(|part| part.starts_with('.') && part != "." && part != ".." && !part.is_empty())
+}
+
+/// Bun.Glob's scanner over Perry's native glob walker. Bun differs from
+/// node:fs glob in three observable defaults: files-only, hidden paths off,
+/// and relative slash-normalized output. `ignore`/`exclude` are accepted as a
+/// compatibility extension for OpenCode tooling; unknown scan options remain
+/// harmless, matching Bun's option parsing.
+#[cfg(feature = "regex-engine")]
+pub(crate) fn run_bun_glob_result(
+    pattern_value: f64,
+    options_value: f64,
+) -> Result<FsGlobRun, f64> {
+    let Some(pattern) = decode_string_value(pattern_value) else {
+        return Err(glob_pattern_string_error("pattern", pattern_value));
+    };
+    let pattern = normalize_slashes(&pattern);
+    let options = bun_glob_options_from_value_result(options_value)?;
+    let Some(re) = glob_regex_from_pattern(&pattern) else {
+        return Ok(FsGlobRun {
+            matches: Vec::new(),
+            with_file_types: false,
+        });
+    };
+    let pattern_is_absolute = Path::new(&pattern).is_absolute();
+    let root = glob_search_root(&pattern);
+    let root_actual = if pattern_is_absolute {
+        root
+    } else {
+        join_slash(&options.cwd_actual, &root)
+    };
+    let mut candidates = Vec::new();
+    walk_paths_for_glob(
+        Path::new(&root_actual),
+        options.follow_symlinks,
+        &mut candidates,
+    );
+    let pattern_mentions_hidden = pattern
+        .split('/')
+        .any(|part| part.starts_with('.') && part != "." && part != "..");
+    let mut matches: BTreeMap<String, FsGlobMatch> = BTreeMap::new();
+    for candidate in &candidates {
+        if options.only_files && !candidate.kind.is_file() {
+            continue;
+        }
+        let relative = relative_to_base(&candidate.actual_path, &options.cwd_actual);
+        let target = if pattern_is_absolute {
+            candidate.actual_path.clone()
+        } else {
+            relative.clone()
+        };
+        if !options.dot && !pattern_mentions_hidden && bun_path_is_hidden(&relative) {
+            continue;
+        }
+        if !re.is_match(&target).unwrap_or(false) {
+            continue;
+        }
+        if options
+            .ignore_patterns
+            .iter()
+            .any(|ignore| ignore.is_match(&relative).unwrap_or(false))
+        {
+            continue;
+        }
+        let Some(mut entry) = glob_match_from_candidate(
+            candidate,
+            pattern_is_absolute || options.absolute,
+            &FsGlobOptions {
+                cwd_actual: options.cwd_actual.clone(),
+                cwd_display: ".".to_string(),
+                with_file_types: false,
+                follow_symlinks: options.follow_symlinks,
+                exclude_patterns: Vec::new(),
+                exclude_fn: None,
+            },
+        ) else {
+            continue;
+        };
+        if options.absolute && !pattern_is_absolute {
+            entry.output = normalize_slashes(&candidate.actual_path);
+        }
+        matches.entry(entry.output.clone()).or_insert(entry);
+    }
+    Ok(FsGlobRun {
+        matches: matches.into_values().collect(),
+        with_file_types: false,
+    })
+}
+
+#[cfg(not(feature = "regex-engine"))]
+pub(crate) fn run_bun_glob_result(
+    pattern_value: f64,
+    _options_value: f64,
+) -> Result<FsGlobRun, f64> {
+    glob_patterns_from_value_result(pattern_value)?;
+    Ok(FsGlobRun {
+        matches: Vec::new(),
+        with_file_types: false,
+    })
+}
+
+#[cfg(feature = "regex-engine")]
+pub(crate) fn bun_glob_matches(pattern_value: f64, path_value: f64) -> Result<bool, f64> {
+    let Some(pattern) = decode_string_value(pattern_value) else {
+        return Err(glob_pattern_string_error("pattern", pattern_value));
+    };
+    let Some(path) = decode_string_value(path_value) else {
+        return Err(glob_pattern_string_error("path", path_value));
+    };
+    Ok(glob_regex_from_pattern(&normalize_slashes(&pattern))
+        .map(|re| re.is_match(&normalize_slashes(&path)).unwrap_or(false))
+        .unwrap_or(false))
+}
+
+#[cfg(not(feature = "regex-engine"))]
+pub(crate) fn bun_glob_matches(pattern_value: f64, path_value: f64) -> Result<bool, f64> {
+    glob_patterns_from_value_result(pattern_value)?;
+    glob_patterns_from_value_result(path_value)?;
+    Ok(false)
 }
 
 /// Regex engine gated off: `fs.glob*` matching is built on the regex engine, so

--- a/crates/perry-runtime/src/fs/dir_glob_watch/watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch/watch.rs
@@ -1050,6 +1050,48 @@ extern "C" fn glob_iterator_self_impl(closure: *const ClosureHeader) -> f64 {
     js_closure_get_capture_f64(closure, 1)
 }
 
+extern "C" fn bun_glob_sync_iterator_next_impl(closure: *const ClosureHeader) -> f64 {
+    let id = js_closure_get_capture_f64(closure, 0) as usize;
+    let action = GLOB_ITERATORS.with(|iterators| {
+        let mut iterators = iterators.borrow_mut();
+        let Some(state) = iterators.get_mut(&id) else {
+            return GlobNextAction::Done;
+        };
+        if let Some(reason) = state.validation_error.take() {
+            state.closed = true;
+            return GlobNextAction::Reject(reason);
+        }
+        if state.closed || state.index >= state.entries.len() {
+            state.closed = true;
+            return GlobNextAction::Done;
+        }
+        let entry = state.entries[state.index].clone();
+        state.index += 1;
+        GlobNextAction::Entry(entry, state.with_file_types)
+    });
+    match action {
+        GlobNextAction::Done => iterator_result(undefined_value(), true),
+        GlobNextAction::Reject(reason) => crate::exception::js_throw(reason),
+        GlobNextAction::Entry(entry, with_file_types) => {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let value = scope.root_nanbox_f64(glob_entry_value(&entry, with_file_types));
+            iterator_result(value.get_nanbox_f64(), false)
+        }
+    }
+}
+
+extern "C" fn bun_glob_sync_iterator_return_impl(closure: *const ClosureHeader) -> f64 {
+    let id = js_closure_get_capture_f64(closure, 0) as usize;
+    GLOB_ITERATORS.with(|iterators| {
+        iterators.borrow_mut().remove(&id);
+    });
+    iterator_result(undefined_value(), true)
+}
+
+extern "C" fn bun_glob_sync_iterator_self_impl(closure: *const ClosureHeader) -> f64 {
+    js_closure_get_capture_f64(closure, 1)
+}
+
 extern "C" fn promise_watcher_next_impl(closure: *const ClosureHeader) -> f64 {
     let id = js_closure_get_capture_f64(closure, 0) as usize;
     let action = PROMISE_WATCHERS.with(|watchers| {
@@ -1126,6 +1168,9 @@ fn ensure_watch_method_arities() {
         js_register_closure_arity(glob_iterator_next_impl as *const u8, 0);
         js_register_closure_arity(glob_iterator_return_impl as *const u8, 0);
         js_register_closure_arity(glob_iterator_self_impl as *const u8, 0);
+        js_register_closure_arity(bun_glob_sync_iterator_next_impl as *const u8, 0);
+        js_register_closure_arity(bun_glob_sync_iterator_return_impl as *const u8, 0);
+        js_register_closure_arity(bun_glob_sync_iterator_self_impl as *const u8, 0);
     });
 }
 
@@ -1281,6 +1326,43 @@ fn build_glob_iterator_object(id: usize) -> f64 {
     self_value
 }
 
+fn build_bun_glob_sync_iterator_object(id: usize) -> f64 {
+    ensure_watch_method_arities();
+    let obj = crate::object::js_object_alloc(0, 3);
+    let self_value = boxed_ptr(obj as *const u8);
+    set_named_field(
+        obj,
+        b"next",
+        method_value(
+            bun_glob_sync_iterator_next_impl as *const u8,
+            id,
+            self_value,
+        ),
+    );
+    set_named_field(
+        obj,
+        b"return",
+        method_value(
+            bun_glob_sync_iterator_return_impl as *const u8,
+            id,
+            self_value,
+        ),
+    );
+    let iterator = crate::symbol::well_known_symbol("iterator");
+    if !iterator.is_null() {
+        let symbol_value = boxed_ptr(iterator as *const u8);
+        let method = method_value(
+            bun_glob_sync_iterator_self_impl as *const u8,
+            id,
+            self_value,
+        );
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(self_value, symbol_value, method);
+        }
+    }
+    self_value
+}
+
 pub(crate) fn js_fs_promises_glob_iterator(pattern_value: f64, options_value: f64) -> f64 {
     let (entries, with_file_types, validation_error) =
         match run_fs_glob_result(pattern_value, options_value) {
@@ -1301,6 +1383,49 @@ pub(crate) fn js_fs_promises_glob_iterator(pattern_value: f64, options_value: f6
         );
     });
     build_glob_iterator_object(id)
+}
+
+pub(crate) fn js_bun_glob_async_iterator(pattern_value: f64, options_value: f64) -> f64 {
+    let (entries, with_file_types, validation_error) =
+        match run_bun_glob_result(pattern_value, options_value) {
+            Ok(run) => (run.matches, run.with_file_types, None),
+            Err(err) => (Vec::new(), false, Some(err)),
+        };
+    let id = next_glob_iterator_id();
+    GLOB_ITERATORS.with(|iterators| {
+        iterators.borrow_mut().insert(
+            id,
+            GlobIteratorState {
+                entries,
+                index: 0,
+                with_file_types,
+                closed: false,
+                validation_error,
+            },
+        );
+    });
+    build_glob_iterator_object(id)
+}
+
+pub(crate) fn js_bun_glob_sync_iterator(pattern_value: f64, options_value: f64) -> f64 {
+    let run = match run_bun_glob_result(pattern_value, options_value) {
+        Ok(run) => run,
+        Err(err) => crate::exception::js_throw(err),
+    };
+    let id = next_glob_iterator_id();
+    GLOB_ITERATORS.with(|iterators| {
+        iterators.borrow_mut().insert(
+            id,
+            GlobIteratorState {
+                entries: run.matches,
+                index: 0,
+                with_file_types: run.with_file_types,
+                closed: false,
+                validation_error: None,
+            },
+        );
+    });
+    build_bun_glob_sync_iterator_object(id)
 }
 
 fn normalized_watch_args(arg1: f64, arg2: f64) -> (f64, Option<f64>) {

--- a/crates/perry-runtime/src/fs/dirent.rs
+++ b/crates/perry-runtime/src/fs/dirent.rs
@@ -38,6 +38,11 @@ impl DirentKind {
             is_socket: dirent_is_socket(ft),
         }
     }
+
+    #[cfg(feature = "regex-engine")]
+    pub(crate) fn is_file(self) -> bool {
+        self.is_file
+    }
 }
 
 #[cfg(unix)]

--- a/crates/perry-runtime/src/object/native_module_dispatch/dispatch_a_c.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch/dispatch_a_c.rs
@@ -264,6 +264,8 @@ pub(crate) unsafe fn nm_dispatch_bun(ctx: &NmCtx, module_name: &str, method_name
         ("bun", "hash") => crate::bun_compat::js_bun_hash(arg(0), arg(1)),
         ("bun", "file") => crate::bun_compat::js_bun_file(arg(0)),
         ("bun", "write") => crate::bun_compat::js_bun_write(arg(0), arg(1)),
+        ("bun", "Glob") => crate::bun_compat::js_bun_glob_new(arg(0)),
+        ("bun", "unsupported") => crate::bun_compat::js_bun_unsupported(arg(0)),
         ("bun", "pathToFileURL") => crate::url::js_url_path_to_file_url(arg(0), arg(1)),
         ("bun", "fileURLToPath") => crate::url::js_url_file_url_to_path(arg(0), arg(1)),
         _ => f64::from_bits(JSValue::undefined().bits()),

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -27,6 +27,7 @@ fn debug_hir_uses_regex(hir_debug: &str) -> bool {
         || hir_debug.contains("property: \"matchAll\"")
         || hir_debug.contains("property: \"glob\"")
         || hir_debug.contains("property: \"globSync\"")
+        || hir_debug.contains("method: \"Glob\"")
 }
 
 /// zlib per-codec cherry-pick (stdlib cherry-pick): a `node:zlib` import
@@ -574,6 +575,9 @@ mod tests {
         ));
         assert!(debug_hir_uses_regex(
             r#"NativeMethodCall { module: String("path.win32"), method: String("matchesGlob"), args: [] }"#
+        ));
+        assert!(debug_hir_uses_regex(
+            r#"NativeMethodCall { module: "bun", method: "Glob", args: [] }"#
         ));
     }
 

--- a/crates/perry/tests/issue_6560_bun_globals.rs
+++ b/crates/perry/tests/issue_6560_bun_globals.rs
@@ -192,6 +192,95 @@ stdout ret: 10
     assert_eq!(stdout, expected);
 }
 
+/// #8514: binary reads and file: URL paths are part of the maintained
+/// OpenCode BunFile contract, rather than export-shape-only compatibility.
+#[test]
+fn bun_file_url_bytes_and_invalid_path_errors() {
+    let stdout = compile_and_run(
+        r#"
+async function main() {
+  const path = process.cwd() + "/binary data.bin";
+  const url = new URL("file://" + path.replace(" ", "%20"));
+  await Bun.write(url, new Uint8Array([0, 127, 128, 255]));
+  const file = Bun.file(url);
+  const bytes = await file.bytes();
+  console.log(file.name.endsWith("binary data.bin"), bytes.constructor.name, bytes.length);
+  console.log(bytes[0], bytes[1], bytes[2], bytes[3]);
+  try {
+    Bun.file(null as any);
+  } catch (error: any) {
+    console.log(error.name, error.message.includes("file path"));
+  }
+}
+main();
+"#,
+    );
+    assert_eq!(stdout, "true Uint8Array 4\n0 127 128 255\nTypeError true\n");
+}
+
+/// #8514: Bun.Glob is used by the pinned OpenCode build/tooling graph. Cover
+/// both iterator forms, scan options, ignore filtering, dotfiles, matching,
+/// and slash-normalized relative output against a real directory tree.
+#[test]
+fn bun_glob_scan_iteration_options_and_ignores() {
+    let stdout = compile_and_run(
+        r#"
+import { mkdirSync } from "node:fs";
+
+async function main() {
+  const cwd = process.cwd() + "/glob-root";
+  mkdirSync(cwd + "/sub/deep", { recursive: true });
+  mkdirSync(cwd + "/empty", { recursive: true });
+  await Bun.write(cwd + "/a.ts", "a");
+  await Bun.write(cwd + "/.hidden.ts", "h");
+  await Bun.write(cwd + "/sub/b.ts", "b");
+  await Bun.write(cwd + "/sub/.dot.ts", "d");
+  await Bun.write(cwd + "/sub/c.js", "c");
+  await Bun.write(cwd + "/sub/deep/z.ts", "z");
+
+  const glob = new Bun.Glob("**/*.ts");
+  console.log("match", glob.match("sub/b.ts"), glob.match("sub/c.js"));
+  console.log("sync", JSON.stringify([...glob.scanSync({ cwd })].sort()));
+  console.log("dot", JSON.stringify([...glob.scanSync({ cwd, dot: true })].sort()));
+  console.log("ignore", JSON.stringify([...glob.scanSync({ cwd, ignore: ["sub/**"] })].sort()));
+  console.log("absolute", [...glob.scanSync({ cwd, absolute: true })].every((x) => x.startsWith(cwd + "/")));
+  console.log("dirs", [...new Bun.Glob("**").scanSync({ cwd, onlyFiles: false })].includes("sub/deep"));
+  const sync = glob.scanSync(cwd);
+  console.log("next", JSON.stringify(sync.next()));
+  const asyncItems: string[] = [];
+  for await (const item of glob.scan({ cwd })) asyncItems.push(item);
+  console.log("async", JSON.stringify(asyncItems.sort()));
+}
+main();
+"#,
+    );
+    let expected = "\
+match true false
+sync [\"a.ts\",\"sub/b.ts\",\"sub/deep/z.ts\"]
+dot [\".hidden.ts\",\"a.ts\",\"sub/.dot.ts\",\"sub/b.ts\",\"sub/deep/z.ts\"]
+ignore [\"a.ts\"]
+absolute true
+dirs true
+next {\"value\":\"a.ts\",\"done\":false}
+async [\"a.ts\",\"sub/b.ts\",\"sub/deep/z.ts\"]
+";
+    assert_eq!(stdout, expected);
+}
+
+#[test]
+fn unsupported_bun_calls_fail_explicitly() {
+    let stdout = compile_and_run(
+        r#"
+try {
+  Bun.serve({ port: 0 });
+} catch (error: any) {
+  console.log(error.name, error.message);
+}
+"#,
+    );
+    assert_eq!(stdout, "Error Bun.serve is not supported by Perry\n");
+}
+
 #[test]
 fn bun_stdin_text_reads_all() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- add Bun.Glob construction, matching, sync scanning, and async iteration over the native glob walker
- complete Bun.file/Bun.write binary and file-URL handling, including BunFile.bytes()
- surface explicit errors for unsupported direct Bun API calls
- enable regex feature detection for Bun.Glob and add focused OpenCode compatibility coverage

## Tests

- cargo test -p perry --test issue_6560_bun_globals bun_glob_scan_iteration_options_and_ignores -- --nocapture
- cargo test -p perry --test issue_6560_bun_globals bun_file_url_bytes_and_invalid_path_errors -- --nocapture
- cargo test -p perry --test issue_6560_bun_globals unsupported_bun_calls_fail_explicitly -- --nocapture
- cargo test -p perry-runtime bun_compat::tests::payload_bytes_preserves_uint8array_binary_data --lib
- cargo test -p perry-runtime bun_compat::string_width::tests --lib
- cargo test -p perry --bin perry regex_gate_detects_static_and_dynamic_path_matches_glob
- cargo check -p perry-runtime -p perry-hir -p perry-codegen -p perry
- cargo check -p perry-runtime --no-default-features
- cargo fmt --all -- --check

No version bump.

Fixes #8514