### PR TITLE
fix(net): make listener GC rewrite test deterministic

### DIFF
--- a/crates/perry-ext-net/src/tests.rs
+++ b/crates/perry-ext-net/src/tests.rs
@@ -5,6 +5,7 @@ static GC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 struct GcTestGuard {
     frame: u64,
+    previous_force_evacuation: Option<std::ffi::OsString>,
     _lock: MutexGuard<'static, ()>,
 }
 
@@ -13,9 +14,23 @@ impl GcTestGuard {
         let lock = GC_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Rewriting is observable only when the collector moves the root.
+        // Unit-test heaps are normally too quiet for the evacuation policy to
+        // choose that path, so make the test's collection deterministic. The
+        // lock serializes this crate's GC tests, and Drop restores any value
+        // supplied by the test runner.
+        let previous_force_evacuation = std::env::var_os("PERRY_GC_FORCE_EVACUATE");
+        // SAFETY: GC_TEST_LOCK is held until this guard is dropped, so no
+        // other GC test in this binary observes the temporary environment
+        // value.
+        unsafe { std::env::set_var("PERRY_GC_FORCE_EVACUATE", "1") };
         perry_runtime::gc::js_gc_write_barriers_emitted(1);
-        let frame = perry_runtime::gc::js_shadow_frame_push(0);
-        Self { frame, _lock: lock }
+        let frame = perry_runtime::gc::js_shadow_frame_push(1);
+        Self {
+            frame,
+            previous_force_evacuation,
+            _lock: lock,
+        }
     }
 }
 
@@ -23,6 +38,14 @@ impl Drop for GcTestGuard {
     fn drop(&mut self) {
         perry_runtime::gc::js_shadow_frame_pop(self.frame);
         perry_runtime::gc::js_gc_write_barriers_emitted(0);
+        // SAFETY: GC_TEST_LOCK is still held here and is released only after
+        // this Drop implementation returns.
+        unsafe {
+            match self.previous_force_evacuation.take() {
+                Some(value) => std::env::set_var("PERRY_GC_FORCE_EVACUATE", value),
+                None => std::env::remove_var("PERRY_GC_FORCE_EVACUATE"),
+            }
+        }
     }
 }
 
@@ -65,6 +88,12 @@ fn gc_mutable_scanner_rewrites_listener_roots() {
     let _guard = GcTestGuard::new();
     perry_ffi::gc_register_mutable_root_scanner_named("perry-ext-net", scan_net_roots);
 
+    // Keep an ordinary shadow-stack root as the control. Its rewrite proves
+    // the collection copied live objects independently of scan_net_roots, so
+    // a listener that stays at its old address is an actual scanner failure.
+    let control = young_gc_root();
+    perry_runtime::gc::js_shadow_slot_set(0, control as u64);
+
     let socket_id = -9_001;
     let _cleanup = NetHandleCleanup::new(vec![socket_id]);
     let callback = young_gc_root();
@@ -78,7 +107,19 @@ fn gc_mutable_scanner_rewrites_listener_roots() {
             .push(callback);
     }
 
+    let copying_cycles_before = perry_runtime::gc::copying_minor_cycles();
+    let moved_objects_before = perry_runtime::gc::moved_objects_total();
     let _ = perry_runtime::gc::gc_collect_minor();
+
+    assert!(
+        perry_runtime::gc::copying_minor_cycles() > copying_cycles_before,
+        "minor GC did not run the copying collector, so the scanner was not exercised"
+    );
+    assert!(
+        perry_runtime::gc::moved_objects_total() > moved_objects_before,
+        "copying minor did not relocate an object, so the scanner was not exercised"
+    );
+    assert_rewritten(control, perry_runtime::gc::js_shadow_slot_get(0) as i64);
 
     let after = {
         let listeners = statics::listeners().lock().unwrap();


### PR DESCRIPTION
## Summary

Make `perry-ext-net` listener-root GC coverage deterministic by arranging an evacuating minor and proving the collection moved an independent control root before checking the scanner rewrite.

## Changes

- force evacuation only for the serialized GC-test guard lifetime and restore any pre-existing environment value
- root a control allocation in the shadow stack so collector movement is independent of `scan_net_roots`
- assert copying-cycle and moved-object liveness before asserting the listener callback address changed
- no workspace version bump, CLAUDE.md edit, or CHANGELOG.md edit

## Related issue

Closes #8636

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `RUST_TEST_THREADS=1 cargo test --profile perry-dev -p perry-ext-net --lib` (28 passed)
- [x] targeted regression with outer `PERRY_GC_FORCE_EVACUATE=0` (passed)
- [x] `cargo clippy --profile perry-dev -p perry-ext-net --all-targets --no-deps`
- [x] `./scripts/test_affected_crates.sh --base upstream/main` (1,032 `perry` tests passed; `perry-ext-net` library covered separately above)
- [x] lint delta gates, including GC env/scanner checks and `unrooted_local_shape.py --no-raise-vs upstream/main`

The full generated lint tier has one pre-existing failure on current main: `unrooted_local_shape.py --check` reports `crates/perry-stdlib/src/net/mod.rs` at 5 findings over a ceiling of 3. This PR does not touch that file, and the no-raise-vs-main ratchet passes.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the project commit-prefix convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved garbage-collection test coverage for object relocation and root updates.
  * Tests now safely preserve and restore existing garbage-collection settings.
  * Added validation that copying collection runs and correctly relocates objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->