### PR TITLE
test(link): guard prebuilt stdlib HTTP isolation (#8587)

### DIFF
--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -19,7 +19,10 @@ crate-type = ["rlib"]
 # Default: include everything for backwards compatibility
 default = ["full"]
 
-# Full stdlib - everything included
+# Full stdlib - every self-contained implementation. External pump features
+# must stay out of this list: release archives enable `full` without linking
+# their per-program provider archives, and adding an external HTTP pump here
+# made HTTP-free Linux UI links require libperry_ext_http.a (#5983, #8587).
 full = ["http-server", "http-client", "database", "crypto", "compression", "email", "websocket", "image", "scheduler", "ids", "html-parser", "rate-limit", "validation", "net", "tls", "bundled-dotenv", "bundled-lru-cache", "bundled-exponential-backoff", "bundled-events", "bundled-decimal", "bundled-dayjs", "bundled-moment", "bundled-commander", "bundled-streams"]
 
 # Minimal core - just what's needed for basic programs

--- a/crates/perry/tests/issue_8587_prebuilt_stdlib_http_isolation.rs
+++ b/crates/perry/tests/issue_8587_prebuilt_stdlib_http_isolation.rs
@@ -1,0 +1,68 @@
+//! Regression coverage for #8587.
+//!
+//! Release archives build `perry-stdlib-static` with its default feature set.
+//! That eventually enables `perry-stdlib/full`, which must remain
+//! self-contained: the `external-http-*-pump` features declare C symbols that
+//! are provided only when the compiler also selects `libperry_ext_http.a`.
+//! Making either pump part of `full` breaks otherwise HTTP-free prebuilt
+//! consumers such as a minimal Linux `perry/ui` application.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn local_feature_closure(
+    features: &toml::Table,
+    roots: impl IntoIterator<Item = String>,
+) -> BTreeSet<String> {
+    let mut pending: Vec<String> = roots.into_iter().collect();
+    let mut enabled = BTreeSet::new();
+
+    while let Some(feature) = pending.pop() {
+        if !enabled.insert(feature.clone()) {
+            continue;
+        }
+
+        let Some(members) = features.get(&feature).and_then(toml::Value::as_array) else {
+            continue;
+        };
+        for member in members.iter().filter_map(toml::Value::as_str) {
+            // Only bare names refer to another feature in this manifest.
+            // `dep:name` and `crate/feature` entries leave this feature graph.
+            if !member.starts_with("dep:") && !member.contains('/') {
+                pending.push(member.trim_end_matches('?').to_owned());
+            }
+        }
+    }
+
+    enabled
+}
+
+#[test]
+fn release_full_stdlib_does_not_enable_external_http_pumps() {
+    let manifest_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../perry-stdlib/Cargo.toml");
+    let source = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+    let manifest: toml::Value = toml::from_str(&source)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", manifest_path.display()));
+    let features = manifest
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .expect("perry-stdlib must declare a [features] table");
+
+    for pump in ["external-http-client-pump", "external-http-server-pump"] {
+        assert!(
+            features.contains_key(pump),
+            "the regression guard must track the current external HTTP pump feature name: {pump}"
+        );
+    }
+
+    let default = local_feature_closure(features, ["default".to_owned()]);
+    for pump in ["external-http-client-pump", "external-http-server-pump"] {
+        assert!(
+            !default.contains(pump),
+            "perry-stdlib's release/default feature graph must not enable `{pump}`: it creates \
+             unresolved libperry_ext_http.a references in HTTP-free prebuilt links (#8587)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- document that the release/default stdlib feature graph may contain only self-contained implementations
- add a regression test that follows transitive Cargo feature edges and rejects either external HTTP pump in the default release archive

## Root cause

Perry 0.5.1220 briefly enabled `external-http-client-pump` through `perry-stdlib/full`. That feature emits references provided only by `libperry_ext_http.a`, while HTTP-free `perry/ui` builds do not select that archive. The same coupling accounts for the extra symbols seen after adding `fetch()`.

The behavior fix already landed in #5983 and shipped in 0.5.1239, but it had no focused regression guard. This PR pins that release-link contract so the 0.5.1220 configuration cannot recur, including through an indirect feature edge.

## Tests

- `cargo test -p perry --test issue_8587_prebuilt_stdlib_http_isolation`
- `cargo test -p perry-stdlib --lib` (120 passed)
- `rustfmt --edition 2021 --check crates/perry/tests/issue_8587_prebuilt_stdlib_http_isolation.rs`
- `git diff --check`

No version bump.

Closes #8587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the full standard library feature includes self-contained implementations and excludes external HTTP pump features.
  * Documented the link-time impact of enabling an external HTTP pump.

* **Tests**
  * Added regression coverage verifying external HTTP pump features remain disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->