### PR TITLE
fix(runtime): add acquire fence before dense subclass seqlock recheck

### DIFF
--- a/crates/perry-runtime/src/array/subclass.rs
+++ b/crates/perry-runtime/src/array/subclass.rs
@@ -81,7 +81,11 @@ fn cached_dense_layout(key: u64) -> Option<DenseSubclassLayout> {
     let slots = entry.slots.load(Ordering::Relaxed);
     let bounds = entry.bounds.load(Ordering::Relaxed);
     // Recheck the seqlock before interpreting either word so readers never
-    // combine payloads from two colliding publishers.
+    // combine payloads from two colliding publishers. The fence stops the
+    // relaxed payload loads above from being reordered past this recheck on
+    // weakly ordered targets - an Acquire load alone only orders what comes
+    // after it, not what precedes it in program order.
+    std::sync::atomic::fence(Ordering::Acquire);
     if entry.sequence.load(Ordering::Acquire) != sequence {
         return None;
     }


### PR DESCRIPTION
This fixes a data race in the dense-array subclass layout cache where a reader could combine fields from two different cache publishers and return a wrong element value instead of crashing.

<details>
<summary><strong>Root cause and fix</strong> - a relaxed payload read can be reordered past an acquire recheck on weakly-ordered hardware</summary>

`cached_dense_layout` reads two payload fields with relaxed ordering and then rechecks a sequence counter with an acquire load to make sure no writer touched the cache slot in between. An acquire load only holds back operations that come after it in the code, so it does nothing to stop the two payload reads that come before it from being reordered later by the CPU on weakly-ordered hardware like ARM. If a different cache key collides into the same slot and gets published while a reader is mid-read, the reader can end up combining one field from the old layout with the other field from the new layout. This adds an explicit acquire fence between the payload reads and the recheck, which is the standard fix for this kind of seqlock reader bug.

CodeRabbit originally flagged this exact issue on pull request `#8668`, which closed without the fix landing. This PR carries the same fix forward against current main.

`cargo check -p perry-runtime --lib` produces no diagnostics for `array/subclass.rs`. The crate currently fails to build for an unrelated, pre-existing reason: `perf_histogram.rs` calls `algebraic_sub`/`algebraic_mul` without the crate declaring `#![feature(float_algebraic)]`. I confirmed this is unrelated to this change by checking that every diagnostic file path points at `perf_histogram.rs`, never `array/subclass.rs`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array layout validation on systems with weaker memory-ordering guarantees.
  * Helps ensure reliable behavior when accessing cached array layout information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->