### PR TITLE
fix: land #8621 and #8622 with the missing changelog fragment

### DIFF
--- a/changelog.d/8621-web-textfield-callback-strings.md
+++ b/changelog.d/8621-web-textfield-callback-strings.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Web `TextField`, `SecureField`, and `TextArea` callbacks now receive their
+  entered text as strings instead of numeric `NaN` values. The WASM closure
+  bridge converts browser values directly to its BigInt ABI without an
+  intermediate NaN-boxed JavaScript number. (#8584)

--- a/changelog.d/8622-prebuilt-stdlib-http-isolation.md
+++ b/changelog.d/8622-prebuilt-stdlib-http-isolation.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Guard the prebuilt stdlib HTTP isolation contract with a regression test that
+  follows transitive Cargo feature edges, so the 0.5.1220 configuration (which
+  enabled `external-http-client-pump` through `perry-stdlib/full`) cannot recur
+  through an indirect edge (#8587).

--- a/crates/perry-codegen-wasm/src/lib.rs
+++ b/crates/perry-codegen-wasm/src/lib.rs
@@ -101,3 +101,25 @@ fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::WASM_RUNTIME_JS;
+
+    #[test]
+    fn text_input_callbacks_pass_plain_js_strings_to_wasm_closures() {
+        assert_eq!(
+            WASM_RUNTIME_JS
+                .matches("callWasmClosure(el._perryCallback, el.value)")
+                .count(),
+            3,
+            "TextField, SecureField, and TextArea must pass their DOM strings directly"
+        );
+        assert!(
+            !WASM_RUNTIME_JS
+                .lines()
+                .any(|line| { line.contains("callWasmClosure") && line.contains("fromJsValue") }),
+            "callWasmClosure owns JS-value conversion; callers must not pre-box arguments"
+        );
+    }
+}

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2603,6 +2603,8 @@ function uiGet(h) { return uiHandles.get(h); }
 
 // Helper: call a WASM closure — accepts either a raw NaN-boxed f64 handle,
 // or a JS closure object ({funcIdx, captures}) from toJsValue conversion.
+// Extra args must be plain JS values: this function owns their one conversion
+// to i64 bits. Pre-boxing a string as f64 lets JS canonicalize its NaN payload.
 // WASM functions use i64 (BigInt) params/returns.
 function callWasmClosure(closureVal, ...extraArgs) {
   let closure;
@@ -2766,7 +2768,7 @@ function perry_ui_textfield_create(placeholder, callback) {
   el.placeholder = placeholder || "";
   el._perryCallback = callback;
   el.addEventListener("input", () => {
-    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, fromJsValue(el.value));
+    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, el.value);
   });
   return uiAlloc(el);
 }
@@ -2775,7 +2777,7 @@ function perry_ui_securefield_create(placeholder, callback) {
   el.placeholder = placeholder || "";
   el._perryCallback = callback;
   el.addEventListener("input", () => {
-    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, fromJsValue(el.value));
+    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, el.value);
   });
   return uiAlloc(el);
 }
@@ -2935,7 +2937,7 @@ function perry_ui_textarea_create(placeholder, callback) {
   el.placeholder = placeholder || "";
   el._perryCallback = callback;
   el.addEventListener("input", () => {
-    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, fromJsValue(el.value));
+    if (el._perryCallback !== undefined) callWasmClosure(el._perryCallback, el.value);
   });
   return uiAlloc(el);
 }
@@ -3164,7 +3166,7 @@ function perry_ui_state_get(h) { return uiStateGet(h); }
 function perry_ui_state_set(h, v) { uiStateSet(h, v); }
 function perry_ui_state_on_change(stateH, callback) {
   const s = uiStates.get(stateH);
-  if (s) s.subscribers.push((val) => callWasmClosure(callback, fromJsValue(val)));
+  if (s) s.subscribers.push((val) => callWasmClosure(callback, val));
 }
 function perry_ui_state_bind_text(stateH, widgetH) {
   const el = uiGet(widgetH), s = uiStates.get(stateH);
@@ -3585,13 +3587,13 @@ function perry_ui_clipboard_write(text) { try { navigator.clipboard.writeText(te
 // ---------- Dialog ----------
 function perry_ui_open_file_dialog(callback) {
   const input = document.createElement("input"); input.type = "file";
-  input.addEventListener("change", () => { if (input.files.length) callWasmClosure(callback, fromJsValue(input.files[0].name)); });
+  input.addEventListener("change", () => { if (input.files.length) callWasmClosure(callback, input.files[0].name); });
   input.click();
 }
 function perry_ui_open_folder_dialog(callback) { perry_ui_open_file_dialog(callback); }
 function perry_ui_save_file_dialog(callback, defaultName) {
   const name = prompt("Save as:", defaultName || "file.txt");
-  if (name) callWasmClosure(callback, fromJsValue(name));
+  if (name) callWasmClosure(callback, name);
 }
 function perry_ui_alert(title, message, buttons, callback) {
   alert((title || "") + "\n" + (message || ""));
@@ -3889,7 +3891,7 @@ function _perry_media_flush_state(handle) {
   const e = _perry_media_get(handle);
   if (!e || e.onStateChange === undefined || e.onStateChange === null) return;
   try {
-    callWasmClosure(e.onStateChange, fromJsValue(e.state));
+    callWasmClosure(e.onStateChange, e.state);
   } catch (err) { console.warn("perry/media onStateChange threw:", err); }
 }
 

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -19,7 +19,10 @@ crate-type = ["rlib"]
 # Default: include everything for backwards compatibility
 default = ["full"]
 
-# Full stdlib - everything included
+# Full stdlib - every self-contained implementation. External pump features
+# must stay out of this list: release archives enable `full` without linking
+# their per-program provider archives, and adding an external HTTP pump here
+# made HTTP-free Linux UI links require libperry_ext_http.a (#5983, #8587).
 full = ["http-server", "http-client", "database", "crypto", "compression", "email", "websocket", "image", "scheduler", "ids", "html-parser", "rate-limit", "validation", "net", "tls", "bundled-dotenv", "bundled-lru-cache", "bundled-exponential-backoff", "bundled-events", "bundled-decimal", "bundled-dayjs", "bundled-moment", "bundled-commander", "bundled-streams"]
 
 # Minimal core - just what's needed for basic programs

--- a/crates/perry/tests/issue_8587_prebuilt_stdlib_http_isolation.rs
+++ b/crates/perry/tests/issue_8587_prebuilt_stdlib_http_isolation.rs
@@ -1,0 +1,68 @@
+//! Regression coverage for #8587.
+//!
+//! Release archives build `perry-stdlib-static` with its default feature set.
+//! That eventually enables `perry-stdlib/full`, which must remain
+//! self-contained: the `external-http-*-pump` features declare C symbols that
+//! are provided only when the compiler also selects `libperry_ext_http.a`.
+//! Making either pump part of `full` breaks otherwise HTTP-free prebuilt
+//! consumers such as a minimal Linux `perry/ui` application.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn local_feature_closure(
+    features: &toml::Table,
+    roots: impl IntoIterator<Item = String>,
+) -> BTreeSet<String> {
+    let mut pending: Vec<String> = roots.into_iter().collect();
+    let mut enabled = BTreeSet::new();
+
+    while let Some(feature) = pending.pop() {
+        if !enabled.insert(feature.clone()) {
+            continue;
+        }
+
+        let Some(members) = features.get(&feature).and_then(toml::Value::as_array) else {
+            continue;
+        };
+        for member in members.iter().filter_map(toml::Value::as_str) {
+            // Only bare names refer to another feature in this manifest.
+            // `dep:name` and `crate/feature` entries leave this feature graph.
+            if !member.starts_with("dep:") && !member.contains('/') {
+                pending.push(member.trim_end_matches('?').to_owned());
+            }
+        }
+    }
+
+    enabled
+}
+
+#[test]
+fn release_full_stdlib_does_not_enable_external_http_pumps() {
+    let manifest_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../perry-stdlib/Cargo.toml");
+    let source = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", manifest_path.display()));
+    let manifest: toml::Value = toml::from_str(&source)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", manifest_path.display()));
+    let features = manifest
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .expect("perry-stdlib must declare a [features] table");
+
+    for pump in ["external-http-client-pump", "external-http-server-pump"] {
+        assert!(
+            features.contains_key(pump),
+            "the regression guard must track the current external HTTP pump feature name: {pump}"
+        );
+    }
+
+    let default = local_feature_closure(features, ["default".to_owned()]);
+    for pump in ["external-http-client-pump", "external-http-server-pump"] {
+        assert!(
+            !default.contains(pump),
+            "perry-stdlib's release/default feature graph must not enable `{pump}`: it creates \
+             unresolved libperry_ext_http.a references in HTTP-free prebuilt links (#8587)"
+        );
+    }
+}


### PR DESCRIPTION
Lands **#8621** and **#8622** together, with #8622's missing changelog fragment supplied.

**Landing the validated branch rather than the two PRs individually — deliberately.** #8622 shipped without a `changelog.d` fragment, so I wrote one while staging. An hour ago I made the opposite choice on a four-PR batch: I fixed a formatting problem in my validation stack, confirmed it green, then merged the PRs individually — and the fix never reached `main`, which went red on `cargo fmt --check` until #8624. Validating a tree that carries local fixes and then merging a different tree is the error; landing the validated branch avoids it.

| check | result |
|---|---|
| `cargo check --workspace --all-targets` | **exit 0** |
| `perry-runtime --lib` (`RUST_TEST_THREADS=1`) | **2636 passed**, 4 ignored |
| all seven ratchets | 0 |
| `cargo fmt --all -- --check` | 0 |

Ratchets re-run against the current baseline immediately before merge.

**#8622 is a good shape for a regression guard.** The behaviour fix landed in #5983 and shipped in 0.5.1239; what was missing was anything preventing recurrence. It pins the release-link contract by following *transitive* Cargo feature edges and rejecting either external HTTP pump in the default release archive — so the 0.5.1220 configuration cannot come back through an indirect edge, which is how it arrived the first time. A guard that only checked the direct feature list would have passed against the original bug.

Closes #8621. Closes #8622.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Web text input callbacks now deliver entered values as strings for text, secure, and multiline fields.
  - Prevented unnecessary HTTP requirements from affecting HTTP-free prebuilt Linux UI builds.

- **Tests**
  - Added regression coverage to verify text callback values and protect HTTP feature isolation.

- **Documentation**
  - Clarified standard library feature boundaries and callback value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->