### PR TITLE
fix(gc): register mutable root scanners per thread

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,6 +410,15 @@ jobs:
           python3 scripts/gc_runtime_root_holders.py --self-test
           python3 scripts/gc_runtime_root_holders.py
 
+      # #8530. Mutable-root scanner registries are thread-local, so guarding a
+      # registration call with a process-global Once/OnceLock/AtomicBool (or a
+      # mutex boolean) leaves every heap after the first without those roots.
+      - name: Thread-local GC scanner registration audit
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/check_gc_scanner_latches.py --self-test
+          python3 scripts/check_gc_scanner_latches.py
+
       # #8174. A side table whose KEY is a raw heap address, REKEYED in place by
       # `visit_metadata_*` (rewritten if the object moved, deliberately not
       # marked), depends on `gc::dead_owner` dropping that key when the object

--- a/crates/perry-runtime/src/cluster.rs
+++ b/crates/perry-runtime/src/cluster.rs
@@ -11,7 +11,7 @@
 //! the primary-coordinated shared ephemeral port for `listen(0)` are tracked
 //! in #4962.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::sync::{Once, OnceLock};
 
@@ -51,6 +51,8 @@ impl ClusterState {
 
 thread_local! {
     static CLUSTER_STATE: RefCell<ClusterState> = RefCell::new(ClusterState::new());
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static CLUSTER_GC_REGISTERED: Cell<bool> = const { Cell::new(false) };
 }
 
 static CLUSTER_INIT: Once = Once::new();
@@ -600,8 +602,14 @@ pub extern "C" fn js_cluster_disconnect(callback: f64) -> f64 {
 }
 
 fn ensure_cluster_runtime() {
-    CLUSTER_INIT.call_once(|| {
+    CLUSTER_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         crate::gc::gc_register_mutable_root_scanner_named("node_cluster", cluster_root_scanner);
+        registered.set(true);
+    });
+    CLUSTER_INIT.call_once(|| {
         register_cluster_arities();
     });
 }

--- a/crates/perry-runtime/src/messaging.rs
+++ b/crates/perry-runtime/src/messaging.rs
@@ -5,9 +5,10 @@ use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader}
 use crate::object::{self, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
+use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
 use std::ptr::null_mut;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::Mutex;
 
 type MessageChannelFactory = extern "C" fn() -> f64;
@@ -156,15 +157,23 @@ struct PortState {
 }
 
 static PORT_STATES: Mutex<Option<HashMap<usize, PortState>>> = Mutex::new(None);
-static GC_SCANNER_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+crate::perry_thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static GC_SCANNER_REGISTERED: Cell<bool> = const { Cell::new(false) };
+}
 
 fn ensure_gc_scanner_registered() {
-    if !GC_SCANNER_REGISTERED.swap(true, Ordering::AcqRel) {
+    GC_SCANNER_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         crate::gc::gc_register_mutable_root_scanner_named(
             "messaging_ports",
             port_states_root_scanner_mut,
         );
-    }
+        registered.set(true);
+    });
 }
 
 /// Keep queued message values, `onmessage` handlers, listener closures, and the

--- a/crates/perry-runtime/src/object/native_this_alias.rs
+++ b/crates/perry-runtime/src/object/native_this_alias.rs
@@ -66,9 +66,22 @@ fn object_addr_of(value: f64) -> usize {
 crate::perry_thread_local! {
     static ALIAS_ACTIVE: Cell<bool> = const { Cell::new(false) };
     static ALIASES: RefCell<Vec<AliasEntry>> = const { RefCell::new(Vec::new()) };
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static SCANNER_REGISTERED: Cell<bool> = const { Cell::new(false) };
 }
 
-static SCANNER_REGISTERED: std::sync::Once = std::sync::Once::new();
+fn ensure_scanner_registered() {
+    SCANNER_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
+        crate::gc::gc_register_mutable_root_scanner_named(
+            "runtime:native-this-alias",
+            scan_alias_roots,
+        );
+        registered.set(true);
+    });
+}
 
 fn scan_alias_roots(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     ALIASES.with(|a| {
@@ -142,12 +155,7 @@ pub(crate) fn maybe_alias_explicit_this_construction(callee: f64, this_arg: f64,
         return;
     }
 
-    SCANNER_REGISTERED.call_once(|| {
-        crate::gc::gc_register_mutable_root_scanner_named(
-            "runtime:native-this-alias",
-            scan_alias_roots,
-        );
-    });
+    ensure_scanner_registered();
     ALIASES.with(|a| {
         let mut aliases = a.borrow_mut();
         if let Some(existing) = aliases.iter_mut().find(|e| e.obj_addr == obj_addr) {
@@ -236,12 +244,7 @@ unsafe fn construct_native_server_with_this(module: &str, this_val: f64, a0: f64
         && super::is_valid_obj_ptr(obj_addr as *const u8)
         && !crate::closure::is_closure_ptr(obj_addr)
     {
-        SCANNER_REGISTERED.call_once(|| {
-            crate::gc::gc_register_mutable_root_scanner_named(
-                "runtime:native-this-alias",
-                scan_alias_roots,
-            );
-        });
+        ensure_scanner_registered();
         ALIASES.with(|a| {
             let mut aliases = a.borrow_mut();
             if let Some(existing) = aliases.iter_mut().find(|e| e.obj_addr == obj_addr) {

--- a/crates/perry-stdlib/src/commander.rs
+++ b/crates/perry-stdlib/src/commander.rs
@@ -95,14 +95,21 @@ impl CommanderHandle {
 // ---------------------------------------------------------------------------
 // GC root scanning — pin user-supplied .action() closures across collections.
 
-static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 fn ensure_gc_scanner_registered() {
-    GC_REGISTERED.call_once(|| {
+    GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:commander",
             scan_commander_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/cron.rs
+++ b/crates/perry-stdlib/src/cron.rs
@@ -31,7 +31,7 @@ use perry_runtime::gc::{gc_register_mutable_root_scanner_named, RuntimeRootVisit
 use perry_runtime::{js_string_from_bytes, StringHeader};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex, Once};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Instant;
 
 /// Cron job handle.
@@ -85,7 +85,10 @@ unsafe impl Send for CronTimer {}
 
 static CRON_TIMERS: StdMutex<Vec<CronTimer>> = StdMutex::new(Vec::new());
 static CRON_NEXT_TIMER_ID: StdMutex<i64> = StdMutex::new(1);
-static CRON_GC_REGISTERED: Once = Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static CRON_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 /// Compute the next firing time for a cron schedule, or `None` if the
 /// schedule has no future occurrences (which would terminate the job).
@@ -98,11 +101,14 @@ fn next_cron_instant(schedule: &Schedule) -> Option<Instant> {
     Some(Instant::now() + std::time::Duration::from_millis(ms))
 }
 
-/// Register the cron GC root scanner exactly once. Safe to call from any
-/// `js_cron_*` entry point on the main thread.
+/// Register the cron GC root scanner once on each thread.
 fn ensure_gc_scanner_registered() {
-    CRON_GC_REGISTERED.call_once(|| {
+    CRON_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         gc_register_mutable_root_scanner_named("stdlib:cron", scan_cron_roots_mut);
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/crypto/hash_handles.rs
+++ b/crates/perry-stdlib/src/crypto/hash_handles.rs
@@ -1,7 +1,7 @@
 use super::*;
 use perry_runtime::{js_closure_call0, js_closure_call1, ClosureHeader};
 use std::collections::HashMap;
-use std::sync::{Mutex, Once};
+use std::sync::Mutex;
 
 /// node validates the `data` arg of `hash.update`/`hmac.update` is a string
 /// or `Buffer`/`TypedArray`/`DataView` before touching it. Without this a
@@ -62,14 +62,21 @@ lazy_static::lazy_static! {
     static ref CRYPTO_STREAM_PENDING_EVENTS: Mutex<Vec<CryptoStreamEvent>> = Mutex::new(Vec::new());
 }
 
-static CRYPTO_STREAM_GC_REGISTERED: Once = Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static CRYPTO_STREAM_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 fn ensure_crypto_stream_gc_scanner() {
-    CRYPTO_STREAM_GC_REGISTERED.call_once(|| {
+    CRYPTO_STREAM_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:crypto-streams",
             scan_crypto_stream_roots,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/domain.rs
+++ b/crates/perry-stdlib/src/domain.rs
@@ -99,20 +99,25 @@ impl DomainHandle {
     }
 }
 
-static DOMAIN_GC_REGISTERED: Once = Once::new();
 static DOMAIN_WRAPPERS_REGISTERED: Once = Once::new();
 
 thread_local! {
     static ACTIVE_DOMAINS: RefCell<Vec<Handle>> = const { RefCell::new(Vec::new()) };
     static ACTIVE_DOMAINS_TOUCHED: Cell<bool> = const { Cell::new(false) };
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static DOMAIN_GC_REGISTERED: Cell<bool> = const { Cell::new(false) };
 }
 
 fn ensure_gc_scanner_registered() {
-    DOMAIN_GC_REGISTERED.call_once(|| {
+    DOMAIN_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:domain",
             scan_domain_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -296,19 +296,26 @@ pub struct EventEmitterHandle {
 unsafe impl Send for EventEmitterHandle {}
 unsafe impl Sync for EventEmitterHandle {}
 
-static EVENTS_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static EVENTS_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
-/// Register the EventEmitter GC root scanner exactly once. User closures
+/// Register the EventEmitter GC root scanner once per thread. User closures
 /// passed to `emitter.on(event, cb)` live inside EventEmitterHandle
 /// values in the handle registry; without this scanner, a malloc-triggered
 /// GC between `.on(...)` and the next `.emit(...)` would sweep the
 /// closure — same root cause as issue #35 for net.Socket listeners.
 fn ensure_gc_scanner_registered() {
-    EVENTS_GC_REGISTERED.call_once(|| {
+    EVENTS_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:events",
             scan_events_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/exponential_backoff.rs
+++ b/crates/perry-stdlib/src/exponential_backoff.rs
@@ -17,7 +17,7 @@ use perry_runtime::{
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex, Once};
+use std::sync::{LazyLock, Mutex};
 
 /// Check if an f64 value represents a "real" success value.
 /// NaN-boxed tagged values (pointers, strings, int32, booleans, etc.) are valid results.
@@ -91,14 +91,21 @@ struct BackoffState {
 static STATES: LazyLock<Mutex<HashMap<u64, BackoffState>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-static GC_REGISTERED: Once = Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 fn ensure_backoff_gc_scanner() {
-    GC_REGISTERED.call_once(|| {
+    GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:exponential-backoff",
             scan_backoff_roots,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/fetch/gc.rs
+++ b/crates/perry-stdlib/src/fetch/gc.rs
@@ -113,13 +113,19 @@ impl FetchRootVisitor for FfiFetchRootVisitor {
     }
 }
 
-static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
-/// Register the Fetch root scanner exactly once. Called from every site that
+/// Register the Fetch root scanner once on each thread. Called from every site that
 /// stores a heap value into one of the registries, before the store, so the
 /// value is reachable from the first collection after it lands.
 pub(super) fn ensure_gc_registered() {
-    GC_REGISTERED.call_once(|| {
+    GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         const SOURCE: &[u8] = b"stdlib:fetch";
         unsafe {
             perry_ffi_gc_register_mutable_root_scanner_named(
@@ -129,6 +135,7 @@ pub(super) fn ensure_gc_registered() {
                 scan_fetch_roots_ffi,
             );
         }
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -101,14 +101,19 @@ lazy_static::lazy_static! {
     static ref NEXT_NET_ID: Mutex<i64> = Mutex::new(1);
 }
 
-static NET_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static NET_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
-/// Register the net GC root scanner exactly once. Safe to call from any
-/// `js_net_*` entry point on the main thread. Mirrors the pattern in
-/// `cron.rs::ensure_gc_scanner_registered`.
+/// Register the net GC root scanner once on each thread.
 fn ensure_gc_scanner_registered() {
-    NET_GC_REGISTERED.call_once(|| {
+    NET_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named("stdlib:net", scan_net_roots_mut);
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -202,14 +202,21 @@ thread_local! {
 // borrow is ever held across an allocation that could re-enter this scanner.
 // ---------------------------------------------------------------------------
 
-static READLINE_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static READLINE_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 fn ensure_gc_scanner_registered() {
-    READLINE_GC_REGISTERED.call_once(|| {
+    READLINE_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:readline",
             scan_readline_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/sqlite.rs
+++ b/crates/perry-stdlib/src/sqlite.rs
@@ -7,7 +7,7 @@ use crate::common::{for_each_handle_mut_of, Handle};
 use rusqlite::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::{Mutex, Once, OnceLock};
+use std::sync::{Mutex, OnceLock};
 
 mod backup;
 mod better;
@@ -215,10 +215,14 @@ pub(crate) const TAG_NULL_BITS: u64 = 0x7FFC_0000_0000_0002;
 pub(crate) const JS_SAFE_INTEGER_MAX: i64 = 9_007_199_254_740_991;
 pub(crate) const JS_SAFE_INTEGER_MIN: i64 = -9_007_199_254_740_991;
 
-pub(crate) static NODE_SQLITE_GC_SCANNER: Once = Once::new();
 pub(crate) static NODE_SQLITE_CUSTOM_FUNCTIONS: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
 pub(crate) static NODE_SQLITE_CUSTOM_AGGREGATES: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
 pub(crate) static NODE_SQLITE_ACTIVE_AGGREGATES: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static NODE_SQLITE_GC_SCANNER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 pub(crate) fn node_sqlite_custom_functions() -> &'static Mutex<HashSet<usize>> {
     NODE_SQLITE_CUSTOM_FUNCTIONS.get_or_init(|| Mutex::new(HashSet::new()))
@@ -233,11 +237,15 @@ pub(crate) fn node_sqlite_active_aggregates() -> &'static Mutex<HashSet<usize>> 
 }
 
 pub(crate) fn ensure_node_sqlite_gc_scanner_registered() {
-    NODE_SQLITE_GC_SCANNER.call_once(|| {
+    NODE_SQLITE_GC_SCANNER.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:node_sqlite",
             scan_node_sqlite_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/streams/gc.rs
+++ b/crates/perry-stdlib/src/streams/gc.rs
@@ -78,13 +78,21 @@ impl StreamRootVisitor for FfiStreamRootVisitor {
     }
 }
 
-static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+static CALLBACKS_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 /// Register through the stable C ABI so a separately packaged stdlib installs
-/// its scanner in the process-wide runtime provider, not in fallback Rust glue
-/// that may also be present in the stdlib image.
+/// its scanner in the current thread's runtime registry, not in fallback Rust
+/// glue that may also be present in the stdlib image.
 pub(super) fn ensure_gc_registered() {
-    GC_REGISTERED.call_once(|| {
+    GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         const SOURCE: &[u8] = b"stdlib:streams";
         unsafe {
             perry_ffi_gc_register_mutable_root_scanner_named(
@@ -94,13 +102,14 @@ pub(super) fn ensure_gc_registered() {
                 scan_stream_roots_ffi,
             );
         }
-        unsafe {
-            provider_js_register_stream_consumer_callbacks(
-                js_readable_stream_get_reader,
-                js_reader_read,
-            );
-            provider_js_register_stream_expando_set(expando::stream_expando_set_hook);
-        }
+        registered.set(true);
+    });
+    CALLBACKS_REGISTERED.call_once(|| unsafe {
+        provider_js_register_stream_consumer_callbacks(
+            js_readable_stream_get_reader,
+            js_reader_read,
+        );
+        provider_js_register_stream_expando_set(expando::stream_expando_set_hook);
     });
 }
 

--- a/crates/perry-stdlib/src/tls.rs
+++ b/crates/perry-stdlib/src/tls.rs
@@ -49,8 +49,12 @@ static TLS_LISTENERS: OnceLock<Mutex<HashMap<i64, HashMap<String, Vec<i64>>>>> =
 static TLS_ONCE_FLAGS: OnceLock<Mutex<HashMap<i64, HashMap<String, HashSet<i64>>>>> =
     OnceLock::new();
 static TLS_PENDING_EVENTS: OnceLock<Mutex<Vec<PendingTlsEvent>>> = OnceLock::new();
-static TLS_GC_REGISTERED: Once = Once::new();
 static RUSTLS_PROVIDER_INSTALLED: Once = Once::new();
+
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static TLS_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 struct TlsServerState {
     shutdown_tx: Option<oneshot::Sender<()>>,
@@ -279,8 +283,12 @@ fn ensure_crypto_provider_installed() {
 }
 
 fn ensure_tls_gc_scanner_registered() {
-    TLS_GC_REGISTERED.call_once(|| {
+    TLS_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named("stdlib:tls", scan_tls_roots_mut);
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/worker_threads.rs
+++ b/crates/perry-stdlib/src/worker_threads.rs
@@ -12,7 +12,7 @@ use std::io::{self, BufRead, Write};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Sender};
-use std::sync::{LazyLock, Mutex, Once};
+use std::sync::{LazyLock, Mutex};
 
 use perry_runtime::closure::ClosureHeader;
 use perry_runtime::string::{js_string_from_bytes, StringHeader};
@@ -113,6 +113,10 @@ thread_local! {
     /// after every delivered message so the worker exits without waiting for
     /// another parent command.
     static CURRENT_WORKER_CLOSE_REQUESTED: Cell<bool> = const { Cell::new(false) };
+    // The mutable-root scanner registry is thread-local, so these latches must be too.
+    static ENVIRONMENT_DATA_GC_REGISTERED: Cell<bool> = const { Cell::new(false) };
+    static WORKER_GC_REGISTERED: Cell<bool> = const { Cell::new(false) };
+    static PARENT_PORT_EVENT_GC_REGISTERED: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Per-port state for a same-process MessageChannel (#3157). A `MessageChannel`
@@ -176,8 +180,6 @@ struct EventListener {
     once: bool,
 }
 
-static ENVIRONMENT_DATA_GC_REGISTERED: Once = Once::new();
-static WORKER_GC_REGISTERED: Once = Once::new();
 static NEXT_WORKER_ID: AtomicU64 = AtomicU64::new(1);
 static WORKERS: LazyLock<Mutex<HashMap<u64, WorkerRecord>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -225,20 +227,28 @@ enum WorkerEvent {
 }
 
 fn ensure_environment_data_gc_scanner() {
-    ENVIRONMENT_DATA_GC_REGISTERED.call_once(|| {
+    ENVIRONMENT_DATA_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:worker_threads:environmentData",
             scan_environment_data_roots_mut,
         );
+        registered.set(true);
     });
 }
 
 fn ensure_worker_gc_scanner() {
-    WORKER_GC_REGISTERED.call_once(|| {
+    WORKER_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:worker_threads:workers",
             scan_worker_roots_mut,
         );
+        registered.set(true);
     });
 }
 
@@ -1464,14 +1474,16 @@ pub(super) fn js_worker_threads_parent_port_event_remove(event_ptr: i64, callbac
     parent_port_event_listener(event_ptr, callback, false)
 }
 
-static PARENT_PORT_EVENT_GC_REGISTERED: Once = Once::new();
-
 fn ensure_parent_port_event_gc_scanner() {
-    PARENT_PORT_EVENT_GC_REGISTERED.call_once(|| {
+    PARENT_PORT_EVENT_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named(
             "stdlib:worker_threads:parentPortEventListeners",
             scan_parent_port_event_roots_mut,
         );
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -71,10 +71,13 @@ lazy_static::lazy_static! {
 }
 
 #[cfg(not(target_os = "ios"))]
-static WS_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static WS_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
-/// Register the ws GC root scanner exactly once. Safe to call from any
-/// ws FFI entry point on the main thread. Mirrors `net::ensure_gc_scanner_registered`
+/// Register the ws GC root scanner once on each thread. Mirrors
+/// `net::ensure_gc_scanner_registered`
 /// (issue #35) — user closures passed to `.on(event, cb)` are stored in
 /// WS_CLIENT_LISTENERS (for client sockets) or inside a WsServerHandle
 /// (for servers); neither is visible to the GC mark phase without this
@@ -83,8 +86,12 @@ static WS_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 /// memory.
 #[cfg(not(target_os = "ios"))]
 fn ensure_gc_scanner_registered() {
-    WS_GC_REGISTERED.call_once(|| {
+    WS_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named("stdlib:ws", scan_ws_roots_mut);
+        registered.set(true);
     });
 }
 

--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -666,15 +666,22 @@ const ZLIB_STREAM_HANDLE_ID_START: i64 =
 const ZLIB_STREAM_HANDLE_ID_END: i64 =
     perry_runtime::value::addr_class::ZLIB_HANDLE_BAND_END as i64;
 
-static ZLIB_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+thread_local! {
+    // The mutable-root scanner registry is thread-local, so this latch must be too.
+    static ZLIB_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
-/// Register the zlib-stream GC root scanner once. Listener closures
+/// Register the zlib-stream GC root scanner once per thread. Listener closures
 /// (`s.on('data', cb)`) are only referenced from `ZLIB_LISTENERS`; without
 /// rooting them a GC between `.on()` and the deferred dispatch would free the
 /// closure body (the same hazard net.Socket guards against — issue #35).
 fn ensure_zlib_gc_scanner() {
-    ZLIB_GC_REGISTERED.call_once(|| {
+    ZLIB_GC_REGISTERED.with(|registered| {
+        if registered.get() {
+            return;
+        }
         perry_runtime::gc::gc_register_mutable_root_scanner_named("stdlib:zlib", scan_zlib_roots);
+        registered.set(true);
     });
 }
 

--- a/scripts/check_gc_scanner_latches.py
+++ b/scripts/check_gc_scanner_latches.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Reject process-global latches around thread-local GC scanner registration.
+
+`MUTABLE_ROOT_SCANNERS` and the FFI scanner registries are thread-local. A
+process-global `Once`, `OnceLock`, `AtomicBool`, or `Mutex<bool>` therefore
+cannot guard a `gc_register_*root_scanner*` call: the first thread consumes the
+latch and all later heaps run without that scanner (#8530).
+
+This build-free gate follows the latch into its `call_once` / `get_or_init`
+closure (and the equivalent atomic `if` body). It deliberately permits a
+process-global latch for unrelated setup in the same function, which is needed
+when registration and genuinely process-wide callback wiring are split.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CRATES = ("crates/perry-runtime/src", "crates/perry-stdlib/src")
+MIN_REGISTRATIONS = 30
+
+THREAD_LOCAL_RE = re.compile(
+    r"(?m)^[ \t]*(?:(?:std|crate)::)?(?:thread_local|perry_thread_local)!\s*\{"
+)
+STATIC_RE = re.compile(
+    r"\bstatic\s+([A-Za-z_][A-Za-z_0-9]*)\s*:\s*([^=;]+?)\s*="
+)
+PROCESS_LATCH_TYPE_RE = re.compile(
+    r"(?:\bOnce\b|\bOnceLock\s*<|\bAtomicBool\b|\bMutex\s*<\s*bool\s*>)"
+)
+REGISTER_RE = re.compile(
+    r"\b(?:gc|perry_ffi_gc)_register_[A-Za-z_0-9]*root_scanner[A-Za-z_0-9]*\s*\("
+)
+ONCE_METHODS = ("call_once", "get_or_init", "get_or_try_init")
+ATOMIC_GUARD_METHODS = ("load", "swap", "compare_exchange", "compare_exchange_weak")
+RAW_STRING_RE = re.compile(r"(?:br|r)(?P<hashes>#{0,16})\"")
+
+
+def read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def mask_non_code(src: str) -> str:
+    """Blank comments and literals while preserving offsets and newlines."""
+    out = list(src)
+    i = 0
+    while i < len(src):
+        if src.startswith("//", i):
+            end = src.find("\n", i + 2)
+            end = len(src) if end < 0 else end
+            for j in range(i, end):
+                out[j] = " "
+            i = end
+            continue
+        if src.startswith("/*", i):
+            depth = 1
+            j = i + 2
+            while j < len(src) and depth:
+                if src.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif src.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            for k in range(i, j):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+
+        raw = RAW_STRING_RE.match(src, i)
+        if raw:
+            marker = '"' + raw.group("hashes")
+            start = i
+            end = src.find(marker, raw.end())
+            end = len(src) if end < 0 else end + len(marker)
+            for j in range(start, end):
+                if out[j] != "\n":
+                    out[j] = " "
+            i = end
+            continue
+
+        if src[i] == '"':
+            j = i + 1
+            while j < len(src):
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                j += 1
+                if src[j - 1] == '"':
+                    break
+            for k in range(i, min(j, len(src))):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+
+        # Mask character literals without mistaking Rust lifetimes (`'a`) for
+        # literals. A real char closes on this line and within a few bytes.
+        if src[i] == "'":
+            j = i + 1
+            if j < len(src) and src[j] == "\\":
+                j += 2
+            else:
+                j += 1
+            if j < len(src) and src[j] == "'":
+                j += 1
+                for k in range(i, j):
+                    out[k] = " "
+                i = j
+                continue
+        i += 1
+    return "".join(out)
+
+
+def matching_delimiter(src: str, opening: int, left: str, right: str) -> int | None:
+    depth = 0
+    for i in range(opening, len(src)):
+        if src[i] == left:
+            depth += 1
+        elif src[i] == right:
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def thread_local_spans(masked: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for match in THREAD_LOCAL_RE.finditer(masked):
+        opening = masked.find("{", match.start(), match.end())
+        closing = matching_delimiter(masked, opening, "{", "}")
+        if closing is not None:
+            spans.append((opening, closing))
+    return spans
+
+
+def process_latches(masked: str) -> set[str]:
+    tls_spans = thread_local_spans(masked)
+    result: set[str] = set()
+    for match in STATIC_RE.finditer(masked):
+        if not PROCESS_LATCH_TYPE_RE.search(match.group(2)):
+            continue
+        if any(start < match.start() < end for start, end in tls_spans):
+            continue
+        result.add(match.group(1))
+    return result
+
+
+def line_number(src: str, offset: int) -> int:
+    return src.count("\n", 0, offset) + 1
+
+
+def scan_source(src: str, rel: str) -> tuple[list[str], int]:
+    masked = mask_non_code(src)
+    registrations = len(REGISTER_RE.findall(masked))
+    problems: list[str] = []
+
+    for latch in sorted(process_latches(masked)):
+        for method in ONCE_METHODS:
+            use_re = re.compile(rf"\b{re.escape(latch)}\s*\.\s*{method}\s*\(")
+            for match in use_re.finditer(masked):
+                opening = masked.find("(", match.start(), match.end())
+                closing = matching_delimiter(masked, opening, "(", ")")
+                if closing is None or not REGISTER_RE.search(masked, opening, closing):
+                    continue
+                problems.append(
+                    f"{rel}:{line_number(src, match.start())}: process-global `{latch}` "
+                    f"uses `{method}` around GC scanner registration; the scanner registry "
+                    "is thread-local, so use a thread-local `Cell<bool>` latch"
+                )
+
+        for method in ATOMIC_GUARD_METHODS:
+            use_re = re.compile(rf"\b{re.escape(latch)}\s*\.\s*{method}\s*\(")
+            for match in use_re.finditer(masked):
+                opening = masked.find("(", match.start(), match.end())
+                closing = matching_delimiter(masked, opening, "(", ")")
+                if closing is None:
+                    continue
+                block_open = masked.find("{", closing + 1, min(len(masked), closing + 300))
+                if block_open < 0 or ";" in masked[closing + 1 : block_open]:
+                    continue
+                condition_start = masked.rfind("if", max(0, match.start() - 300), match.start())
+                if condition_start < 0:
+                    continue
+                block_close = matching_delimiter(masked, block_open, "{", "}")
+                if block_close is None or not REGISTER_RE.search(masked, block_open, block_close):
+                    continue
+                problems.append(
+                    f"{rel}:{line_number(src, match.start())}: process-global `{latch}` "
+                    f"uses atomic `{method}` to guard GC scanner registration; the scanner "
+                    "registry is thread-local, so use a thread-local `Cell<bool>` latch"
+                )
+
+        lock_re = re.compile(
+            rf"\blet\s+(?:mut\s+)?(?P<guard>[A-Za-z_][A-Za-z_0-9]*)\s*=\s*"
+            rf"{re.escape(latch)}\s*\.\s*(?:lock|try_lock)\s*\("
+        )
+        for match in lock_re.finditer(masked):
+            initializer_end = masked.find(";", match.end(), min(len(masked), match.end() + 1000))
+            if initializer_end < 0:
+                continue
+            guard = re.escape(match.group("guard"))
+            guarded_if = re.compile(rf"\bif\s*!\s*\*?\s*{guard}\b[^{{;]*\{{")
+            if_match = guarded_if.search(
+                masked, initializer_end + 1, min(len(masked), initializer_end + 1000)
+            )
+            if if_match is None:
+                continue
+            block_open = masked.find("{", if_match.start(), if_match.end())
+            block_close = matching_delimiter(masked, block_open, "{", "}")
+            if block_close is None or not REGISTER_RE.search(masked, block_open, block_close):
+                continue
+            problems.append(
+                f"{rel}:{line_number(src, match.start())}: process-global `{latch}` uses a "
+                "mutex boolean to guard GC scanner registration; the scanner registry is "
+                "thread-local, so use a thread-local `Cell<bool>` latch"
+            )
+
+    return problems, registrations
+
+
+def scan_tree(root: Path, enforce_floor: bool = True) -> tuple[list[str], int]:
+    problems: list[str] = []
+    registrations = 0
+    for crate in CRATES:
+        for path in sorted((root / crate).rglob("*.rs")):
+            rel = path.relative_to(root).as_posix()
+            found, count = scan_source(read_source(path), rel)
+            problems.extend(found)
+            registrations += count
+    if enforce_floor and registrations < MIN_REGISTRATIONS:
+        problems.append(
+            f"scanner-registration scan found only {registrations} calls; expected at least "
+            f"{MIN_REGISTRATIONS}, so the gate's scope or parser has silently shrunk"
+        )
+    return sorted(problems), registrations
+
+
+def self_test() -> int:
+    bad_shapes = {
+        "Once::call_once": """
+static REGISTERED: Once = Once::new();
+fn ensure() { REGISTERED.call_once(|| gc_register_mutable_root_scanner(scan)); }
+""",
+        "OnceLock::get_or_init": """
+static REGISTERED: OnceLock<()> = OnceLock::new();
+fn ensure() { REGISTERED.get_or_init(|| { gc_register_mutable_root_scanner_named("x", scan); }); }
+""",
+        "AtomicBool::swap": """
+static REGISTERED: AtomicBool = AtomicBool::new(false);
+fn ensure() {
+    if !REGISTERED.swap(true, Ordering::AcqRel) {
+        gc_register_mutable_root_scanner(scan);
+    }
+}
+""",
+        "Mutex<bool>": """
+static REGISTERED: Mutex<bool> = Mutex::new(false);
+fn ensure() {
+    let mut registered = REGISTERED.lock().unwrap();
+    if !*registered {
+        gc_register_mutable_root_scanner(scan);
+        *registered = true;
+    }
+}
+""",
+    }
+    good_shapes = {
+        "thread-local Once": """
+thread_local! { static REGISTERED: Once = Once::new(); }
+fn ensure() { REGISTERED.with(|r| r.call_once(|| gc_register_mutable_root_scanner(scan))); }
+""",
+        "thread-local Cell": """
+thread_local! { static REGISTERED: Cell<bool> = const { Cell::new(false) }; }
+fn ensure() {
+    REGISTERED.with(|r| {
+        if !r.get() { gc_register_mutable_root_scanner(scan); r.set(true); }
+    });
+}
+""",
+        "split process setup": """
+static CALLBACKS: Once = Once::new();
+thread_local! { static REGISTERED: Cell<bool> = const { Cell::new(false) }; }
+fn ensure() {
+    REGISTERED.with(|r| { if !r.get() { gc_register_mutable_root_scanner(scan); r.set(true); } });
+    CALLBACKS.call_once(register_process_callbacks);
+}
+""",
+        "comments and strings": r'''
+static REGISTERED: Once = Once::new();
+// REGISTERED.call_once(|| gc_register_mutable_root_scanner(scan));
+const NOTE: &str = "REGISTERED.call_once(|| gc_register_mutable_root_scanner(scan))";
+''',
+    }
+
+    failures: list[str] = []
+    for label, src in bad_shapes.items():
+        problems, _ = scan_source(src, "probe.rs")
+        if not problems:
+            failures.append(f"{label} was not rejected")
+    for label, src in good_shapes.items():
+        problems, _ = scan_source(src, "probe.rs")
+        if problems:
+            failures.append(f"{label} was rejected: {'; '.join(problems)}")
+
+    if failures:
+        for failure in failures:
+            print(f"self-test FAILED: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "GC scanner latch self-test: OK "
+        f"({len(bad_shapes)} bad shapes rejected, {len(good_shapes)} good shapes accepted)"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="prove the checker can fail")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+
+    problems, registrations = scan_tree(REPO)
+    if problems:
+        print("process-global GC scanner registration latches found:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"GC scanner latch policy OK: {registrations} registration calls checked "
+        "across perry-runtime and perry-stdlib"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- replace process-global GC scanner registration latches with per-thread Cell<bool> latches across the affected runtime and stdlib subsystems
- keep genuinely process-wide setup process-wide by splitting the cluster arity and streams callback latches
- fix the same missed AtomicBool pattern in messaging and add a CI audit for Once, OnceLock, AtomicBool, and Mutex<bool> guards around mutable-root scanner registration
- no version bump

The new audit identifies 21 pre-fix bad latch sites across the 18 affected files and finds none after this change.

## Testing

- cargo check -p perry-runtime -p perry-stdlib
- cargo test -p perry-runtime --lib (2611 passed, 4 ignored)
- cargo test -p perry-stdlib --lib (126 passed)
- python3 scripts/check_gc_scanner_latches.py --self-test
- python3 scripts/check_gc_scanner_latches.py
- SKIP_COMPILE_GATES=1 BASE_SHA=upstream/main scripts/run_lint_gates.sh (all 52 script gates passed)

Closes #8530


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection support across threaded runtime and standard-library features.
  * Ensured per-thread resources and callbacks are tracked correctly, reducing the risk of missed roots or memory-management issues in multithreaded workloads.

* **Tests**
  * Added automated checks to detect incorrect garbage-collection registration patterns.
  * Added self-tests covering valid and invalid registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->