### PR TITLE
style: rustfmt ic_miss.rs (lint is red on main)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1517
+**Current Version:** 0.5.1518
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5598,7 +5598,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5666,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "cc",
  "libc",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5708,7 +5708,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5774,14 +5774,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "serde",
  "serde_json",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1517"
+version = "0.5.1518"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "clap",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "block2",
  "objc2",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5843,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "chrono",
  "cron",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "rand 0.10.1",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5925,14 +5925,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5998,7 +5998,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "bson",
  "futures-util",
@@ -6038,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "fancy-regex",
  "notify",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6136,7 +6136,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6146,14 +6146,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "serde",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "brotli",
  "flate2",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6267,7 +6267,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6309,14 +6309,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6411,14 +6411,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6427,14 +6427,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "rand 0.10.1",
  "serde",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.0",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6502,7 +6502,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1517"
+version = "0.5.1518"
 
 [[package]]
 name = "perry-ui-test"
@@ -6529,11 +6529,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1517"
+version = "0.5.1518"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "block2",
  "libc",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6600,14 +6600,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1517"
+version = "0.5.1518"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1517"
+version = "0.5.1518"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/8573-fmt-ic-miss.md
+++ b/changelog.d/8573-fmt-ic-miss.md
@@ -1,0 +1,13 @@
+**`lint` is red on `main`: `ic_miss.rs` is unformatted.**
+
+`lint` fails at its "Check formatting" step on `main`. #8572 converted `field_get_set/ic_miss.rs`'s raw-handle reads to the scoping combinators but landed the result unformatted, so `cargo fmt --all -- --check` reports a diff:
+
+```
+Diff in crates/perry-runtime/src/object/field_get_set/ic_miss.rs:1315:
+-                key.with_const_ptr(|k| {
+-                    crate::object::js_object_set_field_by_name(o, k, 42.0)
+-                })
++            key.with_const_ptr(|k| crate::object::js_object_set_field_by_name(o, k, 42.0))
+```
+
+This is `cargo fmt --all` output only — 12 lines in that one file, no other file touched, no semantic change. `cargo fmt --all -- --check` exits 0 afterwards.

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -1315,14 +1315,14 @@ mod c3c_pic_tests {
         let key = crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
         let key = scope.root_string_ptr(key);
         obj.with_mut_ptr(|o| {
-                key.with_const_ptr(|k| {
-                    crate::object::js_object_set_field_by_name(o, k, 42.0)
-                })
-            });
+            key.with_const_ptr(|k| crate::object::js_object_set_field_by_name(o, k, 42.0))
+        });
 
         let mut cache = [0i64; super::PIC_CACHE_WORDS];
         assert_eq!(
-            obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache))),
+            obj.with_mut_ptr(
+                |o| key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache))
+            ),
             42.0
         );
         assert_ne!(
@@ -1345,10 +1345,8 @@ mod c3c_pic_tests {
         let key = crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
         let key = scope.root_string_ptr(key);
         obj.with_mut_ptr(|o| {
-                key.with_const_ptr(|k| {
-                    crate::object::js_object_set_field_by_name(o, k, 17.0)
-                })
-            });
+            key.with_const_ptr(|k| crate::object::js_object_set_field_by_name(o, k, 17.0))
+        });
         crate::object::set_accessor_descriptor(
             obj.with_mut_ptr(|o: *mut crate::object::ObjectHeader| o as usize),
             "pic_guarded_data".to_string(),
@@ -1356,9 +1354,11 @@ mod c3c_pic_tests {
         );
 
         let mut cache = [0i64; super::PIC_CACHE_WORDS];
-        let via_pic = obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache)));
-        let via_ladder =
-            obj.with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_by_name_f64(o, k)));
+        let via_pic = obj.with_mut_ptr(|o| {
+            key.with_const_ptr(|k| super::js_object_get_field_ic_miss(o, k, &mut cache))
+        });
+        let via_ladder = obj
+            .with_mut_ptr(|o| key.with_const_ptr(|k| super::js_object_get_field_by_name_f64(o, k)));
         assert_eq!(
             via_pic.to_bits(),
             via_ladder.to_bits(),


### PR DESCRIPTION
**`lint` is red on `main`: `ic_miss.rs` is unformatted.**

`lint` fails at its "Check formatting" step on `main`. #8572 converted `field_get_set/ic_miss.rs`'s raw-handle reads to the scoping combinators but landed the result unformatted, so `cargo fmt --all -- --check` reports a diff:

```
Diff in crates/perry-runtime/src/object/field_get_set/ic_miss.rs:1315:
-                key.with_const_ptr(|k| {
-                    crate::object::js_object_set_field_by_name(o, k, 42.0)
-                })
+            key.with_const_ptr(|k| crate::object::js_object_set_field_by_name(o, k, 42.0))
```

This is `cargo fmt --all` output only — 12 lines in that one file, no other file touched, no semantic change. `cargo fmt --all -- --check` exits 0 afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented release version to 0.5.1518.
  * Added a changelog entry for formatting corrections.

* **Maintenance**
  * Incremented the workspace version to 0.5.1518.
  * Standardized formatting in internal test code without changing behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->