### PR TITLE
style: rustfmt the module-global typed-array test (main fmt is red)

### DIFF
--- a/changelog.d/8623-fmt-module-global-ta-test.md
+++ b/changelog.d/8623-fmt-module-global-ta-test.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Format `crates/perry/tests/module_global_typed_array_read.rs`, which landed
+  unformatted with #8617 and left `cargo fmt --check` red on `main`.

--- a/crates/perry/tests/module_global_typed_array_read.rs
+++ b/crates/perry/tests/module_global_typed_array_read.rs
@@ -117,7 +117,10 @@ fn module_global_float64array_read_is_inlined_and_bit_exact() {
     let fast = run(&dir.path().join("fast"), dir.path());
     let slow = run(&dir.path().join("slow"), dir.path());
     assert_eq!(fast, EXPECTED, "fast-path output");
-    assert_eq!(slow, fast, "fast path must be bit-exact with js_typed_array_get");
+    assert_eq!(
+        slow, fast,
+        "fast path must be bit-exact with js_typed_array_get"
+    );
 }
 
 const I32_SOURCE: &str = r#"
@@ -161,5 +164,8 @@ fn module_global_int32array_read_is_inlined_and_bit_exact() {
     let fast = run(&dir.path().join("fast32"), dir.path());
     let slow = run(&dir.path().join("slow32"), dir.path());
     assert_eq!(fast, I32_EXPECTED);
-    assert_eq!(slow, fast, "i32 fast path must be bit-exact with the runtime getter");
+    assert_eq!(
+        slow, fast,
+        "i32 fast path must be bit-exact with the runtime getter"
+    );
 }


### PR DESCRIPTION
`cargo fmt --all -- --check` is **exit 1 on `main`** (`73df2a6e7`):

```
Diff in crates/perry/tests/module_global_typed_array_read.rs:117
Diff in crates/perry/tests/module_global_typed_array_read.rs:161
```

The file is #8617's new integration test, and it landed unformatted. Eight lines of whitespace, no code change.

**This is my process error, and the shape is worth recording.** I caught the same formatting problem while staging #8617 in a validation stack, fixed it *there*, and confirmed the stack green — then merged the four PRs individually with `gh pr merge`. So the tree I validated included a fix that the tree I merged did not. Validating a stack that carries local fixes and then merging the unfixed PRs means the thing validated is not the thing that lands.

The fix for next time is either to push staging fixes to the PR branches before merging, or to land the validated stack itself rather than the individual PRs — as I did for the join reconciliation and the cache-key union resolutions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formatting issues in typed array tests so formatting checks pass successfully.
  * Preserved existing Float64Array and Int32Array assertion behavior while improving readability.

* **Documentation**
  * Added a changelog entry documenting the formatting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->