### PR TITLE
test(codegen): restore the unary-pos assertions lost in the #8657 squash

### DIFF
--- a/changelog.d/8658-restore-lost-unary-pos-assertions.md
+++ b/changelog.d/8658-restore-lost-unary-pos-assertions.md
@@ -1,0 +1,11 @@
+Restored three `computed_store_rooting_tests` assertions that were lost when
+#8650 was squash-merged as part of #8657.
+
+#8650 changed unary `+` on a non-numeric operand to emit `js_dynamic_pos`
+instead of `js_number_coerce` (`expr/unary.rs`, `UnaryOp::Pos`) and updated the
+three tests that assert on that helper. The squash kept the emission change and
+dropped the test edit, so the assertions kept naming the old helper and failed
+deterministically.
+
+No product behaviour changes: the tests now name the helper the compiler
+actually emits, which is what #8650 intended.

--- a/crates/perry-codegen/src/expr/computed_store_rooting_tests.rs
+++ b/crates/perry-codegen/src/expr/computed_store_rooting_tests.rs
@@ -796,7 +796,7 @@ fn collecting_masked_window_index_declines_the_hoisted_pointer_tier() {
 
     let collecting = masked_window_index_coercion_loop(Type::Any);
     assert!(
-        calls(&collecting, "js_number_coerce"),
+        calls(&collecting, "js_dynamic_pos"),
         "unary + over an any key must exercise the collecting coercion witness:\n{collecting}"
     );
     assert!(
@@ -819,7 +819,7 @@ fn collecting_rhs_between_masked_reads_declines_the_hoisted_pointer_tier() {
 
     let collecting = masked_window_rhs_coercion_loop(Type::Any);
     assert!(
-        calls(&collecting, "js_number_coerce"),
+        calls(&collecting, "js_dynamic_pos"),
         "the any-typed RHS must exercise the user-coercion witness:\n{collecting}"
     );
     assert!(
@@ -842,7 +842,7 @@ fn collecting_rhs_declines_the_straight_line_masked_region() {
 
     let collecting = masked_window_rhs_coercion_region(Type::Any);
     assert!(
-        calls(&collecting, "js_number_coerce"),
+        calls(&collecting, "js_dynamic_pos"),
         "the any-typed region RHS must exercise the user-coercion witness:\n{collecting}"
     );
     assert!(


### PR DESCRIPTION
**`main` is red; this makes it green.** Three
`expr::computed_store_rooting_tests` cases fail **4/4** on `main` and **0/3**
with this change.

## What happened

#8650 changed unary `+` on a non-numeric operand to emit `js_dynamic_pos`
instead of `js_number_coerce` (`expr/unary.rs`, `UnaryOp::Pos`), and updated the
three tests that assert on that helper. When I squash-merged it as part of
#8657, the **emission change survived and the test edit did not** — so the
assertions kept naming a helper the compiler no longer emits at that site.

Bisected:

| commit | failures |
|---|---|
| `c2da03439` | 0/3 |
| **`06e1ab349`** (#8657) | **4/4** |
| `b5359b4de` (#8664) | 3/3 |
| `2382a9f15` (current main) | 4/4 |

Each of #8657's five PRs is 0/3 alone, and all five re-merged together are also
0/3 — only the landed squash fails, which is what isolates it to the merge
rather than to any PR.

## My error, recorded

I saw these same three tests fail 3/12 while validating #8657 and judged them
"likely pre-existing codegen tier nondeterminism," landing with a note. That was
wrong twice over: the failure was real and caused by my merge, and the
"nondeterminism" framing sent me looking at load sensitivity instead of at the
diff. #8658 was filed on that mistaken premise and should be re-scoped — the
intermittency I measured then was masking a deterministic breakage, not
describing one.

The lesson is narrow and worth keeping: a squash that drops one hunk of a PR
while keeping another produces a tree that no reviewer approved, and no
individual-PR check can see it. The only thing that catches it is testing the
merged result — which I did, and then explained away.

No product behaviour changes here; the tests now name the helper the compiler
actually emits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored coverage for unary `+` operations on non-numeric values.
  * Corrected assertions for masked indexes, right-hand-side expressions, and straight-line execution scenarios.

* **Documentation**
  * Added a changelog entry documenting the restored test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->