### PR TITLE
runtime: keep wasm-bindgen memory and tables live

### DIFF
--- a/changelog.d/8508-wasm-bindgen-live-state.md
+++ b/changelog.d/8508-wasm-bindgen-live-state.md
@@ -1,0 +1,6 @@
+### runtime: keep wasm-bindgen memory and table exports live
+
+WebAssembly exports now synchronize writes through `memory.buffer`, preserve
+numeric multi-value results, coerce numeric arguments against the Wasm
+signature, and expose `externref` table `get`/`set`/`grow`. This enables the
+runtime state patterns used by file-packaged wasm-bindgen Node modules.

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -206,6 +206,33 @@ extern "C" {
     fn perry_wasm_host_instance_drop(inst: *mut c_void);
     fn perry_wasm_host_instance_memory_len(inst: *mut c_void) -> usize;
     fn perry_wasm_host_instance_memory_copy(inst: *mut c_void, out: *mut u8, len: usize) -> usize;
+    fn perry_wasm_host_instance_memory_write(
+        inst: *mut c_void,
+        data: *const u8,
+        len: usize,
+    ) -> usize;
+    fn perry_wasm_host_instance_table_len(
+        inst: *mut c_void,
+        name: *const c_char,
+        name_len: usize,
+    ) -> usize;
+    fn perry_wasm_host_instance_table_set(
+        inst: *mut c_void,
+        name: *const c_char,
+        name_len: usize,
+        index: usize,
+        bits: u64,
+        is_null: i32,
+    ) -> i32;
+    fn perry_wasm_host_instance_table_grow(
+        inst: *mut c_void,
+        name: *const c_char,
+        name_len: usize,
+        delta: usize,
+        bits: u64,
+        is_null: i32,
+        out_old_len: *mut usize,
+    ) -> i32;
     fn perry_wasm_host_instance_take_exit_code(inst: *mut c_void, out_code: *mut i32) -> i32;
     fn perry_wasm_host_call_export(
         inst: *mut c_void,
@@ -214,8 +241,10 @@ extern "C" {
         arg_kinds: *const u8,
         arg_bits: *const u64,
         arg_count: usize,
-        out_kind: *mut u8,
+        out_kinds: *mut u8,
         out_bits: *mut u64,
+        out_capacity: usize,
+        out_count: *mut usize,
         out_err: *mut *mut c_char,
     ) -> i32;
 }
@@ -625,6 +654,69 @@ fn copy_instance_memory(inst: *mut c_void, buffer: f64) {
     }
 }
 
+fn write_instance_memory(inst: *mut c_void, buffer: f64) {
+    let ptr = unbox_pointer(buffer) as *mut crate::buffer::BufferHeader;
+    if ptr.is_null() || !crate::buffer::is_array_buffer(ptr as usize) {
+        return;
+    }
+    let len = unsafe { (*ptr).length.max(0) as usize };
+    unsafe {
+        perry_wasm_host_instance_memory_write(inst, crate::buffer::buffer_data_mut(ptr), len);
+    }
+}
+
+fn memory_buffer_value(memory: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let memory = scope.root_nanbox_f64(memory);
+    let value = JSValue::from_bits(memory.get_nanbox_f64().to_bits());
+    if !value.is_pointer() {
+        return nanbox_undefined();
+    }
+    let key = scope.root_string_ptr(named_key(b"buffer"));
+    crate::object::js_object_get_field_by_name_f64(
+        JSValue::from_bits(memory.get_nanbox_f64().to_bits())
+            .as_pointer::<crate::object::ObjectHeader>(),
+        key.get_raw_const_ptr::<crate::string::StringHeader>(),
+    )
+}
+
+fn sync_memory_to_wasm(inst: *mut c_void, memory: f64) {
+    write_instance_memory(inst, memory_buffer_value(memory));
+}
+
+fn sync_memory_from_wasm(inst: *mut c_void, memory: f64) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let memory = scope.root_nanbox_f64(memory);
+    let memory_value = JSValue::from_bits(memory.get_nanbox_f64().to_bits());
+    if !memory_value.is_pointer() {
+        return;
+    }
+    let host_len = unsafe { perry_wasm_host_instance_memory_len(inst) };
+    if host_len == 0 || host_len > i32::MAX as usize {
+        return;
+    }
+    let old_buffer = scope.root_nanbox_f64(memory_buffer_value(memory.get_nanbox_f64()));
+    let old_ptr = unbox_pointer(old_buffer.get_nanbox_f64()) as *mut crate::buffer::BufferHeader;
+    let old_len = if !old_ptr.is_null() && crate::buffer::is_array_buffer(old_ptr as usize) {
+        unsafe { (*old_ptr).length.max(0) as usize }
+    } else {
+        0
+    };
+    let buffer = if old_len == host_len {
+        old_buffer.get_nanbox_f64()
+    } else {
+        let new_buffer = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
+            crate::buffer::js_array_buffer_new(host_len as i32) as i64,
+        ));
+        let memory_ptr = JSValue::from_bits(memory.get_nanbox_f64().to_bits())
+            .as_pointer::<crate::object::ObjectHeader>()
+            as *mut crate::object::ObjectHeader;
+        let _ = object_set(memory_ptr, b"buffer", new_buffer.get_nanbox_f64());
+        new_buffer.get_nanbox_f64()
+    };
+    copy_instance_memory(inst, buffer);
+}
+
 unsafe extern "C" fn call_wasm_import(
     context: u64,
     module: *const u8,
@@ -721,14 +813,15 @@ fn call_captured_wasm_export(closure: *const crate::closure::ClosureHeader, args
     let scope = crate::gc::RuntimeHandleScope::new();
     let inst = crate::closure::js_closure_get_capture_f64(closure, 0) as usize as *mut c_void;
     let name = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 1));
-    let buffer = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 2));
+    let memory = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 2));
     let instance = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 3));
     let imports = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 4));
     unsafe {
         perry_wasm_host_instance_set_import_context(inst, imports.get_nanbox_f64().to_bits())
     };
+    sync_memory_to_wasm(inst, memory.get_nanbox_f64());
     let result = call_export_n(nanbox_pointer_raw(inst), name.get_nanbox_f64(), args);
-    copy_instance_memory(inst, buffer.get_nanbox_f64());
+    sync_memory_from_wasm(inst, memory.get_nanbox_f64());
     let mut exit_code = 0;
     if unsafe { perry_wasm_host_instance_take_exit_code(inst, &mut exit_code) } != 0 {
         let instance = unbox_pointer(instance.get_nanbox_f64()) as *mut crate::object::ObjectHeader;
@@ -780,12 +873,12 @@ fn make_export_function(
     inst: *mut c_void,
     name: &[u8],
     arity: usize,
-    memory_buffer: f64,
+    memory: f64,
     instance: f64,
     imports: f64,
 ) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
-    let memory_buffer = scope.root_nanbox_f64(memory_buffer);
+    let memory = scope.root_nanbox_f64(memory);
     let instance = scope.root_nanbox_f64(instance);
     let imports = scope.root_nanbox_f64(imports);
     let (func_ptr, declared_arity) = match arity {
@@ -807,7 +900,7 @@ fn make_export_function(
     let closure_ptr = closure.get_raw_mut_ptr::<crate::closure::ClosureHeader>();
     crate::closure::js_closure_set_capture_f64(closure_ptr, 0, inst as usize as f64);
     crate::closure::js_closure_set_capture_f64(closure_ptr, 1, name_value.get_nanbox_f64());
-    crate::closure::js_closure_set_capture_f64(closure_ptr, 2, memory_buffer.get_nanbox_f64());
+    crate::closure::js_closure_set_capture_f64(closure_ptr, 2, memory.get_nanbox_f64());
     crate::closure::js_closure_set_capture_f64(closure_ptr, 3, instance.get_nanbox_f64());
     crate::closure::js_closure_set_capture_f64(closure_ptr, 4, imports.get_nanbox_f64());
     crate::object::set_bound_native_closure_name(
@@ -817,18 +910,234 @@ fn make_export_function(
     crate::value::js_nanbox_pointer(closure_ptr as i64)
 }
 
+fn table_method_context<'scope>(
+    scope: &'scope crate::gc::RuntimeHandleScope,
+    closure: *const crate::closure::ClosureHeader,
+) -> (
+    *mut c_void,
+    crate::gc::RuntimeHandle<'scope>,
+    crate::gc::RuntimeHandle<'scope>,
+) {
+    let inst = crate::closure::js_closure_get_capture_f64(closure, 0) as usize as *mut c_void;
+    let name = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 1));
+    let table = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 2));
+    (inst, name, table)
+}
+
+fn table_values(table: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let table = scope.root_nanbox_f64(table);
+    let table_value = JSValue::from_bits(table.get_nanbox_f64().to_bits());
+    if !table_value.is_pointer() {
+        return nanbox_undefined();
+    }
+    let key = scope.root_string_ptr(named_key(b"__wasmValues"));
+    crate::object::js_object_get_field_by_name_f64(
+        JSValue::from_bits(table.get_nanbox_f64().to_bits())
+            .as_pointer::<crate::object::ObjectHeader>(),
+        key.get_raw_const_ptr::<crate::string::StringHeader>(),
+    )
+}
+
+extern "C" fn js_wasm_table_get(closure: *const crate::closure::ClosureHeader, index: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let (_inst, _name, table) = table_method_context(&scope, closure);
+    let values = scope.root_nanbox_f64(table_values(table.get_nanbox_f64()));
+    let values = JSValue::from_bits(values.get_nanbox_f64().to_bits());
+    if !values.is_pointer() || !index.is_finite() || index < 0.0 {
+        return nanbox_undefined();
+    }
+    crate::array::js_array_get_f64(
+        values.as_pointer::<crate::array::ArrayHeader>(),
+        index as u32,
+    )
+}
+
+extern "C" fn js_wasm_table_set(
+    closure: *const crate::closure::ClosureHeader,
+    index: f64,
+    value: f64,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let (inst, name, table) = table_method_context(&scope, closure);
+    let Some((name_ptr, name_len)) = extract_string_bytes(name.get_nanbox_f64()) else {
+        return nanbox_undefined();
+    };
+    let is_null = (value.to_bits() == crate::value::TAG_NULL) as i32;
+    let ok = unsafe {
+        perry_wasm_host_instance_table_set(
+            inst,
+            name_ptr as *const c_char,
+            name_len,
+            index.max(0.0) as usize,
+            value.to_bits(),
+            is_null,
+        )
+    };
+    if ok != 0 {
+        let values = scope.root_nanbox_f64(table_values(table.get_nanbox_f64()));
+        let values_value = JSValue::from_bits(values.get_nanbox_f64().to_bits());
+        if values_value.is_pointer() {
+            let values_ptr = values_value.as_pointer::<crate::array::ArrayHeader>()
+                as *mut crate::array::ArrayHeader;
+            crate::array::js_array_set_f64(values_ptr, index.max(0.0) as u32, value);
+        }
+    }
+    nanbox_undefined()
+}
+
+extern "C" fn js_wasm_table_grow(
+    closure: *const crate::closure::ClosureHeader,
+    delta: f64,
+    value: f64,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let (inst, name, table) = table_method_context(&scope, closure);
+    let Some((name_ptr, name_len)) = extract_string_bytes(name.get_nanbox_f64()) else {
+        return nanbox_undefined();
+    };
+    let value_bits = value.to_bits();
+    let is_null = matches!(
+        value_bits,
+        crate::value::TAG_NULL | crate::value::TAG_UNDEFINED
+    ) as i32;
+    let mut old_len = 0usize;
+    let ok = unsafe {
+        perry_wasm_host_instance_table_grow(
+            inst,
+            name_ptr as *const c_char,
+            name_len,
+            delta.max(0.0) as usize,
+            value_bits,
+            is_null,
+            &mut old_len,
+        )
+    };
+    if ok == 0 {
+        return nanbox_undefined();
+    }
+    let values = scope.root_nanbox_f64(table_values(table.get_nanbox_f64()));
+    let values_value = JSValue::from_bits(values.get_nanbox_f64().to_bits());
+    if !values_value.is_pointer() {
+        return nanbox_undefined();
+    }
+    let mut values_ptr =
+        values_value.as_pointer::<crate::array::ArrayHeader>() as *mut crate::array::ArrayHeader;
+    let fill = if is_null != 0 {
+        f64::from_bits(crate::value::TAG_NULL)
+    } else {
+        value
+    };
+    for _ in 0..delta.max(0.0) as usize {
+        values_ptr = crate::array::js_array_push_f64(values_ptr, fill);
+        values.set_nanbox_f64(array_value(values_ptr));
+    }
+    let table_value = JSValue::from_bits(table.get_nanbox_f64().to_bits());
+    if table_value.is_pointer() {
+        let _ = object_set(
+            table_value.as_pointer::<crate::object::ObjectHeader>()
+                as *mut crate::object::ObjectHeader,
+            b"length",
+            old_len.saturating_add(delta.max(0.0) as usize) as f64,
+        );
+    }
+    old_len as f64
+}
+
+fn make_table_method(
+    inst: *mut c_void,
+    name: f64,
+    table: f64,
+    func_ptr: *const u8,
+    arity: u32,
+    display_name: &str,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let name = scope.root_nanbox_f64(name);
+    let table = scope.root_nanbox_f64(table);
+    let closure = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(func_ptr, 3));
+    let closure_ptr = closure.get_raw_mut_ptr::<crate::closure::ClosureHeader>();
+    if closure_ptr.is_null() {
+        return nanbox_undefined();
+    }
+    crate::closure::js_register_closure_arity(func_ptr, arity);
+    crate::closure::js_closure_set_capture_f64(closure_ptr, 0, inst as usize as f64);
+    crate::closure::js_closure_set_capture_f64(closure_ptr, 1, name.get_nanbox_f64());
+    crate::closure::js_closure_set_capture_f64(closure_ptr, 2, table.get_nanbox_f64());
+    crate::object::set_bound_native_closure_name(closure_ptr, display_name);
+    crate::value::js_nanbox_pointer(closure_ptr as i64)
+}
+
+fn make_export_table(inst: *mut c_void, name: &[u8]) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let table = scope.root_nanbox_f64(object_value(crate::object::js_object_alloc(0, 0)));
+    let name_value = scope.root_nanbox_f64(string_value(name));
+    let Some((name_ptr, name_len)) = extract_string_bytes(name_value.get_nanbox_f64()) else {
+        return nanbox_undefined();
+    };
+    let len =
+        unsafe { perry_wasm_host_instance_table_len(inst, name_ptr as *const c_char, name_len) };
+    if len == usize::MAX {
+        return nanbox_undefined();
+    }
+    let values = scope.root_nanbox_f64(array_value(crate::array::js_array_alloc(len as u32)));
+    for _ in 0..len {
+        let values_ptr = JSValue::from_bits(values.get_nanbox_f64().to_bits())
+            .as_pointer::<crate::array::ArrayHeader>()
+            as *mut crate::array::ArrayHeader;
+        let values_ptr =
+            crate::array::js_array_push_f64(values_ptr, f64::from_bits(crate::value::TAG_NULL));
+        values.set_nanbox_f64(array_value(values_ptr));
+    }
+    let table_ptr = JSValue::from_bits(table.get_nanbox_f64().to_bits())
+        .as_pointer::<crate::object::ObjectHeader>()
+        as *mut crate::object::ObjectHeader;
+    let _ = object_set(table_ptr, b"__wasmValues", values.get_nanbox_f64());
+    let methods = [
+        ("get", js_wasm_table_get as *const u8, 1u32),
+        ("grow", js_wasm_table_grow as *const u8, 2u32),
+        ("set", js_wasm_table_set as *const u8, 2u32),
+    ];
+    for (method_name, func_ptr, arity) in methods {
+        let method = scope.root_nanbox_f64(make_table_method(
+            inst,
+            name_value.get_nanbox_f64(),
+            table.get_nanbox_f64(),
+            func_ptr,
+            arity,
+            method_name,
+        ));
+        let table_ptr = JSValue::from_bits(table.get_nanbox_f64().to_bits())
+            .as_pointer::<crate::object::ObjectHeader>()
+            as *mut crate::object::ObjectHeader;
+        let _ = object_set(table_ptr, method_name.as_bytes(), method.get_nanbox_f64());
+    }
+    let table_ptr = JSValue::from_bits(table.get_nanbox_f64().to_bits())
+        .as_pointer::<crate::object::ObjectHeader>()
+        as *mut crate::object::ObjectHeader;
+    let _ = object_set(table_ptr, b"length", len as f64);
+    table.get_nanbox_f64()
+}
+
 fn make_instance_value(module: *mut c_void, inst: *mut c_void, imports: f64, receiver: f64) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let imports = scope.root_nanbox_f64(imports);
     let memory_len = unsafe { perry_wasm_host_instance_memory_len(inst) };
-    let memory_buffer = scope.root_nanbox_f64(if memory_len == 0 {
-        nanbox_undefined()
+    let memory = if memory_len == 0 {
+        scope.root_nanbox_f64(nanbox_undefined())
     } else {
-        let buffer = crate::buffer::js_array_buffer_new(memory_len.min(i32::MAX as usize) as i32);
-        let value = crate::value::js_nanbox_pointer(buffer as i64);
-        copy_instance_memory(inst, value);
-        value
-    });
+        let buffer = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
+            crate::buffer::js_array_buffer_new(memory_len.min(i32::MAX as usize) as i32) as i64,
+        ));
+        copy_instance_memory(inst, buffer.get_nanbox_f64());
+        let object = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
+        let object = object_set(
+            object.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+            b"buffer",
+            buffer.get_nanbox_f64(),
+        );
+        scope.root_nanbox_f64(object_value(object))
+    };
     // `new WebAssembly.Instance(...)` arrives with a receiver whose
     // [[Prototype]] was already linked to `WebAssembly.Instance.prototype` by
     // the generic construct path. Populate that object in place so
@@ -860,18 +1169,12 @@ fn make_instance_value(module: *mut c_void, inst: *mut c_void, imports: f64, rec
                 inst,
                 name,
                 unsafe { perry_wasm_host_module_export_func_arity(module, index) },
-                memory_buffer.get_nanbox_f64(),
+                memory.get_nanbox_f64(),
                 instance.get_nanbox_f64(),
                 imports.get_nanbox_f64(),
             ),
-            WASM_EXTERN_KIND_MEMORY => {
-                let memory = object_set(
-                    crate::object::js_object_alloc(0, 0),
-                    b"buffer",
-                    memory_buffer.get_nanbox_f64(),
-                );
-                object_value(memory)
-            }
+            WASM_EXTERN_KIND_MEMORY => memory.get_nanbox_f64(),
+            WASM_EXTERN_KIND_TABLE => make_export_table(inst, name),
             _ => nanbox_undefined(),
         });
         let exports_ptr = object_set(
@@ -1090,8 +1393,10 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
         }
     }
 
-    let mut out_kind: u8 = WASM_VAL_KIND_NONE;
-    let mut out_bits: u64 = 0;
+    const MAX_RESULTS: usize = 16;
+    let mut out_kinds = [WASM_VAL_KIND_NONE; MAX_RESULTS];
+    let mut out_bits = [0u64; MAX_RESULTS];
+    let mut out_count = 0usize;
     let mut err: *mut c_char = std::ptr::null_mut();
     let ok = unsafe {
         perry_wasm_host_call_export(
@@ -1101,8 +1406,10 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
             kinds.as_ptr(),
             bits.as_ptr(),
             kinds.len(),
-            &mut out_kind,
-            &mut out_bits,
+            out_kinds.as_mut_ptr(),
+            out_bits.as_mut_ptr(),
+            MAX_RESULTS,
+            &mut out_count,
             &mut err,
         )
     };
@@ -1110,13 +1417,33 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
         emit_error_to_stderr("WebAssembly.RuntimeError", err);
         return nanbox_undefined();
     }
-    let result = match out_kind {
-        WASM_VAL_KIND_I32 => (out_bits as u32 as i32) as f64,
-        WASM_VAL_KIND_I64 => (out_bits as i64) as f64,
-        WASM_VAL_KIND_F32 => f32::from_bits(out_bits as u32) as f64,
-        WASM_VAL_KIND_F64 => f64::from_bits(out_bits),
-        WASM_VAL_KIND_NONE => nanbox_undefined(),
+    let decode = |kind: u8, bits: u64| match kind {
+        WASM_VAL_KIND_I32 => (bits as u32 as i32) as f64,
+        WASM_VAL_KIND_I64 => (bits as i64) as f64,
+        WASM_VAL_KIND_F32 => f32::from_bits(bits as u32) as f64,
+        WASM_VAL_KIND_F64 => f64::from_bits(bits),
         _ => nanbox_undefined(),
+    };
+    let result = match out_count {
+        0 => nanbox_undefined(),
+        1 => decode(out_kinds[0], out_bits[0]),
+        count => {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let array = scope.root_nanbox_f64(array_value(crate::array::js_array_alloc(
+                count.min(MAX_RESULTS) as u32,
+            )));
+            for index in 0..count.min(MAX_RESULTS) {
+                let array_ptr = JSValue::from_bits(array.get_nanbox_f64().to_bits())
+                    .as_pointer::<crate::array::ArrayHeader>()
+                    as *mut crate::array::ArrayHeader;
+                let array_ptr = crate::array::js_array_push_f64(
+                    array_ptr,
+                    decode(out_kinds[index], out_bits[index]),
+                );
+                array.set_nanbox_f64(array_value(array_ptr));
+            }
+            array.get_nanbox_f64()
+        }
     };
     // Avoid leaking the unused err buffer on success.
     if !err.is_null() {

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -673,11 +673,13 @@ fn memory_buffer_value(memory: f64) -> f64 {
         return nanbox_undefined();
     }
     let key = scope.root_string_ptr(named_key(b"buffer"));
-    crate::object::js_object_get_field_by_name_f64(
-        JSValue::from_bits(memory.get_nanbox_f64().to_bits())
-            .as_pointer::<crate::object::ObjectHeader>(),
-        key.get_raw_const_ptr::<crate::string::StringHeader>(),
-    )
+    key.with_const_ptr(|key: *const crate::string::StringHeader| {
+        crate::object::js_object_get_field_by_name_f64(
+            JSValue::from_bits(memory.get_nanbox_f64().to_bits())
+                .as_pointer::<crate::object::ObjectHeader>(),
+            key,
+        )
+    })
 }
 
 fn sync_memory_to_wasm(inst: *mut c_void, memory: f64) {
@@ -932,11 +934,13 @@ fn table_values(table: f64) -> f64 {
         return nanbox_undefined();
     }
     let key = scope.root_string_ptr(named_key(b"__wasmValues"));
-    crate::object::js_object_get_field_by_name_f64(
-        JSValue::from_bits(table.get_nanbox_f64().to_bits())
-            .as_pointer::<crate::object::ObjectHeader>(),
-        key.get_raw_const_ptr::<crate::string::StringHeader>(),
-    )
+    key.with_const_ptr(|key: *const crate::string::StringHeader| {
+        crate::object::js_object_get_field_by_name_f64(
+            JSValue::from_bits(table.get_nanbox_f64().to_bits())
+                .as_pointer::<crate::object::ObjectHeader>(),
+            key,
+        )
+    })
 }
 
 extern "C" fn js_wasm_table_get(closure: *const crate::closure::ClosureHeader, index: f64) -> f64 {
@@ -1056,16 +1060,25 @@ fn make_table_method(
     let name = scope.root_nanbox_f64(name);
     let table = scope.root_nanbox_f64(table);
     let closure = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(func_ptr, 3));
-    let closure_ptr = closure.get_raw_mut_ptr::<crate::closure::ClosureHeader>();
-    if closure_ptr.is_null() {
+    if closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| closure.is_null()) {
         return nanbox_undefined();
     }
     crate::closure::js_register_closure_arity(func_ptr, arity);
-    crate::closure::js_closure_set_capture_f64(closure_ptr, 0, inst as usize as f64);
-    crate::closure::js_closure_set_capture_f64(closure_ptr, 1, name.get_nanbox_f64());
-    crate::closure::js_closure_set_capture_f64(closure_ptr, 2, table.get_nanbox_f64());
-    crate::object::set_bound_native_closure_name(closure_ptr, display_name);
-    crate::value::js_nanbox_pointer(closure_ptr as i64)
+    closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| {
+        crate::closure::js_closure_set_capture_f64(closure, 0, inst as usize as f64)
+    });
+    closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| {
+        crate::closure::js_closure_set_capture_f64(closure, 1, name.get_nanbox_f64())
+    });
+    closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| {
+        crate::closure::js_closure_set_capture_f64(closure, 2, table.get_nanbox_f64())
+    });
+    closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| {
+        crate::object::set_bound_native_closure_name(closure, display_name)
+    });
+    closure.with_mut_ptr(|closure: *mut crate::closure::ClosureHeader| {
+        crate::value::js_nanbox_pointer(closure as i64)
+    })
 }
 
 fn make_export_table(inst: *mut c_void, name: &[u8]) -> f64 {
@@ -1131,11 +1144,9 @@ fn make_instance_value(module: *mut c_void, inst: *mut c_void, imports: f64, rec
         ));
         copy_instance_memory(inst, buffer.get_nanbox_f64());
         let object = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
-        let object = object_set(
-            object.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
-            b"buffer",
-            buffer.get_nanbox_f64(),
-        );
+        let object = object.with_mut_ptr(|object: *mut crate::object::ObjectHeader| {
+            object_set(object, b"buffer", buffer.get_nanbox_f64())
+        });
         scope.root_nanbox_f64(object_value(object))
     };
     // `new WebAssembly.Instance(...)` arrives with a receiver whose

--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -11,9 +11,11 @@
 //! That keeps the wasmi version surface small and lets us swap engines
 //! (wasmtime, etc.) behind the same shape later.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use wasmi::{Engine, ExternType, Linker, Module, Store, Val};
+use wasmi::{Engine, ExternRef, ExternType, Linker, Module, Ref, Store, Table, Val, ValType};
 
 /// Numeric WebAssembly value. MVP supports only the four core numeric types;
 /// `externref` / `funcref` / `v128` are out of scope (see issue #76, "Open
@@ -34,17 +36,6 @@ impl WasmVal {
             Val::F32(x) => Some(WasmVal::F32(f32::from_bits(x.to_bits()))),
             Val::F64(x) => Some(WasmVal::F64(f64::from_bits(x.to_bits()))),
             _ => None,
-        }
-    }
-
-    fn to_wasmi(self) -> Val {
-        match self {
-            WasmVal::I32(x) => Val::I32(x),
-            WasmVal::I64(x) => Val::I64(x),
-            // wasmi 1.x re-exports F32/F64 at the crate root; `wasmi::core`
-            // is private there (0.x accepted `wasmi::core::F32/F64`).
-            WasmVal::F32(x) => Val::F32(wasmi::F32::from_bits(x.to_bits())),
-            WasmVal::F64(x) => Val::F64(wasmi::F64::from_bits(x.to_bits())),
         }
     }
 }
@@ -76,6 +67,121 @@ struct WasmHostState {
     exit_code: Option<i32>,
     import_callback: Option<WasmImportCallback>,
     import_context: u64,
+}
+
+#[derive(Clone, Copy)]
+struct PendingTableValue {
+    bits: u64,
+    is_null: bool,
+}
+
+enum PendingTableOp {
+    Set {
+        name: String,
+        index: usize,
+        value: PendingTableValue,
+    },
+    Grow {
+        name: String,
+        delta: usize,
+        value: PendingTableValue,
+    },
+}
+
+struct ActiveInstanceTables {
+    instance: usize,
+    lengths: HashMap<String, usize>,
+    overrides: HashMap<(String, usize), PendingTableValue>,
+    ops: Vec<PendingTableOp>,
+}
+
+thread_local! {
+    /// JS imports may call methods on an exported table while wasmi already
+    /// has the instance Store mutably borrowed. Queue those mutations until
+    /// the Wasm call unwinds instead of re-entering the same Store through the
+    /// C ABI (which would create aliased mutable Rust references).
+    static ACTIVE_INSTANCE_TABLES: RefCell<Vec<ActiveInstanceTables>> = const { RefCell::new(Vec::new()) };
+}
+
+fn begin_instance_call(inst: &mut WasmInstanceHandle) {
+    let instance_id = inst as *mut WasmInstanceHandle as usize;
+    let mut lengths = HashMap::new();
+    for export in inst.inner._module.0.module.exports() {
+        let ExternType::Table(table_type) = export.ty() else {
+            continue;
+        };
+        if table_type.element() != ValType::ExternRef {
+            continue;
+        }
+        let Some(table) = inst
+            .inner
+            .instance
+            .get_table(&inst.inner.store, export.name())
+        else {
+            continue;
+        };
+        if let Ok(len) = usize::try_from(table.size(&inst.inner.store)) {
+            lengths.insert(export.name().to_string(), len);
+        }
+    }
+    ACTIVE_INSTANCE_TABLES.with(|active| {
+        active.borrow_mut().push(ActiveInstanceTables {
+            instance: instance_id,
+            lengths,
+            overrides: HashMap::new(),
+            ops: Vec::new(),
+        });
+    });
+}
+
+fn finish_instance_call(inst: &mut WasmInstanceHandle) -> Result<(), WasmHostError> {
+    let instance_id = inst as *mut WasmInstanceHandle as usize;
+    let active = ACTIVE_INSTANCE_TABLES.with(|active| active.borrow_mut().pop());
+    let Some(active) = active else {
+        return Ok(());
+    };
+    debug_assert_eq!(active.instance, instance_id);
+    for op in active.ops {
+        match op {
+            PendingTableOp::Set { name, index, value } => {
+                let Some(table) = instance_table(inst, &name) else {
+                    return Err(WasmHostError::Runtime(format!(
+                        "table export {name:?} disappeared during imported callback"
+                    )));
+                };
+                let value = table_value(inst, value.bits, value.is_null as i32);
+                table
+                    .set(&mut inst.inner.store, index as u64, value)
+                    .map_err(|error| WasmHostError::Runtime(error.to_string()))?;
+            }
+            PendingTableOp::Grow { name, delta, value } => {
+                let Some(table) = instance_table(inst, &name) else {
+                    return Err(WasmHostError::Runtime(format!(
+                        "table export {name:?} disappeared during imported callback"
+                    )));
+                };
+                let value = table_value(inst, value.bits, value.is_null as i32);
+                table
+                    .grow(&mut inst.inner.store, delta as u64, value)
+                    .map_err(|error| WasmHostError::Runtime(error.to_string()))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn with_active_instance_tables<R>(
+    instance: usize,
+    f: impl FnOnce(&mut ActiveInstanceTables) -> R,
+) -> Option<R> {
+    ACTIVE_INSTANCE_TABLES.with(|active| {
+        let mut active = active.borrow_mut();
+        let state = active
+            .iter_mut()
+            .rev()
+            .find(|state| state.instance == instance)?;
+        Some(f(state))
+    })
 }
 
 pub type WasmImportCallback = unsafe extern "C" fn(
@@ -251,13 +357,32 @@ fn instantiate_with_import_callback(
     })
 }
 
-/// Call an exported function by name. Returns the first return value (MVP
-/// assumes 0-or-1 result, matching the numeric-only subset).
+fn coerce_numeric_value(value: WasmVal, expected: ValType) -> Option<Val> {
+    let number = match value {
+        WasmVal::I32(value) => value as f64,
+        WasmVal::I64(value) => value as f64,
+        WasmVal::F32(value) => value as f64,
+        WasmVal::F64(value) => value,
+    };
+    match expected {
+        ValType::I32 => Some(Val::I32(number as i32)),
+        ValType::I64 => Some(Val::I64(number as i64)),
+        ValType::F32 => Some(Val::F32(wasmi::F32::from_bits((number as f32).to_bits()))),
+        ValType::F64 => Some(Val::F64(wasmi::F64::from_bits(number.to_bits()))),
+        ValType::V128 | ValType::FuncRef | ValType::ExternRef => None,
+    }
+}
+
+/// Call an exported function by name. Numeric JavaScript inputs are coerced
+/// against the declared Wasm parameter types, and all numeric results are
+/// returned in declaration order. wasm-bindgen uses multi-value returns for
+/// pointer/length pairs, so preserving only the first result is not enough for
+/// real generated glue.
 pub fn call_export(
     inst: &mut WasmInstanceHandle,
     name: &str,
     args: &[WasmVal],
-) -> Result<Option<WasmVal>, WasmHostError> {
+) -> Result<Vec<WasmVal>, WasmHostError> {
     let func = inst
         .inner
         .instance
@@ -274,18 +399,36 @@ pub fn call_export(
         )));
     }
 
-    let wasmi_args: Vec<Val> = args.iter().map(|v| v.to_wasmi()).collect();
-    let results_len = ty.results().len();
-    if results_len > 1 {
-        return Err(WasmHostError::UnsupportedSignature(format!(
-            "{name}: multi-value return not supported in MVP"
-        )));
-    }
-    let mut results: Vec<Val> = vec![Val::I32(0); results_len];
-    func.call(&mut inst.inner.store, &wasmi_args, &mut results)
-        .map_err(|e| WasmHostError::Runtime(e.to_string()))?;
+    let wasmi_args: Vec<Val> = args
+        .iter()
+        .copied()
+        .zip(ty.params().iter().copied())
+        .map(|(value, expected)| {
+            coerce_numeric_value(value, expected).ok_or_else(|| {
+                WasmHostError::UnsupportedSignature(format!(
+                    "{name}: unsupported parameter type {expected:?}"
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let mut results: Vec<Val> = ty.results().iter().copied().map(Val::default).collect();
+    begin_instance_call(inst);
+    let call_result = func.call(&mut inst.inner.store, &wasmi_args, &mut results);
+    let table_result = finish_instance_call(inst);
+    call_result.map_err(|e| WasmHostError::Runtime(e.to_string()))?;
+    table_result?;
 
-    Ok(results.first().and_then(WasmVal::from_wasmi))
+    results
+        .iter()
+        .map(|value| {
+            WasmVal::from_wasmi(value).ok_or_else(|| {
+                WasmHostError::UnsupportedSignature(format!(
+                    "{name}: unsupported result type {:?}",
+                    value.ty()
+                ))
+            })
+        })
+        .collect()
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -633,6 +776,237 @@ pub extern "C" fn perry_wasm_host_instance_memory_copy(
     copied
 }
 
+/// Copy caller-provided bytes into the exported `memory`. This keeps the
+/// wasmi allocation coherent with writes made through the JavaScript-facing
+/// `memory.buffer` between exported function calls.
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_memory_write(
+    inst: *mut WasmInstanceHandle,
+    data: *const u8,
+    len: usize,
+) -> usize {
+    if data.is_null() {
+        return 0;
+    }
+    let Some(inst) = (unsafe { inst.as_mut() }) else {
+        return 0;
+    };
+    let Some(memory) = inst.inner.instance.get_memory(&inst.inner.store, "memory") else {
+        return 0;
+    };
+    let target = memory.data_mut(&mut inst.inner.store);
+    let copied = target.len().min(len);
+    unsafe { std::ptr::copy_nonoverlapping(data, target.as_mut_ptr(), copied) };
+    copied
+}
+
+fn instance_table(inst: &WasmInstanceHandle, name: &str) -> Option<Table> {
+    inst.inner.instance.get_table(&inst.inner.store, name)
+}
+
+/// Return the current length of an exported table, or `usize::MAX` when the
+/// export does not exist or cannot be represented on this platform.
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_table_len(
+    inst: *mut WasmInstanceHandle,
+    name: *const c_char,
+    name_len: usize,
+) -> usize {
+    let Some(inst) = (unsafe { inst.as_ref() }) else {
+        return usize::MAX;
+    };
+    let Some(name) = utf8_arg(name, name_len) else {
+        return usize::MAX;
+    };
+    if let Some(len) = with_active_instance_tables(inst as *const _ as usize, |active| {
+        active.lengths.get(name).copied()
+    }) {
+        return len.unwrap_or(usize::MAX);
+    }
+    instance_table(inst, name)
+        .and_then(|table| usize::try_from(table.size(&inst.inner.store)).ok())
+        .unwrap_or(usize::MAX)
+}
+
+/// Read an `externref` table entry. Perry stores the nan-boxed JavaScript
+/// value bits inside wasmi's opaque `ExternRef`; null remains a real null ref.
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_table_get(
+    inst: *mut WasmInstanceHandle,
+    name: *const c_char,
+    name_len: usize,
+    index: usize,
+    out_bits: *mut u64,
+    out_is_null: *mut i32,
+) -> i32 {
+    if out_bits.is_null() || out_is_null.is_null() {
+        return 0;
+    }
+    let Some(inst) = (unsafe { inst.as_ref() }) else {
+        return 0;
+    };
+    let Some(name) = utf8_arg(name, name_len) else {
+        return 0;
+    };
+    if let Some(value) = with_active_instance_tables(inst as *const _ as usize, |active| {
+        active.overrides.get(&(name.to_string(), index)).copied()
+    }) {
+        let Some(value) = value else {
+            // The instance Store is already borrowed by wasmi. Existing
+            // entries that JS has not overwritten cannot be inspected until
+            // the call unwinds.
+            return 0;
+        };
+        unsafe {
+            *out_bits = value.bits;
+            *out_is_null = value.is_null as i32;
+        }
+        return 1;
+    }
+    let Some(table) = instance_table(inst, name) else {
+        return 0;
+    };
+    let Some(Val::ExternRef(value)) = table.get(&inst.inner.store, index as u64) else {
+        return 0;
+    };
+    match value {
+        Ref::Null => unsafe {
+            *out_bits = 0;
+            *out_is_null = 1;
+        },
+        Ref::Val(value) => {
+            let Some(bits) = value.data(&inst.inner.store).downcast_ref::<u64>() else {
+                return 0;
+            };
+            unsafe {
+                *out_bits = *bits;
+                *out_is_null = 0;
+            }
+        }
+    }
+    1
+}
+
+fn table_value(inst: &mut WasmInstanceHandle, bits: u64, is_null: i32) -> Val {
+    if is_null != 0 {
+        Val::ExternRef(Ref::Null)
+    } else {
+        Val::from(ExternRef::new(&mut inst.inner.store, bits))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_table_set(
+    inst: *mut WasmInstanceHandle,
+    name: *const c_char,
+    name_len: usize,
+    index: usize,
+    bits: u64,
+    is_null: i32,
+) -> i32 {
+    let Some(inst) = (unsafe { inst.as_mut() }) else {
+        return 0;
+    };
+    let Some(name) = utf8_arg(name, name_len) else {
+        return 0;
+    };
+    let pending_value = PendingTableValue {
+        bits,
+        is_null: is_null != 0,
+    };
+    if let Some(queued) = with_active_instance_tables(inst as *mut _ as usize, |active| {
+        let Some(len) = active.lengths.get(name).copied() else {
+            return false;
+        };
+        if index >= len {
+            return false;
+        }
+        active
+            .overrides
+            .insert((name.to_string(), index), pending_value);
+        active.ops.push(PendingTableOp::Set {
+            name: name.to_string(),
+            index,
+            value: pending_value,
+        });
+        true
+    }) {
+        return queued as i32;
+    }
+    let Some(table) = instance_table(inst, name) else {
+        return 0;
+    };
+    if table.ty(&inst.inner.store).element() != ValType::ExternRef {
+        return 0;
+    }
+    let value = table_value(inst, bits, is_null);
+    table
+        .set(&mut inst.inner.store, index as u64, value)
+        .is_ok() as i32
+}
+
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_table_grow(
+    inst: *mut WasmInstanceHandle,
+    name: *const c_char,
+    name_len: usize,
+    delta: usize,
+    bits: u64,
+    is_null: i32,
+    out_old_len: *mut usize,
+) -> i32 {
+    if out_old_len.is_null() {
+        return 0;
+    }
+    let Some(inst) = (unsafe { inst.as_mut() }) else {
+        return 0;
+    };
+    let Some(name) = utf8_arg(name, name_len) else {
+        return 0;
+    };
+    let pending_value = PendingTableValue {
+        bits,
+        is_null: is_null != 0,
+    };
+    if let Some(old_len) = with_active_instance_tables(inst as *mut _ as usize, |active| {
+        let old_len = *active.lengths.get(name)?;
+        let new_len = old_len.checked_add(delta)?;
+        active.lengths.insert(name.to_string(), new_len);
+        for index in old_len..new_len {
+            active
+                .overrides
+                .insert((name.to_string(), index), pending_value);
+        }
+        active.ops.push(PendingTableOp::Grow {
+            name: name.to_string(),
+            delta,
+            value: pending_value,
+        });
+        Some(old_len)
+    }) {
+        let Some(old_len) = old_len else {
+            return 0;
+        };
+        unsafe { *out_old_len = old_len };
+        return 1;
+    }
+    let Some(table) = instance_table(inst, name) else {
+        return 0;
+    };
+    if table.ty(&inst.inner.store).element() != ValType::ExternRef {
+        return 0;
+    }
+    let value = table_value(inst, bits, is_null);
+    let Ok(old_len) = table.grow(&mut inst.inner.store, delta as u64, value) else {
+        return 0;
+    };
+    let Ok(old_len) = usize::try_from(old_len) else {
+        return 0;
+    };
+    unsafe { *out_old_len = old_len };
+    1
+}
+
 /// Consume the status captured by WASI `proc_exit`, if that import ran.
 #[no_mangle]
 pub extern "C" fn perry_wasm_host_instance_take_exit_code(
@@ -662,9 +1036,9 @@ pub const WASM_VAL_KIND_NONE: u8 = 0xFF;
 
 /// Call an export by name. Args are encoded as parallel arrays:
 /// `arg_kinds[i]` is the type tag, `arg_bits[i]` is the raw 64-bit payload
-/// (i32/f32 widened, i64/f64 as-is). On success writes `*out_kind` /
-/// `*out_bits` (or `WASM_VAL_KIND_NONE` for void exports). On error returns
-/// 0 and writes `*out_err`.
+/// (i32/f32 widened, i64/f64 as-is). On success writes every result into the
+/// parallel output arrays and sets `*out_count`. On error returns 0 and writes
+/// `*out_err`.
 #[no_mangle]
 pub extern "C" fn perry_wasm_host_call_export(
     inst: *mut WasmInstanceHandle,
@@ -673,11 +1047,17 @@ pub extern "C" fn perry_wasm_host_call_export(
     arg_kinds: *const u8,
     arg_bits: *const u64,
     arg_count: usize,
-    out_kind: *mut u8,
+    out_kinds: *mut u8,
     out_bits: *mut u64,
+    out_capacity: usize,
+    out_count: *mut usize,
     out_err: *mut *mut c_char,
 ) -> i32 {
-    if inst.is_null() || name.is_null() || out_kind.is_null() || out_bits.is_null() {
+    if inst.is_null()
+        || name.is_null()
+        || out_count.is_null()
+        || (out_capacity != 0 && (out_kinds.is_null() || out_bits.is_null()))
+    {
         capture_err(out_err, WasmHostError::Runtime("null arg".into()));
         return 0;
     }
@@ -713,25 +1093,31 @@ pub extern "C" fn perry_wasm_host_call_export(
         args.push(v);
     }
     match call_export(inst, name_str, &args) {
-        Ok(None) => {
-            unsafe {
-                *out_kind = WASM_VAL_KIND_NONE;
-                *out_bits = 0;
+        Ok(values) if values.len() <= out_capacity => {
+            for (index, value) in values.iter().copied().enumerate() {
+                let (kind, bits) = match value {
+                    WasmVal::I32(value) => (WASM_VAL_KIND_I32, value as u32 as u64),
+                    WasmVal::I64(value) => (WASM_VAL_KIND_I64, value as u64),
+                    WasmVal::F32(value) => (WASM_VAL_KIND_F32, value.to_bits() as u64),
+                    WasmVal::F64(value) => (WASM_VAL_KIND_F64, value.to_bits()),
+                };
+                unsafe {
+                    *out_kinds.add(index) = kind;
+                    *out_bits.add(index) = bits;
+                }
             }
+            unsafe { *out_count = values.len() };
             1
         }
-        Ok(Some(v)) => {
-            let (k, b) = match v {
-                WasmVal::I32(x) => (WASM_VAL_KIND_I32, x as u32 as u64),
-                WasmVal::I64(x) => (WASM_VAL_KIND_I64, x as u64),
-                WasmVal::F32(x) => (WASM_VAL_KIND_F32, x.to_bits() as u64),
-                WasmVal::F64(x) => (WASM_VAL_KIND_F64, x.to_bits()),
-            };
-            unsafe {
-                *out_kind = k;
-                *out_bits = b;
-            }
-            1
+        Ok(values) => {
+            capture_err(
+                out_err,
+                WasmHostError::UnsupportedSignature(format!(
+                    "{name_str}: {} results exceed host capacity {out_capacity}",
+                    values.len()
+                )),
+            );
+            0
         }
         Err(e) => {
             capture_err(out_err, e);
@@ -750,6 +1136,28 @@ mod tests {
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f,
         0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00,
         0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b,
+    ];
+    /// Module with an exported memory, byte load/store helpers, and a
+    /// two-result function whose input is declared as f64.
+    const LIVE_MEMORY_MULTI_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0f, 0x03, 0x60, 0x00, 0x01, 0x7f,
+        0x60, 0x01, 0x7f, 0x00, 0x60, 0x01, 0x7c, 0x02, 0x7f, 0x7c, 0x03, 0x04, 0x03, 0x00, 0x01,
+        0x02, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x20, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72,
+        0x79, 0x02, 0x00, 0x04, 0x6c, 0x6f, 0x61, 0x64, 0x00, 0x00, 0x05, 0x73, 0x74, 0x6f, 0x72,
+        0x65, 0x00, 0x01, 0x04, 0x70, 0x61, 0x69, 0x72, 0x00, 0x02, 0x0a, 0x1a, 0x03, 0x07, 0x00,
+        0x41, 0x00, 0x2d, 0x00, 0x00, 0x0b, 0x09, 0x00, 0x41, 0x00, 0x20, 0x00, 0x3a, 0x00, 0x00,
+        0x0b, 0x06, 0x00, 0x41, 0x07, 0x20, 0x00, 0x0b,
+    ];
+    const EXTERNREF_TABLE_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x04, 0x04, 0x01, 0x6f, 0x00, 0x02, 0x07,
+        0x08, 0x01, 0x04, 0x72, 0x65, 0x66, 0x73, 0x01, 0x00,
+    ];
+    const EXTERNREF_TABLE_CYCLE_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x02,
+        0x15, 0x01, 0x0c, 0x2e, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x67, 0x6c, 0x75, 0x65,
+        0x04, 0x69, 0x6e, 0x69, 0x74, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x04, 0x04, 0x01, 0x6f,
+        0x00, 0x02, 0x07, 0x10, 0x02, 0x04, 0x72, 0x65, 0x66, 0x73, 0x01, 0x00, 0x05, 0x73, 0x74,
+        0x61, 0x72, 0x74, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
     ];
     /// `(module (import "env" "f" (func (param i32) (result i32))))`.
     const IMPORT_FUNC_WASM: &[u8] = &[
@@ -782,7 +1190,177 @@ mod tests {
         let mut inst = instantiate(&module).expect("instantiate");
         let result =
             call_export(&mut inst, "add", &[WasmVal::I32(2), WasmVal::I32(3)]).expect("call");
-        assert_eq!(result, Some(WasmVal::I32(5)));
+        assert_eq!(result, vec![WasmVal::I32(5)]);
+    }
+
+    #[test]
+    fn live_memory_round_trips_and_multi_results_are_preserved() {
+        let module = compile(LIVE_MEMORY_MULTI_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+
+        let input = [42u8];
+        assert_eq!(
+            perry_wasm_host_instance_memory_write(&mut inst, input.as_ptr(), input.len()),
+            1
+        );
+        assert_eq!(
+            call_export(&mut inst, "load", &[]).expect("load"),
+            vec![WasmVal::I32(42)]
+        );
+
+        call_export(&mut inst, "store", &[WasmVal::I32(99)]).expect("store");
+        let mut output = [0u8];
+        assert_eq!(
+            perry_wasm_host_instance_memory_copy(&mut inst, output.as_mut_ptr(), output.len()),
+            1
+        );
+        assert_eq!(output, [99]);
+
+        assert_eq!(
+            call_export(&mut inst, "pair", &[WasmVal::I32(3)]).expect("pair"),
+            vec![WasmVal::I32(7), WasmVal::F64(3.0)]
+        );
+    }
+
+    #[test]
+    fn exported_externref_table_round_trips_host_values() {
+        let module = compile(EXTERNREF_TABLE_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+        let name = b"refs";
+        assert_eq!(
+            perry_wasm_host_instance_table_len(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len()
+            ),
+            2
+        );
+        assert_eq!(
+            perry_wasm_host_instance_table_set(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                1,
+                0x1234,
+                0,
+            ),
+            1
+        );
+        let mut bits = 0;
+        let mut is_null = 1;
+        assert_eq!(
+            perry_wasm_host_instance_table_get(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                1,
+                &mut bits,
+                &mut is_null,
+            ),
+            1
+        );
+        assert_eq!((bits, is_null), (0x1234, 0));
+
+        let mut old_len = 0;
+        assert_eq!(
+            perry_wasm_host_instance_table_grow(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                3,
+                0,
+                1,
+                &mut old_len,
+            ),
+            1
+        );
+        assert_eq!(old_len, 2);
+        assert_eq!(
+            perry_wasm_host_instance_table_len(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len()
+            ),
+            5
+        );
+    }
+
+    unsafe extern "C" fn reentrant_table_import_callback(
+        context: u64,
+        _module: *const u8,
+        _module_len: usize,
+        _name: *const u8,
+        _name_len: usize,
+        _arg_kinds: *const u8,
+        _arg_bits: *const u64,
+        _arg_count: usize,
+        _result_kinds: *const u8,
+        _result_bits: *mut u64,
+        _result_count: usize,
+    ) -> i32 {
+        let inst = context as *mut WasmInstanceHandle;
+        let name = b"refs";
+        let mut old_len = 0;
+        assert_eq!(
+            perry_wasm_host_instance_table_grow(
+                inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                2,
+                0,
+                1,
+                &mut old_len,
+            ),
+            1
+        );
+        assert_eq!(old_len, 2);
+        assert_eq!(
+            perry_wasm_host_instance_table_set(
+                inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                3,
+                0x5678,
+                0,
+            ),
+            1
+        );
+        1
+    }
+
+    #[test]
+    fn table_mutations_from_import_callbacks_are_deferred_safely() {
+        let module = compile(EXTERNREF_TABLE_CYCLE_WASM).expect("compile");
+        let mut inst =
+            instantiate_with_import_callback(&module, Some(reentrant_table_import_callback), 0)
+                .expect("instantiate");
+        inst.inner.store.data_mut().import_context =
+            &mut inst as *mut WasmInstanceHandle as usize as u64;
+        call_export(&mut inst, "start", &[]).expect("start");
+
+        let name = b"refs";
+        assert_eq!(
+            perry_wasm_host_instance_table_len(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+            ),
+            4
+        );
+        let mut bits = 0;
+        let mut is_null = 1;
+        assert_eq!(
+            perry_wasm_host_instance_table_get(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+                3,
+                &mut bits,
+                &mut is_null,
+            ),
+            1
+        );
+        assert_eq!((bits, is_null), (0x5678, 0));
     }
 
     #[test]
@@ -800,7 +1378,7 @@ mod tests {
         let module = compile(IMPORT_F64_RESULT_WASM).expect("compile");
         let mut inst = instantiate(&module).expect("instantiate with f64 import");
         let result = call_export(&mut inst, "call", &[]).expect("call import");
-        assert_eq!(result, Some(WasmVal::F64(0.0)));
+        assert_eq!(result, vec![WasmVal::F64(0.0)]);
     }
 
     unsafe extern "C" fn f64_import_callback(
@@ -832,7 +1410,7 @@ mod tests {
             instantiate_with_import_callback(&module, Some(f64_import_callback), 6.5f64.to_bits())
                 .expect("instantiate with callback");
         let result = call_export(&mut inst, "call", &[]).expect("call import");
-        assert_eq!(result, Some(WasmVal::F64(6.5)));
+        assert_eq!(result, vec![WasmVal::F64(6.5)]);
     }
 
     #[test]

--- a/crates/perry/tests/issue_5234_wasm_esm_import.rs
+++ b/crates/perry/tests/issue_5234_wasm_esm_import.rs
@@ -71,12 +71,43 @@ const MEMORY_WASM: &[u8] = &[
     0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00,
 ];
 
+/// A module with live memory reads/writes and a wasm-bindgen-style
+/// multi-value result `(i32, f64)`.
+const LIVE_MEMORY_MULTI_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0f, 0x03, 0x60, 0x00, 0x01, 0x7f, 0x60,
+    0x01, 0x7f, 0x00, 0x60, 0x01, 0x7c, 0x02, 0x7f, 0x7c, 0x03, 0x04, 0x03, 0x00, 0x01, 0x02, 0x05,
+    0x03, 0x01, 0x00, 0x01, 0x07, 0x20, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00,
+    0x04, 0x6c, 0x6f, 0x61, 0x64, 0x00, 0x00, 0x05, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x00, 0x01, 0x04,
+    0x70, 0x61, 0x69, 0x72, 0x00, 0x02, 0x0a, 0x1a, 0x03, 0x07, 0x00, 0x41, 0x00, 0x2d, 0x00, 0x00,
+    0x0b, 0x09, 0x00, 0x41, 0x00, 0x20, 0x00, 0x3a, 0x00, 0x00, 0x0b, 0x06, 0x00, 0x41, 0x07, 0x20,
+    0x00, 0x0b,
+];
+
+/// `(module (table (export "refs") 2 externref))`
+const EXTERNREF_TABLE_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x04, 0x04, 0x01, 0x6f, 0x00, 0x02, 0x07, 0x08,
+    0x01, 0x04, 0x72, 0x65, 0x66, 0x73, 0x01, 0x00,
+];
+
+/// A wasm-bindgen-style cycle: the exported function calls JS glue which
+/// mutates the module's exported externref table while Wasm is on the stack.
+const EXTERNREF_TABLE_CYCLE_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x02, 0x15,
+    0x01, 0x0c, 0x2e, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x67, 0x6c, 0x75, 0x65, 0x04, 0x69,
+    0x6e, 0x69, 0x74, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x04, 0x04, 0x01, 0x6f, 0x00, 0x02, 0x07,
+    0x10, 0x02, 0x04, 0x72, 0x65, 0x66, 0x73, 0x01, 0x00, 0x05, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00,
+    0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+];
+
 const MAIN_FIXTURE: &str = r#"
 import wasmDefault, { add } from "./add.wasm";
 import * as wasmNamespace from "./add.wasm";
 import { call as importedCall } from "./imported.wasm";
 import { throughGlue } from "./glue";
 import memoryDefault, { memory } from "./memory.wasm";
+import liveDefault, { load, store, pair, memory as liveMemory } from "./live-memory.wasm";
+import { refs } from "./externref-table.wasm";
+import { runTableCycle } from "./table-glue";
 import addWasmPath from "./file-add.wasm" with { type: "file" };
 import importedWasmPath from "./file-imported.wasm" with { type: "file" };
 import { readFileSync } from "node:fs";
@@ -88,6 +119,20 @@ console.log("imported=" + importedCall(41));
 console.log("circular=" + throughGlue(8));
 console.log("memory=" + memory.buffer.byteLength);
 console.log("defaultMemory=" + memoryDefault.memory.buffer.byteLength);
+
+// wasm-bindgen writes arguments through memory.buffer before calling an
+// export, then reads returned bytes after the call. Both directions must stay
+// coherent with the host engine, and multi-value returns must remain arrays.
+new Uint8Array(liveMemory.buffer)[0] = 42;
+console.log("liveLoad=" + load());
+store(99);
+console.log("liveStore=" + new Uint8Array(liveDefault.memory.buffer)[0]);
+const pairResult = pair(3);
+console.log("multi=" + pairResult[0] + ":" + pairResult[1]);
+const oldTableLength = refs.grow(3);
+refs.set(4, true);
+console.log("table=" + oldTableLength + ":" + refs.length + ":" + refs.get(4));
+console.log("tableCycle=" + runTableCycle());
 
 // #8508: wasm-bindgen's Node loader compiles file-backed bytes first, then
 // synchronously constructs an Instance with its glue imports object.
@@ -115,6 +160,20 @@ export function throughGlue(value: number): number {
 }
 "#;
 
+const TABLE_GLUE_FIXTURE: &str = r#"
+import { refs, start } from "./externref-table-cycle.wasm";
+
+export function init(): void {
+    refs.grow(2);
+    refs.set(3, true);
+}
+
+export function runTableCycle(): string {
+    start();
+    return refs.length + ":" + refs.get(3);
+}
+"#;
+
 fn write_fixture(root: &std::path::Path) {
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD
@@ -127,7 +186,17 @@ fn write_fixture(root: &std::path::Path) {
     std::fs::write(root.join("file-imported.wasm"), IMPORTED_WASM)
         .expect("write file imported.wasm");
     std::fs::write(root.join("memory.wasm"), MEMORY_WASM).expect("write memory.wasm");
+    std::fs::write(root.join("live-memory.wasm"), LIVE_MEMORY_MULTI_WASM)
+        .expect("write live memory wasm");
+    std::fs::write(root.join("externref-table.wasm"), EXTERNREF_TABLE_WASM)
+        .expect("write externref table wasm");
+    std::fs::write(
+        root.join("externref-table-cycle.wasm"),
+        EXTERNREF_TABLE_CYCLE_WASM,
+    )
+    .expect("write externref table cycle wasm");
     std::fs::write(root.join("glue.ts"), GLUE_FIXTURE).expect("write glue.ts");
+    std::fs::write(root.join("table-glue.ts"), TABLE_GLUE_FIXTURE).expect("write table glue ts");
     std::fs::write(root.join("main.ts"), MAIN_FIXTURE).expect("write main.ts");
 }
 
@@ -181,6 +250,11 @@ fn wasm_esm_import_instantiates_and_exposes_exports() {
     assert!(stdout.contains("circular=9"), "stdout:\n{stdout}");
     assert!(stdout.contains("memory=65536"), "stdout:\n{stdout}");
     assert!(stdout.contains("defaultMemory=65536"), "stdout:\n{stdout}");
+    assert!(stdout.contains("liveLoad=42"), "stdout:\n{stdout}");
+    assert!(stdout.contains("liveStore=99"), "stdout:\n{stdout}");
+    assert!(stdout.contains("multi=7:3"), "stdout:\n{stdout}");
+    assert!(stdout.contains("table=2:5:true"), "stdout:\n{stdout}");
+    assert!(stdout.contains("tableCycle=4:true"), "stdout:\n{stdout}");
     assert!(stdout.contains("fileInstance=21"), "stdout:\n{stdout}");
     assert!(stdout.contains("fileImported=21"), "stdout:\n{stdout}");
     assert!(stdout.contains("instanceLength=1"), "stdout:\n{stdout}");

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -268,7 +268,10 @@ When the wasmi host is linked, `new WebAssembly.Module(bytes)` and the
 synchronous `new WebAssembly.Instance(module, imports)` constructor execute
 real modules in Perry's numeric function/import subset. This includes WASM
 bytes exposed through the embedded `import ... with { type: "file" }` loader;
-tables, globals, non-function imports, reference values, and streaming remain
+the JS-visible `memory.buffer` is synchronized before and after calls,
+numeric multi-value results use the standard array shape, and exported
+`externref` tables support `get`, `set`, and `grow`. Imported tables/memories,
+globals, general reference-valued function signatures, and streaming remain
 outside that subset.
 
 Two spellings, two paths:


### PR DESCRIPTION
## Summary

- synchronize JavaScript writes into exported WebAssembly memory before calls and copy Wasm writes and growth back afterward
- preserve numeric multi-value returns and coerce numeric arguments using the declared Wasm signature
- expose exported externref tables with get, set, grow, and GC-retained JS values
- defer table mutations made through imported JS callbacks until wasmi releases its Store, covering the wasm-bindgen import cycle safely
- extend the packaged .wasm end-to-end fixture and document the supported subset

## Validation

- `cargo test -p perry-wasm-host`
- `cargo check -p perry-runtime --features wasm-host`
- `cargo test -p perry --test issue_5234_wasm_esm_import -- --nocapture`
- `cargo clippy -p perry-wasm-host -- -D warnings`
- compiled the patched `@silvia-odwyer/photon-node@0.3.4` loader with `with { type: "file" }`, then ran the binary from an unrelated empty directory: `size=2x1`, `pixels=8:255:0`

## Scope

This lands the Photon and wasm-bindgen live-state slice of #8508. Imported tables, memories, and globals plus the web-tree-sitter dynamic grammar path remain follow-up work, so this PR intentionally references rather than closes the umbrella issue.

No version bump.

Refs #8508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved WebAssembly memory synchronization during runtime calls.
  * Added support for numeric functions returning multiple values as arrays.
  * Added `externref` table operations: reading, updating, and growing tables.
  * Added numeric argument coercion for WebAssembly calls.

* **Documentation**
  * Updated WebAssembly support documentation to clarify supported features and limitations.

* **Bug Fixes**
  * Improved table mutation handling during callbacks and cyclic initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->