### PR TITLE
fix(hir): share function and var declaration bindings

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -539,6 +539,37 @@ fn collect_assigned_function_binding_candidates(ast_module: &ast::Module) -> Has
     out
 }
 
+/// Names introduced by `var` declarations in the module's var scope.
+///
+/// A same-named top-level FunctionDeclaration and `var` declaration share one
+/// binding. Collect these before function lowering so the function's hoisted
+/// value can seed that binding instead of a later var pre-scan creating a
+/// separate, undefined local that shadows it. The statement walker deliberately
+/// descends through blocks/loops/try/switch but not nested functions or classes.
+fn collect_module_var_binding_names(ast_module: &ast::Module) -> HashSet<String> {
+    let mut names = Vec::new();
+    for item in &ast_module.body {
+        match item {
+            ast::ModuleItem::Stmt(stmt) => {
+                crate::lower_decl::collect_var_binding_names_from_stmt(stmt, &mut names);
+            }
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(export_decl)) => {
+                if let ast::Decl::Var(var_decl) = &export_decl.decl {
+                    if var_decl.kind == ast::VarDeclKind::Var {
+                        for decl in &var_decl.decls {
+                            crate::lower_decl::collect_var_binding_names_from_pat(
+                                &decl.name, &mut names,
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    names.into_iter().collect()
+}
+
 /// #5833: names assigned by a **direct top-level** `name = ...`/`name++`
 /// expression statement (module scope, not nested in any block/if/loop/
 /// function). Deliberately narrower than
@@ -932,6 +963,7 @@ pub fn lower_module_full(
     // Skip 'declare function' statements (functions with no body) - they are external FFI
     // BUT: also skip overload signatures if an implementation exists
     let reassigned_function_candidates = collect_assigned_function_binding_candidates(ast_module);
+    let module_var_binding_names = collect_module_var_binding_names(ast_module);
     // #5833: a narrower, binding-aware-enough scan stashed on `ctx` so
     // `stmt.rs`'s top-level `Decl::Class` arm can gate its opt-in local-slot
     // seeding (see both `reassigned_top_level_identifiers`'s doc comment and
@@ -1008,11 +1040,21 @@ pub fn lower_module_full(
             let func_id = ctx.fresh_func();
             ctx.register_func(func_name.clone(), func_id);
             if reassigned_function_candidates.contains(&func_name)
-                && ctx.lookup_local(&func_name).is_none()
+                || module_var_binding_names.contains(&func_name)
             {
-                let local_id = ctx.define_local(func_name.clone(), Type::Any);
+                // FunctionDeclaration and `var` of the same name share one
+                // mutable binding. Seed it with every declaration in source
+                // order so duplicate function declarations leave the last
+                // function installed at entry, then let any source-position
+                // `var f = value` overwrite that same slot when it executes.
+                let local_id = ctx
+                    .lookup_local(&func_name)
+                    .unwrap_or_else(|| ctx.define_local(func_name.clone(), Type::Any));
                 ctx.record_local_source_span(local_id, fn_decl.ident.span);
                 ctx.function_valued_locals.insert(local_id);
+                if module_var_binding_names.contains(&func_name) {
+                    ctx.var_hoisted_ids.insert(local_id);
+                }
                 module.init.push(Stmt::Let {
                     id: local_id,
                     name: func_name.clone(),

--- a/crates/perry/tests/issue_5894_function_var_binding.rs
+++ b/crates/perry/tests/issue_5894_function_var_binding.rs
@@ -1,0 +1,98 @@
+//! Regression for #5894 / Test262 `language/reserved-words/unreserved-words.js`.
+//!
+//! A top-level FunctionDeclaration and a same-named `var` declaration share a
+//! single binding. The function value is installed during declaration
+//! instantiation; a bare `var f;` is inert, while `var f = value` overwrites it
+//! only when execution reaches the initializer. Perry used to pre-register the
+//! `var` as a separate undefined local, shadowing the function even before the
+//! declaration's source position.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn function_and_var_declarations_share_the_hoisted_binding() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+// The Test262 harness defines `assert` as a function, assigns helper
+// properties, and the test later declares `var assert = 1`.
+function assert() {}
+(assert as any)._isSameValue = "ready";
+console.log("helper-before-var:", (assert as any)._isSameValue);
+var assert = 1;
+console.log("helper-after-var:", assert);
+
+// An uninitialised var redeclaration must not replace the hoisted function.
+console.log("bare-before:", bare());
+function bare() { return "bare-function"; }
+var bare;
+console.log("bare-after:", bare());
+
+// A var nested in a block still belongs to the module var scope and shares
+// the function binding, even when its initializer never executes.
+console.log("nested-before:", nested());
+function nested() { return "nested-function"; }
+if (false) { var nested = 2; }
+console.log("nested-after:", nested());
+
+// Duplicate function declarations install the last declaration at entry;
+// the same-named bare var remains inert.
+console.log("duplicate-before:", duplicate());
+function duplicate() { return "first"; }
+function duplicate() { return "second"; }
+var duplicate;
+console.log("duplicate-after:", duplicate());
+console.log("DONE");
+"#,
+    )
+    .expect("write entry");
+
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    for expected in [
+        "helper-before-var: ready",
+        "helper-after-var: 1",
+        "bare-before: bare-function",
+        "bare-after: bare-function",
+        "nested-before: nested-function",
+        "nested-after: nested-function",
+        "duplicate-before: second",
+        "duplicate-after: second",
+        "DONE",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {expected:?}\nstdout:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- collect module-var-scope names before lowering top-level function declarations
- seed same-named function and `var` declarations into one hoisted mutable binding
- preserve source-position overwrites, inert bare `var`, nested `var`, and last-duplicate-function semantics
- add a compile-and-run regression covering the Test262 harness failure and related declaration shapes

## Test262
- `language/reserved-words`: 25/26 -> 26/26 (100% parity)
- `language/global-code`: unchanged at 26 pass / 2 runtime-fail
- pinned Test262 revision: `4249661388e5d3f92a85186213da140a6481490f`

## Validation
- `cargo test --release -p perry --test issue_5894_function_var_binding -- --nocapture`
- `cargo test --release -p perry --test issue_5579_script_global_function_reflection -- --nocapture`
- `cargo test --release -p perry-hir --lib` (334 passed, 1 ignored)
- `cargo fmt --manifest-path crates/perry-hir/Cargo.toml -- --check`
- `cargo fmt --manifest-path crates/perry/Cargo.toml -- --check`
- `rustfmt --edition 2021 --check crates/perry-hir/src/lower/lower_module_fn.rs crates/perry/tests/issue_5894_function_var_binding.rs`
- repository file-size gate (no Rust source files over the 2,000-line threshold outside its allowlist)

No version or release metadata changes.

Refs #5894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected top-level `var` and function declaration handling.
  - Ensured shared hoisted bindings behave consistently across blocks, loops, switches, and error-handling constructs.
  - Preserved expected behavior for redeclarations, initializers, and duplicate function declarations.

- **Tests**
  - Added regression coverage validating execution and output for function and `var` binding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->