### PR TITLE
fix(compile): require(<builtin>) implies stdlib, plus wasm-host test isolation (#8547)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1516
+**Current Version:** 0.5.1517
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,7 +5522,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "cc",
  "libc",
@@ -5599,7 +5599,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5649,7 +5649,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5698,14 +5698,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "serde",
  "serde_json",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1516"
+version = "0.5.1517"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "clap",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "block2",
  "objc2",
@@ -5749,7 +5749,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5758,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "chrono",
  "cron",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5849,14 +5849,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5922,7 +5922,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "bson",
  "futures-util",
@@ -5962,7 +5962,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6040,7 +6040,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6058,14 +6058,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6083,7 +6083,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "brotli",
  "flate2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6205,14 +6205,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6307,14 +6307,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6323,14 +6323,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.0",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1516"
+version = "0.5.1517"
 
 [[package]]
 name = "perry-ui-test"
@@ -6425,11 +6425,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1516"
+version = "0.5.1517"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "block2",
  "libc",
@@ -6477,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6496,14 +6496,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1516"
+version = "0.5.1517"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1516"
+version = "0.5.1517"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/8552-require-stdlib-link-with-isolation.md
+++ b/changelog.d/8552-require-stdlib-link-with-isolation.md
@@ -1,0 +1,28 @@
+**`require('<builtin>')` linked runtime-only, so stdlib-backed builtins returned `undefined` (#8547) — re-landed with the test-isolation bug that defeated the first attempt.**
+
+```
+import * as http from 'node:http';   →  Linking (with stdlib)...   typeof createServer() === "object"
+const http = require('http');        →  Linking (runtime-only)...  typeof createServer() === undefined
+```
+
+`ctx.native_module_imports` drives `needs_stdlib` and therefore the link mode, but it was populated only by the ESM import walk. A CommonJS `require("http")` never landed in it, so the link came out runtime-only, `perry-stdlib`'s `common/dispatch/init.rs` never ran, `JS_NATIVE_HTTP_DISPATCH` stayed null, and the `("http", "createServer")` arm returned `undefined`. Nothing about it was http-specific.
+
+The lowered HIR cannot answer this: for `require('http')` the CJS shim emits a *runtime* dispatcher that switches over builtin names as string literals, and that switch contains a case for **every** builtin regardless of use — a static scan would match the table, not the call. The fix therefore reads literal call sites via the extractor that already exists for CJS wrapping (`cjs_wrap::extract_require_specifiers`).
+
+Scope, measured — the change can only add stdlib linking for a program that genuinely references a stdlib-backed builtin:
+
+| program | link mode | binary |
+|---|---|---|
+| `console.log(...)` only | runtime-only (unchanged) | 7.7 MB |
+| `require("path")` (runtime-only module) | runtime-only (unchanged) | 7.8 MB |
+| `require("http")` | with stdlib (was runtime-only) | 14 MB |
+
+**Why the first attempt (#8548) was reverted, and what actually changes here.** It broke `issue_5247_property_read_source_location` with `undefined reference to perry_wasm_host_*` at link time. The cause was not the detection — it was a pre-existing test-isolation bug this change happened to expose:
+
+`issue_5234_wasm_esm_import` is the only thing in the workspace that builds `perry-runtime` with `perry-runtime/wasm-host`, and it built into the **shared** `target/debug`. That replaces `libperry_runtime.a` with one that compiles `webassembly.rs` in, whose undefined `perry_wasm_host_*` references only `libperry_wasm_host.a` satisfies — and that archive is put on the link line only for programs that themselves reference `WebAssembly.*`. Any other suite in the same `cargo test --workspace` job that links runtime-only against the poisoned archive fails. Whichever build wrote the archive last decided the outcome, which is why this was latent until #8548 perturbed the ordering.
+
+`issue_5234` now builds into a dedicated `target/perry-wasm-host-test`, mirroring what the compiler's own no-auto path already does for exactly this reason (`build_wasm_host_runtime` in `optimized_libs/no_auto.rs` uses `target/perry-wasm-host-runtime` so "the prebuilt libperry_runtime.a is not clobbered").
+
+Verified together in one `cargo test` invocation, which is the configuration that failed before: `issue_4903_listen_callback_deferred` **0/2 → 2/2**, `issue_5247_property_read_source_location` **3/3**, `issue_5234_wasm_esm_import` **1/1**.
+
+Closes #8547.

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -54,9 +54,11 @@ use extract_exports::{
     extract_object_literal_exports_from_require, extract_single_module_exports_assignment,
     module_reexport_specs,
 };
+// #8547: the stdlib-link decision needs the literal `require()` specifiers.
+pub(crate) use extract_requires::extract_require_specifiers;
 use extract_requires::{
-    extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
-    function_local_specs, identifier_is_declared_binding, identifier_is_reassigned,
+    extract_export_star_specs, extract_require_aliases_with_ranges, function_local_specs,
+    identifier_is_declared_binding, identifier_is_reassigned,
 };
 use hoist_classes::{
     extract_top_level_class_decls, rewrite_module_exports_class_expression,

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -386,6 +386,24 @@ fn collect_module_one(
         &ctx.compile_packages,
         canonical.parent().unwrap_or_else(|| Path::new(".")),
     );
+
+    // #8547: a builtin reached through `require("http")` never appears in the
+    // ESM import walk below, so `needs_stdlib` stayed false, the link came out
+    // runtime-only, `perry-stdlib`'s dispatch init never ran, and every
+    // stdlib-backed export returned `undefined` (`http.createServer` was the
+    // reported case; the bug is not http-specific). The lowered body cannot
+    // answer this — the CJS shim resolves the name through a generated runtime
+    // switch that contains EVERY builtin — so recover it from the literal call
+    // sites, which is what `extract_require_specifiers` already finds for CJS
+    // wrapping. Dynamic `require(someVar)` stays undetectable and unchanged.
+    for spec in super::cjs_wrap::extract_require_specifiers(&source) {
+        if !perry_hir::requires_stdlib(&spec) {
+            continue;
+        }
+        ctx.needs_stdlib = true;
+        let normalized = spec.strip_prefix("node:").unwrap_or(&spec).to_string();
+        ctx.native_module_imports.insert(normalized);
+    }
     if was_cjs_wrapped && ctx.debug_symbols {
         if let Some(prefix_lines) = cjs_wrap_body_prefix_lines {
             let lines_after_transform = source.bytes().filter(|&b| b == b'\n').count();

--- a/crates/perry/tests/issue_5234_wasm_esm_import.rs
+++ b/crates/perry/tests/issue_5234_wasm_esm_import.rs
@@ -17,11 +17,29 @@ fn workspace_root() -> PathBuf {
         .expect("canonicalize workspace root")
 }
 
-fn target_debug_dir() -> PathBuf {
+/// Dedicated target dir for this suite's `wasm-host`-enabled runtime.
+///
+/// #8547: this test is the only thing in the workspace that builds
+/// `perry-runtime` with `perry-runtime/wasm-host`. Built into the SHARED
+/// `target/debug`, it replaces `libperry_runtime.a` with one that compiles
+/// `webassembly.rs` in — and that archive carries undefined references to
+/// `perry_wasm_host_*`, which only `libperry_wasm_host.a` satisfies and which a
+/// runtime-only link line does not include. Every other suite in the same
+/// `cargo test --workspace` job that links runtime-only against that archive
+/// then fails at link time (`issue_5247_property_read_source_location` was the
+/// casualty). Isolating the build mirrors what the compiler's own no-auto path
+/// already does for exactly this reason — see `build_wasm_host_runtime` in
+/// `optimized_libs/no_auto.rs`, whose dedicated `target/perry-wasm-host-runtime`
+/// exists so "the prebuilt libperry_runtime.a is not clobbered".
+fn wasm_host_target_dir() -> PathBuf {
     std::env::var_os("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| workspace_root().join("target"))
-        .join("debug")
+        .join("perry-wasm-host-test")
+}
+
+fn target_debug_dir() -> PathBuf {
+    wasm_host_target_dir().join("debug")
 }
 
 fn ensure_runtime_archives() {
@@ -30,6 +48,7 @@ fn ensure_runtime_archives() {
         let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
         let runtime_build = Command::new(&cargo)
             .current_dir(workspace_root())
+            .env("CARGO_TARGET_DIR", wasm_host_target_dir())
             .arg("build")
             .arg("-p")
             .arg("perry-runtime-static")


### PR DESCRIPTION
**`require('<builtin>')` linked runtime-only, so stdlib-backed builtins returned `undefined` (#8547) — re-landed with the test-isolation bug that defeated the first attempt.**

```
import * as http from 'node:http';   →  Linking (with stdlib)...   typeof createServer() === "object"
const http = require('http');        →  Linking (runtime-only)...  typeof createServer() === undefined
```

`ctx.native_module_imports` drives `needs_stdlib` and therefore the link mode, but it was populated only by the ESM import walk. A CommonJS `require("http")` never landed in it, so the link came out runtime-only, `perry-stdlib`'s `common/dispatch/init.rs` never ran, `JS_NATIVE_HTTP_DISPATCH` stayed null, and the `("http", "createServer")` arm returned `undefined`. Nothing about it was http-specific.

The lowered HIR cannot answer this: for `require('http')` the CJS shim emits a *runtime* dispatcher that switches over builtin names as string literals, and that switch contains a case for **every** builtin regardless of use — a static scan would match the table, not the call. The fix therefore reads literal call sites via the extractor that already exists for CJS wrapping (`cjs_wrap::extract_require_specifiers`).

Scope, measured — the change can only add stdlib linking for a program that genuinely references a stdlib-backed builtin:

| program | link mode | binary |
|---|---|---|
| `console.log(...)` only | runtime-only (unchanged) | 7.7 MB |
| `require("path")` (runtime-only module) | runtime-only (unchanged) | 7.8 MB |
| `require("http")` | with stdlib (was runtime-only) | 14 MB |

**Why the first attempt (#8548) was reverted, and what actually changes here.** It broke `issue_5247_property_read_source_location` with `undefined reference to perry_wasm_host_*` at link time. The cause was not the detection — it was a pre-existing test-isolation bug this change happened to expose:

`issue_5234_wasm_esm_import` is the only thing in the workspace that builds `perry-runtime` with `perry-runtime/wasm-host`, and it built into the **shared** `target/debug`. That replaces `libperry_runtime.a` with one that compiles `webassembly.rs` in, whose undefined `perry_wasm_host_*` references only `libperry_wasm_host.a` satisfies — and that archive is put on the link line only for programs that themselves reference `WebAssembly.*`. Any other suite in the same `cargo test --workspace` job that links runtime-only against the poisoned archive fails. Whichever build wrote the archive last decided the outcome, which is why this was latent until #8548 perturbed the ordering.

`issue_5234` now builds into a dedicated `target/perry-wasm-host-test`, mirroring what the compiler's own no-auto path already does for exactly this reason (`build_wasm_host_runtime` in `optimized_libs/no_auto.rs` uses `target/perry-wasm-host-runtime` so "the prebuilt libperry_runtime.a is not clobbered").

Verified together in one `cargo test` invocation, which is the configuration that failed before: `issue_4903_listen_callback_deferred` **0/2 → 2/2**, `issue_5247_property_read_source_location` **3/3**, `issue_5234_wasm_esm_import` **1/1**.

Closes #8547.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CommonJS `require()` handling for built-in Node.js modules, ensuring standard library features such as `http` are correctly recognized and available at runtime.
  - Improved test isolation to prevent unrelated build artifacts from affecting WebAssembly-related validation.

- **Documentation**
  - Updated the documented release version to 0.5.1517.
  - Added changelog details covering the built-in module resolution fix and improved verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->