### PR TITLE
fix(runtime): exclude prototypes from learned instance width

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -51,6 +51,8 @@ mod state;
 mod vm_brand;
 
 // ── state.rs ────────────────────────────────────────────────────────────────
+#[cfg(test)]
+pub(crate) use state::class_decl_prototype_object_root_store;
 pub(crate) use state::{
     class_decl_prototype_object, class_decl_prototype_value,
     class_decl_prototype_value_for_instance_class, class_delete_own_dynamic_prop,

--- a/crates/perry-runtime/src/object/spill.rs
+++ b/crates/perry-runtime/src/object/spill.rs
@@ -134,6 +134,7 @@ pub(crate) fn spill_set(obj_ptr: usize, field_index: usize, vbits: u64) {
                 // path below) with the same `field_index + 1`.
                 if field_index >= (*spill).length as usize {
                     note_learned_inline_fields(
+                        obj as usize,
                         (*obj).class_id,
                         (field_index as u32).saturating_add(1),
                     );
@@ -241,7 +242,11 @@ fn spill_set_slow(obj_ptr: usize, field_index: usize, vbits: u64) {
         // First write at this width for this object — record the class's
         // high-water mark (the fast path only records when growing an
         // existing buffer's length).
-        note_learned_inline_fields((*obj).class_id, (field_index as u32).saturating_add(1));
+        note_learned_inline_fields(
+            obj_ptr,
+            (*obj).class_id,
+            (field_index as u32).saturating_add(1),
+        );
         // Root the owner: meta/buffer allocation below can trigger a moving
         // minor GC. Reload through the handle after every allocation.
         let scope = crate::gc::RuntimeHandleScope::new();
@@ -385,8 +390,22 @@ fn hot_learned_inline_fields() -> &'static LearnedInlineTable {
 }
 
 #[inline]
-fn note_learned_inline_fields(class_id: u32, needed_fields: u32) {
+fn note_learned_inline_fields(obj_ptr: usize, class_id: u32, needed_fields: u32) {
     if class_id == 0 || needed_fields > LEARNED_INLINE_MAX_FIELDS {
+        return;
+    }
+    // Declared and function-class prototype objects carry the INSTANCE class
+    // id so reflection and prototype dispatch can recover their owner. Their
+    // own storage width is unrelated to an instance's field layout: a class
+    // with eight instance fields can easily have dozens of prototype methods.
+    // Learning from that spill makes later instances allocate at the
+    // prototype width and stamps a different birth ShapeId, permanently
+    // defeating exact-shape field/method guards. Both prototype registries are
+    // keyed by the same class id, so pointer equality is an exact, O(1) veto.
+    let obj = obj_ptr as *mut ObjectHeader;
+    if crate::object::class_decl_prototype_object(class_id) == obj
+        || crate::object::class_prototype_object(class_id) == obj
+    {
         return;
     }
     let slot = (class_id as usize).wrapping_mul(0x9E37_79B1) % LEARNED_INLINE_TABLE_SIZE;
@@ -445,7 +464,11 @@ pub(crate) fn overflow_set(obj_ptr: usize, field_index: usize, vbits: u64) {
     // Learn the class's true width so FUTURE instances allocate it inline.
     unsafe {
         let hdr = obj_ptr as *const ObjectHeader;
-        note_learned_inline_fields((*hdr).class_id, (field_index as u32).saturating_add(1));
+        note_learned_inline_fields(
+            obj_ptr,
+            (*hdr).class_id,
+            (field_index as u32).saturating_add(1),
+        );
     }
     let st = crate::state::state();
     let cached_slot = unsafe {
@@ -481,4 +504,42 @@ pub(crate) fn overflow_set(obj_ptr: usize, field_index: usize, vbits: u64) {
     }
     crate::gc::layout_note_slot(obj_ptr, field_index, vbits);
     crate::gc::runtime_write_barrier_external_slot(obj_ptr, slot_addr, vbits);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prototype_spills_do_not_teach_instance_inline_width() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const DECLARED_CID: u32 = 0x6B45_5A11;
+        const FUNCTION_CID: u32 = 0x6B45_5A12;
+
+        let declared_proto = js_object_alloc(DECLARED_CID, 0);
+        crate::object::class_decl_prototype_object_root_store(DECLARED_CID, declared_proto);
+        overflow_set(declared_proto as usize, 12, crate::value::TAG_UNDEFINED);
+        assert_eq!(
+            learned_inline_field_count(DECLARED_CID),
+            0,
+            "declared Class.prototype storage is not an instance-layout sample"
+        );
+
+        let function_proto = js_object_alloc(FUNCTION_CID, 0);
+        crate::object::class_prototype_object_root_store(FUNCTION_CID, function_proto);
+        overflow_set(function_proto as usize, 15, crate::value::TAG_UNDEFINED);
+        assert_eq!(
+            learned_inline_field_count(FUNCTION_CID),
+            0,
+            "function prototype storage is not an instance-layout sample"
+        );
+
+        let instance = js_object_alloc(DECLARED_CID, 0);
+        overflow_set(instance as usize, 12, crate::value::TAG_UNDEFINED);
+        assert_eq!(
+            learned_inline_field_count(DECLARED_CID),
+            13,
+            "a real instance overflow must still teach the class high-water mark"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- exclude registered declared-class and function-class prototype objects from learned instance inline-width samples
- pass the concrete owner identity to every width-learning call site
- keep ordinary instance spills training the class high-water mark

## Root cause

Prototype objects intentionally carry their owning instance class id for reflection and prototype dispatch. The learned inline-width table keyed only on that class id, so installing methods/properties on a prototype could teach the allocator that future instances needed the prototype's much larger storage width.

In the ECS reproducer, an eight-field class's prototype spill trained a live width of 33. New instances were then born with a different ShapeId than the compiler-published eight-field method guard, so the exact guard could never succeed.

The fix retains width learning and changes its admission contract to include object identity. It rejects only exact pointers registered in `CLASS_DECL_PROTOTYPE_OBJECTS` or `CLASS_PROTOTYPE_OBJECTS`; a real instance with the same class id still updates the high-water mark.

## Tests

- focused prototype/instance regression with default object-owned spill — passed
- same regression with `PERRY_OBJECT_SPILL=0` legacy storage — passed
- `cargo test --release -p perry-runtime --lib` — 2,617 passed, 4 ignored
- spill-filter cohort — 5 passed
- `cargo check --release -p perry-runtime`
- `cargo fmt --all -- --check`
- complete upstream ECS functional corpus with the accepted prototype stack — 35/37 files and 461/463 cases, matching the established Perry baseline (only the known singleton shorthand and `Symbol.dispose` mismatches)

This is one of three serial exact-guard blockers found in the ECS query profile. The combined accepted stack reduced the six query units from 4.0688 ms/op to 1.1052 ms/op; this PR deliberately does not claim that combined speedup as an isolated effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object storage behavior so prototype objects no longer influence instance field layout learning.
  * Preserved accurate field handling for regular object instances.

* **Tests**
  * Added coverage verifying prototype spills are ignored while instance spills continue to update learned field counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->