### PR TITLE
perf(codegen): share numeric guards across dynamic add trees

### DIFF
--- a/changelog.d/8675-dynamic-add-tree-guard.md
+++ b/changelog.d/8675-dynamic-add-tree-guard.md
@@ -1,0 +1,9 @@
+### Performance
+
+- Lower dynamic `+` trees with three or more leaves behind one shared numeric
+  guard. Number-only executions use native additions, while the cold arm keeps
+  the original tree, evaluation order, associativity, and complete dynamic
+  string/BigInt/Symbol/object-coercion behavior. On the `codehz/ecs` 10k
+  accumulation query, 11 alternating Mac mini pairs reduced median time by
+  4.11%, with 11/11 wins and every semantic oracle passing. The read-only
+  query was neutral, and this change does not claim Node parity.

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -303,6 +303,24 @@ fn add_tree_leaves<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
     }
 }
 
+/// Whether a fully-dynamic `+` tree is worth one shared numeric guard.
+///
+/// A three-or-more-leaf tree is the common accumulator shape
+/// `sum += row.x + row.y`: lowering each node independently otherwise pays
+/// the dynamic add helper twice even when every runtime value is a number. At
+/// two leaves the guard merely moves the helper behind a branch; starting at
+/// three it can replace two or more helper calls with one shared tag check.
+///
+/// Do not require a static numeric hint here. The important accumulator case
+/// is often a captured local plus fields read from interface-shaped objects,
+/// so every leaf is `Any` to codegen. The guard itself is the runtime proof;
+/// its cold arm preserves the original tree and exact dynamic `+` semantics.
+fn dynamic_add_tree_benefits_shared_guard(expr: &Expr) -> bool {
+    let mut leaves = Vec::new();
+    add_tree_leaves(expr, &mut leaves);
+    leaves.len() >= 3
+}
+
 /// Rebuild the `+` tree over already-lowered leaf values, node for node, so the
 /// original associativity survives. `fast` picks the inline `fadd`; otherwise
 /// every node goes through the spec-`+` helper.
@@ -889,9 +907,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         || crate::type_analysis::expr_produces_canonical_raw_f64(ctx, left))
                     && (right_bool
                         || crate::type_analysis::expr_produces_canonical_raw_f64(ctx, right));
-                if !(both_numeric || boolean_numeric_add)
-                    || add_operands_have_pod_materialization_hazard(ctx, left, right)
-                {
+                let materialization_hazard =
+                    add_operands_have_pod_materialization_hazard(ctx, left, right);
+                if !(both_numeric || boolean_numeric_add) || materialization_hazard {
+                    if dynamic_add_tree_benefits_shared_guard(expr) && !materialization_hazard {
+                        return lower_guarded_numeric_add(ctx, expr);
+                    }
                     return lower_rooted_dynamic_binary(
                         ctx,
                         "js_dynamic_string_or_number_add",

--- a/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
+++ b/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
@@ -1,0 +1,92 @@
+//! IR coverage for the shared numeric guard on fully dynamic `+` trees.
+
+use perry_hir::types::Type;
+use perry_hir::{BinaryOp, Expr, Stmt};
+
+use crate::temp_root_coverage::main_ir_for as ir_for;
+
+const A: u32 = 1;
+const B: u32 = 2;
+const C: u32 = 3;
+const RESULT: u32 = 4;
+
+fn any_local(id: u32, name: &str, init: Expr) -> Stmt {
+    Stmt::Let {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(init),
+    }
+}
+
+fn add(left: Expr, right: Expr) -> Expr {
+    Expr::Binary {
+        op: BinaryOp::Add,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+fn dynamic_locals() -> Vec<Stmt> {
+    vec![
+        any_local(A, "a", Expr::Undefined),
+        any_local(B, "b", Expr::Undefined),
+        any_local(C, "c", Expr::Undefined),
+    ]
+}
+
+fn result(expr: Expr) -> Stmt {
+    Stmt::Let {
+        id: RESULT,
+        name: "result".to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(expr),
+    }
+}
+
+#[test]
+fn three_leaf_dynamic_add_tree_uses_one_shared_guard() {
+    let mut body = dynamic_locals();
+    body.push(result(add(
+        Expr::LocalGet(A),
+        add(Expr::LocalGet(B), Expr::LocalGet(C)),
+    )));
+    let ir = ir_for("three_leaf_dynamic_add_tree", body);
+
+    assert_eq!(
+        ir.matches("\nguarded_add.numeric.").count(),
+        1,
+        "the tree should have one shared numeric block:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("fadd double").count(),
+        2,
+        "the fast arm must preserve both additions:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("call double @js_dynamic_string_or_number_add(")
+            .count(),
+        2,
+        "the cold arm must preserve both dynamic additions:\n{ir}"
+    );
+}
+
+#[test]
+fn two_leaf_dynamic_add_stays_on_direct_dispatch() {
+    let mut body = dynamic_locals();
+    body.push(result(add(Expr::LocalGet(A), Expr::LocalGet(B))));
+    let ir = ir_for("two_leaf_dynamic_add", body);
+
+    assert!(
+        !ir.contains("guarded_add.numeric") && !ir.contains("fadd double"),
+        "a single dynamic add should not pay for a separate guard diamond:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("call double @js_dynamic_string_or_number_add(")
+            .count(),
+        1,
+        "a single dynamic add should keep direct dispatch:\n{ir}"
+    );
+}

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -2158,6 +2158,8 @@ mod compare;
 mod compare_tests;
 mod conditional;
 mod dyn_extern_i18n;
+#[cfg(test)]
+mod dynamic_add_tree_tests;
 mod env_clones;
 mod fs_await;
 mod index_get;


### PR DESCRIPTION
## Summary

- recognize dynamic `+` trees with at least three leaves
- lower every leaf once, preserve the original tree associativity, and use one shared all-number guard for a native `fadd` arm
- preserve the original `js_dynamic_string_or_number_add` tree as the cold arm for strings, BigInt, Symbols, and object coercion
- keep two-leaf dynamic additions on their existing direct helper path, where a separate guard diamond does not pay for itself

## Why

Accumulator expressions such as `sum += row.x + row.y` commonly reach codegen with all three leaves boxed as `Any`, especially across callback and interface boundaries. Lowering each `+` node independently then calls the full dynamic addition helper twice even when all runtime values are numbers.

The compiler already has a guarded numeric-tree lowering that evaluates leaves once and reconstructs the source tree in both arms. This change admits fully dynamic trees only when they have three or more leaves, which is the first point where one shared guard can replace multiple dynamic helpers.

This PR is stacked on #8674 (which is stacked on #8672). Please review/merge those first; this PR contains only commit `ed9d86bce` relative to its base, followed by the required changelog fragment.

## Correctness

- `cargo fmt --all -- --check`
- focused IR tests prove:
  - a three-leaf dynamic tree has one numeric arm with two `fadd`s and retains two dynamic helpers in the cold arm
  - a two-leaf dynamic add remains unchanged
- `cargo test -p perry-codegen --lib`: 1,191 passed, 0 failed, 1 ignored
- standalone Node/Perry fixture matched exactly for:
  - numeric trees
  - left- and right-associated string-sensitive results
  - BigInt trees and mixed-BigInt TypeErrors
  - Symbol TypeErrors
  - observable `Symbol.toPrimitive` ordering in both associativities
- the standalone fixture also passed with `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`
- unchanged full `codehz/ecs` comprehensive suite: 7/7 passed with exact 50,005,000 accumulation checksum
- retained AArch64 assembly has two `fadd`s on the numeric arm and both original dynamic-helper calls on the cold arm

The exact committed compiler emitted the same `__text` SHA-256 as the benchmarked artifact (`b19ad70a31fa27d93f26e50bf1d140e5d577ebc9a0c256b3a9d762855f9fc90a`).

## Performance

Apple M1 Mac mini on AC power. Each cohort followed a 60-sample quiet-host gate with every sample at or below 25% active CPU, used `taskpolicy -t 0 -l 0`, and alternated process order.

Against the exact #8674 code (`repeat=64`), 11 accumulation pairs measured:

| codehz/ecs kernel | #8674 median | candidate median | median paired reduction | wins |
| --- | ---: | ---: | ---: | ---: |
| 10k accumulation query | 0.26989 ms/op | 0.25891 ms/op | 4.11% | 11/11 |

All 22 processes passed the 7/7 suite oracle and exact checksum. A separate three-pair read-only regression check was neutral at the paired median (-0.033%, 1/3 wins); this optimization does not target that callback.

This is a measured incremental improvement, not a claim of Node parity. The remaining gap is dominated by the guarded ECS loop body and indirect boxed callback boundary.
