### PR TITLE
test(packages): remove stale Effect advisory gate remnants (#5890)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3169,7 +3169,7 @@ jobs:
       - name: Run Effect fixture
         run: |
           cd tests/release/packages/effect-basic
-          PERRY_EFFECT_BASIC_ADVISORY=1 PERRY_BIN="$GITHUB_WORKSPACE/target/release/perry" bash fixture.sh
+          PERRY_BIN="$GITHUB_WORKSPACE/target/release/perry" bash fixture.sh
 
       - name: Upload Effect fixture logs
         if: always()

--- a/tests/release/packages/README.md
+++ b/tests/release/packages/README.md
@@ -77,8 +77,8 @@ The harness defines its own pass/fail/skip totals; downstream consumers
 The `effect-basic` and `ink-link-smoke` fixtures also have named CI jobs in
 `.github/workflows/test.yml`. They run on release tags, on manual dispatch with
 `run_extended_tests=true`, and on PRs with the `run-extended-tests` label. The
-Effect job opts into a currently advisory compile/run signal with
-`PERRY_EFFECT_BASIC_ADVISORY=1`; the default tier-3 sweep records it as SKIP so
-known Effect end-to-end gaps do not block unrelated package releases. The Ink
-job intentionally stops at compile/link plus symbol inspection; end-to-end Ink
-rendering remains tracked separately from the release fixture contract.
+Effect fixture compiles and runs in both the default tier-3 sweep and its named
+job. The named job remains advisory, matching the tier-3 convention, so broader
+Effect end-to-end gaps do not block unrelated changes. The Ink job intentionally
+stops at compile/link plus symbol inspection; end-to-end Ink rendering remains
+tracked separately from the release fixture contract.

--- a/tests/release/packages/effect-basic/fixture.sh
+++ b/tests/release/packages/effect-basic/fixture.sh
@@ -14,7 +14,7 @@ fi
 # instead of skipping behind an opt-in flag. The CI job stays advisory
 # (`continue-on-error: true`) per the tier-3 convention. The historical
 # `PERRY_EFFECT_BASIC_ADVISORY=1` gate (added in #4391 when Effect reliably
-# failed) is gone; the env var is now a harmless no-op.
+# failed) was removed in #6572.
 
 fixture_setup "$NAME" || exit 1
 fixture_compile_run_diff "$NAME"


### PR DESCRIPTION
## Summary

Completes the cleanup left after #6572 closed #5890: the Effect fixture runs by default, so its CI invocation and package-test documentation should no longer describe or export the removed advisory gate.

## Changes

- Stop exporting the unused `PERRY_EFFECT_BASIC_ADVISORY` variable in the named Effect smoke job.
- Document that Effect runs in both the default tier-3 sweep and its named advisory job.
- Clarify the fixture comment to identify #6572 as the removal point for the historical gate.

## Related issue

Refs #5890. Follow-up to #6572.

## Test plan

- [x] `git diff --check`
- [x] `.github/workflows/test.yml` parses with PyYAML
- [x] `bash -n tests/release/packages/effect-basic/fixture.sh`
- [x] `bash fixture.sh --__did-skip-marker` exits 1 as expected
- [ ] `cargo build --release` (not run; no Rust changes)
- [ ] `cargo test --workspace` (not run; no Rust changes)

## Checklist

- [x] No workspace version, `CLAUDE.md`, or `CHANGELOG.md` changes
- [x] Commit follows the repository prefix convention
- [x] Read `CONTRIBUTING.md` and the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Effect fixture to run in its standard mode during CI validation.
  * Included the Effect fixture in both the default release sweep and its dedicated CI job.
  * Clarified fixture validation behavior and removed outdated advisory-mode references.

* **Documentation**
  * Updated release test documentation to reflect the current Effect and Ink validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->