### PR TITLE
docs: regenerate API reference

### DIFF
--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2059 entries across 134 modules
+// Coverage: 2065 entries across 135 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -370,8 +370,10 @@ declare module "bun:ffi" {
   /** stdlib */
   export const FFIType: any;
   /** stdlib */
+  export const read: any;
+  /** stdlib */
   export const suffix: any;
-  /** stdlib @perryStub stage 3 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function CFunction(...args: any[]): any;
   /** stdlib */
   export function CString(...args: any[]): any;
@@ -379,17 +381,15 @@ declare module "bun:ffi" {
   export function JSCallback(...args: any[]): any;
   /** stdlib */
   export function dlopen(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function linkSymbols(...args: any[]): any;
   /** stdlib */
   export function ptr(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
-  export function read(...args: any[]): any;
   /** stdlib */
   export function toArrayBuffer(...args: any[]): any;
   /** stdlib */
   export function toBuffer(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function viewSource(...args: any[]): any;
 }
 
@@ -1583,6 +1583,21 @@ declare module "fetch" {
   export class Response { [key: string]: any; }
   /** stdlib */
   export default function (...args: any[]): any;
+}
+
+declare module "ffi" {
+  /** stdlib */
+  export const suffix: any;
+  /** stdlib */
+  export function dlopen(...args: any[]): any;
+  /** stdlib */
+  export function getRawPointer(...args: any[]): any;
+  /** stdlib */
+  export function toArrayBuffer(...args: any[]): any;
+  /** stdlib */
+  export function toBuffer(...args: any[]): any;
+  /** stdlib */
+  export function toString(...args: any[]): any;
 }
 
 declare module "fs" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3009 entries across 136 modules.
+Total: 3015 entries across 137 modules.
 
 ## Modules
 
@@ -52,6 +52,7 @@ Total: 3009 entries across 136 modules.
 - [`exponential-backoff`](#exponential-backoff)
 - [`fastify`](#fastify)
 - [`fetch`](#fetch)
+- [`ffi`](#ffi)
 - [`fs`](#fs)
 - [`fs/promises`](#fspromises)
 - [`http`](#http)
@@ -437,20 +438,20 @@ Total: 3009 entries across 136 modules.
 
 ### Methods
 
-- `CFunction` — module ⚠ **stub** — stage 3 — not yet implemented, throws at runtime (#6562)
+- `CFunction` — module
 - `CString` — module
 - `JSCallback` — module
 - `dlopen` — module
-- `linkSymbols` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
+- `linkSymbols` — module
 - `ptr` — module
-- `read` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
 - `toArrayBuffer` — module
 - `toBuffer` — module
-- `viewSource` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
+- `viewSource` — module
 
 ### Properties
 
 - `FFIType`
+- `read`
 - `suffix`
 
 ## `bun:sqlite`
@@ -1425,6 +1426,20 @@ Total: 3009 entries across 136 modules.
 ### Methods
 
 - `default` — module
+
+## `ffi`
+
+### Methods
+
+- `dlopen` — module
+- `getRawPointer` — module
+- `toArrayBuffer` — module
+- `toBuffer` — module
+- `toString` — module
+
+### Properties
+
+- `suffix`
 
 ## `fs`
 


### PR DESCRIPTION
Regenerates the checked-in API reference and TypeScript declarations after the FFI manifest changes. This clears the current release-blocking API-doc drift check.

Validation:
- generated output matches perry --print-api-manifest for the current 0.5.1519 tree
- SKIP_COMPILE_GATES=1 BASE_SHA=origin/main scripts/run_lint_gates.sh (53/53 passed)
- cargo fmt --all -- --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API reference manifest to include the new `ffi` module and its available methods and property.
  - Refined `bun:ffi` API declarations, including the `read` export and related entries.
  - Updated documented API coverage counts to reflect the expanded module and entry listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->