### PR TITLE
perf(codegen): narrow the x|0 i32-slot lever to stable-packed loops

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -636,25 +636,28 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // still see the current value.
             if let Some(i32_slot) = ctx.i32_counter_slots.get(id).cloned() {
                 let structurally_i32 = can_lower_expr_as_i32_in_current_region(ctx, value);
-                // When `x` is a canonical raw Number, `x | 0` may feed the canonical
-                // i32 slot directly: materializing a double here only to
-                // convert it back would duplicate the spec ToInt32. Keep the
-                // canonical gate explicit — declared Number types are erased,
-                // so a local can still hold a String or BigInt at runtime.
+                // Within a stable-packed numeric clone, when `x` is a
+                // canonical raw Number, `x | 0` may feed the canonical i32
+                // slot directly: materializing a double here only to convert
+                // it back would duplicate the spec ToInt32. Keep BOTH gates
+                // explicit. Declared Number types are erased, so a local can
+                // still hold a String or BigInt at runtime; and other loop
+                // clones own narrower indexed-load contracts that their
+                // existing assignment lowering must continue to see.
                 //
-                // This is a claim about the VALUE the ordinary lowering of `x`
-                // produces, NOT a licence to re-evaluate `x`'s operands
-                // natively — see the lowering below.
+                // The canonical gate is a claim about the VALUE the ordinary
+                // lowering of `x` produces, NOT a licence to re-evaluate `x`'s
+                // operands natively — see the lowering below.
                 let explicit_numeric_toint32 = matches!(
-                value.as_ref(),
-                Expr::Binary {
-                    op: BinaryOp::BitOr,
-                    left,
-                    right,
-                    ..
-                } if matches!(right.as_ref(), Expr::Integer(0))
-                    && crate::type_analysis::expr_produces_canonical_raw_f64(ctx, left)
-                );
+                    value.as_ref(),
+                    Expr::Binary {
+                        op: BinaryOp::BitOr,
+                        left,
+                        right,
+                        ..
+                    } if matches!(right.as_ref(), Expr::Integer(0))
+                        && crate::type_analysis::expr_produces_canonical_raw_f64(ctx, left)
+                ) && !ctx.stable_packed_loop_facts.is_empty();
                 if !ctx.closure_captures.contains_key(id)
                     && !(ctx.boxed_vars.contains(id) && !ctx.module_globals.contains_key(id))
                     && (structurally_i32 || explicit_numeric_toint32)

--- a/crates/perry-codegen/src/stmt/stable_packed_loop.rs
+++ b/crates/perry-codegen/src/stmt/stable_packed_loop.rs
@@ -215,10 +215,19 @@ fn match_candidate(
         },
         _ => return None,
     };
+    let receiver = Expr::LocalGet(array_id);
     if ctx.reassigned_locals.contains(&array_id)
         || ctx.closure_captures.contains_key(&array_id)
         || (ctx.locals.contains_key(&array_id) && ctx.boxed_vars.contains(&array_id))
         || (!ctx.locals.contains_key(&array_id) && !ctx.module_globals.contains_key(&array_id))
+        // TypedArrays have their own element-width-aware indexed lowering.
+        // Even though the runtime guard would decline their non-Array header,
+        // emitting the speculative clone can feed its numeric facts into
+        // function-wide native-representation selection. In particular a
+        // Uint32Array XOR then lost the required signed i32 canonicalization
+        // in the generic copy. Known TypedArrays are never valid candidates,
+        // so reject them before cloning rather than relying on the guard.
+        || crate::type_analysis::is_typed_array_expr(ctx, &receiver)
         || super::loops::stmts_mutate_local(body, counter_id)
         // A fast-loop `break` reaches that clone's exit block. Live-length
         // versions use the same block to enter the generic continuation, so

--- a/crates/perry/tests/issue_8690_loop_versioned_arraylike.rs
+++ b/crates/perry/tests/issue_8690_loop_versioned_arraylike.rs
@@ -189,6 +189,42 @@ console.log(checksum);
 }
 
 #[test]
+fn typed_array_loops_keep_their_width_aware_lowering() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = r#"
+function xorU32(values: Uint32Array, n: number): number {
+  let result = 0 | 0;
+  for (let i = 0; i < n; i++) {
+    result = (result ^ values[i & 7]) | 0;
+  }
+  return result | 0;
+}
+
+const values = Uint32Array.from([
+  1, 4000000000, 0xffffffff, 7, 0x80000000, 0, 42, 999,
+]);
+console.log(xorU32(values, 8));
+"#;
+    let (bin, stderr) = compile(dir.path(), source, true);
+    let output = run(&bin, dir.path(), false);
+    assert_success(&output);
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "-1852517324\n");
+
+    let ll_path = stderr
+        .lines()
+        .find_map(|line| line.split("kept LLVM IR: ").nth(1))
+        .map(str::trim)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("PERRY_LLVM_KEEP_IR did not report an IR path\n{stderr}"));
+    let ir = std::fs::read_to_string(&ll_path).expect("read kept LLVM IR");
+    let xor = function_ir(&ir, "__xorU32(");
+    assert!(
+        !xor.contains("js_packed_arraylike_loop_guard"),
+        "a statically known TypedArray must not enter Array loop versioning\n{xor}"
+    );
+}
+
+#[test]
 fn mutations_and_moving_gc_resume_with_generic_semantics() {
     let dir = tempfile::tempdir().expect("tempdir");
     let source = r#"


### PR DESCRIPTION
Lands the remaining commit from #8719, rebased onto current `main`.

#8719's main body already landed via #8755. This is its follow-up, **cherry-picked so it carries only its own content** — merging the branch would have reverted #8740, #8742, #8743 and #8763, whose changes its stale base predates. I verified afterwards that the five files those PRs touch are blob-identical to `main`.

### What it does
The lever now additionally requires `!ctx.stable_packed_loop_facts.is_empty()`, because other loop clones own narrower indexed-load contracts that their existing assignment lowering must continue to see.

The conflict with the landed soundness fix turned out to be **comment-only** — the code auto-merged — and both halves survive, verified in both directions:
- vs `main`, the only functional change is the narrowed gate
- vs the original commit, the sound lowering (`lower_expr` + `toint32_fast`) is restored, so the unproven path still reaches `js_dynamic_bitxor`

### Validation
- **All 30 `lint`-job checkers pass**
- Negative control `char_code_at_on_an_unproven_receiver_keeps_the_runtime_lowering` is **byte-identical to `main`** (blob `86b697d489c8`); all three `char_code_at` probes pass
- `perry-codegen --lib`: **1229 passed, 0 failed**
- `perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2674 passed, 0 failed**
- Squashed tree verified identical to the validated tree

### A coverage note worth recording
Those three `char_code_at` probes bound their loops with `i < 64` rather than an array length, so **under the narrowed gate they no longer enter the branch #8755 fixed** — they still pass, but via the generic tail. The branch's end-to-end coverage is `read_only_loops_have_preheader_proofs_and_fallback_free_fast_blocks` in `issue_8690_loop_versioned_arraylike.rs`, which this commit extends.

**That e2e suite could not be executed here.** It needs the compiler plus the `-static` wrapper archives, and free disk would not hold them — I built the wrappers but the test run did not complete before the volume ran down. So the soundness branch is correct by construction and by IR inspection, but its behavioural coverage is currently unexercised. Worth running on a machine with room.