### PR TITLE
fix(ui): root persistent JavaScript callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,6 +6462,7 @@ dependencies = [
 name = "perry-ui"
 version = "0.5.1519"
 dependencies = [
+ "perry-ffi",
  "perry-ui-model",
 ]
 

--- a/changelog.d/8713-ui-callback-gc-roots.md
+++ b/changelog.d/8713-ui-callback-gc-roots.md
@@ -1,0 +1,5 @@
+### Fixed
+
+Root persistent `perry/ui` JavaScript callbacks and state values across garbage
+collections on every native UI backend, including callbacks retained by native
+timer, hotkey, and focus-event closures.

--- a/crates/perry-audio-miniaudio/src/lib.rs
+++ b/crates/perry-audio-miniaudio/src/lib.rs
@@ -20,7 +20,7 @@
 use libc::{c_char, c_float, c_int, c_uint, c_void};
 use std::cell::RefCell;
 use std::ffi::CString;
-use std::sync::Mutex;
+use std::sync::{Mutex, Once};
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -227,6 +227,8 @@ struct Fade {
     then_stop: bool,
 }
 
+static GC_SCANNER_REGISTERED: Once = Once::new();
+
 thread_local! {
     static ENGINE: RefCell<Option<MaBox<MA_ENGINE_SIZE>>> = RefCell::new(None);
     static SOUNDS: RefCell<Vec<Option<SoundEntry>>> = RefCell::new(Vec::new());
@@ -236,6 +238,32 @@ thread_local! {
     static MASTER_VOLUME: RefCell<f32> = RefCell::new(1.0);
     static PENDING_ENDED: RefCell<Vec<usize>> = RefCell::new(Vec::new());
     static PENDING_LOADED: RefCell<Vec<usize>> = RefCell::new(Vec::new());
+}
+
+fn ensure_gc_scanner_registered() {
+    GC_SCANNER_REGISTERED.call_once(|| {
+        perry_ffi::gc_register_mutable_root_scanner_named(
+            "perry-audio-miniaudio",
+            scan_miniaudio_gc_roots,
+        );
+    });
+}
+
+fn scan_miniaudio_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
 }
 
 /// Voice indices whose miniaudio end_callback fired on the audio thread.
@@ -460,6 +488,7 @@ pub extern "C" fn perry_audio_unload(sound: f64) {
 
 #[no_mangle]
 pub extern "C" fn perry_audio_on_loaded(sound: f64, callback: f64) {
+    ensure_gc_scanner_registered();
     let idx = match classify(sound) {
         HandleKind::Sound(i) => i,
         _ => return,
@@ -1174,6 +1203,7 @@ pub extern "C" fn perry_audio_get_position(playback: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn perry_audio_on_ended(playback: f64, callback: f64) {
+    ensure_gc_scanner_registered();
     let idx = match classify(playback) {
         HandleKind::Playback(i) => i,
         _ => return,

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -438,6 +438,22 @@ impl<'a> GcRootVisitor<'a> {
         )
     }
 
+    /// Visit a raw const heap pointer slot.
+    ///
+    /// Native UI backends commonly unbox a closure once and retain its code
+    /// pointer as `*const u8`. The collector treats const and mutable pointee
+    /// types identically; it only needs the address of the mutable pointer
+    /// *slot* so an evacuating collection can rewrite it.
+    ///
+    /// Returns `true` when the runtime rewrote the slot to a forwarded address.
+    pub fn visit_raw_const_ptr_slot<T>(&mut self, slot: &mut *const T) -> bool {
+        (self.visit)(
+            FFI_ROOT_SLOT_RAW_MUT_PTR,
+            slot as *mut *const T as *mut c_void,
+            self.ctx,
+        )
+    }
+
     /// Visit a NaN-boxed JS value stored as an `f64`.
     ///
     /// Returns `true` when the runtime rewrote the slot to a forwarded address.
@@ -907,6 +923,32 @@ extern "C" fn scan_registered_mutable_root_by_id(
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    extern "C" fn rewrite_const_pointer_slot(
+        kind: u32,
+        slot: *mut c_void,
+        ctx: *mut c_void,
+    ) -> bool {
+        assert_eq!(kind, FFI_ROOT_SLOT_RAW_MUT_PTR);
+        unsafe {
+            *(slot as *mut *const u8) = ctx as *const u8;
+        }
+        true
+    }
+
+    #[test]
+    fn const_pointer_root_slot_is_rewritten() {
+        let original = 1_u8;
+        let replacement = 2_u8;
+        let mut slot = &original as *const u8;
+        let mut visitor = GcRootVisitor::new(
+            rewrite_const_pointer_slot,
+            &replacement as *const u8 as *mut c_void,
+        );
+
+        assert!(visitor.visit_raw_const_ptr_slot(&mut slot));
+        assert_eq!(slot, &replacement as *const u8);
+    }
 
     #[test]
     fn round_trip_simple_value() {

--- a/crates/perry-ui-android/src/app.rs
+++ b/crates/perry-ui-android/src/app.rs
@@ -25,6 +25,7 @@ pub(crate) use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Create an app. Stores config for deferred creation. Returns app handle (i64).
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_registered();
     let title = if title_ptr.is_null() {
         "Perry App".to_string()
     } else {
@@ -390,6 +391,19 @@ pub fn on_activate(callback: f64) {
 pub fn on_terminate(callback: f64) {
     ON_TERMINATE_CALLBACK.with(|c| {
         *c.borrow_mut() = Some(callback);
+    });
+}
+
+pub(crate) fn scan_android_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    ON_ACTIVATE_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    ON_TERMINATE_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
     });
 }
 

--- a/crates/perry-ui-android/src/callback.rs
+++ b/crates/perry-ui-android/src/callback.rs
@@ -51,6 +51,16 @@ fn pump_microtasks() {
 static CALLBACKS: Mutex<Option<HashMap<i64, f64>>> = Mutex::new(None);
 static NEXT_KEY: AtomicI64 = AtomicI64::new(1);
 
+pub(crate) fn scan_android_callback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    if let Ok(mut callbacks) = CALLBACKS.lock() {
+        if let Some(callbacks) = callbacks.as_mut() {
+            for callback in callbacks.values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    }
+}
+
 /// Read the closure currently stored under `key`, or `None` if it's
 /// been removed. Used by the pointer dispatcher to fetch the current
 /// callback without going through `invoke*`.

--- a/crates/perry-ui-android/src/gc.rs
+++ b/crates/perry-ui-android/src/gc.rs
@@ -1,0 +1,23 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-android", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::app::scan_android_app_gc_roots(visitor);
+    crate::callback::scan_android_callback_gc_roots(visitor);
+    crate::media_playback::scan_android_media_playback_gc_roots(visitor);
+    crate::state::scan_android_state_gc_roots(visitor);
+    crate::widgets::lazyvstack::scan_android_lazyvstack_gc_roots(visitor);
+    crate::widgets::picker::scan_android_picker_gc_roots(visitor);
+    crate::widgets::webview::scan_android_webview_gc_roots(visitor);
+    crate::ws::scan_android_ws_gc_roots(visitor);
+}

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -19,6 +19,7 @@ pub mod drag_drop;
 pub mod fetch;
 pub mod ffi;
 pub mod file_dialog;
+mod gc;
 #[cfg(feature = "geisterhand")]
 pub mod geisterhand_style;
 pub mod geolocation;
@@ -132,6 +133,7 @@ pub(crate) fn catch_panic_void(name: &str, f: impl FnOnce() + std::panic::Unwind
 /// Called by the JVM when the native library is loaded via System.loadLibrary().
 #[no_mangle]
 pub extern "C" fn JNI_OnLoad(vm: jni::JavaVM, _reserved: *mut std::ffi::c_void) -> jni::sys::jint {
+    gc::ensure_registered();
     unsafe {
         __android_log_print(
             3,
@@ -177,6 +179,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInit(
     mut env: jni::JNIEnv,
     _class: jni::objects::JClass,
 ) {
+    gc::ensure_registered();
     // Recover state that `JNI_OnLoad` would normally set up, in case a linked
     // native library's own `JNI_OnLoad` shadowed Perry's (see
     // `jni_bridge::ensure_vm` and `PERRY_DISABLE_MTE_CTOR`). The constructor

--- a/crates/perry-ui-android/src/media_playback.rs
+++ b/crates/perry-ui-android/src/media_playback.rs
@@ -90,6 +90,19 @@ thread_local! {
     static PUMP_COUNTER: RefCell<u32> = const { RefCell::new(0) };
 }
 
+pub(crate) fn scan_android_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-android/src/state.rs
+++ b/crates/perry-ui-android/src/state.rs
@@ -68,6 +68,24 @@ thread_local! {
     static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<TextFieldBinding>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_android_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.callback_ptr);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Check if a f64 value is a NaN-boxed string. Accepts heap

--- a/crates/perry-ui-android/src/widgets/lazyvstack.rs
+++ b/crates/perry-ui-android/src/widgets/lazyvstack.rs
@@ -17,6 +17,14 @@ thread_local! {
     static LAZY_STATES: RefCell<HashMap<i64, LazyState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_android_lazyvstack_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LAZY_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.render_closure);
+        }
+    });
+}
+
 pub fn create(count: f64, render_closure: f64) -> i64 {
     // Create ScrollView
     let scroll_handle = super::scrollview::create();

--- a/crates/perry-ui-android/src/widgets/picker.rs
+++ b/crates/perry-ui-android/src/widgets/picker.rs
@@ -17,6 +17,14 @@ thread_local! {
     static PICKER_STATES: RefCell<HashMap<i64, PickerState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_android_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PICKER_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_change);
+        }
+    });
+}
+
 pub fn create(label_ptr: *const u8, on_change: f64, _style: i64) -> i64 {
     let _label = unsafe { str_from_header(label_ptr) };
     let mut env = jni_bridge::get_env();

--- a/crates/perry-ui-android/src/widgets/webview.rs
+++ b/crates/perry-ui-android/src/widgets/webview.rs
@@ -38,6 +38,21 @@ thread_local! {
     static WEBVIEW_STATES: RefCell<HashMap<i64, WebViewState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_android_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+    EVAL_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-android/src/ws.rs
+++ b/crates/perry-ui-android/src/ws.rs
@@ -53,6 +53,15 @@ unsafe impl Send for SendPromise {}
 /// The pump tick drains this and calls js_promise_resolve on the main thread.
 static PENDING_RESOLVES: Mutex<Vec<(SendPromise, f64)>> = Mutex::new(Vec::new());
 
+pub(crate) fn scan_android_ws_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    if let Ok(mut pending) = PENDING_RESOLVES.lock() {
+        for (promise, value) in pending.iter_mut() {
+            visitor.visit_raw_mut_ptr_slot(&mut promise.0);
+            visitor.visit_nanbox_f64_slot(value);
+        }
+    }
+}
+
 /// Extract a Rust &str from a Perry StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-gtk4/src/app.rs
+++ b/crates/perry-ui-gtk4/src/app.rs
@@ -38,6 +38,9 @@ thread_local! {
     /// Timer callbacks queued before the app activates (interval_ms, callback f64).
     /// After activation, set_timer schedules directly via install_timer().
     static TIMER_CALLBACKS: RefCell<Vec<(f64, f64)>> = RefCell::new(Vec::new());
+    /// Callbacks owned by installed GLib timers, keyed so the GC can rewrite them.
+    static ACTIVE_TIMER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+    static NEXT_TIMER_CALLBACK_KEY: RefCell<usize> = const { RefCell::new(1) };
     /// True once connect_activate has fired — set_timer can then call glib::timeout_add_local
     /// directly instead of buffering.
     static APP_ACTIVATED: RefCell<bool> = RefCell::new(false);
@@ -92,6 +95,7 @@ pub(crate) use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Create an app with title, width, height.
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_gc_scanner_registered();
     ensure_gtk_init();
 
     let title = if title_ptr.is_null() {
@@ -676,14 +680,27 @@ pub fn add_keyboard_shortcut(key_ptr: *const u8, modifiers: f64, callback: f64) 
 /// the GTK main thread after the GLib MainContext is active.
 fn install_timer(interval_ms: f64, callback: f64) {
     let ms = interval_ms as u64;
+    let callback_key = NEXT_TIMER_CALLBACK_KEY.with(|next| {
+        let mut next = next.borrow_mut();
+        let key = *next;
+        *next = next.wrapping_add(1).max(1);
+        key
+    });
+    ACTIVE_TIMER_CALLBACKS.with(|callbacks| {
+        callbacks.borrow_mut().insert(callback_key, callback);
+    });
     glib::timeout_add_local(std::time::Duration::from_millis(ms), move || {
         unsafe {
             js_run_stdlib_pump();
             js_promise_run_microtasks();
         }
-        let ptr = unsafe { js_nanbox_get_pointer(callback) } as *const u8;
-        unsafe {
-            js_closure_call0(ptr);
+        let callback =
+            ACTIVE_TIMER_CALLBACKS.with(|callbacks| callbacks.borrow().get(&callback_key).copied());
+        if let Some(callback) = callback {
+            let ptr = unsafe { js_nanbox_get_pointer(callback) } as *const u8;
+            unsafe {
+                js_closure_call0(ptr);
+            }
         }
         #[cfg(feature = "geisterhand")]
         {
@@ -696,6 +713,36 @@ fn install_timer(interval_ms: f64, callback: f64) {
         }
         glib::ControlFlow::Continue
     });
+}
+
+pub(crate) fn scan_gtk4_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PENDING_SHORTCUTS.with(|shortcuts| {
+        for shortcut in shortcuts.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut shortcut.callback);
+        }
+    });
+    SHORTCUT_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TIMER_CALLBACKS.with(|timers| {
+        for (_, callback) in timers.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    ACTIVE_TIMER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    for slot in [&ON_ACTIVATE_CALLBACK, &ON_TERMINATE_CALLBACK] {
+        slot.with(|slot| {
+            if let Some(callback) = slot.borrow_mut().as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
 }
 
 /// Set a repeating timer. interval_ms = milliseconds between ticks.

--- a/crates/perry-ui-gtk4/src/audio.rs
+++ b/crates/perry-ui-gtk4/src/audio.rs
@@ -23,6 +23,14 @@ static RUNNING: AtomicBool = AtomicBool::new(false);
 
 static AUDIO_CALLBACK: Mutex<Option<f64>> = Mutex::new(None);
 
+pub(crate) fn scan_gtk4_audio_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    if let Ok(mut callback) = AUDIO_CALLBACK.lock() {
+        if let Some(callback) = callback.as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    }
+}
+
 // Recording state
 static RECORDING: AtomicBool = AtomicBool::new(false);
 static RECORDED_SAMPLES: Mutex<Vec<f32>> = Mutex::new(Vec::new());

--- a/crates/perry-ui-gtk4/src/camera.rs
+++ b/crates/perry-ui-gtk4/src/camera.rs
@@ -49,6 +49,20 @@ struct FrameData {
     stride: i32,
 }
 
+pub(crate) fn scan_gtk4_camera_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CAMERA_VIEWS.with(|views| {
+        if let Ok(mut views) = views.lock() {
+            for view in views.values_mut() {
+                if let Ok(mut callback) = view.frame_callback.lock() {
+                    if let Some(callback) = callback.as_mut() {
+                        visitor.visit_nanbox_f64_slot(callback);
+                    }
+                }
+            }
+        }
+    });
+}
+
 pub fn create() -> i64 {
     crate::app::ensure_gtk_init();
 

--- a/crates/perry-ui-gtk4/src/drag_drop.rs
+++ b/crates/perry-ui-gtk4/src/drag_drop.rs
@@ -72,6 +72,16 @@ thread_local! {
     static DRAG_SOURCE_ATTACHED: RefCell<HashMap<i64, ()>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_drag_drop_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&DROP_CB, &DRAG_TEXT, &DRAG_FILE, &DRAG_URL] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 /// Extract a `&str` from a runtime `StringHeader` pointer (same layout as
 /// `clipboard.rs` / `widgets/button.rs`).
 use perry_ffi::copy_string_from_raw as str_from_header;

--- a/crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs
+++ b/crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs
@@ -65,6 +65,14 @@ thread_local! {
     static RESIZE_CALLBACK: std::cell::RefCell<Option<f64>> = std::cell::RefCell::new(None);
 }
 
+pub(crate) fn scan_gtk4_platform_ffi_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    RESIZE_CALLBACK.with(|callback| {
+        if let Some(callback) = callback.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// perry_on_resize(callback) — store callback; called with (width, height) on resize.
 #[no_mangle]
 pub extern "C" fn __wrapper_perry_on_resize(_closure_ptr: i64, callback: f64) -> f64 {

--- a/crates/perry-ui-gtk4/src/gc.rs
+++ b/crates/perry-ui-gtk4/src/gc.rs
@@ -1,0 +1,36 @@
+use std::sync::Once;
+
+static GC_SCANNER_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_gc_scanner_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_SCANNER_REGISTERED.call_once(|| {
+        perry_ffi::gc_register_mutable_root_scanner_named("perry-ui-gtk4", scan_gtk4_gc_roots);
+    });
+}
+
+fn scan_gtk4_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    crate::app::scan_gtk4_app_gc_roots(visitor);
+    crate::audio::scan_gtk4_audio_gc_roots(visitor);
+    crate::camera::scan_gtk4_camera_gc_roots(visitor);
+    crate::drag_drop::scan_gtk4_drag_drop_gc_roots(visitor);
+    crate::ffi::platform_audio_camera_toast::scan_gtk4_platform_ffi_gc_roots(visitor);
+    crate::media_playback::scan_gtk4_media_playback_gc_roots(visitor);
+    crate::menu::scan_gtk4_menu_gc_roots(visitor);
+    crate::state::scan_gtk4_state_gc_roots(visitor);
+    crate::toolbar::scan_gtk4_toolbar_gc_roots(visitor);
+    crate::tray::scan_gtk4_tray_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_gtk4_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_gtk4_button_gc_roots(visitor);
+    crate::widgets::command_palette::scan_gtk4_command_palette_gc_roots(visitor);
+    crate::widgets::image_gallery::scan_gtk4_image_gallery_gc_roots(visitor);
+    crate::widgets::lazyvstack::scan_gtk4_lazyvstack_gc_roots(visitor);
+    crate::widgets::picker::scan_gtk4_picker_gc_roots(visitor);
+    crate::widgets::scrollview::scan_gtk4_scrollview_gc_roots(visitor);
+    crate::widgets::securefield::scan_gtk4_securefield_gc_roots(visitor);
+    crate::widgets::slider::scan_gtk4_slider_gc_roots(visitor);
+    crate::widgets::textarea::scan_gtk4_textarea_gc_roots(visitor);
+    crate::widgets::textfield::scan_gtk4_textfield_gc_roots(visitor);
+    crate::widgets::toggle::scan_gtk4_toggle_gc_roots(visitor);
+    crate::widgets::webview::scan_gtk4_webview_gc_roots(visitor);
+}

--- a/crates/perry-ui-gtk4/src/lib.rs
+++ b/crates/perry-ui-gtk4/src/lib.rs
@@ -9,6 +9,7 @@ pub mod deeplinks_stub;
 pub mod dialog;
 pub mod drag_drop;
 pub mod file_dialog;
+mod gc;
 pub mod issue_552_stub;
 pub mod keyboard;
 pub mod keychain;

--- a/crates/perry-ui-gtk4/src/media_playback.rs
+++ b/crates/perry-ui-gtk4/src/media_playback.rs
@@ -82,6 +82,19 @@ thread_local! {
     static POLL_TIMEOUT_INSTALLED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_gtk4_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-gtk4/src/menu.rs
+++ b/crates/perry-ui-gtk4/src/menu.rs
@@ -30,6 +30,23 @@ thread_local! {
     pub(crate) static PENDING_MENUBAR: RefCell<Option<i64>> = RefCell::new(None);
 }
 
+pub(crate) fn scan_gtk4_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENUS.with(|menus| {
+        for menu in menus.borrow_mut().iter_mut() {
+            for item in menu {
+                if let MenuItemEntry::Item { callback, .. } = item {
+                    visitor.visit_nanbox_f64_slot(callback);
+                }
+            }
+        }
+    });
+    MENU_ITEM_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/state.rs
+++ b/crates/perry-ui-gtk4/src/state.rs
@@ -82,6 +82,24 @@ thread_local! {
     static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<std::rc::Rc<TextFieldBinding>>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.callback);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-gtk4/src/toolbar.rs
+++ b/crates/perry-ui-gtk4/src/toolbar.rs
@@ -9,6 +9,14 @@ thread_local! {
     static NEXT_TB_CB_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_toolbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOOLBAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/tray.rs
+++ b/crates/perry-ui-gtk4/src/tray.rs
@@ -333,6 +333,16 @@ fn trays() -> &'static Mutex<Vec<Option<TrayHandle>>> {
     TRAYS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
+pub(crate) fn scan_gtk4_tray_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    if let Ok(mut trays) = trays().lock() {
+        for tray in trays.iter_mut().flatten() {
+            if let Ok(mut state) = tray.state.lock() {
+                visitor.visit_nanbox_f64_slot(&mut state.on_click);
+            }
+        }
+    }
+}
+
 /// Dedicated tokio runtime for the tray's KSNI service — re-used
 /// across all tray icons (KSNI services share a single DBus connection
 /// via zbus's shared session bus, so one runtime is sufficient).

--- a/crates/perry-ui-gtk4/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-gtk4/src/widgets/bottom_nav.rs
@@ -38,6 +38,14 @@ thread_local! {
     static STATES: RefCell<HashMap<i64, BottomNavState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_select);
+        }
+    });
+}
+
 pub fn create(on_select: f64) -> i64 {
     crate::app::ensure_gtk_init();
     let bar = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);

--- a/crates/perry-ui-gtk4/src/widgets/button.rs
+++ b/crates/perry-ui-gtk4/src/widgets/button.rs
@@ -9,6 +9,14 @@ thread_local! {
     static NEXT_BUTTON_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/widgets/command_palette.rs
+++ b/crates/perry-ui-gtk4/src/widgets/command_palette.rs
@@ -44,6 +44,14 @@ thread_local! {
     });
 }
 
+pub(crate) fn scan_gtk4_command_palette_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATE.with(|state| {
+        for command in &mut state.borrow_mut().commands {
+            visitor.visit_nanbox_f64_slot(&mut command.on_run);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn refresh_filter() {

--- a/crates/perry-ui-gtk4/src/widgets/image_gallery.rs
+++ b/crates/perry-ui-gtk4/src/widgets/image_gallery.rs
@@ -28,6 +28,14 @@ thread_local! {
     static STATES: RefCell<HashMap<i64, GalleryState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_image_gallery_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_index_change);
+        }
+    });
+}
+
 pub fn create(on_index_change: f64) -> i64 {
     crate::app::ensure_gtk_init();
     let scrolled = gtk4::ScrolledWindow::new();

--- a/crates/perry-ui-gtk4/src/widgets/lazyvstack.rs
+++ b/crates/perry-ui-gtk4/src/widgets/lazyvstack.rs
@@ -17,6 +17,14 @@ struct LazyVStackState {
     render_closure: f64,
 }
 
+pub(crate) fn scan_gtk4_lazyvstack_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LAZY_VSTACKS.with(|stacks| {
+        for stack in stacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut stack.render_closure);
+        }
+    });
+}
+
 /// Create a lazy vertical stack that renders items from a closure.
 /// count = number of items, render_closure = NaN-boxed closure(index) -> widget_handle
 pub fn create(count: f64, render_closure: f64) -> i64 {

--- a/crates/perry-ui-gtk4/src/widgets/picker.rs
+++ b/crates/perry-ui-gtk4/src/widgets/picker.rs
@@ -12,6 +12,14 @@ thread_local! {
     static PICKER_MODELS: RefCell<HashMap<i64, StringList>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/widgets/scrollview.rs
+++ b/crates/perry-ui-gtk4/src/widgets/scrollview.rs
@@ -18,6 +18,14 @@ thread_local! {
     static SCROLL_END_STATES: RefCell<HashMap<i64, ScrollEndState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SCROLL_END_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.closure);
+        }
+    });
+}
+
 /// Create a GtkScrolledWindow with vertical scrollbar. Returns widget handle.
 pub fn create() -> i64 {
     crate::app::ensure_gtk_init();

--- a/crates/perry-ui-gtk4/src/widgets/securefield.rs
+++ b/crates/perry-ui-gtk4/src/widgets/securefield.rs
@@ -8,6 +8,14 @@ thread_local! {
     static NEXT_SECUREFIELD_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_securefield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SECUREFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/widgets/slider.rs
+++ b/crates/perry-ui-gtk4/src/widgets/slider.rs
@@ -9,6 +9,14 @@ thread_local! {
     static NEXT_SLIDER_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/widgets/textarea.rs
+++ b/crates/perry-ui-gtk4/src/widgets/textarea.rs
@@ -9,6 +9,14 @@ thread_local! {
     static NEXT_TEXTAREA_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_textarea_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTAREA_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-gtk4/src/widgets/textfield.rs
+++ b/crates/perry-ui-gtk4/src/widgets/textfield.rs
@@ -11,6 +11,14 @@ thread_local! {
     static REGISTERED_ENTRIES: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_gtk4_textfield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;

--- a/crates/perry-ui-gtk4/src/widgets/toggle.rs
+++ b/crates/perry-ui-gtk4/src/widgets/toggle.rs
@@ -11,6 +11,14 @@ thread_local! {
     static NEXT_TOGGLE_ID: RefCell<usize> = RefCell::new(1);
 }
 
+pub(crate) fn scan_gtk4_toggle_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOGGLE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 // TAG_TRUE and TAG_FALSE from perry-runtime NaN-boxing
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;

--- a/crates/perry-ui-gtk4/src/widgets/webview.rs
+++ b/crates/perry-ui-gtk4/src/widgets/webview.rs
@@ -33,6 +33,16 @@ thread_local! {
     static WEBVIEW_STATES: RefCell<HashMap<i64, WebViewState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_gtk4_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-ios/src/adaptive_layout.rs
+++ b/crates/perry-ui-ios/src/adaptive_layout.rs
@@ -68,6 +68,14 @@ thread_local! {
     static LAST_SNAPSHOT: RefCell<Option<LayoutSnapshot>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_ios_adaptive_layout_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LISTENERS.with(|listeners| {
+        for listener in listeners.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(listener);
+        }
+    });
+}
+
 static NEXT_LISTENER_ID: AtomicI64 = AtomicI64::new(1);
 
 fn size_class_name(value: isize) -> &'static str {

--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -34,6 +34,7 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 /// Create an app. Stores config in thread-local for deferred creation.
 /// Returns app handle (i64).
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_registered();
     let title = if title_ptr.is_null() {
         "Perry App".to_string()
     } else {
@@ -52,6 +53,14 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
     });
 
     1 // Single app handle
+}
+
+pub(crate) fn scan_ios_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TIMER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
 }
 
 /// Set the root widget (body) of the app.

--- a/crates/perry-ui-ios/src/audio_playback.rs
+++ b/crates/perry-ui-ios/src/audio_playback.rs
@@ -152,6 +152,23 @@ thread_local! {
     static WARNED_VARISPEED_FALLBACK: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_ios_audio_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================

--- a/crates/perry-ui-ios/src/background.rs
+++ b/crates/perry-ui-ios/src/background.rs
@@ -47,6 +47,14 @@ thread_local! {
         const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_ios_background_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLERS.with(|handlers| {
+        for handler in handlers.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn boolean_truthy(v: f64) -> bool {

--- a/crates/perry-ui-ios/src/camera.rs
+++ b/crates/perry-ui-ios/src/camera.rs
@@ -81,6 +81,14 @@ thread_local! {
     static TAP_TARGET: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
 }
 
+pub(crate) fn scan_ios_camera_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TAP_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 // =============================================================================
 // Camera delegate — receives frames from AVCaptureVideoDataOutput
 // =============================================================================

--- a/crates/perry-ui-ios/src/deeplinks.rs
+++ b/crates/perry-ui-ios/src/deeplinks.rs
@@ -46,6 +46,14 @@ thread_local! {
     static LAUNCH_URL: RefCell<String> = const { RefCell::new(String::new()) };
 }
 
+pub(crate) fn scan_ios_deeplinks_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLER.with(|slot| {
+        if let Some(handler) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 unsafe fn nanbox_str(s: &str) -> f64 {
     let bytes = s.as_bytes();
     let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);

--- a/crates/perry-ui-ios/src/drag_drop.rs
+++ b/crates/perry-ui-ios/src/drag_drop.rs
@@ -53,6 +53,16 @@ thread_local! {
     static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_drag_drop_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&DROP_CB, &DRAG_TEXT, &DRAG_FILE, &DRAG_URL] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-ios/src/gc.rs
+++ b/crates/perry-ui-ios/src/gc.rs
@@ -1,0 +1,49 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-ios", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::adaptive_layout::scan_ios_adaptive_layout_gc_roots(visitor);
+    crate::app::scan_ios_app_gc_roots(visitor);
+    crate::audio_playback::scan_ios_audio_playback_gc_roots(visitor);
+    crate::background::scan_ios_background_gc_roots(visitor);
+    crate::camera::scan_ios_camera_gc_roots(visitor);
+    crate::deeplinks::scan_ios_deeplinks_gc_roots(visitor);
+    crate::drag_drop::scan_ios_drag_drop_gc_roots(visitor);
+    crate::geolocation::scan_ios_geolocation_gc_roots(visitor);
+    crate::location::scan_ios_location_gc_roots(visitor);
+    crate::media_playback::scan_ios_media_playback_gc_roots(visitor);
+    crate::menu::scan_ios_menu_gc_roots(visitor);
+    crate::network::scan_ios_network_gc_roots(visitor);
+    crate::notifications::scan_ios_notifications_gc_roots(visitor);
+    crate::pointer::scan_ios_pointer_gc_roots(visitor);
+    crate::state::scan_ios_state_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_ios_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_ios_button_gc_roots(visitor);
+    crate::widgets::calendar::scan_ios_calendar_gc_roots(visitor);
+    crate::widgets::combobox::scan_ios_combobox_gc_roots(visitor);
+    crate::widgets::date_picker::scan_ios_date_picker_gc_roots(visitor);
+    crate::widgets::image_gallery::scan_ios_image_gallery_gc_roots(visitor);
+    crate::widgets::scan_ios_widgets_gc_roots(visitor);
+    crate::widgets::picker::scan_ios_picker_gc_roots(visitor);
+    crate::widgets::rich_text::scan_ios_rich_text_gc_roots(visitor);
+    crate::widgets::scrollview::scan_ios_scrollview_gc_roots(visitor);
+    crate::widgets::securefield::scan_ios_securefield_gc_roots(visitor);
+    crate::widgets::slider::scan_ios_slider_gc_roots(visitor);
+    crate::widgets::tabbar::scan_ios_tabbar_gc_roots(visitor);
+    crate::widgets::textarea::scan_ios_textarea_gc_roots(visitor);
+    crate::widgets::textfield::scan_ios_textfield_gc_roots(visitor);
+    crate::widgets::toggle::scan_ios_toggle_gc_roots(visitor);
+    crate::widgets::tree_view::scan_ios_tree_view_gc_roots(visitor);
+    crate::widgets::webview::scan_ios_webview_gc_roots(visitor);
+    crate::widgets::wheel_picker::scan_ios_wheel_picker_gc_roots(visitor);
+}

--- a/crates/perry-ui-ios/src/geolocation.rs
+++ b/crates/perry-ui-ios/src/geolocation.rs
@@ -76,6 +76,25 @@ thread_local! {
     static PERMISSION_REQUESTS: RefCell<HashMap<usize, PermissionRequest>> = RefCell::new(HashMap::new());
     static DELEGATE_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
+
+pub(crate) fn scan_ios_geolocation_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PENDING_ONE_SHOTS.with(|requests| {
+        for request in requests.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.on_success);
+            visitor.visit_nanbox_f64_slot(&mut request.on_error);
+        }
+    });
+    WATCHES.with(|watches| {
+        for watch in watches.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut watch.callback);
+        }
+    });
+    PERMISSION_REQUESTS.with(|requests| {
+        for request in requests.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.callback);
+        }
+    });
+}
 static NEXT_WATCH_ID: AtomicI64 = AtomicI64::new(1);
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-ios/src/lib.rs
+++ b/crates/perry-ui-ios/src/lib.rs
@@ -12,6 +12,7 @@ pub mod deeplinks;
 pub mod drag_drop;
 pub mod file_dialog;
 pub mod foundation_models;
+mod gc;
 pub mod geolocation;
 pub mod image_picker;
 pub mod keyboard;

--- a/crates/perry-ui-ios/src/location.rs
+++ b/crates/perry-ui-ios/src/location.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_REGISTERED: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_ios_location_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LOCATION_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Invoke the stored JS callback with (lat, lon), draining promises first.
 unsafe fn invoke_callback(lat: f64, lon: f64) {
     let cb = LOCATION_CALLBACK.with(|c| c.borrow_mut().take());

--- a/crates/perry-ui-ios/src/media_playback.rs
+++ b/crates/perry-ui-ios/src/media_playback.rs
@@ -135,6 +135,19 @@ thread_local! {
     static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_ios_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-ios/src/menu.rs
+++ b/crates/perry-ui-ios/src/menu.rs
@@ -45,6 +45,21 @@ thread_local! {
     static ACTION_CALLBACKS: RefCell<Vec<(usize, f64)>> = RefCell::new(Vec::new());
 }
 
+pub(crate) fn scan_ios_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENUS.with(|menus| {
+        for item in menus.borrow_mut().iter_mut().flatten() {
+            if let MenuItemEntry::Item { callback, .. } = item {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    ACTION_CALLBACKS.with(|callbacks| {
+        for (_, callback) in callbacks.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-ios/src/network.rs
+++ b/crates/perry-ui-ios/src/network.rs
@@ -78,6 +78,14 @@ thread_local! {
     static CACHED: RefCell<Status> = const { RefCell::new(Status::unknown()) };
     static LISTENERS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
+
+pub(crate) fn scan_ios_network_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LISTENERS.with(|listeners| {
+        for listener in listeners.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(listener);
+        }
+    });
+}
 static NEXT_LISTENER_ID: AtomicI64 = AtomicI64::new(1);
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-ios/src/notifications.rs
+++ b/crates/perry-ui-ios/src/notifications.rs
@@ -30,6 +30,21 @@ thread_local! {
     static TAP_DELEGATE: RefCell<Option<Retained<PerryNotificationDelegate>>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_ios_notifications_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for slot in [
+        &ON_REMOTE_TOKEN_CALLBACK,
+        &ON_REMOTE_RECEIVE_CALLBACK,
+        &ON_BACKGROUND_RECEIVE_CALLBACK,
+        &ON_TAP_CALLBACK,
+    ] {
+        slot.with(|slot| {
+            if let Some(callback) = slot.borrow_mut().as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 /// Monotonic id used to look up a stored completion block from a Promise
 /// callback's capture. Starts at 1 so 0 can stay an unambiguous "missing".
 static NEXT_COMPLETION_HANDLE: AtomicI64 = AtomicI64::new(1);

--- a/crates/perry-ui-ios/src/pointer.rs
+++ b/crates/perry-ui-ios/src/pointer.rs
@@ -49,6 +49,16 @@ thread_local! {
         RefCell::new(std::collections::HashSet::new());
 }
 
+pub(crate) fn scan_ios_pointer_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&MOUSE_DOWN_CB, &MOUSE_UP_CB, &MOUSE_MOVE_CB] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 pub struct PerryPointerRecognizerIvars {
     key: Cell<usize>,
 }

--- a/crates/perry-ui-ios/src/state.rs
+++ b/crates/perry-ui-ios/src/state.rs
@@ -77,6 +77,29 @@ thread_local! {
     static DEFERRED_REBUILDS: RefCell<Vec<DeferredRebuild>> = RefCell::new(Vec::new());
 }
 
+pub(crate) fn scan_ios_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    DEFERRED_REBUILDS.with(|rebuilds| {
+        for rebuild in rebuilds.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut rebuild.render_closure);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Check if a f64 value is a NaN-boxed string (STRING_TAG = 0x7FFF).

--- a/crates/perry-ui-ios/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-ios/src/widgets/bottom_nav.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_select);
+        }
+    });
+}
+
 pub struct PerryBottomNavDelegateIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-ios/src/widgets/button.rs
+++ b/crates/perry-ui-ios/src/widgets/button.rs
@@ -10,6 +10,19 @@ thread_local! {
     static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TAP_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/calendar.rs
+++ b/crates/perry-ui-ios/src/widgets/calendar.rs
@@ -27,6 +27,14 @@ thread_local! {
     static CALENDAR_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_calendar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALENDAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryCalendarTargetIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-ios/src/widgets/combobox.rs
+++ b/crates/perry-ui-ios/src/widgets/combobox.rs
@@ -40,6 +40,14 @@ thread_local! {
     static COMBOBOX_DELEGATES: RefCell<HashMap<i64, Retained<PerryComboboxDelegate>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_combobox_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    COMBOBOX_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn fire_callback(handle: i64, value: &str) {

--- a/crates/perry-ui-ios/src/widgets/date_picker.rs
+++ b/crates/perry-ui-ios/src/widgets/date_picker.rs
@@ -28,6 +28,14 @@ thread_local! {
     static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_date_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DATEPICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryDatePickerTargetIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-ios/src/widgets/image_gallery.rs
+++ b/crates/perry-ui-ios/src/widgets/image_gallery.rs
@@ -43,6 +43,14 @@ thread_local! {
     static DELEGATE_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_image_gallery_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_index_change);
+        }
+    });
+}
+
 pub struct PerryGalleryDelegateIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-ios/src/widgets/mod.rs
+++ b/crates/perry-ui-ios/src/widgets/mod.rs
@@ -741,6 +741,14 @@ thread_local! {
     static DOUBLE_CLICK_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_widgets_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DOUBLE_CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Set the enabled state of any UIControl-based widget.
 pub fn set_enabled(handle: i64, enabled: bool) {
     if let Some(view) = get_widget(handle) {

--- a/crates/perry-ui-ios/src/widgets/picker.rs
+++ b/crates/perry-ui-ios/src/widgets/picker.rs
@@ -12,6 +12,14 @@ thread_local! {
     static PICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/rich_text.rs
+++ b/crates/perry-ui-ios/src/widgets/rich_text.rs
@@ -30,6 +30,14 @@ thread_local! {
     static CHANGE_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_rich_text_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn ns_string_to_rust(ns: *mut AnyObject) -> String {

--- a/crates/perry-ui-ios/src/widgets/scrollview.rs
+++ b/crates/perry-ui-ios/src/widgets/scrollview.rs
@@ -32,6 +32,19 @@ thread_local! {
     static REFRESH_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    REFRESH_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    SCROLL_END_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.closure);
+        }
+    });
+}
+
 pub struct PerryRefreshTargetIvars {
     callback_key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-ios/src/widgets/securefield.rs
+++ b/crates/perry-ui-ios/src/widgets/securefield.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SECUREFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_securefield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SECUREFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/slider.rs
+++ b/crates/perry-ui-ios/src/widgets/slider.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SLIDER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/tabbar.rs
+++ b/crates/perry-ui-ios/src/widgets/tabbar.rs
@@ -52,6 +52,14 @@ thread_local! {
     static DELEGATE_MAP: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_tabbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TABBAR_STATE.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_change);
+        }
+    });
+}
+
 // ── UITabBarDelegate ─────────────────────────────────────────
 
 pub struct PerryTabBarDelegateIvars {

--- a/crates/perry-ui-ios/src/widgets/textarea.rs
+++ b/crates/perry-ui-ios/src/widgets/textarea.rs
@@ -10,6 +10,14 @@ thread_local! {
     static TEXTAREA_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_textarea_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTAREA_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/textfield.rs
+++ b/crates/perry-ui-ios/src/widgets/textfield.rs
@@ -10,6 +10,19 @@ thread_local! {
     static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_textfield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    SUBMIT_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-ios/src/widgets/toggle.rs
+++ b/crates/perry-ui-ios/src/widgets/toggle.rs
@@ -11,6 +11,14 @@ thread_local! {
     static TOGGLE_SWITCHES: RefCell<HashMap<i64, Retained<UIView>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_toggle_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOGGLE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 

--- a/crates/perry-ui-ios/src/widgets/tree_view.rs
+++ b/crates/perry-ui-ios/src/widgets/tree_view.rs
@@ -69,6 +69,14 @@ thread_local! {
     static TREES: RefCell<Vec<TreeEntry>> = const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_ios_tree_view_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TREES.with(|trees| {
+        for tree in trees.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut tree.on_select);
+        }
+    });
+}
+
 fn rebuild_flat(entry_idx: usize) {
     let (root, expanded_snapshot) = TREES.with(|t| {
         let trees = t.borrow();

--- a/crates/perry-ui-ios/src/widgets/webview.rs
+++ b/crates/perry-ui-ios/src/widgets/webview.rs
@@ -37,6 +37,16 @@ thread_local! {
     static HANDLE_TO_KEY: RefCell<HashMap<i64, usize>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-ios/src/widgets/wheel_picker.rs
+++ b/crates/perry-ui-ios/src/widgets/wheel_picker.rs
@@ -17,6 +17,14 @@ thread_local! {
     static DELEGATES: RefCell<HashMap<i64, Retained<PerryWheelPickerDelegate>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_ios_wheel_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -12,6 +12,8 @@ use objc2_foundation::{MainThreadMarker, NSObject, NSString};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{LazyLock, Mutex};
 
 use crate::widgets;
 
@@ -64,6 +66,7 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Create an app with title, width, height.
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_registered();
     let title = if title_ptr.is_null() {
         "Perry App".to_owned()
     } else {
@@ -740,6 +743,25 @@ thread_local! {
     static SHORTCUT_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+static GLOBAL_HOTKEY_CALLBACKS: LazyLock<Mutex<HashMap<usize, f64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static NEXT_GLOBAL_HOTKEY_CALLBACK: AtomicUsize = AtomicUsize::new(1);
+
+fn invoke_global_hotkey_callback(key: usize) {
+    let callback = GLOBAL_HOTKEY_CALLBACKS
+        .lock()
+        .ok()
+        .and_then(|callbacks| callbacks.get(&key).copied());
+    if let Some(callback) = callback {
+        let callback_ptr = unsafe { js_nanbox_get_pointer(callback) } as *const u8;
+        if !callback_ptr.is_null() {
+            unsafe {
+                js_closure_call0(callback_ptr);
+            }
+        }
+    }
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
@@ -1011,7 +1033,12 @@ pub fn register_global_hotkey(key_ptr: *const u8, modifiers: f64, callback: f64)
         return;
     }
 
-    let callback_ptr = unsafe { js_nanbox_get_pointer(callback) } as usize;
+    let callback_key = NEXT_GLOBAL_HOTKEY_CALLBACK.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut callbacks) = GLOBAL_HOTKEY_CALLBACKS.lock() {
+        callbacks.insert(callback_key, callback);
+    } else {
+        return;
+    }
     let mod_bits = modifiers as u64;
     let target_key = key_str.to_lowercase();
 
@@ -1053,7 +1080,7 @@ pub fn register_global_hotkey(key_ptr: *const u8, modifiers: f64, callback: f64)
                     // Mask to device-independent modifier flags only
                     let relevant_mods = event_mods & 0xFFFF0000;
                     if event_key == target_key_global && relevant_mods == ns_mods {
-                        js_closure_call0(callback_ptr as *const u8);
+                        invoke_global_hotkey_callback(callback_key);
                     }
                 }
             }
@@ -1085,7 +1112,7 @@ pub fn register_global_hotkey(key_ptr: *const u8, modifiers: f64, callback: f64)
                         let event_mods: u64 = msg_send![event, modifierFlags];
                         let relevant_mods = event_mods & 0xFFFF0000;
                         if event_key == target_key_local && relevant_mods == ns_mods {
-                            js_closure_call0(callback_ptr as *const u8);
+                            invoke_global_hotkey_callback(callback_key);
                         }
                     }
                 }
@@ -1721,10 +1748,13 @@ pub fn window_on_focus_lost(window_handle: i64, callback: f64) {
                 let center: Retained<AnyObject> =
                     objc2::msg_send![objc2::class!(NSNotificationCenter), defaultCenter];
                 let name = NSString::from_str("NSWindowDidResignKeyNotification");
-                let callback_copy = callback;
                 let block = block2::RcBlock::new(move |_notif: *const AnyObject| {
-                    let ptr = js_nanbox_get_pointer(callback_copy) as *const u8;
-                    js_closure_call0(ptr);
+                    let callback = WINDOW_FOCUS_LOST_CBS
+                        .with(|callbacks| callbacks.borrow().get(&window_handle).copied());
+                    if let Some(callback) = callback {
+                        let ptr = js_nanbox_get_pointer(callback) as *const u8;
+                        js_closure_call0(ptr);
+                    }
                 });
                 let _: Retained<AnyObject> = objc2::msg_send![
                     &*center,
@@ -1737,6 +1767,41 @@ pub fn window_on_focus_lost(window_handle: i64, callback: f64) {
             }
         }
     });
+}
+
+pub(crate) fn scan_macos_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PENDING_SHORTCUTS.with(|shortcuts| {
+        for shortcut in shortcuts.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut shortcut.callback);
+        }
+    });
+    for slot in [&ON_TERMINATE_CALLBACK, &ON_ACTIVATE_CALLBACK] {
+        slot.with(|slot| {
+            if let Some(callback) = slot.borrow_mut().as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+    SHORTCUT_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TIMER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    WINDOW_FOCUS_LOST_CBS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    if let Ok(mut callbacks) = GLOBAL_HOTKEY_CALLBACKS.lock() {
+        for callback in callbacks.values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    }
 }
 
 // ============================================

--- a/crates/perry-ui-macos/src/audio_playback.rs
+++ b/crates/perry-ui-macos/src/audio_playback.rs
@@ -149,6 +149,23 @@ thread_local! {
     static WARNED_VARISPEED_FALLBACK: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_macos_audio_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================

--- a/crates/perry-ui-macos/src/background.rs
+++ b/crates/perry-ui-macos/src/background.rs
@@ -59,6 +59,14 @@ thread_local! {
         const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_macos_background_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLERS.with(|handlers| {
+        for handler in handlers.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn boolean_truthy(v: f64) -> bool {

--- a/crates/perry-ui-macos/src/deeplinks.rs
+++ b/crates/perry-ui-macos/src/deeplinks.rs
@@ -49,6 +49,14 @@ thread_local! {
     static APP_LAUNCHED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+pub(crate) fn scan_macos_deeplinks_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLER.with(|slot| {
+        if let Some(handler) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 unsafe fn nanbox_str(s: &str) -> f64 {
     let bytes = s.as_bytes();
     let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);

--- a/crates/perry-ui-macos/src/drag_drop.rs
+++ b/crates/perry-ui-macos/src/drag_drop.rs
@@ -67,6 +67,16 @@ thread_local! {
     static ORIG_MOUSEDOWN: RefCell<HashMap<usize, Imp>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_drag_drop_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&DROP_CB, &DRAG_TEXT, &DRAG_FILE, &DRAG_URL] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 /// Extract a `&str` from a runtime `StringHeader` pointer (same layout as
 /// `clipboard.rs` / `button.rs`).
 use perry_ffi::copy_string_from_raw as str_from_header;

--- a/crates/perry-ui-macos/src/gc.rs
+++ b/crates/perry-ui-macos/src/gc.rs
@@ -1,0 +1,50 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-macos", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::app::scan_macos_app_gc_roots(visitor);
+    crate::audio_playback::scan_macos_audio_playback_gc_roots(visitor);
+    crate::background::scan_macos_background_gc_roots(visitor);
+    crate::deeplinks::scan_macos_deeplinks_gc_roots(visitor);
+    crate::drag_drop::scan_macos_drag_drop_gc_roots(visitor);
+    crate::geolocation::scan_macos_geolocation_gc_roots(visitor);
+    crate::location::scan_macos_location_gc_roots(visitor);
+    crate::media_playback::scan_macos_media_playback_gc_roots(visitor);
+    crate::menu::scan_macos_menu_gc_roots(visitor);
+    crate::network::scan_macos_network_gc_roots(visitor);
+    crate::notifications::scan_macos_notifications_gc_roots(visitor);
+    crate::pointer::scan_macos_pointer_gc_roots(visitor);
+    crate::state::scan_macos_state_gc_roots(visitor);
+    crate::tray::scan_macos_tray_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_macos_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_macos_button_gc_roots(visitor);
+    crate::widgets::calendar::scan_macos_calendar_gc_roots(visitor);
+    crate::widgets::combobox::scan_macos_combobox_gc_roots(visitor);
+    crate::widgets::command_palette::scan_macos_command_palette_gc_roots(visitor);
+    crate::widgets::date_picker::scan_macos_date_picker_gc_roots(visitor);
+    crate::widgets::image_gallery::scan_macos_image_gallery_gc_roots(visitor);
+    crate::widgets::lazyvstack::scan_macos_lazyvstack_gc_roots(visitor);
+    crate::widgets::scan_macos_widgets_gc_roots(visitor);
+    crate::widgets::picker::scan_macos_picker_gc_roots(visitor);
+    crate::widgets::rich_text::scan_macos_rich_text_gc_roots(visitor);
+    crate::widgets::scrollview::scan_macos_scrollview_gc_roots(visitor);
+    crate::widgets::securefield::scan_macos_securefield_gc_roots(visitor);
+    crate::widgets::slider::scan_macos_slider_gc_roots(visitor);
+    crate::widgets::table::scan_macos_table_gc_roots(visitor);
+    crate::widgets::textarea::scan_macos_textarea_gc_roots(visitor);
+    crate::widgets::textfield::scan_macos_textfield_gc_roots(visitor);
+    crate::widgets::toggle::scan_macos_toggle_gc_roots(visitor);
+    crate::widgets::toolbar::scan_macos_toolbar_gc_roots(visitor);
+    crate::widgets::tree_view::scan_macos_tree_view_gc_roots(visitor);
+    crate::widgets::webview::scan_macos_webview_gc_roots(visitor);
+}

--- a/crates/perry-ui-macos/src/geolocation.rs
+++ b/crates/perry-ui-macos/src/geolocation.rs
@@ -78,6 +78,25 @@ thread_local! {
     static PERMISSION_REQUESTS: RefCell<HashMap<usize, PermissionRequest>> = RefCell::new(HashMap::new());
     static DELEGATE_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
+
+pub(crate) fn scan_macos_geolocation_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PENDING_ONE_SHOTS.with(|requests| {
+        for request in requests.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.on_success);
+            visitor.visit_nanbox_f64_slot(&mut request.on_error);
+        }
+    });
+    WATCHES.with(|watches| {
+        for watch in watches.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut watch.callback);
+        }
+    });
+    PERMISSION_REQUESTS.with(|requests| {
+        for request in requests.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut request.callback);
+        }
+    });
+}
 static NEXT_WATCH_ID: AtomicI64 = AtomicI64::new(1);
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -10,6 +10,7 @@ pub mod deeplinks;
 pub mod drag_drop;
 pub mod ffi;
 pub mod file_dialog;
+mod gc;
 pub mod geolocation;
 pub mod image_picker;
 pub mod keychain;

--- a/crates/perry-ui-macos/src/location.rs
+++ b/crates/perry-ui-macos/src/location.rs
@@ -31,6 +31,14 @@ thread_local! {
     static DELEGATE_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_macos_location_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LOCATION_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Invoke the stored JS callback with (lat, lon), draining promises first.
 unsafe fn invoke_callback(lat: f64, lon: f64) {
     let cb = LOCATION_CALLBACK.with(|c| c.borrow_mut().take());

--- a/crates/perry-ui-macos/src/media_playback.rs
+++ b/crates/perry-ui-macos/src/media_playback.rs
@@ -120,6 +120,19 @@ thread_local! {
     static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_macos_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-macos/src/menu.rs
+++ b/crates/perry-ui-macos/src/menu.rs
@@ -14,6 +14,14 @@ thread_local! {
     pub(crate) static PENDING_USER_MENUBAR: RefCell<Option<Retained<NSMenu>>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_macos_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENU_ITEM_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/network.rs
+++ b/crates/perry-ui-macos/src/network.rs
@@ -69,6 +69,14 @@ thread_local! {
     static CACHED: RefCell<Status> = const { RefCell::new(Status::unknown()) };
     static LISTENERS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
+
+pub(crate) fn scan_macos_network_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LISTENERS.with(|listeners| {
+        for listener in listeners.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(listener);
+        }
+    });
+}
 static NEXT_LISTENER_ID: AtomicI64 = AtomicI64::new(1);
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-macos/src/notifications.rs
+++ b/crates/perry-ui-macos/src/notifications.rs
@@ -21,6 +21,20 @@ thread_local! {
     static TAP_DELEGATE: RefCell<Option<Retained<PerryNotificationDelegate>>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_macos_notifications_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for slot in [
+        &ON_REMOTE_TOKEN_CALLBACK,
+        &ON_REMOTE_RECEIVE_CALLBACK,
+        &ON_TAP_CALLBACK,
+    ] {
+        slot.with(|slot| {
+            if let Some(callback) = slot.borrow_mut().as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_nanbox_string(ptr: i64) -> f64;

--- a/crates/perry-ui-macos/src/pointer.rs
+++ b/crates/perry-ui-macos/src/pointer.rs
@@ -96,6 +96,16 @@ thread_local! {
         RefCell::new(std::collections::HashSet::new());
 }
 
+pub(crate) fn scan_macos_pointer_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&MOUSE_DOWN_CB, &MOUSE_UP_CB, &MOUSE_MOVE_CB, &HOVER_CB] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 /// Install the single global NSEvent local monitor on first use. The
 /// monitor block is leaked intentionally (lives for the app's lifetime)
 /// — `addLocalMonitorForEventsMatchingMask:handler:` retains the block

--- a/crates/perry-ui-macos/src/state.rs
+++ b/crates/perry-ui-macos/src/state.rs
@@ -85,6 +85,24 @@ thread_local! {
     static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-macos/src/tray.rs
+++ b/crates/perry-ui-macos/src/tray.rs
@@ -21,6 +21,14 @@ thread_local! {
     static TRAY_CLICK_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_tray_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TRAY_CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-macos/src/widgets/bottom_nav.rs
@@ -52,6 +52,14 @@ thread_local! {
     static TARGET_TO_HANDLE: RefCell<HashMap<usize, (i64, i64)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BOTTOM_NAVS.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_select);
+        }
+    });
+}
+
 pub struct PerryBottomNavTargetIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-macos/src/widgets/button.rs
+++ b/crates/perry-ui-macos/src/widgets/button.rs
@@ -11,6 +11,14 @@ thread_local! {
     static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/calendar.rs
+++ b/crates/perry-ui-macos/src/widgets/calendar.rs
@@ -30,6 +30,14 @@ thread_local! {
     static CALENDAR_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_calendar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALENDAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryCalendarTargetIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-macos/src/widgets/combobox.rs
+++ b/crates/perry-ui-macos/src/widgets/combobox.rs
@@ -22,6 +22,14 @@ thread_local! {
     static COMBOBOX_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_combobox_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    COMBOBOX_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/command_palette.rs
+++ b/crates/perry-ui-macos/src/widgets/command_palette.rs
@@ -41,6 +41,14 @@ thread_local! {
     static TABLE_VIEW: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_macos_command_palette_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    COMMANDS.with(|commands| {
+        for command in commands.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut command.on_run);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn refresh_filter() {

--- a/crates/perry-ui-macos/src/widgets/date_picker.rs
+++ b/crates/perry-ui-macos/src/widgets/date_picker.rs
@@ -30,6 +30,14 @@ thread_local! {
     static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_date_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DATEPICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryDatePickerTargetIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-macos/src/widgets/image_gallery.rs
+++ b/crates/perry-ui-macos/src/widgets/image_gallery.rs
@@ -41,6 +41,14 @@ thread_local! {
     static OBSERVER_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_image_gallery_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    GALLERIES.with(|galleries| {
+        for gallery in galleries.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut gallery.on_index_change);
+        }
+    });
+}
+
 pub struct PerryGalleryObserverIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-macos/src/widgets/lazyvstack.rs
+++ b/crates/perry-ui-macos/src/widgets/lazyvstack.rs
@@ -236,6 +236,19 @@ thread_local! {
     static SCROLL_END_OBSERVER_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_lazyvstack_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LAZY_VSTACKS.with(|stacks| {
+        for stack in stacks.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut stack.render_closure);
+        }
+    });
+    SCROLL_END_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.closure);
+        }
+    });
+}
+
 pub struct PerryLazyVStackScrollObserverIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-macos/src/widgets/mod.rs
+++ b/crates/perry-ui-macos/src/widgets/mod.rs
@@ -1125,6 +1125,24 @@ thread_local! {
     static CLICK_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_widgets_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HOVER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    DOUBLE_CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Set an on-hover callback for a widget. As of issue #1868 the
 /// callback receives `(isHovering: boolean)` — fires `true` on enter
 /// and `false` on leave through the same closure. Implementation lives

--- a/crates/perry-ui-macos/src/widgets/picker.rs
+++ b/crates/perry-ui-macos/src/widgets/picker.rs
@@ -10,6 +10,14 @@ thread_local! {
     static PICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/rich_text.rs
+++ b/crates/perry-ui-macos/src/widgets/rich_text.rs
@@ -40,6 +40,14 @@ thread_local! {
     static CHANGE_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_rich_text_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn ns_string_to_rust(ns: *mut AnyObject) -> String {

--- a/crates/perry-ui-macos/src/widgets/scrollview.rs
+++ b/crates/perry-ui-macos/src/widgets/scrollview.rs
@@ -211,6 +211,14 @@ thread_local! {
     static SCROLL_END_OBSERVER_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SCROLL_END_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.closure);
+        }
+    });
+}
+
 pub struct PerryScrollEndObserverIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-macos/src/widgets/securefield.rs
+++ b/crates/perry-ui-macos/src/widgets/securefield.rs
@@ -13,6 +13,14 @@ thread_local! {
     static SECUREFIELD_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_securefield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SECUREFIELD_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/slider.rs
+++ b/crates/perry-ui-macos/src/widgets/slider.rs
@@ -11,6 +11,14 @@ thread_local! {
     static SLIDER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/table.rs
+++ b/crates/perry-ui-macos/src/widgets/table.rs
@@ -36,6 +36,16 @@ thread_local! {
     static TABLES: RefCell<Vec<TableEntry>> = const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_macos_table_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TABLES.with(|tables| {
+        for table in tables.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut table.render_closure);
+            visitor.visit_nanbox_f64_slot(&mut table.select_closure);
+            visitor.visit_nanbox_f64_slot(&mut table.sort_closure);
+        }
+    });
+}
+
 fn find_entry_idx(handle: i64) -> Option<usize> {
     TABLES.with(|t| t.borrow().iter().position(|e| e.handle == handle))
 }

--- a/crates/perry-ui-macos/src/widgets/textarea.rs
+++ b/crates/perry-ui-macos/src/widgets/textarea.rs
@@ -13,6 +13,14 @@ thread_local! {
     static TEXTAREA_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_textarea_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTAREA_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/textfield.rs
+++ b/crates/perry-ui-macos/src/widgets/textfield.rs
@@ -18,6 +18,24 @@ thread_local! {
     static TEXTFIELD_FOCUS_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_textfield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTFIELD_CALLBACKS.with(|callbacks| {
+        for (callback, _, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TEXTFIELD_SUBMIT_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TEXTFIELD_FOCUS_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-macos/src/widgets/toggle.rs
+++ b/crates/perry-ui-macos/src/widgets/toggle.rs
@@ -15,6 +15,14 @@ thread_local! {
     static TOGGLE_SWITCHES: RefCell<HashMap<i64, Retained<NSView>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_toggle_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOGGLE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 // TAG_TRUE and TAG_FALSE from perry-runtime NaN-boxing
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;

--- a/crates/perry-ui-macos/src/widgets/toolbar.rs
+++ b/crates/perry-ui-macos/src/widgets/toolbar.rs
@@ -31,6 +31,21 @@ thread_local! {
     static TOOLBAR_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_toolbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOOLBARS.with(|toolbars| {
+        for toolbar in toolbars.borrow_mut().iter_mut() {
+            for item in &mut toolbar.items {
+                visitor.visit_nanbox_f64_slot(&mut item.callback);
+            }
+        }
+    });
+    TOOLBAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryToolbarTargetIvars {
     callback_key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-macos/src/widgets/tree_view.rs
+++ b/crates/perry-ui-macos/src/widgets/tree_view.rs
@@ -50,6 +50,14 @@ thread_local! {
     static ITEMS: RefCell<HashMap<i64, Retained<PerryTreeItem>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_tree_view_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TREES.with(|trees| {
+        for tree in trees.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut tree.on_select);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 // ===========================================================================

--- a/crates/perry-ui-macos/src/widgets/webview.rs
+++ b/crates/perry-ui-macos/src/widgets/webview.rs
@@ -69,6 +69,16 @@ thread_local! {
     static HANDLE_TO_KEY: RefCell<HashMap<i64, usize>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_macos_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-tvos/src/app.rs
+++ b/crates/perry-ui-tvos/src/app.rs
@@ -34,6 +34,7 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 /// Create an app. Stores config in thread-local for deferred creation.
 /// Returns app handle (i64).
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_registered();
     let title = if title_ptr.is_null() {
         "Perry App".to_string()
     } else {
@@ -52,6 +53,14 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
     });
 
     1 // Single app handle
+}
+
+pub(crate) fn scan_tvos_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TIMER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
 }
 
 /// Set the root widget (body) of the app.

--- a/crates/perry-ui-tvos/src/audio_playback.rs
+++ b/crates/perry-ui-tvos/src/audio_playback.rs
@@ -152,6 +152,23 @@ thread_local! {
     static WARNED_VARISPEED_FALLBACK: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_tvos_audio_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================

--- a/crates/perry-ui-tvos/src/background.rs
+++ b/crates/perry-ui-tvos/src/background.rs
@@ -38,6 +38,14 @@ thread_local! {
         const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_tvos_background_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLERS.with(|handlers| {
+        for handler in handlers.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn boolean_truthy(v: f64) -> bool {

--- a/crates/perry-ui-tvos/src/gc.rs
+++ b/crates/perry-ui-tvos/src/gc.rs
@@ -1,0 +1,33 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-tvos", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::app::scan_tvos_app_gc_roots(visitor);
+    crate::audio_playback::scan_tvos_audio_playback_gc_roots(visitor);
+    crate::background::scan_tvos_background_gc_roots(visitor);
+    crate::location::scan_tvos_location_gc_roots(visitor);
+    crate::media_playback::scan_tvos_media_playback_gc_roots(visitor);
+    crate::menu::scan_tvos_menu_gc_roots(visitor);
+    crate::pointer::scan_tvos_pointer_gc_roots(visitor);
+    crate::state::scan_tvos_state_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_tvos_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_tvos_button_gc_roots(visitor);
+    crate::widgets::scan_tvos_widgets_gc_roots(visitor);
+    crate::widgets::scrollview::scan_tvos_scrollview_gc_roots(visitor);
+    crate::widgets::securefield::scan_tvos_securefield_gc_roots(visitor);
+    crate::widgets::slider::scan_tvos_slider_gc_roots(visitor);
+    crate::widgets::tabbar::scan_tvos_tabbar_gc_roots(visitor);
+    crate::widgets::textarea::scan_tvos_textarea_gc_roots(visitor);
+    crate::widgets::textfield::scan_tvos_textfield_gc_roots(visitor);
+    crate::widgets::toggle::scan_tvos_toggle_gc_roots(visitor);
+}

--- a/crates/perry-ui-tvos/src/lib.rs
+++ b/crates/perry-ui-tvos/src/lib.rs
@@ -9,6 +9,7 @@ pub mod crash_log;
 pub mod deeplinks_stub;
 pub mod drag_drop;
 pub mod file_dialog;
+mod gc;
 pub mod issue_552_stub;
 pub mod keyboard;
 pub mod location;

--- a/crates/perry-ui-tvos/src/location.rs
+++ b/crates/perry-ui-tvos/src/location.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_REGISTERED: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_tvos_location_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LOCATION_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Invoke the stored JS callback with (lat, lon), draining promises first.
 unsafe fn invoke_callback(lat: f64, lon: f64) {
     let cb = LOCATION_CALLBACK.with(|c| c.borrow_mut().take());

--- a/crates/perry-ui-tvos/src/media_playback.rs
+++ b/crates/perry-ui-tvos/src/media_playback.rs
@@ -120,6 +120,19 @@ thread_local! {
     static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_tvos_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-tvos/src/menu.rs
+++ b/crates/perry-ui-tvos/src/menu.rs
@@ -45,6 +45,21 @@ thread_local! {
     static ACTION_CALLBACKS: RefCell<Vec<(usize, f64)>> = RefCell::new(Vec::new());
 }
 
+pub(crate) fn scan_tvos_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENUS.with(|menus| {
+        for item in menus.borrow_mut().iter_mut().flatten() {
+            if let MenuItemEntry::Item { callback, .. } = item {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    ACTION_CALLBACKS.with(|callbacks| {
+        for (_, callback) in callbacks.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-tvos/src/pointer.rs
+++ b/crates/perry-ui-tvos/src/pointer.rs
@@ -49,6 +49,16 @@ thread_local! {
         RefCell::new(std::collections::HashSet::new());
 }
 
+pub(crate) fn scan_tvos_pointer_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&MOUSE_DOWN_CB, &MOUSE_UP_CB, &MOUSE_MOVE_CB] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 pub struct PerryPointerRecognizerIvars {
     key: Cell<usize>,
 }

--- a/crates/perry-ui-tvos/src/state.rs
+++ b/crates/perry-ui-tvos/src/state.rs
@@ -63,6 +63,24 @@ thread_local! {
     static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Check if a f64 value is a NaN-boxed string (STRING_TAG = 0x7FFF).

--- a/crates/perry-ui-tvos/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-tvos/src/widgets/bottom_nav.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_select);
+        }
+    });
+}
+
 pub struct PerryBottomNavDelegateIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-tvos/src/widgets/button.rs
+++ b/crates/perry-ui-tvos/src/widgets/button.rs
@@ -10,6 +10,19 @@ thread_local! {
     static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TAP_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-tvos/src/widgets/mod.rs
+++ b/crates/perry-ui-tvos/src/widgets/mod.rs
@@ -529,6 +529,14 @@ thread_local! {
     static DOUBLE_CLICK_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_widgets_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DOUBLE_CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Set the enabled state of any UIControl-based widget.
 pub fn set_enabled(handle: i64, enabled: bool) {
     if let Some(view) = get_widget(handle) {

--- a/crates/perry-ui-tvos/src/widgets/scrollview.rs
+++ b/crates/perry-ui-tvos/src/widgets/scrollview.rs
@@ -28,6 +28,14 @@ thread_local! {
     static REFRESH_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    REFRESH_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryRefreshTargetIvars {
     callback_key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-tvos/src/widgets/securefield.rs
+++ b/crates/perry-ui-tvos/src/widgets/securefield.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SECUREFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_securefield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SECUREFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-tvos/src/widgets/slider.rs
+++ b/crates/perry-ui-tvos/src/widgets/slider.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SLIDER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-tvos/src/widgets/tabbar.rs
+++ b/crates/perry-ui-tvos/src/widgets/tabbar.rs
@@ -52,6 +52,14 @@ thread_local! {
     static DELEGATE_MAP: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_tabbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TABBAR_STATE.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_change);
+        }
+    });
+}
+
 // ── UITabBarDelegate ─────────────────────────────────────────
 
 pub struct PerryTabBarDelegateIvars {

--- a/crates/perry-ui-tvos/src/widgets/textarea.rs
+++ b/crates/perry-ui-tvos/src/widgets/textarea.rs
@@ -10,6 +10,14 @@ thread_local! {
     static TEXTAREA_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_textarea_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTAREA_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-tvos/src/widgets/textfield.rs
+++ b/crates/perry-ui-tvos/src/widgets/textfield.rs
@@ -10,6 +10,19 @@ thread_local! {
     static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_textfield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    SUBMIT_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-tvos/src/widgets/toggle.rs
+++ b/crates/perry-ui-tvos/src/widgets/toggle.rs
@@ -11,6 +11,14 @@ thread_local! {
     static TOGGLE_SWITCHES: RefCell<HashMap<i64, Retained<UIView>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_tvos_toggle_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOGGLE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 

--- a/crates/perry-ui-visionos/src/app.rs
+++ b/crates/perry-ui-visionos/src/app.rs
@@ -30,6 +30,7 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 /// Create an app. Stores config in thread-local for deferred creation.
 /// Returns app handle (i64).
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_registered();
     let title = if title_ptr.is_null() {
         "Perry App".to_string()
     } else {
@@ -48,6 +49,14 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
     });
 
     1 // Single app handle
+}
+
+pub(crate) fn scan_visionos_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TIMER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
 }
 
 /// Set the root widget (body) of the app.

--- a/crates/perry-ui-visionos/src/audio_playback.rs
+++ b/crates/perry-ui-visionos/src/audio_playback.rs
@@ -152,6 +152,23 @@ thread_local! {
     static WARNED_VARISPEED_FALLBACK: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_visionos_audio_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================

--- a/crates/perry-ui-visionos/src/background.rs
+++ b/crates/perry-ui-visionos/src/background.rs
@@ -39,6 +39,14 @@ thread_local! {
         const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_visionos_background_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLERS.with(|handlers| {
+        for handler in handlers.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn boolean_truthy(v: f64) -> bool {

--- a/crates/perry-ui-visionos/src/camera.rs
+++ b/crates/perry-ui-visionos/src/camera.rs
@@ -81,6 +81,14 @@ thread_local! {
     static TAP_TARGET: RefCell<Option<Retained<AnyObject>>> = RefCell::new(None);
 }
 
+pub(crate) fn scan_visionos_camera_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TAP_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 // =============================================================================
 // Camera delegate — receives frames from AVCaptureVideoDataOutput
 // =============================================================================

--- a/crates/perry-ui-visionos/src/drag_drop.rs
+++ b/crates/perry-ui-visionos/src/drag_drop.rs
@@ -59,6 +59,16 @@ thread_local! {
     static DRAG_URL: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_drag_drop_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&DROP_CB, &DRAG_TEXT, &DRAG_FILE, &DRAG_URL] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 unsafe fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-visionos/src/gc.rs
+++ b/crates/perry-ui-visionos/src/gc.rs
@@ -1,0 +1,41 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-visionos", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::app::scan_visionos_app_gc_roots(visitor);
+    crate::audio_playback::scan_visionos_audio_playback_gc_roots(visitor);
+    crate::background::scan_visionos_background_gc_roots(visitor);
+    crate::camera::scan_visionos_camera_gc_roots(visitor);
+    crate::drag_drop::scan_visionos_drag_drop_gc_roots(visitor);
+    crate::location::scan_visionos_location_gc_roots(visitor);
+    crate::media_playback::scan_visionos_media_playback_gc_roots(visitor);
+    crate::menu::scan_visionos_menu_gc_roots(visitor);
+    crate::pointer::scan_visionos_pointer_gc_roots(visitor);
+    crate::state::scan_visionos_state_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_visionos_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_visionos_button_gc_roots(visitor);
+    crate::widgets::calendar::scan_visionos_calendar_gc_roots(visitor);
+    crate::widgets::combobox::scan_visionos_combobox_gc_roots(visitor);
+    crate::widgets::date_picker::scan_visionos_date_picker_gc_roots(visitor);
+    crate::widgets::scan_visionos_widgets_gc_roots(visitor);
+    crate::widgets::rich_text::scan_visionos_rich_text_gc_roots(visitor);
+    crate::widgets::scrollview::scan_visionos_scrollview_gc_roots(visitor);
+    crate::widgets::securefield::scan_visionos_securefield_gc_roots(visitor);
+    crate::widgets::slider::scan_visionos_slider_gc_roots(visitor);
+    crate::widgets::tabbar::scan_visionos_tabbar_gc_roots(visitor);
+    crate::widgets::textarea::scan_visionos_textarea_gc_roots(visitor);
+    crate::widgets::textfield::scan_visionos_textfield_gc_roots(visitor);
+    crate::widgets::tree_view::scan_visionos_tree_view_gc_roots(visitor);
+    crate::widgets::webview::scan_visionos_webview_gc_roots(visitor);
+    crate::widgets::wheel_picker::scan_visionos_wheel_picker_gc_roots(visitor);
+}

--- a/crates/perry-ui-visionos/src/lib.rs
+++ b/crates/perry-ui-visionos/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crash_log;
 pub mod deeplinks_stub;
 pub mod drag_drop;
 pub mod file_dialog;
+mod gc;
 #[cfg(feature = "geisterhand")]
 pub mod geisterhand_style;
 pub mod issue_552_stub;

--- a/crates/perry-ui-visionos/src/location.rs
+++ b/crates/perry-ui-visionos/src/location.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_REGISTERED: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_visionos_location_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LOCATION_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Invoke the stored JS callback with (lat, lon), draining promises first.
 unsafe fn invoke_callback(lat: f64, lon: f64) {
     let cb = LOCATION_CALLBACK.with(|c| c.borrow_mut().take());

--- a/crates/perry-ui-visionos/src/media_playback.rs
+++ b/crates/perry-ui-visionos/src/media_playback.rs
@@ -120,6 +120,19 @@ thread_local! {
     static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_visionos_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-visionos/src/menu.rs
+++ b/crates/perry-ui-visionos/src/menu.rs
@@ -45,6 +45,21 @@ thread_local! {
     static ACTION_CALLBACKS: RefCell<Vec<(usize, f64)>> = RefCell::new(Vec::new());
 }
 
+pub(crate) fn scan_visionos_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENUS.with(|menus| {
+        for item in menus.borrow_mut().iter_mut().flatten() {
+            if let MenuItemEntry::Item { callback, .. } = item {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    ACTION_CALLBACKS.with(|callbacks| {
+        for (_, callback) in callbacks.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-visionos/src/pointer.rs
+++ b/crates/perry-ui-visionos/src/pointer.rs
@@ -49,6 +49,16 @@ thread_local! {
         RefCell::new(std::collections::HashSet::new());
 }
 
+pub(crate) fn scan_visionos_pointer_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&MOUSE_DOWN_CB, &MOUSE_UP_CB, &MOUSE_MOVE_CB] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 pub struct PerryPointerRecognizerIvars {
     key: Cell<usize>,
 }

--- a/crates/perry-ui-visionos/src/state.rs
+++ b/crates/perry-ui-visionos/src/state.rs
@@ -63,6 +63,24 @@ thread_local! {
     static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Check if a f64 value is a NaN-boxed string (STRING_TAG = 0x7FFF).

--- a/crates/perry-ui-visionos/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-visionos/src/widgets/bottom_nav.rs
@@ -36,6 +36,14 @@ thread_local! {
     static DELEGATE_TO_HANDLE: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_select);
+        }
+    });
+}
+
 pub struct PerryBottomNavDelegateIvars {
     key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-visionos/src/widgets/button.rs
+++ b/crates/perry-ui-visionos/src/widgets/button.rs
@@ -10,6 +10,19 @@ thread_local! {
     static BUTTON_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    TAP_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-visionos/src/widgets/calendar.rs
+++ b/crates/perry-ui-visionos/src/widgets/calendar.rs
@@ -27,6 +27,14 @@ thread_local! {
     static CALENDAR_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_calendar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALENDAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryCalendarTargetVisionOSIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-visionos/src/widgets/combobox.rs
+++ b/crates/perry-ui-visionos/src/widgets/combobox.rs
@@ -40,6 +40,14 @@ thread_local! {
     static COMBOBOX_DELEGATES: RefCell<HashMap<i64, Retained<PerryComboboxDelegate>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_combobox_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    COMBOBOX_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn fire_callback(handle: i64, value: &str) {

--- a/crates/perry-ui-visionos/src/widgets/date_picker.rs
+++ b/crates/perry-ui-visionos/src/widgets/date_picker.rs
@@ -28,6 +28,14 @@ thread_local! {
     static DATEPICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_date_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DATEPICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryDatePickerTargetVisionOSIvars {
     pub handle: Cell<i64>,
 }

--- a/crates/perry-ui-visionos/src/widgets/mod.rs
+++ b/crates/perry-ui-visionos/src/widgets/mod.rs
@@ -688,6 +688,14 @@ thread_local! {
     static DOUBLE_CLICK_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_widgets_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DOUBLE_CLICK_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Set the enabled state of any UIControl-based widget.
 pub fn set_enabled(handle: i64, enabled: bool) {
     if let Some(view) = get_widget(handle) {

--- a/crates/perry-ui-visionos/src/widgets/rich_text.rs
+++ b/crates/perry-ui-visionos/src/widgets/rich_text.rs
@@ -30,6 +30,14 @@ thread_local! {
     static CHANGE_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_rich_text_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn ns_string_to_rust(ns: *mut AnyObject) -> String {

--- a/crates/perry-ui-visionos/src/widgets/scrollview.rs
+++ b/crates/perry-ui-visionos/src/widgets/scrollview.rs
@@ -30,6 +30,14 @@ thread_local! {
     static REFRESH_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    REFRESH_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryRefreshTargetIvars {
     callback_key: std::cell::Cell<usize>,
 }

--- a/crates/perry-ui-visionos/src/widgets/securefield.rs
+++ b/crates/perry-ui-visionos/src/widgets/securefield.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SECUREFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_securefield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SECUREFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-visionos/src/widgets/slider.rs
+++ b/crates/perry-ui-visionos/src/widgets/slider.rs
@@ -10,6 +10,14 @@ thread_local! {
     static SLIDER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-visionos/src/widgets/tabbar.rs
+++ b/crates/perry-ui-visionos/src/widgets/tabbar.rs
@@ -52,6 +52,14 @@ thread_local! {
     static DELEGATE_MAP: RefCell<HashMap<usize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_tabbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TABBAR_STATE.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_change);
+        }
+    });
+}
+
 // ── UITabBarDelegate ─────────────────────────────────────────
 
 pub struct PerryTabBarDelegateIvars {

--- a/crates/perry-ui-visionos/src/widgets/textarea.rs
+++ b/crates/perry-ui-visionos/src/widgets/textarea.rs
@@ -10,6 +10,14 @@ thread_local! {
     static TEXTAREA_CALLBACKS: RefCell<HashMap<usize, (f64, *const AnyObject)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_textarea_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTAREA_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-visionos/src/widgets/textfield.rs
+++ b/crates/perry-ui-visionos/src/widgets/textfield.rs
@@ -10,6 +10,19 @@ thread_local! {
     static TEXTFIELD_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_textfield_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TEXTFIELD_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    SUBMIT_CALLBACKS.with(|callbacks| {
+        for (callback, _) in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-visionos/src/widgets/tree_view.rs
+++ b/crates/perry-ui-visionos/src/widgets/tree_view.rs
@@ -69,6 +69,14 @@ thread_local! {
     static TREES: RefCell<Vec<TreeEntry>> = const { RefCell::new(Vec::new()) };
 }
 
+pub(crate) fn scan_visionos_tree_view_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TREES.with(|trees| {
+        for tree in trees.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut tree.on_select);
+        }
+    });
+}
+
 fn rebuild_flat(entry_idx: usize) {
     let (root, expanded_snapshot) = TREES.with(|t| {
         let trees = t.borrow();

--- a/crates/perry-ui-visionos/src/widgets/webview.rs
+++ b/crates/perry-ui-visionos/src/widgets/webview.rs
@@ -37,6 +37,16 @@ thread_local! {
     static HANDLE_TO_KEY: RefCell<HashMap<i64, usize>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn nanbox_str(s: &str) -> f64 {

--- a/crates/perry-ui-visionos/src/widgets/wheel_picker.rs
+++ b/crates/perry-ui-visionos/src/widgets/wheel_picker.rs
@@ -16,6 +16,14 @@ thread_local! {
     static DELEGATES: RefCell<HashMap<i64, Retained<PerryWheelPickerDelegate>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_visionos_wheel_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-watchos/src/audio_playback.rs
+++ b/crates/perry-ui-watchos/src/audio_playback.rs
@@ -152,6 +152,23 @@ thread_local! {
     static WARNED_VARISPEED_FALLBACK: RefCell<bool> = RefCell::new(false);
 }
 
+pub(crate) fn scan_watchos_audio_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SOUNDS.with(|sounds| {
+        for sound in sounds.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = sound.on_loaded.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+    VOICES.with(|voices| {
+        for voice in voices.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = voice.on_ended.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================

--- a/crates/perry-ui-watchos/src/background.rs
+++ b/crates/perry-ui-watchos/src/background.rs
@@ -39,6 +39,14 @@ thread_local! {
     static HANDLERS: RefCell<HashMap<String, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_watchos_background_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    HANDLERS.with(|handlers| {
+        for handler in handlers.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(handler);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 unsafe fn invoke_handler(handler: f64) {

--- a/crates/perry-ui-watchos/src/gc.rs
+++ b/crates/perry-ui-watchos/src/gc.rs
@@ -1,0 +1,21 @@
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
+static GC_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui-watchos", scan_roots);
+    });
+}
+
+fn scan_roots(visitor: &mut GcRootVisitor<'_>) {
+    crate::audio_playback::scan_watchos_audio_playback_gc_roots(visitor);
+    crate::background::scan_watchos_background_gc_roots(visitor);
+    crate::media_playback::scan_watchos_media_playback_gc_roots(visitor);
+    crate::notifications::scan_watchos_notifications_gc_roots(visitor);
+    crate::state::scan_watchos_state_gc_roots(visitor);
+    crate::tree::scan_watchos_tree_gc_roots(visitor);
+}

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -11,6 +11,7 @@ pub mod audio;
 pub mod audio_playback;
 pub mod background;
 pub mod drag_drop;
+mod gc;
 pub mod haptics;
 pub mod media_playback;
 pub mod notifications;
@@ -36,6 +37,7 @@ pub fn cstring_from_header(ptr: *const u8) -> Option<CString> {
 
 #[no_mangle]
 pub extern "C" fn perry_ui_app_create(title_ptr: i64, width: f64, height: f64) -> i64 {
+    gc::ensure_registered();
     app::app_create(title_ptr as *const u8, width, height)
 }
 

--- a/crates/perry-ui-watchos/src/media_playback.rs
+++ b/crates/perry-ui-watchos/src/media_playback.rs
@@ -144,6 +144,19 @@ thread_local! {
     static END_OBSERVER_REGISTERED: RefCell<bool> = const { RefCell::new(false) };
 }
 
+pub(crate) fn scan_watchos_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-watchos/src/notifications.rs
+++ b/crates/perry-ui-watchos/src/notifications.rs
@@ -48,6 +48,14 @@ thread_local! {
     static TAP_DELEGATE: RefCell<Option<Retained<PerryNotificationDelegate>>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_watchos_notifications_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    ON_TAP_CALLBACK.with(|slot| {
+        if let Some(callback) = slot.borrow_mut().as_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub struct PerryNotificationDelegateIvars;
 
 define_class!(

--- a/crates/perry-ui-watchos/src/state.rs
+++ b/crates/perry-ui-watchos/src/state.rs
@@ -63,6 +63,24 @@ thread_local! {
     static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_watchos_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 fn is_nanboxed_string(value: f64) -> bool {

--- a/crates/perry-ui-watchos/src/tree.rs
+++ b/crates/perry-ui-watchos/src/tree.rs
@@ -176,6 +176,19 @@ thread_local! {
     static TREE_VERSION: Cell<u64> = Cell::new(0);
 }
 
+pub(crate) fn scan_watchos_tree_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    NODES.with(|nodes| {
+        for node in nodes.borrow_mut().iter_mut() {
+            if let Some(callback) = node.action_closure.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = node.on_change_closure.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 fn bump_version() {
     TREE_VERSION.with(|v| v.set(v.get().wrapping_add(1)));
 }

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -442,6 +442,7 @@ fn to_wide(s: &str) -> Vec<u16> {
 
 /// Create an app window. Returns app handle (1-based).
 pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
+    crate::gc::ensure_gc_scanner_registered();
     let title = unsafe { str_from_header(title_ptr) };
     let w = if width > 0.0 { width } else { 800.0 };
     let h = if height > 0.0 { height } else { 600.0 };
@@ -538,6 +539,36 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
             apps.len() as i64
         })
     }
+}
+
+pub(crate) fn scan_windows_app_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PENDING_SHORTCUTS.with(|shortcuts| {
+        for shortcut in shortcuts.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut shortcut.callback);
+        }
+    });
+    SHORTCUTS.with(|shortcuts| {
+        for shortcut in shortcuts.borrow_mut().iter_mut() {
+            visitor.visit_raw_const_ptr_slot(&mut shortcut.callback_ptr);
+        }
+    });
+    TIMERS.with(|timers| {
+        for timer in timers.borrow_mut().iter_mut() {
+            visitor.visit_raw_const_ptr_slot(&mut timer.callback_ptr);
+        }
+    });
+    for slot in [&ON_ACTIVATE_CALLBACK, &ON_TERMINATE_CALLBACK] {
+        slot.with(|slot| {
+            if let Some(callback) = slot.borrow_mut().as_mut() {
+                visitor.visit_raw_const_ptr_slot(callback);
+            }
+        });
+    }
+    GLOBAL_HOTKEY_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_raw_const_ptr_slot(callback);
+        }
+    });
 }
 
 /// Set the root widget of an app.

--- a/crates/perry-ui-windows/src/drag_drop.rs
+++ b/crates/perry-ui-windows/src/drag_drop.rs
@@ -129,6 +129,16 @@ thread_local! {
     static DRAG_SUBCLASSED: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
 }
 
+pub(crate) fn scan_windows_drag_drop_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [&DROP_CB, &DRAG_TEXT, &DRAG_FILE, &DRAG_URL] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn has_any_drag_source(key: usize) -> bool {
     DRAG_TEXT.with(|m| m.borrow().contains_key(&key))

--- a/crates/perry-ui-windows/src/gc.rs
+++ b/crates/perry-ui-windows/src/gc.rs
@@ -1,0 +1,39 @@
+use std::sync::Once;
+
+static GC_SCANNER_REGISTERED: Once = Once::new();
+
+pub(crate) fn ensure_gc_scanner_registered() {
+    perry_ui::ensure_gc_scanner_registered();
+    GC_SCANNER_REGISTERED.call_once(|| {
+        perry_ffi::gc_register_mutable_root_scanner_named(
+            "perry-ui-windows",
+            scan_windows_gc_roots,
+        );
+    });
+}
+
+fn scan_windows_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    crate::app::scan_windows_app_gc_roots(visitor);
+    crate::drag_drop::scan_windows_drag_drop_gc_roots(visitor);
+    crate::media_playback::scan_windows_media_playback_gc_roots(visitor);
+    crate::menu::scan_windows_menu_gc_roots(visitor);
+    crate::pointer::scan_windows_pointer_gc_roots(visitor);
+    crate::state::scan_windows_state_gc_roots(visitor);
+    crate::toolbar::scan_windows_toolbar_gc_roots(visitor);
+    crate::tray::scan_windows_tray_gc_roots(visitor);
+    crate::window::scan_windows_window_gc_roots(visitor);
+    crate::widgets::bottom_nav::scan_windows_bottom_nav_gc_roots(visitor);
+    crate::widgets::button::scan_windows_button_gc_roots(visitor);
+    crate::widgets::calendar::scan_windows_calendar_gc_roots(visitor);
+    crate::widgets::combobox::scan_windows_combobox_gc_roots(visitor);
+    crate::widgets::command_palette::scan_windows_command_palette_gc_roots(visitor);
+    crate::widgets::date_picker::scan_windows_date_picker_gc_roots(visitor);
+    crate::widgets::image_gallery::scan_windows_image_gallery_gc_roots(visitor);
+    crate::widgets::lazyvstack::scan_windows_lazyvstack_gc_roots(visitor);
+    crate::widgets::rich_text::scan_windows_rich_text_gc_roots(visitor);
+    crate::widgets::scrollview::scan_windows_scrollview_gc_roots(visitor);
+    crate::widgets::slider::scan_windows_slider_gc_roots(visitor);
+    crate::widgets::table::scan_windows_table_gc_roots(visitor);
+    crate::widgets::tree_view::scan_windows_tree_view_gc_roots(visitor);
+    crate::widgets::webview::scan_windows_webview_gc_roots(visitor);
+}

--- a/crates/perry-ui-windows/src/lib.rs
+++ b/crates/perry-ui-windows/src/lib.rs
@@ -9,6 +9,7 @@ pub mod dpi_compat;
 pub mod drag_drop;
 #[cfg(target_os = "windows")]
 pub mod dwm;
+mod gc;
 pub mod issue_552_stub;
 #[cfg(target_os = "windows")]
 pub mod keyboard;

--- a/crates/perry-ui-windows/src/media_playback.rs
+++ b/crates/perry-ui-windows/src/media_playback.rs
@@ -87,6 +87,19 @@ thread_local! {
     static PUMP_LAST_TICK_MS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
+pub(crate) fn scan_windows_media_playback_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    PLAYERS.with(|players| {
+        for player in players.borrow_mut().iter_mut().flatten() {
+            if let Some(callback) = player.on_state_change.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+            if let Some(callback) = player.on_time_update.as_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // String helpers
 // ---------------------------------------------------------------------------

--- a/crates/perry-ui-windows/src/menu.rs
+++ b/crates/perry-ui-windows/src/menu.rs
@@ -51,6 +51,21 @@ thread_local! {
     static PENDING_MENUBAR: RefCell<Option<i64>> = RefCell::new(None);
 }
 
+pub(crate) fn scan_windows_menu_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    MENUS.with(|menus| {
+        for menu in menus.borrow_mut().iter_mut() {
+            for item in &mut menu.items {
+                visitor.visit_raw_const_ptr_slot(&mut item.callback_ptr);
+            }
+        }
+    });
+    MENU_CALLBACKS.with(|callbacks| {
+        for (_, callback) in callbacks.borrow_mut().iter_mut() {
+            visitor.visit_raw_const_ptr_slot(callback);
+        }
+    });
+}
+
 /// Create a context menu. Returns menu handle (1-based).
 pub fn create() -> i64 {
     #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/pointer.rs
+++ b/crates/perry-ui-windows/src/pointer.rs
@@ -62,6 +62,22 @@ thread_local! {
     static HOVER_STATE: RefCell<HashMap<i64, bool>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_pointer_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    for callbacks in [
+        &MOUSE_DOWN_CB,
+        &MOUSE_UP_CB,
+        &MOUSE_MOVE_CB,
+        &HOVER_CB,
+        &CLICK_CB,
+    ] {
+        callbacks.with(|callbacks| {
+            for callback in callbacks.borrow_mut().values_mut() {
+                visitor.visit_nanbox_f64_slot(callback);
+            }
+        });
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn install_subclass(handle: i64) {
     let Some(hwnd) = crate::widgets::get_hwnd(handle) else {

--- a/crates/perry-ui-windows/src/state.rs
+++ b/crates/perry-ui-windows/src/state.rs
@@ -81,6 +81,24 @@ thread_local! {
     static TEXTFIELD_BINDINGS: RefCell<HashMap<i64, Vec<std::rc::Rc<TextFieldBinding>>>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_state_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    STATES.with(|states| {
+        for state in states.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.value);
+        }
+    });
+    FOR_EACH_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_nanbox_f64_slot(&mut binding.render_closure);
+        }
+    });
+    ON_CHANGE_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut().flatten() {
+            visitor.visit_raw_const_ptr_slot(&mut binding.callback_ptr);
+        }
+    });
+}
+
 /// Extract a &str from a *const StringHeader pointer.
 use perry_ffi::copy_string_from_raw as str_from_header;
 

--- a/crates/perry-ui-windows/src/toolbar.rs
+++ b/crates/perry-ui-windows/src/toolbar.rs
@@ -18,6 +18,16 @@ struct ToolbarItem {
     callback: f64,
 }
 
+pub(crate) fn scan_windows_toolbar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TOOLBARS.with(|toolbars| {
+        for items in toolbars.borrow_mut().values_mut() {
+            for item in items {
+                visitor.visit_nanbox_f64_slot(&mut item.callback);
+            }
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-windows/src/tray.rs
+++ b/crates/perry-ui-windows/src/tray.rs
@@ -76,6 +76,14 @@ thread_local! {
     static NEXT_TRAY_UID: std::cell::Cell<u32> = std::cell::Cell::new(1);
 }
 
+pub(crate) fn scan_windows_tray_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TRAYS.with(|trays| {
+        for tray in trays.borrow_mut().iter_mut() {
+            visitor.visit_raw_const_ptr_slot(&mut tray.callback_ptr);
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 fn to_wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()

--- a/crates/perry-ui-windows/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-windows/src/widgets/bottom_nav.rs
@@ -65,6 +65,14 @@ thread_local! {
     static ITEM_LOOKUP: RefCell<HashMap<u16, (i64, i64)>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_bottom_nav_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    NAVS.with(|navs| {
+        for nav in navs.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut nav.on_select);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/widgets/button.rs
+++ b/crates/perry-ui-windows/src/widgets/button.rs
@@ -59,6 +59,14 @@ thread_local! {
     static BTN_HWND_TO_HANDLE: RefCell<HashMap<isize, i64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_button_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    BUTTON_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_raw_const_ptr_slot(callback);
+        }
+    });
+}
+
 /// Create a Button. Returns widget handle.
 pub fn create(label_ptr: *const u8, on_press: f64) -> i64 {
     let label = unsafe { str_from_header(label_ptr) };

--- a/crates/perry-ui-windows/src/widgets/calendar.rs
+++ b/crates/perry-ui-windows/src/widgets/calendar.rs
@@ -41,6 +41,14 @@ thread_local! {
     static CALENDAR_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_calendar_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALENDAR_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 #[repr(C)]
 #[derive(Default, Copy, Clone)]

--- a/crates/perry-ui-windows/src/widgets/combobox.rs
+++ b/crates/perry-ui-windows/src/widgets/combobox.rs
@@ -44,6 +44,14 @@ thread_local! {
     static CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_combobox_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub fn create(initial_ptr: *const u8, on_change: f64) -> i64 {
     let initial = unsafe { str_from_header(initial_ptr) };
     let control_id = alloc_control_id();

--- a/crates/perry-ui-windows/src/widgets/command_palette.rs
+++ b/crates/perry-ui-windows/src/widgets/command_palette.rs
@@ -51,6 +51,14 @@ thread_local! {
     static POPUP: RefCell<Option<(HWND, HWND, HWND)>> = const { RefCell::new(None) };
 }
 
+pub(crate) fn scan_windows_command_palette_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    COMMANDS.with(|commands| {
+        for command in commands.borrow_mut().iter_mut() {
+            visitor.visit_nanbox_f64_slot(&mut command.on_run);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/widgets/date_picker.rs
+++ b/crates/perry-ui-windows/src/widgets/date_picker.rs
@@ -52,6 +52,14 @@ thread_local! {
     static DATEPICKER_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_date_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    DATEPICKER_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 #[repr(C)]
 #[derive(Default, Copy, Clone)]

--- a/crates/perry-ui-windows/src/widgets/image_gallery.rs
+++ b/crates/perry-ui-windows/src/widgets/image_gallery.rs
@@ -38,6 +38,14 @@ thread_local! {
     static GALLERIES: RefCell<HashMap<i64, GalleryEntry>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_image_gallery_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    GALLERIES.with(|galleries| {
+        for gallery in galleries.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut gallery.on_index_change);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/widgets/lazyvstack.rs
+++ b/crates/perry-ui-windows/src/widgets/lazyvstack.rs
@@ -19,6 +19,14 @@ thread_local! {
     static LAZYVSTACK_STATES: RefCell<HashMap<i64, LazyVStackState>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_lazyvstack_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    LAZYVSTACK_STATES.with(|stacks| {
+        for stack in stacks.borrow_mut().values_mut() {
+            visitor.visit_raw_const_ptr_slot(&mut stack.render_closure);
+        }
+    });
+}
+
 /// Create a LazyVStack that renders `count` items using a closure.
 /// Returns the outer scrollview handle (which is the LazyVStack handle).
 /// count = number of items, render_closure = NaN-boxed closure(index) -> widget handle.

--- a/crates/perry-ui-windows/src/widgets/rich_text.rs
+++ b/crates/perry-ui-windows/src/widgets/rich_text.rs
@@ -100,6 +100,14 @@ thread_local! {
     static CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_rich_text_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 pub fn create(width: f64, height: f64, on_change: f64) -> i64 {
     let control_id = alloc_control_id();
 

--- a/crates/perry-ui-windows/src/widgets/scrollview.rs
+++ b/crates/perry-ui-windows/src/widgets/scrollview.rs
@@ -43,6 +43,14 @@ struct ScrollEndEntry {
     armed: bool,
 }
 
+pub(crate) fn scan_windows_scrollview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SCROLL_END_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.closure);
+        }
+    });
+}
+
 extern "C" {
     fn js_closure_call0(closure: *const u8) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;

--- a/crates/perry-ui-windows/src/widgets/slider.rs
+++ b/crates/perry-ui-windows/src/widgets/slider.rs
@@ -34,6 +34,14 @@ thread_local! {
     static SLIDER_INFO: RefCell<HashMap<i64, SliderInfo>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_slider_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    SLIDER_INFO.with(|sliders| {
+        for slider in sliders.borrow_mut().values_mut() {
+            visitor.visit_raw_const_ptr_slot(&mut slider.callback_ptr);
+        }
+    });
+}
+
 /// TBM_GETPOS is not exported by the windows crate 0.58 — define it manually.
 /// WM_USER (0x0400) + 0 = 1024
 #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/widgets/table.rs
+++ b/crates/perry-ui-windows/src/widgets/table.rs
@@ -83,6 +83,16 @@ thread_local! {
     static TABLE_LAYOUT_IN_PROGRESS: Cell<bool> = const { Cell::new(false) };
 }
 
+pub(crate) fn scan_windows_table_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    TABLES.with(|tables| {
+        for table in tables.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut table.render_closure);
+            visitor.visit_nanbox_f64_slot(&mut table.select_closure);
+            visitor.visit_nanbox_f64_slot(&mut table.sort_closure);
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 const TABLE_SUBCLASS_ID: usize = 0x6616;
 

--- a/crates/perry-ui-windows/src/widgets/tree_view.rs
+++ b/crates/perry-ui-windows/src/widgets/tree_view.rs
@@ -36,6 +36,14 @@ thread_local! {
     static CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_tree_view_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 #[cfg(target_os = "windows")]

--- a/crates/perry-ui-windows/src/widgets/webview.rs
+++ b/crates/perry-ui-windows/src/widgets/webview.rs
@@ -166,6 +166,16 @@ thread_local! {
         RefCell::new(std::collections::HashSet::new());
 }
 
+pub(crate) fn scan_windows_webview_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    WEBVIEW_STATES.with(|states| {
+        for state in states.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(&mut state.on_should_navigate);
+            visitor.visit_nanbox_f64_slot(&mut state.on_loaded);
+            visitor.visit_nanbox_f64_slot(&mut state.on_error);
+        }
+    });
+}
+
 #[cfg(target_os = "windows")]
 const WEBVIEW_SUBCLASS_ID: usize = 0x77_76_69_77; // 'w','v','i','w'
 

--- a/crates/perry-ui-windows/src/window.rs
+++ b/crates/perry-ui-windows/src/window.rs
@@ -341,6 +341,14 @@ thread_local! {
     pub(crate) static FOCUS_LOST_CALLBACKS: RefCell<HashMap<i64, f64>> = RefCell::new(HashMap::new());
 }
 
+pub(crate) fn scan_windows_window_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    FOCUS_LOST_CALLBACKS.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+}
+
 /// Hide a window without destroying it.
 pub fn hide(window_handle: i64) {
     #[cfg(target_os = "windows")]

--- a/crates/perry-ui/Cargo.toml
+++ b/crates/perry-ui/Cargo.toml
@@ -11,4 +11,5 @@ workspace = true
 crate-type = ["rlib"]
 
 [dependencies]
+perry-ffi.workspace = true
 perry-ui-model.workspace = true

--- a/crates/perry-ui/src/key_dispatch.rs
+++ b/crates/perry-ui/src/key_dispatch.rs
@@ -222,3 +222,30 @@ fn dispatch(callback: f64, code: KeyCode, mods: u32, is_down: bool, is_repeat: b
         }
     }
 }
+
+pub(crate) fn scan_key_dispatch_gc_roots(visitor: &mut perry_ffi::GcRootVisitor<'_>) {
+    KEY_DOWN_CB.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+    KEY_UP_CB.with(|callbacks| {
+        for callback in callbacks.borrow_mut().values_mut() {
+            visitor.visit_nanbox_f64_slot(callback);
+        }
+    });
+
+    for slot in [
+        &APP_KEY_DOWN_CB,
+        &APP_KEY_UP_CB,
+        &ACTIVE_DOWN_CB,
+        &ACTIVE_UP_CB,
+    ] {
+        slot.with(|callback| {
+            let mut value = callback.get();
+            if visitor.visit_nanbox_f64_slot(&mut value) {
+                callback.set(value);
+            }
+        });
+    }
+}

--- a/crates/perry-ui/src/lib.rs
+++ b/crates/perry-ui/src/lib.rs
@@ -4,6 +4,26 @@ pub mod state;
 pub mod styling_matrix;
 pub mod widget;
 
+use std::sync::Once;
+
+use perry_ffi::{gc_register_mutable_root_scanner_named, GcRootVisitor};
+
 pub use keys::{KeyCode, KEY_TABLE};
 pub use state::StateId;
 pub use widget::{WidgetHandle, WidgetKind};
+
+static GC_REGISTERED: Once = Once::new();
+
+/// Register roots owned by the platform-independent UI dispatcher.
+///
+/// Platform backends call this from their own GC registration path before
+/// they retain any user callback.
+pub fn ensure_gc_scanner_registered() {
+    GC_REGISTERED.call_once(|| {
+        gc_register_mutable_root_scanner_named("perry-ui", scan_gc_roots);
+    });
+}
+
+fn scan_gc_roots(visitor: &mut GcRootVisitor<'_>) {
+    key_dispatch::scan_key_dispatch_gc_roots(visitor);
+}

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -465,9 +465,1263 @@
       "name": "WS_CONNECTIONS",
       "verdict": "not_a_gc_pointer",
       "why": "Keyed by ws id; WsConnection is Rust-owned (command sender, buffered message Strings, state flags). Listener closures live in WS_CLIENT_LISTENERS, which scan_ws_roots_mut visits."
+    },
+    {
+      "file": "crates/perry-ui-android/src/app.rs",
+      "name": "PENDING_CONFIG",
+      "verdict": "not_a_gc_pointer",
+      "why": "AppConfig is pre-launch native UI configuration: Rust strings, dimensions, flags, and widget handles; it retains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/callback.rs",
+      "name": "NEXT_KEY",
+      "verdict": "not_a_gc_pointer",
+      "why": "NEXT_KEY is a monotonic numeric id/counter used to address native or callback-registry state; it is never a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/drag_drop.rs",
+      "name": "DRAG_KEYS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/menu.rs",
+      "name": "CONTEXT_MENUS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Context-menu bindings map native widget handles to numeric menu handles only; callbacks are rooted separately."
+    },
+    {
+      "file": "crates/perry-ui-android/src/menu.rs",
+      "name": "MENUS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Android menu entries retain Rust titles and numeric keys into the scanned global CALLBACKS registry; they do not retain callback bits."
+    },
+    {
+      "file": "crates/perry-ui-android/src/pointer.rs",
+      "name": "KEYS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/sheet.rs",
+      "name": "SHEETS",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of sheet.rs:SHEETS (RefCell<HashMap<i64, SheetState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-android/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-android/src/system.rs",
+      "name": "NOTIFICATION_REMOTE_TOKEN_KEY",
+      "verdict": "not_a_gc_pointer",
+      "why": "NOTIFICATION_REMOTE_TOKEN_KEY is a monotonic numeric id/counter used to address native or callback-registry state; it is never a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/system.rs",
+      "name": "NOTIFICATION_TAP_KEY",
+      "verdict": "not_a_gc_pointer",
+      "why": "NOTIFICATION_TAP_KEY is a monotonic numeric id/counter used to address native or callback-registry state; it is never a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/toolbar.rs",
+      "name": "TOOLBARS",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of toolbar.rs:TOOLBARS (RefCell<HashMap<i64, ToolbarState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/bloomview.rs",
+      "name": "BLOOM_WINDOWS",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/bloomview.rs:BLOOM_WINDOWS (Mutex<Vec<(i64, i64)>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/bottom_nav.rs",
+      "name": "STATES",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/bottom_nav.rs:STATES (RefCell<HashMap<i64, BottomNavState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGE_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+      "name": "CANVAS_STATES",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/canvas.rs:CANVAS_STATES (LazyLock<Mutex<HashMap<i64, CanvasState>>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/image_gallery.rs",
+      "name": "STATES",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/image_gallery.rs:STATES (RefCell<HashMap<i64, GalleryState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/navstack.rs",
+      "name": "NAV_STATES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/scrollview.rs",
+      "name": "REFRESH_LAYOUTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/tabbar.rs",
+      "name": "TABBAR_STATE",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/tabbar.rs:TABBAR_STATE (RefCell<HashMap<i64, TabBarState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
+      "name": "TREE_NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
+      "name": "TREE_VIEWS",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of widgets/tree_view.rs:TREE_VIEWS (RefCell<HashMap<i64, TreeViewState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-android/src/window.rs",
+      "name": "WINDOWS",
+      "verdict": "not_a_gc_pointer",
+      "why": "A field-by-field audit of window.rs:WINDOWS (RefCell<HashMap<i64, WindowState>>) found only Rust-owned strings/collections, native objects or widget handles, and numeric UI state; no field accepts or preserves a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-geisterhand/src/chaos.rs",
+      "name": "EVENTS_FIRED",
+      "verdict": "not_a_gc_pointer",
+      "why": "EVENTS_FIRED is a monotonic numeric id/counter used to address native or callback-registry state; it is never a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/app.rs",
+      "name": "APPS",
+      "verdict": "not_a_gc_pointer",
+      "why": "App entries retain native window/application objects and scalar window configuration. Callback roots are kept in dedicated scanned tables."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/media_playback.rs",
+      "name": "CMD_RX",
+      "verdict": "not_a_gc_pointer",
+      "why": "MPRIS channel endpoint transports the private native Command enum (playback operations and scalar handles); no JavaScript value crosses it."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/media_playback.rs",
+      "name": "CMD_TX",
+      "verdict": "not_a_gc_pointer",
+      "why": "MPRIS channel endpoint transports the private native Command enum (playback operations and scalar handles); no JavaScript value crosses it."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/menu.rs",
+      "name": "MENUBARS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Menu-bar entries contain native menu objects, Rust titles, and numeric menu handles. Item callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+      "name": "CANVAS_COMMANDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+      "name": "CANVAS_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/chart.rs",
+      "name": "CHARTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Chart entries contain a chart kind, Rust labels/title, native handles, and numeric data points. The f64 values are plotted numbers, not JavaScript roots."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/mod.rs",
+      "name": "BORDER_STATE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/rich_tooltip.rs",
+      "name": "BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Rich-tooltip binding retains native UI objects, widget handles, and a numeric delay/token; it contains no JavaScript callback or heap value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/text_registry.rs",
+      "name": "TEXT_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/textfield.rs",
+      "name": "REGISTERED_ENTRIES",
+      "verdict": "not_a_gc_pointer",
+      "why": "List of numeric native text-field widget handles used by blur_all; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-gtk4/src/widgets/tree_view.rs",
+      "name": "NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/adaptive_layout.rs",
+      "name": "LAST_SNAPSHOT",
+      "verdict": "not_a_gc_pointer",
+      "why": "Adaptive-layout snapshot copies native viewport dimensions, size class, orientation, and platform flags; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/app.rs",
+      "name": "PENDING_CONFIG",
+      "verdict": "not_a_gc_pointer",
+      "why": "AppConfig is pre-launch native UI configuration: Rust strings, dimensions, flags, and widget handles; it retains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/audio_playback.rs",
+      "name": "BUSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Audio BusEntry values contain native mixer nodes and scalar volume/mute/solo state. JavaScript callbacks live only in scanned sound and voice entries."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/audio_playback.rs",
+      "name": "FADES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Fade entries contain playback/bus handles and numeric envelope progress; they never store JavaScript values or GC heap pointers."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/background.rs",
+      "name": "REGISTERED_BLOCKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Objective-C blocks capture stable Rust/native identifiers for OS delivery. JavaScript callbacks remain in the separately scanned HANDLERS table."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/menu.rs",
+      "name": "MENUBARS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Menu-bar entries contain native menu objects, Rust titles, and numeric menu handles. Item callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/network.rs",
+      "name": "MONITOR_BLOCK",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Network.framework monitor block captures only native monitor state; JavaScript listeners are held in and rewritten through LISTENERS."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/notifications.rs",
+      "name": "NEXT_COMPLETION_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "NEXT_COMPLETION_HANDLE is a monotonic numeric id/counter used to address native or callback-registry state; it is never a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/notifications.rs",
+      "name": "PENDING_COMPLETIONS",
+      "verdict": "not_a_gc_pointer",
+      "why": "The table owns OS-provided notification completion blocks with integer arguments, not JavaScript closures."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/pointer.rs",
+      "name": "INSTALLED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Set of numeric widget handles whose native hook or behavior is installed; no JavaScript value is stored."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/pointer.rs",
+      "name": "RECOG_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/bottom_nav.rs",
+      "name": "DELEGATE_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+      "name": "CANVAS_COMMANDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGES",
+      "verdict": "not_a_gc_pointer",
+      "why": "CanvasImage owns native image objects and decoded raster dimensions only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+      "name": "CANVAS_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/chart.rs",
+      "name": "CHARTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Chart entries contain a chart kind, Rust labels/title, native handles, and numeric data points. The f64 values are plotted numbers, not JavaScript roots."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/image_gallery.rs",
+      "name": "DELEGATE_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/navstack.rs",
+      "name": "NAV_STACKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/picker.rs",
+      "name": "PICKER_SELECTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Picker selection cache stores only numeric widget handles and selected row indices."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/rich_tooltip.rs",
+      "name": "BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Rich-tooltip binding retains native UI objects, widget handles, and a numeric delay/token; it contains no JavaScript callback or heap value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
+      "name": "SCROLL_MUTATION_GATE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Scroll mutation gate is native reentrancy/bookkeeping state made of widget handles and boolean/counter fields."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/tabbar.rs",
+      "name": "DELEGATE_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/tree_view.rs",
+      "name": "NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-ios/src/widgets/wheel_picker.rs",
+      "name": "SELECTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Picker selection cache stores only numeric widget handles and selected row indices."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/app.rs",
+      "name": "APPS",
+      "verdict": "not_a_gc_pointer",
+      "why": "App entries retain native window/application objects and scalar window configuration. Callback roots are kept in dedicated scanned tables."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/audio_playback.rs",
+      "name": "BUSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Audio BusEntry values contain native mixer nodes and scalar volume/mute/solo state. JavaScript callbacks live only in scanned sound and voice entries."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/audio_playback.rs",
+      "name": "FADES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Fade entries contain playback/bus handles and numeric envelope progress; they never store JavaScript values or GC heap pointers."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/background.rs",
+      "name": "REGISTERED_BLOCKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Objective-C blocks capture stable Rust/native identifiers for OS delivery. JavaScript callbacks remain in the separately scanned HANDLERS table."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/network.rs",
+      "name": "MONITOR_BLOCK",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Network.framework monitor block captures only native monitor state; JavaScript listeners are held in and rewritten through LISTENERS."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/pointer.rs",
+      "name": "MOVE_DEDUP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Pointer-motion deduplication cache stores native x/y coordinates; its f64 values are geometry scalars."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "TEXTFIELD_TO_BINDING",
+      "verdict": "not_a_gc_pointer",
+      "why": "Reverse index of native text-field handles to Rust TextFieldBinding records; neither side contains a JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/bottom_nav.rs",
+      "name": "TARGET_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+      "name": "CANVAS_COMMANDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGES",
+      "verdict": "not_a_gc_pointer",
+      "why": "CanvasImage owns native image objects and decoded raster dimensions only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+      "name": "CANVAS_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/chart.rs",
+      "name": "CHARTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Chart entries contain a chart kind, Rust labels/title, native handles, and numeric data points. The f64 values are plotted numbers, not JavaScript roots."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/image_gallery.rs",
+      "name": "OBSERVER_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
+      "name": "SCROLL_END_OBSERVER_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+      "name": "BG_COLOR_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
+      "name": "PARENT_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/navstack.rs",
+      "name": "NAV_STACKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/rich_tooltip.rs",
+      "name": "BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Rich-tooltip binding retains native UI objects, widget handles, and a numeric delay/token; it contains no JavaScript callback or heap value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/scrollview.rs",
+      "name": "SCROLL_END_OBSERVER_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/tree_view.rs",
+      "name": "NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-macos/src/widgets/zstack.rs",
+      "name": "ZSTACK_HANDLES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Set of numeric widget handles whose native hook or behavior is installed; no JavaScript value is stored."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/app.rs",
+      "name": "PENDING_CONFIG",
+      "verdict": "not_a_gc_pointer",
+      "why": "AppConfig is pre-launch native UI configuration: Rust strings, dimensions, flags, and widget handles; it retains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+      "name": "BUSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Audio BusEntry values contain native mixer nodes and scalar volume/mute/solo state. JavaScript callbacks live only in scanned sound and voice entries."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
+      "name": "FADES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Fade entries contain playback/bus handles and numeric envelope progress; they never store JavaScript values or GC heap pointers."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/background.rs",
+      "name": "REGISTERED_BLOCKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Objective-C blocks capture stable Rust/native identifiers for OS delivery. JavaScript callbacks remain in the separately scanned HANDLERS table."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/menu.rs",
+      "name": "MENUBARS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Menu-bar entries contain native menu objects, Rust titles, and numeric menu handles. Item callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/pointer.rs",
+      "name": "INSTALLED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Set of numeric widget handles whose native hook or behavior is installed; no JavaScript value is stored."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/pointer.rs",
+      "name": "RECOG_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/bottom_nav.rs",
+      "name": "DELEGATE_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+      "name": "CANVAS_COMMANDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGES",
+      "verdict": "not_a_gc_pointer",
+      "why": "CanvasImage owns native image objects and decoded raster dimensions only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+      "name": "CANVAS_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/navstack.rs",
+      "name": "NAV_STACKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/picker.rs",
+      "name": "PICKER_SELECTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Picker selection cache stores only numeric widget handles and selected row indices."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/tabbar.rs",
+      "name": "DELEGATE_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-tvos/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/app.rs",
+      "name": "PENDING_CONFIG",
+      "verdict": "not_a_gc_pointer",
+      "why": "AppConfig is pre-launch native UI configuration: Rust strings, dimensions, flags, and widget handles; it retains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+      "name": "BUSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Audio BusEntry values contain native mixer nodes and scalar volume/mute/solo state. JavaScript callbacks live only in scanned sound and voice entries."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
+      "name": "FADES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Fade entries contain playback/bus handles and numeric envelope progress; they never store JavaScript values or GC heap pointers."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/background.rs",
+      "name": "REGISTERED_BLOCKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Retained Objective-C blocks capture stable Rust/native identifiers for OS delivery. JavaScript callbacks remain in the separately scanned HANDLERS table."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/menu.rs",
+      "name": "MENUBARS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Menu-bar entries contain native menu objects, Rust titles, and numeric menu handles. Item callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/pointer.rs",
+      "name": "INSTALLED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Set of numeric widget handles whose native hook or behavior is installed; no JavaScript value is stored."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/pointer.rs",
+      "name": "RECOG_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/bottom_nav.rs",
+      "name": "DELEGATE_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+      "name": "CANVAS_COMMANDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGES",
+      "verdict": "not_a_gc_pointer",
+      "why": "CanvasImage owns native image objects and decoded raster dimensions only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+      "name": "CANVAS_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
+      "name": "IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/chart.rs",
+      "name": "CHARTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Chart entries contain a chart kind, Rust labels/title, native handles, and numeric data points. The f64 values are plotted numbers, not JavaScript roots."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/navstack.rs",
+      "name": "NAV_STACKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/picker.rs",
+      "name": "PICKER_SELECTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Picker selection cache stores only numeric widget handles and selected row indices."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/rich_tooltip.rs",
+      "name": "BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Rich-tooltip binding retains native UI objects, widget handles, and a numeric delay/token; it contains no JavaScript callback or heap value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/tabbar.rs",
+      "name": "DELEGATE_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/tree_view.rs",
+      "name": "NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-visionos/src/widgets/wheel_picker.rs",
+      "name": "SELECTED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Picker selection cache stores only numeric widget handles and selected row indices."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+      "name": "BUSES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Audio BusEntry values contain native mixer nodes and scalar volume/mute/solo state. JavaScript callbacks live only in scanned sound and voice entries."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
+      "name": "FADES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Fade entries contain playback/bus handles and numeric envelope progress; they never store JavaScript values or GC heap pointers."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-watchos/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/app.rs",
+      "name": "APPS",
+      "verdict": "not_a_gc_pointer",
+      "why": "App entries retain native window/application objects and scalar window configuration. Callback roots are kept in dedicated scanned tables."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/media_playback.rs",
+      "name": "Q",
+      "verdict": "not_a_gc_pointer",
+      "why": "The queued f64 is a numeric media-player handle paired with a WinRT transport-button enum, not a NaN-boxed JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/menu.rs",
+      "name": "CONTEXT_MENU_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Context-menu bindings map native widget handles to numeric menu handles only; callbacks are rooted separately."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "MULTI_TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MultiTextBinding contains a widget handle and TextPart values made only of Rust strings or numeric state ids."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "SLIDER_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "SliderBinding stores only the native slider widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "TEXTFIELD_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextFieldBinding stores a native text-field handle and a Rust reentrancy flag; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "TEXT_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "TextBinding stores widget handles plus Rust prefix/suffix strings; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "TOGGLE_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "ToggleBinding stores only the native toggle widget handle used for two-way updates."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/state.rs",
+      "name": "VISIBILITY_BINDINGS",
+      "verdict": "not_a_gc_pointer",
+      "why": "VisibilityBinding contains only numeric widget handles to show or hide."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/bottom_nav.rs",
+      "name": "ITEM_LOOKUP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/button.rs",
+      "name": "BTN_HWND_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/button.rs",
+      "name": "BUTTON_CONTENT",
+      "verdict": "not_a_gc_pointer",
+      "why": "Button presentation cache stores Rust text/icon paths and a numeric position enum; callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+      "name": "CANVAS_CMDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGE_CACHE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Image cache maps Rust source strings to numeric native image handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+      "name": "CANVAS_IMAGE_SIZES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Canvas size cache stores width/height drawing scalars keyed by numeric handles, not NaN-boxed JavaScript data."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
+      "name": "CANVAS_LAST_FRAME",
+      "verdict": "not_a_gc_pointer",
+      "why": "Draw-command buffers contain Rust strings/native image handles and numeric geometry, color, and stroke scalars, not JavaScript values."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/chart.rs",
+      "name": "CHARTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Chart entries contain a chart kind, Rust labels/title, native handles, and numeric data points. The f64 values are plotted numbers, not JavaScript roots."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/map_view.rs",
+      "name": "HWND_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/map_view.rs",
+      "name": "MAPS",
+      "verdict": "not_a_gc_pointer",
+      "why": "MapState contains latitude/longitude/span scalars, native WinRT map objects, Rust error text, and counters; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "BORDER_STATE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "BORDER_SUBCLASSED",
+      "verdict": "not_a_gc_pointer",
+      "why": "Set of numeric widget handles whose native hook or behavior is installed; no JavaScript value is stored."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "CORNER_RADII",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "HWND_MAP",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "OPACITY_VALUES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "PARENT_SHADOW_REGISTRY",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native shadow routing registry maps parent HWND identities to numeric Perry widget handles only."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "SHADOW_PARAMS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native styling cache contains widget handles and geometry, opacity, shadow, border, or RGBA f64 scalars only; it accepts no arbitrary JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
+      "name": "WIDGETS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Widget registry contains native HWND objects, layout/style scalars, and numeric child handles. JavaScript callbacks are kept in scanned tables."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/navstack.rs",
+      "name": "NAV_STACKS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Navigation state contains Rust page titles and numeric widget handles/indices only; no JavaScript value is retained."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/pdf_view.rs",
+      "name": "PDFS",
+      "verdict": "not_a_gc_pointer",
+      "why": "PDF state contains a Rust path, numeric page indices/counts, and a zoom scalar; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/rich_tooltip.rs",
+      "name": "TOOLTIPS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Rich-tooltip binding retains native UI objects, widget handles, and a numeric delay/token; it contains no JavaScript callback or heap value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/scrollview.rs",
+      "name": "SCROLL_STATES",
+      "verdict": "not_a_gc_pointer",
+      "why": "ScrollState contains native pixel offsets, viewport/content sizes, and an optional numeric child widget handle only."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/text.rs",
+      "name": "DECORATION_VALUES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text-decoration cache pairs numeric widget handles with an integer decoration enum; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/text.rs",
+      "name": "HWND_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/text_registry.rs",
+      "name": "TEXT_IDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Text registry maps Rust string ids to numeric native widget handles; it contains no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/tree_view.rs",
+      "name": "NODES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Tree node storage contains Rust ids/labels and numeric child-node handles only; selection callbacks live in separately scanned storage."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/widgets/webview.rs",
+      "name": "HWND_TO_HANDLE",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/window.rs",
+      "name": "HWND_TO_WINDOW",
+      "verdict": "not_a_gc_pointer",
+      "why": "Native event-routing index made only of observer/control identities, callback-registry keys, and numeric Perry widget handles; it stores no JavaScript value."
+    },
+    {
+      "file": "crates/perry-ui-windows/src/window.rs",
+      "name": "WINDOW_ROOTS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Window-root registry maps numeric window handles to numeric root-widget handles; neither value is a JavaScript heap pointer."
     }
   ],
-  "_FRONTIER_README": "Identity-pinned ratchet over the perry-ui* crates and otherwise-unclassified core perry_thread_local! declarations (see the census docstring, 'The identity-pinned frontier'). Entries are debt baselines, not verdicts. A new uncovered holder fails until deliberately pinned, and a fixed holder fails until its stale entry is deleted. An optional scanner names cross-file coverage and must remain registered; deleting that registration invalidates the pin and fails the gate. Covered same-file holders must NOT be pinned.",
+  "_FRONTIER_README": "Identity-pinned debt ratchet over new perry-ui* candidates and otherwise-unclassified core perry_thread_local! declarations (see the census docstring, \u201cThe identity-pinned frontier\u201d). A new uncovered holder fails until it is scanned, receives a researched holders verdict, or is deliberately pinned as debt. Moving a researched false positive to holders graduates it from this list. A fixed or classified holder makes its old frontier pin stale, so the receipt must be deleted.",
   "frontier": [
     {
       "file": "crates/perry-runtime/src/array/element_shape.rs",
@@ -1113,1878 +2367,6 @@
     {
       "file": "crates/perry-runtime/src/yoga.rs",
       "name": "GC_SCANNER_REGISTERED"
-    },
-    {
-      "file": "crates/perry-ui-android/src/app.rs",
-      "name": "ON_ACTIVATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-android/src/app.rs",
-      "name": "ON_TERMINATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-android/src/app.rs",
-      "name": "PENDING_CONFIG"
-    },
-    {
-      "file": "crates/perry-ui-android/src/callback.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/callback.rs",
-      "name": "NEXT_KEY"
-    },
-    {
-      "file": "crates/perry-ui-android/src/drag_drop.rs",
-      "name": "DRAG_KEYS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/menu.rs",
-      "name": "CONTEXT_MENUS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/menu.rs",
-      "name": "MENUS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/pointer.rs",
-      "name": "KEYS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/sheet.rs",
-      "name": "SHEETS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "ON_CHANGE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/system.rs",
-      "name": "NOTIFICATION_REMOTE_TOKEN_KEY"
-    },
-    {
-      "file": "crates/perry-ui-android/src/system.rs",
-      "name": "NOTIFICATION_TAP_KEY"
-    },
-    {
-      "file": "crates/perry-ui-android/src/toolbar.rs",
-      "name": "TOOLBARS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/bloomview.rs",
-      "name": "BLOOM_WINDOWS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/bottom_nav.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGE_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
-      "name": "CANVAS_STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/image_gallery.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/lazyvstack.rs",
-      "name": "LAZY_STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/navstack.rs",
-      "name": "NAV_STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/picker.rs",
-      "name": "PICKER_STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/scrollview.rs",
-      "name": "REFRESH_LAYOUTS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/tabbar.rs",
-      "name": "TABBAR_STATE"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
-      "name": "TREE_NODES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/tree_view.rs",
-      "name": "TREE_VIEWS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/webview.rs",
-      "name": "EVAL_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-android/src/window.rs",
-      "name": "WINDOWS"
-    },
-    {
-      "file": "crates/perry-ui-android/src/ws.rs",
-      "name": "PENDING_RESOLVES"
-    },
-    {
-      "file": "crates/perry-ui-geisterhand/src/chaos.rs",
-      "name": "EVENTS_FIRED"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "APPS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "ON_ACTIVATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "ON_TERMINATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "PENDING_SHORTCUTS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "SHORTCUT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/app.rs",
-      "name": "TIMER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/audio.rs",
-      "name": "AUDIO_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/camera.rs",
-      "name": "CAMERA_VIEWS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
-      "name": "DRAG_FILE"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
-      "name": "DRAG_TEXT"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
-      "name": "DRAG_URL"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/drag_drop.rs",
-      "name": "DROP_CB"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs",
-      "name": "RESIZE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/media_playback.rs",
-      "name": "CMD_RX"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/media_playback.rs",
-      "name": "CMD_TX"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/menu.rs",
-      "name": "MENUBARS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/menu.rs",
-      "name": "MENUS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/menu.rs",
-      "name": "MENU_ITEM_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "ON_CHANGE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/toolbar.rs",
-      "name": "TOOLBAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/tray.rs",
-      "name": "TRAYS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/bottom_nav.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/button.rs",
-      "name": "BUTTON_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
-      "name": "CANVAS_COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
-      "name": "CANVAS_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/chart.rs",
-      "name": "CHARTS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/command_palette.rs",
-      "name": "STATE"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/image_gallery.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/lazyvstack.rs",
-      "name": "LAZY_VSTACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/mod.rs",
-      "name": "BORDER_STATE"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/picker.rs",
-      "name": "PICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/rich_tooltip.rs",
-      "name": "BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/scrollview.rs",
-      "name": "SCROLL_END_STATES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/securefield.rs",
-      "name": "SECUREFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/slider.rs",
-      "name": "SLIDER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/text_registry.rs",
-      "name": "TEXT_REGISTRY"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/textarea.rs",
-      "name": "TEXTAREA_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/textfield.rs",
-      "name": "REGISTERED_ENTRIES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/toggle.rs",
-      "name": "TOGGLE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/tree_view.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-gtk4/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/adaptive_layout.rs",
-      "name": "LAST_SNAPSHOT"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/adaptive_layout.rs",
-      "name": "LISTENERS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/app.rs",
-      "name": "PENDING_CONFIG"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/app.rs",
-      "name": "TIMER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/audio_playback.rs",
-      "name": "BUSES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/audio_playback.rs",
-      "name": "FADES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/audio_playback.rs",
-      "name": "SOUNDS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/audio_playback.rs",
-      "name": "VOICES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/background.rs",
-      "name": "HANDLERS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/background.rs",
-      "name": "REGISTERED_BLOCKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/camera.rs",
-      "name": "TAP_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/deeplinks.rs",
-      "name": "HANDLER"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/drag_drop.rs",
-      "name": "DRAG_FILE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/drag_drop.rs",
-      "name": "DRAG_TEXT"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/drag_drop.rs",
-      "name": "DRAG_URL"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/drag_drop.rs",
-      "name": "DROP_CB"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/geolocation.rs",
-      "name": "PENDING_ONE_SHOTS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/geolocation.rs",
-      "name": "PERMISSION_REQUESTS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/geolocation.rs",
-      "name": "WATCHES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/location.rs",
-      "name": "LOCATION_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/menu.rs",
-      "name": "ACTION_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/menu.rs",
-      "name": "MENUBARS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/menu.rs",
-      "name": "MENUS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/network.rs",
-      "name": "LISTENERS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/network.rs",
-      "name": "MONITOR_BLOCK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "NEXT_COMPLETION_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "ON_BACKGROUND_RECEIVE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "ON_REMOTE_RECEIVE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "ON_REMOTE_TOKEN_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "ON_TAP_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/notifications.rs",
-      "name": "PENDING_COMPLETIONS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/pointer.rs",
-      "name": "INSTALLED"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/pointer.rs",
-      "name": "MOUSE_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/pointer.rs",
-      "name": "MOUSE_MOVE_CB"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/pointer.rs",
-      "name": "MOUSE_UP_CB"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/pointer.rs",
-      "name": "RECOG_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "DEFERRED_REBUILDS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "ON_CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/bottom_nav.rs",
-      "name": "DELEGATE_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/bottom_nav.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/button.rs",
-      "name": "BUTTON_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/button.rs",
-      "name": "TAP_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/calendar.rs",
-      "name": "CALENDAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
-      "name": "CANVAS_COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
-      "name": "CANVAS_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/chart.rs",
-      "name": "CHARTS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/combobox.rs",
-      "name": "COMBOBOX_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/date_picker.rs",
-      "name": "DATEPICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/image_gallery.rs",
-      "name": "DELEGATE_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/image_gallery.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/mod.rs",
-      "name": "DOUBLE_CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/navstack.rs",
-      "name": "NAV_STACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/picker.rs",
-      "name": "PICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/picker.rs",
-      "name": "PICKER_SELECTED"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/rich_text.rs",
-      "name": "CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/rich_tooltip.rs",
-      "name": "BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
-      "name": "REFRESH_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
-      "name": "SCROLL_END_STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/scrollview.rs",
-      "name": "SCROLL_MUTATION_GATE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/securefield.rs",
-      "name": "SECUREFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/slider.rs",
-      "name": "SLIDER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/tabbar.rs",
-      "name": "DELEGATE_MAP"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/tabbar.rs",
-      "name": "TABBAR_STATE"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/textarea.rs",
-      "name": "TEXTAREA_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/textfield.rs",
-      "name": "SUBMIT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/toggle.rs",
-      "name": "TOGGLE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/tree_view.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/tree_view.rs",
-      "name": "TREES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/wheel_picker.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-ios/src/widgets/wheel_picker.rs",
-      "name": "SELECTED"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "APPS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "ON_ACTIVATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "ON_TERMINATE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "PENDING_SHORTCUTS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "SHORTCUT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "TIMER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/app.rs",
-      "name": "WINDOW_FOCUS_LOST_CBS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/audio_playback.rs",
-      "name": "BUSES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/audio_playback.rs",
-      "name": "FADES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/audio_playback.rs",
-      "name": "SOUNDS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/audio_playback.rs",
-      "name": "VOICES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/background.rs",
-      "name": "HANDLERS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/background.rs",
-      "name": "REGISTERED_BLOCKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/deeplinks.rs",
-      "name": "HANDLER"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/drag_drop.rs",
-      "name": "DRAG_FILE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/drag_drop.rs",
-      "name": "DRAG_TEXT"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/drag_drop.rs",
-      "name": "DRAG_URL"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/drag_drop.rs",
-      "name": "DROP_CB"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/geolocation.rs",
-      "name": "PENDING_ONE_SHOTS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/geolocation.rs",
-      "name": "PERMISSION_REQUESTS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/geolocation.rs",
-      "name": "WATCHES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/location.rs",
-      "name": "LOCATION_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/menu.rs",
-      "name": "MENU_ITEM_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/network.rs",
-      "name": "LISTENERS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/network.rs",
-      "name": "MONITOR_BLOCK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/notifications.rs",
-      "name": "ON_REMOTE_RECEIVE_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/notifications.rs",
-      "name": "ON_REMOTE_TOKEN_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/notifications.rs",
-      "name": "ON_TAP_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/pointer.rs",
-      "name": "HOVER_CB"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/pointer.rs",
-      "name": "MOUSE_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/pointer.rs",
-      "name": "MOUSE_MOVE_CB"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/pointer.rs",
-      "name": "MOUSE_UP_CB"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/pointer.rs",
-      "name": "MOVE_DEDUP"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "ON_CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "TEXTFIELD_TO_BINDING"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/tray.rs",
-      "name": "TRAY_CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/bottom_nav.rs",
-      "name": "BOTTOM_NAVS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/bottom_nav.rs",
-      "name": "TARGET_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/button.rs",
-      "name": "BUTTON_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/calendar.rs",
-      "name": "CALENDAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
-      "name": "CANVAS_COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
-      "name": "CANVAS_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/chart.rs",
-      "name": "CHARTS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/combobox.rs",
-      "name": "COMBOBOX_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/command_palette.rs",
-      "name": "COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/date_picker.rs",
-      "name": "DATEPICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/image_gallery.rs",
-      "name": "GALLERIES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/image_gallery.rs",
-      "name": "OBSERVER_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
-      "name": "LAZY_VSTACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
-      "name": "SCROLL_END_OBSERVER_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/lazyvstack.rs",
-      "name": "SCROLL_END_STATES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
-      "name": "BG_COLOR_MAP"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
-      "name": "CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
-      "name": "DOUBLE_CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
-      "name": "HOVER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/mod.rs",
-      "name": "PARENT_MAP"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/navstack.rs",
-      "name": "NAV_STACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/picker.rs",
-      "name": "PICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/rich_text.rs",
-      "name": "CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/rich_tooltip.rs",
-      "name": "BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/scrollview.rs",
-      "name": "SCROLL_END_OBSERVER_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/scrollview.rs",
-      "name": "SCROLL_END_STATES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/securefield.rs",
-      "name": "SECUREFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/slider.rs",
-      "name": "SLIDER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/table.rs",
-      "name": "TABLES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/textarea.rs",
-      "name": "TEXTAREA_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_FOCUS_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_SUBMIT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/toggle.rs",
-      "name": "TOGGLE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/toolbar.rs",
-      "name": "TOOLBARS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/toolbar.rs",
-      "name": "TOOLBAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/tree_view.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/tree_view.rs",
-      "name": "TREES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-macos/src/widgets/zstack.rs",
-      "name": "ZSTACK_HANDLES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/app.rs",
-      "name": "PENDING_CONFIG"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/app.rs",
-      "name": "TIMER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
-      "name": "BUSES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
-      "name": "FADES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
-      "name": "SOUNDS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/audio_playback.rs",
-      "name": "VOICES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/background.rs",
-      "name": "HANDLERS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/background.rs",
-      "name": "REGISTERED_BLOCKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/location.rs",
-      "name": "LOCATION_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/menu.rs",
-      "name": "ACTION_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/menu.rs",
-      "name": "MENUBARS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/menu.rs",
-      "name": "MENUS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/pointer.rs",
-      "name": "INSTALLED"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/pointer.rs",
-      "name": "MOUSE_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/pointer.rs",
-      "name": "MOUSE_MOVE_CB"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/pointer.rs",
-      "name": "MOUSE_UP_CB"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/pointer.rs",
-      "name": "RECOG_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "ON_CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/bottom_nav.rs",
-      "name": "DELEGATE_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/bottom_nav.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/button.rs",
-      "name": "BUTTON_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/button.rs",
-      "name": "TAP_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
-      "name": "CANVAS_COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
-      "name": "CANVAS_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/mod.rs",
-      "name": "DOUBLE_CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/navstack.rs",
-      "name": "NAV_STACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/picker.rs",
-      "name": "PICKER_SELECTED"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/scrollview.rs",
-      "name": "REFRESH_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/securefield.rs",
-      "name": "SECUREFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/slider.rs",
-      "name": "SLIDER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/tabbar.rs",
-      "name": "DELEGATE_MAP"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/tabbar.rs",
-      "name": "TABBAR_STATE"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/textarea.rs",
-      "name": "TEXTAREA_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/textfield.rs",
-      "name": "SUBMIT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-tvos/src/widgets/toggle.rs",
-      "name": "TOGGLE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/app.rs",
-      "name": "PENDING_CONFIG"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/app.rs",
-      "name": "TIMER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
-      "name": "BUSES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
-      "name": "FADES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
-      "name": "SOUNDS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/audio_playback.rs",
-      "name": "VOICES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/background.rs",
-      "name": "HANDLERS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/background.rs",
-      "name": "REGISTERED_BLOCKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/camera.rs",
-      "name": "TAP_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/drag_drop.rs",
-      "name": "DRAG_FILE"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/drag_drop.rs",
-      "name": "DRAG_TEXT"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/drag_drop.rs",
-      "name": "DRAG_URL"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/drag_drop.rs",
-      "name": "DROP_CB"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/location.rs",
-      "name": "LOCATION_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/menu.rs",
-      "name": "ACTION_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/menu.rs",
-      "name": "MENUBARS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/menu.rs",
-      "name": "MENUS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/pointer.rs",
-      "name": "INSTALLED"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/pointer.rs",
-      "name": "MOUSE_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/pointer.rs",
-      "name": "MOUSE_MOVE_CB"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/pointer.rs",
-      "name": "MOUSE_UP_CB"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/pointer.rs",
-      "name": "RECOG_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "ON_CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/bottom_nav.rs",
-      "name": "DELEGATE_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/bottom_nav.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/button.rs",
-      "name": "BUTTON_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/button.rs",
-      "name": "TAP_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/calendar.rs",
-      "name": "CALENDAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
-      "name": "CANVAS_COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
-      "name": "CANVAS_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/canvas.rs",
-      "name": "IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/chart.rs",
-      "name": "CHARTS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/combobox.rs",
-      "name": "COMBOBOX_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/date_picker.rs",
-      "name": "DATEPICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/mod.rs",
-      "name": "DOUBLE_CLICK_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/navstack.rs",
-      "name": "NAV_STACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/picker.rs",
-      "name": "PICKER_SELECTED"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/rich_text.rs",
-      "name": "CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/rich_tooltip.rs",
-      "name": "BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/scrollview.rs",
-      "name": "REFRESH_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/securefield.rs",
-      "name": "SECUREFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/slider.rs",
-      "name": "SLIDER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/tabbar.rs",
-      "name": "DELEGATE_MAP"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/tabbar.rs",
-      "name": "TABBAR_STATE"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/textarea.rs",
-      "name": "TEXTAREA_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/textfield.rs",
-      "name": "SUBMIT_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/textfield.rs",
-      "name": "TEXTFIELD_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/tree_view.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/tree_view.rs",
-      "name": "TREES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/wheel_picker.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-visionos/src/widgets/wheel_picker.rs",
-      "name": "SELECTED"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
-      "name": "BUSES"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
-      "name": "FADES"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
-      "name": "SOUNDS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/audio_playback.rs",
-      "name": "VOICES"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/background.rs",
-      "name": "HANDLERS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/notifications.rs",
-      "name": "ON_TAP_CALLBACK"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "ON_CHANGE_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/tree.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-watchos/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/app.rs",
-      "name": "APPS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/app.rs",
-      "name": "PENDING_SHORTCUTS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/drag_drop.rs",
-      "name": "DRAG_FILE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/drag_drop.rs",
-      "name": "DRAG_TEXT"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/drag_drop.rs",
-      "name": "DRAG_URL"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/drag_drop.rs",
-      "name": "DROP_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/media_playback.rs",
-      "name": "PLAYERS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/media_playback.rs",
-      "name": "Q"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/menu.rs",
-      "name": "CONTEXT_MENU_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/pointer.rs",
-      "name": "CLICK_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/pointer.rs",
-      "name": "HOVER_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/pointer.rs",
-      "name": "MOUSE_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/pointer.rs",
-      "name": "MOUSE_MOVE_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/pointer.rs",
-      "name": "MOUSE_UP_CB"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "FOR_EACH_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "MULTI_TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "SLIDER_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "STATES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "TEXTFIELD_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "TEXT_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "TOGGLE_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/state.rs",
-      "name": "VISIBILITY_BINDINGS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/toolbar.rs",
-      "name": "TOOLBARS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/tray.rs",
-      "name": "TRAYS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/bottom_nav.rs",
-      "name": "ITEM_LOOKUP"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/bottom_nav.rs",
-      "name": "NAVS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/button.rs",
-      "name": "BTN_HWND_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/button.rs",
-      "name": "BUTTON_CONTENT"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/calendar.rs",
-      "name": "CALENDAR_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
-      "name": "CANVAS_CMDS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGE_CACHE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
-      "name": "CANVAS_IMAGE_SIZES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/canvas.rs",
-      "name": "CANVAS_LAST_FRAME"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/chart.rs",
-      "name": "CHARTS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/combobox.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/command_palette.rs",
-      "name": "COMMANDS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/date_picker.rs",
-      "name": "DATEPICKER_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/image_gallery.rs",
-      "name": "GALLERIES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/lazyvstack.rs",
-      "name": "LAZYVSTACK_STATES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/map_view.rs",
-      "name": "HWND_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/map_view.rs",
-      "name": "MAPS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "BORDER_STATE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "BORDER_SUBCLASSED"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "CORNER_RADII"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "HWND_MAP"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "OPACITY_VALUES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "PARENT_SHADOW_REGISTRY"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "SHADOW_PARAMS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/mod.rs",
-      "name": "WIDGETS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/navstack.rs",
-      "name": "NAV_STACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/pdf_view.rs",
-      "name": "PDFS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/rich_text.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/rich_tooltip.rs",
-      "name": "TOOLTIPS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/scrollview.rs",
-      "name": "SCROLL_END_STATES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/scrollview.rs",
-      "name": "SCROLL_STATES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/slider.rs",
-      "name": "SLIDER_INFO"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/table.rs",
-      "name": "TABLES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/text.rs",
-      "name": "DECORATION_VALUES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/text.rs",
-      "name": "HWND_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/text_registry.rs",
-      "name": "TEXT_IDS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/tree_view.rs",
-      "name": "CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/tree_view.rs",
-      "name": "NODES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/webview.rs",
-      "name": "HWND_TO_HANDLE"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/widgets/webview.rs",
-      "name": "WEBVIEW_STATES"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/window.rs",
-      "name": "FOCUS_LOST_CALLBACKS"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/window.rs",
-      "name": "HWND_TO_WINDOW"
-    },
-    {
-      "file": "crates/perry-ui-windows/src/window.rs",
-      "name": "WINDOW_ROOTS"
-    },
-    {
-      "file": "crates/perry-ui/src/key_dispatch.rs",
-      "name": "KEY_DOWN_CB"
-    },
-    {
-      "file": "crates/perry-ui/src/key_dispatch.rs",
-      "name": "KEY_UP_CB"
     }
   ]
 }

--- a/scripts/gc_runtime_root_holders.py
+++ b/scripts/gc_runtime_root_holders.py
@@ -337,6 +337,15 @@ FN_DEF = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|extern\s+\"[^\"]*\"\s+)*fn\s+(\w+)"
 )
 IDENT = re.compile(r"\b[A-Za-z_]\w*\b")
+# Free/qualified function calls only. Method names must not enter the scanner
+# call graph: walking `.values_mut()`/`.iter_mut()` as though they were free
+# functions can reach unrelated same-named helpers and falsely certify a
+# holder that the scanner never mentions. The body of the scanner still
+# contains closure bodies, so direct holder visits such as
+# `TABLE.with(|table| ...)` remain visible to the per-file coverage check.
+CALLED_FUNCTION = re.compile(
+    r"(?<![.])\b([A-Za-z_]\w*)\s*(?:<[^(){};]*>)?\s*\("
+)
 
 # A declaration: `static NAME: TYPE =` — covers `pub(crate) static`, the bodies
 # of `thread_local!` blocks (which use the same syntax), `lazy_static!`'s
@@ -927,39 +936,48 @@ def scan(root: Path) -> tuple[list[dict], int, set[str]]:
         seeds.add(name)
         seed_files.setdefault(name, set()).update(p for p, _ in matched)
 
-    reachable: set[str] = set()
-    frontier = set(seeds)
-    # Files whose functions may be walked for a given reachable name. Root-level
-    # names are pinned to the registration's file(s); deeper hops are not
-    # (nothing in the text says which module a call resolved to), and the
-    # docstring says so.
-    for depth in range(MAX_SCANNER_DEPTH):
-        nxt: set[str] = set()
-        for name in frontier:
-            if name in reachable:
-                continue
-            reachable.add(name)
-            allowed = seed_files.get(name) if depth == 0 else None
+    def reachable_text(call_pattern: re.Pattern) -> dict[Path, str]:
+        reachable: set[str] = set()
+        frontier = set(seeds)
+        # Files whose functions may be walked for a given reachable name.
+        # Root-level names are pinned to the registration's file(s); deeper
+        # hops are not (nothing in the text says which module a call resolved
+        # to), and the docstring says so.
+        for depth in range(MAX_SCANNER_DEPTH):
+            nxt: set[str] = set()
+            for name in frontier:
+                if name in reachable:
+                    continue
+                reachable.add(name)
+                allowed = seed_files.get(name) if depth == 0 else None
+                for path, body in bodies.get(name, []):
+                    if allowed is not None and path not in allowed:
+                        continue
+                    if allowed is None and not crate_hosts_reachable_code(path):
+                        continue
+                    nxt.update(call_pattern.findall(body))
+            frontier = {n for n in nxt if n in bodies and n not in reachable}
+            if not frontier:
+                break
+
+        by_file: dict[Path, str] = {}
+        for name in reachable:
+            allowed = seed_files.get(name)
             for path, body in bodies.get(name, []):
                 if allowed is not None and path not in allowed:
                     continue
                 if allowed is None and not crate_hosts_reachable_code(path):
                     continue
-                nxt.update(IDENT.findall(body))
-        frontier = {n for n in nxt if n in bodies and n not in reachable}
-        if not frontier:
-            break
+                by_file[path] = by_file.get(path, "") + "\n" + body
+        return by_file
 
-    # per-file text of every reachable function defined in that file
-    reachable_text_by_file: dict[Path, str] = {}
-    for name in reachable:
-        allowed = seed_files.get(name)
-        for path, body in bodies.get(name, []):
-            if allowed is not None and path not in allowed:
-                continue
-            if allowed is None and not crate_hosts_reachable_code(path):
-                continue
-            reachable_text_by_file[path] = reachable_text_by_file.get(path, "") + "\n" + body
+    # The #8701 UI campaign needs the strict free-function graph: method
+    # names such as `.values_mut()` otherwise collide with unrelated helpers
+    # across the many ported backend crates and falsely certify UI tables. Keep
+    # the pre-existing conservative graph for older tiers so this focused
+    # campaign does not silently reclassify unrelated historical inventory.
+    reachable_text_by_file = reachable_text(CALLED_FUNCTION)
+    legacy_reachable_text_by_file = reachable_text(IDENT)
 
     # 3. classify declarations
     holders: list[dict] = []
@@ -970,7 +988,9 @@ def scan(root: Path) -> tuple[list[dict], int, set[str]]:
             declarations_in_perry_tls(text) if tier == "core" else set()
         )
         bodies_here = function_bodies(text)
-        covered_text = reachable_text_by_file.get(path, "")
+        covered_text = (
+            reachable_text_by_file if tier == "frontier" else legacy_reachable_text_by_file
+        ).get(path, "")
         if tier == "core":
             allocating_context = "\n".join(
                 body
@@ -1044,6 +1064,7 @@ def apply_frontier(
     holders: list[dict],
     frontier: list[dict],
     registered_scanners: set[str] | None = None,
+    classified_inventory: list[dict] | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """(new_unpinned, stale_entries) for the frontier ratchet.
 
@@ -1054,6 +1075,9 @@ def apply_frontier(
     then invalidates the pin instead of silently leaving it matched.
     """
     pinned = {(entry["file"], entry["name"]): entry for entry in frontier}
+    classified = {
+        (entry["file"], entry["name"]) for entry in (classified_inventory or [])
+    }
     used: set[tuple[str, str]] = set()
     unpinned: list[dict] = []
     for holder in holders:
@@ -1061,6 +1085,11 @@ def apply_frontier(
             continue
         key = (holder["file"], holder["name"])
         if holder["covered"]:
+            continue
+        if key in classified:
+            # A researched verdict graduates an identity-ratcheted candidate
+            # out of the debt-only frontier. apply_inventory validates and
+            # consumes the verdict; any old frontier pin becomes stale below.
             continue
         entry = pinned.get(key)
         required_scanner = (entry or {}).get("scanner")
@@ -1134,11 +1163,11 @@ def apply_inventory(
     used: set[tuple[str, str]] = set()
     unclassified: list[dict] = []
     for holder in holders:
-        if holder.get("ratchet", holder.get("tier", "core") == "frontier"):
-            continue  # ratcheted by apply_frontier, not verdict-gated
         if holder["covered"]:
             continue
         key = (holder["file"], holder["name"])
+        if holder.get("ratchet", holder.get("tier", "core") == "frontier") and key not in index:
+            continue  # unresolved frontier debt remains apply_frontier's responsibility
         if key in index:
             used.add(key)
         else:
@@ -1195,7 +1224,7 @@ def report(root: Path, quiet: bool = False) -> int:
     malformed = inventory_problems(inventory)
     frontier = load_frontier(INVENTORY_PATH)
     frontier_new, frontier_stale = apply_frontier(
-        holders, frontier, registered_scanners
+        holders, frontier, registered_scanners, inventory
     )
 
     status = 0
@@ -1364,6 +1393,22 @@ pub fn scan_dup_roots_mut(v: &mut V) { for p in DUP_A_TABLE.borrow_mut().iter_mu
     "crates/perry-runtime/src/dup_b.rs": """
 static DUP_B_TABLE: RefCell<Vec<*mut ObjectHeader>> = RefCell::new(Vec::new());
 pub fn scan_dup_roots_mut(v: &mut V) { for p in DUP_B_TABLE.borrow_mut().iter_mut() { v.visit(p); } }
+""",
+    # A method call must not be treated as a free helper call. Before #8701,
+    # `.values_mut()` reached this unrelated `fn values_mut` and falsely
+    # certified METHOD_COLLISION_TABLE even though the scanner never names it.
+    "crates/perry-ui-method/src/method_collision.rs": """
+static METHOD_COLLISION_TABLE: RefCell<Vec<*mut ObjectHeader>> = RefCell::new(Vec::new());
+fn values_mut(v: &mut V) {
+    for p in METHOD_COLLISION_TABLE.borrow_mut().iter_mut() { v.visit(p); }
+}
+fn ensure_registered() {
+    gc_register_mutable_root_scanner(scan_method_collision_roots_mut);
+}
+pub fn scan_method_collision_roots_mut(v: &mut V) {
+    let mut numeric = HashMap::<usize, usize>::new();
+    for value in numeric.values_mut() { *value += 1; }
+}
 """,
     # An ffi-side crate registering through the C-ABI trampoline. Exercises:
     # nested parens in the registration args (`SOURCE.as_ptr()`), an
@@ -1582,6 +1627,13 @@ def self_test() -> int:
         "function in a different module; registering dup_a's must not certify "
         "dup_b's holder",
     )
+    expect(
+        "crates/perry-ui-method/src/method_collision.rs",
+        "METHOD_COLLISION_TABLE",
+        False,
+        "a scanner method call named values_mut must not reach an unrelated free helper",
+        tier="frontier",
+    )
 
     # --- ffi-side shapes: the 2026-08 blind spot, planted -------------------
     expect(
@@ -1683,6 +1735,36 @@ def self_test() -> int:
         failures.append(
             "an exact frontier baseline still reported "
             f"{len(unpinned)} unpinned / {len(stale)} stale"
+        )
+    promoted = planted_frontier[0]
+    promoted_inventory = [
+        {
+            "file": promoted["file"],
+            "name": promoted["name"],
+            "verdict": "not_a_gc_pointer",
+            "why": "planted researched verdict for a frontier candidate",
+        }
+    ]
+    unclassified_promoted, stale_promoted = apply_inventory(
+        holders, promoted_inventory
+    )
+    if stale_promoted or any(
+        h["file"] == promoted["file"] and h["name"] == promoted["name"]
+        for h in unclassified_promoted
+    ):
+        failures.append("a researched frontier verdict was not consumed by the inventory")
+    promoted_new, promoted_frontier_stale = apply_frontier(
+        holders, exact_baseline, classified_inventory=promoted_inventory
+    )
+    if any(
+        h["file"] == promoted["file"] and h["name"] == promoted["name"]
+        for h in promoted_new
+    ) or not any(
+        e["file"] == promoted["file"] and e["name"] == promoted["name"]
+        for e in promoted_frontier_stale
+    ):
+        failures.append(
+            "graduating a frontier candidate to a verdict did not stale its debt pin"
         )
     _unpinned, stale = apply_frontier(
         holders,
@@ -1801,6 +1883,7 @@ def self_test() -> int:
         real_holders,
         load_frontier(INVENTORY_PATH),
         real_registered_scanners,
+        inventory,
     )
     if frontier_stale:
         failures.append(


### PR DESCRIPTION
Closes #8701

## Summary
- register one mutable GC root scanner for the shared dispatcher and every platform UI crate, visiting and rewriting every persisted JavaScript callback and state value
- keep GTK timers and macOS native blocks behind rewriteable keyed tables, cover the shared miniaudio callbacks, and add raw const-pointer slot visitation for Windows callbacks
- graduate all 474 UI census candidates: 265 are scanner-covered and 209 are audited non-GC holders; strengthen the census call-graph and promotion regressions

## Validation
- `python3 scripts/gc_runtime_root_holders.py --self-test`
- `python3 scripts/gc_runtime_root_holders.py` (zero UI frontier entries)
- `cargo test -p perry-ffi -- --test-threads=1`
- `cargo check -p perry-ffi -p perry-ui -p perry-ui-macos -p perry-audio-miniaudio`
- `cargo check -p perry-ui-ios --target aarch64-apple-ios`
- `cargo check -p perry-ui-tvos --target aarch64-apple-tvos`
- `cargo check -p perry-ui-visionos --target aarch64-apple-visionos`
- `cargo check -p perry-ui-watchos --target aarch64-apple-watchos`
- Android and Windows crates type-check for their cross targets with only the unavailable native miniaudio C compilation skipped
- GTK cross-check is blocked at the host dependency boundary because GStreamer development metadata is not installed

No package version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI stability by retaining JavaScript callbacks and state values across garbage collection on all native UI platforms.
  * Preserved callbacks used by timers, keyboard shortcuts, focus events, media playback, notifications, gestures, and UI widgets.
* **Documentation**
  * Added changelog coverage for the garbage-collection reliability improvements.
* **Tests**
  * Expanded validation for callback retention and garbage-collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->