### PR TITLE
perf(string): fuse accumulator concat chains

### DIFF
--- a/changelog.d/8497-string-append-chain.md
+++ b/changelog.d/8497-string-append-chain.md
@@ -1,0 +1,7 @@
+perf(string): fuse proven `s = s + a + b + ...` accumulator chains into one
+rooted runtime operation (#8497). The runtime now appends every suffix directly
+when a unique accumulator has capacity, or allocates the complete result once,
+instead of first materializing the suffix and then entering a separate append
+envelope. On `iso_miss`, this reduces instructions retired by 7.91% and cycles
+by 9.34% across five shuffled interleaved repeats; no other corpus row moves by
+more than 0.41% in instructions. Observed peak RSS changes by +48 KiB (+0.15%).

--- a/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
+++ b/crates/perry-codegen/src/codegen/declared_string_add_tests.rs
@@ -333,12 +333,12 @@ fn a_chain_whose_second_part_is_proven_still_folds() {
 }
 
 #[test]
-fn a_self_append_chain_retains_the_accumulator_and_fuses_only_the_suffix() {
+fn a_self_append_chain_fuses_the_accumulator_and_suffix() {
     // `s = s + "[" + name + "]"` is the #8394 accumulator shape. Folding
     // all four parts into `js_string_concat_chain` copies the growing `s`
-    // prefix on every iteration. The self-append lowering must instead build
-    // the three-part suffix once and hand it to `js_string_append`, whose
-    // unique-owner path grows the accumulator geometrically.
+    // prefix on every iteration. Building a three-part suffix first still
+    // creates short-lived garbage; the append-chain lowering must hand all
+    // four parts to one helper whose unique-owner path grows geometrically.
     let value = add(
         add(
             add(Expr::LocalGet(1), Expr::String("[".to_string())),
@@ -359,13 +359,13 @@ fn a_self_append_chain_retains_the_accumulator_and_fuses_only_the_suffix() {
     let ir = function_ir(module);
 
     assert!(
-        ir.contains("call i64 @js_string_append_known_heap("),
+        ir.contains("call i64 @js_string_append_chain("),
         "the growing prefix must reach the amortized append path:\n{ir}"
     );
     assert_eq!(
         ir.matches("call i64 @js_string_concat_chain(").count(),
-        1,
-        "only the fixed-size suffix should use the n-way concat fold:\n{ir}"
+        0,
+        "the suffix must not be allocated before it is appended:\n{ir}"
     );
 }
 
@@ -423,7 +423,7 @@ fn a_self_append_chain_keeps_an_opaque_numeric_head_pair_intact() {
     let ir = function_ir(module);
 
     assert!(
-        !ir.contains("call i64 @js_string_append_known_heap("),
+        !ir.contains("call i64 @js_string_append_chain("),
         "an opaque numeric-capable head pair must remain in source-tree order:\n{ir}"
     );
 }
@@ -455,8 +455,8 @@ fn a_module_global_self_append_uses_the_amortized_path_and_demotes_extractions()
     let ir = function_ir(module);
 
     assert!(
-        ir.contains("call i64 @js_string_append_known_heap("),
-        "a module root is binding storage and can retain the unique string owner:\n{ir}"
+        ir.contains("call i64 @js_string_append_chain("),
+        "a module root is binding storage and can retain the unique string owner across the fused chain:\n{ir}"
     );
     assert!(
         ir.contains("call void @js_string_addref_if_heap_string("),

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -10,6 +10,7 @@ use perry_hir::{BinaryOp, Expr, UpdateOp};
 
 use crate::lower_string_concat::{
     can_lower_string_self_append, flatten_string_add_chain, lower_string_self_append,
+    lower_string_self_append_chain,
 };
 use crate::nanbox::double_literal;
 use crate::native_value::MaterializationReason;
@@ -575,15 +576,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         None
                     };
                     if let Some(parts) = accumulator_parts {
-                        let mut suffix = parts[1].clone();
-                        for part in &parts[2..] {
-                            suffix = Expr::Binary {
-                                op: BinaryOp::Add,
-                                left: Box::new(suffix),
-                                right: Box::new((*part).clone()),
-                            };
-                        }
-                        let v = lower_string_self_append(ctx, *id, &suffix)?;
+                        let v = lower_string_self_append_chain(ctx, *id, &parts[1..])?;
                         emit_shadow_slot_update_for_expr(ctx, *id, &v, value);
                         super::record_native_arena_owner_assignment(ctx, *id, value.as_ref());
                         return Ok(v);

--- a/crates/perry-codegen/src/lower_string_concat.rs
+++ b/crates/perry-codegen/src/lower_string_concat.rs
@@ -153,6 +153,46 @@ pub(crate) fn lower_string_self_append(
     lower_tag_dispatched_str_self_append(ctx, rhs, &target)
 }
 
+/// Lower `str = str + a + b + ...` without allocating the `a + b + ...`
+/// suffix first. The first array element is an owner read of `str`, so it
+/// retains the unique-string bit; the runtime either grows that value in
+/// place or allocates the complete result once.
+pub(crate) fn lower_string_self_append_chain(
+    ctx: &mut FnCtx<'_>,
+    local_id: u32,
+    suffix_parts: &[&Expr],
+) -> Result<String> {
+    debug_assert!(suffix_parts.len() >= 2);
+    debug_assert!(suffix_parts.len() < CONCAT_CHAIN_MAX_PARTS);
+
+    let target = StringAppendTarget::for_local(ctx, local_id)
+        .ok_or_else(|| anyhow!("string self-append chain: local {} not in scope", local_id))?;
+    let lhs = target.load(ctx)?;
+    let lhs_collects = suffix_parts
+        .iter()
+        .any(|part| operand_may_collect(ctx, part));
+
+    with_rooted_group(ctx, suffix_parts.len() + 1, |ctx, group| {
+        let lhs_root = group.adopt_emitted(ctx, Repr::Boxed, &lhs, lhs_collects);
+        let mut suffix_roots = Vec::with_capacity(suffix_parts.len());
+        for (index, part) in suffix_parts.iter().enumerate() {
+            let later_collects = suffix_parts[index + 1..]
+                .iter()
+                .any(|later| operand_may_collect(ctx, later));
+            suffix_roots.push(group.lower(ctx, part, later_collects)?);
+        }
+
+        let mut values = Vec::with_capacity(suffix_parts.len() + 1);
+        values.push(group.reread_emitted(ctx, lhs_root));
+        for root in suffix_roots {
+            values.push(group.reread(ctx, root)?);
+        }
+        let result = emit_string_append_chain(ctx, &values);
+        target.store(ctx, &result)?;
+        Ok(result)
+    })
+}
+
 /// Repsel Phase 3a: is this expression PROVEN to lower to a heap-tagged
 /// (`STRING_TAG`) NaN-box — never SSO bits, never a non-string? String
 /// literals load the interned pool handle (`@.str.N.handle`, always a heap
@@ -749,6 +789,30 @@ pub(crate) fn emit_string_concat_chain(ctx: &mut FnCtx<'_>, parts: &[String]) ->
         I64,
         "js_string_concat_chain",
         &[(I64, &base_i64), (I32, &format!("{}", n))],
+    );
+    nanbox_string_inline(blk, &result_handle)
+}
+
+/// Emit the shared parts buffer for an accumulator chain. `parts[0]` is the
+/// binding's owner read rather than an ordinary `LocalGet`, which is what lets
+/// the runtime preserve unique ownership across loop iterations.
+fn emit_string_append_chain(ctx: &mut FnCtx<'_>, parts: &[String]) -> String {
+    debug_assert!(parts.len() >= 3);
+    debug_assert!(parts.len() <= CONCAT_CHAIN_MAX_PARTS);
+
+    let n = parts.len();
+    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, CONCAT_CHAIN_MAX_PARTS);
+    let blk = ctx.block();
+    for (i, val) in parts.iter().enumerate() {
+        let slot = blk.gep(DOUBLE, &buf_reg, &[(I64, &i.to_string())]);
+        blk.store(DOUBLE, val, &slot);
+    }
+    let base_i64 = blk.next_reg();
+    blk.emit_raw(format!("{} = ptrtoint ptr {} to i64", base_i64, buf_reg));
+    let result_handle = blk.call(
+        I64,
+        "js_string_append_chain",
+        &[(I64, &base_i64), (I32, &n.to_string())],
     );
     nanbox_string_inline(blk, &result_handle)
 }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -47,6 +47,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // second arg is the count. Returns a raw string handle.
     // (`crates/perry-runtime/src/string.rs::js_string_concat_chain`)
     module.declare_function("js_string_concat_chain", I64, &[I64, I32]);
+    // Self-append variant of the N-way chain. The first part is the binding's
+    // current owner value; the runtime may extend it in place when unique and
+    // otherwise writes the complete result in one allocation.
+    module.declare_function("js_string_append_chain", I64, &[I64, I32]);
 
     // In-place append for the `x = x + y` pattern. When `x` has
     // refcount=1 (unique owner), the runtime mutates in-place and

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -497,6 +497,148 @@ pub extern "C" fn js_string_concat_chain(parts: *const f64, n: i32) -> *mut Stri
     }
 }
 
+/// N-way concat for `s = s + a + b + ...`, where `parts[0]` is an owner read
+/// of `s`. An all-heap-string chain can copy the suffix pieces straight into a
+/// unique accumulator, or allocate the complete result once when it cannot.
+/// Other value shapes retain the ordinary concat-chain semantics.
+#[no_mangle]
+pub extern "C" fn js_string_append_chain(parts: *const f64, n: i32) -> *mut StringHeader {
+    let n = (n as usize).min(CONCAT_CHAIN_MAX_PARTS);
+    if n < 2 || parts.is_null() {
+        return js_string_concat_chain(parts, n as i32);
+    }
+    if n <= 4 {
+        append_chain_all_heap_strings::<4>(parts, n)
+    } else if n <= 8 {
+        append_chain_all_heap_strings::<8>(parts, n)
+    } else {
+        append_chain_all_heap_strings::<CONCAT_CHAIN_MAX_PARTS>(parts, n)
+    }
+}
+
+/// All-heap-string fast path for [`js_string_append_chain`]. Falling back to
+/// `js_string_concat_chain` preserves dynamic/SSO coercion and the `s + s`
+/// overlap case without adding those branches to the hot copy loop.
+fn append_chain_all_heap_strings<const MAX_PARTS: usize>(
+    parts: *const f64,
+    n: usize,
+) -> *mut StringHeader {
+    let mut piece_ptrs: [*const StringHeader; MAX_PARTS] = [std::ptr::null(); MAX_PARTS];
+    let mut piece_lens: [u32; MAX_PARTS] = [0; MAX_PARTS];
+    let mut total_blen = 0u32;
+    let mut total_u16 = 0u32;
+    let mut piece_flags = 0u32;
+
+    for i in 0..n {
+        let bits = unsafe { *parts.add(i) }.to_bits();
+        if bits >> 48 != 0x7FFF {
+            return js_string_concat_chain(parts, n as i32);
+        }
+        let piece = (bits & 0x0000_FFFF_FFFF_FFFF) as *const StringHeader;
+        if !is_valid_string_ptr(piece) || (i > 0 && piece == piece_ptrs[0]) {
+            return js_string_concat_chain(parts, n as i32);
+        }
+        let blen = unsafe { (*piece).byte_len };
+        piece_ptrs[i] = piece;
+        piece_lens[i] = blen;
+        total_blen = total_blen.saturating_add(blen);
+        total_u16 = total_u16.saturating_add(unsafe { (*piece).utf16_len });
+        piece_flags |= unsafe { (*piece).flags };
+    }
+
+    let dest = piece_ptrs[0] as *mut StringHeader;
+    let dest_blen = piece_lens[0];
+    let suffix_blen = total_blen.saturating_sub(dest_blen);
+    if suffix_blen == 0 {
+        return dest;
+    }
+
+    unsafe {
+        if (*dest).refcount == 1 && total_blen <= (*dest).capacity {
+            let mut cursor = (string_data(dest) as *mut u8).add(dest_blen as usize);
+            for i in 1..n {
+                let len = piece_lens[i] as usize;
+                ptr::copy_nonoverlapping(string_data(piece_ptrs[i]), cursor, len);
+                cursor = cursor.add(len);
+            }
+            (*dest).byte_len = total_blen;
+            (*dest).utf16_len = total_u16;
+            (*dest).flags |= piece_flags;
+            return if piece_flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+                canonicalize_surrogate_pairs(dest)
+            } else {
+                dest
+            };
+        }
+    }
+
+    // An empty one-frame accumulator keeps exact capacity: no RSS-for-speed
+    // reserve. Once a non-empty accumulator grows, match js_string_append's
+    // existing geometric capacity so later iterations remain amortized.
+    let capacity = if dest_blen == 0 {
+        total_blen
+    } else {
+        total_blen.saturating_mul(2).max(32)
+    };
+
+    if let Some((result, cursor)) = string_storage_alloc_no_collect(capacity) {
+        return unsafe {
+            init_string_header(result, total_u16, total_blen, capacity, 1, piece_flags);
+            copy_heap_chain(&piece_ptrs, &piece_lens, n, cursor);
+            if piece_flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+                canonicalize_surrogate_pairs(result)
+            } else {
+                result
+            }
+        };
+    }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let mut handles = [None; MAX_PARTS];
+    for i in 0..n {
+        handles[i] = Some(scope.root_string_ptr(piece_ptrs[i]));
+    }
+    let (result, mut cursor) = string_storage_alloc(capacity);
+    unsafe {
+        init_string_header(result, total_u16, total_blen, capacity, 1, piece_flags);
+        for i in 0..n {
+            let len = piece_lens[i] as usize;
+            if len == 0 {
+                continue;
+            }
+            handles[i]
+                .expect("append-chain string handle")
+                .with_const_ptr::<StringHeader, _>(|piece| {
+                    ptr::copy_nonoverlapping(string_data(piece), cursor, len);
+                });
+            cursor = cursor.add(len);
+        }
+        if piece_flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+            canonicalize_surrogate_pairs(result)
+        } else {
+            result
+        }
+    }
+}
+
+unsafe fn copy_heap_chain<const MAX_PARTS: usize>(
+    piece_ptrs: &[*const StringHeader; MAX_PARTS],
+    piece_lens: &[u32; MAX_PARTS],
+    n: usize,
+    mut cursor: *mut u8,
+) {
+    for i in 0..n {
+        let len = piece_lens[i] as usize;
+        if len == 0 {
+            continue;
+        }
+        unsafe {
+            ptr::copy_nonoverlapping(string_data(piece_ptrs[i]), cursor, len);
+            cursor = cursor.add(len);
+        }
+    }
+}
+
 #[cfg(test)]
 thread_local! {
 /// #7912 counter: how many chains took the unrooted fast path below. A gate

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -155,8 +155,8 @@ pub(crate) use compare::{
     js_string_key_bytes, js_string_key_matches, js_string_key_matches_bytes, utf16_cmp_bytes,
 };
 pub use concat::{
-    js_string_add_value, js_string_concat, js_string_concat_box, js_string_concat_chain,
-    js_string_concat_value, js_value_add_string, js_value_concat_string,
+    js_string_add_value, js_string_append_chain, js_string_concat, js_string_concat_box,
+    js_string_concat_chain, js_string_concat_value, js_value_add_string, js_value_concat_string,
 };
 pub(crate) use format::fix_exponent_format;
 pub(crate) use format::js_format_f64;

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -536,6 +536,68 @@ fn test_string_append_loop() {
     );
 }
 
+#[test]
+fn string_append_chain_owns_one_result_and_reuses_capacity() {
+    fn boxed(s: *mut StringHeader) -> f64 {
+        f64::from_bits(crate::value::STRING_TAG | (s as u64 & crate::value::POINTER_MASK))
+    }
+    fn heap(text: &str) -> *mut StringHeader {
+        js_string_from_bytes(text.as_ptr(), text.len() as u32)
+    }
+
+    let first_parts = [
+        boxed(heap("")),
+        boxed(heap("[")),
+        boxed(heap("n")),
+        boxed(heap("]")),
+    ];
+    let first = js_string_append_chain(first_parts.as_ptr(), first_parts.len() as i32);
+    assert_eq!(string_as_str(first), "[n]");
+    assert_eq!(unsafe { (*first).refcount }, 1);
+    assert_eq!(unsafe { (*first).capacity }, 3);
+
+    let second_parts = [
+        boxed(first),
+        boxed(heap("[")),
+        boxed(heap("fib")),
+        boxed(heap("]")),
+    ];
+    let second = js_string_append_chain(second_parts.as_ptr(), second_parts.len() as i32);
+    assert_ne!(second, first);
+    assert_eq!(string_as_str(second), "[n][fib]");
+    assert_eq!(unsafe { (*second).refcount }, 1);
+    assert!(unsafe { (*second).capacity } >= 32);
+
+    let third_parts = [
+        boxed(second),
+        boxed(heap("[")),
+        boxed(heap("x")),
+        boxed(heap("]")),
+    ];
+    let third = js_string_append_chain(third_parts.as_ptr(), third_parts.len() as i32);
+    assert_eq!(third, second);
+    assert_eq!(string_as_str(third), "[n][fib][x]");
+}
+
+#[test]
+fn string_append_chain_falls_back_for_overlap_and_dynamic_parts() {
+    fn boxed(s: *mut StringHeader) -> f64 {
+        f64::from_bits(crate::value::STRING_TAG | (s as u64 & crate::value::POINTER_MASK))
+    }
+
+    let value = js_string_from_bytes(b"ab".as_ptr(), 2);
+    let overlap = [boxed(value), boxed(value)];
+    let doubled = js_string_append_chain(overlap.as_ptr(), overlap.len() as i32);
+    assert_ne!(doubled, value);
+    assert_eq!(string_as_str(value), "ab");
+    assert_eq!(string_as_str(doubled), "abab");
+
+    let suffix = js_string_from_bytes(b"x".as_ptr(), 1);
+    let dynamic = [42.0, boxed(suffix)];
+    let joined = js_string_append_chain(dynamic.as_ptr(), dynamic.len() as i32);
+    assert_eq!(string_as_str(joined), "42x");
+}
+
 // ── Repsel Phase 3a: js_string_compare_value ───────────────────────────────
 
 #[test]


### PR DESCRIPTION
Lands #8497 (refs #8410) — fuses `s = s + a + b + ...` accumulator chains into a single rooted runtime call.

### Audit

This touches the two things that are non-negotiable in this area — in-place string mutation and raw payload pointers held across an allocation — so I read both paths rather than trusting the suites.

**Uniqueness gate.** In-place reuse is gated on `(*dest).refcount == 1 && total_blen <= (*dest).capacity`. Fresh headers are created shared at refcount 0, so `== 1` correctly admits only uniquely-owned accumulators, and the capacity bound is checked before the copy. The aliasing/overlap case has its own fallback test (`string_append_chain_falls_back_for_overlap_and_dynamic_parts`).

**Rooting, runtime side.** The fast path uses `string_storage_alloc_no_collect`, so the raw `piece_ptrs` cannot go stale there. On the collecting fallback it roots every piece in a `RuntimeHandleScope` *before* `string_storage_alloc`, and then reloads each one through `with_const_ptr` rather than reusing the pre-collection raw pointer:

```rust
handles[i].expect("append-chain string handle")
    .with_const_ptr::<StringHeader, _>(|piece| {
        ptr::copy_nonoverlapping(string_data(piece), cursor, len);
    });
```

That is the #7341 API used as intended — rooting *and* reloading, not rooting alone.

**Rooting, codegen side.** `with_rooted_group` adopts the accumulator and each suffix operand, then re-reads every one via `reread_emitted`/`reread` after all lowering that can collect. Reordering without the re-read is exactly what left a stale argument in #8427; this does the re-read.

`js_string_append_chain` also matches its pre-existing sibling `js_string_concat_chain` exactly in signature and `extern "C"` convention, so it introduces no new ABI surface.

### Validation
- 9 ratchet gates + `cargo fmt --all --check`: pass (including `string_payload_access_inventory.py`, the project's own borrow instrument)
- `perry-codegen --lib`: **1198 passed, 0 failed**
- `perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2654 passed, 0 failed**
- All three new tests verified running by name, not inferred from the total
- Pushed tree verified identical to the validated tree

No version-file changes; the author's `changelog.d/` fragment carried through.

The author's own A/B used the correct discipline — identical `-p perry -p perry-runtime-static -p perry-stdlib-static` set on both arms with archive mtimes verified after each build, five shuffled interleaved repeats, medians reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved chained string concatenation, reducing unnecessary intermediate allocations.
  - Benchmarks show up to 9.34% fewer CPU cycles in affected workloads, with minimal impact elsewhere.

- **Bug Fixes**
  - Improved handling of self-appending strings, including capacity reuse and dynamic values.
  - Preserved correct string lengths, encoding, ownership, and fallback behavior across chained appends.

- **Tests**
  - Added coverage for chained appends, buffer reuse, ownership behavior, overlapping values, and non-string inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->