### PR TITLE
fix: clear TLS and GC-spill release blockers

### DIFF
--- a/changelog.d/8754-external-http-tls-preflight.md
+++ b/changelog.d/8754-external-http-tls-preflight.md
@@ -2,4 +2,6 @@ Fixed optimized `node:net`, `node:http`, `node:https`, and `node:http2` builds
 after the TLS parity split. These external wrappers now retain Perry's shared
 TLS server and SNI/ALPN preflight provider without also linking the bundled
 network implementation, eliminating the `js_tls_client_preflight` undefined
-symbol that blocked HTTP gap and GC-stress fixtures at compile time.
+symbol that blocked HTTP gap and GC-stress fixtures at compile time. External
+`tls.connect` overload arguments also remain rooted when a user-replaced
+`createSecureContext` callback triggers a moving collection.

--- a/changelog.d/8754-external-http-tls-preflight.md
+++ b/changelog.d/8754-external-http-tls-preflight.md
@@ -1,0 +1,5 @@
+Fixed optimized `node:net`, `node:http`, `node:https`, and `node:http2` builds
+after the TLS parity split. These external wrappers now retain Perry's shared
+TLS server and SNI/ALPN preflight provider without also linking the bundled
+network implementation, eliminating the `js_tls_client_preflight` undefined
+symbol that blocked HTTP gap and GC-stress fixtures at compile time.

--- a/crates/perry-ext-net/src/tls.rs
+++ b/crates/perry-ext-net/src/tls.rs
@@ -649,6 +649,17 @@ pub(crate) fn record_tls_handshake(
 /// ABI — see `NA_F64` lowering in perry-codegen.
 #[no_mangle]
 pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64 {
+    // `js_tls_prepare_connect` may invoke a user-replaced createSecureContext
+    // before overload resolution. Keep every incoming value in the runtime's
+    // moving-GC root stack, and re-read the selected options/callback values
+    // after every later callback-capable runtime call.
+    let root_scope = perry_ffi::TransientRootScope::enter();
+    let rooted_args = [
+        root_scope.root_nanbox(arg1),
+        root_scope.root_nanbox(arg2),
+        root_scope.root_nanbox(arg3),
+        root_scope.root_nanbox(arg4),
+    ];
     extern "C" {
         fn js_tls_prepare_connect();
     }
@@ -685,29 +696,30 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
         (j.is_bool() && !j.to_bool()) || (j.is_number() && j.to_number() == 0.0)
     };
 
-    let (host, port, servername, verify, cb_f64, metadata_options);
-    if let Some(h) = as_string(arg1) {
+    let (host, port, servername, verify, callback_arg, metadata_options_arg);
+    if let Some(h) = as_string(rooted_args[0].get()) {
         // Legacy Perry positional: (host, port, servername?, verify?).
-        let p = JsValue::from_bits(arg2.to_bits());
+        let p = JsValue::from_bits(rooted_args[1].get().to_bits());
         if !p.is_number() && !p.is_int32() {
             return 0;
         }
         port = p.to_number() as u16;
-        servername = as_string(arg3).unwrap_or_else(|| h.clone());
+        servername = as_string(rooted_args[2].get()).unwrap_or_else(|| h.clone());
         host = h;
-        verify = !explicitly_off(arg4);
-        cb_f64 = None;
-        metadata_options = f64::from_bits(0x7FFC_0000_0000_0001);
-    } else if JsValue::from_bits(arg1.to_bits()).is_number()
-        || JsValue::from_bits(arg1.to_bits()).is_int32()
+        verify = !explicitly_off(rooted_args[3].get());
+        callback_arg = None;
+        metadata_options_arg = None;
+    } else if JsValue::from_bits(rooted_args[0].get().to_bits()).is_number()
+        || JsValue::from_bits(rooted_args[0].get().to_bits()).is_int32()
     {
         // Node positional form: tls.connect(port[, host][, options][, cb]).
-        js_net_validate_connect_port(arg1);
-        port = JsValue::from_bits(arg1.to_bits()).to_number() as u16;
+        js_net_validate_connect_port(rooted_args[0].get());
+        port = JsValue::from_bits(rooted_args[0].get().to_bits()).to_number() as u16;
         let mut opt_host: Option<String> = None;
-        let mut opts: Option<f64> = None;
-        let mut cb: Option<f64> = None;
-        for v in [arg2, arg3, arg4] {
+        let mut opts_arg: Option<usize> = None;
+        let mut cb_arg: Option<usize> = None;
+        for index in [1, 2, 3] {
+            let v = rooted_args[index].get();
             if opt_host.is_none() {
                 if let Some(h) = as_string(v) {
                     opt_host = Some(h);
@@ -715,41 +727,42 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
                 }
             }
             if is_closure(v) {
-                cb = cb.or(Some(v));
+                cb_arg = cb_arg.or(Some(index));
             } else if is_nanboxed_pointer(v) {
-                opts = opts.or(Some(v));
+                opts_arg = opts_arg.or(Some(index));
             }
         }
-        if let Some(options) = opts {
+        if let Some(index) = opts_arg {
             extern "C" {
                 fn js_tls_validate_positional_connect_options(options: f64);
             }
-            js_tls_validate_positional_connect_options(options);
+            js_tls_validate_positional_connect_options(rooted_args[index].get());
         }
         host = opt_host
             .or_else(|| {
-                opts.and_then(|o| {
-                    get_object_string_field(o, "host")
-                        .or_else(|| get_object_string_field(o, "hostname"))
+                opts_arg.and_then(|index| {
+                    let options = rooted_args[index].get();
+                    get_object_string_field(options, "host")
+                        .or_else(|| get_object_string_field(rooted_args[index].get(), "hostname"))
                 })
             })
             .filter(|h| !h.is_empty())
             .unwrap_or_else(|| "localhost".to_string());
-        servername = opts
-            .and_then(|o| get_object_string_field(o, "servername"))
+        servername = opts_arg
+            .and_then(|index| get_object_string_field(rooted_args[index].get(), "servername"))
             .unwrap_or_else(|| host.clone());
-        verify = opts
-            .and_then(|o| get_object_bool_field(o, "rejectUnauthorized"))
+        verify = opts_arg
+            .and_then(|index| get_object_bool_field(rooted_args[index].get(), "rejectUnauthorized"))
             .unwrap_or(true);
-        cb_f64 = cb;
-        metadata_options = opts.unwrap_or_else(|| f64::from_bits(0x7FFC_0000_0000_0001));
-    } else if is_nanboxed_pointer(arg1) && !is_closure(arg1) {
+        callback_arg = cb_arg;
+        metadata_options_arg = opts_arg;
+    } else if is_nanboxed_pointer(rooted_args[0].get()) && !is_closure(rooted_args[0].get()) {
         // Node options form: tls.connect(options[, callback]).
         extern "C" {
             fn js_tls_validate_connect_options(options: f64);
         }
-        js_tls_validate_connect_options(arg1);
-        if let Some(socket_value) = crate::get_object_value_field(arg1, "socket") {
+        js_tls_validate_connect_options(rooted_args[0].get());
+        if let Some(socket_value) = crate::get_object_value_field(rooted_args[0].get(), "socket") {
             let socket_js = JsValue::from_bits(socket_value.to_bits());
             let handle = if socket_js.is_pointer() {
                 crate::unbox_pointer(socket_value) as i64
@@ -757,15 +770,15 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
                 0
             };
             if handle != 0 {
-                host = get_object_string_field(arg1, "host")
-                    .or_else(|| get_object_string_field(arg1, "hostname"))
+                host = get_object_string_field(rooted_args[0].get(), "host")
+                    .or_else(|| get_object_string_field(rooted_args[0].get(), "hostname"))
                     .unwrap_or_else(|| "localhost".to_string());
-                servername =
-                    get_object_string_field(arg1, "servername").unwrap_or_else(|| host.clone());
-                verify = get_object_bool_field(arg1, "rejectUnauthorized").unwrap_or(true);
-                cb_f64 = is_closure(arg2).then_some(arg2);
-                metadata_options = arg1;
-                let config = tls_client_config_data(metadata_options);
+                servername = get_object_string_field(rooted_args[0].get(), "servername")
+                    .unwrap_or_else(|| host.clone());
+                verify = get_object_bool_field(rooted_args[0].get(), "rejectUnauthorized")
+                    .unwrap_or(true);
+                callback_arg = is_closure(rooted_args[1].get()).then_some(1);
+                let config = tls_client_config_data(rooted_args[0].get());
                 extern "C" {
                     fn js_tls_client_record_start(
                         handle: i64,
@@ -776,12 +789,12 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
                 }
                 js_tls_client_record_start(
                     handle,
-                    metadata_options,
+                    rooted_args[0].get(),
                     servername.as_ptr(),
                     servername.len(),
                 );
-                if let Some(cb) = cb_f64 {
-                    let cb_ptr = unbox_pointer(cb) as i64;
+                if let Some(index) = callback_arg {
+                    let cb_ptr = unbox_pointer(rooted_args[index].get()) as i64;
                     if cb_ptr != 0 {
                         statics::listeners()
                             .lock()
@@ -793,7 +806,7 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
                             .push(cb_ptr);
                     }
                 }
-                let preflight = tls_preflight(0, &servername, metadata_options);
+                let preflight = tls_preflight(0, &servername, rooted_args[0].get());
                 if preflight != 0 {
                     crate::push_event(crate::PendingNetEvent::Error(
                         handle,
@@ -807,29 +820,35 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
                 return handle;
             }
         }
-        port = match get_object_number_field(arg1, "port") {
+        port = match get_object_number_field(rooted_args[0].get(), "port") {
             Some(p) => {
                 js_net_validate_connect_port(p);
                 p as u16
             }
             None => return 0,
         };
-        host = match get_object_string_field(arg1, "host")
-            .or_else(|| get_object_string_field(arg1, "hostname"))
+        host = match get_object_string_field(rooted_args[0].get(), "host")
+            .or_else(|| get_object_string_field(rooted_args[0].get(), "hostname"))
         {
             Some(h) if !h.is_empty() => h,
             _ => "localhost".to_string(),
         };
-        servername = get_object_string_field(arg1, "servername").unwrap_or_else(|| host.clone());
-        verify = get_object_bool_field(arg1, "rejectUnauthorized").unwrap_or(true);
-        cb_f64 = is_closure(arg2).then_some(arg2);
-        metadata_options = arg1;
+        servername = get_object_string_field(rooted_args[0].get(), "servername")
+            .unwrap_or_else(|| host.clone());
+        verify = get_object_bool_field(rooted_args[0].get(), "rejectUnauthorized").unwrap_or(true);
+        callback_arg = is_closure(rooted_args[1].get()).then_some(1);
+        metadata_options_arg = Some(0);
     } else {
         return 0;
     }
 
-    let config = tls_client_config_data(metadata_options);
-    if signal_is_pre_aborted(metadata_options) {
+    let metadata_options = || {
+        metadata_options_arg
+            .map(|index| rooted_args[index].get())
+            .unwrap_or_else(|| f64::from_bits(0x7FFC_0000_0000_0001))
+    };
+    let config = tls_client_config_data(metadata_options());
+    if signal_is_pre_aborted(metadata_options()) {
         let handle = crate::js_net_socket_alloc();
         extern "C" {
             fn js_tls_client_record_start(
@@ -841,14 +860,14 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
         }
         js_tls_client_record_start(
             handle,
-            metadata_options,
+            metadata_options(),
             servername.as_ptr(),
             servername.len(),
         );
         schedule_tls_abort(handle);
         return handle;
     }
-    let preflight = tls_preflight(port, &servername, metadata_options);
+    let preflight = tls_preflight(port, &servername, metadata_options());
     if preflight != 0 {
         let handle = crate::js_net_socket_alloc();
         extern "C" {
@@ -861,7 +880,7 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
         }
         js_tls_client_record_start(
             handle,
-            metadata_options,
+            metadata_options(),
             servername.as_ptr(),
             servername.len(),
         );
@@ -885,14 +904,14 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
             }
             js_tls_client_record_start(
                 handle,
-                metadata_options,
+                metadata_options(),
                 metadata_servername.as_ptr(),
                 metadata_servername.len(),
             );
         });
-    if let Some(cb) = cb_f64 {
+    if let Some(index) = callback_arg {
         if handle != 0 {
-            let cb_ptr = unbox_pointer(cb) as i64;
+            let cb_ptr = unbox_pointer(rooted_args[index].get()) as i64;
             if cb_ptr != 0 {
                 statics::listeners()
                     .lock()

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -200,8 +200,16 @@ external-events-construct = []
 # TLS — direct `tls.connect()` and `socket.upgradeToTLS()` (Postgres SSLRequest flow).
 # Uses rustls (not native-tls) to avoid OpenSSL on every platform and keep Android
 # cross-compile unblocked; matches reqwest/tokio-tungstenite/mongodb feature flags.
-tls = [
-    "bundled-net",
+#
+# `tls-runtime` contains the shared TLS server/preflight implementation. The
+# `external-net-tls` adapter uses that implementation while resolving
+# `js_tls_connect` from perry-ext-net; compiling bundled net beside the wrapper
+# would reintroduce duplicate `js_net_*` / `js_tls_connect` symbols. The public
+# `tls` umbrella retains its historical bundled-net behavior.
+tls = ["bundled-net", "tls-runtime"]
+external-net-tls = ["tls-runtime"]
+tls-runtime = [
+    "async-runtime",
     "dep:tokio-rustls",
     "dep:rustls",
     "dep:rustls-native-certs",

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -625,7 +625,11 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
         count += net_count;
     }
 
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     {
         count += unsafe { crate::tls::js_tls_process_pending() };
     }
@@ -794,7 +798,11 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
             return 1;
         }
     }
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     {
         if crate::tls::js_tls_has_active_handles() != 0 {
             return 1;

--- a/crates/perry-stdlib/src/common/dispatch/init.rs
+++ b/crates/perry-stdlib/src/common/dispatch/init.rs
@@ -667,7 +667,11 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
         }
         js_register_http_agent_handle_probe(http_agent_probe);
     }
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     {
         unsafe extern "C" fn tls_handle_kind_probe(handle: i64) -> u8 {
             if crate::tls::is_tls_server_handle(handle) {
@@ -750,7 +754,11 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     #[cfg(feature = "database-sqlite")]
     perry_runtime::js_set_native_sqlite_dispatch(crate::sqlite::js_node_sqlite_native_dispatch);
     perry_runtime::js_set_native_domain_dispatch(crate::domain::js_domain_native_dispatch);
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     perry_runtime::js_set_native_tls_dispatch(crate::tls::js_tls_native_dispatch);
 
     // #2533: route captured / aliased http/https/http2 `createServer` back to

--- a/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
@@ -467,7 +467,11 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
         return crate::crypto::dispatch_sign(handle, method_name, &args);
     }
 
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     if crate::tls::should_dispatch_tls_handle(handle, method_name) {
         return crate::tls::dispatch_tls_handle(handle, method_name, &args);
     }

--- a/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
@@ -36,7 +36,11 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         return value;
     }
 
-    #[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+    #[cfg(all(
+        feature = "tls-runtime",
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
     if let Some(value) = crate::tls::dispatch_tls_property(handle, property_name) {
         return value;
     }

--- a/crates/perry-stdlib/src/lib.rs
+++ b/crates/perry-stdlib/src/lib.rs
@@ -177,9 +177,17 @@ pub mod net;
     not(target_os = "android")
 ))]
 pub use net::*;
-#[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+#[cfg(all(
+    feature = "tls-runtime",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
 pub mod tls;
-#[cfg(all(feature = "tls", not(target_os = "ios"), not(target_os = "android")))]
+#[cfg(all(
+    feature = "tls-runtime",
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
 pub use tls::*;
 
 // === Databases ===

--- a/crates/perry-stdlib/src/tls/module_api.rs
+++ b/crates/perry-stdlib/src/tls/module_api.rs
@@ -17,6 +17,24 @@ use super::{
     TLS_DISPATCH_MISSING_BITS,
 };
 
+#[cfg(feature = "bundled-net")]
+unsafe fn dispatch_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64 {
+    crate::net::js_tls_connect(arg1, arg2, arg3, arg4)
+}
+
+#[cfg(all(not(feature = "bundled-net"), feature = "external-net-tls"))]
+unsafe fn dispatch_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64 {
+    unsafe extern "C" {
+        fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f64) -> i64;
+    }
+    js_tls_connect(arg1, arg2, arg3, arg4)
+}
+
+#[cfg(not(any(feature = "bundled-net", feature = "external-net-tls")))]
+unsafe fn dispatch_tls_connect(_arg1: f64, _arg2: f64, _arg3: f64, _arg4: f64) -> i64 {
+    0
+}
+
 fn split_subject_alt_names(san: &str) -> Vec<(String, String)> {
     let mut out = Vec::new();
     for part in san.split(',') {
@@ -292,7 +310,7 @@ pub unsafe extern "C" fn js_tls_native_dispatch(
             // Pass the args through raw — js_tls_connect resolves Node's
             // `connect(options[, cb])` / `connect(port[, host][, options][,
             // cb])` overloads plus the legacy positional form itself (#4971).
-            let handle = crate::net::js_tls_connect(arg(0), arg(1), arg(2), arg(3));
+            let handle = dispatch_tls_connect(arg(0), arg(1), arg(2), arg(3));
             if handle == 0 {
                 // Unresolvable args (e.g. no port) — undefined beats a
                 // NaN-boxed null pointer that every later method call

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -11,6 +12,25 @@ use super::super::{
     find_perry_workspace_root, is_android_target, is_windows_target, rust_target_triple,
     CompilationContext,
 };
+
+/// Select the provider for TLS module/server state after well-known routing.
+///
+/// perry-ext-net (directly or through perry-ext-http) owns the socket/connect
+/// symbols, but calls back into perry-stdlib for TLS SNI/ALPN preflight. Keep
+/// that provider without compiling bundled net beside the external wrapper.
+pub(super) fn finalize_tls_transport_features(
+    features: &mut BTreeSet<&'static str>,
+    imports_tls: bool,
+    external_net_transport: bool,
+) {
+    if external_net_transport {
+        features.remove("tls");
+        features.remove("bundled-net");
+        features.insert("external-net-tls");
+    } else if imports_tls {
+        features.insert("tls");
+    }
+}
 
 /// Rebuild perry-runtime + perry-stdlib in a single cargo invocation with
 /// the chosen Cargo features and panic mode, and return paths to the
@@ -158,6 +178,7 @@ pub(crate) fn build_optimized_libs(
     // through perry-stdlib's tokio. Their workspace-built .a stays
     // fine.
     let mut tokio_using_bindings: Vec<(String, String, Option<String>)> = Vec::new();
+    let mut external_net_transport = false;
     // Web Fetch is selected independently from the external node:http
     // binding. `uses_fetch` adds `web-fetch` in compute_required_features.
     if use_well_known {
@@ -278,6 +299,9 @@ pub(crate) fn build_optimized_libs(
                     binding.lib.clone(),
                     binding.tracking.clone(),
                 ));
+            }
+            if matches!(module_normalized, "net" | "http" | "https" | "http2") {
+                external_net_transport = true;
             }
             // Strip the perry-stdlib feature(s) this binding was
             // covering. `module_to_features` is the same table
@@ -454,14 +478,11 @@ pub(crate) fn build_optimized_libs(
     }
 
     // `net` maps to `[bundled-net, tls]` because its bundled implementation
-    // owns upgradeToTLS. Routing net to perry-ext-net strips both features,
-    // but an independent `node:tls` import still needs the stdlib TLS module
-    // for Server/TLSSocket constructors and their dynamic method dispatcher.
-    // Reassert that shared feature after all well-known removals so iteration
-    // order cannot make a direct `new tls.TLSSocket(...)` lose its provider.
-    if imports_tls {
-        features.insert("tls");
-    }
+    // owns upgradeToTLS. External net/http owns connect/socket symbols but
+    // still calls perry-stdlib's SNI/ALPN preflight provider. Select the split
+    // `external-net-tls` adapter in that case; a direct TLS-only program keeps
+    // the historical `tls` umbrella (and therefore bundled net).
+    finalize_tls_transport_features(&mut features, imports_tls, external_net_transport);
 
     // The UI backends (perry-ui-gtk4 on Linux, perry-ui-macos, perry-ui-windows)
     // reach into perry-stdlib's async bridge from GLib/NSTimer/WM_TIMER

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -473,6 +473,24 @@ fn ext_binding_build_routing_split() {
 }
 
 #[test]
+fn external_net_transport_keeps_tls_provider_without_bundled_net() {
+    let mut features = std::collections::BTreeSet::from(["bundled-net", "tls"]);
+    super::driver::finalize_tls_transport_features(&mut features, true, true);
+    assert_eq!(
+        features,
+        std::collections::BTreeSet::from(["external-net-tls"]),
+        "external net/http must keep TLS preflight without duplicate bundled-net symbols"
+    );
+}
+
+#[test]
+fn direct_tls_without_external_transport_keeps_legacy_umbrella() {
+    let mut features = std::collections::BTreeSet::new();
+    super::driver::finalize_tls_transport_features(&mut features, true, false);
+    assert_eq!(features, std::collections::BTreeSet::from(["tls"]));
+}
+
+#[test]
 fn unknown_modules_default_to_workspace_path() {
     // Defensive default: if a module isn't in the allowlist,
     // treat it as CPU-only (existing v0.5.586 behavior).

--- a/crates/perry/tests/gc_root_spill_mixed_frames_8583.rs
+++ b/crates/perry/tests/gc_root_spill_mixed_frames_8583.rs
@@ -164,7 +164,8 @@ fn mixed_statepoint_and_shadow_frames_survive_a_relocating_minor() {
     // proves nothing. The report names each shadow-framed function at default
     // verbosity (#8421: the change is never silent).
     assert!(
-        spilled_err.contains("keeps its") && spilled_err.contains("GC roots in a shadow frame"),
+        spilled_err.contains("keeps its")
+            && spilled_err.contains("in a shadow frame instead of statepoints"),
         "PERRY_ROOT_SPILL_RELOCATIONS=1 was expected to spill at least one \
          function, but the compile reported none:\nstderr:\n{spilled_err}"
     );

--- a/test-files/test_issue_8754_tls_connect_args_gc_rooting.ts
+++ b/test-files/test_issue_8754_tls_connect_args_gc_rooting.ts
@@ -1,0 +1,57 @@
+// parity-env: PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+// `tls.connect` consults a user-replaced createSecureContext before it resolves
+// either overload. The callback forces a moving collection while the original
+// options object and secureConnect callback exist only in the external-net FFI
+// arguments. Both must be re-read from transient roots after the callback.
+import tls from "node:tls";
+import { readFileSync } from "node:fs";
+import { isIP } from "node:net";
+
+declare function gc(): void;
+
+const fixture = new URL("../test-parity/node-suite/tls/fixtures/", import.meta.url);
+const key = readFileSync(new URL("localhost-key.pem", fixture));
+const cert = readFileSync(new URL("localhost-cert.pem", fixture));
+const originalCreateSecureContext = tls.createSecureContext;
+
+if (isIP("127.0.0.1") !== 4) throw new Error("node:net route unavailable");
+
+(tls as any).createSecureContext = (options: any) => {
+  const churn: Array<{ value: string }> = [];
+  for (let i = 0; i < 2000; i++) churn.push({ value: "tls-root-" + i });
+  if (typeof gc === "function") gc();
+  return originalCreateSecureContext(options);
+};
+
+const server = tls.createServer({ key, cert }, (socket) => socket.end());
+server.listen(0, "127.0.0.1", () => {
+  const port = (server.address() as any).port;
+  const options = { port, host: "127.0.0.1", rejectUnauthorized: false };
+  const optionsClient = tls.connect(options, function () {
+    console.log(
+      "options:",
+      this === optionsClient,
+      options.host,
+      options.rejectUnauthorized,
+    );
+  });
+  optionsClient.on("close", () => {
+    const positionalOptions = { rejectUnauthorized: false };
+    const positionalClient = tls.connect(
+      port,
+      "127.0.0.1",
+      positionalOptions,
+      function () {
+        console.log(
+          "positional:",
+          this === positionalClient,
+          positionalOptions.rejectUnauthorized,
+        );
+      },
+    );
+    positionalClient.on("close", () => {
+      (tls as any).createSecureContext = originalCreateSecureContext;
+      server.close();
+    });
+  });
+});

--- a/test-parity/expected/test_issue_8754_tls_connect_args_gc_rooting.txt
+++ b/test-parity/expected/test_issue_8754_tls_connect_args_gc_rooting.txt
@@ -1,0 +1,2 @@
+options: true 127.0.0.1 false
+positional: true false


### PR DESCRIPTION
## Summary

- keep the stdlib TLS server/preflight provider when `net`, `http`, `https`, or `http2` routes to the optimized external wrappers
- split bundled and external `js_tls_connect` adapters so the external path does not reintroduce duplicate net symbols
- root all external TLS connect inputs across user-replaced `createSecureContext` and preflight callbacks
- accept the enriched root-spill diagnostic in the mixed-frame cargo integration test
- cover both feature-selection routes and both Node `tls.connect` overloads

## Release blockers

This fixes the `_js_tls_client_preflight` undefined-symbol compile failures in the gap and GC-stress suites, including `test_gap_gc_http2_pending_event_callback_rooting`, plus the cargo integration test that rejected the current root-spill diagnostic despite observing the expected spills.

## Local verification

- `cargo fmt --all -- --check`
- `cargo check -p perry-stdlib --no-default-features --features external-net-tls`
- `cargo check -p perry-stdlib --no-default-features --features tls`
- focused `perry` tests for external and direct TLS feature selection
- `cargo check -p perry-ext-net`
- `cargo test -p perry-ext-net --lib` (30 passed)
- Node oracle for the new options/positional TLS rooting parity fixture
- test-registration checker and self-test
- clean-runner evidence for the root-spill diagnostic from CI run 32739246257