### PR TITLE
test(zlib): ratchet implemented async symbols

### DIFF
--- a/changelog.d/8601-zlib-async-symbol-ratchet.md
+++ b/changelog.d/8601-zlib-async-symbol-ratchet.md
@@ -1,0 +1,3 @@
+Updated the optimized zlib coverage ratchet to require the asynchronous
+`deflateRaw`, `inflateRaw`, and `unzip` extension symbols that are already
+implemented and dispatched by `perry-ext-zlib`.

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -1148,11 +1148,6 @@ fn ext_zlib_covers_every_stdlib_symbol_the_flip_strips() {
         "js_zlib_has_active_handles",
         "js_zlib_native_dispatch",
         "js_zlib_process_pending",
-        // Genuine one-shot gaps. Same shape as the #8005 pair; they have not
-        // broken a link only because no gap test links them on this path yet.
-        "js_zlib_deflate_raw",
-        "js_zlib_inflate_raw",
-        "js_zlib_unzip",
     ];
 
     fn exported_zlib_symbols(dir: &Path) -> std::collections::BTreeSet<String> {


### PR DESCRIPTION
## Summary

- remove the stale known-gap exemptions for `js_zlib_deflate_raw`, `js_zlib_inflate_raw`, and `js_zlib_unzip`
- make the optimized-library coverage test require the async zlib exports that are already implemented and dispatched by `perry-ext-zlib`

This is a test-ratchet correction only; it changes no runtime behavior. It also fixes the current base-related `cargo-test` failure observed while validating #8588.

## Test

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/perry-pr-prestatepoint/target cargo test --release -p perry --bin perry commands::compile::optimized_libs::tests::ext_zlib_covers_every_stdlib_symbol_the_flip_strips -- --exact --nocapture`