### PR TITLE
fix(runtime): refresh rooted arrays during iteration

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -63,22 +63,69 @@ impl<'s> RootedIterArray<'s> {
     /// observes the original receiver object — at its CURRENT address).
     #[inline(always)]
     fn receiver(&self) -> f64 {
-        self.handle.get_nanbox_f64()
+        array_receiver_value(self.arr())
     }
 
     #[inline(always)]
     fn arr(&self) -> *const ArrayHeader {
-        (self.handle.get_nanbox_u64() & crate::value::POINTER_MASK) as *const ArrayHeader
+        let rooted =
+            (self.handle.get_nanbox_u64() & crate::value::POINTER_MASK) as *const ArrayHeader;
+        let live = clean_arr_ptr(rooted);
+        if live != rooted {
+            // Array growth and moving GC leave forwarding stubs behind. Keep
+            // the root current so subsequent loop iterations do not inspect
+            // the stub's overwritten length/capacity word as an ArrayHeader.
+            self.handle.set_nanbox_f64(array_receiver_value(live));
+        }
+        live
     }
 
     #[inline(always)]
     unsafe fn present(&self, index: usize) -> Option<f64> {
-        present_array_element(array_elements_ptr(self.arr()), index)
+        let arr = self.arr();
+        if index >= (*arr).length as usize {
+            return None;
+        }
+        present_array_element(array_elements_ptr(arr), index)
     }
 
     #[inline(always)]
     unsafe fn get_or_undefined(&self, index: usize) -> f64 {
-        array_element_get_value(array_elements_ptr(self.arr()), index)
+        let arr = self.arr();
+        if index >= (*arr).length as usize {
+            return undefined_value();
+        }
+        array_element_get_value(array_elements_ptr(arr), index)
+    }
+}
+
+#[cfg(test)]
+mod rooted_iter_array_tests {
+    use super::*;
+
+    #[test]
+    fn forwarded_array_observes_shrunk_length_during_callback_iteration() {
+        unsafe {
+            let mut arr = js_array_alloc(3);
+            arr = js_array_push_f64(arr, 1.0);
+            arr = js_array_push_f64(arr, 2.0);
+            arr = js_array_push_f64(arr, 3.0);
+
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let rooted = RootedIterArray::new(&scope, arr);
+            let mut live_arr = js_array_grow(arr, (*arr).capacity + 1);
+            assert_ne!(live_arr, arr);
+            let _removed = js_array_splice(live_arr, 1, 1, ptr::null(), 0, &mut live_arr);
+
+            assert_eq!((*live_arr).length, 2);
+            assert_eq!(rooted.arr(), clean_arr_ptr(live_arr));
+            assert_eq!(rooted.get_or_undefined(1), 3.0);
+            assert_eq!(
+                rooted.get_or_undefined(2).to_bits(),
+                crate::value::TAG_UNDEFINED
+            );
+            assert_eq!(rooted.present(2), None);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the Array.prototype.find and findIndex mutation-during-iteration failures from the #5898 Test262 worklist. Callback-driven array relocation now refreshes the rooted receiver, and reads beyond a callback-shrunk logical length return absent/undefined instead of stale tail storage.

## Changes

- Resolve array-growth and moving-GC forwarding stubs before each callback-loop access, then self-heal the runtime root.
- Check the current logical length before reading inline array elements.
- Add a focused runtime regression test covering forwarding followed by splice shrinkage.

## Related issue

Refs #5898 — completes the find/findIndex array-altered-during-loop subcluster.

## Test plan

- [x] cargo build --release -p perry-runtime-static -p perry-stdlib-static
- [x] cargo test --release -p perry-runtime forwarded_array_observes_shrunk_length_during_callback_iteration -- --test-threads=1
- [x] Test262 built-ins/Array/prototype/find + findIndex: 36 pass, 0 failures (pinned SHA 4249661388e5d3f92a85186213da140a6481490f)
- [x] Full Test262 built-ins/Array slice: 2498 pass, 0 diff, 29 existing runtime failures, 0 compile failures; selected failures absent
- [x] cargo fmt -p perry-runtime -- --check
- [x] python scripts/check_test_registration.py
- [ ] Full workspace test suite (not run locally)

## Screenshots / output

Before: 34/36 pass in the selected Test262 directories; both array-altered-during-loop cases failed with stale Bike instead of undefined.

After: 36/36 pass.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose feat/fix/docs/chore prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array iteration reliability when arrays move during memory management.
  * Array accesses now respect the current array length, preventing reads beyond shortened arrays.
  * Correctly handles forwarded arrays, missing elements, and out-of-range lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->