### PR TITLE
fix(intl): resolve DateTimeFormat locale options

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -33,6 +33,8 @@ mod locale;
 mod locales;
 use locales::{get_canonical_locales_thunk, supported_values_of_thunk};
 mod date_collator;
+mod date_time_locale;
+use date_time_locale::resolve_date_time_locale;
 mod date_names;
 #[cfg(feature = "intl-datetime")]
 pub(crate) mod icu_dtf;
@@ -1089,20 +1091,16 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 &["lookup", "best fit"],
                 "best fit",
             );
-            // `calendar` must match the Unicode locale `type` nonterminal; store
-            // the canonicalized ID so `resolvedOptions().calendar` reflects it.
-            if let Some(calendar) = get_locale_extension_option(current_options(), "calendar") {
-                match canonicalize_calendar_id(&calendar) {
-                    Some(canonical) => set_internal_field_from_raw_handle(
-                        &obj_handle,
-                        KEY_CALENDAR,
-                        string_value(&canonical),
-                    ),
-                    None => throw_range_error(&format!(
-                        "Value {calendar} out of range for Intl options property calendar"
-                    )),
-                }
-            }
+            // `calendar` must match the Unicode locale `type` nonterminal.
+            // Unsupported well-formed values fall through ResolveLocale.
+            let calendar_option =
+                get_locale_extension_option(current_options(), "calendar").map(|calendar| {
+                    canonicalize_calendar_id(&calendar).unwrap_or_else(|| {
+                        throw_range_error(&format!(
+                            "Value {calendar} out of range for Intl options property calendar"
+                        ))
+                    })
+                });
             // `numberingSystem` must be a well-formed `type` nonterminal. Read
             // it here (preserving the GetOption order options-order.js asserts),
             // then run ResolveLocale for `nu` — reconciling the option with the
@@ -1117,25 +1115,43 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                     }
                     ns.to_ascii_lowercase()
                 });
-            let (dtf_locale, dtf_numbering) =
-                resolve_numbering_system(&locale, dtf_opt_ns.as_deref());
-            set_internal_field_from_raw_handle(&obj_handle, KEY_LOCALE, string_value(&dtf_locale));
-            set_internal_field_from_raw_handle(
-                &obj_handle,
-                KEY_NUMBERING_SYSTEM,
-                string_value(&dtf_numbering),
-            );
             // hour12 (boolean) then hourCycle (enum) — both only surface in
             // `resolvedOptions` when the resolved pattern has an hour field.
-            if let Some(h12) = get_bool_option(current_options(), "hour12") {
-                set_internal_field_from_raw_handle(&obj_handle, KEY_HOUR12, bool_value(h12));
-            }
-            if let Some(hc) = get_option_string(current_options(), "hourCycle") {
+            let hour12 = get_bool_option(current_options(), "hour12");
+            let hour_cycle_option = get_option_string(current_options(), "hourCycle");
+            if let Some(ref hc) = hour_cycle_option {
                 if !["h11", "h12", "h23", "h24"].contains(&hc.as_str()) {
                     throw_range_error(&format!(
                         "Value {hc} out of range for Intl options property hourCycle"
                     ));
                 }
+            }
+            let resolved = resolve_date_time_locale(
+                &locale,
+                calendar_option.as_deref(),
+                dtf_opt_ns.as_deref(),
+                hour12,
+                hour_cycle_option.as_deref(),
+            );
+            set_internal_field_from_raw_handle(
+                &obj_handle,
+                KEY_LOCALE,
+                string_value(&resolved.locale),
+            );
+            set_internal_field_from_raw_handle(
+                &obj_handle,
+                KEY_CALENDAR,
+                string_value(&resolved.calendar),
+            );
+            set_internal_field_from_raw_handle(
+                &obj_handle,
+                KEY_NUMBERING_SYSTEM,
+                string_value(&resolved.numbering_system),
+            );
+            if let Some(h12) = hour12 {
+                set_internal_field_from_raw_handle(&obj_handle, KEY_HOUR12, bool_value(h12));
+            }
+            if let Some(hc) = resolved.hour_cycle {
                 set_internal_field_from_raw_handle(&obj_handle, KEY_HOUR_CYCLE, string_value(&hc));
             }
             // ECMA-402 DefaultTimeZone(): when no `timeZone` option is given, use

--- a/crates/perry-runtime/src/intl/date_time_locale.rs
+++ b/crates/perry-runtime/src/intl/date_time_locale.rs
@@ -1,0 +1,177 @@
+//! ResolveLocale support for `Intl.DateTimeFormat`'s `ca`, `hc`, and `nu`
+//! relevant extension keys.
+
+use super::*;
+
+/// The calendars Perry exposes through `Intl.supportedValuesOf("calendar")`.
+/// CreateDateTimeFormat may only retain one of these values; well-formed future
+/// or implementation-specific identifiers fall back through ResolveLocale.
+const SUPPORTED_CALENDARS: &[&str] = &[
+    "buddhist",
+    "chinese",
+    "coptic",
+    "dangi",
+    "ethioaa",
+    "ethiopic",
+    "gregory",
+    "hebrew",
+    "indian",
+    "islamic",
+    "islamic-civil",
+    "islamic-rgsa",
+    "islamic-tbla",
+    "islamic-umalqura",
+    "iso8601",
+    "japanese",
+    "persian",
+    "roc",
+];
+
+pub(super) struct DateTimeLocaleResolution {
+    pub(super) locale: String,
+    pub(super) calendar: String,
+    pub(super) numbering_system: String,
+    /// Effective `hc` override from the extension or options. Locale defaults
+    /// remain absent so ICU can select its own CLDR preference.
+    pub(super) hour_cycle: Option<String>,
+}
+
+fn base_locale(locale: &str) -> String {
+    locale
+        .split('-')
+        .take_while(|part| part.len() != 1)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn supported_calendar(value: &str) -> Option<String> {
+    let canonical = canonicalize_calendar_id(value)?;
+    SUPPORTED_CALENDARS
+        .contains(&canonical.as_str())
+        .then_some(canonical)
+}
+
+fn supported_hour_cycle(value: &str) -> Option<String> {
+    ["h11", "h12", "h23", "h24"]
+        .contains(&value)
+        .then(|| value.to_string())
+}
+
+fn push_keyword(locale: &mut String, started: &mut bool, key: &str, value: &str) {
+    if !*started {
+        locale.push_str("-u");
+        *started = true;
+    }
+    locale.push('-');
+    locale.push_str(key);
+    locale.push('-');
+    locale.push_str(value);
+}
+
+/// Apply ResolveLocale to DateTimeFormat's relevant extension keys. Only a
+/// supported `ca`, `hc`, or `nu` keyword may survive in the resolved locale;
+/// unrelated keys and unsupported values are removed. A supported explicit
+/// option wins, while an unsupported option leaves a supported extension value
+/// in place. `hour12` suppresses both the `hourCycle` option and the `hc`
+/// extension, as required by CreateDateTimeFormat.
+pub(super) fn resolve_date_time_locale(
+    requested: &str,
+    calendar_option: Option<&str>,
+    numbering_option: Option<&str>,
+    hour12: Option<bool>,
+    hour_cycle_option: Option<&str>,
+) -> DateTimeLocaleResolution {
+    let ext_calendar = unicode_extension_keyword(requested, "ca")
+        .as_deref()
+        .and_then(supported_calendar);
+    let opt_calendar = calendar_option.and_then(supported_calendar);
+    let calendar = opt_calendar
+        .or_else(|| ext_calendar.clone())
+        .unwrap_or_else(|| "gregory".to_string());
+
+    let ext_numbering = unicode_extension_keyword(requested, "nu")
+        .map(|value| value.to_ascii_lowercase())
+        .filter(|value| numbering_system::is_supported_numbering_system(value));
+    let opt_numbering = numbering_option
+        .map(|value| value.to_ascii_lowercase())
+        .filter(|value| numbering_system::is_supported_numbering_system(value));
+    let numbering_system = opt_numbering
+        .or_else(|| ext_numbering.clone())
+        .unwrap_or_else(|| "latn".to_string());
+
+    let ext_hour_cycle = unicode_extension_keyword(requested, "hc")
+        .as_deref()
+        .and_then(supported_hour_cycle);
+    let hour_cycle = if hour12.is_some() {
+        None
+    } else {
+        hour_cycle_option
+            .and_then(supported_hour_cycle)
+            .or_else(|| ext_hour_cycle.clone())
+    };
+
+    let mut locale = base_locale(requested);
+    let mut started = false;
+    if ext_calendar.as_deref() == Some(calendar.as_str()) {
+        push_keyword(&mut locale, &mut started, "ca", &calendar);
+    }
+    if hour12.is_none() && ext_hour_cycle.as_deref() == hour_cycle.as_deref() {
+        if let Some(ref hc) = hour_cycle {
+            push_keyword(&mut locale, &mut started, "hc", hc);
+        }
+    }
+    if ext_numbering.as_deref() == Some(numbering_system.as_str()) {
+        push_keyword(&mut locale, &mut started, "nu", &numbering_system);
+    }
+
+    DateTimeLocaleResolution {
+        locale,
+        calendar,
+        numbering_system,
+        hour_cycle,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_supported_and_unsupported_calendar_values() {
+        let kept = resolve_date_time_locale("en-u-ca-iso8601", Some("invalid"), None, None, None);
+        assert_eq!(kept.locale, "en-u-ca-iso8601");
+        assert_eq!(kept.calendar, "iso8601");
+
+        let replaced =
+            resolve_date_time_locale("en-u-ca-gregory", Some("iso8601"), None, None, None);
+        assert_eq!(replaced.locale, "en");
+        assert_eq!(replaced.calendar, "iso8601");
+
+        let future = resolve_date_time_locale("en-u-ca-bangla", Some("vikram"), None, None, None);
+        assert_eq!(future.locale, "en");
+        assert_eq!(future.calendar, "gregory");
+
+        let alias = resolve_date_time_locale("en", Some("ethiopic-amete-alem"), None, None, None);
+        assert_eq!(alias.calendar, "ethioaa");
+
+        let existing = resolve_date_time_locale("en", Some("islamic"), None, None, None);
+        assert_eq!(existing.calendar, "islamic");
+    }
+
+    #[test]
+    fn removes_irrelevant_extensions_and_resolves_hc_and_nu() {
+        let irrelevant =
+            resolve_date_time_locale("ja-JP-u-cu-usd-tz-usnyc", None, None, None, None);
+        assert_eq!(irrelevant.locale, "ja-JP");
+
+        let overridden =
+            resolve_date_time_locale("en-u-hc-h23-nu-arab", None, None, None, Some("h11"));
+        assert_eq!(overridden.locale, "en-u-nu-arab");
+        assert_eq!(overridden.hour_cycle.as_deref(), Some("h11"));
+        assert_eq!(overridden.numbering_system, "arab");
+
+        let hour12 = resolve_date_time_locale("en-u-hc-h11", None, None, Some(false), Some("h23"));
+        assert_eq!(hour12.locale, "en");
+        assert_eq!(hour12.hour_cycle, None);
+    }
+}

--- a/crates/perry-runtime/src/intl/list_relative_plural.rs
+++ b/crates/perry-runtime/src/intl/list_relative_plural.rs
@@ -24,11 +24,11 @@ pub(crate) fn canonicalize_calendar_id(raw: &str) -> Option<String> {
         }
     }
     let lower = raw.to_ascii_lowercase();
-    // BCP-47 `-u-ca-` type aliases (TR35): a handful of legacy IDs canonicalize
-    // to their preferred form. Everything else passes through lowercased.
+    // BCP-47 `-u-ca-` type aliases (TR35): deprecated IDs canonicalize to
+    // their preferred form. Everything else passes through lowercased.
     let canonical = match lower.as_str() {
         "islamicc" => "islamic-civil",
-        "ethioaa" => "ethiopic-amete-alem",
+        "ethiopic-amete-alem" => "ethioaa",
         other => other,
     };
     Some(canonical.to_string())

--- a/test-files/test_gap_intl_datetimeformat_locale_resolution_5899.ts
+++ b/test-files/test_gap_intl_datetimeformat_locale_resolution_5899.ts
@@ -1,0 +1,41 @@
+// #5899 — CreateDateTimeFormat ResolveLocale for the `ca`, `hc`, and `nu`
+// relevant extension keys. Unsupported values fall back, supported extensions
+// survive only when they are actually selected, explicit options override the
+// extension, and unrelated Unicode keys never leak into the resolved locale.
+
+function show(
+  label: string,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = {},
+): void {
+  const resolved = new Intl.DateTimeFormat(locale, options).resolvedOptions();
+  console.log(
+    label,
+    resolved.locale,
+    resolved.calendar,
+    resolved.numberingSystem,
+    resolved.hourCycle ?? "-",
+  );
+}
+
+show("future option", "en", { calendar: "bangla" });
+show("future extension", "en-u-ca-vikram");
+show("calendar alias", "en", { calendar: "ethiopic-amete-alem" });
+show("keep calendar", "en-u-ca-iso8601", { calendar: "invalid" });
+show("drop calendars", "en-u-ca-invalid", { calendar: "invalid2" });
+show("replace calendar", "en-u-ca-gregory", { calendar: "iso8601" });
+show("same calendar", "en-u-ca-iso8601", { calendar: "iso8601" });
+show("null calendar", "en-u-ca-iso8601", {
+  calendar: null as unknown as string,
+});
+
+show("irrelevant", "ja-JP-u-cu-usd-tz-usnyc");
+show("numbering", "en-u-nu-arab");
+show("replace hc", "en-u-hc-h23", { hour: "numeric", hourCycle: "h11" });
+show("same hc", "en-u-hc-h23", { hour: "numeric", hourCycle: "h23" });
+show("hour12 wins", "en-u-hc-h11", {
+  hour: "numeric",
+  hour12: false,
+  hourCycle: "h11",
+});
+show("extension hc", "en-u-hc-h11", { hour: "numeric" });


### PR DESCRIPTION
## Summary
- resolve DateTimeFormat's `ca`, `hc`, and `nu` Unicode extension keys together through CreateDateTimeFormat locale negotiation
- fall back from unsupported calendar values, canonicalize calendar aliases, remove irrelevant Unicode keys, and apply `hour12`/`hourCycle` precedence
- add focused unit coverage and a 14-case Perry/Node regression program

## Verification
- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test -p perry-runtime date_time_locale --lib` (2 passed)
- Perry/Node byte-for-byte comparison for `test_gap_intl_datetimeformat_locale_resolution_5899.ts` (14 probes)
- `scripts/test262_subset.py --root vendor/test262 --dir intl402/DateTimeFormat --jobs 8 --timeout 60`: 192 pass, 31 pre-existing runtime failures, 0 compile failures; six #5899 cases fixed with no newly failing test names
- `cargo fmt -p perry-runtime -- --check`
- `bash scripts/check_file_size.sh`
- `git diff --check`

`cargo fmt --all -- --check` exceeds the Windows process command-line limit in this workspace (`os error 206`); the touched package and files pass rustfmt checks.

No version, lockfile, changelog, or `CLAUDE.md` changes.

Refs #5899