### PR TITLE
merge: land #8637 (finish #4975 HTTP review gaps) with changelog fragment

### DIFF
--- a/changelog.d/8637-http-review-followup.md
+++ b/changelog.d/8637-http-review-followup.md
@@ -1,0 +1,14 @@
+Closed the remaining #4975 review findings on the HTTP/HTTPS parity work:
+exact mixed on/once ClientRequest listener ordering and removal, decoder state
+retained across streamed base64/UTF-16 chunks, non-panicking TLS ticket-key RNG
+with `sessionTimeout` expiry enforced, zero-byte writes reported as `WriteZero`,
+port-aware TLS cache invalidation, and locale-independent HTTP-date validation.
+
+`scripts/unrooted_local_shape.py` also got stricter. `RuntimeHandleScope` was a
+blanket `ROOTED_MARKER`, so *any* function merely mentioning it was exempt from
+the whole analysis. It is now tracked as a lexically-scoped exemption that
+expires when its block closes, and the self-test pins both directions: a new
+required probe (`planted_after_runtime_scope` — a stale pointer used after the
+scope block ends, which the blanket exemption structurally could not catch) and
+a new clean control (`clean_active_runtime_scope`). The event-helper roots the
+stricter analysis exposed are fixed in the same change.

--- a/crates/perry-api-manifest/src/entries/part_4.rs
+++ b/crates/perry-api-manifest/src/entries/part_4.rs
@@ -838,6 +838,8 @@ pub(crate) const API_MANIFEST_PART_4: &[ApiEntry] = &[
     method("http", "setEncoding", true, Some("IncomingMessage")),
     method("http", "setTimeout", true, Some("IncomingMessage")),
     method("http", "__get_req", true, Some("IncomingMessage")),
+    method("http", "__get_socket", true, Some("IncomingMessage")),
+    method("http", "__get_connection", true, Some("IncomingMessage")),
     method("http", "socket", true, Some("IncomingMessage")),
     method("http", "connection", true, Some("IncomingMessage")),
     method("http", "req", true, Some("IncomingMessage")),

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -147,7 +147,9 @@ pub struct AgentHandle {
     /// reqwest intentionally hides them; this mirror preserves the cache and
     /// eviction semantics without exposing backend internals.
     pub max_cached_sessions: usize,
-    pub tls_sessions: HashMap<String, u64>,
+    /// Opaque session id and the server port it belongs to. Keeping the port
+    /// structurally avoids guessing inside the colon-delimited Agent key.
+    pub tls_sessions: HashMap<String, (u64, u16)>,
     pub tls_session_order: VecDeque<String>,
     pub next_tls_session: u64,
     /// HTTPS options supplied to the Agent constructor. Request-local
@@ -744,92 +746,103 @@ fn release_request_inner(
     socket: Handle,
     keep_alive: bool,
 ) -> Option<(Handle, bool, Handle)> {
-    let agent = get_handle_mut::<AgentHandle>(handle)?;
-    if let Some(active) = agent.sockets.get_mut(key) {
-        *active = active.saturating_sub(1);
-        if *active == 0 {
-            agent.sockets.remove(key);
+    let free_generation = {
+        let agent = get_handle_mut::<AgentHandle>(handle)?;
+        if let Some(active) = agent.sockets.get_mut(key) {
+            *active = active.saturating_sub(1);
+            if *active == 0 {
+                agent.sockets.remove(key);
+            }
         }
-    }
-    if let Some(active) = agent.active_socket_handles.get_mut(key) {
-        active.retain(|candidate| *candidate != socket);
-        if active.is_empty() {
-            agent.active_socket_handles.remove(key);
+        if let Some(active) = agent.active_socket_handles.get_mut(key) {
+            active.retain(|candidate| *candidate != socket);
+            if active.is_empty() {
+                agent.active_socket_handles.remove(key);
+            }
         }
-    }
 
-    let next = agent
-        .queued_requests
-        .get_mut(key)
-        .and_then(|queue| (!queue.is_empty()).then(|| queue.remove(0)));
-    if let Some(next_handle) = next {
-        let remaining = agent.queued_requests.get(key).map(Vec::len).unwrap_or(0);
-        if remaining == 0 {
-            agent.queued_requests.remove(key);
-            agent.requests.remove(key);
-        } else {
-            agent.requests.insert(key.to_string(), remaining as u32);
+        let next = agent
+            .queued_requests
+            .get_mut(key)
+            .and_then(|queue| (!queue.is_empty()).then(|| queue.remove(0)));
+        if let Some(next_handle) = next {
+            let remaining = agent.queued_requests.get(key).map(Vec::len).unwrap_or(0);
+            if remaining == 0 {
+                agent.queued_requests.remove(key);
+                agent.requests.remove(key);
+            } else {
+                agent.requests.insert(key.to_string(), remaining as u32);
+            }
+            let (next_socket, reused) = if keep_alive && socket != 0 {
+                (socket, true)
+            } else {
+                if socket != 0 {
+                    perry_ext_net::js_ext_net_destroy_socket(socket);
+                }
+                (allocate_agent_socket(), false)
+            };
+            perry_ext_net::js_ext_net_set_http_agent_phase(next_socket, 1);
+            agent
+                .active_socket_handles
+                .entry(key.to_string())
+                .or_default()
+                .push(next_socket);
+            *agent.sockets.entry(key.to_string()).or_default() += 1;
+            return Some((next_handle, reused, next_socket));
         }
-        let (next_socket, reused) = if keep_alive && socket != 0 {
-            (socket, true)
+
+        if keep_alive && agent.keep_alive && !agent.destroyed && socket != 0 {
+            let free = agent.free_sockets.entry(key.to_string()).or_default();
+            if (*free as f64) < agent.max_free_sockets.max(0.0) {
+                *free += 1;
+                perry_ext_net::js_ext_net_set_http_agent_phase(socket, 0);
+                agent
+                    .free_socket_handles
+                    .entry(key.to_string())
+                    .or_default()
+                    .push(socket);
+                agent.next_free_socket_generation =
+                    agent.next_free_socket_generation.wrapping_add(1);
+                let generation = agent.next_free_socket_generation;
+                agent.free_socket_generations.insert(socket, generation);
+                Some(generation)
+            } else {
+                perry_ext_net::js_ext_net_destroy_socket(socket);
+                None
+            }
         } else {
             if socket != 0 {
                 perry_ext_net::js_ext_net_destroy_socket(socket);
             }
-            (allocate_agent_socket(), false)
-        };
-        perry_ext_net::js_ext_net_set_http_agent_phase(next_socket, 1);
-        agent
-            .active_socket_handles
-            .entry(key.to_string())
-            .or_default()
-            .push(next_socket);
-        *agent.sockets.entry(key.to_string()).or_default() += 1;
-        return Some((next_handle, reused, next_socket));
-    }
-
-    if keep_alive && agent.keep_alive && !agent.destroyed && socket != 0 {
-        let free = agent.free_sockets.entry(key.to_string()).or_default();
-        if (*free as f64) < agent.max_free_sockets.max(0.0) {
-            *free += 1;
-            perry_ext_net::js_ext_net_set_http_agent_phase(socket, 0);
-            agent
-                .free_socket_handles
-                .entry(key.to_string())
-                .or_default()
-                .push(socket);
-            agent.next_free_socket_generation = agent.next_free_socket_generation.wrapping_add(1);
-            let generation = agent.next_free_socket_generation;
-            agent.free_socket_generations.insert(socket, generation);
-            unsafe {
-                let event = alloc_string("free");
-                perry_ext_net::js_ext_net_socket_emit(
-                    socket,
-                    event.as_raw() as i64,
-                    std::ptr::null(),
-                    0,
-                );
-            }
-            let key = key.to_string();
-            perry_ffi::spawn_async(async move {
-                // reqwest owns the physical pooled connection, so the public
-                // net.Socket facade cannot receive its idle read/EOF edge.
-                // Conservatively retire an unclaimed facade after the I/O
-                // guard window; immediate/next-tick reuse cancels this via the
-                // generation check below.
-                tokio::time::sleep(std::time::Duration::from_millis(40)).await;
-                crate::push_event(crate::PendingHttpEvent::AgentIdleExpire {
-                    agent_handle: handle,
-                    key,
-                    socket,
-                    generation,
-                });
-            });
-        } else {
-            perry_ext_net::js_ext_net_destroy_socket(socket);
+            None
         }
-    } else if socket != 0 {
-        perry_ext_net::js_ext_net_destroy_socket(socket);
+    };
+
+    if let Some(generation) = free_generation {
+        unsafe {
+            let event = alloc_string("free");
+            perry_ext_net::js_ext_net_socket_emit(
+                socket,
+                event.as_raw() as i64,
+                std::ptr::null(),
+                0,
+            );
+        }
+        let key = key.to_string();
+        perry_ffi::spawn_async(async move {
+            // reqwest owns the physical pooled connection, so the public
+            // net.Socket facade cannot receive its idle read/EOF edge.
+            // Conservatively retire an unclaimed facade after the I/O
+            // guard window; immediate/next-tick reuse cancels this via the
+            // generation check below.
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            crate::push_event(crate::PendingHttpEvent::AgentIdleExpire {
+                agent_handle: handle,
+                key,
+                socket,
+                generation,
+            });
+        });
     }
     None
 }

--- a/crates/perry-ext-http/src/agent/tls_compat.rs
+++ b/crates/perry-ext-http/src/agent/tls_compat.rs
@@ -57,12 +57,12 @@ pub(crate) fn client_for_agent_tls(
         .clone())
 }
 
-pub(crate) fn tls_session_for_request(handle: Handle, key: &str) -> (u64, bool) {
+pub(crate) fn tls_session_for_request(handle: Handle, key: &str, port: u16) -> (u64, bool) {
     let Some(agent) = get_handle_mut::<AgentHandle>(handle) else {
         return (1, false);
     };
     if agent.max_cached_sessions > 0 {
-        if let Some(session) = agent.tls_sessions.get(key).copied() {
+        if let Some((session, _)) = agent.tls_sessions.get(key).copied() {
             return (session, true);
         }
     }
@@ -76,7 +76,7 @@ pub(crate) fn tls_session_for_request(handle: Handle, key: &str) -> (u64, bool) 
                 break;
             }
         }
-        agent.tls_sessions.insert(key.to_string(), session);
+        agent.tls_sessions.insert(key.to_string(), (session, port));
         agent.tls_session_order.push_back(key.to_string());
     }
     (session, false)
@@ -91,10 +91,13 @@ pub(crate) fn merge_tls_defaults(handle: Handle, request: &mut crate::tls_client
 }
 
 pub(crate) fn invalidate_tls_sessions_for_server_port(port: u16) {
-    let marker = format!(":{port}:");
     iter_handles_of_mut::<AgentHandle, _>(|agent| {
-        agent.tls_sessions.retain(|key, _| !key.contains(&marker));
-        agent.tls_session_order.retain(|key| !key.contains(&marker));
+        agent
+            .tls_sessions
+            .retain(|_, (_, session_port)| *session_port != port);
+        agent
+            .tls_session_order
+            .retain(|key| agent.tls_sessions.contains_key(key));
     });
 }
 fn default_https_agent_handle() -> Handle {

--- a/crates/perry-ext-http/src/client_events.rs
+++ b/crates/perry-ext-http/src/client_events.rs
@@ -17,34 +17,39 @@ extern "C" {
 }
 
 /// Forward a body chunk to a `.pipe(dest)` destination: `dest.write(chunk)`.
-/// `dest_bits` is the NaN-boxed destination value captured by `pipe()`.
-unsafe fn forward_pipe_write(dest_bits: u64, bytes: &[u8], encoding: Option<&str>) {
-    if bytes.is_empty() {
-        return;
-    }
-    let name = alloc_string("write");
-    let name_ptr = name.as_raw();
-    if name_ptr.is_null() {
-        return;
-    }
-    let chunk = body_chunk_value(bytes, encoding);
+/// Both arguments are NaN-boxed JS values and are rooted before method-name
+/// allocation or dynamic dispatch can collect.
+unsafe fn forward_pipe_write_value(dest: f64, chunk: f64) {
     if chunk.to_bits() == TAG_UNDEFINED {
         return;
     }
-    let args = [chunk];
-    js_native_call_method_str_key(f64::from_bits(dest_bits), name_ptr as i64, args.as_ptr(), 1);
+    let scope = perry_ffi::TransientRootScope::enter();
+    let dest = scope.root_nanbox(dest);
+    let chunk = scope.root_nanbox(chunk);
+    let name = alloc_string("write");
+    let name = scope.root_nanbox(f64::from_bits(
+        JsValue::from_string_ptr(name.as_raw()).bits(),
+    ));
+    let args = [chunk.get()];
+    js_native_call_method_str_key(
+        dest.get(),
+        (name.get().to_bits() & PTR_MASK) as i64,
+        args.as_ptr(),
+        1,
+    );
 }
 
 /// Finish a `.pipe(dest)` destination once the response body ends: `dest.end()`.
 unsafe fn forward_pipe_end(dest_bits: u64) {
+    let scope = perry_ffi::TransientRootScope::enter();
+    let dest = scope.root_nanbox(f64::from_bits(dest_bits));
     let name = alloc_string("end");
-    let name_ptr = name.as_raw();
-    if name_ptr.is_null() {
-        return;
-    }
+    let name = scope.root_nanbox(f64::from_bits(
+        JsValue::from_string_ptr(name.as_raw()).bits(),
+    ));
     js_native_call_method_str_key(
-        f64::from_bits(dest_bits),
-        name_ptr as i64,
+        dest.get(),
+        (name.get().to_bits() & PTR_MASK) as i64,
         std::ptr::null(),
         0,
     );
@@ -56,12 +61,47 @@ unsafe fn forward_pipe_end(dest_bits: u64) {
 ///
 /// Listener entries are raw closure headers registered via `.on()`; they
 /// stay live for the program's lifetime (GC scanner pins them).
+fn take_client_event_listener_entries(listeners: &mut Vec<ClientEventListener>) -> Vec<i64> {
+    let callbacks = listeners.iter().map(|listener| listener.callback).collect();
+    listeners.retain(|listener| !listener.once);
+    callbacks
+}
+
 fn take_request_event_listeners(request: &mut ClientRequestHandle, event: &str) -> Vec<i64> {
-    let mut listeners = request.listeners.get(event).cloned().unwrap_or_default();
-    if let Some(once) = request.once_listeners.remove(event) {
-        listeners.extend(once.into_iter().map(|listener| listener.callback));
+    let Some(listeners) = request.listeners.get_mut(event) else {
+        return Vec::new();
+    };
+    take_client_event_listener_entries(listeners)
+}
+
+#[cfg(test)]
+mod listener_order_tests {
+    use super::*;
+
+    #[test]
+    fn mixed_persistent_and_once_listeners_keep_registration_order() {
+        let mut listeners = vec![
+            ClientEventListener::persistent(11),
+            ClientEventListener {
+                callback: 22,
+                raw_wrapper: 222,
+                once: true,
+            },
+            ClientEventListener::persistent(33),
+        ];
+
+        assert_eq!(
+            take_client_event_listener_entries(&mut listeners),
+            vec![11, 22, 33]
+        );
+        assert_eq!(
+            listeners
+                .iter()
+                .map(|listener| listener.callback)
+                .collect::<Vec<_>>(),
+            vec![11, 33]
+        );
     }
-    listeners
 }
 
 pub(crate) unsafe fn fire_request_event_listeners(request_handle: Handle, event: &str) {
@@ -247,6 +287,7 @@ pub(crate) unsafe fn handle_response_event(
         body,
         listeners: HashMap::new(),
         encoding: None,
+        decoder_pending: Vec::new(),
         pipes: Vec::new(),
         socket_handle,
         request_handle,
@@ -286,22 +327,33 @@ pub(crate) unsafe fn handle_response_event(
     // Issue #1124: bytes cross the FFI boundary as a JS Buffer
     // (`alloc_buffer`), not a lossily-decoded string — unless
     // `res.setEncoding(enc)` asked for Readable's string-chunk behavior.
-    let (data_listeners, encoding) = get_handle_mut::<IncomingMessageHandle>(incoming)
+    let (data_listeners, encoding, pipes) = get_handle_mut::<IncomingMessageHandle>(incoming)
         .map(|r| {
             (
                 r.listeners.get("data").cloned().unwrap_or_default(),
                 r.encoding.clone(),
+                r.pipes.clone(),
             )
         })
         .unwrap_or_default();
-    if !data_listeners.is_empty() && !body_clone.is_empty() {
+    let delivery_scope = perry_ffi::TransientRootScope::enter();
+    let data_listeners = delivery_scope.root_addrs(&data_listeners);
+    let pipes = pipes
+        .iter()
+        .map(|bits| delivery_scope.root_nanbox(f64::from_bits(*bits)))
+        .collect::<Vec<_>>();
+    if (!data_listeners.is_empty() || !pipes.is_empty()) && !body_clone.is_empty() {
         let arg = body_chunk_value(&body_clone, encoding.as_deref());
-        if arg.to_bits() != TAG_UNDEFINED {
-            for cb in data_listeners {
-                if cb != 0 {
-                    let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-                    let _ = closure.call1(arg);
+        let arg = delivery_scope.root_nanbox(arg);
+        if arg.get().to_bits() != TAG_UNDEFINED {
+            for cb in &data_listeners {
+                if cb.get() != 0 {
+                    let closure = JsClosure::from_raw(cb.get() as *const RawClosureHeader);
+                    let _ = closure.call1(arg.get());
                 }
+            }
+            for dest in &pipes {
+                forward_pipe_write_value(dest.get(), arg.get());
             }
         }
     }
@@ -310,22 +362,27 @@ pub(crate) unsafe fn handle_response_event(
     let end_listeners = get_handle_mut::<IncomingMessageHandle>(incoming)
         .and_then(|r| r.listeners.get("end").cloned())
         .unwrap_or_default();
+    let end_scope = perry_ffi::TransientRootScope::enter();
+    let end_listeners = end_scope.root_addrs(&end_listeners);
     for cb in end_listeners {
-        if cb != 0 {
-            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+        if cb.get() != 0 {
+            let closure = JsClosure::from_raw(cb.get() as *const RawClosureHeader);
             let _ = closure.call0();
         }
     }
 
-    // Forward the buffered body to any `.pipe(dest)` destinations registered
-    // during the response callback above (node-fetch: `res.pipe(new
-    // PassThrough())`). Deliver the whole body as one write, then end.
+    // End every pipe currently registered, including one added by an `end`
+    // listener while the callbacks above were running.
     let pipes = get_handle_mut::<IncomingMessageHandle>(incoming)
-        .map(|r| r.pipes.clone())
+        .map(|response| response.pipes.clone())
         .unwrap_or_default();
+    let pipe_scope = perry_ffi::TransientRootScope::enter();
+    let pipes = pipes
+        .iter()
+        .map(|bits| pipe_scope.root_nanbox(f64::from_bits(*bits)))
+        .collect::<Vec<_>>();
     for dest in pipes {
-        forward_pipe_write(dest, &body_clone, encoding.as_deref());
-        forward_pipe_end(dest);
+        forward_pipe_end(dest.get().to_bits());
     }
 
     // Node emits `'close'` on the request once the response has fully
@@ -367,6 +424,7 @@ pub(crate) unsafe fn handle_response_head_event(
         body: Vec::new(),
         listeners: HashMap::new(),
         encoding: None,
+        decoder_pending: Vec::new(),
         pipes: Vec::new(),
         socket_handle,
         request_handle,
@@ -423,30 +481,38 @@ pub(crate) unsafe fn handle_response_chunk_event(request_handle: Handle, chunk: 
             )
         })
         .unwrap_or_default();
-    // Forward to `.pipe(dest)` destinations (node-fetch streams the body out
-    // this way and registers no `'data'` listener).
-    for dest in &pipes {
-        forward_pipe_write(*dest, chunk.as_ref(), encoding.as_deref());
-    }
-    if data_listeners.is_empty() {
-        // Buffer for a late `'data'` listener only when the body isn't being
-        // piped out (a pipe consumes it eagerly above).
-        if pipes.is_empty() {
-            if let Some(im) = get_handle_mut::<IncomingMessageHandle>(incoming) {
-                im.body.extend_from_slice(&chunk);
-            }
+    if data_listeners.is_empty() && pipes.is_empty() {
+        if let Some(im) = get_handle_mut::<IncomingMessageHandle>(incoming) {
+            im.body.extend_from_slice(&chunk);
         }
         return;
     }
-    let arg = body_chunk_value(&chunk, encoding.as_deref());
-    if arg.to_bits() == TAG_UNDEFINED {
+    let scope = perry_ffi::TransientRootScope::enter();
+    let data_listeners = scope.root_addrs(&data_listeners);
+    let pipes = pipes
+        .iter()
+        .map(|bits| scope.root_nanbox(f64::from_bits(*bits)))
+        .collect::<Vec<_>>();
+    let arg = get_handle_mut::<IncomingMessageHandle>(incoming).and_then(|response| {
+        streaming_body_chunk_value(
+            chunk.as_ref(),
+            encoding.as_deref(),
+            &mut response.decoder_pending,
+            false,
+        )
+    });
+    let Some(arg) = arg else {
         return;
-    }
+    };
+    let arg = scope.root_nanbox(arg);
     for cb in data_listeners {
-        if cb != 0 {
-            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-            let _ = closure.call1(arg);
+        if cb.get() != 0 {
+            let closure = JsClosure::from_raw(cb.get() as *const RawClosureHeader);
+            let _ = closure.call1(arg.get());
         }
+    }
+    for dest in pipes {
+        forward_pipe_write_value(dest.get(), arg.get());
     }
 }
 
@@ -472,23 +538,42 @@ pub(crate) unsafe fn handle_response_end_event(request_handle: Handle) {
     }
     client_abort::cleanup_request_signal(request_handle);
 
-    let (data_listeners, encoding, buffered) = get_handle_mut::<IncomingMessageHandle>(incoming)
-        .map(|r| {
-            (
-                r.listeners.get("data").cloned().unwrap_or_default(),
-                r.encoding.clone(),
-                std::mem::take(&mut r.body),
+    let (data_listeners, encoding, buffered, pipes) =
+        get_handle_mut::<IncomingMessageHandle>(incoming)
+            .map(|r| {
+                (
+                    r.listeners.get("data").cloned().unwrap_or_default(),
+                    r.encoding.clone(),
+                    std::mem::take(&mut r.body),
+                    r.pipes.clone(),
+                )
+            })
+            .unwrap_or_default();
+    if !data_listeners.is_empty() || !pipes.is_empty() {
+        let scope = perry_ffi::TransientRootScope::enter();
+        let data_listeners = scope.root_addrs(&data_listeners);
+        let pipes = pipes
+            .iter()
+            .map(|bits| scope.root_nanbox(f64::from_bits(*bits)))
+            .collect::<Vec<_>>();
+        let arg = get_handle_mut::<IncomingMessageHandle>(incoming).and_then(|response| {
+            streaming_body_chunk_value(
+                &buffered,
+                encoding.as_deref(),
+                &mut response.decoder_pending,
+                true,
             )
-        })
-        .unwrap_or_default();
-    if !data_listeners.is_empty() && !buffered.is_empty() {
-        let arg = body_chunk_value(&buffered, encoding.as_deref());
-        if arg.to_bits() != TAG_UNDEFINED {
+        });
+        if let Some(arg) = arg {
+            let arg = scope.root_nanbox(arg);
             for cb in data_listeners {
-                if cb != 0 {
-                    let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
-                    let _ = closure.call1(arg);
+                if cb.get() != 0 {
+                    let closure = JsClosure::from_raw(cb.get() as *const RawClosureHeader);
+                    let _ = closure.call1(arg.get());
                 }
+            }
+            for dest in pipes {
+                forward_pipe_write_value(dest.get(), arg.get());
             }
         }
     } else if !buffered.is_empty() {
@@ -502,9 +587,11 @@ pub(crate) unsafe fn handle_response_end_event(request_handle: Handle) {
     let end_listeners = get_handle_mut::<IncomingMessageHandle>(incoming)
         .and_then(|r| r.listeners.get("end").cloned())
         .unwrap_or_default();
+    let end_scope = perry_ffi::TransientRootScope::enter();
+    let end_listeners = end_scope.root_addrs(&end_listeners);
     for cb in end_listeners {
-        if cb != 0 {
-            let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
+        if cb.get() != 0 {
+            let closure = JsClosure::from_raw(cb.get() as *const RawClosureHeader);
             let _ = closure.call0();
         }
     }
@@ -514,8 +601,13 @@ pub(crate) unsafe fn handle_response_end_event(request_handle: Handle) {
     let pipes = get_handle_mut::<IncomingMessageHandle>(incoming)
         .map(|r| r.pipes.clone())
         .unwrap_or_default();
+    let pipe_scope = perry_ffi::TransientRootScope::enter();
+    let pipes = pipes
+        .iter()
+        .map(|bits| pipe_scope.root_nanbox(f64::from_bits(*bits)))
+        .collect::<Vec<_>>();
     for dest in pipes {
-        forward_pipe_end(dest);
+        forward_pipe_end(dest.get().to_bits());
     }
 
     finish_agent_request(request_handle, true);

--- a/crates/perry-ext-http/src/client_outgoing.rs
+++ b/crates/perry-ext-http/src/client_outgoing.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn js_http_set_timeout_full(
             req.listeners
                 .entry("timeout".to_string())
                 .or_default()
-                .push(cb);
+                .push(ClientEventListener::persistent(cb));
         });
     }
     client_request_set_timeout_impl(handle, ms);
@@ -192,4 +192,19 @@ pub(crate) fn arm_client_timeout(request_handle: Handle, ms: u64) {
         std::hint::black_box(&jh);
         std::mem::forget(jh);
     });
+}
+
+/// Emit Node's `TimeoutOverflowWarning` for an out-of-range socket timeout.
+/// Socket timeouts clamp to `TIMEOUT_MAX`, unlike the global timer path.
+pub(crate) unsafe fn emit_socket_timeout_overflow_warning(ms: f64) {
+    let value_text = if ms.is_finite() && ms.fract() == 0.0 {
+        format!("{}", ms as i64)
+    } else {
+        format!("{ms}")
+    };
+    let message = format!(
+        "{value_text} does not fit into a 32-bit signed integer.\n\
+         Timer duration was truncated to 2147483647."
+    );
+    perry_ffi::emit_warning(&message, "TimeoutOverflowWarning");
 }

--- a/crates/perry-ext-http/src/client_request_surface.rs
+++ b/crates/perry-ext-http/src/client_request_surface.rs
@@ -96,12 +96,12 @@ extern "C" fn client_once_wrapper(closure: *const RawClosureHeader, rest: f64) -
                 }
                 return false;
             }
-            let Some(listeners) = request.once_listeners.get_mut(&event) else {
+            let Some(listeners) = request.listeners.get_mut(&event) else {
                 return false;
             };
             let Some(position) = listeners
                 .iter()
-                .rposition(|listener| listener.raw_wrapper == wrapper)
+                .rposition(|listener| listener.once && listener.raw_wrapper == wrapper)
             else {
                 return false;
             };
@@ -660,17 +660,12 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
             get_handle_mut::<ClientRequestHandle>(handle)
                 .map(|req| {
                     let explicit = req.listeners.get(&event).map(|v| v.len()).unwrap_or(0);
-                    let once = req
-                        .once_listeners
-                        .get(&event)
-                        .map(|listeners| listeners.len())
-                        .unwrap_or(0);
                     let implicit_response = if event == "response" && req.response_callback != 0 {
                         1
                     } else {
                         0
                     };
-                    (explicit + once + implicit_response) as f64
+                    (explicit + implicit_response) as f64
                 })
                 .unwrap_or(0.0)
         }
@@ -679,16 +674,19 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
             let raw = method == "rawListeners";
             let callbacks = get_handle_mut::<ClientRequestHandle>(handle)
                 .map(|req| {
-                    let mut callbacks = req.listeners.get(&event).cloned().unwrap_or_default();
-                    callbacks.extend(req.once_listeners.get(&event).into_iter().flatten().map(
-                        |listener| {
+                    let mut callbacks = req
+                        .listeners
+                        .get(&event)
+                        .into_iter()
+                        .flatten()
+                        .map(|listener| {
                             if raw {
                                 listener.raw_wrapper
                             } else {
                                 listener.callback
                             }
-                        },
-                    ));
+                        })
+                        .collect::<Vec<_>>();
                     if event == "response" && req.response_callback != 0 {
                         callbacks.insert(
                             0,
@@ -729,10 +727,11 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
             if !event.is_empty() && cb != 0 {
                 with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
                     let listeners = req.listeners.entry(event.clone()).or_default();
+                    let listener = ClientEventListener::persistent(cb);
                     if method == "prependListener" {
-                        listeners.insert(0, cb);
+                        listeners.insert(0, listener);
                     } else {
-                        listeners.push(cb);
+                        listeners.push(listener);
                     }
                 });
             }
@@ -745,12 +744,13 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
                 let raw_wrapper = create_client_once_wrapper(handle, &event, callback, false);
                 with_handle_mut::<ClientRequestHandle, _, _>(handle, |request| {
                     request
-                        .once_listeners
+                        .listeners
                         .entry(event.clone())
                         .or_default()
-                        .push(ClientOnceListener {
+                        .push(ClientEventListener {
                             callback,
                             raw_wrapper,
+                            once: true,
                         });
                 });
             }
@@ -761,13 +761,7 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
             let cb = client_outgoing::callback_from_bits(arg_bits(1));
             if !event.is_empty() && cb != 0 {
                 with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
-                    if let Some(cbs) = req.listeners.get_mut(&event) {
-                        if let Some(pos) = cbs.iter().rposition(|&c| c == cb) {
-                            cbs.remove(pos);
-                            return;
-                        }
-                    }
-                    if let Some(listeners) = req.once_listeners.get_mut(&event) {
+                    if let Some(listeners) = req.listeners.get_mut(&event) {
                         if let Some(position) = listeners.iter().rposition(|listener| {
                             listener.callback == cb || listener.raw_wrapper == cb
                         }) {
@@ -790,7 +784,6 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
             with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| match &event {
                 Some(e) => {
                     req.listeners.remove(e);
-                    req.once_listeners.remove(e);
                     if e == "response" {
                         req.response_callback = 0;
                         req.response_raw_wrapper = 0;
@@ -798,7 +791,6 @@ fn dispatch_method(handle: Handle, method: &str, args: &[f64]) -> Option<f64> {
                 }
                 None => {
                     req.listeners.clear();
-                    req.once_listeners.clear();
                     req.response_callback = 0;
                     req.response_raw_wrapper = 0;
                 }

--- a/crates/perry-ext-http/src/client_surface.rs
+++ b/crates/perry-ext-http/src/client_surface.rs
@@ -16,6 +16,7 @@ pub unsafe extern "C" fn js_http_incoming_message_set_encoding(
     let mut matched = false;
     with_handle_mut::<IncomingMessageHandle, _, _>(handle, |res| {
         res.encoding = Some(encoding.clone());
+        res.decoder_pending.clear();
         matched = true;
     });
     if matched {
@@ -56,6 +57,7 @@ pub unsafe extern "C" fn js_ext_http_client_incoming_message_set_encoding(
     let encoding = read_str(encoding_ptr).unwrap_or_else(|| "utf8".to_string());
     with_handle_mut::<IncomingMessageHandle, _, _>(handle, |res| {
         res.encoding = Some(encoding);
+        res.decoder_pending.clear();
     });
     handle
 }
@@ -122,17 +124,12 @@ pub unsafe extern "C" fn js_http_client_request_listener_count(
     };
     with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
         let explicit = req.listeners.get(&event).map(|v| v.len()).unwrap_or(0);
-        let once = req
-            .once_listeners
-            .get(&event)
-            .map(|listeners| listeners.len())
-            .unwrap_or(0);
         let implicit_response = if event == "response" && req.response_callback != 0 {
             1
         } else {
             0
         };
-        (explicit + once + implicit_response) as f64
+        (explicit + implicit_response) as f64
     })
     .unwrap_or(0.0)
 }
@@ -298,4 +295,49 @@ pub(crate) fn body_chunk_value(body: &[u8], encoding: Option<&str>) -> f64 {
             }
         }
     }
+}
+
+/// Decode one streamed fragment while retaining bytes that need the next
+/// fragment. `None` means the decoder intentionally has no JS chunk to emit.
+pub(crate) fn streaming_body_chunk_value(
+    body: &[u8],
+    encoding: Option<&str>,
+    pending: &mut Vec<u8>,
+    end: bool,
+) -> Option<f64> {
+    let Some(encoding) = encoding else {
+        return (!body.is_empty()).then(|| body_chunk_value(body, None));
+    };
+    let normalized = encoding.to_ascii_lowercase().replace(['-', '_'], "");
+    if !matches!(
+        normalized.as_str(),
+        "base64" | "base64url" | "utf16le" | "ucs2"
+    ) {
+        return (!body.is_empty()).then(|| body_chunk_value(body, Some(encoding)));
+    }
+
+    pending.extend_from_slice(body);
+    let mut emit_len = match normalized.as_str() {
+        "base64" | "base64url" if end => pending.len(),
+        "base64" | "base64url" => pending.len() / 3 * 3,
+        _ => pending.len() / 2 * 2,
+    };
+    if !end && matches!(normalized.as_str(), "utf16le" | "ucs2") && emit_len >= 2 {
+        let last = u16::from_le_bytes([pending[emit_len - 2], pending[emit_len - 1]]);
+        if (0xd800..=0xdbff).contains(&last) {
+            emit_len -= 2;
+        }
+    }
+    if emit_len == 0 {
+        if end {
+            pending.clear();
+        }
+        return None;
+    }
+    let decoded = pending.drain(..emit_len).collect::<Vec<_>>();
+    if end {
+        // Node's utf16le StringDecoder ignores a final unmatched byte.
+        pending.clear();
+    }
+    Some(body_chunk_value(&decoded, Some(encoding)))
 }

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -429,10 +429,10 @@ pub struct ClientRequestHandle {
     body: Vec<u8>,
     response_callback: i64,
     response_raw_wrapper: i64,
-    /// `.on(event, cb)` listeners (`'response'` / `'error'` / `'timeout'`
-    /// / `'finish'` / `'close'`).
-    listeners: HashMap<String, Vec<i64>>,
-    once_listeners: HashMap<String, Vec<ClientOnceListener>>,
+    /// EventEmitter listeners in their exact registration order. Persistent
+    /// and one-shot entries share a vector so mixed `on` / `once` calls retain
+    /// Node's dispatch, introspection, and removal ordering.
+    listeners: HashMap<String, Vec<ClientEventListener>>,
     timeout_ms: Option<u64>,
     ended: bool,
     /// `flushHeaders()` dispatched the exchange before `end()` was called;
@@ -500,9 +500,20 @@ pub struct ClientRequestHandle {
 }
 
 #[derive(Clone, Copy)]
-struct ClientOnceListener {
+struct ClientEventListener {
     callback: i64,
     raw_wrapper: i64,
+    once: bool,
+}
+
+impl ClientEventListener {
+    fn persistent(callback: i64) -> Self {
+        Self {
+            callback,
+            raw_wrapper: callback,
+            once: false,
+        }
+    }
 }
 
 // SAFETY: closure pointers point into program-global code/data and
@@ -523,6 +534,9 @@ pub struct IncomingMessageHandle {
     pub body: Vec<u8>,
     pub listeners: HashMap<String, Vec<i64>>,
     pub encoding: Option<String>,
+    /// Bytes retained when a streamed transport chunk ends inside a base64
+    /// quantum or UTF-16 code unit.
+    pub decoder_pending: Vec<u8>,
     /// `.pipe(dest)` destinations as NaN-boxed value bits. Node's
     /// `readable.pipe(writable)` forwards every body chunk to `dest.write()`
     /// and ends it with `dest.end()`; node-fetch reads the response body this
@@ -661,7 +675,6 @@ fn make_request_handle(
         response_callback: callback,
         response_raw_wrapper: 0,
         listeners: HashMap::new(),
-        once_listeners: HashMap::new(),
         timeout_ms,
         ended: false,
         flushed_early: false,
@@ -765,15 +778,21 @@ unsafe fn attach_tls_options(handle: Handle, opts_f64: f64) {
     if !url.starts_with("https://") || socket == 0 {
         return;
     }
-    let fallback_servername = reqwest::Url::parse(&url)
-        .ok()
+    let parsed_url = reqwest::Url::parse(&url).ok();
+    let fallback_servername = parsed_url
+        .as_ref()
         .and_then(|url| url.host_str().map(String::from));
+    let server_port = parsed_url
+        .as_ref()
+        .and_then(reqwest::Url::port_or_known_default)
+        .unwrap_or(443);
     let callback_host = tls
         .servername
         .as_deref()
         .or(fallback_servername.as_deref())
         .unwrap_or("");
-    let (session_id, reused) = agent::tls_session_for_request(agent_handle, &agent_key);
+    let (session_id, reused) =
+        agent::tls_session_for_request(agent_handle, &agent_key, server_port);
     if !(tls.check_server_identity_from_agent && reused) {
         if let Some(error) = tls_client::check_server_identity_error(&tls, callback_host) {
             with_handle_mut::<ClientRequestHandle, _, _>(handle, |req| {
@@ -1482,6 +1501,23 @@ pub(crate) unsafe fn client_request_flush_headers(handle: Handle) {
     if client_request_surface::request_destroyed(handle) {
         return;
     }
+    let preflight_error = with_handle_mut::<ClientRequestHandle, _, _>(handle, |request| {
+        request.preflight_error.take()
+    })
+    .flatten();
+    if let Some(error_message) = preflight_error {
+        with_handle_mut::<ClientRequestHandle, _, _>(handle, |request| {
+            request.ended = true;
+        });
+        push_event(PendingHttpEvent::Flushed {
+            request_handle: handle,
+        });
+        push_event(PendingHttpEvent::Error {
+            request_handle: handle,
+            error_message,
+        });
+        return;
+    }
     // #5080 — `flushHeaders()` is a send boundary; when it arms the continue
     // path, that exchange owns the head, so don't also dispatch via reqwest.
     continue_client::arm_expect_continue(handle);
@@ -1714,7 +1750,7 @@ unsafe fn http_on_impl(handle: Handle, event_ptr: *const StringHeader, callback:
         req.listeners
             .entry(event.clone())
             .or_default()
-            .push(callback);
+            .push(ClientEventListener::persistent(callback));
         matched = true;
     });
     if matched {
@@ -1759,7 +1795,7 @@ pub(crate) unsafe fn client_request_set_timeout_impl(handle: Handle, ms: f64) ->
     // Node instead of silently storing the raw value. (#4910)
     const TIMEOUT_MAX: f64 = 2_147_483_647.0;
     let effective = if ms > TIMEOUT_MAX {
-        emit_socket_timeout_overflow_warning(ms);
+        client_outgoing::emit_socket_timeout_overflow_warning(ms);
         TIMEOUT_MAX
     } else {
         ms
@@ -1773,24 +1809,6 @@ pub(crate) unsafe fn client_request_set_timeout_impl(handle: Handle, ms: f64) ->
         };
     });
     handle
-}
-
-/// Emit Node's `TimeoutOverflowWarning` for an out-of-range socket timeout.
-/// The net/timers path warns with a message distinct from the global timer
-/// path ("Timer duration was truncated to 2147483647." rather than "Timeout
-/// duration was set to 1.") because the socket timeout clamps to TIMEOUT_MAX,
-/// not 1. (#4910)
-unsafe fn emit_socket_timeout_overflow_warning(ms: f64) {
-    let value_text = if ms.is_finite() && ms.fract() == 0.0 {
-        format!("{}", ms as i64)
-    } else {
-        format!("{ms}")
-    };
-    let message = format!(
-        "{value_text} does not fit into a 32-bit signed integer.\n\
-         Timer duration was truncated to 2147483647."
-    );
-    perry_ffi::emit_warning(&message, "TimeoutOverflowWarning");
 }
 
 // ------------------------------------------------------------------

--- a/crates/perry-ext-http/src/root_scanner.rs
+++ b/crates/perry-ext-http/src/root_scanner.rs
@@ -18,15 +18,15 @@ pub(super) fn scan_http_roots(visitor: &mut GcRootVisitor<'_>) {
         for cb in &mut req.pending_write_callbacks {
             visitor.visit_i64_slot(cb);
         }
-        for cbs in req.listeners.values_mut() {
-            for cb in cbs {
-                visitor.visit_i64_slot(cb);
-            }
-        }
-        for listeners in req.once_listeners.values_mut() {
+        for listeners in req.listeners.values_mut() {
             for listener in listeners {
+                let shared_wrapper = listener.raw_wrapper == listener.callback;
                 visitor.visit_i64_slot(&mut listener.callback);
-                visitor.visit_i64_slot(&mut listener.raw_wrapper);
+                if shared_wrapper {
+                    listener.raw_wrapper = listener.callback;
+                } else {
+                    visitor.visit_i64_slot(&mut listener.raw_wrapper);
+                }
             }
         }
         if req.tls.check_server_identity_callback != 0 {

--- a/crates/perry-ext-http/src/server/http2_server/pump.rs
+++ b/crates/perry-ext-http/src/server/http2_server/pump.rs
@@ -318,12 +318,14 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                         )
                     })
                     .unwrap_or_default();
+                let scope = perry_ffi::TransientRootScope::enter();
+                let listeners = scope.root_addrs(&listeners);
                 let arg = handle_to_pointer_f64(session_handle);
                 if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
                     session.session_event_emitted = true;
                 }
                 for cb in listeners {
-                    call1(cb, arg);
+                    call1(cb.get(), arg);
                     unsafe {
                         js_promise_run_microtasks();
                     }

--- a/crates/perry-ext-http/src/server/https_server.rs
+++ b/crates/perry-ext-http/src/server/https_server.rs
@@ -46,11 +46,11 @@ use crate::server::tls::{
 /// no encoding is supplied) — see `json_value_to_pem_bytes`. Falls
 /// back to empty PEMs (which the cert-chain parser then rejects) on
 /// any extraction failure so the user sees a clear bind error.
-unsafe fn parse_https_opts(opts_f64: f64) -> (Vec<u8>, Vec<u8>, bool, Option<Vec<u8>>, i64) {
+unsafe fn parse_https_opts(opts_f64: f64) -> (Vec<u8>, Vec<u8>, bool, Option<Vec<u8>>, i64, u32) {
     use perry_ffi::JsValue;
     let mut v = JsValue::from_bits(opts_f64.to_bits());
     if !v.is_pointer_or_raw() {
-        return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0);
+        return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0, 300);
     }
     // Native-call lowering may pass a heap options object as its legacy raw
     // pointer. `json_stringify` expects the canonical POINTER_TAG shape.
@@ -59,11 +59,11 @@ unsafe fn parse_https_opts(opts_f64: f64) -> (Vec<u8>, Vec<u8>, bool, Option<Vec
     }
     let json = match perry_ffi::json_stringify(v) {
         Some(j) => j,
-        None => return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0),
+        None => return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0, 300),
     };
     let parsed: serde_json::Value = match serde_json::from_str(&json) {
         Ok(p) => p,
-        Err(_) => return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0),
+        Err(_) => return (Vec::new(), Vec::new(), true, Some(default_alpn()), 0, 300),
     };
     let key_pem = json_value_to_pem_bytes(parsed.get("key"));
     let cert_pem = json_value_to_pem_bytes(parsed.get("cert"));
@@ -97,7 +97,19 @@ unsafe fn parse_https_opts(opts_f64: f64) -> (Vec<u8>, Vec<u8>, bool, Option<Vec
                 .unwrap_or_else(default_alpn),
         )
     };
-    (key_pem, cert_pem, enable_h2, alpn_protocols, alpn_callback)
+    let session_timeout = parsed
+        .get("sessionTimeout")
+        .and_then(|value| value.as_u64())
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(300);
+    (
+        key_pem,
+        cert_pem,
+        enable_h2,
+        alpn_protocols,
+        alpn_callback,
+        session_timeout,
+    )
 }
 
 fn default_alpn() -> Vec<u8> {
@@ -145,11 +157,14 @@ pub unsafe extern "C" fn js_node_https_create_server(mut opts_f64: f64, mut hand
         opts_f64 = f64::from_bits(crate::server::types::TAG_UNDEFINED);
     }
 
-    let (key_pem, cert_pem, enable_http2_alpn, alpn_protocols, alpn_callback) =
+    let (key_pem, cert_pem, enable_http2_alpn, alpn_protocols, alpn_callback, session_timeout) =
         parse_https_opts(opts_f64);
     let mut base = HttpServer::with_handler(handler);
     crate::server::server::apply_server_options(&mut base, opts_f64);
-    let ticket_key = NodeTicketKey::random().unwrap_or_else(|error| panic!("{error}"));
+    let ticket_key = NodeTicketKey::random(session_timeout).unwrap_or_else(|error| {
+        eprintln!("[node:https] {error}; TLS session tickets disabled");
+        NodeTicketKey::disabled(session_timeout)
+    });
 
     let cert_chain = parse_cert_chain(&cert_pem);
     let certificate_cn = cert_chain
@@ -892,6 +907,7 @@ fn emit_keylog_lines(server_handle: i64, socket: f64, lines: &[Vec<u8>]) {
             .unwrap_or_default();
         let scope = perry_ffi::TransientRootScope::enter();
         let listeners = scope.root_addrs(&listeners);
+        let socket = scope.root_nanbox(socket);
         let line = perry_ffi::alloc_buffer(line);
         let line = scope.root_nanbox(f64::from_bits(JsValue::from_object_ptr(line).bits()));
         for callback in &listeners {
@@ -902,7 +918,7 @@ fn emit_keylog_lines(server_handle: i64, socket: f64, lines: &[Vec<u8>]) {
             unsafe {
                 let closure = JsClosure::from_raw(callback as *const RawClosureHeader);
                 if !closure.is_null() {
-                    let _ = closure.call2(line.get(), socket);
+                    let _ = closure.call2(line.get(), socket.get());
                 }
             }
         }

--- a/crates/perry-ext-http/src/server/mod.rs
+++ b/crates/perry-ext-http/src/server/mod.rs
@@ -407,7 +407,7 @@ mod tests {
             ),
             alpn_protocols: Some(vec![8, b'h', b't', b't', b'p', b'/', b'1', b'.', b'1']),
             alpn_callback: https_alpn_callback,
-            ticket_key: crate::server::tls::NodeTicketKey::random().unwrap(),
+            ticket_key: crate::server::tls::NodeTicketKey::random(300).unwrap(),
             certificate_cn: None,
         });
 

--- a/crates/perry-ext-http/src/server/server/io_activity.rs
+++ b/crates/perry-ext-http/src/server/server/io_activity.rs
@@ -78,8 +78,7 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ReadActivity<S> {
                     Poll::Pending
                 }
                 Poll::Ready(Ok(_)) => {
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
+                    Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::WriteZero)))
                 }
                 Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
                 Poll::Pending => Poll::Pending,
@@ -164,9 +163,21 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ReadActivity<S> {
         cx: &mut std::task::Context<'_>,
     ) -> Poll<std::io::Result<()>> {
         let this = self.get_mut();
+        if !this.response_head.is_empty() {
+            let mut buffered_head = std::mem::take(&mut this.response_head);
+            if buffered_head.starts_with(b"HTTP/1.0 ") {
+                buffered_head[7] = b'1';
+            }
+            this.pending_write.extend_from_slice(&buffered_head);
+            this.response_version_rewrite_offset = None;
+            this.rewrite_chunked_header.store(false, Ordering::Release);
+        }
         while !this.pending_write.is_empty() {
             match Pin::new(&mut this.inner).poll_write(cx, &this.pending_write) {
-                Poll::Ready(Ok(0)) | Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(0)) => {
+                    return Poll::Ready(Err(std::io::Error::from(std::io::ErrorKind::WriteZero)))
+                }
+                Poll::Pending => return Poll::Pending,
                 Poll::Ready(Ok(written)) => {
                     this.pending_write.drain(..written);
                 }
@@ -177,10 +188,13 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ReadActivity<S> {
     }
 
     fn poll_shutdown(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        match self.as_mut().poll_flush(cx) {
+            Poll::Ready(Ok(())) => Pin::new(&mut self.get_mut().inner).poll_shutdown(cx),
+            other => other,
+        }
     }
 }
 
@@ -212,5 +226,61 @@ mod tests {
             b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\nabc"
         );
         assert!(!rewrite.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_an_incomplete_buffered_response_head() {
+        let (stream, mut peer) = tokio::io::duplex(4096);
+        let rewrite = Arc::new(AtomicBool::new(true));
+        let mut writer =
+            ReadActivity::new(stream, Arc::new(AtomicBool::new(false)), rewrite.clone());
+        writer
+            .write_all(b"HTTP/1.0 200 OK\r\nContent-Len")
+            .await
+            .unwrap();
+        writer.shutdown().await.unwrap();
+
+        let mut bytes = Vec::new();
+        peer.read_to_end(&mut bytes).await.unwrap();
+        assert_eq!(bytes, b"HTTP/1.1 200 OK\r\nContent-Len");
+        assert!(!rewrite.load(Ordering::Acquire));
+    }
+
+    struct ZeroWriter;
+
+    impl AsyncWrite for ZeroWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn flush_reports_write_zero_instead_of_hanging() {
+        let rewrite = Arc::new(AtomicBool::new(true));
+        let mut writer = ReadActivity::new(ZeroWriter, Arc::new(AtomicBool::new(false)), rewrite);
+        writer
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Len")
+            .await
+            .unwrap();
+        let error = writer.flush().await.expect_err("zero write must fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::WriteZero);
     }
 }

--- a/crates/perry-ext-http/src/server/tls.rs
+++ b/crates/perry-ext-http/src/server/tls.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 use std::fmt::Write as _;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::digest::{digest, SHA256};
@@ -70,7 +71,8 @@ impl fmt::Debug for TicketCipher {
 /// material for a stable AEAD ticket key; replacement affects new handshakes
 /// on this server only and never clears unrelated client Agent caches.
 pub struct NodeTicketKey {
-    cipher: RwLock<TicketCipher>,
+    cipher: RwLock<Option<TicketCipher>>,
+    lifetime_secs: u32,
 }
 
 impl fmt::Debug for NodeTicketKey {
@@ -82,30 +84,47 @@ impl fmt::Debug for NodeTicketKey {
 }
 
 impl NodeTicketKey {
-    pub fn random() -> Result<Arc<Self>, String> {
+    fn now_secs() -> Option<u64> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|age| age.as_secs())
+    }
+
+    pub fn random(lifetime_secs: u32) -> Result<Arc<Self>, String> {
         let mut keys = [0_u8; 48];
         SystemRandom::new()
             .fill(&mut keys)
             .map_err(|_| "rustls: unable to generate session ticket keys".to_string())?;
-        Self::from_keys(&keys).map(Arc::new)
+        Self::from_keys(&keys, lifetime_secs).map(Arc::new)
     }
 
-    fn from_keys(keys: &[u8; 48]) -> Result<Self, String> {
+    /// A ticket provider that advertises no ticket support until
+    /// `setTicketKeys()` supplies explicit key material.
+    pub fn disabled(lifetime_secs: u32) -> Arc<Self> {
+        Arc::new(Self {
+            cipher: RwLock::new(None),
+            lifetime_secs,
+        })
+    }
+
+    fn from_keys(keys: &[u8; 48], lifetime_secs: u32) -> Result<Self, String> {
         let mut key_name = [0_u8; 16];
         key_name.copy_from_slice(&keys[..16]);
         let material = digest(&SHA256, keys);
         let key = UnboundKey::new(&aead::CHACHA20_POLY1305, material.as_ref())
             .map_err(|_| "rustls: invalid session ticket key material".to_string())?;
         Ok(Self {
-            cipher: RwLock::new(TicketCipher {
+            cipher: RwLock::new(Some(TicketCipher {
                 key_name,
                 key: LessSafeKey::new(key),
-            }),
+            })),
+            lifetime_secs,
         })
     }
 
     pub fn set_keys(&self, keys: &[u8; 48]) -> Result<(), String> {
-        let replacement = Self::from_keys(keys)?;
+        let replacement = Self::from_keys(keys, self.lifetime_secs)?;
         let replacement = replacement
             .cipher
             .into_inner()
@@ -116,23 +135,16 @@ impl NodeTicketKey {
             .map_err(|_| "rustls: session ticket key lock poisoned".to_string())? = replacement;
         Ok(())
     }
-}
 
-impl ProducesTickets for NodeTicketKey {
-    fn enabled(&self) -> bool {
-        true
-    }
-
-    fn lifetime(&self) -> u32 {
-        12 * 60 * 60
-    }
-
-    fn encrypt(&self, plain: &[u8]) -> Option<Vec<u8>> {
+    fn encrypt_at(&self, plain: &[u8], issued_at: u64) -> Option<Vec<u8>> {
         let cipher = self.cipher.read().ok()?;
+        let cipher = cipher.as_ref()?;
         let mut nonce_bytes = [0_u8; 12];
         SystemRandom::new().fill(&mut nonce_bytes).ok()?;
         let nonce = Nonce::assume_unique_for_key(nonce_bytes);
-        let mut sealed = plain.to_vec();
+        let mut sealed = Vec::with_capacity(8 + plain.len());
+        sealed.extend_from_slice(&issued_at.to_be_bytes());
+        sealed.extend_from_slice(plain);
         cipher
             .key
             .seal_in_place_append_tag(nonce, Aad::from(&cipher.key_name), &mut sealed)
@@ -144,13 +156,12 @@ impl ProducesTickets for NodeTicketKey {
         Some(ticket)
     }
 
-    fn decrypt(&self, ticket: &[u8]) -> Option<Vec<u8>> {
+    fn decrypt_at(&self, ticket: &[u8], now: u64) -> Option<Vec<u8>> {
         if ticket.len() < 16 + 12 + aead::CHACHA20_POLY1305.tag_len() {
             return None;
         }
         let cipher = self.cipher.read().ok()?;
-        // The ticket key name is sent in cleartext and is not secret, so an
-        // ordinary equality check is sufficient here.
+        let cipher = cipher.as_ref()?;
         if ticket[..16] != cipher.key_name {
             return None;
         }
@@ -161,7 +172,32 @@ impl ProducesTickets for NodeTicketKey {
             .key
             .open_in_place(nonce, Aad::from(&cipher.key_name), &mut sealed)
             .ok()?;
-        Some(plain.to_vec())
+        let issued_at = u64::from_be_bytes(plain.get(..8)?.try_into().ok()?);
+        if issued_at > now || now - issued_at > u64::from(self.lifetime_secs) {
+            return None;
+        }
+        Some(plain[8..].to_vec())
+    }
+}
+
+impl ProducesTickets for NodeTicketKey {
+    fn enabled(&self) -> bool {
+        self.cipher
+            .read()
+            .map(|cipher| cipher.is_some())
+            .unwrap_or(false)
+    }
+
+    fn lifetime(&self) -> u32 {
+        self.lifetime_secs
+    }
+
+    fn encrypt(&self, plain: &[u8]) -> Option<Vec<u8>> {
+        self.encrypt_at(plain, Self::now_secs()?)
+    }
+
+    fn decrypt(&self, ticket: &[u8]) -> Option<Vec<u8>> {
+        self.decrypt_at(ticket, Self::now_secs()?)
     }
 }
 
@@ -350,12 +386,13 @@ mod tests {
     fn rotating_ticket_keys_invalidates_only_old_tickets() {
         let initial = [0x11; 48];
         let rotated = [0x22; 48];
-        let ticket_key = NodeTicketKey::from_keys(&initial).expect("initial ticket key");
+        let ticket_key = NodeTicketKey::from_keys(&initial, 300).expect("initial ticket key");
         let old_ticket = ticket_key.encrypt(b"session").expect("encrypted ticket");
         assert_eq!(
             ticket_key.decrypt(&old_ticket).as_deref(),
             Some(b"session".as_slice())
         );
+        assert_eq!(ticket_key.lifetime(), 300);
 
         ticket_key.set_keys(&rotated).expect("rotate ticket key");
         assert!(ticket_key.decrypt(&old_ticket).is_none());
@@ -364,6 +401,18 @@ mod tests {
             ticket_key.decrypt(&new_ticket).as_deref(),
             Some(b"new session".as_slice())
         );
+    }
+
+    #[test]
+    fn tickets_expire_after_the_configured_session_timeout() {
+        let ticket_key = NodeTicketKey::from_keys(&[0x33; 48], 300).expect("ticket key");
+        let ticket = ticket_key.encrypt_at(b"session", 1_000).expect("ticket");
+        assert_eq!(
+            ticket_key.decrypt_at(&ticket, 1_300).as_deref(),
+            Some(b"session".as_slice())
+        );
+        assert!(ticket_key.decrypt_at(&ticket, 1_301).is_none());
+        assert!(ticket_key.decrypt_at(&ticket, 999).is_none());
     }
 }
 

--- a/crates/perry-ext-http/src/server/upgrade.rs
+++ b/crates/perry-ext-http/src/server/upgrade.rs
@@ -79,6 +79,8 @@ pub(crate) fn fire_upgrade_listeners(
     if listeners.is_empty() {
         return;
     }
+    let scope = perry_ffi::TransientRootScope::enter();
+    let listeners = scope.root_addrs(&listeners);
 
     let req_f64 = handle_to_pointer_f64(im_handle);
     // Encode ws_id as NaN-boxed POINTER_TAG so `unbox_to_i64` (the
@@ -95,16 +97,17 @@ pub(crate) fn fire_upgrade_listeners(
         let header = alloc_string(&s);
         f64::from_bits(STRING_TAG | (header.as_raw() as u64 & PTR_MASK))
     };
+    let head_str = scope.root_nanbox(head_str);
 
-    for cb in &listeners {
-        if *cb == 0 {
+    for cb in listeners {
+        if cb.get() == 0 {
             continue;
         }
         unsafe {
-            let raw = *cb as *const RawClosureHeader;
+            let raw = cb.get() as *const RawClosureHeader;
             let closure = JsClosure::from_raw(raw);
             if !closure.is_null() {
-                let _ = closure.call3(req_f64, ws_id_f64, head_str);
+                let _ = closure.call3(req_f64, ws_id_f64, head_str.get());
             }
             js_promise_run_microtasks();
         }

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -75,7 +75,18 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
     let request_once_wrapper = young_gc_root();
     let incoming_listener = young_gc_root();
     let mut request_listeners = HashMap::new();
-    request_listeners.insert("error".to_string(), vec![request_listener]);
+    request_listeners.insert(
+        "error".to_string(),
+        vec![ClientEventListener::persistent(request_listener)],
+    );
+    request_listeners.insert(
+        "timeout".to_string(),
+        vec![ClientEventListener {
+            callback: request_once_callback,
+            raw_wrapper: request_once_wrapper,
+            once: true,
+        }],
+    );
     let request_handle = register_handle(ClientRequestHandle {
         method: "GET".to_string(),
         url: "http://localhost/".to_string(),
@@ -84,13 +95,6 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
         response_callback,
         response_raw_wrapper,
         listeners: request_listeners,
-        once_listeners: HashMap::from([(
-            "timeout".to_string(),
-            vec![ClientOnceListener {
-                callback: request_once_callback,
-                raw_wrapper: request_once_wrapper,
-            }],
-        )]),
         timeout_ms: None,
         ended: false,
         flushed_early: false,
@@ -124,6 +128,7 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
         body: Vec::new(),
         listeners: incoming_listeners,
         encoding: None,
+        decoder_pending: Vec::new(),
         pipes: Vec::new(),
         socket_handle: 0,
         request_handle,
@@ -136,14 +141,11 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
             .expect("request handle should remain live");
         assert_rewritten(response_callback, req.response_callback);
         assert_rewritten(response_raw_wrapper, req.response_raw_wrapper);
-        assert_rewritten(request_listener, req.listeners["error"][0]);
-        assert_rewritten(
-            request_once_callback,
-            req.once_listeners["timeout"][0].callback,
-        );
+        assert_rewritten(request_listener, req.listeners["error"][0].callback);
+        assert_rewritten(request_once_callback, req.listeners["timeout"][0].callback);
         assert_rewritten(
             request_once_wrapper,
-            req.once_listeners["timeout"][0].raw_wrapper,
+            req.listeners["timeout"][0].raw_wrapper,
         );
         let msg = get_handle::<IncomingMessageHandle>(incoming_handle)
             .expect("incoming message handle should remain live");
@@ -180,7 +182,6 @@ fn drain_streamed_body(chunks: &[&[u8]]) -> Vec<u8> {
         response_callback: 0,
         response_raw_wrapper: 0,
         listeners: HashMap::new(),
-        once_listeners: HashMap::new(),
         timeout_ms: None,
         ended: false,
         flushed_early: false,
@@ -264,6 +265,42 @@ fn streamed_response_reassembles_chunks_byte_identically() {
 }
 
 #[test]
+fn streamed_text_decoder_preserves_base64_and_utf16_boundaries() {
+    let _guard = GcTestGuard::new();
+
+    let mut pending = Vec::new();
+    assert!(
+        client_surface::streaming_body_chunk_value(b"a", Some("base64"), &mut pending, false,)
+            .is_none()
+    );
+    assert!(
+        client_surface::streaming_body_chunk_value(b"b", Some("base64"), &mut pending, false,)
+            .is_none()
+    );
+    let final_chunk =
+        client_surface::streaming_body_chunk_value(b"", Some("base64"), &mut pending, true)
+            .expect("base64 remainder must flush at end");
+    assert_eq!(
+        unsafe { extract_string_value(final_chunk) }.as_deref(),
+        Some("YWI=")
+    );
+
+    let mut pending = Vec::new();
+    assert!(client_surface::streaming_body_chunk_value(
+        &[b'a'],
+        Some("utf16le"),
+        &mut pending,
+        false,
+    )
+    .is_none());
+    let chunk =
+        client_surface::streaming_body_chunk_value(&[0], Some("utf16le"), &mut pending, false)
+            .expect("split UTF-16 code unit must decode when completed");
+    assert_eq!(unsafe { extract_string_value(chunk) }.as_deref(), Some("a"));
+    assert!(pending.is_empty());
+}
+
+#[test]
 fn has_pending_zero_when_idle() {
     // Serialize with tests that queue real events (the in-flight-guard test
     // below) — clearing the shared queue under their feet would break them.
@@ -316,7 +353,6 @@ fn dispatch_request_stays_visible_to_exit_gate_until_response_queued() {
         response_callback: 0,
         response_raw_wrapper: 0,
         listeners: HashMap::new(),
-        once_listeners: HashMap::new(),
         timeout_ms: None,
         ended: false,
         flushed_early: false,

--- a/crates/perry-ext-http/src/tls_client.rs
+++ b/crates/perry-ext-http/src/tls_client.rs
@@ -992,11 +992,13 @@ pub(crate) unsafe fn check_server_identity_error(
         fn js_error_get_message(error: *mut u8) -> *mut perry_ffi::StringHeader;
     }
     let scope = perry_ffi::TransientRootScope::enter();
+    let callback = scope.root_addr(callback);
     let host = scope.root_nanbox(f64::from_bits(
         perry_ffi::JsValue::from_string_ptr(perry_ffi::alloc_string(host).as_raw()).bits(),
     ));
     let cert = scope.root_nanbox(f64::from_bits(perry_ffi::alloc_object().bits()));
-    let closure = perry_ffi::JsClosure::from_raw(callback as *const perry_ffi::RawClosureHeader);
+    let closure =
+        perry_ffi::JsClosure::from_raw(callback.get() as *const perry_ffi::RawClosureHeader);
     let result = closure.call2(host.get(), cert.get());
     let is_error = perry_ffi::JsValue::from_bits(js_error_is_error(result).to_bits());
     if !is_error.is_bool() || !is_error.to_bool() {

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -137,6 +137,8 @@ fn socket_method_name(prop: &str) -> Option<&'static [u8]> {
         "getTypeOfService" => Some(b"getTypeOfService"),
         "setTypeOfService" => Some(b"setTypeOfService"),
         "setTimeout" => Some(b"setTimeout"),
+        "getMaxListeners" => Some(b"getMaxListeners"),
+        "setMaxListeners" => Some(b"setMaxListeners"),
         "unref" => Some(b"unref"),
         "write" => Some(b"write"),
         "on" => Some(b"on"),
@@ -266,6 +268,10 @@ unsafe fn socket_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> 
         }
         "listenerCount" if !args.is_empty() => {
             crate::js_net_socket_listener_count(handle, unbox_to_i64(args[0]))
+        }
+        "getMaxListeners" => crate::js_ext_net_socket_get_max_listeners(handle),
+        "setMaxListeners" if !args.is_empty() => {
+            crate::js_ext_net_socket_set_max_listeners(handle, unbox_to_f64(args[0]))
         }
         "eventNames" => json_str_to_value(crate::js_net_socket_event_names(handle)),
         "listeners" if !args.is_empty() => {

--- a/crates/perry-stdlib/src/common/dispatch/fastify_net_zlib.rs
+++ b/crates/perry-stdlib/src/common/dispatch/fastify_net_zlib.rs
@@ -210,6 +210,8 @@ pub(crate) unsafe fn dispatch_external_net_socket(handle: i64, method: &str, arg
         fn js_ext_net_socket_remove_listener(handle: i64, event_ptr: i64, cb_ptr: i64) -> i64;
         fn js_ext_net_socket_remove_all_listeners(handle: i64, event_ptr: i64) -> i64;
         fn js_ext_net_socket_listener_count(handle: i64, event_ptr: i64) -> f64;
+        fn js_ext_net_socket_get_max_listeners(handle: i64) -> f64;
+        fn js_ext_net_socket_set_max_listeners(handle: i64, n: f64) -> f64;
         fn js_net_socket_event_names(handle: i64) -> *mut perry_runtime::StringHeader;
         fn js_net_socket_reset_and_destroy(handle: i64) -> i64;
         // Issue #2211 — listeners()/rawListeners() return a *mut ArrayHeader
@@ -304,6 +306,16 @@ pub(crate) unsafe fn dispatch_external_net_socket(handle: i64, method: &str, arg
         "listenerCount" if !args.is_empty() => {
             let event_ptr = unbox_to_i64(args[0]);
             js_ext_net_socket_listener_count(handle, event_ptr)
+        }
+        "getMaxListeners" => js_ext_net_socket_get_max_listeners(handle),
+        "setMaxListeners" if !args.is_empty() => {
+            let bits = args[0].to_bits();
+            let n = if (bits >> 48) == 0x7FFE {
+                (bits as u32 as i32) as f64
+            } else {
+                args[0]
+            };
+            js_ext_net_socket_set_max_listeners(handle, n)
         }
         "eventNames" => json_str_to_value(js_net_socket_event_names(handle)),
         // Issue #2211 — `socket.listeners(event)` / `socket.rawListeners(event)`

--- a/crates/perry-stdlib/src/events/module_helpers.rs
+++ b/crates/perry-stdlib/src/events/module_helpers.rs
@@ -16,11 +16,11 @@ use crate::common::get_handle_mut;
 
 pub(super) unsafe fn call_net_socket_method(handle: i64, name: &str, args: &[f64]) -> f64 {
     let scope = perry_runtime::gc::RuntimeHandleScope::new();
-    let name = scope.root_string_ptr(js_string_from_bytes(name.as_ptr(), name.len() as u32));
     let args = args
         .iter()
         .map(|value| scope.root_nanbox_f64(*value))
         .collect::<Vec<_>>();
+    let name = scope.root_string_ptr(js_string_from_bytes(name.as_ptr(), name.len() as u32));
     let args = args
         .iter()
         .map(|value| value.get_nanbox_f64())

--- a/crates/perry-stdlib/src/events/once_helpers.rs
+++ b/crates/perry-stdlib/src/events/once_helpers.rs
@@ -17,10 +17,10 @@ unsafe fn remove_stream_or_socket_once_listener(
     event_name_ptr: i64,
     listener: i64,
 ) {
-    extern "C" {
-        fn js_is_registered_net_socket_handle(handle: i64) -> i32;
-    }
-    if js_is_registered_net_socket_handle(handle) != 0 {
+    if matches!(
+        event_helper_target(js_nanbox_pointer(handle)),
+        Some(EventHelperTarget::NetSocket(_))
+    ) {
         let _ = super::module_helpers::call_net_socket_method(
             handle,
             "removeListener",
@@ -154,82 +154,104 @@ pub unsafe extern "C" fn js_events_once(
     use perry_runtime::closure::{js_closure_alloc, js_closure_set_capture_ptr};
 
     ensure_gc_scanner_registered();
-    let promise = js_promise_new();
-    let target = match event_helper_target(target_value) {
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let target_value = scope.root_nanbox_f64(target_value);
+    let event_name_handle = scope.root_string_ptr(event_name_ptr);
+    let options = scope.root_nanbox_f64(options);
+    let promise = scope.root_raw_mut_ptr(js_promise_new());
+    let target = match event_helper_target(target_value.get_nanbox_f64()) {
         Some(target) => target,
         None => {
-            js_promise_reject(
-                promise,
-                invalid_arg_type_error(&invalid_instance_arg_message(
-                    "emitter",
-                    "EventEmitter",
-                    target_value,
-                )),
-            );
-            return promise;
+            let error = invalid_arg_type_error(&invalid_instance_arg_message(
+                "emitter",
+                "EventEmitter",
+                target_value.get_nanbox_f64(),
+            ));
+            js_promise_reject(promise.get_raw_mut_ptr(), error);
+            return promise.get_raw_mut_ptr();
         }
     };
-    let event_name = match string_from_header(event_name_ptr) {
+    let event_name = match string_from_header(event_name_handle.get_raw_const_ptr()) {
         Some(name) => name,
-        None => return promise,
+        None => return promise.get_raw_mut_ptr(),
     };
-    let signal = match options_signal_result(options) {
+    let signal = match options_signal_result(options.get_nanbox_f64()) {
         Ok(signal) => signal,
         Err(error) => {
-            js_promise_reject(promise, error);
-            return promise;
+            js_promise_reject(promise.get_raw_mut_ptr(), error);
+            return promise.get_raw_mut_ptr();
         }
     };
-    if signal.is_some_and(signal_is_aborted) {
-        js_promise_reject(promise, perry_runtime::url::js_abort_error_value());
-        return promise;
+    let signal = signal.map(|value| scope.root_nanbox_f64(value));
+    if signal
+        .as_ref()
+        .is_some_and(|value| signal_is_aborted(value.get_nanbox_f64()))
+    {
+        let error = perry_runtime::url::js_abort_error_value();
+        js_promise_reject(promise.get_raw_mut_ptr(), error);
+        return promise.get_raw_mut_ptr();
     }
     if let EventHelperTarget::EventEmitter(handle) = target {
-        let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) else {
-            return promise;
-        };
         let mut pending = PendingOnce {
-            promise,
+            promise: promise.get_raw_mut_ptr(),
             signal: undefined_value(),
             abort_listener: 0,
         };
-        if let Some(signal) = signal {
-            if let Some(signal_ptr) = object_ptr_from_value(signal) {
+        if let Some(signal) = &signal {
+            if object_ptr_from_value(signal.get_nanbox_f64()).is_some() {
                 let abort_listener = js_closure_alloc(events_once_abort_listener as *const u8, 2);
-                js_closure_set_capture_ptr(abort_listener, 0, handle);
-                js_closure_set_capture_ptr(abort_listener, 1, promise as i64);
-                perry_runtime::url::js_abort_signal_add_listener(
-                    signal_ptr,
-                    abort_event_value(),
-                    js_nanbox_pointer(abort_listener as i64),
+                let abort_listener = scope.root_raw_mut_ptr(abort_listener);
+                js_closure_set_capture_ptr(abort_listener.get_raw_mut_ptr(), 0, handle);
+                js_closure_set_capture_ptr(
+                    abort_listener.get_raw_mut_ptr(),
+                    1,
+                    promise.get_raw_mut_ptr::<Promise>() as i64,
                 );
-                pending.signal = signal;
-                pending.abort_listener = abort_listener as i64;
+                let abort_event = scope.root_nanbox_f64(abort_event_value());
+                perry_runtime::url::js_abort_signal_add_listener(
+                    object_ptr_from_value(signal.get_nanbox_f64()).unwrap_or(std::ptr::null_mut()),
+                    abort_event.get_nanbox_f64(),
+                    js_nanbox_pointer(abort_listener.get_raw_mut_ptr::<ClosureHeader>() as i64),
+                );
+                pending.signal = signal.get_nanbox_f64();
+                pending.abort_listener = abort_listener.get_raw_mut_ptr::<ClosureHeader>() as i64;
             }
         }
+        let Some(emitter) = get_handle_mut::<EventEmitterHandle>(handle) else {
+            return promise.get_raw_mut_ptr();
+        };
         emitter
             .pending_once_promises
             .entry(event_name)
             .or_default()
             .push(pending);
-        return promise;
+        return promise.get_raw_mut_ptr();
     }
-    if let EventHelperTarget::EventTarget(target) = target {
+    if let EventHelperTarget::EventTarget(_) = target {
         let listener = js_closure_alloc(events_once_event_target_listener as *const u8, 3);
-        js_closure_set_capture_ptr(listener, 0, promise as i64);
-        js_closure_set_capture_ptr(listener, 1, target as i64);
-        js_closure_set_capture_ptr(listener, 2, event_name_ptr as i64);
+        let listener = scope.root_raw_mut_ptr(listener);
+        let target =
+            object_ptr_from_value(target_value.get_nanbox_f64()).unwrap_or(std::ptr::null_mut());
+        js_closure_set_capture_ptr(
+            listener.get_raw_mut_ptr(),
+            0,
+            promise.get_raw_mut_ptr::<Promise>() as i64,
+        );
+        js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 1, target as i64);
+        js_closure_set_capture_ptr(
+            listener.get_raw_mut_ptr(),
+            2,
+            event_name_handle.get_raw_const_ptr::<StringHeader>() as i64,
+        );
         perry_runtime::event_target::js_event_target_add_event_listener(
             target,
-            event_name_ptr,
-            listener as i64,
+            event_name_handle.get_raw_const_ptr(),
+            listener.get_raw_mut_ptr::<ClosureHeader>() as i64,
         );
-        return promise;
+        return promise.get_raw_mut_ptr();
     }
     if let EventHelperTarget::NetSocket(handle) = target {
         let listens_for_error = event_name == "error";
-        let scope = perry_runtime::gc::RuntimeHandleScope::new();
-        let event_name = scope.root_string_ptr(event_name_ptr);
         perry_runtime::closure::js_register_closure_rest(
             events_once_stream_resolve_listener as *const u8,
             0,
@@ -240,7 +262,11 @@ pub unsafe extern "C" fn js_events_once(
         );
         let listener = js_closure_alloc(events_once_stream_resolve_listener as *const u8, 4);
         let listener = scope.root_raw_mut_ptr(listener);
-        js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 0, promise as i64);
+        js_closure_set_capture_ptr(
+            listener.get_raw_mut_ptr(),
+            0,
+            promise.get_raw_mut_ptr::<Promise>() as i64,
+        );
         js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 1, handle);
         js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 2, 0);
         js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 3, 0);
@@ -250,12 +276,16 @@ pub unsafe extern "C" fn js_events_once(
             let reject_listener =
                 js_closure_alloc(events_once_stream_reject_listener as *const u8, 4);
             let reject_listener = scope.root_raw_mut_ptr(reject_listener);
-            js_closure_set_capture_ptr(reject_listener.get_raw_mut_ptr(), 0, promise as i64);
+            js_closure_set_capture_ptr(
+                reject_listener.get_raw_mut_ptr(),
+                0,
+                promise.get_raw_mut_ptr::<Promise>() as i64,
+            );
             js_closure_set_capture_ptr(reject_listener.get_raw_mut_ptr(), 1, handle);
             js_closure_set_capture_ptr(
                 reject_listener.get_raw_mut_ptr(),
                 2,
-                event_name.get_raw_const_ptr::<StringHeader>() as i64,
+                event_name_handle.get_raw_const_ptr::<StringHeader>() as i64,
             );
             js_closure_set_capture_ptr(
                 reject_listener.get_raw_mut_ptr(),
@@ -285,11 +315,11 @@ pub unsafe extern "C" fn js_events_once(
             handle,
             "once",
             &[
-                js_nanbox_string(event_name.get_raw_const_ptr::<StringHeader>() as i64),
+                js_nanbox_string(event_name_handle.get_raw_const_ptr::<StringHeader>() as i64),
                 js_nanbox_pointer(listener.get_raw_mut_ptr::<ClosureHeader>() as i64),
             ],
         );
-        return promise;
+        return promise.get_raw_mut_ptr();
     }
     if let EventHelperTarget::Stream(handle) = target {
         perry_runtime::closure::js_register_closure_rest(
@@ -301,37 +331,61 @@ pub unsafe extern "C" fn js_events_once(
             0,
         );
         let listener = js_closure_alloc(events_once_stream_resolve_listener as *const u8, 4);
-        js_closure_set_capture_ptr(listener, 0, promise as i64);
-        js_closure_set_capture_ptr(listener, 1, handle);
-        js_closure_set_capture_ptr(listener, 2, 0);
-        js_closure_set_capture_ptr(listener, 3, 0);
-        let event_value = js_nanbox_string(event_name_ptr as i64);
-        let listener_value = js_nanbox_pointer(listener as i64);
+        let listener = scope.root_raw_mut_ptr(listener);
+        js_closure_set_capture_ptr(
+            listener.get_raw_mut_ptr(),
+            0,
+            promise.get_raw_mut_ptr::<Promise>() as i64,
+        );
+        js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 1, handle);
+        js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 2, 0);
+        js_closure_set_capture_ptr(listener.get_raw_mut_ptr(), 3, 0);
         if event_name != "error" {
             let error_event_name = b"error";
             let error_event_ptr =
                 js_string_from_bytes(error_event_name.as_ptr(), error_event_name.len() as u32);
+            let error_event = scope.root_string_ptr(error_event_ptr);
             let reject_listener =
                 js_closure_alloc(events_once_stream_reject_listener as *const u8, 4);
-            js_closure_set_capture_ptr(reject_listener, 0, promise as i64);
-            js_closure_set_capture_ptr(reject_listener, 1, handle);
-            js_closure_set_capture_ptr(reject_listener, 2, event_name_ptr as i64);
-            js_closure_set_capture_ptr(reject_listener, 3, listener as i64);
-            js_closure_set_capture_ptr(listener, 2, reject_listener as i64);
-            js_closure_set_capture_ptr(listener, 3, error_event_ptr as i64);
-            let error_event = js_nanbox_string(error_event_ptr as i64);
-            let reject_listener_value = js_nanbox_pointer(reject_listener as i64);
+            let reject_listener = scope.root_raw_mut_ptr(reject_listener);
+            js_closure_set_capture_ptr(
+                reject_listener.get_raw_mut_ptr(),
+                0,
+                promise.get_raw_mut_ptr::<Promise>() as i64,
+            );
+            js_closure_set_capture_ptr(reject_listener.get_raw_mut_ptr(), 1, handle);
+            js_closure_set_capture_ptr(
+                reject_listener.get_raw_mut_ptr(),
+                2,
+                event_name_handle.get_raw_const_ptr::<StringHeader>() as i64,
+            );
+            js_closure_set_capture_ptr(
+                reject_listener.get_raw_mut_ptr(),
+                3,
+                listener.get_raw_mut_ptr::<ClosureHeader>() as i64,
+            );
+            js_closure_set_capture_ptr(
+                listener.get_raw_mut_ptr(),
+                2,
+                reject_listener.get_raw_mut_ptr::<ClosureHeader>() as i64,
+            );
+            js_closure_set_capture_ptr(
+                listener.get_raw_mut_ptr(),
+                3,
+                error_event.get_raw_const_ptr::<StringHeader>() as i64,
+            );
             let _ = perry_runtime::node_stream::js_node_stream_method_once(
                 handle,
-                error_event,
-                reject_listener_value,
+                js_nanbox_string(error_event.get_raw_const_ptr::<StringHeader>() as i64),
+                js_nanbox_pointer(reject_listener.get_raw_mut_ptr::<ClosureHeader>() as i64),
             );
         }
         let _ = perry_runtime::node_stream::js_node_stream_method_once(
             handle,
-            event_value,
-            listener_value,
+            js_nanbox_string(event_name_handle.get_raw_const_ptr::<StringHeader>() as i64),
+            js_nanbox_pointer(listener.get_raw_mut_ptr::<ClosureHeader>() as i64),
         );
+        return promise.get_raw_mut_ptr();
     }
-    promise
+    promise.get_raw_mut_ptr()
 }

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -723,6 +723,9 @@ fn eligibility(args: &CompileArgs, project_root: &Path) -> Result<(), String> {
     if args.opt_report.is_some() || std::env::var("PERRY_OPT_REPORT").is_ok() {
         return Err("opt-report".to_string());
     }
+    if std::env::var("PERRY_OUTLINE_ENTRY_REPORT").is_ok() {
+        return Err("outline-entry-report".to_string());
+    }
     if args.verify_native_regions || args.emit_attest || args.emit_sandbox {
         return Err("sidecar-or-verify".to_string());
     }

--- a/scripts/node_core_subset.py
+++ b/scripts/node_core_subset.py
@@ -155,16 +155,34 @@ _PID_PREFIX = re.compile(r"^\(node:\d+\)")
 # while removing the wall-clock value from the differential signal.
 _HTTP_DATE = re.compile(
     r"(?<=Date: )(?P<value>(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), "
-    r"\d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
-    r"\d{4} \d{2}:\d{2}:\d{2} GMT)"
+    r"(?P<day>\d{2}) (?P<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
+    r"(?P<year>\d{4}) (?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2}) GMT)"
 )
+
+_HTTP_MONTHS = {
+    month: index
+    for index, month in enumerate(
+        ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"),
+        start=1,
+    )
+}
 
 
 def _normalize_http_date(match: re.Match[str]) -> str:
     value = match.group("value")
     try:
-        dt.datetime.strptime(value, "%a, %d %b %Y %H:%M:%S GMT")
-    except ValueError:
+        dt.date(
+            int(match.group("year")),
+            _HTTP_MONTHS[match.group("month")],
+            int(match.group("day")),
+        )
+    except (KeyError, ValueError):
+        return value
+    if not (
+        0 <= int(match.group("hour")) <= 23
+        and 0 <= int(match.group("minute")) <= 59
+        and 0 <= int(match.group("second")) <= 61
+    ):
         return value
     return "<HTTP-DATE>"
 

--- a/scripts/unrooted_local_shape.py
+++ b/scripts/unrooted_local_shape.py
@@ -109,7 +109,6 @@ COLLECTION_POINTS = ALLOCATORS + (
 # A function that opens a handle scope has adopted the rooting API; its bindings
 # are `raw_handle_debt.py`'s denominator, not this one's.
 ROOTED_MARKERS = (
-    "RuntimeHandleScope",
     "across_mut",
     "across_const",
     "across_nanbox",
@@ -119,7 +118,19 @@ ROOTED_MARKERS = (
 # an allocator nested inside the expression. Do not start tracking the token as
 # though it were itself a heap address. Unlike ROOTED_MARKERS this is local to
 # the binding and does not exempt the rest of the function.
-ROOT_HANDLE_BINDINGS = ("root_nanbox(", "root_addr(", "root_addrs(")
+ROOT_HANDLE_BINDINGS = (
+    "root_addr(",
+    "root_addrs(",
+    "root_bigint_ptr(",
+    "root_heap_word_u64(",
+    "root_nanbox(",
+    "root_nanbox_f64(",
+    "root_nanbox_f64_slice(",
+    "root_nanbox_u64(",
+    "root_raw_const_ptr(",
+    "root_raw_mut_ptr(",
+    "root_string_ptr(",
+)
 
 FN_START = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+|async\s+|unsafe\s+|extern\s+\"[^\"]*\"\s+)*fn\s+(\w+)")
 LET_BIND = re.compile(r"^\s*let\s+(?:mut\s+)?(\w+)\s*(?::[^=]+)?=\s*(.+)$")
@@ -182,9 +193,18 @@ def scan_function(name: str, lines: list[str], start: int, end: int):
     bound: dict[str, int] = {}
     crossed: dict[str, int] = {}
     findings = []
+    lexical_depth = 0
+    runtime_scopes: list[tuple[str, int]] = []
     for offset, line in enumerate(body):
         m = LET_BIND.match(line)
         expression = m.group(2) if m else line
+        runtime_scopes = [
+            (local, depth)
+            for local, depth in runtime_scopes
+            if lexical_depth >= depth and f"drop({local})" not in line
+        ]
+        if m and "RuntimeHandleScope::new(" in expression:
+            runtime_scopes.append((m.group(1), lexical_depth))
 
         # Inspect every expression, not only calls that are themselves
         # collection points. In `let copied = (*raw).field`, `raw` occurs only
@@ -194,14 +214,15 @@ def scan_function(name: str, lines: list[str], start: int, end: int):
         # to later expressions.
         used_here = set(IDENT.findall(expression))
         for local in sorted(used_here & crossed.keys()):
-            findings.append(
-                (
-                    start + offset + 1,
-                    local,
-                    start + bound[local] + 1,
-                    start + crossed[local] + 1,
+            if not runtime_scopes:
+                findings.append(
+                    (
+                        start + offset + 1,
+                        local,
+                        start + bound[local] + 1,
+                        start + crossed[local] + 1,
+                    )
                 )
-            )
 
         if calls_any(expression, COLLECTION_POINTS):
             for local in bound:
@@ -216,6 +237,7 @@ def scan_function(name: str, lines: list[str], start: int, end: int):
             crossed.pop(local, None)
             if calls_any(rhs, POINTER_SOURCES) and not calls_any(rhs, ROOT_HANDLE_BINDINGS):
                 bound[local] = offset
+        lexical_depth += line.count("{") - line.count("}")
     return findings
 
 
@@ -276,11 +298,29 @@ unsafe fn clean_ffi_transient_root() -> *mut ArrayHeader {
     rooted.get() as *mut ArrayHeader
 }
 
+unsafe fn clean_active_runtime_scope() {
+    let scope = RuntimeHandleScope::new();
+    let raw = js_array_alloc(1);
+    let _rooted = scope.root_raw_mut_ptr(raw);
+    let _other = js_array_alloc(0);
+    consume(raw);
+}
+
 unsafe fn planted_after_transient_scope() -> *mut ArrayHeader {
     let stale = js_array_alloc(1);
     {
         let scope = TransientRootScope::enter();
         let _rooted = scope.root_nanbox(js_nanbox_pointer(stale as i64));
+    }
+    let _other = js_array_alloc(0);
+    stale
+}
+
+unsafe fn planted_after_runtime_scope() -> *mut ArrayHeader {
+    let stale = js_array_alloc(1);
+    {
+        let scope = RuntimeHandleScope::new();
+        let _rooted = scope.root_raw_mut_ptr(stale);
     }
     let _other = js_array_alloc(0);
     stale
@@ -382,6 +422,7 @@ def self_test() -> int:
         "planted_plain_return",
         "planted_later_rhs",
         "planted_after_transient_scope",
+        "planted_after_runtime_scope",
     }
     missing = required - names
     if missing:
@@ -391,6 +432,7 @@ def self_test() -> int:
         "clean_single_alloc",
         "clean_use_on_first_collection",
         "clean_ffi_transient_root",
+        "clean_active_runtime_scope",
     } & names
     if forbidden:
         print(f"SELF-TEST FAIL: flagged clean control(s): {sorted(forbidden)}", file=sys.stderr)


### PR DESCRIPTION
Lands #8637 (head `9044c091e`) plus the changelog fragment it omitted.

## Audit (against `main` @ `e727da9e4`)

| check | result |
|---|---|
| stacks cleanly | yes |
| nine ratchets + `cargo fmt` | **all pass** |
| `cargo check --workspace --all-targets` | exit 0, no warnings in touched crates |
| `perry-ext-http` lib | **87 passed, 0 failed** |
| `perry-stdlib` lib | **120 passed, 0 failed** |
| `perry-ext-net` lib | 1 failure — pre-existing (#8636), see below |

Both suite counts match the PR's own reported numbers exactly.

## The gate change is a real strengthening — verified

This PR edits a gate script (`scripts/unrooted_local_shape.py`) and then reports
that gate passing, so the edit itself needed auditing.

`RuntimeHandleScope` was a blanket `ROOTED_MARKER`: **any** function merely
mentioning it was exempt from the entire analysis. It is now tracked as a
lexically-scoped exemption that expires when its block closes (`lexical_depth`
is maintained at line 240, so scopes really do expire — I checked, since a
never-updated depth would have made the "strengthening" cosmetic).

Both directions are pinned by new self-test cases:

- `planted_after_runtime_scope` — **required** finding: a stale pointer used
  after the scope block ends. The old blanket exemption structurally could not
  catch this; confirmed the old script has `"RuntimeHandleScope"` in
  `ROOTED_MARKERS` and no such probe.
- `clean_active_runtime_scope` — **forbidden** finding: no false positive while
  the scope is live.

`--self-test` passes. The event-helper roots the stricter analysis exposed are
fixed in the same change.

## `root_scanner.rs` aliasing fix — ordering is correct

```rust
let shared_wrapper = listener.raw_wrapper == listener.callback;  // BEFORE the visit
visitor.visit_i64_slot(&mut listener.callback);                  // may relocate
if shared_wrapper { listener.raw_wrapper = listener.callback; }  // propagate NEW address
else { visitor.visit_i64_slot(&mut listener.raw_wrapper); }
```

Capturing `shared_wrapper` *before* visiting is what makes this sound. Computed
after, the comparison would fail post-relocation and `raw_wrapper` would be
visited as an already-moved-from address — the #8427 stale-slot shape.

## My #8632 verdicts re-checked

This PR claims to "root TLS/keylog callbacks", so I re-verified the
`not_a_gc_pointer` verdicts I recorded for `PENDING_TLS_CLIENT_ERRORS` /
`PENDING_TLS_KEYLOGS` in #8632. Both structs are unchanged (`i64` handle plus
owned Rust `String` / `Vec<Vec<u8>>`), so those verdicts are still **true**, not
merely still present — worth distinguishing, since the gate checks holders are
classified, not that the classification is still accurate.

## Pre-existing `perry-ext-net` failure (not this PR)

`gc_mutable_scanner_rewrites_listener_roots` fails under a default `cargo test`
and passes under `PERRY_GC_FORCE_EVACUATE=1` (27+1 vs 28+0, back to back). It
asserts a root **moved**, so with no evacuating collection it fails. Already
filed as #8636 and updated with this deterministic repro; the PR's own
"28 passed with forced evacuation" line is consistent with it.

Fork PR, so this lands as a branch rather than a push to the contributor's head ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added socket support for retrieving and setting maximum listener limits.
  - Added configurable HTTPS session-ticket lifetimes, including expiration and safe fallback behavior.

- **Bug Fixes**
  - Improved streaming response decoding for Base64, Base64URL, and split UTF-16 content.
  - Fixed HTTP/HTTPS event listener handling, socket timeouts, upgrade callbacks, and piped response completion.
  - Improved HTTP date validation and normalization.
  - Fixed response flushing and error reporting for zero-byte writes and shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->