### PR TITLE
fix: address #5895 review follow-ups

### DIFF
--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -806,6 +806,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             None => double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
                         };
                         lower_event_emitter_subclass_init(ctx, &this_box);
+                        bind_derived_this_after_super(ctx);
                         let current_class_name =
                             ctx.class_stack.last().cloned().unwrap_or_default();
                         crate::lower_call::apply_field_initializers_recursive(
@@ -1162,6 +1163,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     &this_box,
                     &lowered_args,
                 );
+                // The native base initialized the provisional receiver, so a
+                // successful super() must now initialize the derived `this`
+                // binding before field initializers or the remaining
+                // constructor body can observe it. Without this, an indirect
+                // chain such as Counter -> B -> EventEmitter installed the
+                // emitter surface but the next `this.seen = ...` still threw
+                // the pre-super ReferenceError.
+                bind_derived_this_after_super(ctx);
                 // Spec: derived-class field initializers run AFTER `super()`
                 // returns. The native base is the chain root and has no TS
                 // fields, so everything after it still needs initializing —

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1500,6 +1500,32 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 // via `js_new_function_construct` — see
                 // `perry-codegen/src/lower_call/new.rs`.
             }
+            // A named native-module export whose public name is not a class
+            // name still has a real runtime function value. Route `new` over
+            // that value through the dynamic constructor check instead of the
+            // static `Expr::New { class_name }` fallback, which would merely
+            // allocate an empty placeholder. This is where Node distinguishes
+            // constructable JavaScript wrappers (`repl.start`, `events.init`)
+            // from native non-constructors (`path.toNamespacedPath`). The
+            // runtime's explicit export metadata makes that decision. Keep
+            // capitalized class exports on the specialized paths below.
+            if let Some((module, Some(export))) = ctx.lookup_native_module(&class_name) {
+                if export
+                    .chars()
+                    .next()
+                    .is_some_and(|first| !first.is_uppercase())
+                {
+                    return Ok(Expr::NewDynamic {
+                        callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
+                            object: Box::new(Expr::NativeModuleRef(module.to_string())),
+                            property: export.to_string(),
+                        }),
+                        args,
+                        byte_offset: new_byte_offset,
+                    });
+                }
+            }
             // #wall: an ALIASED named import of a native built-in class
             // (`import { BlockList as Wj4 } from "net"; new Wj4()`) must
             // construct exactly like the un-aliased form. The bare-ident

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -7,7 +7,7 @@
 //! reach them via `crate::lower::lower_module*` (or the `lib.rs`
 //! re-exports — `pub use lower::{lower_module, ...}`).
 
-use crate::types::Type;
+use crate::types::{LocalId, Type};
 use anyhow::Result;
 use std::collections::HashSet;
 use swc_ecma_ast as ast;
@@ -17,6 +17,114 @@ use crate::ir::*;
 use crate::lower_types::hoisted_text_codec::{
     infer_hoisted_text_codec_var_type, require_literal_specifier,
 };
+
+fn reflect_script_var_initializers(
+    stmts: Vec<Stmt>,
+    script_var_ids: &HashSet<LocalId>,
+) -> Vec<Stmt> {
+    let mut reflected = Vec::with_capacity(stmts.len());
+    for mut stmt in stmts {
+        match &mut stmt {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                *then_branch =
+                    reflect_script_var_initializers(std::mem::take(then_branch), script_var_ids);
+                if let Some(branch) = else_branch {
+                    *branch =
+                        reflect_script_var_initializers(std::mem::take(branch), script_var_ids);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+            }
+            Stmt::For { init, body, .. } => {
+                if let Some(init_stmt) = init.take() {
+                    let mut expanded =
+                        reflect_script_var_initializers(vec![*init_stmt], script_var_ids);
+                    if expanded.len() == 1 {
+                        *init = expanded.pop().map(Box::new);
+                    } else {
+                        // A script `var` initializer can be hoisted out of the
+                        // `for` init slot without changing its one-shot order.
+                        // This makes room for the immediately-following global
+                        // mirror, since HIR's init field holds only one Stmt.
+                        reflected.append(&mut expanded);
+                    }
+                }
+                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+            }
+            Stmt::Labeled { body, .. } => {
+                let inner = std::mem::replace(body, Box::new(Stmt::Break));
+                let mut expanded = reflect_script_var_initializers(vec![*inner], script_var_ids);
+                *body = if expanded.len() == 1 {
+                    Box::new(expanded.pop().expect("one reflected labeled statement"))
+                } else {
+                    // Non-loop labels are already represented as run-once
+                    // do/while statements. Keep the same representation if a
+                    // direct labeled declaration expands to declaration +
+                    // mirror so `break label` still targets one statement.
+                    Box::new(Stmt::DoWhile {
+                        body: expanded,
+                        condition: Expr::Bool(false),
+                    })
+                };
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+                if let Some(catch) = catch {
+                    catch.body = reflect_script_var_initializers(
+                        std::mem::take(&mut catch.body),
+                        script_var_ids,
+                    );
+                }
+                if let Some(finally) = finally {
+                    *finally =
+                        reflect_script_var_initializers(std::mem::take(finally), script_var_ids);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    case.body = reflect_script_var_initializers(
+                        std::mem::take(&mut case.body),
+                        script_var_ids,
+                    );
+                }
+            }
+            Stmt::Let { .. }
+            | Stmt::Expr(_)
+            | Stmt::Return(_)
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::Throw(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+
+        let global_var = match &stmt {
+            Stmt::Let { id, name, .. } if script_var_ids.contains(id) => Some((*id, name.clone())),
+            _ => None,
+        };
+        reflected.push(stmt);
+        if let Some((id, name)) = global_var {
+            reflected.push(Stmt::Expr(Expr::PropertySet {
+                object: Box::new(Expr::GlobalThisExpr),
+                property: name,
+                value: Box::new(Expr::LocalGet(id)),
+            }));
+        }
+    }
+    reflected
+}
 
 fn should_enable_react_automatic_jsx(name: &str, ast_module: &ast::Module) -> bool {
     let is_jsx_source = name.ends_with(".tsx")
@@ -1231,28 +1339,13 @@ pub fn lower_module_full(
             .iter()
             .filter_map(|name| ctx.lookup_local(name))
             .collect();
-        // Script `var` bindings are properties of the global object. Insert
-        // the mirror immediately after each top-level initializer so code
-        // later in the same script observes the initialized value through
-        // `globalThis` (ES modules keep their lexical/module binding only).
-        let mut reflected = Vec::with_capacity(module.init.len());
-        for stmt in std::mem::take(&mut module.init) {
-            let global_var = match &stmt {
-                Stmt::Let { id, name, .. } if script_var_decl_ids.contains(id) => {
-                    Some((*id, name.clone()))
-                }
-                _ => None,
-            };
-            reflected.push(stmt);
-            if let Some((id, name)) = global_var {
-                reflected.push(Stmt::Expr(Expr::PropertySet {
-                    object: Box::new(Expr::GlobalThisExpr),
-                    property: name,
-                    value: Box::new(Expr::LocalGet(id)),
-                }));
-            }
-        }
-        module.init = reflected;
+        // Script `var` bindings are properties of the global object. Mirror
+        // every write at its actual execution point, including declarations
+        // nested in blocks, loops, switch arms and try/catch/finally. Matching
+        // by LocalId prevents a same-named lexical shadow from leaking onto
+        // globalThis (ES modules keep their module binding only).
+        module.init =
+            reflect_script_var_initializers(std::mem::take(&mut module.init), &script_var_decl_ids);
     }
     if ctx.is_entry_module && !is_esm_entry {
         const RESTRICTED_GLOBAL_NAMES: [&str; 3] = ["undefined", "NaN", "Infinity"];

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -21,6 +21,7 @@ use crate::lower_types::hoisted_text_codec::{
 fn reflect_script_var_initializers(
     stmts: Vec<Stmt>,
     script_vars: &HashMap<LocalId, String>,
+    next_local_id: &mut LocalId,
 ) -> Vec<Stmt> {
     let mut reflected = Vec::with_capacity(stmts.len());
     for mut stmt in stmts {
@@ -30,21 +31,35 @@ fn reflect_script_var_initializers(
                 else_branch,
                 ..
             } => {
-                *then_branch =
-                    reflect_script_var_initializers(std::mem::take(then_branch), script_vars);
+                *then_branch = reflect_script_var_initializers(
+                    std::mem::take(then_branch),
+                    script_vars,
+                    next_local_id,
+                );
                 if let Some(branch) = else_branch {
-                    *branch = reflect_script_var_initializers(std::mem::take(branch), script_vars);
+                    *branch = reflect_script_var_initializers(
+                        std::mem::take(branch),
+                        script_vars,
+                        next_local_id,
+                    );
                 }
             }
             Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
-                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
+                *body = reflect_script_var_initializers(
+                    std::mem::take(body),
+                    script_vars,
+                    next_local_id,
+                );
             }
             Stmt::For {
                 init, update, body, ..
             } => {
                 if let Some(init_stmt) = init.take() {
-                    let mut expanded =
-                        reflect_script_var_initializers(vec![*init_stmt], script_vars);
+                    let mut expanded = reflect_script_var_initializers(
+                        vec![*init_stmt],
+                        script_vars,
+                        next_local_id,
+                    );
                     if expanded.len() == 1 {
                         *init = expanded.pop().map(Box::new);
                     } else {
@@ -56,13 +71,25 @@ fn reflect_script_var_initializers(
                     }
                 }
                 if let Some(update_expr) = update.take() {
-                    *update = Some(reflect_script_var_update_expr(update_expr, script_vars));
+                    let mut update_temps = Vec::new();
+                    *update = Some(reflect_script_var_update_expr(
+                        update_expr,
+                        script_vars,
+                        next_local_id,
+                        &mut update_temps,
+                    ));
+                    reflected.append(&mut update_temps);
                 }
-                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
+                *body = reflect_script_var_initializers(
+                    std::mem::take(body),
+                    script_vars,
+                    next_local_id,
+                );
             }
             Stmt::Labeled { body, .. } => {
                 let inner = std::mem::replace(body, Box::new(Stmt::Break));
-                let mut expanded = reflect_script_var_initializers(vec![*inner], script_vars);
+                let mut expanded =
+                    reflect_script_var_initializers(vec![*inner], script_vars, next_local_id);
                 *body = if expanded.len() > 1 && matches!(expanded.last(), Some(Stmt::For { .. })) {
                     // A reflected `for (var ...)` init expands to the init,
                     // its global mirror, and the loop. Keep those one-shot
@@ -91,16 +118,24 @@ fn reflect_script_var_initializers(
                 catch,
                 finally,
             } => {
-                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
+                *body = reflect_script_var_initializers(
+                    std::mem::take(body),
+                    script_vars,
+                    next_local_id,
+                );
                 if let Some(catch) = catch {
                     catch.body = reflect_script_var_initializers(
                         std::mem::take(&mut catch.body),
                         script_vars,
+                        next_local_id,
                     );
                 }
                 if let Some(finally) = finally {
-                    *finally =
-                        reflect_script_var_initializers(std::mem::take(finally), script_vars);
+                    *finally = reflect_script_var_initializers(
+                        std::mem::take(finally),
+                        script_vars,
+                        next_local_id,
+                    );
                 }
             }
             Stmt::Switch { cases, .. } => {
@@ -108,6 +143,7 @@ fn reflect_script_var_initializers(
                     case.body = reflect_script_var_initializers(
                         std::mem::take(&mut case.body),
                         script_vars,
+                        next_local_id,
                     );
                 }
             }
@@ -140,50 +176,81 @@ fn reflect_script_var_initializers(
     reflected
 }
 
-fn reflect_script_var_update_expr(expr: Expr, script_vars: &HashMap<LocalId, String>) -> Expr {
-    let mut reflected = Vec::new();
-    reflect_script_var_update_parts(expr, script_vars, &mut reflected);
-    if reflected.len() == 1 {
-        reflected.pop().expect("one reflected update expression")
-    } else {
-        Expr::Sequence(reflected)
-    }
-}
-
-fn reflect_script_var_update_parts(
-    expr: Expr,
+fn reflect_script_var_update_expr(
+    mut expr: Expr,
     script_vars: &HashMap<LocalId, String>,
-    reflected: &mut Vec<Expr>,
-) {
+    next_local_id: &mut LocalId,
+    temp_decls: &mut Vec<Stmt>,
+) -> Expr {
+    // A loop update is an arbitrary expression tree, not necessarily a bare
+    // assignment or a top-level comma sequence. Rewrite children first in
+    // their evaluation order so writes nested in call arguments, computed
+    // keys, conditionals, etc. are mirrored at the instant they execute.
+    crate::walker::walk_expr_children_mut(&mut expr, &mut |child| {
+        let original = std::mem::replace(child, Expr::Undefined);
+        *child = reflect_script_var_update_expr(original, script_vars, next_local_id, temp_decls);
+    });
+
     match expr {
-        Expr::Sequence(exprs) => {
-            for expr in exprs {
-                reflect_script_var_update_parts(expr, script_vars, reflected);
-            }
+        Expr::LocalSet(id, value) if script_vars.contains_key(&id) => Expr::Sequence(vec![
+            Expr::LocalSet(id, value),
+            script_var_mirror_expr(id, script_vars),
+        ]),
+        Expr::Update {
+            id,
+            op,
+            prefix: true,
+        } if script_vars.contains_key(&id) => Expr::Sequence(vec![
+            Expr::Update {
+                id,
+                op,
+                prefix: true,
+            },
+            script_var_mirror_expr(id, script_vars),
+        ]),
+        Expr::Update {
+            id,
+            op,
+            prefix: false,
+        } if script_vars.contains_key(&id) => {
+            // The mirror must run after the update, while postfix `x++` must
+            // still evaluate to the old value for its parent expression. Save
+            // that result in a compiler-only local, publish the new binding,
+            // then restore the expression result.
+            let temp_id = *next_local_id;
+            *next_local_id += 1;
+            temp_decls.push(Stmt::Let {
+                id: temp_id,
+                name: format!("__perry_script_var_postfix_{temp_id}"),
+                ty: Type::Any,
+                mutable: true,
+                init: None,
+            });
+            Expr::Sequence(vec![
+                Expr::LocalSet(
+                    temp_id,
+                    Box::new(Expr::Update {
+                        id,
+                        op,
+                        prefix: false,
+                    }),
+                ),
+                script_var_mirror_expr(id, script_vars),
+                Expr::LocalGet(temp_id),
+            ])
         }
-        Expr::LocalSet(id, value) => {
-            reflected.push(Expr::LocalSet(id, value));
-            reflect_script_var_update(id, script_vars, reflected);
-        }
-        Expr::Update { id, op, prefix } => {
-            reflected.push(Expr::Update { id, op, prefix });
-            reflect_script_var_update(id, script_vars, reflected);
-        }
-        expr => reflected.push(expr),
+        expr => expr,
     }
 }
 
-fn reflect_script_var_update(
-    id: LocalId,
-    script_vars: &HashMap<LocalId, String>,
-    reflected: &mut Vec<Expr>,
-) {
-    if let Some(name) = script_vars.get(&id) {
-        reflected.push(Expr::PropertySet {
-            object: Box::new(Expr::GlobalThisExpr),
-            property: name.clone(),
-            value: Box::new(Expr::LocalGet(id)),
-        });
+fn script_var_mirror_expr(id: LocalId, script_vars: &HashMap<LocalId, String>) -> Expr {
+    Expr::PropertySet {
+        object: Box::new(Expr::GlobalThisExpr),
+        property: script_vars
+            .get(&id)
+            .expect("script var mirror requires a script var")
+            .clone(),
+        value: Box::new(Expr::LocalGet(id)),
     }
 }
 
@@ -1405,8 +1472,11 @@ pub fn lower_module_full(
         // nested in blocks, loops, switch arms and try/catch/finally. Matching
         // by LocalId prevents a same-named lexical shadow from leaking onto
         // globalThis (ES modules keep their module binding only).
-        module.init =
-            reflect_script_var_initializers(std::mem::take(&mut module.init), &script_vars);
+        module.init = reflect_script_var_initializers(
+            std::mem::take(&mut module.init),
+            &script_vars,
+            &mut ctx.next_local_id,
+        );
     }
     if ctx.is_entry_module && !is_esm_entry {
         const RESTRICTED_GLOBAL_NAMES: [&str; 3] = ["undefined", "NaN", "Infinity"];

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -9,7 +9,7 @@
 
 use crate::types::{LocalId, Type};
 use anyhow::Result;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use swc_ecma_ast as ast;
 
 use super::*;
@@ -20,7 +20,7 @@ use crate::lower_types::hoisted_text_codec::{
 
 fn reflect_script_var_initializers(
     stmts: Vec<Stmt>,
-    script_var_ids: &HashSet<LocalId>,
+    script_vars: &HashMap<LocalId, String>,
 ) -> Vec<Stmt> {
     let mut reflected = Vec::with_capacity(stmts.len());
     for mut stmt in stmts {
@@ -31,19 +31,20 @@ fn reflect_script_var_initializers(
                 ..
             } => {
                 *then_branch =
-                    reflect_script_var_initializers(std::mem::take(then_branch), script_var_ids);
+                    reflect_script_var_initializers(std::mem::take(then_branch), script_vars);
                 if let Some(branch) = else_branch {
-                    *branch =
-                        reflect_script_var_initializers(std::mem::take(branch), script_var_ids);
+                    *branch = reflect_script_var_initializers(std::mem::take(branch), script_vars);
                 }
             }
             Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
-                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
             }
-            Stmt::For { init, body, .. } => {
+            Stmt::For {
+                init, update, body, ..
+            } => {
                 if let Some(init_stmt) = init.take() {
                     let mut expanded =
-                        reflect_script_var_initializers(vec![*init_stmt], script_var_ids);
+                        reflect_script_var_initializers(vec![*init_stmt], script_vars);
                     if expanded.len() == 1 {
                         *init = expanded.pop().map(Box::new);
                     } else {
@@ -54,12 +55,44 @@ fn reflect_script_var_initializers(
                         reflected.append(&mut expanded);
                     }
                 }
-                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+                if let Some(update_expr) = update.take() {
+                    let mut updated_globals: Vec<_> = script_vars
+                        .iter()
+                        .filter(|(id, _)| expr_updates_local(&update_expr, **id))
+                        .map(|(id, name)| (*id, name.clone()))
+                        .collect();
+                    updated_globals.sort_unstable_by_key(|(id, _)| *id);
+                    if updated_globals.is_empty() {
+                        *update = Some(update_expr);
+                    } else {
+                        let mut sequence = Vec::with_capacity(1 + updated_globals.len());
+                        sequence.push(update_expr);
+                        sequence.extend(updated_globals.into_iter().map(|(id, name)| {
+                            Expr::PropertySet {
+                                object: Box::new(Expr::GlobalThisExpr),
+                                property: name,
+                                value: Box::new(Expr::LocalGet(id)),
+                            }
+                        }));
+                        *update = Some(Expr::Sequence(sequence));
+                    }
+                }
+                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
             }
             Stmt::Labeled { body, .. } => {
                 let inner = std::mem::replace(body, Box::new(Stmt::Break));
-                let mut expanded = reflect_script_var_initializers(vec![*inner], script_var_ids);
-                *body = if expanded.len() == 1 {
+                let mut expanded = reflect_script_var_initializers(vec![*inner], script_vars);
+                *body = if expanded.len() > 1 && matches!(expanded.last(), Some(Stmt::For { .. })) {
+                    // A reflected `for (var ...)` init expands to the init,
+                    // its global mirror, and the loop. Keep those one-shot
+                    // statements immediately before the labeled loop: wrapping
+                    // the whole expansion in `do { ... } while (false)` would
+                    // make `continue label` target the wrapper instead of the
+                    // original `for` statement.
+                    let loop_stmt = expanded.pop().expect("reflected labeled for statement");
+                    reflected.append(&mut expanded);
+                    Box::new(loop_stmt)
+                } else if expanded.len() == 1 {
                     Box::new(expanded.pop().expect("one reflected labeled statement"))
                 } else {
                     // Non-loop labels are already represented as run-once
@@ -77,23 +110,23 @@ fn reflect_script_var_initializers(
                 catch,
                 finally,
             } => {
-                *body = reflect_script_var_initializers(std::mem::take(body), script_var_ids);
+                *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
                 if let Some(catch) = catch {
                     catch.body = reflect_script_var_initializers(
                         std::mem::take(&mut catch.body),
-                        script_var_ids,
+                        script_vars,
                     );
                 }
                 if let Some(finally) = finally {
                     *finally =
-                        reflect_script_var_initializers(std::mem::take(finally), script_var_ids);
+                        reflect_script_var_initializers(std::mem::take(finally), script_vars);
                 }
             }
             Stmt::Switch { cases, .. } => {
                 for case in cases {
                     case.body = reflect_script_var_initializers(
                         std::mem::take(&mut case.body),
-                        script_var_ids,
+                        script_vars,
                     );
                 }
             }
@@ -111,7 +144,7 @@ fn reflect_script_var_initializers(
         }
 
         let global_var = match &stmt {
-            Stmt::Let { id, name, .. } if script_var_ids.contains(id) => Some((*id, name.clone())),
+            Stmt::Let { id, name, .. } if script_vars.contains_key(id) => Some((*id, name.clone())),
             _ => None,
         };
         reflected.push(stmt);
@@ -124,6 +157,14 @@ fn reflect_script_var_initializers(
         }
     }
     reflected
+}
+
+fn expr_updates_local(expr: &Expr, target: LocalId) -> bool {
+    match expr {
+        Expr::LocalSet(id, _) | Expr::Update { id, .. } => *id == target,
+        Expr::Sequence(exprs) => exprs.iter().any(|expr| expr_updates_local(expr, target)),
+        _ => false,
+    }
 }
 
 fn should_enable_react_automatic_jsx(name: &str, ast_module: &ast::Module) -> bool {
@@ -1334,10 +1375,10 @@ pub fn lower_module_full(
     let is_esm_entry =
         !module.imports.is_empty() || !module.exports.is_empty() || module.has_top_level_await;
     if ctx.is_entry_module && !is_esm_entry && module.references_global_this {
-        let script_var_decl_ids: HashSet<_> = ctx
+        let script_vars: HashMap<_, _> = ctx
             .script_var_decl_names
             .iter()
-            .filter_map(|name| ctx.lookup_local(name))
+            .filter_map(|name| ctx.lookup_local(name).map(|id| (id, name.clone())))
             .collect();
         // Script `var` bindings are properties of the global object. Mirror
         // every write at its actual execution point, including declarations
@@ -1345,7 +1386,7 @@ pub fn lower_module_full(
         // by LocalId prevents a same-named lexical shadow from leaking onto
         // globalThis (ES modules keep their module binding only).
         module.init =
-            reflect_script_var_initializers(std::mem::take(&mut module.init), &script_var_decl_ids);
+            reflect_script_var_initializers(std::mem::take(&mut module.init), &script_vars);
     }
     if ctx.is_entry_module && !is_esm_entry {
         const RESTRICTED_GLOBAL_NAMES: [&str; 3] = ["undefined", "NaN", "Infinity"];

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -56,26 +56,7 @@ fn reflect_script_var_initializers(
                     }
                 }
                 if let Some(update_expr) = update.take() {
-                    let mut updated_globals: Vec<_> = script_vars
-                        .iter()
-                        .filter(|(id, _)| expr_updates_local(&update_expr, **id))
-                        .map(|(id, name)| (*id, name.clone()))
-                        .collect();
-                    updated_globals.sort_unstable_by_key(|(id, _)| *id);
-                    if updated_globals.is_empty() {
-                        *update = Some(update_expr);
-                    } else {
-                        let mut sequence = Vec::with_capacity(1 + updated_globals.len());
-                        sequence.push(update_expr);
-                        sequence.extend(updated_globals.into_iter().map(|(id, name)| {
-                            Expr::PropertySet {
-                                object: Box::new(Expr::GlobalThisExpr),
-                                property: name,
-                                value: Box::new(Expr::LocalGet(id)),
-                            }
-                        }));
-                        *update = Some(Expr::Sequence(sequence));
-                    }
+                    *update = Some(reflect_script_var_update_expr(update_expr, script_vars));
                 }
                 *body = reflect_script_var_initializers(std::mem::take(body), script_vars);
             }
@@ -159,11 +140,50 @@ fn reflect_script_var_initializers(
     reflected
 }
 
-fn expr_updates_local(expr: &Expr, target: LocalId) -> bool {
+fn reflect_script_var_update_expr(expr: Expr, script_vars: &HashMap<LocalId, String>) -> Expr {
+    let mut reflected = Vec::new();
+    reflect_script_var_update_parts(expr, script_vars, &mut reflected);
+    if reflected.len() == 1 {
+        reflected.pop().expect("one reflected update expression")
+    } else {
+        Expr::Sequence(reflected)
+    }
+}
+
+fn reflect_script_var_update_parts(
+    expr: Expr,
+    script_vars: &HashMap<LocalId, String>,
+    reflected: &mut Vec<Expr>,
+) {
     match expr {
-        Expr::LocalSet(id, _) | Expr::Update { id, .. } => *id == target,
-        Expr::Sequence(exprs) => exprs.iter().any(|expr| expr_updates_local(expr, target)),
-        _ => false,
+        Expr::Sequence(exprs) => {
+            for expr in exprs {
+                reflect_script_var_update_parts(expr, script_vars, reflected);
+            }
+        }
+        Expr::LocalSet(id, value) => {
+            reflected.push(Expr::LocalSet(id, value));
+            reflect_script_var_update(id, script_vars, reflected);
+        }
+        Expr::Update { id, op, prefix } => {
+            reflected.push(Expr::Update { id, op, prefix });
+            reflect_script_var_update(id, script_vars, reflected);
+        }
+        expr => reflected.push(expr),
+    }
+}
+
+fn reflect_script_var_update(
+    id: LocalId,
+    script_vars: &HashMap<LocalId, String>,
+    reflected: &mut Vec<Expr>,
+) {
+    if let Some(name) = script_vars.get(&id) {
+        reflected.push(Expr::PropertySet {
+            object: Box::new(Expr::GlobalThisExpr),
+            property: name.clone(),
+            value: Box::new(Expr::LocalGet(id)),
+        });
     }
 }
 

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -245,6 +245,33 @@ fn test_native_module_binding_value_named_import() {
 }
 
 #[test]
+fn new_named_native_function_routes_through_runtime_constructor_check() {
+    let source = r#"
+import { toNamespacedPath } from "node:path";
+new toNamespacedPath();
+"#;
+    let module = perry_parser::parse_typescript(source, "native-new.ts").expect("source parses");
+    let hir = super::lower_module(&module, "native-new", "native-new.ts").expect("source lowers");
+    assert!(
+        hir.init.iter().any(|stmt| matches!(
+            stmt,
+            Stmt::Expr(crate::ir::Expr::NewDynamic { callee, .. })
+                if matches!(
+                    callee.as_ref(),
+                    crate::ir::Expr::PropertyGet { object, property, .. }
+                        if property == "toNamespacedPath"
+                            && matches!(
+                                object.as_ref(),
+                                crate::ir::Expr::NativeModuleRef(module) if module == "path"
+                            )
+                )
+        )),
+        "new over a named native function must construct its runtime export value: {:#?}",
+        hir.init
+    );
+}
+
+#[test]
 fn test_native_module_binding_value_os_eol() {
     // `import { EOL } from 'os'` resolves to the OsEOL intrinsic value, whether
     // used directly or as a shorthand property.

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -354,12 +354,14 @@ pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
     }
     unsafe {
         let receiver = crate::value::js_nanbox_pointer(arr as i64);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let receiver = scope.root_nanbox_f64(receiver);
         if array_has_own_index(arr, index) {
             return js_array_get_f64(arr, index);
         }
         if let Some(proto_arr) = array_custom_array_prototype(arr) {
             if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
-                return array_inherited_index_get(proto_arr, index, receiver);
+                return array_inherited_index_get(proto_arr, index, receiver.get_nanbox_f64());
             }
         }
         if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
@@ -367,14 +369,17 @@ pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
             if proto != 0 && proto != arr as usize {
                 let proto_arr = proto as *const ArrayHeader;
                 if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
-                    return array_inherited_index_get(proto_arr, index, receiver);
+                    return array_inherited_index_get(proto_arr, index, receiver.get_nanbox_f64());
                 }
             }
         }
         if OBJECT_PROTO_HAS_INDEX.load(Ordering::Relaxed)
             && crate::array::object_prototype_has_index_prop(index)
         {
-            return crate::array::sort_object_prototype_index_get_with_receiver(index, receiver);
+            return crate::array::sort_object_prototype_index_get_with_receiver(
+                index,
+                receiver.get_nanbox_f64(),
+            );
         }
         TAG_UNDEFINED_F64
     }

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -353,12 +353,13 @@ pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
         return TAG_UNDEFINED_F64;
     }
     unsafe {
+        let receiver = crate::value::js_nanbox_pointer(arr as i64);
         if array_has_own_index(arr, index) {
             return js_array_get_f64(arr, index);
         }
         if let Some(proto_arr) = array_custom_array_prototype(arr) {
             if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
-                return js_array_get_f64(proto_arr, index);
+                return array_inherited_index_get(proto_arr, index, receiver);
             }
         }
         if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
@@ -366,17 +367,39 @@ pub(crate) fn array_spec_get(arr: *const ArrayHeader, index: u32) -> f64 {
             if proto != 0 && proto != arr as usize {
                 let proto_arr = proto as *const ArrayHeader;
                 if index < (*proto_arr).length && array_has_own_index(proto_arr, index) {
-                    return js_array_get_f64(proto_arr, index);
+                    return array_inherited_index_get(proto_arr, index, receiver);
                 }
             }
         }
         if OBJECT_PROTO_HAS_INDEX.load(Ordering::Relaxed)
             && crate::array::object_prototype_has_index_prop(index)
         {
-            return crate::array::sort_object_prototype_index_get(index);
+            return crate::array::sort_object_prototype_index_get_with_receiver(index, receiver);
         }
         TAG_UNDEFINED_F64
     }
+}
+
+/// Read an own indexed property from an Array prototype while preserving the
+/// original receiver for an inherited accessor's `this` value.
+unsafe fn array_inherited_index_get(
+    proto_arr: *const ArrayHeader,
+    index: u32,
+    receiver: f64,
+) -> f64 {
+    if array_object_flags(proto_arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
+        if let Some(acc) =
+            crate::object::get_accessor_descriptor(proto_arr as usize, &index.to_string())
+        {
+            if acc.get != 0 {
+                return f64::from_bits(
+                    crate::object::invoke_accessor_getter(acc.get, receiver).bits(),
+                );
+            }
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+    }
+    js_array_get_f64(proto_arr, index)
 }
 
 fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringHeader) -> f64 {

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -161,6 +161,7 @@ pub(crate) use self::prototype_addr::{
 };
 pub(crate) use self::sort::object_prototype_has_index_prop;
 pub(crate) use self::sort::object_prototype_index_get as sort_object_prototype_index_get;
+pub(crate) use self::sort::object_prototype_index_get_with_receiver as sort_object_prototype_index_get_with_receiver;
 pub use self::subclass::{
     array_subclass_dense_snapshot, array_subclass_has_iterator_override, is_array_subclass_instance,
 };

--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -361,6 +361,8 @@ pub(crate) fn object_prototype_index_get(index: u32) -> f64 {
 }
 
 pub(crate) fn object_prototype_index_get_with_receiver(index: u32, receiver: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_nanbox_f64(receiver);
     match object_prototype_value() {
         Some(proto) => {
             // Fire an accessor getter installed via
@@ -370,7 +372,13 @@ pub(crate) fn object_prototype_index_get_with_receiver(index: u32, receiver: f64
             if let Some(acc) = crate::object::get_accessor_descriptor(addr, &index.to_string()) {
                 if acc.get != 0 {
                     return f64::from_bits(
-                        unsafe { crate::object::invoke_accessor_getter(acc.get, receiver) }.bits(),
+                        unsafe {
+                            crate::object::invoke_accessor_getter(
+                                acc.get,
+                                receiver.get_nanbox_f64(),
+                            )
+                        }
+                        .bits(),
                     );
                 }
                 return f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -355,6 +355,12 @@ fn object_prototype_numeric_keys() -> Vec<u32> {
 }
 
 pub(crate) fn object_prototype_index_get(index: u32) -> f64 {
+    let receiver =
+        object_prototype_value().unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+    object_prototype_index_get_with_receiver(index, receiver)
+}
+
+pub(crate) fn object_prototype_index_get_with_receiver(index: u32, receiver: f64) -> f64 {
     match object_prototype_value() {
         Some(proto) => {
             // Fire an accessor getter installed via
@@ -364,7 +370,7 @@ pub(crate) fn object_prototype_index_get(index: u32) -> f64 {
             if let Some(acc) = crate::object::get_accessor_descriptor(addr, &index.to_string()) {
                 if acc.get != 0 {
                     return f64::from_bits(
-                        unsafe { crate::object::invoke_accessor_getter(acc.get, proto) }.bits(),
+                        unsafe { crate::object::invoke_accessor_getter(acc.get, receiver) }.bits(),
                     );
                 }
                 return f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -72,8 +72,8 @@ pub(crate) use detach::{array_buffer_transfer, detach_array_buffer};
 pub(crate) use own_props::test_buffer_own_props_owner_count;
 pub use own_props::{
     buffer_define_own_data_prop, buffer_delete_own_prop, buffer_get_own_prop, buffer_has_own_prop,
-    buffer_own_prop_names, buffer_own_props_possible, buffer_set_own_prop, clear_buffer_own_props,
-    scan_buffer_own_props_roots_mut,
+    buffer_own_prop_names, buffer_own_props_possible, buffer_read_own_prop, buffer_set_own_prop,
+    clear_buffer_own_props, scan_buffer_own_props_roots_mut,
 };
 
 // ---- Re-exports: #8149 integer-indexed-exotic discrimination ----

--- a/crates/perry-runtime/src/buffer/own_props.rs
+++ b/crates/perry-runtime/src/buffer/own_props.rs
@@ -102,6 +102,34 @@ pub fn buffer_get_own_prop(addr: usize, prop: &str) -> Option<f64> {
         .map(f64::from_bits)
 }
 
+/// Read an own buffer expando with ordinary `[[Get]]` semantics.
+///
+/// Accessor descriptors keep an `undefined` placeholder in the data table so
+/// enumeration retains their key order. Readers must therefore consult the
+/// accessor table first and invoke the getter instead of returning that
+/// placeholder. The receiver and getter are rooted across the user call.
+pub fn buffer_read_own_prop(addr: usize, prop: &str) -> Option<f64> {
+    if addr == 0 {
+        return None;
+    }
+    if let Some(accessor) = crate::object::get_accessor_descriptor(addr, prop) {
+        if accessor.get == 0 {
+            return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+        }
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let receiver = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(addr as i64));
+        let getter = scope.root_nanbox_u64(accessor.get);
+        let value = unsafe {
+            crate::object::invoke_accessor_getter(
+                getter.get_nanbox_u64(),
+                receiver.get_nanbox_f64(),
+            )
+        };
+        return Some(f64::from_bits(value.bits()));
+    }
+    buffer_get_own_prop(addr, prop)
+}
+
 /// Every own dynamic prop key recorded for `addr`, in insertion-independent
 /// (sorted) order.
 ///

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -223,23 +223,37 @@ fn native_or_plain_key(name: &str, overridden: bool) -> *mut crate::string::Stri
 /// "no fixed receiver — read IMPLICIT_THIS", which `Function.prototype.call`/
 /// `.apply` sets to the borrowed `this`.
 pub(crate) fn install_event_emitter_prototype_methods(proto: *mut ObjectHeader) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let proto = scope.root_raw_mut_ptr(proto);
     register_stub_arities();
     let methods = super::emitter_methods();
-    let mut on_method: Option<f64> = None;
+    let mut on_method: Option<crate::gc::RuntimeHandle<'_>> = None;
     for (name, func) in methods {
         if name == "addListener" {
-            if let Some(val) = on_method {
-                js_object_set_field_by_name(proto, hidden_key(name.as_bytes()), val);
+            if let Some(val) = &on_method {
+                let key = scope.root_string_ptr(hidden_key(name.as_bytes()));
+                proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
+                    key.with_const_ptr::<crate::StringHeader, _>(|key| {
+                        js_object_set_field_by_name(proto, key, val.get_nanbox_f64())
+                    })
+                });
                 continue;
             }
         }
         let closure = js_closure_alloc(func as *const u8, 1);
         crate::closure::js_closure_set_capture_ptr(closure, 0, crate::value::TAG_UNDEFINED as i64);
-        let val = f64::from_bits(JSValue::pointer(closure as *const u8).bits());
+        let val = scope.root_nanbox_f64(f64::from_bits(
+            JSValue::pointer(closure as *const u8).bits(),
+        ));
         if name == "on" {
             on_method = Some(val);
         }
-        js_object_set_field_by_name(proto, hidden_key(name.as_bytes()), val);
+        let key = scope.root_string_ptr(hidden_key(name.as_bytes()));
+        proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
+            key.with_const_ptr::<crate::StringHeader, _>(|key| {
+                js_object_set_field_by_name(proto, key, val.get_nanbox_f64())
+            })
+        });
     }
 }
 

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -386,17 +386,25 @@ pub unsafe fn dispatch_buffer_method(
     // write methods of a zero-length Buffer with a no-op to MEASURE a packet
     // before allocating it; dispatching the native method regardless would
     // write into the empty buffer and throw RangeError [ERR_OUT_OF_RANGE].
-    if let Some(own) = crate::buffer::buffer_get_own_prop(addr, method_name) {
-        let jv = JSValue::from_bits(own.to_bits());
-        if jv.is_pointer() {
-            let ptr = jv.as_pointer::<u8>() as usize;
-            if crate::closure::is_closure_ptr(ptr) {
-                let prev_this = crate::object::js_implicit_this_set(buf_f64);
-                let r = crate::closure::js_native_call_value(own, args_ptr, args_len);
-                crate::object::js_implicit_this_set(prev_this);
-                return r;
-            }
+    if crate::buffer::buffer_has_own_prop(addr, method_name) {
+        let own_scope = crate::gc::RuntimeHandleScope::new();
+        let own_receiver = own_scope.root_nanbox_f64(buf_f64);
+        let own = crate::buffer::buffer_read_own_prop(addr, method_name)
+            .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+        let own = own_scope.root_nanbox_f64(own);
+        let own_value = own.get_nanbox_f64();
+        let own_js = JSValue::from_bits(own_value.to_bits());
+        if own_js.is_undefined() || own_js.is_null() {
+            crate::closure::throw_not_callable();
         }
+        return match crate::collection_iter::call_with_this_capturing_throw(
+            own_value,
+            own_receiver.get_nanbox_f64(),
+            args,
+        ) {
+            Ok(value) => value,
+            Err(error) => crate::exception::js_throw(error),
+        };
     }
     let arg_i32 = |i: usize| -> i32 {
         if i < args.len() {

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -64,7 +64,7 @@ pub(crate) use state::{
     class_parent_closure, class_parent_closure_root_store, class_prototype_method_is_enumerable,
     class_prototype_method_set_enumerable, class_prototype_method_value_cache_root_store,
     class_prototype_object_root_store, class_static_defined_attrs, class_static_set_defined_attrs,
-    global_object_prototype_bits, is_bound_native_method_closure_value,
+    global_object_prototype_bits, is_bound_native_constructor_closure_value,
     is_non_constructable_builtin_function_value, parent_closure_in_chain,
     throw_non_constructable_builtin_function,
 };

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -1249,6 +1249,15 @@ pub(crate) fn extends_target_must_throw(value: f64) -> bool {
         if is_arrow_function_value(value) || is_non_constructable_builtin_function_value(value) {
             return true;
         }
+        // Native-module constructor exports use the same BOUND_METHOD
+        // trampoline as ordinary method reads. Their module/method captures
+        // are the distinguishing [[Construct]] metadata: rejecting the raw
+        // trampoline here breaks dynamic aliases such as
+        // `const Console = console.Console; new Console(...)` and native base
+        // construction reached through an indirect user-class chain.
+        if is_bound_native_method_closure_value(value) {
+            return false;
+        }
         let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
         if !ptr.is_null() && is_valid_obj_ptr(ptr as *const u8) {
             // A bound *method* (class/instance method read as a value) is never

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -988,14 +988,14 @@ pub unsafe extern "C" fn js_new_function_construct(
             class_cid, class_cid, func_value, args_ptr, args_len,
         );
     }
-    if extends_target_must_throw(func_value) {
-        super::super::object_ops::throw_object_type_error(b"is not a constructor");
-    }
     if is_arrow_function_value(func_value) {
         crate::fs::validate::throw_type_error_with_code(
             "Arrow function is not a constructor",
             "ERR_INVALID_ARG_TYPE",
         );
+    }
+    if extends_target_must_throw(func_value) {
+        super::super::object_ops::throw_object_type_error(b"is not a constructor");
     }
     let cid = synthetic_class_id_for_function(func_value);
     // Allocate the instance with the synthetic class id (or 0 if the
@@ -1673,8 +1673,8 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
                 | "BigUint64Array"
         ) {
             // Validate and initialize the typed-array contents before reading
-            // a custom newTarget prototype.  In particular, a Number/BigInt
-            // element-type mismatch must throw TypeError without observing a
+            // a custom newTarget prototype. In particular, invalid Symbol
+            // element conversion must throw TypeError without observing a
             // poisoned `newTarget.prototype` getter.
             let scope = crate::gc::RuntimeHandleScope::new();
             let nt_h = scope.root_nanbox_f64(nt);

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -313,6 +313,13 @@ pub unsafe extern "C" fn js_new_function_construct(
         super::super::object_ops::throw_object_type_error(b"is not a constructor");
     }
     if let Some((module, method)) = bound_native_callable_module_and_method(func_value) {
+        // Native constructors and ordinary exports share the bound-method
+        // trampoline. Consult the export metadata before falling through to
+        // generic closure construction; some lower-case JavaScript wrappers
+        // are constructors while native functions such as path methods are not.
+        if !super::super::native_module::is_native_module_constructor_export(&module, &method) {
+            super::super::object_ops::throw_object_type_error(b"is not a constructor");
+        }
         if module == "perf_hooks" {
             if let Some(result) =
                 crate::perf_hooks::construct_perf_hooks_class(&method, args_ptr, args_len)
@@ -1215,6 +1222,10 @@ pub(crate) fn js_value_is_constructor(value: f64) -> bool {
     if is_non_constructable_builtin_function_value(value) {
         return false;
     }
+    let ptr = JSValue::from_bits(value.to_bits()).as_pointer::<crate::closure::ClosureHeader>();
+    if crate::closure::closure_is_bound_method(ptr) {
+        return is_bound_native_constructor_closure_value(value);
+    }
     true
 }
 
@@ -1255,7 +1266,7 @@ pub(crate) fn extends_target_must_throw(value: f64) -> bool {
         // trampoline here breaks dynamic aliases such as
         // `const Console = console.Console; new Console(...)` and native base
         // construction reached through an indirect user-class chain.
-        if is_bound_native_method_closure_value(value) {
+        if is_bound_native_constructor_closure_value(value) {
             return false;
         }
         let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();

--- a/crates/perry-runtime/src/object/class_registry/function_prototype.rs
+++ b/crates/perry-runtime/src/object/class_registry/function_prototype.rs
@@ -11,6 +11,15 @@ pub(crate) fn function_would_have_own_prototype(func_value: f64) -> bool {
     {
         return false;
     }
+    let jv = crate::value::JSValue::from_bits(func_value.to_bits());
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+        if crate::closure::closure_is_bound_method(ptr)
+            && !super::super::native_module::bound_native_callable_is_constructor_value(func_value)
+        {
+            return false;
+        }
+    }
     synthetic_class_id_for_function(func_value) != 0
 }
 
@@ -33,15 +42,8 @@ pub(crate) fn ordinary_function_prototype_value_for_read(func_value: f64) -> Opt
             if super::super::native_module::builtin_closure_is_non_constructable_value(func_value) {
                 return None;
             }
-            let is_native_class_export = unsafe {
-                super::super::native_module::bound_native_callable_module_and_method(func_value)
-            }
-            .is_some_and(|(_, method)| {
-                method
-                    .as_bytes()
-                    .first()
-                    .is_some_and(|b| b.is_ascii_uppercase())
-            });
+            let is_native_class_export =
+                super::super::native_module::bound_native_callable_is_constructor_value(func_value);
             if !is_native_class_export {
                 return None;
             }

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::JSValue;
+use crate::{object::object_ops::throw_object_type_error, JSValue};
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 
@@ -122,6 +122,9 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_val
     if let Some((module, method)) = unsafe {
         super::super::native_module::bound_native_callable_module_and_method(parent_value)
     } {
+        if !super::super::native_module::is_native_module_constructor_export(&module, &method) {
+            throw_object_type_error(b"Class extends value is not a constructor");
+        }
         if super::super::native_module::normalize_native_module_alias(&module) == "wasi"
             && method == "WASI"
         {
@@ -129,16 +132,11 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_val
         }
         return;
     }
-    if is_bound_native_method_closure_value(parent_value) {
-        return;
-    }
     // Spec: a non-`null` superclass that is not a constructor throws a TypeError
     // at class-definition time (before any `.prototype` access). (Test262
     // subclass/superclass-* and definition/invalid-extends.)
     if extends_target_must_throw(parent_value) {
-        super::super::object_ops::throw_object_type_error(
-            b"Class extends value is not a constructor",
-        );
+        throw_object_type_error(b"Class extends value is not a constructor");
     }
 
     // #5893 (ClassDefinitionEvaluation): once the superclass is confirmed a

--- a/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
@@ -212,17 +212,29 @@ pub(crate) unsafe fn mirror_prototype_method_on_object(
     if proto.is_null() || name.is_empty() {
         return;
     }
-    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    js_object_set_field_by_name(proto, key, f64::from_bits(value_bits));
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let proto = scope.root_raw_mut_ptr(proto);
+    let value = scope.root_nanbox_u64(value_bits);
+    let key = scope.root_string_ptr(crate::string::js_string_from_bytes(
+        name.as_ptr(),
+        name.len() as u32,
+    ));
+    proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
+        key.with_const_ptr::<crate::StringHeader, _>(|key| {
+            js_object_set_field_by_name(proto, key, value.get_nanbox_f64())
+        })
+    });
     if !enumerable {
         // `js_object_set_field_by_name` records the default (enumerable) attrs;
         // override so reflective own-key enumeration skips a defineProperty-
         // registered non-enumerable method.
-        set_builtin_property_attrs(
-            proto as usize,
-            name.to_string(),
-            PropertyAttrs::new(true, false, true),
-        );
+        proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
+            set_builtin_property_attrs(
+                proto as usize,
+                name.to_string(),
+                PropertyAttrs::new(true, false, true),
+            )
+        });
     }
 }
 

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -38,35 +38,50 @@ pub(crate) fn ensure_function_prototype_object(
         return existing;
     }
 
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let func_handle = scope.root_nanbox_f64(func_value);
     let proto = js_object_alloc(0, 0);
     if proto.is_null() {
         return proto;
     }
+    let proto_handle = scope.root_raw_mut_ptr(proto);
 
-    let constructor_key =
-        crate::string::js_string_from_bytes(b"constructor".as_ptr(), "constructor".len() as u32);
-    js_object_set_field_by_name(proto, constructor_key, func_value);
-    set_builtin_property_attrs(
-        proto as usize,
-        "constructor".to_string(),
-        PropertyAttrs::new(true, false, true),
-    );
+    let constructor_key = scope.root_string_ptr(crate::string::js_string_from_bytes(
+        b"constructor".as_ptr(),
+        "constructor".len() as u32,
+    ));
+    proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
+        constructor_key.with_const_ptr::<crate::StringHeader, _>(|key| {
+            js_object_set_field_by_name(proto, key, func_handle.get_nanbox_f64())
+        })
+    });
+    proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
+        set_builtin_property_attrs(
+            proto as usize,
+            "constructor".to_string(),
+            PropertyAttrs::new(true, false, true),
+        )
+    });
 
     if let Some(object_proto_bits) = global_object_prototype_bits() {
-        super::super::prototype_chain::object_set_static_prototype(
-            proto as usize,
-            object_proto_bits,
-        );
+        proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
+            super::super::prototype_chain::object_set_static_prototype(
+                proto as usize,
+                object_proto_bits,
+            )
+        });
     }
 
-    class_prototype_object_root_store(class_id, proto);
+    proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
+        class_prototype_object_root_store(class_id, proto)
+    });
 
     // #5024: methods registered before the prototype object materialized
     // (`F.prototype.m = v` typically runs long before any reflective
     // `F.prototype` read) live only in CLASS_PROTOTYPE_METHODS. Backfill
     // them as ordinary own properties so enumeration sees them; later
     // registrations write through via class_prototype_method_root_store.
-    let registered: Vec<(String, u64)> = {
+    let registered_bits: Vec<(String, u64)> = {
         CLASS_PROTOTYPE_METHODS.with(|table| {
             let guard = table.read().unwrap();
             guard
@@ -76,9 +91,17 @@ pub(crate) fn ensure_function_prototype_object(
                 .unwrap_or_default()
         })
     };
-    for (name, value_bits) in registered {
+    // The copied side-table values are no longer themselves scanner roots.
+    // Root the whole snapshot before the first mirrored property can allocate.
+    let registered: Vec<_> = registered_bits
+        .into_iter()
+        .map(|(name, value_bits)| (name, scope.root_nanbox_u64(value_bits)))
+        .collect();
+    for (name, value) in registered {
         let enumerable = class_prototype_method_is_enumerable(class_id, &name);
-        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits, enumerable) };
+        proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| unsafe {
+            mirror_prototype_method_on_object(proto, &name, value.get_nanbox_u64(), enumerable)
+        });
     }
 
     // #5477: the bound `events.EventEmitter` / `EventEmitterAsyncResource` export's
@@ -95,17 +118,21 @@ pub(crate) fn ensure_function_prototype_object(
     // (which arms), so binaries without module imports link neither the
     // probe nor the EventEmitter prototype machinery.
     if let Some(ops) = super::super::nm_namespace_ops() {
-        unsafe { (ops.ee_prototype_install)(func_value, proto) };
+        proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| unsafe {
+            (ops.ee_prototype_install)(func_handle.get_nanbox_f64(), proto)
+        });
     }
 
-    let func_bits = func_value.to_bits();
+    let func_bits = func_handle.get_nanbox_u64();
     if (func_bits >> 48) == 0x7FFD {
         let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
         if func_ptr != 0 {
             crate::closure::closure_set_dynamic_prop(
                 func_ptr,
                 "prototype",
-                crate::value::js_nanbox_pointer(proto as i64),
+                proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
+                    crate::value::js_nanbox_pointer(proto as i64)
+                }),
             );
             set_builtin_property_attrs(
                 func_ptr,
@@ -115,7 +142,7 @@ pub(crate) fn ensure_function_prototype_object(
         }
     }
 
-    proto
+    proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| proto)
 }
 
 per_test_global! {
@@ -571,8 +598,13 @@ pub(crate) unsafe fn nm_ee_prototype_install(
     func_value: f64,
     proto: *mut crate::object::ObjectHeader,
 ) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let func_value = scope.root_nanbox_f64(func_value);
+    let proto = scope.root_raw_mut_ptr(proto);
     if let Some((module, method)) =
-        super::super::native_module::bound_native_callable_module_and_method(func_value)
+        super::super::native_module::bound_native_callable_module_and_method(
+            func_value.get_nanbox_f64(),
+        )
     {
         if module.trim_start_matches("node:") == "events"
             && matches!(
@@ -580,7 +612,9 @@ pub(crate) unsafe fn nm_ee_prototype_install(
                 "EventEmitter" | "EventEmitterAsyncResource"
             )
         {
-            crate::node_stream::install_event_emitter_prototype_methods(proto);
+            proto.with_mut_ptr::<crate::object::ObjectHeader, _>(|proto| {
+                crate::node_stream::install_event_emitter_prototype_methods(proto)
+            });
         }
     }
 }

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -64,10 +64,11 @@ pub(crate) fn ensure_function_prototype_object(
     });
 
     if let Some(object_proto_bits) = global_object_prototype_bits() {
+        let object_proto = scope.root_nanbox_u64(object_proto_bits);
         proto_handle.with_mut_ptr::<ObjectHeader, _>(|proto| {
             super::super::prototype_chain::object_set_static_prototype(
                 proto as usize,
-                object_proto_bits,
+                object_proto.get_nanbox_u64(),
             )
         });
     }

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -11,22 +11,11 @@ pub(crate) fn is_non_constructable_builtin_function_value(value: f64) -> bool {
     super::super::native_module::builtin_closure_is_non_constructable_value(value)
 }
 
-/// True when `value` is a bound native-module method/export closure
-/// (`BOUND_METHOD_FUNC_PTR` trampoline — what a `require('stream').Writable`
-/// property read produces). These represent real Node classes/functions and
-/// must be accepted as `extends` targets.
-pub(crate) fn is_bound_native_method_closure_value(value: f64) -> bool {
-    // Gate on the native-module metadata, not the raw BOUND_METHOD_FUNC_PTR
-    // trampoline: reified `Function.prototype.{bind,call,apply}` values
-    // (`reify_function_method_value`) share that trampoline but are NOT native
-    // constructors, so matching the sentinel alone would let `class X extends
-    // obj.method {}` skip the spec-required TypeError and silently stay
-    // parentless. A real native-module export carries a non-empty module name.
-    unsafe {
-        super::super::native_module::bound_native_callable_module_and_method(value)
-            .map(|(module, _)| !module.is_empty())
-            .unwrap_or(false)
-    }
+/// True when `value` is a bound native-module *constructor* export. Native
+/// constructors and ordinary module functions share `BOUND_METHOD_FUNC_PTR`,
+/// so the export's explicit constructor metadata must make the distinction.
+pub(crate) fn is_bound_native_constructor_closure_value(value: f64) -> bool {
+    super::super::native_module::bound_native_callable_is_constructor_value(value)
 }
 
 pub(crate) fn throw_non_constructable_builtin_function() -> ! {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -284,6 +284,27 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                     return f64::from_bits(crate::value::TAG_UNDEFINED);
                 };
                 let addr = crate::value::js_nanbox_get_pointer(receiver.get_nanbox_f64()) as usize;
+                // Plain node Buffers are byte-indexed exotic objects but are
+                // not always marked as Uint8Array owners, so the typed-array
+                // arm above can legitimately decline them. Their canonical
+                // in-bounds byte keys still have ordinary element descriptors;
+                // an out-of-bounds canonical index cannot fall through to an
+                // expando/accessor of the same spelling.
+                if crate::buffer::is_byte_indexed_buffer(addr) {
+                    if let Some(index) = property_name_array_index(&name) {
+                        let buf = addr as *const crate::buffer::BufferHeader;
+                        let len = crate::buffer::js_buffer_length(buf).max(0) as u32;
+                        if index < len && index <= i32::MAX as u32 {
+                            return build_data_descriptor(
+                                f64::from(crate::buffer::js_buffer_get(buf, index as i32)),
+                                true,
+                                true,
+                                true,
+                            );
+                        }
+                        return f64::from_bits(crate::value::TAG_UNDEFINED);
+                    }
+                }
                 if let Some(accessor) = get_accessor_descriptor(addr, &name) {
                     let attrs = get_property_attrs(addr, &name)
                         .unwrap_or_else(|| PropertyAttrs::new(false, false, false));

--- a/crates/perry-runtime/src/object/field_get_set/enumeration.rs
+++ b/crates/perry-runtime/src/object/field_get_set/enumeration.rs
@@ -956,7 +956,7 @@ pub(crate) fn registered_buffer_own_keys(addr: usize) -> Option<Vec<String>> {
 /// The value each key of [`registered_buffer_own_keys`] names: the byte for an
 /// in-bounds index of a byte-indexed buffer, else the stored own property.
 pub(crate) fn registered_buffer_own_value(addr: usize, key: &str) -> f64 {
-    if let Some(v) = crate::buffer::buffer_get_own_prop(addr, key) {
+    if let Some(v) = crate::buffer::buffer_read_own_prop(addr, key) {
         return v;
     }
     if crate::buffer::is_byte_indexed_buffer(addr) {
@@ -973,30 +973,69 @@ pub(crate) fn registered_buffer_own_value(addr: usize, key: &str) -> f64 {
 /// Build the `Object.keys` / `.values` / `.entries` answer for a registered
 /// buffer from [`registered_buffer_own_keys`].
 fn registered_buffer_enum(addr: usize, what: MapSetEnum) -> Option<*mut ArrayHeader> {
-    let keys = registered_buffer_own_keys(addr)?;
-    let mut out = crate::array::js_array_alloc(keys.len().max(1) as u32);
+    if addr == 0 || !crate::buffer::is_registered_buffer(addr) {
+        return None;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_raw_mut_ptr(addr as *mut crate::buffer::BufferHeader);
+    let keys = receiver.with_mut_ptr::<crate::buffer::BufferHeader, _>(|receiver| {
+        registered_buffer_own_keys(receiver as usize)
+    })?;
+    let out = scope.root_raw_mut_ptr(crate::array::js_array_alloc(keys.len().max(1) as u32));
     for key in keys {
         let key_str = || crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
         match what {
             MapSetEnum::Keys => {
-                out = crate::array::js_array_push(out, JSValue::string_ptr(key_str()));
+                let key = scope.root_string_ptr(key_str());
+                let next = out.with_mut_ptr::<ArrayHeader, _>(|out| {
+                    key.with_mut_ptr::<crate::StringHeader, _>(|key| {
+                        crate::array::js_array_push(out, JSValue::string_ptr(key))
+                    })
+                });
+                out.set_raw_mut_ptr(next);
             }
             MapSetEnum::Values => {
-                out = crate::array::js_array_push_f64(out, registered_buffer_own_value(addr, &key));
+                let value =
+                    scope.root_nanbox_f64(receiver.with_mut_ptr::<crate::buffer::BufferHeader, _>(
+                        |receiver| registered_buffer_own_value(receiver as usize, &key),
+                    ));
+                let next = out.with_mut_ptr::<ArrayHeader, _>(|out| {
+                    crate::array::js_array_push_f64(out, value.get_nanbox_f64())
+                });
+                out.set_raw_mut_ptr(next);
             }
             MapSetEnum::Entries => {
-                let pair = crate::array::js_array_alloc(2);
-                let pair = crate::array::js_array_push(pair, JSValue::string_ptr(key_str()));
-                let pair =
-                    crate::array::js_array_push_f64(pair, registered_buffer_own_value(addr, &key));
-                out = crate::array::js_array_push(
-                    out,
-                    JSValue::from_bits(JSValue::pointer(pair as *const u8).bits()),
-                );
+                let pair = scope.root_raw_mut_ptr(crate::array::js_array_alloc(2));
+                let key_value = scope.root_string_ptr(key_str());
+                let next = pair.with_mut_ptr::<ArrayHeader, _>(|pair| {
+                    key_value.with_mut_ptr::<crate::StringHeader, _>(|key| {
+                        crate::array::js_array_push(pair, JSValue::string_ptr(key))
+                    })
+                });
+                pair.set_raw_mut_ptr(next);
+                let value =
+                    scope.root_nanbox_f64(receiver.with_mut_ptr::<crate::buffer::BufferHeader, _>(
+                        |receiver| registered_buffer_own_value(receiver as usize, &key),
+                    ));
+                let next = pair.with_mut_ptr::<ArrayHeader, _>(|pair| {
+                    crate::array::js_array_push_f64(pair, value.get_nanbox_f64())
+                });
+                pair.set_raw_mut_ptr(next);
+                let pair_value =
+                    scope.root_nanbox_f64(pair.with_mut_ptr::<ArrayHeader, _>(|pair| {
+                        crate::value::js_nanbox_pointer(pair as i64)
+                    }));
+                let next = out.with_mut_ptr::<ArrayHeader, _>(|out| {
+                    crate::array::js_array_push(
+                        out,
+                        JSValue::from_bits(pair_value.get_nanbox_u64()),
+                    )
+                });
+                out.set_raw_mut_ptr(next);
             }
         }
     }
-    Some(out)
+    Some(out.with_mut_ptr::<ArrayHeader, _>(|out| out))
 }
 
 /// Get the keys of an object as an array of strings.

--- a/crates/perry-runtime/src/object/global_this/generator.rs
+++ b/crates/perry-runtime/src/object/global_this/generator.rs
@@ -146,16 +146,21 @@ pub(crate) fn wire_async_function_intrinsic_parents() {
     let proto = scope.root_raw_mut_ptr(proto as *mut ObjectHeader);
     let function_ctor = js_get_global_this_builtin_value(b"Function".as_ptr(), 8);
     if crate::value::JSValue::from_bits(function_ctor.to_bits()).is_pointer() {
+        let function_ctor = scope.root_nanbox_f64(function_ctor);
         ctor.with_mut_ptr::<crate::closure::ClosureHeader, _>(|ctor| {
-            crate::closure::closure_set_static_prototype(ctor as usize, function_ctor.to_bits())
+            crate::closure::closure_set_static_prototype(
+                ctor as usize,
+                function_ctor.get_nanbox_f64().to_bits(),
+            )
         });
     }
     let function_proto = builtin_prototype_value("Function");
     if crate::value::JSValue::from_bits(function_proto.to_bits()).is_pointer() {
+        let function_proto = scope.root_nanbox_f64(function_proto);
         proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
             super::super::prototype_chain::object_set_static_prototype(
                 proto as usize,
-                function_proto.to_bits(),
+                function_proto.get_nanbox_f64().to_bits(),
             )
         });
     }

--- a/crates/perry-runtime/src/object/global_this/generator.rs
+++ b/crates/perry-runtime/src/object/global_this/generator.rs
@@ -141,16 +141,23 @@ pub(crate) fn wire_async_function_intrinsic_parents() {
     if ctor == 0 || proto == 0 {
         return;
     }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let ctor = scope.root_raw_mut_ptr(ctor as *mut crate::closure::ClosureHeader);
+    let proto = scope.root_raw_mut_ptr(proto as *mut ObjectHeader);
     let function_ctor = js_get_global_this_builtin_value(b"Function".as_ptr(), 8);
     if crate::value::JSValue::from_bits(function_ctor.to_bits()).is_pointer() {
-        crate::closure::closure_set_static_prototype(ctor as usize, function_ctor.to_bits());
+        ctor.with_mut_ptr::<crate::closure::ClosureHeader, _>(|ctor| {
+            crate::closure::closure_set_static_prototype(ctor as usize, function_ctor.to_bits())
+        });
     }
     let function_proto = builtin_prototype_value("Function");
     if crate::value::JSValue::from_bits(function_proto.to_bits()).is_pointer() {
-        super::super::prototype_chain::object_set_static_prototype(
-            proto as usize,
-            function_proto.to_bits(),
-        );
+        proto.with_mut_ptr::<ObjectHeader, _>(|proto| {
+            super::super::prototype_chain::object_set_static_prototype(
+                proto as usize,
+                function_proto.to_bits(),
+            )
+        });
     }
 }
 

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -363,7 +363,12 @@ pub(crate) unsafe fn call_overridden_iterator_next(
 
     let method = scope.root_nanbox_f64(method);
     super::js_implicit_this_set(iter.get_nanbox_f64());
-    let result = crate::closure::js_native_call_value(method.get_nanbox_f64(), std::ptr::null(), 0);
+    let result = crate::exception::js_call_catching(|| {
+        crate::closure::js_native_call_value(method.get_nanbox_f64(), std::ptr::null(), 0)
+    });
     super::js_implicit_this_set(previous.get_nanbox_f64());
-    Some(result)
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => crate::exception::js_throw(error),
+    }
 }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -21,6 +21,7 @@ mod perf_instance_bind;
 pub(crate) use perf_instance_bind::instance_bound_perf_method;
 mod constants;
 mod constants_tables;
+mod constructor_exports;
 mod module_keys;
 mod namespace_builders;
 mod web_locks;
@@ -47,6 +48,9 @@ pub(crate) use callable_exports::{
     zlib_codes_object,
 };
 pub(crate) use constants::get_native_module_constant;
+pub(crate) use constructor_exports::{
+    bound_native_callable_is_constructor_value, is_native_module_constructor_export,
+};
 pub(crate) use module_keys::{native_module_enumerable_keys, native_module_has_enumerable_key};
 #[cfg(test)]
 pub(crate) use namespace_builders::create_fs_constants_object;

--- a/crates/perry-runtime/src/object/native_module/constructor_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/constructor_exports.rs
@@ -1,0 +1,191 @@
+use super::*;
+
+/// Constructor metadata for native-module callable exports.
+///
+/// Native exports and ordinary module functions share the same bound-method
+/// closure trampoline, so callability alone cannot answer `IsConstructor`.
+/// Keep the distinction explicit here instead of treating every export (or
+/// every capitalized name) as constructable. Node exposes many lower-case
+/// JavaScript wrapper functions that *are* constructable (`repl.start`,
+/// `events.init`, most `fs` callbacks), so this is deliberately an exact
+/// non-constructor metadata table rather than a capitalization heuristic.
+pub(crate) fn is_native_module_constructor_export(module: &str, property: &str) -> bool {
+    let module = normalize_native_module_alias(module);
+    let module = cjs_default_base_module(module).unwrap_or(module);
+    let module = assert_instance_base_module(module).unwrap_or(module);
+    let module = normalize_native_module_alias(module);
+    let property = canonical_native_callable_property(module, property);
+
+    if !is_native_module_callable_export(module, property) {
+        return false;
+    }
+
+    !match module {
+        "assert" | "assert/strict" => matches!(property, "doesNotReject" | "rejects"),
+        "buffer.Buffer" => property == "of",
+        "console" => matches!(
+            property,
+            "assert"
+                | "clear"
+                | "context"
+                | "count"
+                | "countReset"
+                | "createTask"
+                | "debug"
+                | "dir"
+                | "dirxml"
+                | "error"
+                | "group"
+                | "groupCollapsed"
+                | "groupEnd"
+                | "info"
+                | "log"
+                | "profile"
+                | "profileEnd"
+                | "table"
+                | "time"
+                | "timeEnd"
+                | "timeLog"
+                | "timeStamp"
+                | "trace"
+                | "warn"
+        ),
+        "crypto" => matches!(
+            property,
+            "getCiphers"
+                | "getCurves"
+                | "getHashes"
+                | "privateDecrypt"
+                | "privateEncrypt"
+                | "publicDecrypt"
+                | "publicEncrypt"
+                | "timingSafeEqual"
+        ),
+        "crypto.KeyObject" => property == "from",
+        "dns" | "dns/promises" => property == "getServers",
+        "events" => property == "once",
+        "http" => property == "setMaxIdleHTTPParsers",
+        "inspector" => matches!(property, "close" | "url"),
+        "inspector.DOMStorage" => matches!(
+            property,
+            "domStorageItemAdded"
+                | "domStorageItemRemoved"
+                | "domStorageItemUpdated"
+                | "domStorageItemsCleared"
+                | "registerStorage"
+        ),
+        "inspector.Network" => matches!(
+            property,
+            "dataReceived"
+                | "dataSent"
+                | "loadingFailed"
+                | "loadingFinished"
+                | "requestWillBeSent"
+                | "responseReceived"
+                | "webSocketClosed"
+                | "webSocketCreated"
+                | "webSocketHandshakeResponseReceived"
+        ),
+        "inspector.Session" | "inspector/promises.Session" => property == "once",
+        "module" => matches!(property, "flushCompileCache" | "isBuiltin"),
+        "os" => matches!(
+            property,
+            "availableParallelism"
+                | "freemem"
+                | "machine"
+                | "release"
+                | "totalmem"
+                | "type"
+                | "version"
+        ),
+        "path" | "path.posix" | "path.win32" => matches!(
+            property,
+            "basename"
+                | "dirname"
+                | "extname"
+                | "isAbsolute"
+                | "join"
+                | "matchesGlob"
+                | "normalize"
+                | "parse"
+                | "relative"
+                | "resolve"
+                | "toNamespacedPath"
+        ),
+        "process" => matches!(
+            property,
+            "_debugEnd"
+                | "_debugProcess"
+                | "_fatalException"
+                | "_getActiveHandles"
+                | "_getActiveRequests"
+                | "_kill"
+                | "_startProfilerIdleNotifier"
+                | "_stopProfilerIdleNotifier"
+                | "abort"
+                | "availableMemory"
+                | "constrainedMemory"
+                | "dlopen"
+                | "getActiveResourcesInfo"
+                | "getegid"
+                | "geteuid"
+                | "getgid"
+                | "getgroups"
+                | "getuid"
+                | "reallyExit"
+                | "uptime"
+        ),
+        "punycode.ucs2" => property == "encode",
+        "stream" => property == "_isArrayBufferView",
+        "timers/promises" => property == "setInterval",
+        "tls" => property == "getCiphers",
+        "util" => matches!(
+            property,
+            "aborted" | "isDeepStrictEqual" | "parseArgs" | "toUSVString"
+        ),
+        "util.types" | "util/types" => matches!(
+            property,
+            "isAnyArrayBuffer"
+                | "isArgumentsObject"
+                | "isArrayBuffer"
+                | "isArrayBufferView"
+                | "isAsyncFunction"
+                | "isBigIntObject"
+                | "isBooleanObject"
+                | "isBoxedPrimitive"
+                | "isCryptoKey"
+                | "isDate"
+                | "isExternal"
+                | "isGeneratorFunction"
+                | "isGeneratorObject"
+                | "isKeyObject"
+                | "isMap"
+                | "isMapIterator"
+                | "isModuleNamespaceObject"
+                | "isNativeError"
+                | "isNumberObject"
+                | "isPromise"
+                | "isProxy"
+                | "isRegExp"
+                | "isSet"
+                | "isSetIterator"
+                | "isSharedArrayBuffer"
+                | "isStringObject"
+                | "isSymbolObject"
+                | "isWeakMap"
+                | "isWeakSet"
+        ),
+        "v8" => matches!(
+            property,
+            "cachedDataVersionTag" | "stopCoverage" | "takeCoverage"
+        ),
+        "v8.promiseHooks" => matches!(property, "onAfter" | "onBefore" | "onInit" | "onSettled"),
+        "worker_threads" => matches!(property, "moveMessagePortToContext" | "postMessageToThread"),
+        _ => false,
+    }
+}
+
+pub(crate) fn bound_native_callable_is_constructor_value(value: f64) -> bool {
+    unsafe { bound_native_callable_module_and_method(value) }
+        .is_some_and(|(module, property)| is_native_module_constructor_export(&module, &property))
+}

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -208,7 +208,7 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
         && crate::buffer::is_non_indexed_buffer_view(raw as usize)
     {
         if let Some(key) = crate::buffer::canonical_index_key(idx) {
-            return crate::buffer::buffer_get_own_prop(raw as usize, &key)
+            return crate::buffer::buffer_read_own_prop(raw as usize, &key)
                 .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
         }
     }
@@ -223,7 +223,7 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
             // pass wrote into a zero-length Buffer (RangeError
             // [ERR_OUT_OF_RANGE] at the MySQL handshake).
             if let Some(name) = buffer_key_name(idx) {
-                if let Some(v) = crate::buffer::buffer_get_own_prop(raw as usize, &name) {
+                if let Some(v) = crate::buffer::buffer_read_own_prop(raw as usize, &name) {
                     return v;
                 }
                 // The bound closure keeps the name POINTER and re-reads it at

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -273,18 +273,20 @@ fn builtin_prototype_methods_reject_dynamic_new() {
 }
 
 #[test]
-fn bound_native_constructor_export_is_not_rejected_as_a_bound_method() {
-    let _global = crate::gc::global_side_table_test_lock();
-    let console = super::native_module::bound_native_callable_export_value("console", "Console");
-
-    assert!(
-        js_value_is_constructor(console),
-        "console.Console is a constructor"
-    );
-    assert!(
-        !extends_target_must_throw(console),
-        "bound native constructor metadata must win over the shared bound-method trampoline"
-    );
+fn bound_native_constructor_metadata_distinguishes_module_functions() {
+    assert!(super::native_module::is_native_module_constructor_export(
+        "console", "Console"
+    ));
+    assert!(super::native_module::is_native_module_constructor_export(
+        "repl", "start"
+    ));
+    assert!(super::native_module::is_native_module_constructor_export(
+        "events", "init"
+    ));
+    assert!(!super::native_module::is_native_module_constructor_export(
+        "node:path",
+        "toNamespacedPath"
+    ));
 }
 
 #[test]

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -273,6 +273,21 @@ fn builtin_prototype_methods_reject_dynamic_new() {
 }
 
 #[test]
+fn bound_native_constructor_export_is_not_rejected_as_a_bound_method() {
+    let _global = crate::gc::global_side_table_test_lock();
+    let console = super::native_module::bound_native_callable_export_value("console", "Console");
+
+    assert!(
+        js_value_is_constructor(console),
+        "console.Console is a constructor"
+    );
+    assert!(
+        !extends_target_must_throw(console),
+        "bound native constructor metadata must win over the shared bound-method trampoline"
+    );
+}
+
+#[test]
 fn recorded_prototype_constructor_overrides_plain_object_constructor() {
     unsafe {
         let prototype = js_object_alloc(0, 1);

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -2095,7 +2095,7 @@ pub extern "C" fn js_typed_feedback_array_index_get_fallback_boxed(
         && crate::buffer::is_non_indexed_buffer_view(raw_addr)
     {
         if let Some(key) = crate::buffer::canonical_index_key(index) {
-            return crate::buffer::buffer_get_own_prop(raw_addr, &key)
+            return crate::buffer::buffer_read_own_prop(raw_addr, &key)
                 .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
         }
     }

--- a/crates/perry-runtime/src/typedarray/construct.rs
+++ b/crates/perry-runtime/src/typedarray/construct.rs
@@ -227,13 +227,13 @@ unsafe fn typed_array_plain_object_values(val: f64) -> Vec<f64> {
         let iter =
             crate::closure::js_native_call_value(bound_rooted.get_nanbox_f64(), ptr::null(), 0);
         let iter_rooted = scope.root_nanbox_f64(iter);
-        let mut raw: Vec<f64> = Vec::new();
+        let mut raw = Vec::new();
         while let Some(v) =
             crate::collection_iter::iterator_next_value(iter_rooted.get_nanbox_f64())
         {
-            raw.push(v);
+            raw.push(scope.root_nanbox_f64(v));
         }
-        return raw;
+        return crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&raw);
     }
     // Array-like path.
     let len_val = object_like_get(rooted.get_nanbox_f64(), "length");
@@ -250,11 +250,11 @@ unsafe fn typed_array_plain_object_values(val: f64) -> Vec<f64> {
         throw_range_error(format!("Invalid typed array length: {}", len as u64).as_bytes());
     }
     let len = len as u32;
-    let mut raw: Vec<f64> = Vec::with_capacity(len as usize);
+    let mut raw = Vec::with_capacity(len as usize);
     for k in 0..len {
-        raw.push(object_like_get(rooted.get_nanbox_f64(), &k.to_string()));
+        raw.push(scope.root_nanbox_f64(object_like_get(rooted.get_nanbox_f64(), &k.to_string())));
     }
-    raw
+    crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&raw)
 }
 
 /// Collect the raw (uncoerced) source values for `%TypedArray%.from(source)`:
@@ -298,10 +298,16 @@ pub(crate) unsafe fn typed_array_from_source_raw_values(val: f64) -> Vec<f64> {
     // `js_array_from_value` allocated; re-root on the RESULT, which is the
     // value the element reads below must observe.
     let arr_rooted = scope.root_raw_const_ptr(arr);
-    let len = crate::array::js_array_length(arr_rooted.get_raw_const_ptr());
-    (0..len)
-        .map(|i| crate::array::js_array_get_f64(arr_rooted.get_raw_const_ptr(), i))
-        .collect()
+    let len = arr_rooted.with_const_ptr::<ArrayHeader, _>(|arr| crate::array::js_array_length(arr));
+    let raw: Vec<_> = (0..len)
+        .map(|i| {
+            scope.root_nanbox_f64(
+                arr_rooted
+                    .with_const_ptr::<ArrayHeader, _>(|arr| crate::array::js_array_get_f64(arr, i)),
+            )
+        })
+        .collect();
+    crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&raw)
 }
 
 /// Coerce a snapshot of raw element values per `kind` (observable, may throw)
@@ -417,21 +423,56 @@ pub extern "C" fn js_typed_array_new_from_array(
         return typed_array_alloc(kind, 0);
     }
     rooted.set_raw_const_ptr(arr);
-    // InitializeTypedArrayFromArrayLike obtains and drives the source's
-    // iterator. Going through the real iterator protocol matters even for a
-    // dense Array: user code can replace Array.prototype[Symbol.iterator] or
-    // %ArrayIteratorPrototype%.next, and construction must observe either.
-    // Collect the raw values first and only then coerce them, retaining the
-    // mutation/snapshot rule described by `typed_array_from_snapshot`.
-    let source = rooted
-        .with_const_ptr::<ArrayHeader, _>(|source| crate::value::js_nanbox_pointer(source as i64));
-    let iter = crate::symbol::js_get_iterator(source);
-    let iter_rooted = scope.root_nanbox_f64(iter);
+    // GetMethod(source, @@iterator) is observable even for a dense Array. A
+    // callable method drives the real iterator protocol; undefined/null falls
+    // back to InitializeTypedArrayFromArrayLike. In particular, deleting
+    // Array.prototype[Symbol.iterator] must not make `new Uint8Array(array)`
+    // throw. Collect raw values before coercion, retaining the mutation/
+    // snapshot rule described by `typed_array_from_snapshot`.
+    let iterator_symbol = crate::symbol::well_known_symbol("iterator");
+    let method = if iterator_symbol.is_null() {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    } else {
+        let symbol =
+            f64::from_bits(crate::value::JSValue::pointer(iterator_symbol as *const u8).bits());
+        unsafe {
+            crate::symbol::js_object_get_symbol_property(
+                rooted.with_const_ptr::<ArrayHeader, _>(|source| {
+                    crate::value::js_nanbox_pointer(source as i64)
+                }),
+                symbol,
+            )
+        }
+    };
+    let method_bits = method.to_bits();
     let mut raw = Vec::new();
-    while let Some(value) =
-        crate::collection_iter::iterator_next_value(iter_rooted.get_nanbox_f64())
-    {
-        raw.push(scope.root_nanbox_f64(value));
+    if method_bits == crate::value::TAG_UNDEFINED || method_bits == crate::value::TAG_NULL {
+        let len = rooted.with_const_ptr::<ArrayHeader, _>(|arr| crate::array::js_array_length(arr));
+        for index in 0..len {
+            raw.push(
+                scope.root_nanbox_f64(rooted.with_const_ptr::<ArrayHeader, _>(|arr| {
+                    crate::array::js_array_get_f64(arr, index)
+                })),
+            );
+        }
+    } else {
+        let method = scope.root_nanbox_f64(method);
+        let iter = match crate::collection_iter::call_with_this_capturing_throw(
+            method.get_nanbox_f64(),
+            rooted.with_const_ptr::<ArrayHeader, _>(|source| {
+                crate::value::js_nanbox_pointer(source as i64)
+            }),
+            &[],
+        ) {
+            Ok(iter) => iter,
+            Err(error) => crate::exception::js_throw(error),
+        };
+        let iter_rooted = scope.root_nanbox_f64(iter);
+        while let Some(value) =
+            crate::collection_iter::iterator_next_value(iter_rooted.get_nanbox_f64())
+        {
+            raw.push(scope.root_nanbox_f64(value));
+        }
     }
     unsafe { typed_array_from_rooted_snapshot(kind, &raw) }
 }

--- a/crates/perry-runtime/src/typedarray/construct.rs
+++ b/crates/perry-runtime/src/typedarray/construct.rs
@@ -449,11 +449,11 @@ pub extern "C" fn js_typed_array_new_from_array(
     if method_bits == crate::value::TAG_UNDEFINED || method_bits == crate::value::TAG_NULL {
         let len = rooted.with_const_ptr::<ArrayHeader, _>(|arr| crate::array::js_array_length(arr));
         for index in 0..len {
-            raw.push(
-                scope.root_nanbox_f64(rooted.with_const_ptr::<ArrayHeader, _>(|arr| {
-                    crate::array::js_array_get_f64(arr, index)
-                })),
-            );
+            raw.push(scope.root_nanbox_f64(
+                rooted.with_const_ptr::<ArrayHeader, _>(|arr| {
+                    crate::array::array_spec_get(arr, index)
+                }),
+            ));
         }
     } else {
         let method = scope.root_nanbox_f64(method);

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -291,7 +291,7 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         && crate::buffer::is_non_indexed_buffer_view(raw_ptr)
     {
         if let Some(key) = crate::buffer::canonical_index_key(index) {
-            return crate::buffer::buffer_get_own_prop(raw_ptr, &key)
+            return crate::buffer::buffer_read_own_prop(raw_ptr, &key)
                 .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
         }
     }

--- a/test-files/test_gap_array_iterator_manual_next.ts
+++ b/test-files/test_gap_array_iterator_manual_next.ts
@@ -59,3 +59,23 @@ console.log(JSON.stringify([].values().next())); // {"done":true}
 const e2 = [100, 200].entries();
 const [, first] = e2.next().value;
 console.log(first); // 100
+
+// (7) A user replacement can throw. The iterator dispatcher temporarily
+// installs the iterator as the implicit receiver; abrupt completion must
+// restore the surrounding method's receiver before its catch block resumes.
+const iteratorPrototype: any = Object.getPrototypeOf([][Symbol.iterator]());
+const originalNext = iteratorPrototype.next;
+iteratorPrototype.next = function () {
+  throw new Error("replacement next");
+};
+const outerReceiver = {
+  marker: "outer",
+  run(this: any) {
+    try {
+      [1].values().next();
+    } catch (_error) {}
+    return this.marker;
+  },
+};
+console.log("throw restores this:", outerReceiver.run()); // outer
+iteratorPrototype.next = originalNext;

--- a/test-files/test_gap_buffer_ops.ts
+++ b/test-files/test_gap_buffer_ops.ts
@@ -95,6 +95,58 @@ console.log("utf8 len:", Buffer.from("hello").length);
 console.log("emoji len:", Buffer.from("😀").length);
 console.log("empty len:", Buffer.from("").length);
 
+// --- Buffer exotic descriptors and accessor reads ---
+const descriptorBuffer = Buffer.from([7]);
+const byteDescriptor = Object.getOwnPropertyDescriptor(descriptorBuffer, "0");
+console.log(
+  "byte descriptor:",
+  byteDescriptor?.value,
+  byteDescriptor?.writable,
+  byteDescriptor?.enumerable,
+  byteDescriptor?.configurable,
+);
+
+const accessorBuffer: any = Buffer.from([1, 2]);
+let accessorHits = 0;
+Object.defineProperty(accessorBuffer, "computed", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    accessorHits++;
+    return 41;
+  },
+});
+const computedKey: any = "computed";
+console.log("buffer computed getter:", accessorBuffer[computedKey], accessorHits);
+console.log("buffer values getter:", Object.values(accessorBuffer).join(","), accessorHits);
+console.log(
+  "buffer entries getter:",
+  JSON.stringify(Object.entries(accessorBuffer)),
+  accessorHits,
+);
+
+Object.defineProperty(accessorBuffer, "readUInt8", {
+  configurable: true,
+  get() {
+    accessorHits++;
+    return function (_offset: number) {
+      return this === accessorBuffer ? 99 : -1;
+    };
+  },
+});
+console.log("buffer accessor method:", accessorBuffer.readUInt8(0), accessorHits);
+
+const accessorView: any = new DataView(new ArrayBuffer(1));
+Object.defineProperty(accessorView, "0", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return 77;
+  },
+});
+const zeroKey: any = 0;
+console.log("dataview numeric getter:", accessorView[zeroKey]);
+
 // --- Buffer.isBuffer --- (not yet in codegen: BufferIsBuffer)
 // console.log("isBuffer buf:", Buffer.isBuffer(Buffer.from("x")));
 

--- a/test-files/test_gap_console_validate_write.ts
+++ b/test-files/test_gap_console_validate_write.ts
@@ -1,6 +1,8 @@
 // Console stream-write validation parity (#3080).
 // Node's `new Console(...)` throws ERR_CONSOLE_WRITABLE_STREAM (a TypeError)
 // when a resolved stdout/stderr does not expose a callable `write` method.
+import { toNamespacedPath } from "node:path";
+
 const Console = (console as any).Console;
 
 function check(label: string, fn: () => void): void {
@@ -60,3 +62,20 @@ check("opts-both-ok", () => {
   const c = new Console({ stdout: { write() {} }, stderr: { write() {} } });
   void c;
 });
+
+// Native constructors and ordinary module functions use the same runtime
+// callable trampoline. Constructor metadata must preserve Console while still
+// rejecting a non-constructable export in both `extends` and `new`.
+try {
+  class InvalidNativeBase extends toNamespacedPath {}
+  void InvalidNativeBase;
+  console.log("extends-path-function: accepted");
+} catch (e: any) {
+  console.log("extends-path-function:", e.name);
+}
+try {
+  new toNamespacedPath();
+  console.log("new-path-function: accepted");
+} catch (e: any) {
+  console.log("new-path-function:", e.name);
+}

--- a/test-files/test_gap_typed_arrays.ts
+++ b/test-files/test_gap_typed_arrays.ts
@@ -10,6 +10,25 @@ const u2 = new Uint8Array([10, 20, 30, 40, 50]);
 console.log("from array:", u2[0], u2[1], u2[2], u2[3], u2[4]);
 console.log("from array length:", u2.length);
 
+// GetMethod(source, @@iterator) falls back to array-like reads when the
+// method is undefined or null.
+const iteratorDescriptor = Object.getOwnPropertyDescriptor(
+  Array.prototype,
+  Symbol.iterator,
+)!;
+delete (Array.prototype as any)[Symbol.iterator];
+const noPrototypeIterator = new Uint8Array([6, 7]);
+Object.defineProperty(Array.prototype, Symbol.iterator, iteratorDescriptor);
+console.log(
+  "from array without prototype iterator:",
+  noPrototypeIterator[0],
+  noPrototypeIterator[1],
+);
+const nullIteratorSource: any = [8, 9];
+nullIteratorSource[Symbol.iterator] = null;
+const nullIterator = new Uint8Array(nullIteratorSource);
+console.log("from array with null iterator:", nullIterator[0], nullIterator[1]);
+
 // --- Uint8Array read/write ---
 const u3 = new Uint8Array(3);
 u3[0] = 100;

--- a/test-files/test_gap_typed_arrays.ts
+++ b/test-files/test_gap_typed_arrays.ts
@@ -29,6 +29,30 @@ nullIteratorSource[Symbol.iterator] = null;
 const nullIterator = new Uint8Array(nullIteratorSource);
 console.log("from array with null iterator:", nullIterator[0], nullIterator[1]);
 
+// Array-like indexed Get preserves the source as `this` when an inherited
+// accessor supplies the element.
+const inheritedIndexSource: any = new Array(1);
+inheritedIndexSource[Symbol.iterator] = null;
+let inheritedIndexReceiverMatches = false;
+let inheritedIndexGetterCalls = 0;
+const indexedPrototype: any = [];
+Object.defineProperty(indexedPrototype, "0", {
+  configurable: true,
+  get() {
+    inheritedIndexGetterCalls++;
+    inheritedIndexReceiverMatches = this === inheritedIndexSource;
+    return inheritedIndexReceiverMatches ? 73 : 74;
+  },
+});
+Object.setPrototypeOf(inheritedIndexSource, indexedPrototype);
+const inheritedIndexResult = new Int16Array(inheritedIndexSource);
+console.log(
+  "from inherited indexed getter:",
+  inheritedIndexResult[0],
+  inheritedIndexReceiverMatches,
+  inheritedIndexGetterCalls,
+);
+
 // --- Uint8Array read/write ---
 const u3 = new Uint8Array(3);
 u3[0] = 100;

--- a/test-files/test_issue_611_globalthis.ts
+++ b/test-files/test_issue_611_globalthis.ts
@@ -52,6 +52,24 @@ console.log(
   mirroredUpdates.join(","),
 );
 
+// The update may hide the script-var write inside another expression. Mirror
+// it before the next argument reads globalThis, while preserving the old value
+// produced by postfix `++` for the first argument.
+const nestedUpdateSeen: number[] = [];
+for (
+  var nestedUpdateScriptVar = 0;
+  nestedUpdateScriptVar < 1;
+  nestedUpdateSeen.push(
+    nestedUpdateScriptVar++,
+    (globalThis as any).nestedUpdateScriptVar,
+  )
+) {}
+console.log(
+  "nested update:",
+  (globalThis as any).nestedUpdateScriptVar,
+  nestedUpdateSeen.join(","),
+);
+
 switch (1) {
   case 1: {
     var switchScriptVar = "case";

--- a/test-files/test_issue_611_globalthis.ts
+++ b/test-files/test_issue_611_globalthis.ts
@@ -17,3 +17,20 @@ const store = (globalThis as any)[storeId] as Map<string, string>;
 console.log("typeof store:", typeof store);
 store.set("k", "v");
 console.log("store.get('k'):", store.get("k"));
+
+// Script-level `var` remains a global-object binding even when its initializer
+// executes inside a compound statement.
+if (true) {
+  var nestedScriptVar = 42;
+}
+console.log("nested var:", (globalThis as any).nestedScriptVar);
+try {
+  var caughtScriptVar = "try";
+} finally {
+  var finalScriptVar = "finally";
+}
+console.log(
+  "try/finally vars:",
+  (globalThis as any).caughtScriptVar,
+  (globalThis as any).finalScriptVar,
+);

--- a/test-files/test_issue_611_globalthis.ts
+++ b/test-files/test_issue_611_globalthis.ts
@@ -34,3 +34,21 @@ console.log(
   (globalThis as any).caughtScriptVar,
   (globalThis as any).finalScriptVar,
 );
+
+const seen: number[] = [];
+outer: for (var loopScriptVar = 0; loopScriptVar < 3; loopScriptVar++) {
+  if (loopScriptVar === 0) continue outer;
+  seen.push(loopScriptVar);
+}
+console.log(
+  "labeled loop:",
+  (globalThis as any).loopScriptVar,
+  seen.join(","),
+);
+
+switch (1) {
+  case 1:
+    var switchScriptVar = "case";
+    break;
+}
+console.log("switch var:", (globalThis as any).switchScriptVar);

--- a/test-files/test_issue_611_globalthis.ts
+++ b/test-files/test_issue_611_globalthis.ts
@@ -36,7 +36,12 @@ console.log(
 );
 
 const seen: number[] = [];
-outer: for (var loopScriptVar = 0; loopScriptVar < 3; loopScriptVar++) {
+const mirroredUpdates: number[] = [];
+outer: for (
+  var loopScriptVar = 0;
+  loopScriptVar < 3;
+  loopScriptVar++, mirroredUpdates.push((globalThis as any).loopScriptVar)
+) {
   if (loopScriptVar === 0) continue outer;
   seen.push(loopScriptVar);
 }
@@ -44,11 +49,13 @@ console.log(
   "labeled loop:",
   (globalThis as any).loopScriptVar,
   seen.join(","),
+  mirroredUpdates.join(","),
 );
 
 switch (1) {
-  case 1:
+  case 1: {
     var switchScriptVar = "case";
     break;
+  }
 }
 console.log("switch var:", (globalThis as any).switchScriptVar);

--- a/test-parity/expected/test_issue_611_globalthis.txt
+++ b/test-parity/expected/test_issue_611_globalthis.txt
@@ -4,5 +4,5 @@ typeof store: object
 store.get('k'): v
 nested var: 42
 try/finally vars: try finally
-labeled loop: 3 1,2
+labeled loop: 3 1,2 1,2,3
 switch var: case

--- a/test-parity/expected/test_issue_611_globalthis.txt
+++ b/test-parity/expected/test_issue_611_globalthis.txt
@@ -4,3 +4,5 @@ typeof store: object
 store.get('k'): v
 nested var: 42
 try/finally vars: try finally
+labeled loop: 3 1,2
+switch var: case

--- a/test-parity/expected/test_issue_611_globalthis.txt
+++ b/test-parity/expected/test_issue_611_globalthis.txt
@@ -5,4 +5,5 @@ store.get('k'): v
 nested var: 42
 try/finally vars: try finally
 labeled loop: 3 1,2 1,2,3
+nested update: 1 0,1
 switch var: case

--- a/test-parity/expected/test_issue_611_globalthis.txt
+++ b/test-parity/expected/test_issue_611_globalthis.txt
@@ -1,0 +1,6 @@
+v: hello
+typeof v: string
+typeof store: object
+store.get('k'): v
+nested var: 42
+try/finally vars: try finally


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8650 for issue #5895. This closes every final-review finding and the parity regressions exposed while monitoring the merged change.

## Changes

- preserve labeled-loop continue targets and recursively mirror script-level `var` writes inside arbitrary loop-update expression trees at the exact evaluation point
- preserve postfix-update result values with compiler temporaries, including nested call arguments that read `globalThis` later in the same expression
- root and reload prototype parents, registered methods, EventEmitter installation, and inherited indexed-accessor receivers across collection points
- preserve the original array-like receiver through TypedArray indexed `Get` fallback
- centralize accessor-aware Buffer reads and descriptors across indexed dispatch, typed feedback, enumeration, and method calls
- restore implicit iterator receivers when overridden `next` calls throw
- distinguish constructable and non-constructable native-module callable exports with explicit Node constructor metadata
- route lower-case named native imports through runtime constructor checks, preserving constructable wrappers while rejecting exports such as `path.toNamespacedPath` in both `new` and `extends`
- bind derived `this` after direct and indirect EventEmitter/native-base initialization
- add permanent regressions for all corrected paths

## Validation

- pinned #5895 Test262 matrix at 4249661388e5d3f92a85186213da140a6481490f: 179 pass, 0 diff, 0 runtime-fail, 0 compile-fail, 0 skip; self-validation 8/8
- `cargo test -p perry-hir --lib`: 325 passed, 0 failed, 1 ignored
- `cargo test -p perry-runtime --lib -- --test-threads=1`: 2,643 passed, 0 failed, 4 ignored
- release compiler and runtime/stdlib static archives built successfully
- focused parity passes: nested `globalThis` update order, TypedArray receiver, Console/native constructor validation, and indirect native base
- `globalThis` update parity also passes with forced evacuation and evacuation verification
- formatting, diff, file-size, root-holder, raw-handle-debt, and unrooted-local-debt gates pass

## Checklist

- [x] no workspace version bump
- [x] no Cargo.lock, CHANGELOG.md, CLAUDE.md, or changelog fragment change
- [x] review-only delta; already-merged #8650 code is not duplicated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script-level `var` declarations in nested control-flow blocks are now reflected on `globalThis` at runtime.
  * Buffer property access supports accessor properties, accurate descriptors, enumeration, numeric getters, and callable own-property overrides.
  * TypedArray construction correctly handles missing or null array iterators.
  * Native constructor aliases can now be used with class inheritance.
* **Bug Fixes**
  * Improved exception propagation, receiver handling, and inherited accessor behavior.
  * Improved runtime stability during prototype, buffer, and TypedArray operations.
* **Tests**
  * Added coverage for global variables, buffer behavior, iterator errors, native constructors, and TypedArray construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->