### PR TITLE
fix(codegen): validate forwarded array target before header load

### DIFF
--- a/changelog.d/8582-validate-forward-target.md
+++ b/changelog.d/8582-validate-forward-target.md
@@ -1,0 +1,4 @@
+Fixed guarded array reads so a selected forwarding target is validated as a
+heap address before Perry dereferences its header. Invalid or longer forwarding
+chains now route to the boxed fallback instead of permitting a speculative
+native header load.

--- a/crates/perry-codegen/src/codegen/index_method_clone_tests.rs
+++ b/crates/perry-codegen/src/codegen/index_method_clone_tests.rs
@@ -302,6 +302,25 @@ fn guarded_read_can_follow_one_forwarding_edge_but_rechecks_the_live_header() {
         .find(|line| line.contains(" = select i1") && line.contains(", i64 "))
         .and_then(|line| line.trim().split_once(" = ").map(|(name, _)| name))
         .unwrap_or_else(|| panic!("clone has no selected live array handle:\n{clone}"));
+    let selected_target_guard = clone
+        .split("\narr.guard.deref.")
+        .nth(1)
+        .and_then(|body| body.split("\narr.guard.live.").next())
+        .unwrap_or_else(|| panic!("clone has no selected-target guard block:\n{clone}"));
+    assert!(
+        selected_target_guard.contains("label %arr.guard.live.")
+            && selected_target_guard.contains("label %arr.fallback.")
+            && !selected_target_guard.contains(&format!("sub i64 {live_handle}, 8")),
+        "the selected target must branch on its address before any live-header load:\n{selected_target_guard}"
+    );
+    let live_header_guard = clone
+        .split("\narr.guard.live.")
+        .nth(1)
+        .unwrap_or_else(|| panic!("clone has no live-header guard block:\n{clone}"));
+    assert!(
+        live_header_guard.contains(&format!("sub i64 {live_handle}, 8")),
+        "the live header must be loaded only after the selected address is validated:\n{live_header_guard}"
+    );
     let fast = clone
         .split("arr.fast")
         .nth(1)

--- a/crates/perry-codegen/src/expr/index_get/guarded_array.rs
+++ b/crates/perry-codegen/src/expr/index_get/guarded_array.rs
@@ -81,6 +81,8 @@ pub(super) fn lower_guarded_array_index_get(
         // typed-`number[]`-slower-than-untyped inversion for reads.
         let deref_idx = ctx.new_block(&format!("{}.guard.deref", block_prefix));
         let deref_label = ctx.block_label(deref_idx);
+        let live_deref_idx = ctx.new_block(&format!("{}.guard.live", block_prefix));
+        let live_deref_label = ctx.block_label(live_deref_idx);
         let cold_guard_idx = if require_numeric_layout {
             Some(ctx.new_block(&format!("{}.guard.cold", block_prefix)))
         } else {
@@ -102,7 +104,7 @@ pub(super) fn lower_guarded_array_index_get(
         }
 
         ctx.current_block = deref_idx;
-        {
+        let live_handle = {
             let blk = ctx.block();
             let arr_bits = blk.bitcast_double_to_i64(arr_box);
             let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
@@ -133,7 +135,18 @@ pub(super) fn lower_guarded_array_index_get(
             let live_top = blk.lshr(I64, &live_handle, "48");
             let live_top_clear = blk.icmp_eq(I64, &live_top, "0");
             let live_above_handle_band = blk.icmp_ugt(I64, &live_handle, "1048575");
+            let live_heap_candidate = blk.and(I1, &live_top_clear, &live_above_handle_band);
+            // A forwarding word is not trusted until its address is in the
+            // heap band. In particular, do not read the destination header
+            // speculatively: malformed or longer chains must reach the boxed
+            // fallback without a native dereference of the selected target.
+            blk.cond_br(&live_heap_candidate, &live_deref_label, &fallback_label);
+            live_handle
+        };
 
+        ctx.current_block = live_deref_idx;
+        {
+            let blk = ctx.block();
             let live_gc_type_addr = blk.sub(I64, &live_handle, "8");
             let live_gc_type_ptr = blk.inttoptr(I64, &live_gc_type_addr);
             let live_gc_type = blk.load(I8, &live_gc_type_ptr);
@@ -165,9 +178,7 @@ pub(super) fn lower_guarded_array_index_get(
             let capacity_sane = blk.icmp_ule(I32, &capacity, "16000000");
             let length_within_capacity = blk.icmp_ule(I32, &length, &capacity);
 
-            let mut guard_ok = blk.and(I1, &live_top_clear, &live_above_handle_band);
-            guard_ok = blk.and(I1, &guard_ok, &is_array);
-            guard_ok = blk.and(I1, &guard_ok, &not_forwarded);
+            let mut guard_ok = blk.and(I1, &is_array, &not_forwarded);
             guard_ok = blk.and(I1, &guard_ok, &no_descriptors);
             guard_ok = blk.and(I1, &guard_ok, &default_prototype_chain);
             guard_ok = blk.and(I1, &guard_ok, &index_nonnegative);


### PR DESCRIPTION
The one-edge array forwarding guard added in #8580 selected the forwarding word and computed its address-band predicates, but loaded the selected target header before those predicates controlled execution. A malformed or longer-chain target could therefore be dereferenced natively instead of reaching the semantic fallback.

This adds a dedicated validated-target block. The selected address must have clear high bits and be above the handle band before any destination header, length, or capacity load. An invalid selected target routes directly to the boxed fallback; valid targets keep the existing brand, forwarding, descriptor, prototype, bounds, and layout guards.

The emitted-IR regression proves the selected-target block branches to the validated successor or fallback before computing live_handle - 8, and that the destination header load appears only in the validated successor.

Validation:
- cargo test --release -p perry-codegen --lib: 1132 passed
- focused emitted-IR regression passed
- cargo fmt --all -- --check
- cargo check --release -p perry-codegen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of forwarding targets before accessing referenced data.
  - Invalid or excessively long forwarding chains now safely use the boxed fallback path.
  - Added safeguards to prevent malformed addresses from being dereferenced.
  - Improved reliability of indexed access when encountering invalid or unexpected runtime object references.

- **Tests**
  - Added coverage verifying forwarding targets are validated before their headers are accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->