### PR TITLE
fix(gc): convert ic_miss.rs's raw-handle reads to the scoping combinators

### DIFF
--- a/changelog.d/8570-ic-miss-raw-handles.md
+++ b/changelog.d/8570-ic-miss-raw-handles.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Convert `ic_miss.rs`'s twelve bare raw-handle reads to `with_{mut,const}_ptr`.
+  #8560 added them inside `c3c_pic_tests`; they passed the ratchet at the time
+  because the baseline was still 974, and became a violation once #8559's regex
+  capture cleanup lowered it to 925.

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -1300,7 +1300,7 @@ mod c3c_pic_tests {
         let unrelated = crate::object::js_object_alloc(0, 1);
         let unrelated = scope.root_raw_mut_ptr(unrelated);
         crate::object::set_accessor_descriptor(
-            unrelated.get_raw_mut_ptr::<crate::object::ObjectHeader>() as usize,
+            unrelated.with_mut_ptr(|o: *mut crate::object::ObjectHeader| o as usize),
             "pic_unrelated_accessor".to_string(),
             crate::object::AccessorDescriptor::default(),
         );
@@ -1314,19 +1314,15 @@ mod c3c_pic_tests {
         let key_bytes = b"pic_plain_data";
         let key = crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
         let key = scope.root_string_ptr(key);
-        crate::object::js_object_set_field_by_name(
-            obj.get_raw_mut_ptr(),
-            key.get_raw_const_ptr(),
-            42.0,
-        );
+        obj.with_mut_ptr(|o| {
+                key.with_const_ptr(|k| {
+                    crate::object::js_object_set_field_by_name(o, k, 42.0)
+                })
+            });
 
         let mut cache = [0i64; super::PIC_CACHE_WORDS];
         assert_eq!(
-            super::js_object_get_field_ic_miss(
-                obj.get_raw_mut_ptr(),
-                key.get_raw_const_ptr(),
-                &mut cache,
-            ),
+            obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache))),
             42.0
         );
         assert_ne!(
@@ -1348,25 +1344,21 @@ mod c3c_pic_tests {
         let key_bytes = b"pic_guarded_data";
         let key = crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
         let key = scope.root_string_ptr(key);
-        crate::object::js_object_set_field_by_name(
-            obj.get_raw_mut_ptr(),
-            key.get_raw_const_ptr(),
-            17.0,
-        );
+        obj.with_mut_ptr(|o| {
+                key.with_const_ptr(|k| {
+                    crate::object::js_object_set_field_by_name(o, k, 17.0)
+                })
+            });
         crate::object::set_accessor_descriptor(
-            obj.get_raw_mut_ptr::<crate::object::ObjectHeader>() as usize,
+            obj.with_mut_ptr(|o: *mut crate::object::ObjectHeader| o as usize),
             "pic_guarded_data".to_string(),
             crate::object::AccessorDescriptor::default(),
         );
 
         let mut cache = [0i64; super::PIC_CACHE_WORDS];
-        let via_pic = super::js_object_get_field_ic_miss(
-            obj.get_raw_mut_ptr(),
-            key.get_raw_const_ptr(),
-            &mut cache,
-        );
+        let via_pic = obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache)));
         let via_ladder =
-            super::js_object_get_field_by_name_f64(obj.get_raw_mut_ptr(), key.get_raw_const_ptr());
+            obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_by_name_f64(o, k)));
         assert_eq!(
             via_pic.to_bits(),
             via_ladder.to_bits(),


### PR DESCRIPTION
**The raw-handle ratchet is red on `main`** (`b50f50f15`):

```
bare raw-handle reads: 937 (baseline 925)
::error::per-module raw-handle rules: 1 violation(s)
  crates/perry-runtime/src/object/field_get_set/ic_miss.rs: 12 bare read(s) in a module with no ceiling
```

**How it got there is worth recording, because neither PR was wrong.** The twelve reads arrived with #8560, and that PR was validated at `exit=0` — against a baseline of **974**. #8559 (the regex capture-snapshot cleanup) then *lowered* the baseline to **925**, so a change that legitimately passed became a violation after an unrelated PR tightened the ratchet beneath it. That is my miss for not re-running the ratchet immediately before merging rather than only during the audit.

**Converted rather than exempted.** All twelve are argument-position reads feeding non-allocating calls, which is precisely what rule 1 of `raw_handle_debt_files.txt` describes `with_{mut,const}_ptr` for. The existing test-file exemptions in that list are for tests whose *subject is* the raw handle; these are not that, so a ceiling entry would have been the easy answer rather than the correct one.

Verified: `raw_handle_debt.py` exit=0 at 925/925, and `ic_miss` tests **19 passed, 0 failed**.