### PR TITLE
merge: land #8629 (cargo-test prune tolerates a missing target/debug/deps)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1078,7 +1078,7 @@ jobs:
               cargo build --release -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static
               export PERRY_RUNTIME_DIR="$PWD/target/release"
             fi
-            find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
+            find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete 2>/dev/null || true
             # Large perry / perry-stdlib integration-test binaries: serialize
             # builds and prune linked executables between packages so the runner
             # disk doesn't exhaust mid-job.
@@ -1088,7 +1088,7 @@ jobs:
               cargo test -p "$package"
               echo "::endgroup::"
               cargo clean -p "$package" || true
-              find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete
+              find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete 2>/dev/null || true
             done
           else
             # ---- FAST per-PR run (<10 min target) ----

--- a/changelog.d/8629-prune-tolerates-missing-deps.md
+++ b/changelog.d/8629-prune-tolerates-missing-deps.md
@@ -1,0 +1,11 @@
+Fixed the full-tier `cargo-test` job failing after every test passed. The step
+prunes linked test binaries between packages with a bare
+`find target/debug/deps … -delete`, but that directory only exists once
+something has built into it — when the job's scope builds straight to
+`--release` and no `cargo test -p <package>` has run yet, `find` exits 1 and
+GitHub's default `bash -e` fails the whole job.
+
+Both prune calls now tolerate a missing directory. Note the guard also
+suppresses genuine `find` errors: the prune is disk hygiene, so its failure
+should never fail the job, but if it ever silently stops working the symptom
+would be a later disk exhaustion rather than a pointed error.


### PR DESCRIPTION
Lands #8629 (external contributor, fork PR) plus the changelog fragment it was
missing.

## Audit

The mechanism checks out: `find` on a missing directory exits 1, and GitHub
Actions runs `run:` blocks as `bash -e {0}`, so that rc kills the step even
though every test passed. Verified locally — rc 1 before the guard, rc 0 after.

`actionlint` findings are **identical on `origin/main` and on this branch**
(same 3, at lines 1011 and 3489; the PR touches 1078 and 1088), so the
contributor's "no new findings" claim is verified rather than taken on trust.

## One noted tradeoff (not blocking)

`2>/dev/null || true` also suppresses genuine `find` errors. The prune is disk
hygiene and should never fail the job, so swallowing is the right call here —
but if it ever silently stops working, the symptom becomes a later disk
exhaustion rather than a pointed error. Recorded in the changelog fragment.

Fork PR, so this lands as a branch rather than a push to the contributor's
head ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test workflow reliability when the build dependency directory is missing.
  * Cleanup steps no longer fail the full test job because of expected file-search errors.

* **Documentation**
  * Added release notes describing the more tolerant cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->