### PR TITLE
test(fetch): cover multi-app scanner registration

### DIFF
--- a/changelog.d/8546-multi-app-fetch-scanner.md
+++ b/changelog.d/8546-multi-app-fetch-scanner.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Preserve Fetch `Request`, `Headers`, and `FormData` registry roots for every
+  application thread in an embedded multi-app host. Previously a
+  process-global registration latch could install the Fetch scanner only for
+  the first Perry heap, so a second in-process Next application could reject
+  its HTTP handler and return 500. Add a two-application-thread regression test
+  for the per-thread scanner contract. (#8546)

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -192,6 +192,19 @@ pub(super) fn copy_only_root_scanner_counts() -> (usize, usize) {
     (rust_scanners, ffi_scanners)
 }
 
+/// Return the number of named native-package mutable-root scanners registered
+/// for the current Perry thread.
+///
+/// The registry is deliberately thread-local: an embedding host may run
+/// multiple independent Perry heaps in one process, and each heap's collector
+/// must see the scanners installed by its stdlib provider. This small
+/// diagnostic surface lets provider tests verify that contract without running
+/// a collection over fabricated heap pointers.
+#[doc(hidden)]
+pub fn gc_named_ffi_mutable_root_scanner_count() -> usize {
+    FFI_NAMED_MUTABLE_ROOT_SCANNERS.with(|scanners| scanners.borrow().len())
+}
+
 pub(super) fn registered_root_scanners_block_budgeted_gc() -> bool {
     let has_copy_only = ROOT_SCANNERS.with(|scanners| !scanners.borrow().is_empty())
         || FFI_ROOT_SCANNERS.with(|scanners| !scanners.borrow().is_empty());

--- a/crates/perry-stdlib/src/fetch/tests.rs
+++ b/crates/perry-stdlib/src/fetch/tests.rs
@@ -1,5 +1,42 @@
 use super::*;
 
+/// #8546: Coop hosts each in-process deployment on its own dedicated Perry
+/// thread. The Fetch scanner registry is thread-local, so a process-global
+/// registration latch makes the first Next application safe and leaves the
+/// second application's Request / Headers roots invisible to its collector.
+///
+/// Run the two applications sequentially so this test deterministically fails
+/// with the old `Once`: app 1 consumes the process-global latch, then app 2
+/// starts with an empty thread-local scanner registry and cannot register.
+#[test]
+fn fetch_root_scanner_registers_for_each_application_thread() {
+    for application in 1..=2 {
+        let (before, after_first, after_second) = std::thread::spawn(|| {
+            let before = perry_runtime::gc::gc_named_ffi_mutable_root_scanner_count();
+            gc::ensure_gc_registered();
+            let after_first = perry_runtime::gc::gc_named_ffi_mutable_root_scanner_count();
+            gc::ensure_gc_registered();
+            let after_second = perry_runtime::gc::gc_named_ffi_mutable_root_scanner_count();
+            (before, after_first, after_second)
+        })
+        .join()
+        .expect("application thread panicked");
+
+        assert_eq!(
+            before, 0,
+            "application {application} must start with its own empty scanner registry"
+        );
+        assert_eq!(
+            after_first, 1,
+            "application {application} did not install the Fetch root scanner"
+        );
+        assert_eq!(
+            after_second, 1,
+            "application {application} registered the Fetch root scanner twice"
+        );
+    }
+}
+
 #[test]
 fn fetch_handle_ids_use_high_small_handle_range() {
     use perry_runtime::value::addr_class;


### PR DESCRIPTION
## Summary

- add a current-thread scanner-count diagnostic so provider tests can inspect the thread-local FFI mutable-root registry without fabricating heap pointers
- model Coop's two dedicated Perry application threads and assert that each installs exactly one Fetch scanner
- document the multi-app Next dispatch fix without a version bump

## Context

While #8546 was being investigated, #8552 landed the per-thread scanner-latch correction for the underlying bug class. It was not linked to #8546 and had only a static latch audit. This adds behavioral coverage for the exact Fetch path implicated here: with the old process-global `Once`, application 1 registers successfully and application 2 sees an empty scanner registry, leaving its `Request`, `Headers`, and `FormData` roots invisible to that heap's collector.

The regression was sabotage-verified by temporarily restoring the old `Once`: it fails deterministically with `application 2 did not install the Fetch root scanner` (`left: 0`, `right: 1`). Restoring the per-thread latch makes it pass.

## Testing

- `cargo +nightly-2026-08-20 test -p perry-stdlib --no-default-features --features web-fetch fetch_root_scanner_registers_for_each_application_thread --lib -- --nocapture`
- `python3 scripts/check_gc_scanner_latches.py`
- `python3 scripts/gc_runtime_root_holders.py`
- `scripts/check_file_size.sh`
- targeted `rustfmt --check` and `git diff --check`

No version bump; `Cargo.toml` and `Cargo.lock` are unchanged.

Fixes #8546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Fetch functionality in embedded multi-application environments so each application properly initializes its required data scanners.
  * Prevented Fetch request and header data from becoming unavailable to applications after the first one.

* **Tests**
  * Added regression coverage confirming scanner registration works independently for multiple application threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->