### PR TITLE
docs: regenerate the API reference

### DIFF
--- a/changelog.d/8742-regenerate-api-reference.md
+++ b/changelog.d/8742-regenerate-api-reference.md
@@ -1,0 +1,1 @@
+Regenerated the checked-in API reference and TypeScript declarations from the compile-time manifest, picking up the `ffi` module that #8704 added and dropping the `@perryStub … (#6562)` markers from the entries it implemented. Coverage moves from 2,059 entries across 134 modules to 2,065 across 135. This clears the release-blocking api-docs-drift check.

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2059 entries across 134 modules
+// Coverage: 2065 entries across 135 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -370,8 +370,10 @@ declare module "bun:ffi" {
   /** stdlib */
   export const FFIType: any;
   /** stdlib */
+  export const read: any;
+  /** stdlib */
   export const suffix: any;
-  /** stdlib @perryStub stage 3 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function CFunction(...args: any[]): any;
   /** stdlib */
   export function CString(...args: any[]): any;
@@ -379,17 +381,15 @@ declare module "bun:ffi" {
   export function JSCallback(...args: any[]): any;
   /** stdlib */
   export function dlopen(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function linkSymbols(...args: any[]): any;
   /** stdlib */
   export function ptr(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
-  export function read(...args: any[]): any;
   /** stdlib */
   export function toArrayBuffer(...args: any[]): any;
   /** stdlib */
   export function toBuffer(...args: any[]): any;
-  /** stdlib @perryStub stage ≥2 — not yet implemented, throws at runtime (#6562) */
+  /** stdlib */
   export function viewSource(...args: any[]): any;
 }
 
@@ -1583,6 +1583,21 @@ declare module "fetch" {
   export class Response { [key: string]: any; }
   /** stdlib */
   export default function (...args: any[]): any;
+}
+
+declare module "ffi" {
+  /** stdlib */
+  export const suffix: any;
+  /** stdlib */
+  export function dlopen(...args: any[]): any;
+  /** stdlib */
+  export function getRawPointer(...args: any[]): any;
+  /** stdlib */
+  export function toArrayBuffer(...args: any[]): any;
+  /** stdlib */
+  export function toBuffer(...args: any[]): any;
+  /** stdlib */
+  export function toString(...args: any[]): any;
 }
 
 declare module "fs" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3009 entries across 136 modules.
+Total: 3015 entries across 137 modules.
 
 ## Modules
 
@@ -52,6 +52,7 @@ Total: 3009 entries across 136 modules.
 - [`exponential-backoff`](#exponential-backoff)
 - [`fastify`](#fastify)
 - [`fetch`](#fetch)
+- [`ffi`](#ffi)
 - [`fs`](#fs)
 - [`fs/promises`](#fspromises)
 - [`http`](#http)
@@ -437,20 +438,20 @@ Total: 3009 entries across 136 modules.
 
 ### Methods
 
-- `CFunction` — module ⚠ **stub** — stage 3 — not yet implemented, throws at runtime (#6562)
+- `CFunction` — module
 - `CString` — module
 - `JSCallback` — module
 - `dlopen` — module
-- `linkSymbols` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
+- `linkSymbols` — module
 - `ptr` — module
-- `read` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
 - `toArrayBuffer` — module
 - `toBuffer` — module
-- `viewSource` — module ⚠ **stub** — stage ≥2 — not yet implemented, throws at runtime (#6562)
+- `viewSource` — module
 
 ### Properties
 
 - `FFIType`
+- `read`
 - `suffix`
 
 ## `bun:sqlite`
@@ -1425,6 +1426,20 @@ Total: 3009 entries across 136 modules.
 ### Methods
 
 - `default` — module
+
+## `ffi`
+
+### Methods
+
+- `dlopen` — module
+- `getRawPointer` — module
+- `toArrayBuffer` — module
+- `toBuffer` — module
+- `toString` — module
+
+### Properties
+
+- `suffix`
 
 ## `fs`
 


### PR DESCRIPTION
Lands #8742 — regenerates `docs/src/api/reference.md` and `docs/api/perry.d.ts` from the compile-time manifest, clearing the release-blocking api-docs-drift check.

### How I verified it
A regenerated artifact is only as trustworthy as the check that it matches its generator, and re-running `scripts/regen_api_docs.sh` needs a `cargo build --release -p perry` that I couldn't justify with an agent already building and ~5 GB free. So I verified against the **source of truth** instead — `crates/perry-api-manifest/src/entries.rs`, which the script names as its input.

The manifest declares the `ffi` module, and `entries/part_1.rs` carries exactly six entries:

```rust
method("ffi", "dlopen", false, None),
method("ffi", "getRawPointer", false, None),
method("ffi", "toArrayBuffer", false, None),
method("ffi", "toBuffer", false, None),
method("ffi", "toString", false, None),
property("ffi", "suffix"),
```

The generated `.d.ts` exposes precisely those six — the five methods as `export function`, `suffix` as `export const`. One-to-one, nothing extra on either side.

The disappearing `@perryStub stage ≥2 — not yet implemented, throws at runtime (#6562)` markers are also correct rather than an accidental deletion: #8704 implemented that surface and closed #6562, and the remaining `#6562` mentions in the manifest are comments *describing* the implementation ("bun:ffi is implemented entirely in perry-runtime"), not stub annotations.

Coverage moves 2,059 entries / 134 modules → 2,065 / 135, consistent with one new module and six new entries.

### Validation
- **All 30 `lint`-job checkers pass**
- Docs-only change (2 files); no code paths touched, so no suites are implicated
- Squashed tree verified identical to the validated tree

A `changelog.d/` fragment was added — the PR had neither one nor a `skip-changelog` label. No version bump.

> Caveat stated plainly: I did **not** re-run `regen_api_docs.sh` itself, so this confirms the output is consistent with the manifest, not that byte-for-byte it is what the generator emits today. The CI drift check is the authority on that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Regenerated the API reference and TypeScript declarations with expanded coverage.
  * Added documentation for the new `ffi` module, including dynamic loading, pointer, buffer, string, and raw-pointer utilities.
  * Added the `read` API to `bun:ffi` and clarified existing FFI API documentation.
  * Removed outdated stub annotations from implemented FFI APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->