### PR TITLE
perf(codegen): guard direct Uint32Array RMW; scalar-replace aggregate call literals

### DIFF
--- a/benchmarks/compiler_output/fixtures/scalar_replacement_literals.ts
+++ b/benchmarks/compiler_output/fixtures/scalar_replacement_literals.ts
@@ -10,4 +10,29 @@ function scalarReplacementChecksum(): number {
   return values[0] + values[1] + values[2] + values.length;
 }
 
+class Position {}
+class Velocity {}
+
+let aggregateChecksum = 0;
+
+function consumeAggregate(initializers: { component: unknown }[]): void {
+  for (let i = 0; i < initializers.length; i++) {
+    const initializer = initializers[i];
+    if (initializer.component === Position) aggregateChecksum += 1;
+    if (initializer.component === Velocity) aggregateChecksum += 2;
+  }
+}
+
+function scalarAggregateCallChecksum(): number {
+  aggregateChecksum = 0;
+  const iterations = 500_000;
+  for (let i = 0; i < iterations; i++) {
+    consumeAggregate([{ component: Position }, { component: Velocity }]);
+    consumeAggregate([{ component: Position }]);
+    consumeAggregate([{ component: Velocity }]);
+  }
+  return aggregateChecksum;
+}
+
 console.log(scalarReplacementChecksum());
+console.log(scalarAggregateCallChecksum());

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -1349,17 +1349,29 @@ function_contains = "scalarReplacementChecksum"
 regex_none = ["@js_object_get_field", "@js_object_set_field", "@js_array_get", "@js_array_set"]
 detail = "scalar-replaced literals do not use runtime property or array access helpers"
 
+[[workloads.scalar_replacement_literals.ir_checks]]
+name = "known_aggregate_call_no_object_or_array_heap_alloc"
+function_contains = "scalarAggregateCallChecksum"
+regex_none = ["@js_object_alloc", "@js_object_alloc_with_shape", "@js_array_alloc"]
+detail = "known fixed-aggregate consumers scalar-replace descriptor objects and carrier arrays"
+
+[[workloads.scalar_replacement_literals.ir_checks]]
+name = "known_aggregate_call_no_property_or_array_runtime_access"
+function_contains = "scalarAggregateCallChecksum"
+regex_none = ["@js_object_get_field", "@js_object_set_field", "@js_array_get", "@js_array_set"]
+detail = "known fixed-aggregate consumers read scalar fields without runtime aggregate helpers"
+
 [[workloads.scalar_replacement_literals.stdout_checks]]
 name = "scalar_replacement_checksum"
-equals = "17\n"
+equals = "17\n3000000\n"
 detail = "scalar-replacement fixture stdout checksum"
 
 [workloads.scalar_replacement_literals.native_rep_checks]
-function_contains = "scalarReplacementChecksum"
 allow_materialization_reasons = ["runtime_api"]
 
 [[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
 name = "scalar_object_literal_store"
+source_function = "scalarReplacementChecksum"
 expr_kind = "ScalarObjectLiteralInit"
 consumer = "scalar_object_field_store"
 native_rep_name = "js_value"
@@ -1367,6 +1379,7 @@ access_mode = "none"
 
 [[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
 name = "scalar_object_field_get"
+source_function = "scalarReplacementChecksum"
 expr_kind = "ScalarObjectFieldGet"
 consumer = "scalar_object_field_load"
 native_rep_name = "js_value"
@@ -1374,6 +1387,7 @@ access_mode = "none"
 
 [[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
 name = "scalar_object_field_set"
+source_function = "scalarReplacementChecksum"
 expr_kind = "ScalarObjectFieldSet"
 consumer = "scalar_object_field_store"
 native_rep_name = "js_value"
@@ -1381,6 +1395,7 @@ access_mode = "none"
 
 [[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
 name = "scalar_array_literal_store"
+source_function = "scalarReplacementChecksum"
 expr_kind = "ScalarArrayLiteralInit"
 consumer = "scalar_array_element_store"
 native_rep_name = "js_value"
@@ -1388,10 +1403,21 @@ access_mode = "none"
 
 [[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
 name = "scalar_array_index_get"
+source_function = "scalarReplacementChecksum"
 expr_kind = "ScalarArrayIndexGet"
 consumer = "scalar_array_element_load"
 native_rep_name = "js_value"
 access_mode = "none"
+
+[[workloads.scalar_replacement_literals.native_rep_checks.require_records]]
+name = "known_aggregate_call_scalar_fields"
+source_function = "scalarAggregateCallChecksum"
+expr_kind = "ScalarAggregateFieldInit"
+consumer = "scalar_object_field_store"
+native_rep_name = "js_value"
+access_mode = "none"
+notes_contains = "carrier_array=elided"
+min = 4
 
 [workloads.width_aware_buffer_kernels]
 source = "benchmarks/compiler_output/fixtures/width_aware_buffer_kernels.ts"

--- a/benchmarks/issue-8692/RESULTS.md
+++ b/benchmarks/issue-8692/RESULTS.md
@@ -1,0 +1,66 @@
+# Issue #8692 benchmark evidence
+
+Measured 2026-08-24 on an Apple M1 Max running Darwin 25.5.0. The issue
+worktree is based on commit `8224d879a`; the baseline arm uses the same branch
+build with `PERRY_TYPED_ARRAY_RMW=0`. Node is v26.5.1. All Perry inputs were
+compiled with `PERRY_NO_AUTO_OPTIMIZE=1`, the release runtime, `--no-cache`, and
+no PGO.
+
+## Reduced reproduction
+
+The input is `repro.js`: 1,000 `Uint32Array` elements, 2,000 iterations, and
+2,000,000 total dynamic indexed updates. Both arms and Node returned checksum
+`2000`.
+
+Protocol: three warmups followed by 11 alternating enabled/disabled process
+pairs. Times below are medians of the elapsed time measured inside the program.
+RSS is the median of three `/usr/bin/time -l` process runs. Binary sizes are
+exact bytes.
+
+| Build | Median | Paired wins | RSS | Executable |
+| --- | ---: | ---: | ---: | ---: |
+| `PERRY_TYPED_ARRAY_RMW=0` | 80.315 ms | — | 13,500,416 B | 14,734,768 B |
+| guarded direct RMW | 14.760 ms | 11/11 | 13,565,952 B | 14,734,768 B |
+| Node v26.5.1 | 2.620 ms | — | — | — |
+
+The guarded lowering is **5.30x faster** than the disabled baseline. RSS rises
+by 65,536 bytes (0.49%) and executable-size delta is zero. This result does not
+claim Node parity.
+
+The optimized specialized function's `ta.rmw.load`/`ta.rmw.store` blocks contain
+`load i32`, `uitofp`, `fadd`, and `store i32`; they contain none of
+`js_typed_array_index_get_dynamic`, `js_dynamic_string_or_number_add`, or
+`js_typed_array_index_set_dynamic`. The emitted IR retains a full generic
+get/add/set block for precondition failure and a set-only block for post-RHS
+invalidation. The native-representation artifact records
+`TypedArrayRmw.guarded_direct_uint32_add` as `checked_native`, its exact-index and
+bounds guard, the GC-visible receiver reload, and a separate explicit dynamic
+fallback record. A compiler test also records the rejection reason
+`rhs_not_canonical_number`.
+
+## `ecs-benchmark` simple iteration
+
+Source: `ooflorent/ecs-benchmark` at
+`7b53a36606118e8b2a450a2ba4919939c86bbd2e`. Each wrapper imports the repository's
+unchanged `simple_iter` case and calls `setup(1000)`. Iteration counts were
+calibrated per case to keep Perry samples near the upstream harness's roughly
+500 ms target. Node, enabled Perry, and disabled Perry all returned the same
+case name, iteration count, and `semantic: "completed"` record.
+
+After one process warmup, seven enabled/disabled pairs ran simultaneously so
+both arms saw the same shared-host load; child creation order alternated. RSS
+was captured on every measured process. The table reports the median elapsed
+time of each arm. The upstream README documents typical run-to-run variance of
+1–4%, so the increases below are neutral. More decisively, the final Mach-O
+`__text` section is byte-identical between enabled and disabled binaries for all
+four cases: this optimization is not selected by these workloads.
+
+| Case | Iterations | Disabled | Enabled | Delta | Disabled / enabled RSS | Size delta | `__text` SHA-256 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `wolf-ecs/simple_iter` | 250 | 254.540 ms | 259.059 ms | +1.78% | 202,113,024 / 202,244,096 B | 0 B | `b2987e304a8b402d699d80d145a1a1b01391e83591a36e130a4591ffcd9424f6` |
+| `becsy/simple_iter` | 15 | 169.343 ms | 167.251 ms | -1.24% | 46,415,872 / 46,432,256 B | 0 B | `8bdfe53cc561edd2d268b5ec61939ca46bd2140f98303471496b81ab7f7302b1` |
+| `javelin-ecs/simple_iter` | 15 | 284.079 ms | 287.036 ms | +1.04% | 93,716,480 / 93,749,248 B | 0 B | `ec44c45d2a942a29877795c85b68ed218b13c7c0f0073892ad90437485b5cc46` |
+| `piecs/simple_iter` | 1,500 | 736.326 ms | 751.261 ms | +2.03% | 16,171,008 / 16,203,776 B | 0 B | `cd1d310b8ad30a1f90e6dba95ca82dbe4cd8d344188a3868f9744168a7336b8a` |
+
+Exact enabled/disabled executable sizes were respectively 14,949,648;
+16,436,632; 26,191,360; and 14,966,232 bytes for the four rows.

--- a/benchmarks/issue-8692/repro.js
+++ b/benchmarks/issue-8692/repro.js
@@ -1,0 +1,32 @@
+// Reduced wolf-ecs kernel from https://github.com/PerryTS/perry/issues/8692.
+// Compile with `PERRY_NO_AUTO_OPTIMIZE=1` for the ticket's stable A/B protocol.
+class Query extends Array {
+  archetypes = this;
+}
+
+class Archetype extends Array {
+  entities = this;
+}
+
+const entityCount = 1_000;
+const iterations = 2_000;
+const query = new Query();
+const archetype = new Archetype();
+for (let i = 0; i < entityCount; i++) archetype.push(i);
+query.push(archetype);
+
+const components = new Uint32Array(entityCount);
+
+function system(values) {
+  for (let i = 0, length = query.length; i < length; i++) {
+    const current = query[i];
+    for (let j = 0, length = current.length; j < length; j++) {
+      values[current[j]] += 1;
+    }
+  }
+}
+
+const start = performance.now();
+for (let i = 0; i < iterations; i++) system(components);
+const elapsedMs = performance.now() - start;
+console.log(JSON.stringify({ elapsedMs, checksum: components[0] }));

--- a/changelog.d/8692-guarded-uint32-rmw.md
+++ b/changelog.d/8692-guarded-uint32-rmw.md
@@ -1,0 +1,7 @@
+### Performance
+
+- Fuse dynamic-index `Uint32Array` numeric read-modify-write expressions behind
+  explicit representation, backing-store, exact-index, and bounds guards. The
+  hot arm keeps the load/add/store in native SSA, while precondition failure and
+  post-RHS invalidation retain full JavaScript evaluation order and conversion
+  semantics through explicit generic fallbacks.

--- a/changelog.d/8703-scalar-aggregate-calls.md
+++ b/changelog.d/8703-scalar-aggregate-calls.md
@@ -1,0 +1,7 @@
+### Performance
+
+- Scalar-replace short arrays of non-escaping object literals passed to known,
+  bounded aggregate consumers. Their carrier arrays, descriptor objects,
+  property/index accesses, and write barriers are now eliminated after
+  conservative inlining and loop unrolling; identity-observing and otherwise
+  escaping uses continue to materialize normally.

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -754,6 +754,14 @@ pub(crate) fn lower(
             index,
             value,
         } => {
+            if let Some(result) =
+                super::typed_array_rmw::try_lower_guarded_uint32_add(ctx, object, index, value)?
+            {
+                if value_discarded {
+                    return Ok(double_literal(0.0));
+                }
+                return Ok(result);
+            }
             // Issue #611: `globalThis[<key>] = value` writes to the
             // persistent global-this singleton (see the matching IndexGet
             // arm above for context).

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -2197,6 +2197,7 @@ mod index_set_guarded;
 mod index_set_typed_array;
 mod instance_misc1;
 mod member_update;
+mod typed_array_rmw;
 pub(crate) use instance_misc1::builtin_parent_reserved_class_id;
 pub(crate) mod class_field_inline_guard;
 pub(crate) mod element_shape_guard;

--- a/crates/perry-codegen/src/expr/typed_array_rmw.rs
+++ b/crates/perry-codegen/src/expr/typed_array_rmw.rs
@@ -1,0 +1,410 @@
+//! Guarded direct read-modify-write for a numeric typed-array element.
+//!
+//! Compound computed assignments are deliberately lowered through immutable
+//! base/key temporaries by the HIR (`hoist_compound_member_assign`).  That
+//! preserves JavaScript's once-only reference evaluation, but it also hides a
+//! specialized-entry `TaPtr` behind an `Any`-typed exact alias and turns
+//! `values[key] += rhs` into three independently-lowered operations.  Each
+//! operation then loses a different part of the representation proof.
+//!
+//! This module recognizes the representation shape after those temporaries:
+//!
+//! ```text
+//! base[key] = base[key] + numeric_rhs
+//! ```
+//!
+//! when `base` and `key` are immutable locals and `base` traces through exact
+//! local aliases to a Uint32Array candidate.  The runtime guard, rather than a
+//! TypeScript annotation, proves pointer identity, inline storage, concrete
+//! kind, an exact numeric index, and bounds.  Guard failure runs the unchanged
+//! generic get/add/set lowering.  The RHS runs only after the direct load, and
+//! the view/kind/bounds guard is checked again after the RHS; a failure there
+//! performs only the pending set with the already-computed value, so user code
+//! and abrupt completion are never repeated.
+
+use anyhow::Result;
+use perry_hir::{BinaryOp, Expr};
+
+use crate::nanbox::POINTER_MASK_I64;
+use crate::native_value::{
+    BoundsState, BufferAccessMode, BufferElem, ExpectedNativeRep, LoweredValue,
+    MaterializationReason,
+};
+use crate::types::{DOUBLE, I1, I32, I64};
+
+use super::{lower_expr, lower_expr_native, FnCtx};
+
+const UINT32_KIND: u64 = 5;
+
+#[derive(Clone, Copy)]
+struct Candidate<'a> {
+    object: &'a Expr,
+    index: &'a Expr,
+    rhs: &'a Expr,
+    receiver_id: u32,
+}
+
+fn enabled() -> bool {
+    !matches!(
+        std::env::var("PERRY_TYPED_ARRAY_RMW").as_deref(),
+        Ok("0") | Ok("off") | Ok("false") | Ok("OFF") | Ok("FALSE")
+    )
+}
+
+fn local_id(expr: &Expr) -> Option<u32> {
+    match expr {
+        Expr::LocalGet(id) => Some(*id),
+        _ => None,
+    }
+}
+
+fn exact_alias_root(ctx: &FnCtx<'_>, mut id: u32) -> u32 {
+    // The alias map is fail-closed and normally acyclic.  Keep a small bound
+    // anyway so corrupted/debug HIR cannot hang codegen.
+    for _ in 0..64 {
+        let Some(next) = ctx.local_value_aliases.get(&id).copied() else {
+            break;
+        };
+        if next == id {
+            break;
+        }
+        id = next;
+    }
+    id
+}
+
+fn receiver_is_uint32_candidate(ctx: &FnCtx<'_>, id: u32) -> Option<u32> {
+    let root = exact_alias_root(ctx, id);
+    if ctx
+        .buffer_view_slots
+        .get(&root)
+        .is_some_and(|view| matches!(view.elem, BufferElem::U32))
+    {
+        return Some(root);
+    }
+    matches!(
+        ctx.local_type_hint(&root),
+        Some(perry_hir::types::Type::Named(name)) if name == "Uint32Array"
+    )
+    .then_some(root)
+}
+
+fn match_shape<'a>(
+    ctx: &FnCtx<'_>,
+    object: &'a Expr,
+    index: &'a Expr,
+    value: &'a Expr,
+) -> Option<(u32, &'a Expr)> {
+    let (object_id, index_id) = (local_id(object)?, local_id(index)?);
+    // These are the semantic condition that allows one reference snapshot to
+    // replace the two syntactic reads.  The HIR-generated compound-assignment
+    // temps satisfy it, and ordinary immutable user locals do too.
+    if ctx.reassigned_locals.contains(&object_id) || ctx.reassigned_locals.contains(&index_id) {
+        return None;
+    }
+    let Expr::Binary {
+        op: BinaryOp::Add,
+        left,
+        right,
+    } = value
+    else {
+        return None;
+    };
+    let Expr::IndexGet {
+        object: read_object,
+        index: read_index,
+    } = left.as_ref()
+    else {
+        return None;
+    };
+    if local_id(read_object) != Some(object_id) || local_id(read_index) != Some(index_id) {
+        return None;
+    }
+    Some((object_id, right))
+}
+
+fn record_rejection(ctx: &mut FnCtx<'_>, receiver_id: u32, reason: &str) {
+    let rejected = LoweredValue::js_value("0.0".to_string());
+    ctx.record_lowered_value_with_access_mode(
+        "TypedArrayRmw",
+        Some(receiver_id),
+        "TypedArrayRmw.rejected",
+        &rejected,
+        Some(BoundsState::Unknown),
+        None,
+        Some(BufferAccessMode::DynamicFallback),
+        Some(MaterializationReason::RuntimeApi),
+        false,
+        false,
+        vec![
+            "typed_array_rmw=rejected".to_string(),
+            format!("typed_array_rmw_rejection={reason}"),
+        ],
+    );
+}
+
+/// Pointer/inline-storage/kind cache guard.  Returns the unboxed header address
+/// and the guard condition.  The address is used only on a passing edge.
+fn emit_receiver_guard(ctx: &mut FnCtx<'_>, object_box: &str) -> (String, String) {
+    let tag_mask = crate::nanbox::i64_literal(crate::nanbox::TAG_MASK);
+    let blk = ctx.block();
+    let object_bits = blk.bitcast_double_to_i64(object_box);
+    let raw = blk.and(I64, &object_bits, POINTER_MASK_I64);
+    let tagged = blk.and(I64, &object_bits, &tag_mask);
+    let is_pointer = blk.icmp_eq(I64, &tagged, crate::nanbox::POINTER_TAG_I64);
+    let view_guard = blk.load(I64, "@PERRY_TA_VIEW_GUARD");
+    let inline_storage = blk.icmp_eq(I64, &view_guard, "0");
+    let slot = blk.lshr(I64, &raw, "3");
+    let slot = blk.and(I64, &slot, "63");
+    let entry_ptr = blk.gep(
+        "[64 x i64]",
+        "@PERRY_TA_KIND_CACHE",
+        &[(I64, "0"), (I64, &slot)],
+    );
+    let entry = blk.load(I64, &entry_ptr);
+    let cached_addr = blk.lshr(I64, &entry, "8");
+    let address_matches = blk.icmp_eq(I64, &cached_addr, &raw);
+    let kind = blk.and(I64, &entry, "255");
+    let kind_matches = blk.icmp_eq(I64, &kind, &UINT32_KIND.to_string());
+    let guard = blk.and(I1, &is_pointer, &inline_storage);
+    let guard = blk.and(I1, &guard, &address_matches);
+    (raw, blk.and(I1, &guard, &kind_matches))
+}
+
+fn emit_index_range_guard(ctx: &mut FnCtx<'_>, index_box: &str) -> String {
+    // Ordered comparisons reject NaN and every NaN-boxed non-number.  The
+    // upper bound makes the following fptosi-to-i64 defined.
+    let ge_zero = ctx.block().fcmp("oge", index_box, "0.0");
+    let below_u32_limit = ctx.block().fcmp("olt", index_box, "4294967296.0");
+    ctx.block().and(I1, &ge_zero, &below_u32_limit)
+}
+
+fn emit_safe_toint32_range_guard(ctx: &mut FnCtx<'_>, value: &str) -> String {
+    // LlBlock::toint32 implements truncation/modulo through an intermediate
+    // i64.  LLVM fptosi is poison outside the signed-i64 range, so unusually
+    // large finite sums (and NaN/Infinity) take the set-only semantic fallback
+    // instead.  The common Uint32 accumulator stays wholly inline.
+    let above_min = ctx.block().fcmp("oge", value, "-9223372036854775808.0");
+    let below_max = ctx.block().fcmp("olt", value, "9223372036854775808.0");
+    ctx.block().and(I1, &above_min, &below_max)
+}
+
+fn emit_exact_and_bounds_guard(
+    ctx: &mut FnCtx<'_>,
+    raw: &str,
+    index_box: &str,
+) -> (String, String) {
+    let index_i64 = ctx.block().fptosi(DOUBLE, index_box, I64);
+    let roundtrip = ctx.block().sitofp(I64, &index_i64, DOUBLE);
+    let exact = ctx.block().fcmp("oeq", &roundtrip, index_box);
+    let header_ptr = ctx.block().inttoptr(I64, raw);
+    let length = ctx.block().load(I32, &header_ptr);
+    let length_i64 = ctx.block().zext(I32, &length, I64);
+    let in_bounds = ctx.block().icmp_ult(I64, &index_i64, &length_i64);
+    (index_i64, ctx.block().and(I1, &exact, &in_bounds))
+}
+
+fn emit_generic_set(
+    ctx: &mut FnCtx<'_>,
+    object: &Expr,
+    index: &Expr,
+    value: &str,
+) -> Result<String> {
+    // Re-read the immutable reference temporaries after any allocating RHS;
+    // their slots are the GC-visible source of truth.
+    let object_box = lower_expr(ctx, object)?;
+    let index_box = lower_expr(ctx, index)?;
+    Ok(ctx.block().call(
+        DOUBLE,
+        "js_dyn_index_set",
+        &[(DOUBLE, &object_box), (DOUBLE, &index_box), (DOUBLE, value)],
+    ))
+}
+
+/// Try the guarded Uint32Array `base[key] += numeric_rhs` lowering.
+///
+/// `Ok(None)` means the expression is outside this representation contract and
+/// the ordinary IndexSet lowering must remain byte-for-byte in charge.
+pub(super) fn try_lower_guarded_uint32_add(
+    ctx: &mut FnCtx<'_>,
+    object: &Expr,
+    index: &Expr,
+    value: &Expr,
+) -> Result<Option<String>> {
+    if !enabled() {
+        return Ok(None);
+    }
+    let Some((object_id, rhs)) = match_shape(ctx, object, index, value) else {
+        return Ok(None);
+    };
+    let Some(receiver_id) = receiver_is_uint32_candidate(ctx, object_id) else {
+        return Ok(None);
+    };
+    // `+` can concatenate or operate on BigInt.  Admit only a value whose
+    // runtime representation is already proven to be a canonical Number;
+    // declared annotations are intentionally insufficient.
+    if !crate::type_analysis::expr_produces_canonical_raw_f64(ctx, rhs) {
+        record_rejection(ctx, receiver_id, "rhs_not_canonical_number");
+        return Ok(None);
+    }
+    let candidate = Candidate {
+        object,
+        index,
+        rhs,
+        receiver_id,
+    };
+
+    // The HIR has already evaluated the source base and computed key once into
+    // immutable locals.  Loading those values here therefore has no user-code
+    // effect and is the correct reference snapshot for both arms.
+    let object_box = lower_expr(ctx, candidate.object)?;
+    let index_box = lower_expr(ctx, candidate.index)?;
+    let (raw, receiver_ok) = emit_receiver_guard(ctx, &object_box);
+    let index_range_ok = emit_index_range_guard(ctx, &index_box);
+    let precheck_ok = ctx.block().and(I1, &receiver_ok, &index_range_ok);
+
+    let convert_idx = ctx.new_block("ta.rmw.index.convert");
+    let load_idx = ctx.new_block("ta.rmw.load");
+    let full_fallback_idx = ctx.new_block("ta.rmw.full_fallback");
+    let post_guard_idx = ctx.new_block("ta.rmw.post_rhs_guard");
+    let store_idx = ctx.new_block("ta.rmw.store");
+    let set_fallback_idx = ctx.new_block("ta.rmw.set_fallback");
+    let merge_idx = ctx.new_block("ta.rmw.merge");
+    let convert_label = ctx.block_label(convert_idx);
+    let load_label = ctx.block_label(load_idx);
+    let full_fallback_label = ctx.block_label(full_fallback_idx);
+    let post_guard_label = ctx.block_label(post_guard_idx);
+    let store_label = ctx.block_label(store_idx);
+    let set_fallback_label = ctx.block_label(set_fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    ctx.block()
+        .cond_br(&precheck_ok, &convert_label, &full_fallback_label);
+
+    ctx.current_block = convert_idx;
+    let (index_i64, exact_and_in_bounds) = emit_exact_and_bounds_guard(ctx, &raw, &index_box);
+    ctx.block()
+        .cond_br(&exact_and_in_bounds, &load_label, &full_fallback_label);
+
+    // Fast read and JS-number addition.  Load before RHS evaluation: that
+    // ordering is observable when the RHS mutates the same element.
+    ctx.current_block = load_idx;
+    let old_value = {
+        let blk = ctx.block();
+        let data_base = blk.add(I64, &raw, "16");
+        let byte_offset = blk.shl(I64, &index_i64, "2");
+        let address = blk.add(I64, &data_base, &byte_offset);
+        let ptr = blk.inttoptr(I64, &address);
+        let raw_u32 = blk.load(I32, &ptr);
+        blk.uitofp(I32, &raw_u32, DOUBLE)
+    };
+    let rhs = lower_expr_native(ctx, candidate.rhs, ExpectedNativeRep::F64)?.value;
+    let sum = ctx.block().fadd(&old_value, &rhs);
+    ctx.block().br(&post_guard_label);
+    let fast_sum_end = ctx.block().label.clone();
+
+    // The RHS may expose/detach backing storage or otherwise invalidate the
+    // cache.  Revalidate before deriving the store address.  On failure only
+    // PutValue remains; the read and RHS must not be repeated.
+    ctx.current_block = post_guard_idx;
+    // The RHS can allocate and trigger a moving collection.  Reload the
+    // immutable reference temporary from its GC-visible slot instead of
+    // retaining the pre-RHS NaN-boxed pointer SSA value.
+    let post_object_box = lower_expr(ctx, candidate.object)?;
+    let (post_raw, post_receiver_ok) = emit_receiver_guard(ctx, &post_object_box);
+    let (_, post_bounds_ok) = emit_exact_and_bounds_guard(ctx, &post_raw, &index_box);
+    let post_ok = ctx.block().and(I1, &post_receiver_ok, &post_bounds_ok);
+    let conversion_ok = emit_safe_toint32_range_guard(ctx, &sum);
+    let post_ok = ctx.block().and(I1, &post_ok, &conversion_ok);
+    ctx.block()
+        .cond_br(&post_ok, &store_label, &set_fallback_label);
+
+    ctx.current_block = store_idx;
+    {
+        let blk = ctx.block();
+        let data_base = blk.add(I64, &post_raw, "16");
+        let byte_offset = blk.shl(I64, &index_i64, "2");
+        let address = blk.add(I64, &data_base, &byte_offset);
+        let ptr = blk.inttoptr(I64, &address);
+        let wrapped = blk.toint32(&sum);
+        // GC_STORE_AUDIT(POINTER_FREE): Uint32Array backing bytes cannot hold
+        // a heap edge; ToUint32 shares the runtime's modulo-2^32 bit result.
+        blk.store(I32, &wrapped, &ptr);
+        blk.br(&merge_label);
+    }
+    let store_end = ctx.block().label.clone();
+
+    ctx.current_block = set_fallback_idx;
+    let set_fallback_value = emit_generic_set(ctx, candidate.object, candidate.index, &sum)?;
+    ctx.block().br(&merge_label);
+    let set_fallback_end = ctx.block().label.clone();
+
+    // Full semantic fallback: lower the original get/add tree unchanged, then
+    // perform the pending generic set.  This owns non-number keys, OOB,
+    // fractional/negative/NaN indices, proxy/annotation lies, views, detached
+    // stores, and every abrupt-completion case.
+    ctx.current_block = full_fallback_idx;
+    let generic_sum = lower_expr(ctx, value)?;
+    let full_fallback_value =
+        emit_generic_set(ctx, candidate.object, candidate.index, &generic_sum)?;
+    ctx.block().br(&merge_label);
+    let full_fallback_end = ctx.block().label.clone();
+
+    ctx.current_block = merge_idx;
+    let result = ctx.block().phi(
+        DOUBLE,
+        &[
+            (&sum, &store_end),
+            (&set_fallback_value, &set_fallback_end),
+            (&full_fallback_value, &full_fallback_end),
+        ],
+    );
+
+    let lowered = LoweredValue::f64(result.clone());
+    ctx.record_lowered_value_with_access_mode(
+        "TypedArrayRmw",
+        Some(candidate.receiver_id),
+        "TypedArrayRmw.guarded_direct_uint32_add",
+        &lowered,
+        Some(BoundsState::Guarded {
+            guard_id: "typed_array_rmw_exact_index_and_bounds".to_string(),
+        }),
+        None,
+        Some(BufferAccessMode::CheckedNative),
+        None,
+        false,
+        false,
+        vec![
+            "typed_array_rmw=selected".to_string(),
+            "typed_array_kind=Uint32Array".to_string(),
+            "typed_array_guard=pointer+inline_storage+kind_cache+exact_numeric_index+bounds"
+                .to_string(),
+            "post_rhs_guard=backing_store+kind+bounds".to_string(),
+            "post_rhs_receiver=reload_gc_visible_local".to_string(),
+            "uint32_conversion_guard=signed_i64_range".to_string(),
+            "full_fallback=generic_get+js_add+generic_set".to_string(),
+            "post_rhs_fallback=generic_set_without_repeating_rhs".to_string(),
+        ],
+    );
+    let fallback = LoweredValue::js_value(generic_sum);
+    ctx.record_lowered_value_with_access_mode(
+        "TypedArrayRmw",
+        Some(candidate.receiver_id),
+        "TypedArrayRmw.explicit_fallback",
+        &fallback,
+        Some(BoundsState::Unknown),
+        None,
+        Some(BufferAccessMode::DynamicFallback),
+        Some(MaterializationReason::RuntimeApi),
+        false,
+        false,
+        vec![
+            "typed_array_rmw_fallback=guard_failure".to_string(),
+            "evaluation_order=base,key,get,rhs,add,set".to_string(),
+        ],
+    );
+
+    // `fast_sum_end` is deliberately retained as an assertion of CFG shape:
+    // the RHS block must terminate at the post-RHS guard, not at the store.
+    debug_assert_ne!(fast_sum_end, store_end);
+    Ok(Some(result))
+}

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -6,6 +6,7 @@ use super::let_buffer_views::{math_min_length_buffer_ids, register_noalias_buffe
 use super::let_stmt_facts::{
     buffer_local_alias_source, collect_scalar_class_data, native_i32_alias_source,
     note_ptr_shape_scalar_replaced, pod_view_count_source, record_pod_rejection,
+    record_scalar_aggregate_field,
 };
 use super::unused_expr::lower_unused_expr;
 use crate::expr::{
@@ -1901,6 +1902,7 @@ pub(crate) fn lower_let(
                     }
                 }
             }
+            record_scalar_aggregate_field(ctx, id, name, &v);
             v
         } else {
             String::new() // unused below; cleanup blocks check used_i32_init

--- a/crates/perry-codegen/src/stmt/let_stmt_facts.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt_facts.rs
@@ -7,6 +7,40 @@ use super::*;
 
 use crate::native_value::BufferAccessMode;
 
+/// #8691: the aggregate scalar-replacement transform erases the carrier array
+/// and object literals before codegen, leaving one synthetic local per field.
+/// Preserve lowering evidence for those eliminated allocations so the result
+/// remains visible to `--explain-lowering`.
+pub(super) fn record_scalar_aggregate_field(ctx: &mut FnCtx<'_>, id: u32, name: &str, value: &str) {
+    if !name.starts_with("__perry_scalar_aggregate_") {
+        return;
+    }
+    let lowered = crate::native_value::LoweredValue {
+        semantic: crate::native_value::SemanticKind::JsValue,
+        rep: crate::native_value::NativeRep::JsValue,
+        llvm_ty: DOUBLE,
+        value: value.to_string(),
+    };
+    ctx.record_lowered_value_with_access_mode(
+        "ScalarAggregateFieldInit",
+        Some(id),
+        "scalar_object_field_store",
+        &lowered,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        vec![
+            format!("local={name}"),
+            "carrier_array=elided".to_string(),
+            "carrier_object=elided".to_string(),
+            "write_barrier=0".to_string(),
+        ],
+    );
+}
+
 pub(super) fn pod_view_count_source(ctx: &FnCtx<'_>, expr: &perry_hir::Expr) -> String {
     match expr {
         perry_hir::Expr::Integer(n) => format!("constant:{n}"),

--- a/crates/perry-codegen/tests/typed_array_rmw_8692.rs
+++ b/crates/perry-codegen/tests/typed_array_rmw_8692.rs
@@ -1,0 +1,285 @@
+use perry_codegen::{compile_module, CompileOptions};
+use perry_hir::types::Type;
+use perry_hir::{BinaryOp, Expr, Function, Module, Param, Stmt, TYPED_ARRAY_KIND_UINT32};
+
+#[path = "native_proof_support/mod.rs"]
+mod native_proof_support;
+use native_proof_support::{artifact_env_lock, artifact_for_module, NativeRepsEnv};
+
+const VALUES: u32 = 100;
+const KEY: u32 = 101;
+const BASE_TMP: u32 = 102;
+const KEY_TMP: u32 = 103;
+
+fn param(id: u32, name: &str) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn rmw_function(rhs: Expr) -> Function {
+    let read = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(BASE_TMP)),
+        index: Box::new(Expr::LocalGet(KEY_TMP)),
+    };
+    Function {
+        id: 7,
+        name: "bump".to_string(),
+        type_params: Vec::new(),
+        params: vec![param(VALUES, "values"), param(KEY, "key")],
+        return_type: Type::Number,
+        body: vec![
+            // The exact immutable aliases emitted by
+            // `hoist_compound_member_assign` for `values[key] += rhs`.
+            Stmt::Let {
+                id: BASE_TMP,
+                name: "__cmpd_base_test".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::LocalGet(VALUES)),
+            },
+            Stmt::Let {
+                id: KEY_TMP,
+                name: "__cmpd_key_test".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::LocalGet(KEY)),
+            },
+            Stmt::Expr(Expr::IndexSet {
+                object: Box::new(Expr::LocalGet(BASE_TMP)),
+                index: Box::new(Expr::LocalGet(KEY_TMP)),
+                value: Box::new(Expr::Binary {
+                    op: BinaryOp::Add,
+                    left: Box::new(read),
+                    right: Box::new(rhs),
+                }),
+            }),
+            Stmt::Return(Some(Expr::Integer(0))),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    }
+}
+
+fn rmw_module(name: &str, rhs: Expr) -> Module {
+    let mut module = Module::new(name);
+    module.functions.push(rmw_function(rhs));
+    module.init = vec![
+        Stmt::Let {
+            id: 1,
+            name: "values".to_string(),
+            ty: Type::Named("Uint32Array".to_string()),
+            mutable: false,
+            init: Some(Expr::TypedArrayNew {
+                kind: TYPED_ARRAY_KIND_UINT32,
+                arg: Some(Box::new(Expr::Integer(4))),
+            }),
+        },
+        Stmt::Let {
+            id: 2,
+            name: "keys".to_string(),
+            ty: Type::Array(Box::new(Type::Any)),
+            mutable: false,
+            init: Some(Expr::Array(vec![Expr::Integer(0)])),
+        },
+        Stmt::Expr(Expr::Call {
+            callee: Box::new(Expr::FuncRef(7)),
+            args: vec![
+                Expr::LocalGet(1),
+                Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(2)),
+                    index: Box::new(Expr::Integer(0)),
+                },
+            ],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    ];
+    module
+}
+
+fn compile_ir(module: Module) -> String {
+    String::from_utf8(
+        compile_module(
+            &module,
+            CompileOptions {
+                emit_ir_only: true,
+                ..CompileOptions::default()
+            },
+        )
+        .expect("module compiles"),
+    )
+    .expect("LLVM IR is UTF-8")
+}
+
+fn function_containing<'a>(ir: &'a str, marker: &str) -> &'a str {
+    let start = ir
+        .match_indices("define ")
+        .find(|(start, _)| {
+            let end = ir[*start..]
+                .find('\n')
+                .map_or(ir.len(), |offset| start + offset);
+            ir[*start..end].contains(marker)
+        })
+        .map(|(start, _)| start)
+        .unwrap_or_else(|| panic!("function containing `{marker}` not found:\n{ir}"));
+    let rest = &ir[start..];
+    let end = rest.find("\n}\n").map_or(rest.len(), |offset| offset + 3);
+    &rest[..end]
+}
+
+fn block_containing<'a>(function: &'a str, marker: &str) -> &'a str {
+    let start = function
+        .lines()
+        .scan(0usize, |offset, line| {
+            let start = *offset;
+            *offset += line.len() + 1;
+            Some((start, line))
+        })
+        .find(|(_, line)| line.contains(marker) && line.trim_end().ends_with(':'))
+        .map(|(start, _)| start)
+        .unwrap_or_else(|| panic!("block containing `{marker}` not found:\n{function}"));
+    let rest = &function[start..];
+    let end = rest.find("\n\n").unwrap_or(rest.len());
+    &rest[..end]
+}
+
+fn compile_artifact(module: Module) -> serde_json::Value {
+    let _lock = artifact_env_lock();
+    struct ArtifactDir(std::path::PathBuf);
+    impl Drop for ArtifactDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    let dir = ArtifactDir(std::env::temp_dir().join(format!(
+        "perry_typed_array_rmw_8692_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )));
+    std::fs::create_dir_all(&dir.0).unwrap();
+    let _env = NativeRepsEnv::install(&dir.0, false);
+    let name = module.name.clone();
+    compile_module(
+        &module,
+        CompileOptions {
+            emit_ir_only: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect("module compiles with artifact recording");
+    artifact_for_module(&dir.0, &name)
+}
+
+#[test]
+fn specialized_uint32_dynamic_index_rmw_has_a_call_free_fast_arm_and_fallback() {
+    let ir = compile_ir(rmw_module("typed_array_rmw_8692.ts", Expr::Integer(1)));
+    let specialized = function_containing(&ir, "$spec_ta5x4");
+    let load = block_containing(specialized, "ta.rmw.load");
+    let store = block_containing(specialized, "ta.rmw.store");
+    let fallback = block_containing(specialized, "ta.rmw.full_fallback");
+
+    assert!(
+        specialized.contains("@PERRY_TA_VIEW_GUARD")
+            && specialized.contains("@PERRY_TA_KIND_CACHE"),
+        "the selected RMW must retain explicit inline-storage and kind guards:\n{specialized}"
+    );
+    assert!(
+        load.contains("load i32") && load.contains("uitofp i32") && load.contains("fadd"),
+        "the hot read/add arm must stay in native numeric SSA:\n{load}"
+    );
+    assert!(
+        store.contains("store i32"),
+        "Uint32 conversion and the direct backing-store write must remain in the guarded store arm:\n{store}"
+    );
+    for helper in [
+        "js_typed_array_index_get_dynamic",
+        "js_dynamic_string_or_number_add",
+        "js_typed_array_index_set_dynamic",
+    ] {
+        assert!(
+            !load.contains(helper) && !store.contains(helper),
+            "the guarded fast arm must not call `{helper}`:\n{load}\n{store}"
+        );
+    }
+    assert!(
+        fallback.contains("js_typed_array_index_get_dynamic")
+            && fallback.contains("js_dynamic_string_or_number_add"),
+        "guard failure must retain the semantic get/add fallback:\n{fallback}\n{specialized}"
+    );
+    assert!(
+        specialized.contains("ta.rmw.set_fallback")
+            && specialized.contains("call double @js_dyn_index_set"),
+        "post-RHS invalidation must retain a set-only continuation fallback:\n{specialized}"
+    );
+}
+
+#[test]
+fn native_artifact_reports_selected_guards_and_both_fallbacks() {
+    let artifact = compile_artifact(rmw_module(
+        "typed_array_rmw_artifact_8692.ts",
+        Expr::Integer(1),
+    ));
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayRmw"
+                && record["consumer"] == "TypedArrayRmw.guarded_direct_uint32_add"
+                && record["access_mode"] == "checked_native"
+                && record["notes"].as_array().is_some_and(|notes| {
+                    notes.iter().any(|note| note == "typed_array_rmw=selected")
+                        && notes.iter().any(|note| {
+                            note == "post_rhs_fallback=generic_set_without_repeating_rhs"
+                        })
+                        && notes
+                            .iter()
+                            .any(|note| note == "post_rhs_receiver=reload_gc_visible_local")
+                })
+        }),
+        "selected RMW guard/fallback evidence missing:\n{artifact:#}"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayRmw"
+                && record["consumer"] == "TypedArrayRmw.explicit_fallback"
+                && record["access_mode"] == "dynamic_fallback"
+        }),
+        "explicit dynamic fallback evidence missing:\n{artifact:#}"
+    );
+}
+
+#[test]
+fn native_artifact_explains_rejection_for_a_noncanonical_rhs() {
+    let artifact = compile_artifact(rmw_module(
+        "typed_array_rmw_rejected_8692.ts",
+        Expr::String("x".to_string()),
+    ));
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "TypedArrayRmw"
+                && record["consumer"] == "TypedArrayRmw.rejected"
+                && record["notes"].as_array().is_some_and(|notes| {
+                    notes
+                        .iter()
+                        .any(|note| note == "typed_array_rmw_rejection=rhs_not_canonical_number")
+                })
+        }),
+        "RMW rejection reason missing from explain-lowering/native artifacts:\n{artifact:#}"
+    );
+}

--- a/crates/perry-transform/src/aggregate_scalar.rs
+++ b/crates/perry-transform/src/aggregate_scalar.rs
@@ -1,0 +1,884 @@
+//! Scalar replacement for fixed aggregate literals exposed by inlining.
+//!
+//! The ordinary codegen escape pass handles `const point = { x, y }` and
+//! `const values = [x, y]`, but an ECS-style helper exposes a nested shape:
+//!
+//! ```text
+//! const arg = [{ component: Position }, { component: Velocity }];
+//! const item = arg[0];
+//! read(item.component);
+//! ```
+//!
+//! Once a known helper has been inlined and its short loop unrolled, neither
+//! carrier identity is observable. This pass replaces every object field with
+//! a synthetic scalar local, rewrites the proven field reads, and removes the
+//! carrier array and element aliases. Any identity, mutation, reflection,
+//! closure capture, dynamic index, missing/inherited property, or method-call
+//! receiver use rejects the whole candidate and leaves normal materialization
+//! intact.
+
+use std::collections::{HashMap, HashSet};
+
+use perry_hir::types::{LocalId, Type};
+use perry_hir::{Expr, Module, Stmt};
+
+const MAX_SCALAR_AGGREGATE_LEN: usize = 8;
+const MAX_SCALAR_AGGREGATE_FIELDS: usize = 16;
+
+type AnonShapeFields = HashMap<String, Vec<String>>;
+
+pub fn run(module: &mut Module) {
+    let mut next_local_id = crate::generator::compute_max_local_id(module).saturating_add(1);
+    let mut source_span_remaps = Vec::new();
+    // Closed-shape object literals are represented as `new __AnonShape_*`
+    // before transforms run. Constructor parameter names retain the literal's
+    // source field order, while the call arguments retain its value order.
+    let anon_shape_fields: AnonShapeFields = module
+        .classes
+        .iter()
+        .filter(|class| class.name.starts_with("__AnonShape_"))
+        .filter_map(|class| {
+            let constructor = class.constructor.as_ref()?;
+            (!constructor.params.is_empty()).then(|| {
+                (
+                    class.name.clone(),
+                    constructor
+                        .params
+                        .iter()
+                        .map(|param| param.name.clone())
+                        .collect(),
+                )
+            })
+        })
+        .collect();
+
+    scalarize_stmts(
+        &mut module.init,
+        &mut next_local_id,
+        &mut source_span_remaps,
+        &anon_shape_fields,
+    );
+    for function in &mut module.functions {
+        scalarize_stmts(
+            &mut function.body,
+            &mut next_local_id,
+            &mut source_span_remaps,
+            &anon_shape_fields,
+        );
+    }
+    for class in &mut module.classes {
+        if let Some(constructor) = &mut class.constructor {
+            scalarize_stmts(
+                &mut constructor.body,
+                &mut next_local_id,
+                &mut source_span_remaps,
+                &anon_shape_fields,
+            );
+        }
+        for method in &mut class.methods {
+            scalarize_stmts(
+                &mut method.body,
+                &mut next_local_id,
+                &mut source_span_remaps,
+                &anon_shape_fields,
+            );
+        }
+        for (_, getter) in &mut class.getters {
+            scalarize_stmts(
+                &mut getter.body,
+                &mut next_local_id,
+                &mut source_span_remaps,
+                &anon_shape_fields,
+            );
+        }
+        for (_, setter) in &mut class.setters {
+            scalarize_stmts(
+                &mut setter.body,
+                &mut next_local_id,
+                &mut source_span_remaps,
+                &anon_shape_fields,
+            );
+        }
+        for method in &mut class.static_methods {
+            scalarize_stmts(
+                &mut method.body,
+                &mut next_local_id,
+                &mut source_span_remaps,
+                &anon_shape_fields,
+            );
+        }
+    }
+
+    for (source_id, new_id) in source_span_remaps {
+        if let Some(span) = module.local_source_spans.get(&source_id).copied() {
+            module.local_source_spans.insert(new_id, span);
+        }
+    }
+}
+
+fn scalarize_stmts(
+    stmts: &mut Vec<Stmt>,
+    next_local_id: &mut LocalId,
+    source_span_remaps: &mut Vec<(LocalId, LocalId)>,
+    anon_shape_fields: &AnonShapeFields,
+) {
+    let candidates: Vec<LocalId> = stmts
+        .iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::Let {
+                id,
+                mutable: false,
+                init: Some(Expr::Array(elements)),
+                ..
+            } if aggregate_elements_are_plain(elements, anon_shape_fields) => Some(*id),
+            _ => None,
+        })
+        .collect();
+
+    for array_id in candidates {
+        let _ = scalarize_candidate(
+            stmts,
+            array_id,
+            next_local_id,
+            source_span_remaps,
+            anon_shape_fields,
+        );
+    }
+
+    // A candidate created inside a branch/loop belongs to that nested lexical
+    // statement list, so process child lists after the current scope.
+    for stmt in stmts {
+        match stmt {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                scalarize_stmts(
+                    then_branch,
+                    next_local_id,
+                    source_span_remaps,
+                    anon_shape_fields,
+                );
+                if let Some(else_branch) = else_branch {
+                    scalarize_stmts(
+                        else_branch,
+                        next_local_id,
+                        source_span_remaps,
+                        anon_shape_fields,
+                    );
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+            }
+            Stmt::For { init, body, .. } => {
+                if let Some(init) = init {
+                    let mut init_vec = vec![(**init).clone()];
+                    scalarize_stmts(
+                        &mut init_vec,
+                        next_local_id,
+                        source_span_remaps,
+                        anon_shape_fields,
+                    );
+                    if init_vec.len() == 1 {
+                        **init = init_vec.remove(0);
+                    }
+                }
+                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+                if let Some(catch) = catch {
+                    scalarize_stmts(
+                        &mut catch.body,
+                        next_local_id,
+                        source_span_remaps,
+                        anon_shape_fields,
+                    );
+                }
+                if let Some(finally) = finally {
+                    scalarize_stmts(
+                        finally,
+                        next_local_id,
+                        source_span_remaps,
+                        anon_shape_fields,
+                    );
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    scalarize_stmts(
+                        &mut case.body,
+                        next_local_id,
+                        source_span_remaps,
+                        anon_shape_fields,
+                    );
+                }
+            }
+            // A labeled body is one statement rather than a statement list.
+            // Aggregate-call inlining never creates this shape; keep it on the
+            // conservative materialized path instead of inventing a wrapper.
+            Stmt::Labeled { .. }
+            | Stmt::Let { .. }
+            | Stmt::Expr(_)
+            | Stmt::Return(_)
+            | Stmt::Throw(_)
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+}
+
+fn element_properties(
+    element: &Expr,
+    anon_shape_fields: &AnonShapeFields,
+) -> Option<Vec<(String, Expr)>> {
+    match element {
+        Expr::Object(properties) => Some(properties.clone()),
+        Expr::New {
+            class_name,
+            args,
+            cap_args_appended: 0,
+            ..
+        } if class_name.starts_with("__AnonShape_") => {
+            let fields = anon_shape_fields.get(class_name)?;
+            (fields.len() == args.len())
+                .then(|| fields.iter().cloned().zip(args.iter().cloned()).collect())
+        }
+        _ => None,
+    }
+}
+
+fn aggregate_elements_are_plain(elements: &[Expr], anon_shape_fields: &AnonShapeFields) -> bool {
+    !elements.is_empty()
+        && elements.len() <= MAX_SCALAR_AGGREGATE_LEN
+        && elements.iter().all(|element| {
+            element_properties(element, anon_shape_fields).is_some_and(|properties| {
+                !properties.is_empty()
+                    && properties.len() <= MAX_SCALAR_AGGREGATE_FIELDS
+                    && properties.iter().all(|(key, value)| {
+                        key != "__proto__"
+                            && !matches!(
+                                value,
+                                Expr::Closure {
+                                    captures_this: true,
+                                    ..
+                                }
+                            )
+                    })
+            })
+        })
+}
+
+fn const_index(expr: &Expr) -> Option<usize> {
+    match expr {
+        Expr::Integer(value) if *value >= 0 => usize::try_from(*value).ok(),
+        Expr::Number(value)
+            if value.is_finite()
+                && *value >= 0.0
+                && value.fract() == 0.0
+                && *value <= usize::MAX as f64 =>
+        {
+            Some(*value as usize)
+        }
+        _ => None,
+    }
+}
+
+fn scalarize_candidate(
+    stmts: &mut Vec<Stmt>,
+    array_id: LocalId,
+    next_local_id: &mut LocalId,
+    source_span_remaps: &mut Vec<(LocalId, LocalId)>,
+    anon_shape_fields: &AnonShapeFields,
+) -> bool {
+    let Some(elements) = stmts.iter().find_map(|stmt| match stmt {
+        Stmt::Let {
+            id,
+            init: Some(Expr::Array(elements)),
+            ..
+        } if *id == array_id => Some(elements.clone()),
+        _ => None,
+    }) else {
+        return false;
+    };
+    if !aggregate_elements_are_plain(&elements, anon_shape_fields) {
+        return false;
+    }
+
+    let properties: Vec<Vec<(String, Expr)>> = elements
+        .iter()
+        .map(|element| element_properties(element, anon_shape_fields))
+        .collect::<Option<_>>()
+        .expect("aggregate_elements_are_plain checked the shape");
+
+    let keys: Vec<HashSet<String>> = properties
+        .iter()
+        .map(|properties| properties.iter().map(|(key, _)| key.clone()).collect())
+        .collect();
+    let mut aliases = HashMap::new();
+    collect_aliases(stmts, array_id, elements.len(), &mut aliases);
+    if !stmts_are_safe(stmts, array_id, &aliases, &keys) {
+        return false;
+    }
+
+    let mut scalar_lets = Vec::new();
+    let mut fields: Vec<HashMap<String, LocalId>> = Vec::with_capacity(elements.len());
+    for (element_index, properties) in properties.into_iter().enumerate() {
+        let mut element_fields = HashMap::new();
+        for (property_index, (key, value)) in properties.into_iter().enumerate() {
+            let id = *next_local_id;
+            *next_local_id = next_local_id.saturating_add(1);
+            source_span_remaps.push((array_id, id));
+            scalar_lets.push(Stmt::Let {
+                id,
+                name: format!(
+                    "__perry_scalar_aggregate_{array_id}_{element_index}_{property_index}"
+                ),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(value),
+            });
+            // Object literal duplicate keys are last-write-wins, while every
+            // value expression above is still evaluated in source order.
+            element_fields.insert(key, id);
+        }
+        fields.push(element_fields);
+    }
+
+    rewrite_stmts(stmts, array_id, &aliases, &fields);
+    let Some(declaration_index) = stmts
+        .iter()
+        .position(|stmt| matches!(stmt, Stmt::Let { id, .. } if *id == array_id))
+    else {
+        return false;
+    };
+    stmts.splice(declaration_index..=declaration_index, scalar_lets);
+    true
+}
+
+fn collect_aliases(
+    stmts: &[Stmt],
+    array_id: LocalId,
+    len: usize,
+    aliases: &mut HashMap<LocalId, usize>,
+) {
+    for stmt in stmts {
+        if let Stmt::Let {
+            id,
+            mutable: false,
+            init: Some(Expr::IndexGet { object, index }),
+            ..
+        } = stmt
+        {
+            if matches!(object.as_ref(), Expr::LocalGet(candidate) if *candidate == array_id) {
+                if let Some(index) = const_index(index).filter(|index| *index < len) {
+                    aliases.insert(*id, index);
+                }
+            }
+        }
+        match stmt {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_aliases(then_branch, array_id, len, aliases);
+                if let Some(else_branch) = else_branch {
+                    collect_aliases(else_branch, array_id, len, aliases);
+                }
+            }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+                collect_aliases(body, array_id, len, aliases);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                collect_aliases(body, array_id, len, aliases);
+                if let Some(catch) = catch {
+                    collect_aliases(&catch.body, array_id, len, aliases);
+                }
+                if let Some(finally) = finally {
+                    collect_aliases(finally, array_id, len, aliases);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases {
+                    collect_aliases(&case.body, array_id, len, aliases);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn candidate_field(
+    object: &Expr,
+    property: &str,
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashSet<String>],
+) -> Option<usize> {
+    let index = match object {
+        Expr::LocalGet(alias) => aliases.get(alias).copied(),
+        Expr::IndexGet { object, index } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id) => {
+            const_index(index)
+        }
+        _ => None,
+    }?;
+    fields
+        .get(index)
+        .is_some_and(|element| element.contains(property))
+        .then_some(index)
+}
+
+fn expr_is_safe(
+    expr: &Expr,
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashSet<String>],
+) -> bool {
+    match expr {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
+            if candidate_field(object, property, array_id, aliases, fields).is_some() {
+                return true;
+            }
+            if property == "length"
+                && matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id)
+            {
+                return true;
+            }
+        }
+        Expr::IndexGet { object, .. } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id) =>
+        {
+            // Only an alias declaration or a direct property receiver is safe;
+            // both parents intercept this expression before recursion reaches it.
+            return false;
+        }
+        Expr::LocalGet(id) if *id == array_id || aliases.contains_key(id) => return false,
+        Expr::LocalSet(id, _) | Expr::Update { id, .. }
+            if *id == array_id || aliases.contains_key(id) =>
+        {
+            return false;
+        }
+        Expr::Closure {
+            captures,
+            mutable_captures,
+            ..
+        } if captures
+            .iter()
+            .chain(mutable_captures.iter())
+            .any(|id| *id == array_id || aliases.contains_key(id)) =>
+        {
+            return false;
+        }
+        Expr::Call { callee, .. } | Expr::CallSpread { callee, .. }
+            if matches!(
+                callee.as_ref(),
+                Expr::PropertyGet { object, property, .. }
+                    if candidate_field(object, property, array_id, aliases, fields).is_some()
+            ) =>
+        {
+            // `item.method()` observes the original object as `this`.
+            return false;
+        }
+        Expr::Delete(operand)
+            if matches!(
+                operand.as_ref(),
+                Expr::PropertyGet { object, property, .. }
+                    if candidate_field(object, property, array_id, aliases, fields).is_some()
+            ) =>
+        {
+            return false;
+        }
+        _ => {}
+    }
+
+    let mut safe = true;
+    perry_hir::walker::walk_expr_children(expr, &mut |child| {
+        safe &= expr_is_safe(child, array_id, aliases, fields);
+    });
+    safe
+}
+
+fn stmts_are_safe(
+    stmts: &[Stmt],
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashSet<String>],
+) -> bool {
+    for stmt in stmts {
+        let safe = match stmt {
+            Stmt::Let { id, init, .. } if *id == array_id => true,
+            Stmt::Let {
+                id,
+                init: Some(Expr::IndexGet { object, index }),
+                ..
+            } if aliases.contains_key(id)
+                && matches!(object.as_ref(), Expr::LocalGet(candidate) if *candidate == array_id)
+                && const_index(index) == aliases.get(id).copied() =>
+            {
+                true
+            }
+            Stmt::Let { init, .. } => init
+                .as_ref()
+                .is_none_or(|expr| expr_is_safe(expr, array_id, aliases, fields)),
+            Stmt::Expr(expr) | Stmt::Throw(expr) => expr_is_safe(expr, array_id, aliases, fields),
+            Stmt::Return(value) => value
+                .as_ref()
+                .is_none_or(|expr| expr_is_safe(expr, array_id, aliases, fields)),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                expr_is_safe(condition, array_id, aliases, fields)
+                    && stmts_are_safe(then_branch, array_id, aliases, fields)
+                    && else_branch
+                        .as_deref()
+                        .is_none_or(|branch| stmts_are_safe(branch, array_id, aliases, fields))
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                expr_is_safe(condition, array_id, aliases, fields)
+                    && stmts_are_safe(body, array_id, aliases, fields)
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                init.as_deref().is_none_or(|init| {
+                    stmts_are_safe(std::slice::from_ref(init), array_id, aliases, fields)
+                }) && condition
+                    .as_ref()
+                    .is_none_or(|expr| expr_is_safe(expr, array_id, aliases, fields))
+                    && update
+                        .as_ref()
+                        .is_none_or(|expr| expr_is_safe(expr, array_id, aliases, fields))
+                    && stmts_are_safe(body, array_id, aliases, fields)
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                stmts_are_safe(body, array_id, aliases, fields)
+                    && catch
+                        .as_ref()
+                        .is_none_or(|catch| stmts_are_safe(&catch.body, array_id, aliases, fields))
+                    && finally
+                        .as_deref()
+                        .is_none_or(|body| stmts_are_safe(body, array_id, aliases, fields))
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                expr_is_safe(discriminant, array_id, aliases, fields)
+                    && cases.iter().all(|case| {
+                        case.test
+                            .as_ref()
+                            .is_none_or(|test| expr_is_safe(test, array_id, aliases, fields))
+                            && stmts_are_safe(&case.body, array_id, aliases, fields)
+                    })
+            }
+            Stmt::Labeled { body, .. } => stmts_are_safe(
+                std::slice::from_ref(body.as_ref()),
+                array_id,
+                aliases,
+                fields,
+            ),
+            Stmt::PreallocateBoxes(ids)
+            | Stmt::PreallocateTdzBoxes(ids)
+            | Stmt::ReleaseBoxes(ids) => !ids
+                .iter()
+                .any(|id| *id == array_id || aliases.contains_key(id)),
+            Stmt::Break | Stmt::Continue | Stmt::LabeledBreak(_) | Stmt::LabeledContinue(_) => true,
+        };
+        if !safe {
+            return false;
+        }
+    }
+    true
+}
+
+fn replacement_for_expr(
+    expr: &Expr,
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashMap<String, LocalId>],
+) -> Option<Expr> {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    else {
+        return None;
+    };
+    if property == "length" && matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id) {
+        return Some(Expr::Integer(fields.len() as i64));
+    }
+    let index = match object.as_ref() {
+        Expr::LocalGet(alias) => aliases.get(alias).copied(),
+        Expr::IndexGet { object, index } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id) => {
+            const_index(index)
+        }
+        _ => None,
+    }?;
+    fields
+        .get(index)?
+        .get(property)
+        .copied()
+        .map(Expr::LocalGet)
+}
+
+fn rewrite_expr(
+    expr: &mut Expr,
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashMap<String, LocalId>],
+) {
+    if let Some(replacement) = replacement_for_expr(expr, array_id, aliases, fields) {
+        *expr = replacement;
+        return;
+    }
+    perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
+        rewrite_expr(child, array_id, aliases, fields)
+    });
+}
+
+fn rewrite_stmts(
+    stmts: &mut Vec<Stmt>,
+    array_id: LocalId,
+    aliases: &HashMap<LocalId, usize>,
+    fields: &[HashMap<String, LocalId>],
+) {
+    let mut index = 0;
+    while index < stmts.len() {
+        if matches!(&stmts[index], Stmt::Let { id, .. } if aliases.contains_key(id)) {
+            stmts.remove(index);
+            continue;
+        }
+        match &mut stmts[index] {
+            Stmt::Let { init, .. } => {
+                if let Some(init) = init {
+                    rewrite_expr(init, array_id, aliases, fields);
+                }
+            }
+            Stmt::Expr(expr) | Stmt::Throw(expr) => rewrite_expr(expr, array_id, aliases, fields),
+            Stmt::Return(value) => {
+                if let Some(value) = value {
+                    rewrite_expr(value, array_id, aliases, fields);
+                }
+            }
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                rewrite_expr(condition, array_id, aliases, fields);
+                rewrite_stmts(then_branch, array_id, aliases, fields);
+                if let Some(else_branch) = else_branch {
+                    rewrite_stmts(else_branch, array_id, aliases, fields);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                rewrite_expr(condition, array_id, aliases, fields);
+                rewrite_stmts(body, array_id, aliases, fields);
+            }
+            Stmt::For {
+                condition,
+                update,
+                body,
+                ..
+            } => {
+                if let Some(condition) = condition {
+                    rewrite_expr(condition, array_id, aliases, fields);
+                }
+                if let Some(update) = update {
+                    rewrite_expr(update, array_id, aliases, fields);
+                }
+                rewrite_stmts(body, array_id, aliases, fields);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_stmts(body, array_id, aliases, fields);
+                if let Some(catch) = catch {
+                    rewrite_stmts(&mut catch.body, array_id, aliases, fields);
+                }
+                if let Some(finally) = finally {
+                    rewrite_stmts(finally, array_id, aliases, fields);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                rewrite_expr(discriminant, array_id, aliases, fields);
+                for case in cases {
+                    if let Some(test) = &mut case.test {
+                        rewrite_expr(test, array_id, aliases, fields);
+                    }
+                    rewrite_stmts(&mut case.body, array_id, aliases, fields);
+                }
+            }
+            Stmt::Labeled { .. }
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+        index += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perry_hir::CompareOp;
+
+    fn object(value: i64) -> Expr {
+        Expr::Object(vec![("component".to_string(), Expr::Integer(value))])
+    }
+
+    fn property(object: Expr, name: &str) -> Expr {
+        Expr::PropertyGet {
+            object: Box::new(object),
+            property: name.to_string(),
+            byte_offset: 0,
+        }
+    }
+
+    fn aggregate_fixture(observe_identity: bool) -> Module {
+        let mut module = Module::new("aggregate-scalar.ts");
+        module.init = vec![
+            Stmt::Let {
+                id: 1,
+                name: "values".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Array(vec![object(10), object(20)])),
+            },
+            Stmt::Let {
+                id: 2,
+                name: "first".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(1)),
+                    index: Box::new(Expr::Integer(0)),
+                }),
+            },
+            Stmt::Expr(if observe_identity {
+                Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(2)),
+                    right: Box::new(Expr::LocalGet(2)),
+                }
+            } else {
+                property(Expr::LocalGet(2), "component")
+            }),
+        ];
+        module
+    }
+
+    #[test]
+    fn replaces_nested_carriers_with_scalar_field_locals() {
+        let mut module = aggregate_fixture(false);
+        run(&mut module);
+
+        assert!(module.init.iter().all(|stmt| {
+            !matches!(
+                stmt,
+                Stmt::Let {
+                    init: Some(Expr::Array(_) | Expr::Object(_)),
+                    ..
+                }
+            )
+        }));
+        assert!(!module
+            .init
+            .iter()
+            .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })));
+        assert!(matches!(
+            module.init.last(),
+            Some(Stmt::Expr(Expr::LocalGet(_)))
+        ));
+    }
+
+    #[test]
+    fn identity_observation_keeps_materialized_aggregate() {
+        let mut module = aggregate_fixture(true);
+        run(&mut module);
+
+        assert!(module.init.iter().any(|stmt| {
+            matches!(
+                stmt,
+                Stmt::Let {
+                    id: 1,
+                    init: Some(Expr::Array(_)),
+                    ..
+                }
+            )
+        }));
+        assert!(module
+            .init
+            .iter()
+            .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })));
+    }
+
+    #[test]
+    fn mutation_reflection_and_unknown_calls_keep_materialized_aggregate() {
+        let hazards = vec![
+            Expr::PropertySet {
+                object: Box::new(Expr::LocalGet(2)),
+                property: "component".to_string(),
+                value: Box::new(Expr::Integer(30)),
+            },
+            Expr::ObjectKeys(Box::new(Expr::LocalGet(2))),
+            Expr::Call {
+                callee: Box::new(Expr::FuncRef(99)),
+                args: vec![Expr::LocalGet(2)],
+                type_args: Vec::new(),
+                byte_offset: 0,
+            },
+        ];
+
+        for hazard in hazards {
+            let mut module = aggregate_fixture(false);
+            *module.init.last_mut().expect("observer statement") = Stmt::Expr(hazard);
+            run(&mut module);
+
+            assert!(module.init.iter().any(|stmt| {
+                matches!(
+                    stmt,
+                    Stmt::Let {
+                        id: 1,
+                        init: Some(Expr::Array(_)),
+                        ..
+                    }
+                )
+            }));
+        }
+    }
+}

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -166,6 +166,152 @@ pub fn is_inlinable(func: &Function) -> bool {
     true
 }
 
+/// A deliberately narrow extension of the ordinary inliner for issue #8691.
+///
+/// Fixed aggregate literals are especially expensive when a tiny helper walks
+/// them with the canonical `for (let i = 0; i < values.length; i++)` loop. The
+/// general inliner rejects every loop, which prevents the later static-loop
+/// unroller and aggregate scalar-replacement pass from ever seeing the
+/// consumer next to the literal. Admit only a single, bounded, forward loop
+/// over one parameter and only when every use of that parameter is a length
+/// read or an indexed read. The call-site path separately requires a short
+/// array of plain object literals; all other calls keep the normal ABI.
+pub fn scalar_aggregate_loop_param(func: &Function) -> Option<LocalId> {
+    if func.is_async
+        || func.is_generator
+        || !func.captures.is_empty()
+        || func.params.iter().any(|param| param.is_rest)
+        || func.body.len() != 1
+        || body_references_dynamic_this(&func.body)
+        || body_calls_func(&func.body, func.id)
+    {
+        return None;
+    }
+
+    let Stmt::For {
+        init: Some(init),
+        condition: Some(condition),
+        update: Some(update),
+        body,
+    } = &func.body[0]
+    else {
+        return None;
+    };
+    let Stmt::Let {
+        id: index_id,
+        init: Some(Expr::Integer(0)),
+        ..
+    } = init.as_ref()
+    else {
+        return None;
+    };
+    let Expr::Compare {
+        op: perry_hir::CompareOp::Lt,
+        left,
+        right,
+    } = condition
+    else {
+        return None;
+    };
+    if !matches!(left.as_ref(), Expr::LocalGet(id) if id == index_id)
+        || !matches!(
+            update,
+            Expr::Update {
+                id,
+                op: perry_hir::UpdateOp::Increment,
+                ..
+            } if id == index_id
+        )
+    {
+        return None;
+    }
+    let Expr::PropertyGet {
+        object, property, ..
+    } = right.as_ref()
+    else {
+        return None;
+    };
+    let Expr::LocalGet(param_id) = object.as_ref() else {
+        return None;
+    };
+    if property != "length" || !func.params.iter().any(|param| param.id == *param_id) {
+        return None;
+    }
+
+    fn expr_uses_param_safely(expr: &Expr, param_id: LocalId, index_id: LocalId) -> bool {
+        match expr {
+            Expr::IndexGet { object, index } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == param_id) =>
+            {
+                matches!(index.as_ref(), Expr::LocalGet(id) if *id == index_id)
+            }
+            Expr::PropertyGet {
+                object, property, ..
+            } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == param_id) => {
+                property == "length"
+            }
+            Expr::LocalGet(id) if *id == param_id => false,
+            Expr::Closure { captures, .. } if captures.contains(&param_id) => false,
+            // Calls and constructors can observe or mutate module state while
+            // module-init locals are cached. The dedicated path does not need
+            // either shape, so keep its body call-free.
+            Expr::Call { .. } | Expr::CallSpread { .. } | Expr::New { .. } => false,
+            _ => {
+                let mut safe = true;
+                perry_hir::walker::walk_expr_children(expr, &mut |child| {
+                    safe &= expr_uses_param_safely(child, param_id, index_id);
+                });
+                safe
+            }
+        }
+    }
+
+    fn stmts_use_param_safely(
+        stmts: &[Stmt],
+        param_id: LocalId,
+        index_id: LocalId,
+        statement_budget: &mut usize,
+    ) -> bool {
+        for stmt in stmts {
+            *statement_budget += 1;
+            if *statement_budget > MAX_INLINE_STMTS {
+                return false;
+            }
+            let safe = match stmt {
+                Stmt::Let { init, .. } => init
+                    .as_ref()
+                    .is_none_or(|expr| expr_uses_param_safely(expr, param_id, index_id)),
+                Stmt::Expr(expr) | Stmt::Throw(expr) => {
+                    expr_uses_param_safely(expr, param_id, index_id)
+                }
+                Stmt::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                } => {
+                    expr_uses_param_safely(condition, param_id, index_id)
+                        && stmts_use_param_safely(then_branch, param_id, index_id, statement_budget)
+                        && else_branch.as_deref().is_none_or(|branch| {
+                            stmts_use_param_safely(branch, param_id, index_id, statement_budget)
+                        })
+                }
+                Stmt::PreallocateBoxes(_)
+                | Stmt::PreallocateTdzBoxes(_)
+                | Stmt::ReleaseBoxes(_) => true,
+                // Returns and nested/abrupt control flow need a labeled inline
+                // boundary. Keep the first slice intentionally smaller.
+                _ => false,
+            };
+            if !safe {
+                return false;
+            }
+        }
+        true
+    }
+
+    let mut statement_budget = 0;
+    stmts_use_param_safely(body, *param_id, *index_id, &mut statement_budget).then_some(*param_id)
+}
+
 /// Inlinability for a *method* invoked with a known (exact) receiver. Identical
 /// to [`is_inlinable`] except the dynamic-`this` rejection is relaxed: the
 /// method-inliner substitutes `this` for the concrete receiver

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1429,6 +1429,12 @@ pub fn try_inline_simple_call(
         // Check for regular function call
         if let Expr::FuncRef(func_id) = callee.as_ref() {
             if let Some(func) = func_candidates.get(func_id) {
+                // Loop-bearing candidates are admitted only for the dedicated
+                // fixed-aggregate path in `try_inline_call`. Expression-level
+                // inlining has nowhere to place their control flow.
+                if !has_simple_control_flow(&func.body) {
+                    return None;
+                }
                 // Pattern 1: single Return(expr)
                 if func.body.len() == 1 {
                     if let Stmt::Return(Some(return_expr)) = &func.body[0] {
@@ -1702,6 +1708,156 @@ pub fn try_inline_simple_call(
     None
 }
 
+const MAX_SCALAR_AGGREGATE_CALL_LEN: usize = 8;
+
+pub(crate) fn scalar_aggregate_call_len(
+    func: &Function,
+    args: &[Expr],
+) -> Option<(LocalId, usize)> {
+    let param_id = scalar_aggregate_loop_param(func)?;
+    let param_index = func.params.iter().position(|param| param.id == param_id)?;
+    let Expr::Array(elements) = args.get(param_index)? else {
+        return None;
+    };
+    if elements.is_empty()
+        || elements.len() > MAX_SCALAR_AGGREGATE_CALL_LEN
+        || elements.iter().any(|element| match element {
+            Expr::Object(properties) => {
+                properties.is_empty() || properties.iter().any(|(key, _)| key == "__proto__")
+            }
+            // Closed-shape object literals have already been rewritten by HIR
+            // lowering to constructor calls whose positional arguments are the
+            // property values. The replacement pass resolves their field names
+            // from the synthesized class before removing either allocation.
+            Expr::New {
+                class_name,
+                args,
+                cap_args_appended,
+                ..
+            } => {
+                !class_name.starts_with("__AnonShape_")
+                    || args.is_empty()
+                    || args.len() > 16
+                    || *cap_args_appended != 0
+            }
+            _ => true,
+        })
+    {
+        return None;
+    }
+    Some((param_id, elements.len()))
+}
+
+/// Replace the loop-bound read on the original parameter before local-id
+/// substitution. The actual argument remains bound to a normal local until
+/// the post-unroll scalar-replacement pass proves every element use; only the
+/// fresh literal's immutable length is folded here.
+fn fold_scalar_aggregate_param_length(stmts: &mut [Stmt], param_id: LocalId, len: usize) {
+    fn fold_expr(expr: &mut Expr, param_id: LocalId, len: usize) {
+        if matches!(
+            expr,
+            Expr::PropertyGet { object, property, .. }
+                if property == "length"
+                    && matches!(object.as_ref(), Expr::LocalGet(id) if *id == param_id)
+        ) {
+            *expr = Expr::Integer(len as i64);
+            return;
+        }
+        perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
+            fold_expr(child, param_id, len)
+        });
+    }
+
+    for stmt in stmts {
+        match stmt {
+            Stmt::Let { init, .. } => {
+                if let Some(init) = init {
+                    fold_expr(init, param_id, len);
+                }
+            }
+            Stmt::Expr(expr) | Stmt::Throw(expr) => fold_expr(expr, param_id, len),
+            Stmt::Return(value) => {
+                if let Some(value) = value {
+                    fold_expr(value, param_id, len);
+                }
+            }
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                fold_expr(condition, param_id, len);
+                fold_scalar_aggregate_param_length(then_branch, param_id, len);
+                if let Some(else_branch) = else_branch {
+                    fold_scalar_aggregate_param_length(else_branch, param_id, len);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                fold_expr(condition, param_id, len);
+                fold_scalar_aggregate_param_length(body, param_id, len);
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    fold_scalar_aggregate_param_length(
+                        std::slice::from_mut(init.as_mut()),
+                        param_id,
+                        len,
+                    );
+                }
+                if let Some(condition) = condition {
+                    fold_expr(condition, param_id, len);
+                }
+                if let Some(update) = update {
+                    fold_expr(update, param_id, len);
+                }
+                fold_scalar_aggregate_param_length(body, param_id, len);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                fold_scalar_aggregate_param_length(body, param_id, len);
+                if let Some(catch) = catch {
+                    fold_scalar_aggregate_param_length(&mut catch.body, param_id, len);
+                }
+                if let Some(finally) = finally {
+                    fold_scalar_aggregate_param_length(finally, param_id, len);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                fold_expr(discriminant, param_id, len);
+                for case in cases {
+                    if let Some(test) = &mut case.test {
+                        fold_expr(test, param_id, len);
+                    }
+                    fold_scalar_aggregate_param_length(&mut case.body, param_id, len);
+                }
+            }
+            Stmt::Labeled { body, .. } => fold_scalar_aggregate_param_length(
+                std::slice::from_mut(body.as_mut()),
+                param_id,
+                len,
+            ),
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+}
+
 /// Try to inline a call that may have multiple statements
 pub fn try_inline_call(
     expr: &Expr,
@@ -1717,6 +1873,11 @@ pub fn try_inline_call(
         // Handle regular function calls
         if let Expr::FuncRef(func_id) = callee.as_ref() {
             if let Some(func) = func_candidates.get(func_id) {
+                let scalar_aggregate = if has_simple_control_flow(&func.body) {
+                    None
+                } else {
+                    Some(scalar_aggregate_call_len(func, args)?)
+                };
                 // Extra actual args are evaluated before a JS call even when
                 // the callee declares fewer params. The current inliner maps
                 // params with zip(), so it cannot preserve those trailing
@@ -1786,6 +1947,10 @@ pub fn try_inline_call(
                 }
 
                 let mut inlined_body = func.body.clone();
+
+                if let Some((param_id, len)) = scalar_aggregate {
+                    fold_scalar_aggregate_param_length(&mut inlined_body, param_id, len);
+                }
 
                 // Collect all LocalIds from Let statements in the body and remap them
                 let body_local_ids = collect_body_local_ids(&inlined_body);

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -28,8 +28,9 @@ pub use cross_module::{
 // Internal-to-crate re-exports for cross-sibling access via `use super::*;`.
 pub(crate) use analysis::{
     find_max_local_id_in_module, is_inlinable, is_inlinable_method, method_lookup_is_unshadowed,
+    scalar_aggregate_loop_param,
 };
-pub(crate) use call_inliner::inline_calls_in_stmts;
+pub(crate) use call_inliner::{inline_calls_in_stmts, scalar_aggregate_call_len};
 pub(crate) use clamp::{is_clamp3, is_clamp_u8};
 pub(crate) use closure_analysis::{
     body_contains_closure_capturing, body_contains_super_call, body_references_dynamic_this,
@@ -112,6 +113,136 @@ pub fn inline_functions(
         extra_anon_classes,
     );
     span_remaps.finish(&mut module.local_source_spans);
+}
+
+/// Module init caches globals in locals, so an ordinary call between an
+/// inlined impure consumer and its next use could observe stale backing
+/// storage. Admit the #8691 init path only when every executable call is an
+/// eligible call to this one consumer, apart from `console.log` (whose
+/// arguments are evaluated from the cached locals before entering runtime).
+fn impure_scalar_aggregate_init_is_safe(stmts: &[Stmt], target: &Function) -> bool {
+    fn is_console_log(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::PropertyGet { object, property, .. }
+                if property == "log" && matches!(object.as_ref(), Expr::GlobalGet(_))
+        )
+    }
+
+    fn expr_is_safe(expr: &Expr, target: &Function, saw_target: &mut bool) -> bool {
+        match expr {
+            Expr::Call { callee, args, .. } if matches!(callee.as_ref(), Expr::FuncRef(id) if *id == target.id) =>
+            {
+                *saw_target = true;
+                scalar_aggregate_call_len(target, args).is_some()
+                    && args.iter().all(|arg| expr_is_safe(arg, target, saw_target))
+            }
+            Expr::Call { callee, args, .. } if is_console_log(callee) => {
+                args.iter().all(|arg| expr_is_safe(arg, target, saw_target))
+            }
+            Expr::Call { .. } | Expr::CallSpread { .. } => false,
+            Expr::New {
+                class_name,
+                args,
+                cap_args_appended: 0,
+                ..
+            } if class_name.starts_with("__AnonShape_") => {
+                args.iter().all(|arg| expr_is_safe(arg, target, saw_target))
+            }
+            Expr::New { .. } => false,
+            // Creating a closure does not execute its body. A later call would
+            // itself be rejected above, so its body is irrelevant here.
+            Expr::Closure { .. } => true,
+            _ => {
+                let mut safe = true;
+                perry_hir::walker::walk_expr_children(expr, &mut |child| {
+                    safe &= expr_is_safe(child, target, saw_target);
+                });
+                safe
+            }
+        }
+    }
+
+    fn stmts_are_safe(stmts: &[Stmt], target: &Function, saw_target: &mut bool) -> bool {
+        stmts.iter().all(|stmt| match stmt {
+            Stmt::Let { init, .. } => init
+                .as_ref()
+                .is_none_or(|expr| expr_is_safe(expr, target, saw_target)),
+            Stmt::Expr(expr) | Stmt::Throw(expr) => expr_is_safe(expr, target, saw_target),
+            Stmt::Return(value) => value
+                .as_ref()
+                .is_none_or(|expr| expr_is_safe(expr, target, saw_target)),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                expr_is_safe(condition, target, saw_target)
+                    && stmts_are_safe(then_branch, target, saw_target)
+                    && else_branch
+                        .as_deref()
+                        .is_none_or(|branch| stmts_are_safe(branch, target, saw_target))
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                expr_is_safe(condition, target, saw_target)
+                    && stmts_are_safe(body, target, saw_target)
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                init.as_deref().is_none_or(|stmt| {
+                    stmts_are_safe(std::slice::from_ref(stmt), target, saw_target)
+                }) && condition
+                    .as_ref()
+                    .is_none_or(|expr| expr_is_safe(expr, target, saw_target))
+                    && update
+                        .as_ref()
+                        .is_none_or(|expr| expr_is_safe(expr, target, saw_target))
+                    && stmts_are_safe(body, target, saw_target)
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                stmts_are_safe(body, target, saw_target)
+                    && catch
+                        .as_ref()
+                        .is_none_or(|catch| stmts_are_safe(&catch.body, target, saw_target))
+                    && finally
+                        .as_deref()
+                        .is_none_or(|body| stmts_are_safe(body, target, saw_target))
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                expr_is_safe(discriminant, target, saw_target)
+                    && cases.iter().all(|case| {
+                        case.test
+                            .as_ref()
+                            .is_none_or(|test| expr_is_safe(test, target, saw_target))
+                            && stmts_are_safe(&case.body, target, saw_target)
+                    })
+            }
+            Stmt::Labeled { body, .. } => {
+                stmts_are_safe(std::slice::from_ref(body.as_ref()), target, saw_target)
+            }
+            Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => true,
+        })
+    }
+
+    let mut saw_target = false;
+    stmts_are_safe(stmts, target, &mut saw_target) && saw_target
 }
 
 fn inline_functions_inner(
@@ -360,7 +491,7 @@ fn inline_functions_inner(
         if is_clamp3(f) || is_clamp_u8(f) {
             continue;
         }
-        if is_inlinable(f) {
+        if is_inlinable(f) || scalar_aggregate_loop_param(f).is_some() {
             func_candidates.insert(f.id, f.clone());
         }
     }
@@ -563,7 +694,11 @@ fn inline_functions_inner(
     {
         let pure_func_candidates: HashMap<FuncId, Function> = func_candidates
             .iter()
-            .filter(|(_, f)| is_pure_function(f))
+            .filter(|(_, f)| {
+                is_pure_function(f)
+                    || (scalar_aggregate_loop_param(f).is_some()
+                        && impure_scalar_aggregate_init_is_safe(&module.init, f))
+            })
             .map(|(id, f)| (*id, f.clone()))
             .collect();
         let mut next_local_id = module_max_id + 1;

--- a/crates/perry-transform/src/lib.rs
+++ b/crates/perry-transform/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Optimization passes (function inlining)
 //! - i18n string localization
 
+mod aggregate_scalar;
 pub mod async_to_generator;
 pub mod closure;
 pub mod deforest;
@@ -47,5 +48,6 @@ pub use unroll::unroll_static_loops;
 ///   the order here stops the two facts from drifting apart.)
 pub fn post_inline_cleanups(module: &mut perry_hir::Module) {
     unroll_static_loops(module);
+    aggregate_scalar::run(module);
     prop_cse::run(module);
 }

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -112,6 +112,9 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     "PERRY_STATIC_STRING_LOWERING",
     "PERRY_STRING_INIT_CHUNK_SIZE",
     "PERRY_TA_PARAM_F64_READ",
+    // #8692: disables guarded direct Uint32Array read-modify-write lowering;
+    // toggling it changes the generated CFG and helper calls.
+    "PERRY_TYPED_ARRAY_RMW",
     "PERRY_WATCHOS_ARM64_32",
     // #8105 — number-by-construction locals (see the collector of the same
     // name); `=0` empties the fact and changes every affected function's IR.

--- a/scripts/local_binding_type_allowlist.json
+++ b/scripts/local_binding_type_allowlist.json
@@ -4,18 +4,18 @@
     {
       "path": "crates/perry-codegen/src/codegen/closure.rs",
       "function": "compile_closure",
-      "access": "raw:module_receiver_types",
-      "count": 1,
-      "classification": "metadata-only",
-      "reason": "The module map is copied into the closure's source-type metadata; representation consumers use the separate runtime-proof map or emit a live-value guard."
-    },
-    {
-      "path": "crates/perry-codegen/src/codegen/closure.rs",
-      "function": "compile_closure",
       "access": "raw:local_types",
       "count": 1,
       "classification": "metadata-only",
       "reason": "This entry operation merges source-type metadata for closure receivers; raw representation consumers require separate runtime proof or a live guard."
+    },
+    {
+      "path": "crates/perry-codegen/src/codegen/closure.rs",
+      "function": "compile_closure",
+      "access": "raw:module_receiver_types",
+      "count": 1,
+      "classification": "metadata-only",
+      "reason": "The module map is copied into the closure's source-type metadata; representation consumers use the separate runtime-proof map or emit a live-value guard."
     },
     {
       "path": "crates/perry-codegen/src/codegen/mod.rs",
@@ -26,28 +26,12 @@
       "reason": "This iteration derives the typed-ABI metadata oracle while filtering globals; typed entry paths independently guard live argument and capture values."
     },
     {
-      "path": "crates/perry-codegen/src/collectors/byte_read_key.rs",
-      "function": "is_numeric",
-      "access": "raw:binding_types",
-      "count": 1,
-      "classification": "metadata-only",
-      "reason": "This collector inventories declared numeric key candidates; the map contains source metadata and is not itself runtime-value evidence."
-    },
-    {
-      "path": "crates/perry-codegen/src/collectors/pointer_locals.rs",
-      "function": "collect_facts",
-      "access": "raw:local_types",
-      "count": 1,
-      "classification": "representation-proven",
-      "reason": "The membership check prunes the complete-write fixpoint to frame-owned locals; it cannot remove a required root and unknown values remain conservatively pointer-capable."
-    },
-    {
-      "path": "crates/perry-codegen/src/collectors/hir_facts.rs",
-      "function": "seed_module_bindings",
-      "access": "raw:binding_types",
-      "count": 1,
+      "path": "crates/perry-codegen/src/codegen/typed_abi.rs",
+      "function": "typed_arg_is_guard_candidate",
+      "access": "local_type_hint",
+      "count": 2,
       "classification": "runtime-validated",
-      "reason": "Declared array kinds only seed packed-loop candidates; the loop entry guard validates the actual array kind and window."
+      "reason": "Binding and array-element hints only nominate typed routes; every consumer checks or coerces the live JSValue with the selected representation contract and keeps the generic body or semantic runtime helper on failure."
     },
     {
       "path": "crates/perry-codegen/src/codegen/typed_abi.rs",
@@ -58,12 +42,28 @@
       "reason": "The annotation selects only a candidate capture rep; both the public trampoline and direct-call path guard every current capture slot and use the generic body on failure."
     },
     {
-      "path": "crates/perry-codegen/src/codegen/typed_abi.rs",
-      "function": "typed_arg_is_guard_candidate",
-      "access": "local_type_hint",
-      "count": 2,
+      "path": "crates/perry-codegen/src/collectors/byte_read_key.rs",
+      "function": "is_numeric",
+      "access": "raw:binding_types",
+      "count": 1,
+      "classification": "metadata-only",
+      "reason": "This collector inventories declared numeric key candidates; the map contains source metadata and is not itself runtime-value evidence."
+    },
+    {
+      "path": "crates/perry-codegen/src/collectors/hir_facts.rs",
+      "function": "seed_module_bindings",
+      "access": "raw:binding_types",
+      "count": 1,
       "classification": "runtime-validated",
-      "reason": "Binding and array-element hints only nominate typed routes; every consumer checks or coerces the live JSValue with the selected representation contract and keeps the generic body or semantic runtime helper on failure."
+      "reason": "Declared array kinds only seed packed-loop candidates; the loop entry guard validates the actual array kind and window."
+    },
+    {
+      "path": "crates/perry-codegen/src/collectors/pointer_locals.rs",
+      "function": "collect_facts",
+      "access": "raw:local_types",
+      "count": 1,
+      "classification": "representation-proven",
+      "reason": "The membership check prunes the complete-write fixpoint to frame-owned locals; it cannot remove a required root and unknown values remain conservatively pointer-capable."
     },
     {
       "path": "crates/perry-codegen/src/expr/array_methods.rs",
@@ -170,12 +170,36 @@
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
     },
     {
+      "path": "crates/perry-codegen/src/expr/property_set.rs",
+      "function": "guarded_declared_class_store_candidate",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The class hint selects the plain-field store guard; the live class id, keys token, descriptor state, field bounds, and value representation are checked before a raw slot store, while accessors stay dynamic."
+    },
+    {
+      "path": "crates/perry-codegen/src/expr/proxy_reflect.rs",
+      "function": "guarded_declared_class_property_candidate",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The class hint only routes a strict static-name PutValue through PropertySet; its live class/shape/descriptor guard dominates the raw slot access and every miss retains ordinary runtime assignment."
+    },
+    {
       "path": "crates/perry-codegen/src/expr/shadow_slot.rs",
       "function": "expr_is_known_non_pointer_shadow_value",
       "access": "stable_local_type_proof",
       "count": 1,
       "classification": "representation-proven",
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
+    },
+    {
+      "path": "crates/perry-codegen/src/expr/typed_array_rmw.rs",
+      "function": "receiver_is_uint32_candidate",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The Uint32Array hint only nominates a receiver for the direct RMW route; the emitted code proves it at run time with a POINTER_TAG check, the inline-storage view guard, a cached-address match and a UINT32 kind match, and re-checks the view/kind/bounds guard after the RHS so a receiver mutated by the RHS falls back to the generic path."
     },
     {
       "path": "crates/perry-codegen/src/lower_call/closure_analysis.rs",
@@ -200,6 +224,22 @@
       "count": 1,
       "classification": "runtime-validated",
       "reason": "The hint selects js_closure_unbox_callee_checked, which validates the current NaN-boxed callee before invoking it."
+    },
+    {
+      "path": "crates/perry-codegen/src/lower_call/func_ref.rs",
+      "function": "discriminant_path",
+      "access": "stable_local_type_proof",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The discriminant narrowing is licensed by the `===` comparison this lowering emits, and the base proof comes from the write-stable API, so a stale union can only widen the branch back to the generic path."
+    },
+    {
+      "path": "crates/perry-codegen/src/lower_call/func_ref.rs",
+      "function": "guarded_path_type",
+      "access": "stable_local_type_proof",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The path type seeds a candidate descriptor that `js_param_type_guard` validates against the live argument before the specialized clone is entered; an untrue candidate fails the guard and takes the generic entry."
     },
     {
       "path": "crates/perry-codegen/src/lower_call/native/mod.rs",
@@ -235,6 +275,14 @@
     },
     {
       "path": "crates/perry-codegen/src/lower_call/scalar_method.rs",
+      "function": "local_can_use_public_arg_guard",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "runtime-validated",
+      "reason": "The emitted public scalar argument guard validates each current local value before entering the typed method clone."
+    },
+    {
+      "path": "crates/perry-codegen/src/lower_call/scalar_method.rs",
       "function": "walk",
       "access": "local_type_hint",
       "count": 1,
@@ -242,12 +290,12 @@
       "reason": "The scalar clone entry path emits a tag guard for every collected local before evaluating the numeric expression in raw representation."
     },
     {
-      "path": "crates/perry-codegen/src/lower_call/scalar_method.rs",
-      "function": "local_can_use_public_arg_guard",
-      "access": "local_type_hint",
+      "path": "crates/perry-codegen/src/lower_conditional.rs",
+      "function": "lower_conditional",
+      "access": "snapshot_guarded_proof",
       "count": 1,
-      "classification": "runtime-validated",
-      "reason": "The emitted public scalar argument guard validates each current local value before entering the typed method clone."
+      "classification": "metadata-only",
+      "reason": "Restore bookkeeping for a ternary's branch-scoped narrowing: the snapshot is written back after each arm and is never read as a type fact."
     },
     {
       "path": "crates/perry-codegen/src/lower_string_method.rs",
@@ -266,22 +314,6 @@
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
     },
     {
-      "path": "crates/perry-codegen/src/expr/proxy_reflect.rs",
-      "function": "guarded_declared_class_property_candidate",
-      "access": "local_type_hint",
-      "count": 1,
-      "classification": "runtime-validated",
-      "reason": "The class hint only routes a strict static-name PutValue through PropertySet; its live class/shape/descriptor guard dominates the raw slot access and every miss retains ordinary runtime assignment."
-    },
-    {
-      "path": "crates/perry-codegen/src/expr/property_set.rs",
-      "function": "guarded_declared_class_store_candidate",
-      "access": "local_type_hint",
-      "count": 1,
-      "classification": "runtime-validated",
-      "reason": "The class hint selects the plain-field store guard; the live class id, keys token, descriptor state, field bounds, and value representation are checked before a raw slot store, while accessors stay dynamic."
-    },
-    {
       "path": "crates/perry-codegen/src/stmt/element_shape_loop.rs",
       "function": "declared_array_element_type_hint",
       "access": "local_type_hint",
@@ -298,6 +330,14 @@
       "reason": "The numeric annotation admits a candidate clone; the preheader checks the accumulator's current Number tag and the fact is scoped to a store-free, numeric-preserving fast clone."
     },
     {
+      "path": "crates/perry-codegen/src/stmt/if_stmt.rs",
+      "function": "lower_if",
+      "access": "snapshot_guarded_proof",
+      "count": 1,
+      "classification": "metadata-only",
+      "reason": "Restore bookkeeping for an if statement's branch-scoped narrowing: the snapshot is written back after each arm and is never read as a type fact."
+    },
+    {
       "path": "crates/perry-codegen/src/stmt/loops.rs",
       "function": "local_array_element_type",
       "access": "local_type_hint",
@@ -312,22 +352,6 @@
       "count": 1,
       "classification": "representation-proven",
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
-    },
-    {
-      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
-      "function": "set_static_type_args",
-      "access": "local_type_hint",
-      "count": 1,
-      "classification": "representation-proven",
-      "reason": "The source type arguments are read only after stable initializer evidence independently proves that the binding holds a Set; argument representations are separately proven or guarded at each helper selection."
-    },
-    {
-      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
-      "function": "map_static_type_args",
-      "access": "local_type_hint",
-      "count": 1,
-      "classification": "representation-proven",
-      "reason": "The source type arguments are read only after stable initializer evidence independently proves that the binding holds a Map; key and value representations are separately proven or guarded at each helper selection."
     },
     {
       "path": "crates/perry-codegen/src/stmt/loops.rs",
@@ -491,19 +515,19 @@
     },
     {
       "path": "crates/perry-codegen/src/type_analysis/strings.rs",
-      "function": "string_value_is_runtime_guaranteed",
-      "access": "stable_local_type_proof",
-      "count": 1,
-      "classification": "representation-proven",
-      "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
-    },
-    {
-      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
       "function": "is_url_search_params_expr",
       "access": "stable_local_type_proof",
       "count": 2,
       "classification": "representation-proven",
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
+    },
+    {
+      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
+      "function": "map_static_type_args",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "representation-proven",
+      "reason": "The source type arguments are read only after stable initializer evidence independently proves that the binding holds a Map; key and value representations are separately proven or guarded at each helper selection."
     },
     {
       "path": "crates/perry-codegen/src/type_analysis/strings.rs",
@@ -516,6 +540,22 @@
     {
       "path": "crates/perry-codegen/src/type_analysis/strings.rs",
       "function": "set_static_type_args",
+      "access": "local_type_hint",
+      "count": 1,
+      "classification": "representation-proven",
+      "reason": "The source type arguments are read only after stable initializer evidence independently proves that the binding holds a Set; argument representations are separately proven or guarded at each helper selection."
+    },
+    {
+      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
+      "function": "set_static_type_args",
+      "access": "stable_local_type_proof",
+      "count": 1,
+      "classification": "representation-proven",
+      "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
+    },
+    {
+      "path": "crates/perry-codegen/src/type_analysis/strings.rs",
+      "function": "string_value_is_runtime_guaranteed",
       "access": "stable_local_type_proof",
       "count": 1,
       "classification": "representation-proven",
@@ -552,38 +592,6 @@
       "count": 1,
       "classification": "metadata-only",
       "reason": "This indexed scope-stack iteration performs lexical name resolution during HIR construction and does not establish a codegen runtime representation."
-    },
-    {
-      "path": "crates/perry-codegen/src/lower_call/func_ref.rs",
-      "function": "discriminant_path",
-      "access": "stable_local_type_proof",
-      "count": 1,
-      "classification": "runtime-validated",
-      "reason": "The discriminant narrowing is licensed by the `===` comparison this lowering emits, and the base proof comes from the write-stable API, so a stale union can only widen the branch back to the generic path."
-    },
-    {
-      "path": "crates/perry-codegen/src/lower_call/func_ref.rs",
-      "function": "guarded_path_type",
-      "access": "stable_local_type_proof",
-      "count": 1,
-      "classification": "runtime-validated",
-      "reason": "The path type seeds a candidate descriptor that `js_param_type_guard` validates against the live argument before the specialized clone is entered; an untrue candidate fails the guard and takes the generic entry."
-    },
-    {
-      "path": "crates/perry-codegen/src/lower_conditional.rs",
-      "function": "lower_conditional",
-      "access": "snapshot_guarded_proof",
-      "count": 1,
-      "classification": "metadata-only",
-      "reason": "Restore bookkeeping for a ternary's branch-scoped narrowing: the snapshot is written back after each arm and is never read as a type fact."
-    },
-    {
-      "path": "crates/perry-codegen/src/stmt/if_stmt.rs",
-      "function": "lower_if",
-      "access": "snapshot_guarded_proof",
-      "count": 1,
-      "classification": "metadata-only",
-      "reason": "Restore bookkeeping for an if statement's branch-scoped narrowing: the snapshot is written back after each arm and is never read as a type fact."
     }
   ]
 }

--- a/test-files/test_gap_8691_scalar_replace_aggregate_calls.ts
+++ b/test-files/test_gap_8691_scalar_replace_aggregate_calls.ts
@@ -1,0 +1,25 @@
+// #8691: fixed arrays of plain descriptor objects passed to a known helper
+// must retain JS semantics when the inliner, static-loop unroller, and escape
+// proof remove both carrier identities.
+
+class Position {}
+class Velocity {}
+
+let checksum = 0;
+
+function consume(initializers: { component: unknown }[]): void {
+  for (let i = 0; i < initializers.length; i++) {
+    const initializer = initializers[i];
+    if (initializer.component === Position) checksum += 1;
+    if (initializer.component === Velocity) checksum += 2;
+  }
+}
+
+const iterations = 500_000;
+for (let i = 0; i < iterations; i++) {
+  consume([{ component: Position }, { component: Velocity }]);
+  consume([{ component: Position }]);
+  consume([{ component: Velocity }]);
+}
+
+console.log(checksum);

--- a/test-files/test_issue_8692_typed_array_rmw.ts
+++ b/test-files/test_issue_8692_typed_array_rmw.ts
@@ -1,0 +1,133 @@
+// #8692: a Uint32Array indexed `+=` keeps one guarded numeric representation
+// through get/add/set.  The smaller sibling fixture
+// `test_issue_8692_typed_array_rmw_gc.ts` runs the same parameter/global/alias
+// representation under forced moving collections.
+
+// The ticket's complete reduced wolf-ecs reproduction.  Both Node and Perry
+// must report checksum 2000; the compiler-output ratchet separately asserts
+// that the guarded fast arm contains no generic get/add/set helper.
+class Query extends Array<number[]> {
+  archetypes = this;
+}
+
+class Archetype extends Array<number> {
+  entities = this;
+}
+
+const entityCount = 1_000;
+const iterations = 2_000;
+const query = new Query();
+const archetype = new Archetype();
+for (let i = 0; i < entityCount; i++) archetype.push(i);
+query.push(archetype);
+
+const components = new Uint32Array(entityCount);
+
+function system(values: Uint32Array): void {
+  for (let i = 0, length = query.length; i < length; i++) {
+    const current = query[i];
+    for (let j = 0, length = current.length; j < length; j++) {
+      values[current[j]] += 1;
+    }
+  }
+}
+
+for (let i = 0; i < iterations; i++) system(components);
+console.log("repro", components[0], components[entityCount - 1]);
+
+// Dynamic-key guard success plus every important guard-failure class.  A
+// string canonical index must stay semantic even though it cannot use the raw
+// numeric arm; OOB/fractional/NaN/infinite/negative writes remain no-ops.
+function bump(values: Uint32Array, key: any): void {
+  values[key] += 1;
+}
+
+const guarded = new Uint32Array(3);
+guarded[0] = 9;
+const keys: any[] = [0, -1, 1.5, NaN, Infinity, 99, "0"];
+for (let i = 0; i < keys.length; i++) bump(guarded, keys[i]);
+console.log("guards", guarded[0], guarded[1], guarded[2]);
+
+// Uint32 conversion is modulo 2^32, while the assignment expression itself
+// yields the unwrapped numeric sum.
+const wrapping = new Uint32Array(1);
+wrapping[0] = 0xffffffff;
+const expressionValue = (wrapping[0] += 2);
+console.log("wrapping", wrapping[0], expressionValue);
+
+const conversions = new Uint32Array(3);
+conversions[0] = 5;
+const negativeFraction = (conversions[0] += -6.75);
+conversions[1] = 1;
+const hugeFinite = (conversions[1] += 1e300);
+conversions[2] = 1;
+const infinite = (conversions[2] += 1e300 * 1e300);
+console.log(
+  "conversions",
+  conversions[0],
+  negativeFraction,
+  conversions[1],
+  hugeFinite,
+  conversions[2],
+  infinite,
+);
+
+// The read precedes RHS evaluation.  Mutating through an alias in the RHS
+// must not change the old value used by the addition, and RHS is called once.
+const aliased = new Uint32Array(1);
+const same = aliased;
+aliased[0] = 5;
+let rhsCalls = 0;
+function mutatingRhs(): number {
+  rhsCalls++;
+  same[0] = 40;
+  const churn: object[] = [];
+  for (let i = 0; i < 256; i++) churn.push({ i, text: "x".repeat(64) });
+  return 2;
+}
+same[0] += +mutatingRhs();
+console.log("alias-order", aliased[0], rhsCalls);
+
+// Abrupt RHS completion performs no store and is never retried.
+const abrupt = new Uint32Array(1);
+abrupt[0] = 12;
+let throws = 0;
+try {
+  abrupt[0] += +(() => {
+    throws++;
+    throw new Error("stop");
+  })();
+} catch (error) {
+  console.log("abrupt", (error as Error).message, abrupt[0], throws);
+}
+
+// Captured/module-global representation.  The dynamic key prevents a static
+// bounds proof, while the runtime kind/index guard keeps the direct arm safe.
+const globalValues = new Uint32Array(2);
+function capturedBump(key: any): void {
+  globalValues[key] += 1;
+}
+const dynamicKeys: any[] = [0, 1, 0];
+for (let i = 0; i < dynamicKeys.length; i++) capturedBump(dynamicKeys[i]);
+console.log("captured", globalValues[0], globalValues[1]);
+
+// ArrayBuffer views and detached stores are intentionally rejected by the
+// inline-storage guard.  Detaching in the RHS also pins the get-before-RHS and
+// pending-set semantics without allowing a stale direct backing-store write.
+const backing = new ArrayBuffer(4);
+const detached = new Uint32Array(backing);
+detached[0] = 7;
+let detachCalls = 0;
+function detachRhs(): number {
+  detachCalls++;
+  backing.transfer();
+  return 3;
+}
+const detachedResult = (detached[0] += +detachRhs());
+console.log(
+  "detached",
+  detachedResult,
+  detached[0] === undefined,
+  backing.byteLength,
+  detachCalls,
+);

--- a/test-files/test_issue_8692_typed_array_rmw_gc.ts
+++ b/test-files/test_issue_8692_typed_array_rmw_gc.ts
@@ -1,0 +1,28 @@
+// #8692 moving-GC witness for the guarded direct Uint32Array RMW.  Keep this
+// workload deliberately small: scheduling a collection at every opportunity
+// over the ticket's 2,000,000-update performance ratchet would turn a focused
+// correctness arm into a minutes-long parity test.
+// parity-env: PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_SCHEDULE_SEED=8692 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_ALLOC_KB=0 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+
+const values = new Uint32Array(32);
+
+function allocatingOne(round: number, key: number): number {
+  // Unary `+` at the call site makes the RHS a proven Number while retaining
+  // this allocating call between the direct element load and the post-RHS
+  // receiver reload/guard.
+  const churn: object[] = [];
+  for (let i = 0; i < 8; i++) {
+    churn.push({ round, key, i, text: ("gc-" + round + "-" + key + "-" + i).repeat(4) });
+  }
+  return 1;
+}
+
+function bump(target: Uint32Array, key: any, round: number): void {
+  target[key] += +allocatingOne(round, key);
+}
+
+for (let round = 0; round < 8; round++) {
+  for (let i = 0; i < values.length; i++) bump(values, i, round);
+}
+
+console.log("moving-rmw", values[0], values[31]);


### PR DESCRIPTION
Lands #8706 and #8703. (#8704 is held — see below.)

### #8706 — guard direct Uint32Array RMW
A declared type is not a proof, so the thing worth checking here is whether the specialization actually verifies its receiver at run time. It does: the `Uint32Array` hint only *nominates* a candidate, and the emitted code proves it with a `POINTER_TAG` check, the inline-storage view guard, a cached-address match and a `UINT32` kind match — then **re-checks the view/kind/bounds guard after the RHS**, so a receiver the RHS mutated falls back to the generic path.

Its `local_type_hint` read is recorded in `scripts/local_binding_type_allowlist.json` as `runtime-validated`, matching the existing `typed_abi.rs::typed_arg_is_guard_candidate` precedent.

### #8703 — scalar-replace aggregate call literals
Keeps the aggregate materialized whenever identity is observed, a mutation is reflected, or an unknown call could escape it — its own tests cover all three.

### Why #8704 is not in this batch
#8704 (C-ABI FFI) is sound in the areas I was most worried about: `scan_bun_ffi_roots_mut` is a real GC root scanner and it *is* registered (`gc/mod.rs:904`), and the foreign-thread path hands off through an `Arc<(Mutex, Condvar)>` completion rather than calling JS off-thread.

It is held on the raw-handle ratchet, which is a rooting gate, not a formality:

```
crates/perry-runtime/src/bun_ffi/dlopen.rs:   41 bare reads exceeds its ceiling of 5
crates/perry-runtime/src/bun_ffi/callback.rs:  5 bare read(s) in a module with no ceiling
crates/perry-runtime/src/bun_ffi/read.rs:      1 bare read(s) in a module with no ceiling
```

The values are rooted in a scope, but the raw pointer is read bare and passed into calls that can collect — which is exactly the shape #7341 exists to eliminate, and the reason "rooted but stale" bugs surface cycles later. Left to the author to convert with `with_{mut,const}_ptr` / `across_{mut,const,nanbox}`.

### Validation (on the merged result)
- **All 30 `lint`-job checkers pass**
- `perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2655 passed, 0 failed**
- `perry-codegen --lib`: **1214 passed, 0 failed**
- `perry-transform --lib`: **87 passed, 0 failed**
- `perry-codegen --tests` (all integration suites): **0 failures**, including #8706's new `typed_array_rmw_8692` suite at 9/9
- New tests verified running by name rather than inferred from totals

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for dynamic indexed `Uint32Array` updates while preserving JavaScript evaluation and conversion behavior.
  * Reduced allocations for eligible short-lived arrays of object literals in optimized code.
  * Added safeguards so optimizations apply only when program behavior remains equivalent.

* **Bug Fixes**
  * Improved correctness around typed-array updates, aliasing, bounds changes, errors, buffer detachment, and garbage collection.
  * Preserved object identity semantics when processing descriptor arrays.

* **Documentation**
  * Added performance benchmarks and changelog entries covering the new optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->