### PR TITLE
fix(ci): restore the release readiness gates

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -114,7 +114,8 @@ jobs:
   # Soak parity gate + external-tool pin gate. Always-run (deliberately not
   # path-filtered — nub hid this gate in a path-gated job and it silently
   # skipped Rust-only PRs). The scripts are dep-free erasable-TS .mts run
-  # with the pinned Node's native type stripping; no npm install needed.
+  # with the pinned Node's native type stripping. The publish tests exercise
+  # the Socket SDK wrapper, so install the lockfile-pinned dev dependencies.
   soak-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -125,6 +126,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
+          cache: npm
+      - name: Install script test dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Soak window parity (npm run soak)
         run: node scripts/soak/soak.mts --check
       - name: External-tool pins valid (npm run tools:check)

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -1154,29 +1154,9 @@ detail = "checksum function raw numeric field write canonicalizes and performs a
 allow_materialization_reasons = ["runtime_api", "return_abi"]
 
 [[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
-name = "raw_scalar_ctor_field_store_raw_f64"
+name = "raw_scalar_field_store_raw_f64"
 source_function = "rawNumericObjectFieldsChecksum"
-expr_kind = "ScalarThisFieldSet"
-consumer = "scalar_object_field_store.raw_f64"
-native_rep_name = "f64"
-access_mode = "none"
-consumed_fact_kind = "representation"
-consumed_fact_state = "consumed"
-
-[[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
-name = "raw_scalar_field_load_raw_f64"
-source_function = "rawNumericObjectFieldsChecksum"
-expr_kind = "ScalarObjectFieldGet"
-consumer = "scalar_object_field_load.raw_f64"
-native_rep_name = "f64"
-access_mode = "none"
-consumed_fact_kind = "representation"
-consumed_fact_state = "consumed"
-
-[[workloads.raw_numeric_object_fields.native_rep_checks.require_records]]
-name = "raw_scalar_ctor_field_store_raw_f64"
-source_function = "rawNumericObjectFieldsChecksum"
-expr_kind = "ScalarThisFieldSet"
+expr_kind = "ScalarObjectFieldSet"
 consumer = "scalar_object_field_store.raw_f64"
 native_rep_name = "f64"
 access_mode = "none"


### PR DESCRIPTION
Lands #8777, unblocking two release-blocking jobs on `main`.

### The soak-gate failure is mine
`security-audit / soak-gate` was failing with `ERR_MODULE_NOT_FOUND` for `@socketsecurity/sdk`. **That's a regression I introduced in #8762.** I wired `scripts/publish/*.test.mts` into the step that already claimed to run `npm run test:scripts`, and I said at the time I'd "verified first so it cannot redden CI on landing" — but I verified those tests *after* running `npm install` locally, and the job has no dependency-install step. The soak tests never imported the Socket SDK, so the soak-only glob had never needed one.

The fix adds `npm ci --ignore-scripts --no-audit --no-fund` with npm caching before the tests. Simulated locally: `npm ci` then the exact combined command gives **72 tests, 71 pass, 0 fail, 1 skipped** (that skip pre-existing in the soak suite).

### The compiler-output-regression failure
The raw numeric object-field contract expected `ScalarThisFieldSet` while the retained artifact carries `ScalarObjectFieldSet` raw-f64 stores. The record is renamed, its `expr_kind` corrected, and a duplicated store/load pair removed.

**I checked that the removal isn't a relaxation** rather than taking the description's word, since "remove a duplicate" is exactly how a contract quietly gets weaker:

| | main | now |
|---|---|---|
| `require_records` | 19 | 17 |
| require `consumed_fact_state = "consumed"` | 8 | 6 |
| require `consumed_fact_kind = "representation"` | 4 | 2 |

Every decrement is accounted for by the two duplicated records (`raw_scalar_ctor_field_store_raw_f64` and `raw_scalar_field_load_raw_f64` each appeared twice). The surviving store and load records still require the representation fact to be consumed, so the native f64 proof stands.

### Validation
- **All 30 `lint`-job checkers pass**
- The fixed job simulated end-to-end locally, as above
- CI/config-only change; no Rust paths touched
- Squashed tree verified identical to the validated tree

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated validation by installing lockfile-pinned development dependencies with npm caching enabled.
  * Disabled unnecessary install-time scripts, audit checks, and funding prompts during workflow setup.

* **Bug Fixes**
  * Corrected benchmark checks for raw numeric object field representations.
  * Removed a duplicate constructor field-store record while preserving scalar field-load validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->