### PR TITLE
fix(ci): tolerate a missing target/debug/deps in the cargo-test prune step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1078,7 +1078,7 @@ jobs:
               cargo build --release -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static
               export PERRY_RUNTIME_DIR="$PWD/target/release"
             fi
-            find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
+            find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete 2>/dev/null || true
             # Large perry / perry-stdlib integration-test binaries: serialize
             # builds and prune linked executables between packages so the runner
             # disk doesn't exhaust mid-job.
@@ -1088,7 +1088,7 @@ jobs:
               cargo test -p "$package"
               echo "::endgroup::"
               cargo clean -p "$package" || true
-              find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
+              find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete 2>/dev/null || true
             done
           else
             # ---- FAST per-PR run (<10 min target) ----


### PR DESCRIPTION
## Summary

Fixes a CI script bug that has been failing `main`'s scheduled and push runs repeatedly, unrelated to any specific PR's code changes.

<details>
<summary>What broke and why</summary>

The full `cargo-test` job (nightly cron, release tags, `workflow_dispatch`) prunes linked test binaries between packages to avoid exhausting runner disk, using a bare `find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete`.

That directory only exists once something has actually built into it. When the job's scope builds straight to `--release` (the `perry`/`perry-stdlib` branch just above the first prune call) and no `cargo test -p <package>` has run yet, `target/debug/deps` is absent, `find` exits 1, and the whole job fails, even when every test in it passed. I confirmed this against a real run: `cargo test` reported `2595 passed; 0 failed`, and the job still failed on this exact line right after.

</details>

## Changes

Both prune calls in `.github/workflows/test.yml` (`find target/debug/deps ...`) now redirect stderr and fall back to `true`, so a missing directory is treated as a no-op instead of a job failure. The behavior when the directory does exist is unchanged.

## Related issue

n/a

## Test plan

I confirmed the failure mode against a real CI run at `https://github.com/PerryTS/perry/actions/runs/32553699612`, where the `cargo-test` job passed every test and then failed on this exact line with `find: 'target/debug/deps': No such file or directory`. I ran `actionlint` against the edited workflow file and it reported no new findings, only two pre-existing unrelated shellcheck notes elsewhere in the file that this change does not touch. `cargo build --release` and the workspace test suite are not applicable here, since no Rust source changed.

## Checklist

I have not bumped the workspace version or edited CLAUDE.md or CHANGELOG.md. My commit follows the `fix:` prefix convention used in the log. I have read CONTRIBUTING.md and agree to the Code of Conduct.
