### PR TITLE
test(gc): accept enriched root-spill diagnostic

### DIFF
--- a/crates/perry/tests/gc_root_spill_mixed_frames_8583.rs
+++ b/crates/perry/tests/gc_root_spill_mixed_frames_8583.rs
@@ -164,7 +164,8 @@ fn mixed_statepoint_and_shadow_frames_survive_a_relocating_minor() {
     // proves nothing. The report names each shadow-framed function at default
     // verbosity (#8421: the change is never silent).
     assert!(
-        spilled_err.contains("keeps its") && spilled_err.contains("GC roots in a shadow frame"),
+        spilled_err.contains("keeps its")
+            && spilled_err.contains("in a shadow frame instead of statepoints"),
         "PERRY_ROOT_SPILL_RELOCATIONS=1 was expected to spill at least one \
          function, but the compile reported none:\nstderr:\n{spilled_err}"
     );


### PR DESCRIPTION
## Summary

- match the stable semantic portion of the root-spill diagnostic
- tolerate the newer `(incl. call-result temporaries)` detail inserted between the root count and shadow-frame wording

## Release blocker

The current `main` cargo suite reaches the expected root-spill behavior but fails because this assertion still expects the old contiguous wording.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- clean-runner evidence: CI run 32739246257 compiled and ran the fixture, emitted five current-form root-spill diagnostics, then failed only this assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated spill-detection test expectations to reflect revised compiler diagnostic wording.
  * Diagnostics now refer to roots being kept in a shadow frame instead of statepoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->