### PR TITLE
fix(gc): root define/Reflect operands above the typed-array key probe (#8507)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1514
+**Current Version:** 0.5.1515
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,7 +5528,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5588,7 +5588,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "cc",
  "libc",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5638,7 +5638,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5704,14 +5704,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "serde",
  "serde_json",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1514"
+version = "0.5.1515"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "clap",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "block2",
  "objc2",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "chrono",
  "cron",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5855,14 +5855,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "bson",
  "futures-util",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6019,7 +6019,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6064,14 +6064,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "brotli",
  "flate2",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6211,14 +6211,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6313,14 +6313,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6329,14 +6329,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6354,7 +6354,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.0",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1514"
+version = "0.5.1515"
 
 [[package]]
 name = "perry-ui-test"
@@ -6431,11 +6431,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1514"
+version = "0.5.1515"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6469,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "block2",
  "libc",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6502,14 +6502,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1514"
+version = "0.5.1515"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1514"
+version = "0.5.1515"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/8508-implicit-this-two-line-forms.md
+++ b/changelog.d/8508-implicit-this-two-line-forms.md
@@ -1,0 +1,7 @@
+**GC: complete the `IMPLICIT_THIS` receiver-rooting conversion started in #8500.**
+
+#8500 converted 22 receiver save/restore pairs that manipulated the `IMPLICIT_THIS` cell directly, rooting the displaced receiver so an evacuating collection inside the callee cannot leave the restore publishing a pre-move address. Four sites of the identical shape were missed because the save spans two lines (`let prev =` on one line, the `IMPLICIT_THIS.with(|c| c.replace(…))` on the next) and so did not match the pattern used to find the others.
+
+No behavioural test moves — these four are latent rather than currently reachable by a failing case — but leaving four instances of a shape that is known to produce a stale `this` is the kind of residue that costs a future session a week. The conversion is now exhaustive: no unrooted direct-access save/restore pair remains in `perry-runtime`.
+
+Does **not** address #8507 (`defineProperty` / `Reflect` own-key paths under forced evacuation), which is a distinct defect — verified by re-running that suite with these four converted, and again with all 135 `js_implicit_this_set(...)`-call pairs converted.

--- a/changelog.d/8520-define-key-operand-rooting.md
+++ b/changelog.d/8520-define-key-operand-rooting.md
@@ -1,0 +1,27 @@
+**GC: `Object.defineProperty` / `Reflect.defineProperty` filed the property under `"[object Object]"` when the key's coercion collected (#8507).**
+
+A key object whose `toString` allocated enough to trigger an evacuating collection ended up storing the property under `"[object Object]"` instead of its real name:
+
+```ts
+const key = { n: "label", toString() { churn(); return this.n; } };
+const ta = new Int32Array([1, 2, 3]);
+Object.defineProperty(ta, key, { value: payload, configurable: true });
+Object.getOwnPropertyNames(ta);   // was ["0","1","2","[object Object]"], now [...,"label"]
+```
+
+**Cause.** Both entry points probe the TypedArray integer-index path first, and that probe coerces the key inside `canonical_index_for_key` — which runs the user `toString` and can therefore evacuate. Every operand below the probe was still being read from the raw parameters, so they named pre-move addresses. Instrumenting `js_string_coerce` shows the signature directly: two coercions of the **same** pointer returning different answers.
+
+```
+[coerce] ptr=0x…94850 -> "loudkey"
+[coerce] ptr=0x…94850 -> "[object Object]"
+```
+
+A moved key object still parses as an object at its old address, but its own `toString` is no longer reachable there, so the second coercion silently falls back to `Object.prototype.toString`. Both entry points now root the three operands above the probe and re-read them afterwards; `reflect_define_property` additionally re-reads between `array_length_reflect_define`, `obj_value_has_own_key` and `obj_value_attrs`, each of which re-coerces the key.
+
+The `Reflect` half was not merely a lost value: a stale key made the own-key probe answer `false`, which skipped the non-configurable guard entirely and **accepted a redefine that must fail** — a dropped spec invariant, not just a missing property.
+
+**Why it surfaced now.** The suite's own header calls itself a behavioural guard that "starts failing the day a minor-evacuating configuration becomes reachable from compiled code"; #6946 made an explicit `gc()` run an evacuating minor first. These are real defects newly exposed, not regressions.
+
+`gc_string_coerce_property_key_rooting_6943` goes 1/3 → 3/3. Also verified green: `gc_property_key_operand_rooting_6935` (3/3), `gc_dynamic_arith_operand_rooting_6655` (4/4), `gc_side_table_roots_evacuation` (1/1).
+
+Closes #8507.

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1535,8 +1535,10 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                     let getter = (acc.get & crate::value::POINTER_MASK)
                         as *const crate::closure::ClosureHeader;
                     if !getter.is_null() {
-                        let prev_getter_this =
-                            IMPLICIT_THIS.with(|c| c.replace(object().to_bits()));
+                        // #8495: root the displaced receiver across the call below.
+                        let prev_getter_this_scope = crate::gc::RuntimeHandleScope::new();
+                        let prev_getter_this_h = prev_getter_this_scope
+                            .root_nanbox_u64(IMPLICIT_THIS.with(|c| c.replace(object().to_bits())));
                         let method_fn = crate::closure::js_closure_call0(getter);
                         let bound = crate::closure::clone_closure_rebind_this(
                             method_fn.to_bits(),
@@ -1553,7 +1555,7 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
                             call_args.as_ptr(),
                             call_args.len(),
                         );
-                        IMPLICIT_THIS.with(|c| c.set(prev_getter_this));
+                        IMPLICIT_THIS.with(|c| c.set(prev_getter_this_h.get_nanbox_u64()));
                         return result;
                     }
                 }

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -1080,8 +1080,11 @@ pub(super) unsafe fn dispatch_handle(
                                 // Mirrors `resolve_proto_chain_field_with_receiver`
                                 // (the winston `get transports()` fix).
                                 let receiver_f64 = f64::from_bits(jsval.bits());
-                                let prev_this =
-                                    IMPLICIT_THIS.with(|c| c.replace(receiver_f64.to_bits()));
+                                // #8495: root the displaced receiver across the call below.
+                                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                                let prev_this_h = prev_this_scope.root_nanbox_u64(
+                                    IMPLICIT_THIS.with(|c| c.replace(receiver_f64.to_bits())),
+                                );
                                 let prev_override =
                                     super::super::field_get_set::accessor_receiver_override_begin(
                                         receiver_f64,
@@ -1093,7 +1096,7 @@ pub(super) unsafe fn dispatch_handle(
                                 super::super::field_get_set::accessor_receiver_override_end(
                                     prev_override,
                                 );
-                                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                                 if !field_val.is_undefined() && !field_val.is_null() {
                                     resolved_method = Some(ResolvedMethod::ProtoClosure {
                                         field_bits: field_val.bits(),

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -97,14 +97,17 @@ pub(super) unsafe fn dispatch_primitive(
                 );
                 let prop_handle = root_scope.root_nanbox_f64(f64::from_bits(bound));
                 let args = refreshed_args();
-                let prev_this =
-                    IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+                // #8495: root the displaced receiver across the call below.
+                let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                let prev_this_h = prev_this_scope.root_nanbox_u64(
+                    IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits())),
+                );
                 let result = crate::closure::js_native_call_value(
                     prop_handle.get_nanbox_f64(),
                     args.as_ptr(),
                     args.len(),
                 );
-                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                 return Some(result);
             }
         }
@@ -528,14 +531,17 @@ pub(super) unsafe fn dispatch_primitive(
                     );
                     let prop_handle = root_scope.root_nanbox_f64(f64::from_bits(bound));
                     let args = refreshed_args();
-                    let prev_this =
-                        IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+                    // #8495: root the displaced receiver across the call below.
+                    let prev_this_scope = crate::gc::RuntimeHandleScope::new();
+                    let prev_this_h = prev_this_scope.root_nanbox_u64(
+                        IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits())),
+                    );
                     let result = crate::closure::js_native_call_value(
                         prop_handle.get_nanbox_f64(),
                         args.as_ptr(),
                         args.len(),
                     );
-                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    IMPLICIT_THIS.with(|c| c.set(prev_this_h.get_nanbox_u64()));
                     return Some(result);
                 }
                 // Own key present but NOT callable (`re.exec = 5; re.exec()`).

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -430,6 +430,19 @@ pub extern "C" fn js_object_define_property(
         // handles truncates the outer container's newest entries (see
         // `gc::RootedValues`' module docs), so the arms below share this one.
         let scope = crate::gc::RuntimeHandleScope::new();
+        // #8507: root the three NaN-boxed operands HERE, above the typed-array
+        // probe below. That probe coerces the key inside
+        // `canonical_index_for_key`, which runs a user `toString` and can
+        // evacuate — so by the time the ordinary arms further down coerce the
+        // key again, the raw parameter names a pre-move address. A moved key
+        // object still parses as an object at its old address, but its own
+        // `toString` is no longer reachable there, so the second coercion
+        // silently falls back to `Object.prototype.toString` and the property is
+        // filed under "[object Object]". Rooting at the later coercion is too
+        // late; the move has already happened by then.
+        let obj_root = scope.root_heap_word_u64(obj_value.to_bits());
+        let key_root = scope.root_nanbox_f64(key_value);
+        let desc_root = scope.root_nanbox_f64(descriptor_value);
         // #6748 follow-up: decode the descriptor's 6 fields in ONE pass when it
         // is a plain default-prototype object (the overwhelming majority) —
         // the per-field `desc_has_field`/`desc_read_field` helpers each cost a
@@ -457,6 +470,11 @@ pub extern "C" fn js_object_define_property(
                 super::super::TypedArrayDefineOutcome::NotTypedArray => {}
             }
         }
+        // #8507: the probe above coerced the key through user JS, so every
+        // operand below must come from its root, not from the parameters.
+        let obj_value = f64::from_bits(obj_root.get_heap_word_u64());
+        let key_value = key_root.get_nanbox_f64();
+        let descriptor_value = desc_root.get_nanbox_f64();
 
         // Date / RegExp / Error instances are exotic cells, not
         // `ObjectHeader`s — the ordinary define path below would bit-cast

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -249,11 +249,24 @@ pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f6
     // key returns true/false here rather than going through the ordinary object
     // machinery (which would mishandle in-bounds element writes and treats the
     // view as non-extensible).
+    // #8507: the probe below coerces the key inside `canonical_index_for_key`,
+    // which runs a user `toString` and can evacuate. Root the three operands
+    // above it and re-read them after, or everything below names pre-move
+    // addresses: a stale `key` makes `obj_value_has_own_key` answer false, so
+    // the non-configurable guard is skipped and a redefine that must fail is
+    // accepted, and the define files the value under "[object Object]".
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_root = scope.root_heap_word_u64(obj.to_bits());
+    let key_root = scope.root_nanbox_f64(key);
+    let desc_root = scope.root_nanbox_f64(descriptor);
     match unsafe { super::typed_array_define_own_property(obj, key, descriptor) } {
         super::TypedArrayDefineOutcome::Defined => return reflect_bool(true),
         super::TypedArrayDefineOutcome::Rejected => return reflect_bool(false),
         super::TypedArrayDefineOutcome::NotTypedArray => {}
     }
+    let obj = f64::from_bits(obj_root.get_heap_word_u64());
+    let key = key_root.get_nanbox_f64();
+    let descriptor = desc_root.get_nanbox_f64();
     // The array exotic `[[DefineOwnProperty]]` for `length` (ArraySetLength)
     // reports success/failure as a boolean here rather than throwing — bypass
     // the generic non-configurable pre-check below, which would mishandle the
@@ -261,19 +274,32 @@ pub(crate) fn reflect_define_property(obj: f64, key: f64, descriptor: f64) -> f6
     if let Some(ok) = unsafe { super::array_length_reflect_define(obj, key, descriptor) } {
         return reflect_bool(ok);
     }
-    let has_own = obj_value_has_own_key(obj, key);
+    let obj = f64::from_bits(obj_root.get_heap_word_u64());
+    // #8507: `obj_value_has_own_key`, `obj_value_attrs` and
+    // `array_length_reflect_define` each RE-COERCE the key (running the user
+    // `toString` again) and can evacuate, so the operands must be re-read from
+    // their roots between the probes. A stale `key` here makes the own-key
+    // probe answer false, which skips the non-configurable guard below and
+    // accepts a redefine that must fail.
+    let has_own = obj_value_has_own_key(obj, key_root.get_nanbox_f64());
+    let obj = f64::from_bits(obj_root.get_heap_word_u64());
     // Redefining a non-configurable existing property fails.
     if has_own {
-        if let Some((_writable, configurable)) = obj_value_attrs(obj, key) {
+        let attrs = obj_value_attrs(obj, key_root.get_nanbox_f64());
+        if let Some((_writable, configurable)) = attrs {
             if !configurable {
                 return reflect_bool(false);
             }
         }
-    } else if obj_value_no_extend(obj) {
+    } else if obj_value_no_extend(f64::from_bits(obj_root.get_heap_word_u64())) {
         // Defining a brand-new property on a non-extensible object fails.
         return reflect_bool(false);
     }
-    super::js_object_define_property(obj, key, descriptor);
+    super::js_object_define_property(
+        f64::from_bits(obj_root.get_heap_word_u64()),
+        key_root.get_nanbox_f64(),
+        desc_root.get_nanbox_f64(),
+    );
     reflect_bool(true)
 }
 


### PR DESCRIPTION
**GC: `Object.defineProperty` / `Reflect.defineProperty` filed the property under `"[object Object]"` when the key's coercion collected (#8507).**

A key object whose `toString` allocated enough to trigger an evacuating collection ended up storing the property under `"[object Object]"` instead of its real name:

```ts
const key = { n: "label", toString() { churn(); return this.n; } };
const ta = new Int32Array([1, 2, 3]);
Object.defineProperty(ta, key, { value: payload, configurable: true });
Object.getOwnPropertyNames(ta);   // was ["0","1","2","[object Object]"], now [...,"label"]
```

**Cause.** Both entry points probe the TypedArray integer-index path first, and that probe coerces the key inside `canonical_index_for_key` — which runs the user `toString` and can therefore evacuate. Every operand below the probe was still being read from the raw parameters, so they named pre-move addresses. Instrumenting `js_string_coerce` shows the signature directly: two coercions of the **same** pointer returning different answers.

```
[coerce] ptr=0x…94850 -> "loudkey"
[coerce] ptr=0x…94850 -> "[object Object]"
```

A moved key object still parses as an object at its old address, but its own `toString` is no longer reachable there, so the second coercion silently falls back to `Object.prototype.toString`. Both entry points now root the three operands above the probe and re-read them afterwards; `reflect_define_property` additionally re-reads between `array_length_reflect_define`, `obj_value_has_own_key` and `obj_value_attrs`, each of which re-coerces the key.

The `Reflect` half was not merely a lost value: a stale key made the own-key probe answer `false`, which skipped the non-configurable guard entirely and **accepted a redefine that must fail** — a dropped spec invariant, not just a missing property.

**Why it surfaced now.** The suite's own header calls itself a behavioural guard that "starts failing the day a minor-evacuating configuration becomes reachable from compiled code"; #6946 made an explicit `gc()` run an evacuating minor first. These are real defects newly exposed, not regressions.

`gc_string_coerce_property_key_rooting_6943` goes 1/3 → 3/3. Also verified green: `gc_property_key_operand_rooting_6935` (3/3), `gc_dynamic_arith_operand_rooting_6655` (4/4), `gc_side_table_roots_evacuation` (1/1).

Closes #8507.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Object.defineProperty` and `Reflect.defineProperty` handling when property keys require conversion during garbage collection.
  - Preserved correct property key names and ensured invalid redefinitions of non-configurable properties consistently raise errors.
  - Improved reliability when invoking accessors and dynamically rebound methods during garbage collection.

- **Documentation**
  - Added release notes covering property-definition fixes and receiver-handling improvements.

- **Chores**
  - Updated the application version to `0.5.1515`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->