### PR TITLE
feat(native): enforce bundled binding governance

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -523,20 +523,21 @@ jobs:
         # the link deduper then cannot remove the whole second copy, and the
         # HTTP accept loop reads a different async reactor from the one the JS
         # event loop drives.
-        # Best-effort per crate: a wrapper that can't build on this host must
-        # not fail the whole release — the packaging glob below ships
-        # whatever was produced.
+        # #5716: the governance inventory is the explicit shipping set; adding
+        # a crate requires a recorded retain/migration decision. Best-effort
+        # per crate: a wrapper that can't build on this host must not fail the
+        # whole release — packaging below ships whatever was produced.
         if: runner.os != 'Windows' && matrix.old_glibc_image == ''
         run: |
-          for d in crates/perry-ext-*; do
-            [ -d "$d" ] || continue
-            name=$(basename "$d")
+          set -euo pipefail
+          governed_ext_packages=$(./scripts/release_ext_packages.sh)
+          while IFS= read -r name; do
             echo "::group::build $name"
             cargo build --profile dist --target ${{ matrix.target }} \
               -p perry -p perry-runtime-static -p perry-stdlib-static -p "$name" \
               || echo "  (skipped $name — failed to build on this host)"
             echo "::endgroup::"
-          done
+          done <<< "$governed_ext_packages"
 
       # #6351: only GTK4 needs noble. Build the compiler, runtime, stdlib and
       # extension archives in a Debian 11 container so their ABI floor is

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -311,6 +311,13 @@ jobs:
         if: ${{ !cancelled() }}
         run: node scripts/binding_pins.mjs --check
 
+      # #5716: every bundled extension needs an explicit product disposition;
+      # mappings, workspace members, crate directories, release enumeration,
+      # and the published inventory must stay in lock-step.
+      - name: Bundled binding governance
+        if: ${{ !cancelled() }}
+        run: python3 scripts/binding_governance.py --check
+
       # GC write-barrier store-site inventory: every raw heap-slot store in
       # perry-codegen / perry-runtime / perry-stdlib must be barriered or
       # carry a justified GC_STORE_AUDIT(...) marker (or a justified entry

--- a/changelog.d/5716-native-binding-governance.md
+++ b/changelog.d/5716-native-binding-governance.md
@@ -1,0 +1,6 @@
+Defined an enforceable policy for bundled native bindings: ordinary
+JavaScript and TypeScript packages now have recorded upstream-source migration
+targets, native/domain integrations have external-package targets, and shared
+runtime APIs have explicit retain/consolidate decisions. Release builds consume
+the governed inventory, while existing compatibility shims remain bundled until
+their documented migration gates pass.

--- a/crates/perry/well_known_bindings.toml
+++ b/crates/perry/well_known_bindings.toml
@@ -29,6 +29,12 @@
 # Migration order tracks #466 Phase 5 (smallest first). Each entry
 # is gated on the bundled crate actually existing in the workspace
 # — wrappers that haven't been ported yet have no entry.
+#
+# This file describes current resolver behavior, not permission to keep a
+# package-specific Rust rewrite indefinitely. Before adding or removing a
+# bundled crate, update its `migration` in `workspace-architecture.json`; CI
+# requires every ext crate and package mapping to have an explicit decision
+# (#5716).
 
 [bindings.dotenv]
 crate = "perry-ext-dotenv"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
 
 - [Porting Packages (experimental)](packages/porting.md)
 - [Native Bindings — Overview](native-libraries/overview.md)
+  - [Bundled Binding Governance](native-libraries/governance.md)
   - [Authoring a Native Binding](native-libraries/authoring-guide.md)
   - [`perry-ffi` ABI Reference](native-libraries/abi.md)
   - [Manifest Schema (spec v1)](native-libraries/manifest-v1.md)

--- a/docs/src/contributing/crate-policy.md
+++ b/docs/src/contributing/crate-policy.md
@@ -42,6 +42,10 @@ Every member is classified in `workspace-architecture.json`:
 Its `decision` records the reviewed direction: `keep`, `merge`, `externalize`,
 `remove`, or `review`. Decisions describe the architecture roadmap; they do not
 authorize deleting compatibility without the relevant migration and tests.
+Binding entries also carry a `migration` that refines the general decision:
+`core-runtime`, `compile-source`, `external-package`, or `remove`. The native
+[binding governance policy](../native-libraries/governance.md) defines those
+targets and their compatibility gates.
 
 Choose the decision by applying the same seam test consistently:
 

--- a/docs/src/native-libraries/governance.md
+++ b/docs/src/native-libraries/governance.md
@@ -1,0 +1,113 @@
+# Bundled native-binding governance
+
+Perry's compatibility goal is to compile real TypeScript and JavaScript
+packages. A package-specific Rust rewrite can be useful as a temporary bridge,
+but it is not the default compatibility strategy and does not demonstrate that
+Perry can compile the package it replaces.
+
+## Policy
+
+Use this order when adding package compatibility:
+
+1. Compile the upstream JavaScript or TypeScript package source with
+   `perry.compilePackages`.
+2. When that fails on a reusable Node.js or Web API, improve the shared
+   runtime API rather than rewriting the package.
+3. Use `perry.nativeLibrary` only for a true native-addon or system-library
+   boundary. Domain-specific bindings should ship as independently versioned
+   external packages.
+4. Keep an in-tree `perry-ext-*` crate only for a shared runtime API or a small
+   strategic shim whose maintenance and release cost has been accepted
+   explicitly.
+
+A proposal for a new bundled extension must identify the native boundary or
+shared runtime capability, explain why compiling the package source is not
+viable, name an owner, account for build and binary cost, define its
+faithfulness level, and include an exit or consolidation plan. An ordinary npm
+package is not eligible merely because a Rust implementation is convenient.
+
+## Categories and migration gates
+
+- **Runtime API** bindings implement foundational Node.js or Web capabilities
+  used by many packages. They stay in or near core for now and may eventually
+  be consolidated into `perry-stdlib` or the runtime. A third-party package
+  alias can still be reassessed separately.
+- **Source package** bindings replace packages whose upstream implementation
+  can in principle be compiled. Their migration target is the real upstream
+  source plus fixes to shared language, module, and runtime support.
+- **External integration** bindings cross a real native boundary or provide a
+  product/domain integration. Their migration target is an official or
+  third-party package using `perry.nativeLibrary`, with its own release cycle.
+- **Obsolete integration** bindings have no supported long-term owner. Remove
+  them only after checking current consumers and documenting the compatibility
+  impact.
+
+`perry-ext-fetch` is a mixed case: compiling `node-fetch` upstream does not
+remove the Fetch API. The shared `fetch`/`Headers`/`Request`/`Response`
+capability must first live in the runtime; only the package-specific alias and
+wrapper are migration candidates.
+
+Migration candidates remain bundled for compatibility. Remove a source-package
+binding only after a representative upstream version compiles, has conformance
+coverage for the supported surface, and has an upgrade note. Remove an external
+integration only after installable artifacts exist for the supported targets
+and the replacement path is documented. Removing a well-known mapping before
+those gates pass is a breaking change.
+
+The root workspace's `default-members` intentionally excludes extension
+crates. Distribution builds use the inventory below as their explicit shipping
+set; changing that set therefore requires changing the recorded decision and
+passing the governance check.
+
+## Current inventory
+
+`workspace-architecture.json` is the source of truth for the crate decision and
+binding-specific migration target. The CI check requires it to cover every
+`perry-ext-*` directory and workspace member, and joins it with package mappings
+from `well_known_bindings.toml`. Regenerate this table with
+`python3 scripts/binding_governance.py --table`.
+
+<!-- BEGIN GENERATED BINDING GOVERNANCE -->
+| Crate | Package mapping(s) | Category | Migration target | Current status |
+|---|---|---|---|---|
+| `perry-ext-ads` | `perry/ads` | Obsolete integration | Remove after compatibility review | Bundled; removal pending |
+| `perry-ext-argon2` | `argon2` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-axios` | `axios` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-bcrypt` | `bcrypt` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-better-sqlite3` | `better-sqlite3` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-cheerio` | `cheerio` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-commander` | `commander` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-cron` | `cron`<br>`node-cron` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-dayjs` | `date-fns`<br>`dayjs` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-decimal` | `bignumber.js`<br>`decimal.js` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-dotenv` | `dotenv` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-ethers` | `ethers` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-events` | `events` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+| `perry-ext-exponential-backoff` | `exponential-backoff` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-fastify` | `fastify` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-fetch` | `fetch`<br>`node-fetch` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-http` | `http`<br>`http2`<br>`https` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+| `perry-ext-ioredis` | `ioredis`<br>`iovalkey`<br>`redis` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-jsonwebtoken` | `jsonwebtoken` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-lru-cache` | `lru-cache` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-moment` | `moment` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-mongodb` | `mongodb` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-mysql2` | `mysql2`<br>`mysql2/promise` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-nanoid` | `nanoid` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-net` | `net` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+| `perry-ext-node-forge` | `node-forge` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-nodemailer` | `nodemailer` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-parcel-watcher` | `@parcel/watcher`<br>`@parcel/watcher-darwin-arm64`<br>`@parcel/watcher-darwin-x64`<br>`@parcel/watcher-linux-arm64-glibc`<br>`@parcel/watcher-linux-arm64-musl`<br>`@parcel/watcher-linux-x64-glibc`<br>`@parcel/watcher-linux-x64-musl`<br>`@parcel/watcher-win32-arm64`<br>`@parcel/watcher-win32-x64` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-pdf` | `@perryts/pdf` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-pg` | `pg` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-ratelimit` | `rate-limiter-flexible` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-sharp` | `sharp` | External integration | Move to an external native package | Bundled; migration pending |
+| `perry-ext-slugify` | `slugify` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-streams` | `streams` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+| `perry-ext-typescript` | `typescript` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-undici` | `undici` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-uuid` | `uuid` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-validator` | `validator` | Source package | Compile the upstream package source | Bundled; migration pending |
+| `perry-ext-ws` | `ws` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+| `perry-ext-zlib` | `zlib` | Runtime API | Keep near core; consolidate when practical | Bundled; retained |
+<!-- END GENERATED BINDING GOVERNANCE -->

--- a/docs/src/native-libraries/overview.md
+++ b/docs/src/native-libraries/overview.md
@@ -6,6 +6,14 @@ in JavaScript-engine glue — it lands on a Rust function that's been
 linked into the binary as `extern "C"`. This page is the map of how
 that works end-to-end.
 
+Native bindings are an escape hatch for native and system boundaries, not
+Perry's default npm compatibility mechanism. Pure JavaScript and TypeScript
+packages should be compiled from their upstream source, and missing shared
+Node.js or Web APIs should be implemented once in the runtime. The in-tree
+well-known table still contains compatibility shims while those migrations are
+completed; see [Bundled native-binding governance](governance.md) for the
+policy and the decision recorded for every extension crate.
+
 ## The big picture
 
 There are four layers, from most stable to most flexible:
@@ -29,12 +37,12 @@ There are four layers, from most stable to most flexible:
 │       → the user installed an external binding via                │
 │         `bun add @scope/<name>`. Wins over (b) and (c).           │
 │                                                                   │
-│    b. node_modules/<name>/ without perry.nativeLibrary            │
-│       → fall through to V8/JS interpretation.                     │
+│    b. node_modules/<name>/ selected by compilePackages            │
+│       → compile the installed JavaScript/TypeScript source.        │
 │                                                                   │
 │    c. well-known table (well_known_bindings.toml)                 │
-│       → Perry ships the binding in its install. ~30 names like   │
-│         dotenv / mysql2 / axios / ws / lru-cache / commander.     │
+│       → Perry ships a runtime API or transitional compatibility  │
+│         shim. The governance inventory records its destination.  │
 │                                                                   │
 │    d. nothing matches → resolution error at compile time.         │
 └─────────────────────────────────────────────────────────────────┘
@@ -89,11 +97,10 @@ walks each search path looking for `node_modules/mysql2/`:
 - **If `node_modules/mysql2/package.json` exists with a
   `perry.nativeLibrary` block**: parse the manifest, treat the package
   as a native binding. Skip layers (c) and (d).
-- **If `node_modules/mysql2/` exists without a
-  `perry.nativeLibrary` block**: this is a JS-only npm package; fall
-  through to the V8 / JS interpretation path (separate compilation
-  flow).
-- **If `node_modules/mysql2/` doesn't exist at all**: consult the
+- **If `mysql2` is selected through `perry.compilePackages`**: compile the
+  installed JavaScript package source. This is the intended long-term path for
+  `mysql2` and other source packages.
+- **Otherwise**: consult the
   **well-known table** at
   [`crates/perry/well_known_bindings.toml`](https://github.com/PerryTS/perry/blob/main/crates/perry/well_known_bindings.toml).
   The table maps `mysql2` → `perry-ext-mysql2` (a Rust crate that
@@ -205,10 +212,9 @@ crates/
   perry-stdlib/           ← Layer 1: in-tree wrappers (perry/ui, fs,
                             crypto helpers, etc. — anything genuinely
                             coupled to runtime internals)
-  perry-ext-<name>/       ← Layer 3, well-known: mysql2, pg, ioredis,
-                            cron, decimal, dayjs, axios, ethers,
-                            commander, … (~27 today). All depend on
-                            perry-ffi only.
+  perry-ext-<name>/       ← Layer 3: selectively linked runtime APIs and
+                            compatibility shims. Their retained/migration
+                            decisions live in workspace-architecture.json.
 
 External native bindings (Layer 3, third-party — Rust + perry-ffi):
   PerryTS/tursodb-bindings    → bun add @perryts/tursodb
@@ -222,12 +228,13 @@ External pure-TypeScript drivers (compiled via compilePackages):
   PerryTS/redis               → bun add @perryts/redis
 ```
 
-The split between **well-known** in-tree wrappers and **external** is
-a packaging convention, not a technical distinction. Both depend only
-on perry-ffi; both ship `extern "C"` symbols Perry's codegen calls.
-The well-known set is the ~30 packages every JS dev expects to import
-without an `npm install` step (`dotenv`, `axios`, `mysql2`, …).
-External wrappers are everything else.
+The split between **well-known** in-tree wrappers and **external** is a
+packaging convention, not a technical distinction. Both depend only on
+perry-ffi; both ship `extern "C"` symbols Perry's codegen calls. The policy
+difference is intentional: an in-tree wrapper needs a shared runtime reason to
+remain in core. Ordinary source packages should migrate to
+`compilePackages`, while domain-specific native integrations should migrate to
+external packages with independent releases.
 
 The two existing external native wrappers (`tursodb`, `iroh`) cover
 functionality that doesn't have an in-tree perry-stdlib equivalent —
@@ -237,12 +244,13 @@ wrapper without forking Perry.
 
 ## Three paths to a database driver (postgres / mysql / mongodb / redis)
 
-Perry currently ships two parallel database-driver families. Picking
-one is a packaging trade-off, not a feature trade-off:
+Perry currently ships parallel database-driver families. The bundled native
+drivers remain compatibility bridges; compiling real JavaScript/TypeScript
+drivers is the migration target:
 
 | Path | Install | Resolver layer | What it is |
 |---|---|---|---|
-| **Well-known native binding** | nothing (bundled) | (c) | `import 'mysql2'` / `import 'pg'` / `import 'mongodb'` route to in-tree `perry-ext-mysql2` / `perry-ext-pg` / `perry-ext-mongodb`. Rust wrappers around `sqlx` / `mongodb` crates. Versioned in lockstep with Perry. |
+| **Well-known native binding** | nothing (bundled) | (c) | Compatibility path: `import 'mysql2'` / `import 'pg'` / `import 'mongodb'` route to in-tree Rust wrappers. They remain available until the source-package migration gates pass. |
 | **`@perryts/{postgres,mysql,mongodb,redis}`** | `bun add @perryts/postgres` | (a) | Pure-TypeScript wire-protocol drivers — no Rust, no native dep. Use Perry's [`compilePackages`](../packages/porting.md) to compile the TS to native via LLVM. Also run unmodified on Node.js / Bun. Independent semver. |
 | **External native binding** | `bun add @perryts/tursodb` | (a) | Third-party Rust crate using `perry-ffi`, manifest at `package.json::perry.nativeLibrary`. Today: `@perryts/tursodb`, `@perryts/iroh`. |
 
@@ -255,9 +263,9 @@ shim, just don't import `mysql2`.
 
 **When to pick which:**
 
-- **Well-known native (`mysql2` / `pg` / `mongodb`)** — zero install
-  step, fastest path to "it works"; you accept that the driver's
-  feature set tracks Perry's release cadence.
+- **Well-known native (`mysql2` / `pg` / `mongodb`)** — current zero-install
+  compatibility path; its feature set tracks Perry's release cadence and it is
+  scheduled to yield to compiled package source.
 - **`@perryts/postgres` / `@perryts/mysql` / `@perryts/mongodb` / `@perryts/redis`** —
   you want to read / fork / patch the driver in plain TypeScript;
   you want the same code running on Node.js or Bun for fallback;
@@ -270,7 +278,7 @@ shim, just don't import `mysql2`.
 
 | If you want to … | Read |
 |---|---|
-| **Use `mysql2` / `dotenv` / etc. in a Perry program** | Nothing! `import` and go — Perry ships them in the well-known set. |
+| **Use a currently bundled compatibility shim** | `import` it directly, or explicitly select the installed package in `perry.compilePackages` to exercise the preferred source path. |
 | **Use a third-party native binding** | `bun add <package>`, then `import`. Perry's resolver finds it via `node_modules/<pkg>/package.json`. |
 | **Find which packages ship out-of-the-box** | `perry native list` |
 | **Write your own native binding** | `perry native init my-bindings` scaffolds the Cargo crate + `package.json` + `release.yml` for prebuilds. Then read [`abi.md`](abi.md) for the perry-ffi surface and [`manifest-v1.md`](manifest-v1.md) for the manifest schema. |

--- a/docs/src/packages/porting.md
+++ b/docs/src/packages/porting.md
@@ -13,6 +13,20 @@ Perry compiles a practical subset of TypeScript. Most pure TS/JS packages can be
 | Package's core API is built on `Proxy` (ORMs, validation DSLs, reactive stores) | **Probably not portable.** The surface Perry-users touch is the Proxy. |
 | Package is pure TS/JS but uses `Symbol`, `WeakMap`, `console.dir`, etc. | **Patchable.** See [Common gaps](#common-gaps) below. |
 
+## Compatibility policy
+
+Compiling the real package is Perry's default compatibility path. When a pure
+package fails, record the first compiler or runtime gap and fix the shared
+language, module, Node.js, or Web capability when possible. Do not add an
+in-tree `perry-ext-<package>` Rust rewrite to bypass that work.
+
+A Perry native binding is appropriate for the smallest true native or system
+boundary. Package-specific and domain-specific bindings should normally be
+published outside the Perry repository through `perry.nativeLibrary`; only
+foundational runtime APIs and explicitly approved strategic shims belong in
+core. See [Bundled native-binding governance](../native-libraries/governance.md)
+for the admission rules and current migration inventory.
+
 ## Native addon packages
 
 `compilePackages` is only for JavaScript and TypeScript packages. It
@@ -33,9 +47,10 @@ For those packages, use one of these paths instead:
 - write or install a thin Perry native binding that exposes the public
   package API through `perry.nativeLibrary`.
 
-The last option should replace only the native boundary. It should not
-rewrite a whole npm package in Rust unless the package is already just a
-small native facade.
+The last option should replace only the native boundary. Publish it as an
+external package unless it meets the in-tree admission policy; it should not
+rewrite a whole npm package in Rust unless the package is already just a small
+native facade.
 
 ### Known-working packages
 

--- a/docs/src/stdlib/overview.md
+++ b/docs/src/stdlib/overview.md
@@ -1,6 +1,9 @@
 # Standard Library Overview
 
-Perry natively implements many popular npm packages and Node.js APIs. When you import a supported package, Perry compiles it to native code — no JavaScript runtime involved.
+Perry compiles supported npm packages and Node.js APIs to native code — no
+JavaScript runtime involved. Shared runtime APIs have native implementations;
+ordinary JavaScript and TypeScript dependencies should be compiled from their
+upstream source.
 
 ## How It Works
 
@@ -8,13 +11,16 @@ Perry natively implements many popular npm packages and Node.js APIs. When you i
 {{#include ../../examples/stdlib/overview/snippets.ts:imports}}
 ```
 
-Perry recognizes these imports at compile time and routes them to native
-Rust implementations. Most live in standalone `perry-ext-*` crates
-backed by the stable [`perry-ffi` ABI](../native-libraries/abi.md) (the
-"well-known native bindings" registry shipped in v0.5.532); a few of
-the older Node.js built-ins still live in `perry-stdlib`. Either way the
-import surface matches the original npm package, so existing code often
-works unchanged.
+Perry recognizes these imports at compile time. Today, many route to
+standalone `perry-ext-*` Rust compatibility shims backed by the stable
+[`perry-ffi` ABI](../native-libraries/abi.md); a few older Node.js built-ins
+still live in `perry-stdlib`. These shims expose documented supported surfaces
+and remain available during migration, but most ordinary packages are intended
+to move to upstream-source compilation. See the
+[binding governance inventory](../native-libraries/governance.md) for each
+crate's disposition and
+[zero-config bindings and faithfulness](../native-libraries/zero-config-and-faithfulness.md)
+for compatibility guarantees.
 
 ## Supported Packages
 

--- a/scripts/binding_governance.py
+++ b/scripts/binding_governance.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate and render the bundled native-binding governance inventory."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import json
+from pathlib import Path
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCHITECTURE_PATH = ROOT / "workspace-architecture.json"
+BINDINGS_PATH = ROOT / "crates/perry/well_known_bindings.toml"
+CARGO_PATH = ROOT / "Cargo.toml"
+DOC_PATH = ROOT / "docs/src/native-libraries/governance.md"
+START = "<!-- BEGIN GENERATED BINDING GOVERNANCE -->"
+END = "<!-- END GENERATED BINDING GOVERNANCE -->"
+
+# Binding-specific migration targets refine workspace-architecture.json's
+# general keep/externalize/remove decision without creating a second policy.
+MIGRATIONS = {
+    "core-runtime": {
+        "decision": "keep",
+        "category": "Runtime API",
+        "target": "Keep near core; consolidate when practical",
+        "status": "Bundled; retained",
+    },
+    "compile-source": {
+        "decision": "externalize",
+        "category": "Source package",
+        "target": "Compile the upstream package source",
+        "status": "Bundled; migration pending",
+    },
+    "external-package": {
+        "decision": "externalize",
+        "category": "External integration",
+        "target": "Move to an external native package",
+        "status": "Bundled; migration pending",
+    },
+    "remove": {
+        "decision": "remove",
+        "category": "Obsolete integration",
+        "target": "Remove after compatibility review",
+        "status": "Bundled; removal pending",
+    },
+}
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def load_architecture() -> dict:
+    with ARCHITECTURE_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def binding_packages_by_crate() -> dict[str, list[str]]:
+    packages: dict[str, list[str]] = defaultdict(list)
+    for package, entry in load_toml(BINDINGS_PATH)["bindings"].items():
+        packages[entry["crate"]].append(package)
+    return {crate: sorted(names) for crate, names in packages.items()}
+
+
+def workspace_extension_crates() -> set[str]:
+    members = load_toml(CARGO_PATH)["workspace"]["members"]
+    return {
+        Path(member).name
+        for member in members
+        if Path(member).name.startswith("perry-ext-")
+    }
+
+
+def extension_directories() -> set[str]:
+    return {path.name for path in (ROOT / "crates").glob("perry-ext-*") if path.is_dir()}
+
+
+def governance_entries() -> dict[str, dict]:
+    crates = load_architecture().get("crates")
+    if not isinstance(crates, dict):
+        raise ValueError(f"{ARCHITECTURE_PATH}: missing `crates` object")
+    return {
+        name: entry
+        for name, entry in crates.items()
+        if isinstance(entry, dict) and entry.get("category") == "binding"
+    }
+
+
+def format_set_difference(label: str, actual: set[str], expected: set[str]) -> list[str]:
+    failures = []
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        failures.append(f"{label} is missing: {', '.join(missing)}")
+    if extra:
+        failures.append(f"{label} has unexpected entries: {', '.join(extra)}")
+    return failures
+
+
+def validate(entries: dict[str, dict]) -> tuple[list[str], dict[str, list[str]]]:
+    failures: list[str] = []
+    governed = set(entries)
+    mapped = binding_packages_by_crate()
+    mapped_crates = set(mapped)
+    workspace = workspace_extension_crates()
+    directories = extension_directories()
+
+    failures += format_set_difference("architecture binding inventory", governed, directories)
+    failures += format_set_difference("workspace extension members", workspace, directories)
+    failures += format_set_difference("well-known binding crates", mapped_crates, directories)
+
+    required_fields = {"category", "decision", "migration"}
+    for crate, entry in sorted(entries.items()):
+        fields = set(entry)
+        missing_fields = required_fields - fields
+        if missing_fields:
+            failures.append(
+                f"{crate}: missing required governance fields {sorted(missing_fields)}"
+            )
+            continue
+
+        migration = entry["migration"]
+        if not isinstance(migration, str) or migration not in MIGRATIONS:
+            failures.append(f"{crate}: unknown migration target {migration!r}")
+            continue
+        expected_decision = MIGRATIONS[migration]["decision"]
+        if entry["decision"] != expected_decision:
+            failures.append(
+                f"{crate}: migration {migration!r} requires decision "
+                f"{expected_decision!r}, got {entry['decision']!r}"
+            )
+
+    return failures, mapped
+
+
+def render_table(entries: dict[str, dict], packages_by_crate: dict[str, list[str]]) -> str:
+    lines = [
+        "| Crate | Package mapping(s) | Category | Migration target | Current status |",
+        "|---|---|---|---|---|",
+    ]
+    for crate, entry in sorted(entries.items()):
+        policy = MIGRATIONS[entry["migration"]]
+        packages = "<br>".join(f"`{package}`" for package in packages_by_crate[crate])
+        lines.append(
+            f"| `{crate}` | {packages} | {policy['category']} | "
+            f"{policy['target']} | {policy['status']} |"
+        )
+    return "\n".join(lines)
+
+
+def check_doc(table: str) -> list[str]:
+    if not DOC_PATH.is_file():
+        return [f"missing governance document: {DOC_PATH}"]
+    doc = DOC_PATH.read_text()
+    expected = f"{START}\n{table}\n{END}"
+    if expected not in doc:
+        return [
+            "docs/src/native-libraries/governance.md inventory is stale; "
+            "replace the generated block with `python3 scripts/binding_governance.py --table`"
+        ]
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="validate policy and docs")
+    mode.add_argument("--table", action="store_true", help="print the generated Markdown table")
+    args = parser.parse_args()
+
+    try:
+        entries = governance_entries()
+        failures, packages_by_crate = validate(entries)
+    except (
+        json.JSONDecodeError,
+        KeyError,
+        OSError,
+        TypeError,
+        ValueError,
+        tomllib.TOMLDecodeError,
+    ) as error:
+        print(f"binding governance error: {error}", file=sys.stderr)
+        return 1
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}", file=sys.stderr)
+        return 1
+
+    table = render_table(entries, packages_by_crate)
+    if args.table:
+        print(table)
+        return 0
+
+    failures = check_doc(table)
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}", file=sys.stderr)
+        return 1
+    print(f"binding governance OK — {len(entries)} extension crates classified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_linux_glibc_2_31.sh
+++ b/scripts/build_linux_glibc_2_31.sh
@@ -55,18 +55,18 @@ CARGO_TARGET_DIR="$abort_target_dir" CARGO_PROFILE_DIST_PANIC=abort \
 cp "$abort_target_dir/$target/dist/libperry_runtime.a" \
    "$target_dir/$target/dist/libperry_runtime_abort.a"
 
-# Match the ordinary release leg's best-effort extension-library build. Keep
-# perry and both wrappers in each invocation so Cargo resolves one feature
-# union and the final linker can deduplicate their shared dependencies.
-for dir in crates/perry-ext-*; do
-  [ -d "$dir" ] || continue
-  package=$(basename "$dir")
+# Match the ordinary release leg's best-effort extension-library build. #5716:
+# enumerate the explicit governance inventory rather than every matching
+# directory. Keep perry and both wrappers in each invocation so Cargo resolves
+# one feature union and the final linker can deduplicate shared dependencies.
+governed_ext_packages=$(./scripts/release_ext_packages.sh)
+while IFS= read -r package; do
   echo "::group::build $package"
   cargo build --profile dist --target "$target" \
     -p perry -p perry-runtime-static -p perry-stdlib-static -p "$package" \
     || echo "  (skipped $package -- failed to build on the glibc 2.31 sysroot)"
   echo "::endgroup::"
-done
+done <<< "$governed_ext_packages"
 
 compiler="$target_dir/$target/dist/perry"
 max_glibc=$(

--- a/scripts/release_ext_packages.sh
+++ b/scripts/release_ext_packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Print the explicitly governed perry-ext-* package set for release builds.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+registry="$repo_root/workspace-architecture.json"
+
+packages=$(
+  sed -n \
+    's/^[[:space:]]*"\(perry-ext-[A-Za-z0-9-]*\)"[[:space:]]*:[[:space:]]*{[[:space:]]*$/\1/p' \
+    "$registry" | sort
+)
+if [ -z "$packages" ]; then
+  echo "no release extension packages found in $registry" >&2
+  exit 1
+fi
+
+printf '%s\n' "$packages"

--- a/workspace-architecture.json
+++ b/workspace-architecture.json
@@ -140,163 +140,203 @@
     },
     "perry-ext-ads": {
       "category": "binding",
-      "decision": "remove"
+      "decision": "remove",
+      "migration": "remove"
     },
     "perry-ext-argon2": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-axios": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-bcrypt": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-better-sqlite3": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-cheerio": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-commander": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-cron": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-dayjs": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-decimal": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-dotenv": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-ethers": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-events": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ext-exponential-backoff": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-fastify": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-fetch": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-node-forge": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-parcel-watcher": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-undici": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-http": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ext-ioredis": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-jsonwebtoken": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-lru-cache": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-moment": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-mongodb": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-mysql2": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-nanoid": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-net": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ext-nodemailer": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-pdf": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-pg": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-ratelimit": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-sharp": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "external-package"
     },
     "perry-ext-slugify": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-streams": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ext-typescript": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-uuid": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-validator": {
       "category": "binding",
-      "decision": "externalize"
+      "decision": "externalize",
+      "migration": "compile-source"
     },
     "perry-ext-ws": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ext-zlib": {
       "category": "binding",
-      "decision": "keep"
+      "decision": "keep",
+      "migration": "core-runtime"
     },
     "perry-ffi": {
       "category": "runtime-core",


### PR DESCRIPTION
## Summary

Define Perry's bundled-native-binding policy as an enforceable migration contract. The PR preserves every existing compatibility shim while recording whether each extension belongs near core, should yield to compiled upstream source, should move to an external native package, or should be removed after review.

## Changes

- Extend the existing `workspace-architecture.json` policy with migration targets for all 40 `perry-ext-*` crates: 6 core/runtime, 27 upstream-source migrations, 6 external-package migrations, and 1 reviewed removal.
- Add a generated documentation inventory with admission rules and compatibility-safe migration gates.
- Add a CI check that keeps architecture decisions, workspace members, crate directories, package mappings, and the published table in lock-step.
- Make Unix release builds enumerate the explicitly governed extension set instead of implicitly globbing every matching directory.
- Update the native-binding, package-porting, stdlib, and contributor docs to prefer real JS/TS package compilation and shared runtime APIs.
- Keep all current bindings bundled; this PR removes no mapping or compatibility path.

## Related issue

Fixes #5716

## Test plan

- [ ] `cargo build --release` clean (not run; no production Rust changed)
- [ ] Full workspace test scope passes (not run)
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `python3 scripts/binding_governance.py --check`
- [x] `python3 scripts/workspace_architecture.py --self-test`
- [x] `python3 scripts/workspace_architecture.py --check --print-summary`
- [x] `node scripts/binding_pins.mjs --check`
- [x] `cargo test -p perry release_ext_builds_share_the_shipped_runtime_feature_set`
- [x] `cargo run -p perry-doc-tests -- --lint docs/src`
- [x] `./docs/i18n.sh build en`
- [x] `shellcheck scripts/release_ext_packages.sh scripts/build_linux_glibc_2_31.sh`
- [x] Added an affected CI policy check and updated user-facing docs

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository's Conventional Commit style
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining when native bindings are used versus compiling packages from source.
  - Documented supported migration paths, compatibility requirements, and policies for native integrations.
  - Added a dedicated native-binding governance section and navigation entry.
  - Clarified package porting, standard-library behavior, resolver selection, and compatibility-shim usage.
  - Added an inventory of bundled bindings and their current migration status.

- **Build Improvements**
  - Release builds now use a validated inventory of approved native extensions, improving consistency and preventing unintended packages from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->