### PR TITLE
fix(stdlib): drive active HTTP servers on fast waits

### DIFF
--- a/changelog.d/8569-next-dylib-provider-host.md
+++ b/changelog.d/8569-next-dylib-provider-host.md
@@ -1,0 +1,12 @@
+## Keep HTTP servers live during microtask-heavy startup
+
+The single-thread async wait driver's fast path now counts a listening external
+HTTP server as native work. Previously it only drove Tokio for blocking tasks
+and HTTP clients. If JavaScript kept queuing microtasks after `server.listen()`,
+`js_wait_for_event` stayed on that fast path while the server's accept task sat
+unpolled. The production Next App Route provider gate therefore depended on the
+accept task winning its initial spawn race and usually parked without serving
+its first request.
+
+`perry-stdlib` now gives the reactor a bounded turn while an external HTTP
+server is active, and its async-bridge unit tests pin that liveness condition.

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -342,16 +342,21 @@ extern "C" fn stdlib_wait_wake() {
 /// Wait-driver FAST side — a brief native drive invoked by `js_wait_for_event`
 /// when JS work is pending (a notify or queued microtasks). On the single-thread
 /// runtime, in-flight native tasks (a fetch's reqwest `send`, its h2 connection
-/// driver, sibling fetches) run ONLY inside a tick; under constant JS promise
-/// churn the fast-path is taken every iteration, so without this they are starved
-/// forever (the bundle hang). When something native IS in flight, drive one short
-/// (1 ms) tick: `block_on` drains the run queue (starts freshly-spawned sibling
-/// fetches) and parks briefly on the I/O reactor (advancing TLS/h2 round-trips),
-/// ending early if a native result is queued. No-op when nothing native is in
-/// flight, so pure-JS-async pays only an atomic load.
+/// driver, sibling fetches, or a server accept loop) run ONLY inside a tick;
+/// under constant JS promise churn the fast-path is taken every iteration, so
+/// without this they are starved forever (the bundle hang). When something
+/// native IS in flight, drive one short (1 ms) tick: `block_on` drains the run
+/// queue (starts freshly-spawned tasks) and parks briefly on the I/O reactor
+/// (advancing TLS/h2 round-trips and accepting server connections), ending early
+/// if a native result is queued. No-op when nothing native is in flight, so
+/// pure-JS-async pays only atomic loads.
 extern "C" fn stdlib_fast_drive() {
     let n = EXT_BLOCKING_TASKS_INFLIGHT.load(Ordering::Acquire);
-    let native = n > 0 || ext_http_client_inflight_fast();
+    let native = native_fast_drive_needed(
+        n,
+        ext_http_client_inflight_fast(),
+        ext_http_server_active_fast(),
+    );
     if !native {
         return;
     }
@@ -373,6 +378,27 @@ fn ext_http_client_inflight_fast() -> bool {
 #[cfg(not(feature = "external-http-client-pump"))]
 fn ext_http_client_inflight_fast() -> bool {
     false
+}
+
+#[cfg(feature = "external-http-server-pump")]
+fn ext_http_server_active_fast() -> bool {
+    extern "C" {
+        fn js_node_http_server_has_active() -> i32;
+    }
+    unsafe { js_node_http_server_has_active() != 0 }
+}
+#[cfg(not(feature = "external-http-server-pump"))]
+fn ext_http_server_active_fast() -> bool {
+    false
+}
+
+#[inline]
+fn native_fast_drive_needed(
+    blocking_tasks_inflight: usize,
+    http_client_inflight: bool,
+    http_server_active: bool,
+) -> bool {
+    blocking_tasks_inflight > 0 || http_client_inflight || http_server_active
 }
 
 /// Queue a promise resolution to be processed later
@@ -993,6 +1019,14 @@ mod tests {
     fn clear_pending() {
         PENDING_RESOLUTIONS.lock().unwrap().clear();
         PENDING_DEFERRED.lock().unwrap().clear();
+    }
+
+    #[test]
+    fn active_http_server_keeps_the_fast_wait_path_driving_native_tasks() {
+        assert!(!native_fast_drive_needed(0, false, false));
+        assert!(native_fast_drive_needed(0, false, true));
+        assert!(native_fast_drive_needed(0, true, false));
+        assert!(native_fast_drive_needed(1, false, false));
     }
 
     #[test]

--- a/tests/test_next_app_route_dylib.sh
+++ b/tests/test_next_app_route_dylib.sh
@@ -316,7 +316,11 @@ for cold_start in $(seq 1 "$cold_starts"); do
 
     ready=false
     for _ in $(seq 1 240); do
-        if curl --fail --silent --output /dev/null \
+        # A bound listener can accept the TCP connection before its Tokio
+        # accept task has received a reactor turn. Bound each probe so a
+        # provider regression fails with the host log instead of parking this
+        # gate forever inside curl (#8381).
+        if curl --fail --silent --max-time 1 --output /dev/null \
             "http://127.0.0.1:$port/api/benchmark?id=ready&iterations=1"; then
             ready=true
             break


### PR DESCRIPTION
## Summary

Keep external HTTP servers progressing when JavaScript continuously selects the event wait driver's microtask fast path. This removes the race that left the production Next App Route provider host parked before its first request, and bounds the gate's readiness probes so a recurrence produces diagnostics instead of hanging forever.

## Changes

- Treat a listening `perry-ext-http` server as native work in `stdlib_fast_drive`, giving its Tokio accept loop a bounded reactor turn during continuous JS microtask churn.
- Add a focused async-bridge regression test for the fast-drive liveness decision.
- Add `curl --max-time 1` to the provider gate's readiness probe so an accepted-but-unserved connection cannot wedge the harness.
- Document the root cause in `changelog.d`.

The unpatched retained-artifact repro failed readiness in 9/10 cold starts. With the fix, the rebased acceptance run became ready and completed the 21-request verifier.

## Related issue

Closes #8381

## Test plan

- [x] `cargo test --profile perry-dev -p perry-stdlib active_http_server_keeps_the_fast_wait_path_driving_native_tasks --lib`
- [x] `cargo check --profile perry-dev -p perry-stdlib --no-default-features --features async-runtime,external-http-server-pump`
- [x] `PERRY_NEXT_COLD_STARTS=1 PERRY_NEXT_VERIFICATIONS_PER_START=1 tests/test_next_app_route_dylib.sh` (cached compiler/provider targets; production Node oracle also passed during the initial run)
- [x] `bash -n tests/test_next_app_route_dylib.sh`
- [x] `shellcheck tests/test_next_app_route_dylib.sh`
- [x] `git diff --check upstream/main...HEAD`
- [ ] Full compile lint tier: not run because the workspace volume had only ~3 GiB free.
- [ ] Full script lint tier: 51/52 passed; the only failure is the pre-existing upstream-wide `raw_handle_debt.py` finding in `crates/perry-runtime/src/object/field_get_set/ic_miss.rs`. Its diff-aware `--no-raise-vs upstream/main` gate passed.
- [ ] `cargo build --release` clean (not run)
- [ ] Full affected-crate suite (not run; focused stdlib test above passes)
- [x] Regression coverage added in the affected crate
- [x] Docs update not applicable; no public API changed

## Checklist

- [x] I have NOT bumped the workspace version or edited `CLAUDE.md` / `CHANGELOG.md`
- [x] My commit follows the repository's `fix:` convention
- [x] I've read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup liveness when external HTTP servers are listening.
  - Ensured HTTP server activity is handled during startup alongside other asynchronous work.
  - Prevented readiness checks from hanging when a server listener is available but not responsive.

- **Tests**
  - Added coverage for startup behavior involving blocking tasks, HTTP clients, and HTTP servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->