### PR TITLE
fix(gc): pin the two per-thread scanner latches #8552 added (main is red)

### DIFF
--- a/changelog.d/8557-holders-scanner-latch-frontier.md
+++ b/changelog.d/8557-holders-scanner-latch-frontier.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **GC holders census: pin the two per-thread scanner latches that left `main`
+  red.** #8545 taught `scripts/gc_runtime_root_holders.py` to parse
+  `perry_thread_local!` declarations, and #8552 replaced process-global scanner
+  registration latches with per-thread `Cell<bool>` ones. Each change is correct
+  in isolation; together the census gained sight of two latches that no verdict
+  covered (`messaging.rs`'s `GC_SCANNER_REGISTERED`, `native_this_alias.rs`'s
+  `SCANNER_REGISTERED`), and an unclassified holder fails the gate by design.
+
+  Both are idempotence flags for `ensure_*_scanner_registered()` — they store a
+  boolean, never an address — so they are pinned on the identity-ratcheted
+  frontier. That placement is forced rather than chosen: they are rule T (the
+  census cannot see through the type) and the gate rejects a `holders` verdict
+  for a rule-T declaration as stale.

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -704,6 +704,10 @@
       "name": "TEST_FORCE_HELPER_GC"
     },
     {
+      "file": "crates/perry-runtime/src/messaging.rs",
+      "name": "GC_SCANNER_REGISTERED"
+    },
+    {
       "file": "crates/perry-runtime/src/module_require/path_registry.rs",
       "name": "MODULE_PATH_REGISTRY",
       "scanner": "scan_module_path_roots_mut"
@@ -891,6 +895,10 @@
     {
       "file": "crates/perry-runtime/src/object/native_this_alias.rs",
       "name": "ALIAS_ACTIVE"
+    },
+    {
+      "file": "crates/perry-runtime/src/object/native_this_alias.rs",
+      "name": "SCANNER_REGISTERED"
     },
     {
       "file": "crates/perry-runtime/src/object/prop_plan.rs",


### PR DESCRIPTION
## Problem

`main` (`3885ba491`) is **red** on the holders gate:

```
$ python3 scripts/gc_runtime_root_holders.py
crates/perry-runtime/src/messaging.rs:163: GC_SCANNER_REGISTERED: Cell<bool>  [rule T]
crates/perry-runtime/src/object/native_this_alias.rs:70: SCANNER_REGISTERED: Cell<bool>  [rule T]
exit 1
```

This is an interaction between two PRs that are each correct alone:

- **#8545** taught the census to parse `perry_thread_local!`, closing #8544.
- **#8552** replaced process-global scanner-registration latches with per-thread
  `Cell<bool>` ones.

Before #8545 the census could not see a `perry_thread_local!` declaration, so
#8552's new latches were invisible. After it, they are visible and unclassified,
and an unclassified holder fails the gate by design.

CI runs the bare invocation (`test.yml:411`, `:1434`), which is the failing one.
Worth noting `--list` exits **0** on the same tree, so a check that used only
`--list` would show green.

## Change

Pin both on the identity-ratcheted `frontier`.

They are `Cell<bool>` idempotence flags for `ensure_gc_scanner_registered()` /
`ensure_scanner_registered()` — they store a flag, never an address. The tables
whose registration they guard (`PORT_STATES`, `ALIASES`) are the holders with GC
standing, and their scanners visit those values.

The frontier rather than a `holders` verdict is deliberate, and not a
preference: these are rule T (the census cannot see through the type), and the
gate **rejects** a `holders` entry for a rule-T declaration as stale. I tried the
verdict first and it stayed red with `inventory has 2 stale entries`.

## Verification

- `python3 scripts/gc_runtime_root_holders.py` — **exit 1 -> 0**
- `python3 scripts/gc_runtime_root_holders.py --self-test` — OK (89 planted
  declarations classified, 68 inventory entries checked)
- Population after #8545's unmasking: **855 scanned / 621 pinned** (was 633
  scanned before it)
- Sabotage check that the gate can still fail for the case #8544 was filed about:
  deleting `reg_scanner!(crate::module_require::scan_module_path_roots_mut)`
  from `gc/mod.rs` makes the gate exit **1**. #8545's promise holds.

No version bump.
