### PR TITLE
fix(native): preserve POD value boundaries

### DIFF
--- a/changelog.d/8782-pod-copy-native-proof.md
+++ b/changelog.d/8782-pod-copy-native-proof.md
@@ -1,0 +1,1 @@
+Fix POD copies into `any` losing dynamic properties and correct their native ABI evidence state.

--- a/crates/perry-codegen/src/expr/pod_record.rs
+++ b/crates/perry-codegen/src/expr/pod_record.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use perry_hir::Expr;
+use perry_hir::{types::Type, Expr};
 
 use crate::nanbox::{double_literal, POINTER_MASK_I64, TAG_UNDEFINED_I64};
 use crate::native_value::{
@@ -19,10 +19,19 @@ pub(crate) fn copy_pod_local(
     ctx: &mut FnCtx<'_>,
     destination_id: u32,
     source_id: u32,
+    destination_type: &Type,
 ) -> Result<Option<PodLocal>> {
+    let crate::native_value::PodLayoutDecision::Layout(destination_layout) =
+        crate::native_value::layout_decision_for_type(ctx, destination_type)
+    else {
+        return Ok(None);
+    };
     let Some(source) = ctx.pod_records.get(&source_id).cloned() else {
         return Ok(None);
     };
+    if source.layout != destination_layout {
+        return Ok(None);
+    }
     let data_slot = ctx
         .func
         .alloca_entry_bytes_aligned(source.layout.size, source.layout.alignment);
@@ -88,7 +97,7 @@ pub(crate) fn copy_pod_local(
         &lowered,
         None,
         None,
-        Some(MaterializationReason::PodMaterialization),
+        None,
         false,
         false,
         vec![

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -439,7 +439,7 @@ pub(crate) fn lower_let(
     if let Some(init_expr) = init {
         let copied = match init_expr {
             perry_hir::Expr::LocalGet(source_id) if !ctx.boxed_vars.contains(&id) => {
-                crate::expr::copy_pod_local(ctx, id, *source_id)?
+                crate::expr::copy_pod_local(ctx, id, *source_id, &refined_ty)?
             }
             _ => None,
         };

--- a/crates/perry-codegen/tests/native_proof_regressions/pod_manifest.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/pod_manifest.rs
@@ -105,6 +105,45 @@ fn nested_pod_initializers_and_local_assignments_preserve_value_semantics() {
 }
 
 #[test]
+fn pod_local_assigned_to_any_stays_at_the_managed_boundary() {
+    let packet_ty = pod_type(&[("tag", Type::Named("PerryU8".to_string()))]);
+    let module = module(
+        "pod_to_any.ts",
+        vec![
+            pod_let(1, "packet", packet_ty, vec![("tag", int(7))]),
+            Stmt::Let {
+                id: 2,
+                name: "managed".to_string(),
+                ty: Type::Any,
+                mutable: true,
+                init: Some(local(1)),
+            },
+            Stmt::Return(Some(local(2))),
+        ],
+    );
+
+    let artifact = compile_artifact_json_for_module(module);
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        !records.iter().any(|record| {
+            record["local_id"] == 2 && record["consumer"] == "pod_record_value_copy"
+        }),
+        "an `any` destination must not be pulled back into native POD storage:\n{artifact:#}"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record["consumer"] == "pod_record_materialized_value_copy"
+                && record["notes"].as_array().is_some_and(|notes| {
+                    notes
+                        .iter()
+                        .any(|note| note == "value_semantics=copy_at_managed_boundary")
+                })
+        }),
+        "a POD-to-any assignment must cross the managed value-copy boundary:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn checked_native_scalar_conversions_keep_dynamic_pod_initializers_native() {
     let packet_ty = pod_type(&[
         ("signed8", Type::Named("PerryI8".to_string())),

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1376,7 +1376,9 @@ pub fn build_inline_arg_bindings(
             // local (`function f(a){a++}; f(x)` mutated x — S13.2.1_A6),
             // and substituting a literal would produce `5++`.
             let force_let = mutated_params.contains(&param.id);
-            if is_trivial_expr(arg) && !trivial_in_closure && !force_let {
+            let preserve_value_boundary = inline_arg_needs_value_boundary(param, arg);
+            if is_trivial_expr(arg) && !trivial_in_closure && !force_let && !preserve_value_boundary
+            {
                 param_map.insert(param.id, arg.clone());
             } else {
                 let fresh = *next_local_id;
@@ -1409,6 +1411,15 @@ pub fn build_inline_arg_bindings(
     }
 
     Some((setup, param_map))
+}
+
+fn inline_arg_needs_value_boundary(param: &Param, arg: &Expr) -> bool {
+    // A source local passed to a non-primitive parameter must retain the
+    // parameter-binding boundary. In particular, standalone POD records have
+    // value semantics there: codegen materializes a managed copy for `any`
+    // and copies exact POD layouts. Direct substitution would let later POD
+    // recognition target the caller's native local from inside the callee.
+    matches!(arg, Expr::LocalGet(_)) && !param.ty.is_primitive()
 }
 
 /// Try to inline a simple function or method call.
@@ -1911,7 +1922,12 @@ pub fn try_inline_call(
                     // Body-written params get a copy — see
                     // build_inline_arg_bindings (S13.2.1_A6).
                     let force_let = mutated.contains(&param.id);
-                    if is_trivial_expr(arg) && !trivial_in_closure && !force_let {
+                    let preserve_value_boundary = inline_arg_needs_value_boundary(param, arg);
+                    if is_trivial_expr(arg)
+                        && !trivial_in_closure
+                        && !force_let
+                        && !preserve_value_boundary
+                    {
                         param_map.insert(param.id, arg.clone());
                     } else {
                         let local_id = *next_local_id;
@@ -2047,7 +2063,8 @@ pub fn try_inline_call(
                         let trivial_in_closure = is_trivial_expr(arg)
                             && !matches!(arg, Expr::LocalGet(_))
                             && closure_capt.contains(&param.id);
-                        if is_trivial_expr(arg) && !trivial_in_closure {
+                        let preserve_value_boundary = inline_arg_needs_value_boundary(param, arg);
+                        if is_trivial_expr(arg) && !trivial_in_closure && !preserve_value_boundary {
                             param_map.insert(param.id, arg.clone());
                         } else {
                             let local_id = *next_local_id;

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -890,6 +890,39 @@ mod tests {
     }
 
     #[test]
+    fn nonprimitive_local_inline_argument_keeps_a_parameter_binding() {
+        let params = vec![Param {
+            id: 1,
+            name: "value".to_string(),
+            ty: Type::Any,
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }];
+        let mut next_local_id = 100;
+        let (setup, param_map) = call_inliner::build_inline_arg_bindings(
+            &params,
+            &[Expr::LocalGet(42)],
+            &HashSet::new(),
+            &HashSet::new(),
+            &mut next_local_id,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            setup.as_slice(),
+            [Stmt::Let {
+                id: 100,
+                ty: Type::Any,
+                init: Some(Expr::LocalGet(42)),
+                ..
+            }]
+        ));
+        assert!(matches!(param_map.get(&1), Some(Expr::LocalGet(100))));
+    }
+
+    #[test]
     fn cross_module_synthetic_imports_are_sorted() {
         let mut module = Module::new("dest");
         let mut extra_methods = HashMap::new();

--- a/tests/test_c_layout_pod_records.sh
+++ b/tests/test_c_layout_pod_records.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Focused runtime regression for C-layout POD records. The marker types are
-# erased at the TypeScript surface; JS-visible reads, writes, returns, and
-# dynamic escapes must behave like an ordinary object.
+# Focused runtime regression for C-layout POD records. POD assignment and call
+# boundaries have value semantics; once materialized, each independent copy's
+# reads, writes, returns, and dynamic properties behave like an ordinary object.
 
 set -euo pipefail
 
@@ -114,7 +114,7 @@ COMPILE_OUTPUT=$(PERRY_NATIVE_REPS=1 \
 }
 write_evidence "compile.log" "$COMPILE_OUTPUT"
 
-EXPECTED=$'read=7,1.5,2.25,4\ninit=-1,x,1.1\nlie=x\nafter=9,2.5,11\nreturn=4\ncapture=8'
+EXPECTED=$'read=7,1.5,2.25,4\ninit=-1,x,1.1\nlie=x\nafter=9,1.5,11\nreturn=4\ncapture=8'
 RUN_OUTPUT=$(./test_bin 2>&1)
 write_evidence "runtime.stdout" "$RUN_OUTPUT"
 if [ "$RUN_OUTPUT" != "$EXPECTED" ]; then


### PR DESCRIPTION
## Summary

- keep inlined non-primitive local arguments behind a parameter binding so POD value-copy semantics survive inlining
- restrict native POD local copies to exact POD-typed destination layouts and record them as region-local
- update the C-layout POD runtime expectation to the documented value semantics and add focused regressions

## Release blocker

The pinned v0.5.1519 candidate failed `native-abi-evidence-packet`: `pod_record_value_copy` was recorded as materialized while retaining a native `pod_record`. Correcting that evidence exposed an inliner bug where a POD passed to `any` mixed the managed clone with the caller native local, losing dynamic properties.

## Verification

- `BASE_SHA=origin/main scripts/run_lint_gates.sh` — all 55 gates passed
- `cargo test --release -p perry-transform nonprimitive_local_inline_argument_keeps_a_parameter_binding`
- focused perry-codegen POD regressions
- release-mode Perry build
- `PERRY=... bash tests/test_c_layout_pod_records.sh` — PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed copying of plain data values into dynamic (`any`) values so their properties are preserved correctly.
  - Corrected native ABI evidence for these value transfers.
  - Preserved value boundaries when passing non-primitive values through inlined calls.
  - Ensured dynamic mutations do not unexpectedly alter independent C-layout value copies.

- **Tests**
  - Added regression coverage for POD-to-`any` assignments, inline calls, and C-layout value semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->