### PR TITLE
fix(runtime): snapshot regex captures before allocation

### DIFF
--- a/changelog.d/8555-regex-owned-captures.md
+++ b/changelog.d/8555-regex-owned-captures.md
@@ -1,0 +1,14 @@
+**Fix moving-GC safety when materializing regular-expression matches.**
+
+`RegExp.prototype.exec` and non-global `String.prototype.match` kept the
+subject string payload and engine capture objects borrowed while allocating
+their result arrays, capture strings, named groups, metadata, and `d`-flag
+indices. A moving collection at any of those allocation points could relocate
+the subject and leave the remaining captures reading retired nursery bytes.
+
+Both the standard and fancy-regex paths now snapshot capture byte ranges and
+UTF-16 metadata before the first runtime allocation, then copy each capture
+from the current rooted subject with `string_copy_range`. Global
+`String.prototype.match` uses the same range-based materialization. Allocation-
+point GC regressions force the subject to move after matching and verify the
+standard `exec` and fancy `String#match` results remain intact.

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/regexp_last_index.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/regexp_last_index.rs
@@ -1,4 +1,4 @@
-//! Moving-GC regression for `RegExp.prototype.exec` (#8428).
+//! Moving-GC regressions for regex subject borrows (#8428, #8449).
 //!
 //! RegExpBuiltinExec step 4 is `ToLength(Get(R, "lastIndex"))`. When
 //! `lastIndex` holds an object the ToNumber half runs OrdinaryToPrimitive —
@@ -13,6 +13,10 @@
 //! the stomped bytes instead of the relocated subject and the match evaporates.
 //! Liveness is asserted both ways (a copying minor ran; the subject actually
 //! moved), per CLAUDE.md's "a gate must assert its subject was live".
+//!
+//! The #8449 witnesses plant the same moving minor at the first result-array
+//! allocation, after the regex engine has returned captures borrowing the
+//! subject. They cover the standard `exec` and fancy `String#match` paths.
 
 use super::super::super::*;
 use super::super::support::*;
@@ -44,6 +48,22 @@ fn capture_text(element: f64, index: usize) -> String {
         .unwrap_or_else(|| panic!("capture {index} must be a string"));
     let bytes = unsafe { std::slice::from_raw_parts(data, len as usize) };
     String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn assert_captures(matched: *mut ArrayHeader, expected: &[&str]) {
+    assert!(!matched.is_null(), "regex must match the relocated subject");
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let matched_handle = scope.root_raw_mut_ptr(matched);
+    for (index, expected) in expected.iter().enumerate() {
+        let element = matched_handle.with_mut_ptr::<ArrayHeader, _>(|arr| {
+            crate::array::js_array_get_f64(arr, index as u32)
+        });
+        assert_eq!(
+            capture_text(element, index),
+            *expected,
+            "capture {index} read from-space bytes"
+        );
+    }
 }
 
 #[test]
@@ -125,4 +145,93 @@ fn regexp_exec_survives_a_moving_minor_inside_the_lastindex_coercion() {
         last_index, 15,
         "lastIndex must advance past the relocated match"
     );
+}
+
+/// #8449: once the engine has produced `Captures`, the result-array allocation
+/// itself may move the subject. The captures borrow the subject payload, so all
+/// ranges and UTF-16 indices must be snapshotted before this planted collection.
+///
+/// SABOTAGE CHECK: restoring the pre-fix `caps`/`str_data` materialization in
+/// `js_regexp_exec` makes this fail after the subject moves at `js_array_alloc`.
+#[test]
+fn regexp_exec_materializes_an_owned_snapshot_after_an_alloc_point_minor() {
+    let _guard = CopyingNurseryTestGuard::new(4);
+    let _pacing = crate::gc::policy::force_alloc_point_minor_pacing();
+    let _scan = ConservativeScanDisabledGuard::new();
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let subject = heap_string(b"prefix-young-42-suffix");
+    assert!(crate::arena::pointer_in_nursery(subject as usize));
+    let subject_handle = scope.root_string_ptr(subject);
+    let subject_before = subject as usize;
+
+    let re = crate::regex::js_regexp_new(heap_string(br"(?<word>young)-(\d+)"), heap_string(b"gd"));
+    let re_handle = scope.root_raw_mut_ptr(re);
+
+    // The next general-arena block allocation is the result array created only
+    // after the engine has matched and Phase 1 has snapshotted the captures.
+    super::force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+    let collections_before = gc_collection_count();
+    let matched = subject_handle.with_const_ptr::<StringHeader, _>(|subject_now| {
+        re_handle.with_mut_ptr::<RegExpHeader, _>(|re_now| {
+            crate::regex::js_regexp_exec(re_now, subject_now)
+        })
+    });
+
+    assert!(
+        gc_collection_count() > collections_before,
+        "subject not live: the result-array allocation must run a copying minor"
+    );
+    assert_ne!(
+        subject_before,
+        subject_handle.with_const_ptr::<StringHeader, _>(|p| p as usize),
+        "subject not live: the allocation-point minor must move the subject"
+    );
+    assert_captures(matched, &["young-42", "young", "42"]);
+}
+
+/// Fancy-regex and non-global `String#match` used a separate allocation path,
+/// including an `.input` copy and named-group construction from live captures.
+/// Exercise that path with the same allocation-point relocation witness.
+#[test]
+fn string_match_fancy_materializes_an_owned_snapshot_after_an_alloc_point_minor() {
+    let _guard = CopyingNurseryTestGuard::new(4);
+    let _pacing = crate::gc::policy::force_alloc_point_minor_pacing();
+    let _scan = ConservativeScanDisabledGuard::new();
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let subject = heap_string(b"prefix-young-42-suffix");
+    assert!(crate::arena::pointer_in_nursery(subject as usize));
+    let subject_handle = scope.root_string_ptr(subject);
+    let subject_before = subject as usize;
+    let re = crate::regex::js_regexp_new(
+        heap_string(br"(?<=prefix-)(?<word>young)-(\d+)"),
+        heap_string(b"d"),
+    );
+    let re_handle = scope.root_raw_const_ptr(re);
+
+    super::force_next_general_arena_alloc_slow();
+    trigger_guard.make_arena_trigger_due();
+    let collections_before = gc_collection_count();
+    let matched = subject_handle.with_const_ptr::<StringHeader, _>(|subject_now| {
+        re_handle.with_const_ptr::<RegExpHeader, _>(|re_now| {
+            crate::regex::js_string_match(subject_now, re_now)
+        })
+    });
+
+    assert!(
+        gc_collection_count() > collections_before,
+        "subject not live: the match-array allocation must run a copying minor"
+    );
+    assert_ne!(
+        subject_before,
+        subject_handle.with_const_ptr::<StringHeader, _>(|p| p as usize),
+        "subject not live: the allocation-point minor must move the subject"
+    );
+    assert_captures(matched, &["young-42", "young", "42"]);
 }

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -54,9 +54,8 @@ pub use compile::js_regexp_compile_value;
 pub use escape::js_regexp_escape;
 #[cfg(feature = "regex-engine")]
 use exec_array::{
-    byte_index_to_utf16_index, set_exec_array_groups, set_exec_array_indices,
-    set_exec_array_indices_fancy, set_exec_array_metadata, set_exec_array_metadata_value,
-    utf16_index_to_byte,
+    byte_index_to_utf16_index, materialize_exec_match, materialize_match_list,
+    set_exec_array_metadata_value, utf16_index_to_byte, OwnedCapture, OwnedExecMatch,
 };
 #[cfg(feature = "regex-engine")]
 use grammar::{
@@ -1282,41 +1281,6 @@ fn expand_js_replacement_fancy(
         }
     }
     out
-}
-
-/// Build a named-capture `groups` object from a fancy-regex match, or return
-/// null when the pattern declares no named capture groups. Mirrors the
-/// named-group construction in the standard-engine `js_regexp_exec` path
-/// (fresh per-result object + by-name setters so each match grows its own
-/// shape). The returned object must be stored into a GC-visible slot by the
-/// caller immediately; it is rooted via `scope` until then.
-#[cfg(feature = "regex-engine")]
-pub(crate) unsafe fn build_fancy_groups(
-    fre: &fancy_regex::Regex,
-    caps: &fancy_regex::Captures,
-    scope: &crate::gc::RuntimeHandleScope,
-) -> *mut ObjectHeader {
-    let group_names: Vec<(&str, Option<fancy_regex::Match>)> = fre
-        .capture_names()
-        .enumerate()
-        .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        .collect();
-    if group_names.is_empty() {
-        return ptr::null_mut();
-    }
-    let groups_obj = crate::object::js_object_alloc(0, 0);
-    let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-    for (name, m) in &group_names {
-        let val = if let Some(m) = m {
-            js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-        } else {
-            f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-        };
-        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
-    }
-    groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
 }
 
 /// Fancy-regex fallback for the string-replacement (non-callback) forms of

--- a/crates/perry-runtime/src/regex/exec.rs
+++ b/crates/perry-runtime/src/regex/exec.rs
@@ -2,11 +2,7 @@ use super::*;
 
 use std::ptr;
 
-#[cfg(feature = "regex-engine")]
-use crate::array::ArrayHeader;
 use crate::string::StringHeader;
-#[cfg(feature = "regex-engine")]
-use crate::value::js_nanbox_string;
 
 /// regex.exec(string) -> match array (like string.match) with thread-local index/groups
 /// For global regexes, starts matching at lastIndex and updates it.
@@ -18,15 +14,6 @@ pub extern "C" fn js_regexp_exec(
     re: *mut RegExpHeader,
     s: *const StringHeader,
 ) -> *mut crate::array::ArrayHeader {
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-    // #854: POINTER_TAG / POINTER_MASK kept co-located with the NaN-box
-    // tag contract even when this exec helper only reads TAG_UNDEFINED.
-    // Codegen and sibling helpers in regex.rs use the same values.
-    #[allow(dead_code)]
-    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-    #[allow(dead_code)]
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
-
     if !is_valid_regex_ptr(re) || !is_valid_ptr(s) {
         LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
         LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -34,22 +21,9 @@ pub extern "C" fn js_regexp_exec(
     }
 
     // Spec RegExpBuiltinExec step 4 is `ToLength(Get(R, "lastIndex"))`, and it
-    // runs before anything else. The ToNumber half of that coercion executes
-    // USER JS whenever `lastIndex` is coercible (`re.lastIndex = { valueOf() {
-    // … } }` — test262 prototype/exec/{success,failure}-lastindex-access covers
-    // exactly this), and user JS reaches back-edge safepoint polls, so a moving
-    // minor can relocate BOTH arguments inside the window.
-    //
-    // Do the coercion FIRST, with `re` and `s` rooted, and take the subject's
-    // payload borrow only afterwards. `string_as_str` hands out a `&str` into
-    // the inline WTF-8 bytes; rooting rewrites *slots*, never an already
-    // materialized borrow, so a borrow taken ahead of this call reads from-space
-    // for the entire match (#8428, the `HeapKeyBytes` doc states the rule).
-    //
-    // Audited in the same pass: `set_last_index_throwing` does NOT reopen the
-    // window. It reads the property attributes and stores a number; its only
-    // allocation is on the non-writable arm, which throws and therefore never
-    // returns to the borrow.
+    // runs before anything else. The ToNumber half may execute user JS, so root
+    // both arguments and take the subject payload borrow only after it returns
+    // (#8428 / #8446).
     let scope = crate::gc::RuntimeHandleScope::new();
     let re_handle = scope.root_raw_mut_ptr(re);
     let s_handle = scope.root_string_ptr(s);
@@ -57,31 +31,19 @@ pub extern "C" fn js_regexp_exec(
         re_handle
             .across_mut::<RegExpHeader, _>(|| re_handle.with_const_ptr(regex_last_index_offset))
     });
-    let str_data = string_as_str(s);
 
-    unsafe {
+    // Phase 1 (borrowing, no JS allocation): run the engine and snapshot every
+    // subject-derived value into byte ranges/scalars. A rooted pointer slot can
+    // be rewritten by a moving GC; `&str`, `Match`, and `Captures` cannot. None
+    // of them may reach Phase 2 (#8449).
+    let (owned, has_indices) = unsafe {
+        let str_data = string_as_str(s);
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
         let sticky = (*re).sticky;
         let has_indices = (*re).has_indices;
-        // Per spec RegExpBuiltinExec, `lastIndex` drives the search start for
-        // BOTH global and sticky regexes (and lastIndex is reset/updated for
-        // either). A sticky match must additionally *anchor* at lastIndex.
         let use_last_index = global || sticky;
-        // `last_index_read` was taken at the top of the function, before the
-        // borrow: spec step 4 reads `lastIndex` (Get → ToLength) once, up front
-        // and *before* the global/sticky branch (step 8), so the read — and any
-        // `valueOf`/`toString` side effect of a coercible lastIndex — is observed
-        // exactly once even for a non-global/non-sticky regex (test262
-        // prototype/exec/{success,failure}-lastindex-access).
-        // Step 8: a non-global/non-sticky search always starts at 0; the value
-        // read above only drives the search start for a stateful regex.
         let last_index = if use_last_index { last_index_read } else { 0 };
-
-        // `lastIndex` is a JS string index — UTF-16 code units, like
-        // `str.length` — so map it back through the UTF-16 ↔ byte conversion
-        // rather than counting `chars()` (which walks one step per astral
-        // scalar instead of two, over-shooting the intended start).
         let search_start_byte = if use_last_index && last_index > 0 {
             super::exec_array::utf16_index_to_byte(str_data, last_index)
         } else {
@@ -96,228 +58,74 @@ pub extern "C" fn js_regexp_exec(
             LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
             return ptr::null_mut();
         }
-
         let search_str = &str_data[search_start_byte..];
 
-        // Check if this regex has a fancy-regex fallback (lookbehind/lookahead).
-        // Resolved via `lookup_fancy_regex` — the header-resident owned Arc
-        // first, the thread-local FANCY_CACHE second — so the capped cache
-        // (see `REGEX_CACHE_MAX_ENTRIES`) clearing between compile and exec
-        // cannot strand a live fancy regex on the never-matching std
-        // placeholder.
-        let fancy_captures = (|| {
-            if let Some(fre) = lookup_fancy_regex(re) {
-                if let Ok(Some(caps)) = fre.captures(search_str) {
-                    let full = caps.get(0).unwrap();
-                    // Sticky (`y`) requires the match to start exactly at
-                    // lastIndex — i.e. offset 0 of the sliced search string.
-                    if sticky && full.start() != 0 {
-                        return Some(ptr::null_mut());
-                    }
-                    let match_byte_offset = full.start() + search_start_byte;
-                    let match_char_offset =
-                        super::exec_array::byte_index_to_utf16_index(str_data, match_byte_offset);
-                    // Spec order (step 15 precedes the ArrayCreate of step 16),
-                    // and it keeps `re` out of the window opened by the capture
-                    // allocations below — the standard arm already does this.
+        let owned = if let Some(fre) = lookup_fancy_regex(re) {
+            match fre.captures(search_str) {
+                Ok(Some(caps)) if !sticky || caps.get(0).is_some_and(|full| full.start() == 0) => {
+                    let full = caps.get(0).expect("capture zero is the full match");
                     if use_last_index {
-                        let match_end_byte = full.end() + search_start_byte;
                         set_last_index_throwing(
                             re,
-                            super::exec_array::byte_index_to_utf16_index(str_data, match_end_byte),
+                            super::exec_array::byte_index_to_utf16_index(
+                                str_data,
+                                search_start_byte + full.end(),
+                            ),
                         );
                     }
-                    let arr = crate::array::js_array_alloc(caps.len() as u32);
-                    let scope = crate::gc::RuntimeHandleScope::new();
-                    let arr_handle = scope.root_raw_mut_ptr(arr);
-                    (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-                    for i in 0..caps.len() {
-                        let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-                        if let Some(m) = caps.get(i) {
-                            let str_ptr = js_string_from_str(m.as_str());
-                            let nanboxed = js_nanbox_string(str_ptr as i64);
-                            // GC_STORE_AUDIT(BARRIERED): regex exec fancy capture slot uses the shared array slot-store helper.
-                            crate::array::store_array_slot(arr, i, nanboxed.to_bits());
-                        } else {
-                            let undefined = f64::from_bits(TAG_UNDEFINED);
-                            // GC_STORE_AUDIT(BARRIERED): regex exec fancy unmatched capture slot uses the shared array slot-store helper.
-                            crate::array::store_array_slot(arr, i, undefined.to_bits());
-                        }
-                    }
-                    set_exec_array_metadata(
-                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        str_data,
-                        match_char_offset as f64,
-                    );
-                    LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = match_char_offset as f64);
-                    // Extract named-capture groups through the fancy path so
-                    // `/(?<=x)(?<y>\d+)/.exec(s).groups` works for patterns the
-                    // `regex` crate can't compile.
-                    let groups_obj = build_fancy_groups(&fre, &caps, &scope);
-                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups_obj);
-                    set_exec_array_groups(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), groups_obj);
-                    // Build indices array if `d` flag (hasIndices) is set
-                    if has_indices {
-                        set_exec_array_indices_fancy(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            str_data,
-                            search_start_byte,
-                            &fre,
-                            &caps,
-                        );
-                    }
-                    return Some(arr_handle.get_raw_mut_ptr::<ArrayHeader>());
-                }
-                return Some(ptr::null_mut()); // fancy-regex tried but no match
-            }
-            None // no fancy fallback — use standard regex
-        })();
-        if let Some(result) = fancy_captures {
-            if result.is_null() {
-                if use_last_index {
-                    set_last_index_throwing(re, 0);
-                }
-                LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
-                LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                return ptr::null_mut();
-            }
-            return result;
-        }
-
-        let standard_caps = regex.captures(search_str).filter(|caps| {
-            // Sticky (`y`) requires the match to start at lastIndex (offset 0 of
-            // the slice); a leftmost match further in does not count.
-            !sticky || caps.get(0).map(|m| m.start() == 0).unwrap_or(false)
-        });
-        match standard_caps {
-            Some(caps) => {
-                let match_byte_offset = caps.get(0).unwrap().start() + search_start_byte;
-                let match_char_offset =
-                    super::exec_array::byte_index_to_utf16_index(str_data, match_byte_offset);
-
-                if use_last_index {
-                    let match_end_byte = caps.get(0).unwrap().end() + search_start_byte;
-                    let match_end_char =
-                        super::exec_array::byte_index_to_utf16_index(str_data, match_end_byte);
-                    set_last_index_throwing(re, match_end_char);
-                }
-
-                // Create match array: [fullMatch, group1, group2, ...]
-                let arr = crate::array::js_array_alloc(caps.len() as u32);
-                let scope = crate::gc::RuntimeHandleScope::new();
-                let arr_handle = scope.root_raw_mut_ptr(arr);
-                (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-
-                for (i, cap) in caps.iter().enumerate() {
-                    if let Some(m) = cap {
-                        // Allocating string + array re-read as one combinator (#7341).
-                        let (nanboxed, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
-                            js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                        });
-                        // GC_STORE_AUDIT(INIT): fresh exec-array slot; layout is
-                        // noted per store and the exact layout/barrier rebuild
-                        // below the loop covers a mid-loop tenuring (#6386).
-                        crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
-                    } else {
-                        let undefined = f64::from_bits(TAG_UNDEFINED);
-                        let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-                        // GC_STORE_AUDIT(INIT): fresh exec-array slot; see above.
-                        crate::array::note_array_slot_layout_only(arr, i, undefined.to_bits());
-                    }
-                }
-                // GC_STORE_AUDIT(BARRIERED): one exact rebuild replays any
-                // old-gen barriers for the whole capture prefix.
-                crate::array::rebuild_array_layout_exact(
-                    arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                );
-
-                // Store .index in thread-local
-                LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = match_char_offset as f64);
-                // .index/.input attach via the combined fresh-array decoration
-                // below (#6386): one side-table probe for index/input/groups
-                // and a re-boxed (not copied) subject string.
-
-                // Build groups object if named captures exist
-                let group_names: Vec<(&str, Option<regex::Match>)> = regex
-                    .capture_names()
-                    .enumerate()
-                    .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-                    .collect();
-
-                if !group_names.is_empty() {
-                    // Allocate a fresh per-result object (and shape) via
-                    // `js_object_alloc(0, 0)` + by-name setters, NOT a shared
-                    // `js_object_alloc_with_shape(const_id)`. A fixed interned
-                    // shape id makes a later match with different named captures
-                    // inherit the prior call's key names (e.g. `(?<x>…)` then
-                    // `(?<z>…)` exposing `.x` on the second result). This mirrors
-                    // the fix already applied to the `js_string_match` path.
-                    let groups_obj = crate::object::js_object_alloc(0, 0);
-                    let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-                    for (name, m) in &group_names {
-                        let val = if let Some(m) = m {
-                            let str_ptr = js_string_from_str(m.as_str());
-                            js_nanbox_string(str_ptr as i64)
-                        } else {
-                            f64::from_bits(TAG_UNDEFINED)
-                        };
-                        let key_ptr =
-                            crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                        let groups_obj =
-                            groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
-                    }
-                    LAST_EXEC_GROUPS.with(|g| {
-                        *g.borrow_mut() =
-                            groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
-                    });
-                    // `.input` re-boxes the subject, so it must be the CURRENT
-                    // address: the capture/groups allocations above can have
-                    // moved it since `s` was refreshed. The helper itself
-                    // performs no GC allocation, which is what makes the scoped
-                    // `with_const_ptr` argument shape sound here.
-                    s_handle.with_const_ptr::<StringHeader, _>(|s_now| {
-                        super::exec_array::set_exec_array_metadata_groups_fresh(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            s_now,
-                            match_char_offset as f64,
-                            groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
-                        )
-                    });
-                } else {
-                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                    // Current subject address — see the named-groups arm above.
-                    s_handle.with_const_ptr::<StringHeader, _>(|s_now| {
-                        super::exec_array::set_exec_array_metadata_groups_fresh(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            s_now,
-                            match_char_offset as f64,
-                            ptr::null_mut(),
-                        )
-                    });
-                }
-
-                // Build indices array if `d` flag (hasIndices) is set
-                if has_indices {
-                    set_exec_array_indices(
-                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                    Some(OwnedExecMatch::from_fancy(
                         str_data,
                         search_start_byte,
+                        &fre,
                         &caps,
+                        has_indices,
+                    ))
+                }
+                Ok(Some(_)) | Ok(None) | Err(_) => None,
+            }
+        } else {
+            regex
+                .captures(search_str)
+                .filter(|caps| !sticky || caps.get(0).is_some_and(|full| full.start() == 0))
+                .map(|caps| {
+                    let full = caps.get(0).expect("capture zero is the full match");
+                    if use_last_index {
+                        set_last_index_throwing(
+                            re,
+                            super::exec_array::byte_index_to_utf16_index(
+                                str_data,
+                                search_start_byte + full.end(),
+                            ),
+                        );
+                    }
+                    OwnedExecMatch::from_standard(
+                        str_data,
+                        search_start_byte,
                         regex,
-                    );
-                }
+                        &caps,
+                        has_indices,
+                    )
+                })
+        };
 
-                arr_handle.get_raw_mut_ptr::<ArrayHeader>()
+        let Some(owned) = owned else {
+            if use_last_index {
+                set_last_index_throwing(re, 0);
             }
-            None => {
-                if use_last_index {
-                    set_last_index_throwing(re, 0);
-                }
-                LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
-                LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                ptr::null_mut()
-            }
-        }
-    }
+            LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
+            LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+            return ptr::null_mut();
+        };
+        (owned, has_indices)
+    };
+
+    // Phase 2 (allocating, no subject borrow): copy each snapshotted range from
+    // the current rooted subject address. `string_copy_range` roots and re-reads
+    // the source after its destination allocation.
+    let (result, groups) = s_handle.with_const_ptr::<StringHeader, _>(|source_now| unsafe {
+        materialize_exec_match(source_now, &owned, has_indices)
+    });
+    LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = owned.match_index);
+    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups);
+    result
 }

--- a/crates/perry-runtime/src/regex/exec_array.rs
+++ b/crates/perry-runtime/src/regex/exec_array.rs
@@ -9,28 +9,153 @@
 pub(super) use super::utf16::{byte_index_to_utf16_index, utf16_index_to_byte};
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
+use crate::string::{StringHeader, STRING_FLAG_HAS_LONE_SURROGATES};
 use crate::value::js_nanbox_string;
 
 use super::js_string_from_str;
 
-pub(super) fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index: f64) {
-    if arr.is_null() {
-        return;
-    }
-    let index_key = js_string_from_str("index");
-    crate::array::js_array_set_string_key(arr, index_key, index);
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 
-    let input_key = js_string_from_str("input");
-    let input_str = js_string_from_str(input);
-    let input_value = js_nanbox_string(input_str as i64);
-    crate::array::js_array_set_string_key(arr, input_key, input_value);
+/// A capture snapshotted while the subject payload is borrowed. Runtime result
+/// materialization uses only these scalar offsets after the borrow is dropped.
+#[derive(Clone, Copy)]
+pub(super) struct OwnedCapture {
+    byte_start: usize,
+    byte_len: u32,
+    utf16_len: u32,
+    flags: u32,
+    utf16_range: Option<(f64, f64)>,
 }
 
-/// [`set_exec_array_metadata`] variant taking the `input` property as an
-/// already-boxed string VALUE (typically the rooted original subject) instead
-/// of a `&str` to copy. Both the array and the input value are rooted across
-/// the internal key-string allocations, which can trigger a (potentially
-/// moving) minor GC.
+impl OwnedCapture {
+    pub(super) fn from_range(str_data: &str, byte_start: usize, byte_end: usize) -> Self {
+        Self::from_range_with_indices(str_data, byte_start, byte_end, false)
+    }
+
+    fn from_range_with_indices(
+        str_data: &str,
+        byte_start: usize,
+        byte_end: usize,
+        with_indices: bool,
+    ) -> Self {
+        let bytes = &str_data.as_bytes()[byte_start..byte_end];
+        let utf16_len = crate::string::compute_utf16_len_wtf8(bytes);
+        let flags = if crate::string::bytes_have_lone_surrogate(bytes) {
+            STRING_FLAG_HAS_LONE_SURROGATES
+        } else {
+            0
+        };
+        Self {
+            byte_start,
+            byte_len: bytes.len() as u32,
+            utf16_len,
+            flags,
+            utf16_range: with_indices.then(|| {
+                (
+                    byte_index_to_utf16_index(str_data, byte_start) as f64,
+                    byte_index_to_utf16_index(str_data, byte_end) as f64,
+                )
+            }),
+        }
+    }
+}
+
+/// All subject-derived state needed to build one RegExp match result. This is
+/// deliberately owned/scalar-only: no `&str`, `regex::Match`, or `Captures`
+/// may survive into the allocation phase (#8449).
+pub(super) struct OwnedExecMatch {
+    captures: Vec<Option<OwnedCapture>>,
+    named: Vec<(String, usize)>,
+    pub(super) match_index: f64,
+}
+
+impl OwnedExecMatch {
+    pub(super) fn from_standard(
+        str_data: &str,
+        search_start_byte: usize,
+        regex: &regex::Regex,
+        caps: &regex::Captures,
+        has_indices: bool,
+    ) -> Self {
+        let captures: Vec<Option<OwnedCapture>> = caps
+            .iter()
+            .map(|capture| {
+                capture.map(|m| {
+                    OwnedCapture::from_range_with_indices(
+                        str_data,
+                        search_start_byte + m.start(),
+                        search_start_byte + m.end(),
+                        has_indices,
+                    )
+                })
+            })
+            .collect();
+        let named = regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(index, name)| name.map(|name| (name.to_string(), index)))
+            .collect();
+        let match_index = captures
+            .first()
+            .and_then(|capture| capture.as_ref())
+            .map(|capture| {
+                capture.utf16_range.map(|range| range.0).unwrap_or_else(|| {
+                    byte_index_to_utf16_index(str_data, capture.byte_start) as f64
+                })
+            })
+            .unwrap_or(0.0);
+        Self {
+            captures,
+            named,
+            match_index,
+        }
+    }
+
+    pub(super) fn from_fancy(
+        str_data: &str,
+        search_start_byte: usize,
+        regex: &fancy_regex::Regex,
+        caps: &fancy_regex::Captures,
+        has_indices: bool,
+    ) -> Self {
+        let captures: Vec<Option<OwnedCapture>> = (0..caps.len())
+            .map(|index| {
+                caps.get(index).map(|m| {
+                    OwnedCapture::from_range_with_indices(
+                        str_data,
+                        search_start_byte + m.start(),
+                        search_start_byte + m.end(),
+                        has_indices,
+                    )
+                })
+            })
+            .collect();
+        let named = regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(index, name)| name.map(|name| (name.to_string(), index)))
+            .collect();
+        let match_index = captures
+            .first()
+            .and_then(|capture| capture.as_ref())
+            .map(|capture| {
+                capture.utf16_range.map(|range| range.0).unwrap_or_else(|| {
+                    byte_index_to_utf16_index(str_data, capture.byte_start) as f64
+                })
+            })
+            .unwrap_or(0.0);
+        Self {
+            captures,
+            named,
+            match_index,
+        }
+    }
+}
+
+/// Match-result metadata helper taking the `input` property as an already-boxed
+/// string VALUE (typically the rooted original subject) instead of a `&str` to
+/// copy. Both the array and the input value are rooted across the internal
+/// key-string allocations, which can trigger a (potentially moving) minor GC.
 pub(super) fn set_exec_array_metadata_value(arr: *mut ArrayHeader, input_value: f64, index: f64) {
     if arr.is_null() {
         return;
@@ -54,8 +179,7 @@ pub(super) fn set_exec_array_metadata_value(arr: *mut ArrayHeader, input_value: 
 }
 
 /// Combined `index`/`input`/`groups` decoration for a FRESHLY built
-/// match-result array (#6386). Differences from calling
-/// [`set_exec_array_metadata`] + [`set_exec_array_groups`]:
+/// match-result array (#6386).
 ///
 /// * `input` re-boxes the already-heap-allocated subject `StringHeader`
 ///   instead of copying the whole subject per match (the string is demoted
@@ -97,271 +221,194 @@ pub(super) fn set_exec_array_metadata_groups_fresh(
     }
 }
 
-/// Attach the `groups` own property to a regex match-result array.
-///
-/// Mirrors `set_exec_array_metadata` for `index`/`input`: the result of
-/// `regex.exec(s)` / `s.match(regex)` carries `groups` as a real own property
-/// so reads stay correct under aliasing and interleaved matches — a stored
-/// `m.groups` survives a later `re2.exec(...)`, instead of resolving through a
-/// single most-recent-match thread-local (`LAST_EXEC_GROUPS`). Per ECMA-262
-/// RegExpBuiltinExec, `groups` is the named-capture object when the pattern
-/// has named groups, else `undefined`.
-pub(super) fn set_exec_array_groups(arr: *mut ArrayHeader, groups_obj: *mut ObjectHeader) {
-    if arr.is_null() {
-        return;
-    }
-    let groups_key = js_string_from_str("groups");
-    let value = if groups_obj.is_null() {
-        f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-    } else {
-        crate::value::js_nanbox_pointer(groups_obj as i64)
-    };
-    crate::array::js_array_set_string_key(arr, groups_key, value);
+fn copy_owned_capture(
+    source: &crate::gc::RuntimeHandle<'_>,
+    capture: OwnedCapture,
+) -> *mut StringHeader {
+    source.with_const_ptr::<StringHeader, _>(|source_now| {
+        crate::string::string_copy_range(
+            source_now,
+            capture.byte_start,
+            capture.byte_len,
+            capture.utf16_len,
+            capture.flags,
+        )
+    })
 }
 
-/// Attach the `indices` own property to a regex match-result array when the
-/// `d` flag (hasIndices) is set. Per ECMA-262 RegExpBuiltinExec, `indices` is
-/// an array where each element is `[start, end]` for the corresponding capture
-/// group. Element 0 is the full match, elements 1..N are capture groups.
-/// Unmatched groups are `undefined`. The `indices` array also has a `.groups`
-/// property with named captures mapping to `[start, end]` pairs.
-pub(super) fn set_exec_array_indices(
-    arr: *mut ArrayHeader,
-    str_data: &str,
-    search_start_byte: usize,
-    caps: &regex::Captures,
-    regex: &regex::Regex,
+unsafe fn attach_owned_indices(
+    result_handle: &crate::gc::RuntimeHandle<'_>,
+    data: &OwnedExecMatch,
+    scope: &crate::gc::RuntimeHandleScope,
 ) {
-    if arr.is_null() {
-        return;
-    }
+    let indices = crate::array::js_array_alloc(data.captures.len() as u32);
+    let indices_handle = scope.root_raw_mut_ptr(indices);
+    (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = data.captures.len() as u32;
 
-    let scope = crate::gc::RuntimeHandleScope::new();
-
-    // Build the indices array: [[start, end], [start, end], ...]
-    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
-    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
-    unsafe {
-        (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-    }
-
-    for (i, cap) in caps.iter().enumerate() {
-        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-        if let Some(m) = cap {
-            // Convert byte offsets to JS string indices (UTF-16 code units),
-            // consistent with `.index` / `lastIndex` / `str.length`.
-            let start_byte = m.start() + search_start_byte;
-            let end_byte = m.end() + search_start_byte;
-            let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
-            let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
-
-            // Create [start, end] pair
-            let pair = crate::array::js_array_alloc(2);
-            let pair_handle = scope.root_raw_mut_ptr(pair);
-            unsafe {
-                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    0,
-                    start_char.to_bits(),
-                );
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    1,
-                    end_char.to_bits(),
-                );
-            }
-
-            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
-            unsafe {
-                crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
-            }
-        } else {
-            // Unmatched capture group -> undefined
-            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-            unsafe {
-                crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
-            }
-        }
-    }
-
-    // If there are named groups, attach .groups property to indices array
-    let has_named_groups = regex.capture_names().any(|n| n.is_some());
-    if has_named_groups {
-        let groups_obj = crate::object::js_object_alloc(0, 0);
-        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-
-        for (name, m) in regex
-            .capture_names()
-            .enumerate()
-            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        {
-            let val = if let Some(m) = m {
-                let start_byte = m.start() + search_start_byte;
-                let end_byte = m.end() + search_start_byte;
-                let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
-                let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
-
-                // Create [start, end] pair for named group
-                let pair = crate::array::js_array_alloc(2);
-                let pair_handle = scope.root_raw_mut_ptr(pair);
-                unsafe {
-                    (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                    crate::array::store_array_slot(
-                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        0,
-                        start_char.to_bits(),
-                    );
-                    crate::array::store_array_slot(
-                        pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                        1,
-                        end_char.to_bits(),
-                    );
-                }
-                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-                crate::value::js_nanbox_pointer(pair_ptr as i64)
-            } else {
-                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-            };
-
-            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
-        }
-
-        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
-        let indices_key = js_string_from_str("groups");
-        crate::array::js_array_set_string_key(
-            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
-            indices_key,
-            f64::from_bits(groups_nanboxed.to_bits()),
-        );
-    }
-
-    // Attach indices array to the match result
-    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
-    let indices_key = js_string_from_str("indices");
-    crate::array::js_array_set_string_key(
-        arr,
-        indices_key,
-        f64::from_bits(indices_nanboxed.to_bits()),
-    );
-}
-
-/// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).
-pub(super) unsafe fn set_exec_array_indices_fancy(
-    arr: *mut ArrayHeader,
-    str_data: &str,
-    search_start_byte: usize,
-    fre: &fancy_regex::Regex,
-    caps: &fancy_regex::Captures,
-) {
-    if arr.is_null() {
-        return;
-    }
-
-    let scope = crate::gc::RuntimeHandleScope::new();
-
-    // Build the indices array: [[start, end], [start, end], ...]
-    let indices_arr = crate::array::js_array_alloc(caps.len() as u32);
-    let indices_handle = scope.root_raw_mut_ptr(indices_arr);
-    (*indices_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-
-    for i in 0..caps.len() {
-        let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-        if let Some(m) = caps.get(i) {
-            let start_byte = m.start() + search_start_byte;
-            let end_byte = m.end() + search_start_byte;
-            let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
-            let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
-
-            // Create [start, end] pair
+    for (index, capture) in data.captures.iter().enumerate() {
+        let value = if let Some(capture) = capture {
             let pair = crate::array::js_array_alloc(2);
             let pair_handle = scope.root_raw_mut_ptr(pair);
             (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
+            let (start, end) = capture
+                .utf16_range
+                .expect("hasIndices snapshots every UTF-16 capture range");
             crate::array::store_array_slot(
                 pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
                 0,
-                start_char.to_bits(),
+                start.to_bits(),
             );
             crate::array::store_array_slot(
                 pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
                 1,
-                end_char.to_bits(),
+                end.to_bits(),
             );
-
-            let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-            let nanboxed = crate::value::js_nanbox_pointer(pair_ptr as i64);
-            crate::array::store_array_slot(indices_arr_ptr, i, nanboxed.to_bits());
+            crate::value::js_nanbox_pointer(pair_handle.get_raw_mut_ptr::<ArrayHeader>() as i64)
         } else {
-            // Unmatched capture group -> undefined
-            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-            crate::array::store_array_slot(indices_arr_ptr, i, undefined.to_bits());
-        }
-    }
-
-    // If there are named groups, attach .groups property to indices array
-    let has_named_groups = fre.capture_names().any(|n| n.is_some());
-    if has_named_groups {
-        let groups_obj = crate::object::js_object_alloc(0, 0);
-        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-
-        for (name, m) in fre
-            .capture_names()
-            .enumerate()
-            .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        {
-            let val = if let Some(m) = m {
-                let start_byte = m.start() + search_start_byte;
-                let end_byte = m.end() + search_start_byte;
-                let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
-                let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
-
-                // Create [start, end] pair for named group
-                let pair = crate::array::js_array_alloc(2);
-                let pair_handle = scope.root_raw_mut_ptr(pair);
-                (*pair_handle.get_raw_mut_ptr::<ArrayHeader>()).length = 2;
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    0,
-                    start_char.to_bits(),
-                );
-                crate::array::store_array_slot(
-                    pair_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    1,
-                    end_char.to_bits(),
-                );
-                let pair_ptr = pair_handle.get_raw_mut_ptr::<ArrayHeader>();
-                crate::value::js_nanbox_pointer(pair_ptr as i64)
-            } else {
-                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-            };
-
-            let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            let groups_obj_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-            crate::object::js_object_set_field_by_name(groups_obj_ptr, key_ptr, val);
-        }
-
-        let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        let groups_nanboxed = crate::value::js_nanbox_pointer(groups_ptr as i64);
-        let indices_key = js_string_from_str("groups");
-        crate::array::js_array_set_string_key(
+            f64::from_bits(TAG_UNDEFINED)
+        };
+        crate::array::store_array_slot(
             indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
-            indices_key,
-            f64::from_bits(groups_nanboxed.to_bits()),
+            index,
+            value.to_bits(),
         );
     }
 
-    // Attach indices array to the match result
-    let indices_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
-    let indices_nanboxed = crate::value::js_nanbox_pointer(indices_ptr as i64);
-    let indices_key = js_string_from_str("indices");
+    if !data.named.is_empty() {
+        let groups = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups);
+        for (name, capture_index) in &data.named {
+            // ECMAScript exposes the same index-pair object at `indices[i]`
+            // and `indices.groups.name`; re-read it from the rooted array.
+            let value = crate::array::js_array_get_f64(
+                indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                *capture_index as u32,
+            );
+            let value_handle = scope.root_nanbox_f64(value);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            groups_handle.with_mut_ptr::<ObjectHeader, _>(|groups_now| {
+                crate::object::js_object_set_field_by_name(
+                    groups_now,
+                    key,
+                    value_handle.get_nanbox_f64(),
+                )
+            });
+        }
+
+        let (groups_key, groups_now) =
+            groups_handle.across_mut::<ObjectHeader, _>(|| js_string_from_str("groups"));
+        let groups_value = crate::value::js_nanbox_pointer(groups_now as i64);
+        crate::array::js_array_set_string_key(
+            indices_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            groups_key,
+            groups_value,
+        );
+    }
+
+    let (indices_key, indices_now) =
+        indices_handle.across_mut::<ArrayHeader, _>(|| js_string_from_str("indices"));
+    let indices_value = crate::value::js_nanbox_pointer(indices_now as i64);
     crate::array::js_array_set_string_key(
-        arr,
+        result_handle.get_raw_mut_ptr::<ArrayHeader>(),
         indices_key,
-        f64::from_bits(indices_nanboxed.to_bits()),
+        indices_value,
     );
+}
+
+/// Phase 2 for `RegExp#exec` and non-global `String#match`: allocate solely
+/// from an owned byte-range snapshot. `source` is rooted before the first JS
+/// allocation and each capture copy re-reads it after allocating its result.
+pub(super) unsafe fn materialize_exec_match(
+    source: *const StringHeader,
+    data: &OwnedExecMatch,
+    has_indices: bool,
+) -> (*mut ArrayHeader, *mut ObjectHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let source_handle = scope.root_string_ptr(source);
+
+    let result = crate::array::js_array_alloc(data.captures.len() as u32);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    (*result_handle.get_raw_mut_ptr::<ArrayHeader>()).length = data.captures.len() as u32;
+
+    for (index, capture) in data.captures.iter().enumerate() {
+        if let Some(capture) = capture {
+            let (string, result_now) = result_handle
+                .across_mut::<ArrayHeader, _>(|| copy_owned_capture(&source_handle, *capture));
+            let value = js_nanbox_string(string as i64);
+            crate::array::store_array_slot(result_now, index, value.to_bits());
+        } else {
+            crate::array::store_array_slot(
+                result_handle.get_raw_mut_ptr::<ArrayHeader>(),
+                index,
+                TAG_UNDEFINED,
+            );
+        }
+    }
+
+    let groups_handle = if data.named.is_empty() {
+        None
+    } else {
+        let groups = crate::object::js_object_alloc(0, 0);
+        let groups_handle = scope.root_raw_mut_ptr(groups);
+        for (name, capture_index) in &data.named {
+            let value = if let Some(capture) = data.captures[*capture_index] {
+                js_nanbox_string(copy_owned_capture(&source_handle, capture) as i64)
+            } else {
+                f64::from_bits(TAG_UNDEFINED)
+            };
+            let value_handle = scope.root_nanbox_f64(value);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            groups_handle.with_mut_ptr::<ObjectHeader, _>(|groups_now| {
+                crate::object::js_object_set_field_by_name(
+                    groups_now,
+                    key,
+                    value_handle.get_nanbox_f64(),
+                )
+            });
+        }
+        Some(groups_handle)
+    };
+
+    let groups = groups_handle
+        .as_ref()
+        .map(|handle| handle.get_raw_mut_ptr::<ObjectHeader>())
+        .unwrap_or(std::ptr::null_mut());
+    source_handle.with_const_ptr::<StringHeader, _>(|source_now| {
+        set_exec_array_metadata_groups_fresh(
+            result_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            source_now,
+            data.match_index,
+            groups,
+        )
+    });
+
+    if has_indices {
+        attach_owned_indices(&result_handle, data, &scope);
+    }
+
+    let groups = groups_handle
+        .as_ref()
+        .map(|handle| handle.get_raw_mut_ptr::<ObjectHeader>())
+        .unwrap_or(std::ptr::null_mut());
+    (result_handle.get_raw_mut_ptr::<ArrayHeader>(), groups)
+}
+
+/// Phase 2 for global `String#match`, which returns only the full-match strings.
+pub(super) unsafe fn materialize_match_list(
+    source: *const StringHeader,
+    matches: &[OwnedCapture],
+) -> *mut ArrayHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let source_handle = scope.root_string_ptr(source);
+    let result = crate::array::js_array_alloc(matches.len() as u32);
+    let result_handle = scope.root_raw_mut_ptr(result);
+    (*result_handle.get_raw_mut_ptr::<ArrayHeader>()).length = matches.len() as u32;
+
+    for (index, capture) in matches.iter().enumerate() {
+        let (string, result_now) = result_handle
+            .across_mut::<ArrayHeader, _>(|| copy_owned_capture(&source_handle, *capture));
+        let value = js_nanbox_string(string as i64);
+        crate::array::store_array_slot(result_now, index, value.to_bits());
+    }
+    result_handle.get_raw_mut_ptr::<ArrayHeader>()
 }

--- a/crates/perry-runtime/src/regex/match_string.rs
+++ b/crates/perry-runtime/src/regex/match_string.rs
@@ -2,11 +2,8 @@ use super::*;
 
 use std::ptr;
 
-#[cfg(feature = "regex-engine")]
 use crate::array::ArrayHeader;
 use crate::string::StringHeader;
-#[cfg(feature = "regex-engine")]
-use crate::value::js_nanbox_string;
 
 /// Coerce a `String.prototype.search`/`match` argument into a RegExp
 /// (ECMA-262 §22.1.3.12 / §22.1.3.20 → `RegExpCreate`). A RegExp value passes
@@ -25,27 +22,21 @@ fn coerce_search_arg_to_regex(arg: f64) -> *const RegExpHeader {
     }
     // `undefined` → empty pattern. Build a real empty `StringHeader` (NOT a
     // null pointer): the resulting RegExp header's `pattern_ptr` is later
-    // dereferenced by `js_string_match`'s `lookup_fancy_regex`
-    // (`string_as_str((*re).pattern_ptr)`), which would SIGSEGV on null.
+    // dereferenced by `lookup_fancy_regex`.
     let src: *const StringHeader = if jv.is_undefined() {
         crate::string::js_string_from_str("") as *const StringHeader
     } else {
         crate::builtins::js_string_coerce(arg) as *const StringHeader
     };
-    // `flags` may be read the same way; pass an empty header rather than null.
     let flags = crate::string::js_string_from_str("") as *const StringHeader;
     js_regexp_new(src, flags)
 }
 
 /// `String.prototype.search(regexp)` (ECMA-262 §22.1.3.12) with full argument
-/// coercion: a non-RegExp arg is turned into `RegExpCreate(ToString(arg))`
-/// (so `"x".search("pat")`, `.search(undefined)`, and `.search({toString})`
-/// all work). `s` is the already-`ToString`-coerced `this`.
+/// coercion. `s` is the already-`ToString`-coerced `this`.
 #[cfg(feature = "regex-engine")]
 #[no_mangle]
 pub extern "C" fn js_string_search_value(s: *const StringHeader, arg: f64) -> i32 {
-    // Root the receiver across the (possibly allocating / GC-triggering)
-    // argument coercion so a moving collector can't dangle `s`.
     let scope = crate::gc::RuntimeHandleScope::new();
     let s_handle = scope.root_string_ptr(s);
     let re = coerce_search_arg_to_regex(arg);
@@ -66,7 +57,12 @@ pub extern "C" fn js_string_match_value(s: *const StringHeader, arg: f64) -> *mu
     js_string_match(s, re)
 }
 
-/// Find matches in a string
+enum OwnedStringMatch {
+    Global(Vec<OwnedCapture>),
+    NonGlobal(OwnedExecMatch, bool),
+}
+
+/// Find matches in a string.
 /// string.match(regex) -> string[] | null (returns array pointer, null if no match)
 #[cfg(feature = "regex-engine")]
 #[no_mangle]
@@ -78,265 +74,65 @@ pub extern "C" fn js_string_match(
         return ptr::null_mut();
     }
 
-    let str_data = string_as_str(s);
-
-    unsafe {
+    // Phase 1 (borrowing, no JS allocation): capture byte ranges and all
+    // UTF-16/WTF-8 metadata while the engine's `Captures` may borrow `s`.
+    let owned = unsafe {
+        let str_data = string_as_str(s);
         let regex = &*(*re).regex_ptr;
         let global = (*re).global;
+        let has_indices = (*re).has_indices;
 
-        // If this regex couldn't be compiled by the `regex` crate (e.g.
-        // backreferences like `(\w)\1*`, used by date-fns' format token
-        // regex), `get_or_compile_regex` substituted a never-match
-        // `[^\s\S]` placeholder and stashed the real pattern in
-        // `FANCY_CACHE`. Route through fancy-regex so `.match()` returns
-        // real results instead of always-null.
         if let Some(fre) = lookup_fancy_regex(re) {
             if global {
-                // Collect all non-overlapping matches via fancy-regex's
-                // find_iter. Mirrors the `regex` crate global path below.
-                let mut matches: Vec<String> = Vec::new();
-                let mut iter = fre.find_iter(str_data);
-                while let Some(Ok(m)) = iter.next() {
-                    matches.push(m.as_str().to_string());
-                }
+                let matches: Vec<OwnedCapture> = fre
+                    .find_iter(str_data)
+                    .filter_map(Result::ok)
+                    .map(|m| OwnedCapture::from_range(str_data, m.start(), m.end()))
+                    .collect();
                 if matches.is_empty() {
                     return ptr::null_mut();
                 }
-                let arr = crate::array::js_array_alloc(matches.len() as u32);
-                let scope = crate::gc::RuntimeHandleScope::new();
-                let arr_handle = scope.root_raw_mut_ptr(arr);
-                (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = matches.len() as u32;
-                for (i, m) in matches.iter().enumerate() {
-                    // `across_mut` runs the allocating pair and hands back the
-                    // post-collection array address, so the receiver is never
-                    // bound stale in between (#7341).
-                    let (nanboxed, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
-                        let str_ptr = js_string_from_str(m);
-                        js_nanbox_string(str_ptr as i64)
-                    });
-                    // GC_STORE_AUDIT(BARRIERED): regex match array slot uses the shared array slot-store helper.
-                    crate::array::store_array_slot(arr, i, nanboxed.to_bits());
-                }
-                return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+                OwnedStringMatch::Global(matches)
             } else {
-                // Non-global: first match + capture groups (parallels the
-                // standard-regex non-global branch below).
-                match fre.captures(str_data) {
-                    Ok(Some(caps)) => {
-                        let arr = crate::array::js_array_alloc(caps.len() as u32);
-                        let scope = crate::gc::RuntimeHandleScope::new();
-                        let arr_handle = scope.root_raw_mut_ptr(arr);
-                        (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-                        for i in 0..caps.len() {
-                            if let Some(m) = caps.get(i) {
-                                // See the sibling above (#7341).
-                                let (nanboxed, arr) =
-                                    arr_handle.across_mut::<ArrayHeader, _>(|| {
-                                        let str_ptr = js_string_from_str(m.as_str());
-                                        js_nanbox_string(str_ptr as i64)
-                                    });
-                                // GC_STORE_AUDIT(BARRIERED): regex capture array slot uses the shared array slot-store helper.
-                                crate::array::store_array_slot(arr, i, nanboxed.to_bits());
-                            } else {
-                                let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-                                let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-                                // GC_STORE_AUDIT(BARRIERED): regex unmatched capture slot uses the shared array slot-store helper.
-                                crate::array::store_array_slot(arr, i, undefined.to_bits());
-                            }
-                        }
-                        // Attach .index / .input as real own properties.
-                        let match_char_offset = caps
-                            .get(0)
-                            .map(|m| super::utf16::byte_index_to_utf16_index(str_data, m.start()))
-                            .unwrap_or(0);
-                        set_exec_array_metadata(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            str_data,
-                            match_char_offset as f64,
-                        );
-                        // Extract named-capture groups through the fancy path
-                        // (fancy-regex exposes `capture_names()` just like the
-                        // `regex` crate), so `s.match(/(?<=x)(?<y>\d+)/).groups`
-                        // works for lookbehind+named patterns.
-                        let groups_obj = build_fancy_groups(&fre, &caps, &scope);
-                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups_obj);
-                        set_exec_array_groups(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            groups_obj,
-                        );
-                        // Build `indices` if the `d` flag (hasIndices) is set —
-                        // non-global `String.prototype.match` delegates to
-                        // RegExpExec, so it carries the same `indices` as exec().
-                        if (*re).has_indices {
-                            set_exec_array_indices_fancy(
-                                arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                                str_data,
-                                0,
-                                &fre,
-                                &caps,
-                            );
-                        }
-                        return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-                    }
-                    _ => {
-                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                        return ptr::null_mut();
-                    }
-                }
+                let Ok(Some(caps)) = fre.captures(str_data) else {
+                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                    return ptr::null_mut();
+                };
+                OwnedStringMatch::NonGlobal(
+                    OwnedExecMatch::from_fancy(str_data, 0, &fre, &caps, has_indices),
+                    has_indices,
+                )
             }
-        }
-
-        if global {
-            // Global flag: return all matches
-            let matches: Vec<&str> = regex.find_iter(str_data).map(|m| m.as_str()).collect();
-
+        } else if global {
+            let matches: Vec<OwnedCapture> = regex
+                .find_iter(str_data)
+                .map(|m| OwnedCapture::from_range(str_data, m.start(), m.end()))
+                .collect();
             if matches.is_empty() {
                 return ptr::null_mut();
             }
-
-            // Create array of string pointers
-            let arr = crate::array::js_array_alloc(matches.len() as u32);
-            let scope = crate::gc::RuntimeHandleScope::new();
-            let arr_handle = scope.root_raw_mut_ptr(arr);
-            (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = matches.len() as u32;
-
-            for (i, m) in matches.iter().enumerate() {
-                // Allocating string + array re-read as one combinator (#7341).
-                let (nanboxed, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
-                    js_nanbox_string(js_string_from_str(m) as i64)
-                });
-                // GC_STORE_AUDIT(BARRIERED): regex global match array slot uses the shared array slot-store helper.
-                crate::array::store_array_slot(arr, i, nanboxed.to_bits());
-            }
-
-            arr_handle.get_raw_mut_ptr::<ArrayHeader>()
+            OwnedStringMatch::Global(matches)
         } else {
-            // Non-global: return first match only (or with capture groups)
-            match regex.captures(str_data) {
-                Some(caps) => {
-                    // Return array with full match and capture groups
-                    let arr = crate::array::js_array_alloc(caps.len() as u32);
-                    let scope = crate::gc::RuntimeHandleScope::new();
-                    let arr_handle = scope.root_raw_mut_ptr(arr);
-                    (*arr_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+            let Some(caps) = regex.captures(str_data) else {
+                LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
+                return ptr::null_mut();
+            };
+            OwnedStringMatch::NonGlobal(
+                OwnedExecMatch::from_standard(str_data, 0, regex, &caps, has_indices),
+                has_indices,
+            )
+        }
+    };
 
-                    for (i, cap) in caps.iter().enumerate() {
-                        if let Some(m) = cap {
-                            // Allocating string + array re-read as one combinator (#7341).
-                            let (nanboxed, arr) = arr_handle.across_mut::<ArrayHeader, _>(|| {
-                                js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                            });
-                            // GC_STORE_AUDIT(INIT): fresh match-array slot; layout is
-                            // noted per store and the exact layout/barrier rebuild
-                            // below the loop covers a mid-loop tenuring (#6386).
-                            crate::array::note_array_slot_layout_only(arr, i, nanboxed.to_bits());
-                        } else {
-                            // Undefined capture group - store as undefined (TAG_UNDEFINED = 0x7FFC_0000_0000_0001)
-                            let undefined = f64::from_bits(0x7FFC_0000_0000_0001);
-                            let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
-                            // GC_STORE_AUDIT(INIT): fresh match-array slot; see above.
-                            crate::array::note_array_slot_layout_only(arr, i, undefined.to_bits());
-                        }
-                    }
-                    // GC_STORE_AUDIT(BARRIERED): one exact rebuild replays any
-                    // old-gen barriers for the whole capture prefix.
-                    crate::array::rebuild_array_layout_exact(
-                        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                    );
-
-                    // Attach .index / .input as real own properties (mirrors
-                    // js_regexp_exec) so they survive aliasing and a later match
-                    // on another regex, instead of a most-recent-match thread-local.
-                    // Deferred into the combined fresh-array decoration below
-                    // (#6386) so index/input/groups cost one side-table probe
-                    // and the subject string is re-boxed, not copied.
-                    let match_char_offset = caps
-                        .get(0)
-                        .map(|m| super::utf16::byte_index_to_utf16_index(str_data, m.start()))
-                        .unwrap_or(0);
-
-                    // Build groups object for named captures (same shape as
-                    // `regex.exec(str)` does in `js_regexp_exec`). Stored in
-                    // `LAST_EXEC_GROUPS` thread-local so the HIR fold for
-                    // `result.groups` (extended in lower.rs::is_regex_exec_init
-                    // to also recognize `str.match(regex)` results) reads it
-                    // via the existing `Expr::RegExpExecGroups` codegen path.
-                    // Same caveats as exec()'s thread-local: only the most
-                    // recent match's groups are stashed, so `m1.groups` after
-                    // an intervening `m2 = ...match(...)` reads m2's groups —
-                    // acceptable for the common inline `m.groups.x` pattern.
-                    let group_names: Vec<(&str, Option<regex::Match>)> = regex
-                        .capture_names()
-                        .enumerate()
-                        .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-                        .collect();
-                    if !group_names.is_empty() {
-                        // Use the by-name setter (and a plain `js_object_alloc`)
-                        // so each match's groups object grows its own shape from
-                        // its own keys. Pre-fix this took the
-                        // `js_object_alloc_with_shape(shape_id=const, ...)` path
-                        // — every match's groups object collapsed to the same
-                        // interned shape, so a later match with different named
-                        // captures inherited the prior call's key names (e.g.
-                        // `.match(/(?<year>...)/)` followed by
-                        // `.match(/(?<id>...)/)` made the second result expose
-                        // `.year` instead of `.id`).
-                        let groups_obj = crate::object::js_object_alloc(0, 0);
-                        let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-                        for (name, m) in &group_names {
-                            let val = if let Some(m) = m {
-                                let str_ptr = js_string_from_str(m.as_str());
-                                js_nanbox_string(str_ptr as i64)
-                            } else {
-                                f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
-                            };
-                            let key_ptr = crate::string::js_string_from_bytes(
-                                name.as_ptr(),
-                                name.len() as u32,
-                            );
-                            let groups_obj =
-                                groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                            crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
-                        }
-                        LAST_EXEC_GROUPS.with(|g| {
-                            *g.borrow_mut() =
-                                groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>()
-                        });
-                        super::exec_array::set_exec_array_metadata_groups_fresh(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            s,
-                            match_char_offset as f64,
-                            groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
-                        );
-                    } else {
-                        LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                        super::exec_array::set_exec_array_metadata_groups_fresh(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            s,
-                            match_char_offset as f64,
-                            ptr::null_mut(),
-                        );
-                    }
-
-                    // Build `indices` if the `d` flag (hasIndices) is set —
-                    // non-global `String.prototype.match` delegates to
-                    // RegExpExec, so it carries the same `indices` as exec().
-                    if (*re).has_indices {
-                        set_exec_array_indices(
-                            arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
-                            str_data,
-                            0,
-                            &caps,
-                            regex,
-                        );
-                    }
-
-                    arr_handle.get_raw_mut_ptr::<ArrayHeader>()
-                }
-                None => {
-                    LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
-                    ptr::null_mut()
-                }
+    // Phase 2 (allocating, no subject borrow): materializers root the subject
+    // before their first runtime allocation and copy only from saved ranges.
+    unsafe {
+        match owned {
+            OwnedStringMatch::Global(matches) => materialize_match_list(s, &matches),
+            OwnedStringMatch::NonGlobal(data, has_indices) => {
+                let (result, groups) = materialize_exec_match(s, &data, has_indices);
+                LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = groups);
+                result
             }
         }
     }


### PR DESCRIPTION
## Summary

- snapshot standard and fancy regex captures into owned byte ranges before any runtime allocation
- materialize exec and String#match results from the rooted subject via string_copy_range
- precompute UTF-16 capture indices and add moving-minor allocation-point regressions for both paths

## Validation

- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p perry-runtime
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p perry-runtime gc::tests::runtime_roots::regexp_last_index --lib
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p perry-runtime regex::tests --lib
- allocation witness sabotage-checked against pre-fix upstream code (fails after the subject moves)
- raw-handle, unrooted-local, string-payload, GC-store, and file-size inventories pass

Fixes #8449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular-expression result handling when garbage collection moves the input string during matching.
  * Fixed potential issues with `RegExp#exec` and `String.prototype.match`, including global, sticky, fancy-regex, capture-group, named-group, and indices results.
  * Preserved correct `lastIndex` behavior and match contents during allocation-triggering operations.
* **Tests**
  * Added regression coverage for subject movement during regular-expression execution and match-result creation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->