### PR TITLE
fix(runtime): inherit Object prototype on class instances

### DIFF
--- a/changelog.d/8780-class-instance-object-prototype-read.md
+++ b/changelog.d/8780-class-instance-object-prototype-read.md
@@ -1,0 +1,4 @@
+Fixed inherited `Object.prototype` property reads on declared class instances.
+Classes without their own `toString` or `valueOf` now resolve the default
+methods instead of reporting the properties as present while reading them as
+`undefined`, restoring ordinary string coercion such as `String(new C())`.

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -240,7 +240,16 @@ pub(crate) unsafe fn ordinary_object_prototype_property_value(
         return None;
     }
     let class_id = (*obj).class_id;
-    if class_id != 0 && !is_anon_shape_class_id(class_id) {
+    // Declared ES class instances have a registered class id, but still end
+    // their implicit prototype chain at Object.prototype.  Their class
+    // methods/accessors have already been consulted before this fallback, so
+    // a miss must remain eligible for Object.prototype (including user-added
+    // properties).  Keep excluding unregistered native/synthetic class ids:
+    // those object kinds resolve their own intrinsic prototype chains.
+    if class_id != 0
+        && !is_anon_shape_class_id(class_id)
+        && !super::super::class_registry::is_class_id_registered(class_id)
+    {
         return None;
     }
     default_object_prototype_property_value(obj as usize, key)


### PR DESCRIPTION
Lands #8780.

A registered ES class instance whose class methods and accessors all missed was excluded from the ordinary `Object.prototype` read fallback, so inherited reads — `String(new C())` among them — failed. Declared class instances *do* end their implicit prototype chain at `Object.prototype`, and their own methods are consulted before this fallback runs, so a miss must remain eligible.

The exclusion now additionally requires the class id to be **unregistered**, which keeps native and synthetic class ids on their existing intrinsic prototype paths:

```rust
if class_id != 0
    && !is_anon_shape_class_id(class_id)
    && !class_registry::is_class_id_registered(class_id)
```

### Validation (on the merged result)
- **All 30 `lint`-job checkers pass**
- `perry-runtime --lib` (`RUST_TEST_THREADS=1`): **2674 passed, 0 failed**
- `perry-codegen --lib`: **1230 passed, 0 failed**
- `perry-codegen --tests` (all integration suites): **0 failures**
- Squashed tree verified identical to the validated tree

The PR carried its own `changelog.d/` fragment. No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited `Object.prototype` properties on class instances.
  * Restored expected default `toString` and `valueOf` behavior, including normal string conversion for class instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->