### PR TITLE
fix(gc): pin the scanner latches #8552 added to the root-holder inventory

### DIFF
--- a/changelog.d/8557-pin-scanner-latch-holders.md
+++ b/changelog.d/8557-pin-scanner-latch-holders.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Pin the two thread-local scanner latches #8552 introduced (`messaging.rs`'s
+  `GC_SCANNER_REGISTERED`, `native_this_alias.rs`'s `SCANNER_REGISTERED`) in the
+  GC root-holder inventory. Both are `Cell<bool>` and cannot hold a heap
+  pointer, but the identity ratchet requires every new holder to be recorded.

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -704,6 +704,10 @@
       "name": "TEST_FORCE_HELPER_GC"
     },
     {
+      "file": "crates/perry-runtime/src/messaging.rs",
+      "name": "GC_SCANNER_REGISTERED"
+    },
+    {
       "file": "crates/perry-runtime/src/module_require/path_registry.rs",
       "name": "MODULE_PATH_REGISTRY",
       "scanner": "scan_module_path_roots_mut"
@@ -891,6 +895,10 @@
     {
       "file": "crates/perry-runtime/src/object/native_this_alias.rs",
       "name": "ALIAS_ACTIVE"
+    },
+    {
+      "file": "crates/perry-runtime/src/object/native_this_alias.rs",
+      "name": "SCANNER_REGISTERED"
     },
     {
       "file": "crates/perry-runtime/src/object/prop_plan.rs",


### PR DESCRIPTION
`gc_runtime_root_holders` has been **red on `main`** since #8552 merged:

```
gc_runtime_root_holders: NEW identity-ratcheted holders not pinned in the inventory's `frontier` list
  crates/perry-runtime/src/messaging.rs:163: GC_SCANNER_REGISTERED: Cell<bool>  [rule T]
  crates/perry-runtime/src/object/native_this_alias.rs:70: SCANNER_REGISTERED: Cell<bool>  [rule T]
```

Both are the thread-local latches #8552 introduced when converting process-global scanner registration (#8530). A `Cell<bool>` cannot hold a heap pointer, so this is a **record-keeping fix, not a GC-safety verdict** — the gate's own wording is that a pinned entry is not a verdict, and that distinction is worth preserving.

This is my miss: I ran this gate while validating #8552 and read its output through `head -1`, so I saw the summary line and never checked the exit code. Same shape as reading a pipeline's status instead of the script's.

After the fix: `exit=0`, 855 holder declarations scanned, 687 identity-ratcheted, 162 scanner-reached.