### PR TITLE
fix(release): clear full-suite regressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3424,7 +3424,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build compiler + UI backend + harness
-        run: cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static -p ${{ matrix.ui_backend }} -p perry-doc-tests
+        # The database/mail examples route through async wrapper staticlibs.
+        # Build them in this SAME Cargo graph as perry-stdlib: otherwise each
+        # no-auto fallback build bundles a distinct tokio TLS/runtime and the
+        # linker rejects the unsafe pair (#507, #7629).
+        run: cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static -p ${{ matrix.ui_backend }} -p perry-doc-tests -p perry-ext-ioredis -p perry-ext-mongodb -p perry-ext-mysql2 -p perry-ext-pg -p perry-ext-nodemailer
 
       - name: Pre-build Apple UI libs for cross-compile (macOS only)
         if: matrix.os == 'macos-14'

--- a/changelog.d/8789-release-sweep-regressions.md
+++ b/changelog.d/8789-release-sweep-regressions.md
@@ -1,0 +1,1 @@
+Fix release-sweep regressions in primitive and Error prototype lookup, callable Proxy coercion, cross-function aggregates, typed-array inlining, symbol-root scanning, and doc-test wrapper builds.

--- a/changelog.d/8789-release-sweep-regressions.md
+++ b/changelog.d/8789-release-sweep-regressions.md
@@ -1,1 +1,1 @@
-Fix release-sweep regressions in primitive and Error prototype lookup, callable Proxy coercion, cross-function aggregates, typed-array inlining, symbol-root scanning, and doc-test wrapper builds.
+Fix release-sweep regressions in primitive and Error prototype lookup, callable Proxy coercion, cross-function aggregates, typed-array inlining, symbol-root scanning, Ring archive reduction, and doc-test wrapper builds.

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/side_table_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/side_table_scanners.rs
@@ -329,6 +329,59 @@ fn test_symbol_side_table_registered_scanner_rewrites_roots_and_metadata() {
 }
 
 #[test]
+fn test_symbol_side_table_budgeted_scanner_heals_entries_after_owner_rekey() {
+    let _guard = GcTestIsolationGuard::new();
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    crate::symbol::test_clear_symbol_side_table_roots();
+
+    let owner = crate::object::js_object_alloc(0, 0) as usize;
+    let sym_key = unsafe { alloc_nursery_test_symbol() };
+    let value = young_leaf();
+    let valid_ptrs = build_valid_pointer_set();
+    let owner_old = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_OBJECT) as usize;
+    let sym_key_old = unsafe { alloc_old_test_symbol() };
+    let value_old = crate::arena::arena_alloc_gc_old(64, 8, GC_TYPE_STRING) as usize;
+    unsafe {
+        set_forwarding_address(
+            header_from_user_ptr(owner as *const u8) as *mut GcHeader,
+            owner_old as *mut u8,
+        );
+        set_forwarding_address(
+            header_from_user_ptr(sym_key as *const u8) as *mut GcHeader,
+            sym_key_old as *mut u8,
+        );
+        set_forwarding_address(
+            header_from_user_ptr(value as *const u8) as *mut GcHeader,
+            value_old as *mut u8,
+        );
+    }
+    crate::symbol::test_seed_symbol_property_root(owner, sym_key, string_bits(value));
+
+    // One slot per step forces the owner-rekey and entry-rewrite slots into
+    // separate budget slices. The later slice must still find and rewrite the
+    // entry after its owner key moved in the earlier slice.
+    let mut state = crate::symbol::new_symbol_side_table_root_scan_state();
+    let mut visitor = RuntimeRootVisitor::for_rewrite(&valid_ptrs);
+    loop {
+        let mut remaining = 1;
+        if crate::symbol::scan_symbol_side_table_roots_mut_step(
+            &mut visitor,
+            state.as_mut(),
+            &mut remaining,
+        ) {
+            break;
+        }
+    }
+
+    assert!(!crate::symbol::test_symbol_property_owner_exists(owner));
+    assert_eq!(
+        crate::symbol::test_symbol_property_root_bits(owner_old, sym_key_old),
+        Some(string_bits(value_old))
+    );
+    crate::symbol::test_clear_symbol_side_table_roots();
+}
+
+#[test]
 fn test_runtime_root_visitor_rewrites_raw_pointer_slots() {
     // `nursery_user` is live across the `arena_alloc_gc_old` call below.
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -189,12 +189,15 @@ unsafe fn prototype_property_value_with_guard(
     // (#7795 removed the two resolution calls that used to allocate here as
     // well — the rooting is still required for the prototype read itself.)
     //
-    // Root both before the first of those calls and read each back at its
+    // Root all three before the first of those calls and read each back at its
     // point of use. NaN-boxed handles only, so this module adds no bare
     // `get_raw_*_ptr` to `scripts/raw_handle_debt.py`.
     let scope = crate::gc::RuntimeHandleScope::new();
+    let proto_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(proto_addr as i64));
     let key_h = scope.root_nanbox_f64(crate::value::nanbox_string_key(key));
     let receiver_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(receiver_addr as i64));
+    let proto_ptr =
+        || crate::value::js_nanbox_get_pointer(proto_h.get_nanbox_f64()) as *mut ObjectHeader;
     let key = || {
         crate::value::js_nanbox_get_pointer(key_h.get_nanbox_f64()) as *const crate::StringHeader
     };
@@ -210,8 +213,7 @@ unsafe fn prototype_property_value_with_guard(
     // (`scan_prototype_addr_cache_roots_mut`) — the array index-read fast path
     // already depends on it. `Object.prototype` is non-writable and
     // non-configurable per spec, so the memo cannot go stale.
-    let proto_ptr = proto_addr as *mut ObjectHeader;
-    if proto_ptr as usize == receiver_addr() {
+    if proto_ptr() as usize == receiver_addr() {
         return None;
     }
     let receiver = crate::value::js_nanbox_pointer(receiver_addr() as i64);
@@ -224,7 +226,7 @@ unsafe fn prototype_property_value_with_guard(
     let previous_this_h = scope.root_nanbox_f64(previous_this);
     let prev_override = accessor_receiver_override_begin(receiver);
     let prev_override_h = prev_override.map(|v| scope.root_nanbox_f64(v));
-    let property = js_object_get_field_by_name(proto_ptr, key());
+    let property = js_object_get_field_by_name(proto_ptr(), key());
     accessor_receiver_override_end(prev_override_h.map(|h| h.get_nanbox_f64()));
     super::super::js_implicit_this_set(previous_this_h.get_nanbox_f64());
     if property.is_undefined() {

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -163,6 +163,22 @@ unsafe fn default_object_prototype_property_value(
     key: *const crate::StringHeader,
 ) -> Option<JSValue> {
     let _guard = object_prototype_lookup_guard()?;
+    let proto_addr = crate::array::object_prototype_addr();
+    if proto_addr == 0 {
+        return None;
+    }
+    prototype_property_value_with_guard(proto_addr, receiver_addr, key)
+}
+
+/// Read an inherited property while the caller holds
+/// [`ObjectPrototypeLookupGuard`]. Keeping guard acquisition outside this
+/// helper lets Error-family lookup resolve a lazy builtin prototype without a
+/// recursive ordinary-object fallback.
+unsafe fn prototype_property_value_with_guard(
+    proto_addr: usize,
+    receiver_addr: usize,
+    key: *const crate::StringHeader,
+) -> Option<JSValue> {
     // #7498: THIS IS THE FRAME `PERRY_GC_PROTECT_FROMSPACE=1` FAULTS IN on the
     // `[...obj.arr]` path — a 56-byte from-space `GC_TYPE_STRING`, i.e. `key`.
     // Both arguments are GC-managed and both are live across the call below
@@ -194,10 +210,6 @@ unsafe fn default_object_prototype_property_value(
     // (`scan_prototype_addr_cache_roots_mut`) — the array index-read fast path
     // already depends on it. `Object.prototype` is non-writable and
     // non-configurable per spec, so the memo cannot go stale.
-    let proto_addr = crate::array::object_prototype_addr();
-    if proto_addr == 0 {
-        return None;
-    }
     let proto_ptr = proto_addr as *mut ObjectHeader;
     if proto_ptr as usize == receiver_addr() {
         return None;
@@ -246,11 +258,78 @@ pub(crate) unsafe fn ordinary_object_prototype_property_value(
     // a miss must remain eligible for Object.prototype (including user-added
     // properties).  Keep excluding unregistered native/synthetic class ids:
     // those object kinds resolve their own intrinsic prototype chains.
-    if class_id != 0
-        && !is_anon_shape_class_id(class_id)
-        && !super::super::class_registry::is_class_id_registered(class_id)
-    {
-        return None;
+    if class_id != 0 && !is_anon_shape_class_id(class_id) {
+        if !super::super::class_registry::is_class_id_registered(class_id) {
+            return None;
+        }
+        if super::super::extends_builtin_error(class_id) {
+            // Error subclasses end at an Error-family prototype before
+            // Object.prototype. Hold the recursion guard while resolving the
+            // lazy builtin: constructor/prototype lookup itself may miss an
+            // ordinary property, and must not re-enter this same fallback.
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let receiver_h =
+                scope.root_nanbox_f64(crate::value::js_nanbox_pointer(obj as usize as i64));
+            let key_h = scope.root_nanbox_f64(crate::value::nanbox_string_key(key));
+            let _guard = object_prototype_lookup_guard()?;
+            let mut current = class_id;
+            let mut prototype_name = "Error";
+            for _ in 0..32 {
+                match current {
+                    crate::error::CLASS_ID_TYPE_ERROR => {
+                        prototype_name = "TypeError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_RANGE_ERROR => {
+                        prototype_name = "RangeError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_REFERENCE_ERROR => {
+                        prototype_name = "ReferenceError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_SYNTAX_ERROR => {
+                        prototype_name = "SyntaxError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_EVAL_ERROR => {
+                        prototype_name = "EvalError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_URI_ERROR => {
+                        prototype_name = "URIError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_AGGREGATE_ERROR => {
+                        prototype_name = "AggregateError";
+                        break;
+                    }
+                    crate::error::CLASS_ID_ERROR => break,
+                    _ => match super::super::get_parent_class_id(current) {
+                        Some(parent) if parent != 0 && parent != current => current = parent,
+                        _ => break,
+                    },
+                }
+            }
+            let prototype = super::super::builtin_prototype_value(prototype_name);
+            let prototype_value = JSValue::from_bits(prototype.to_bits());
+            if prototype_value.is_pointer() {
+                let prototype_addr = prototype_value.as_pointer::<ObjectHeader>() as usize;
+                if prototype_addr != 0 {
+                    let receiver_addr =
+                        crate::value::js_nanbox_get_pointer(receiver_h.get_nanbox_f64()) as usize;
+                    let key = crate::value::js_nanbox_get_pointer(key_h.get_nanbox_f64())
+                        as *const crate::StringHeader;
+                    if let Some(value) =
+                        prototype_property_value_with_guard(prototype_addr, receiver_addr, key)
+                    {
+                        return Some(value);
+                    }
+                }
+            }
+            // The guard drops with this branch; let the ordinary final
+            // fallback consult Object.prototype on a genuine Error miss.
+        }
     }
     default_object_prototype_property_value(obj as usize, key)
 }

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -472,6 +472,14 @@ pub(super) unsafe fn dispatch_common(
             ) {
                 return Some(result);
             }
+            // A direct primitive-wrapper call resolves through
+            // Number/Boolean/BigInt.prototype and returns the primitive's
+            // internal value. The explicit Object.prototype.valueOf.call(x)
+            // form uses object_prototype_value_of_thunk instead, where ToObject
+            // intentionally produces a wrapper.
+            if !jsval.is_pointer() {
+                return Some(object);
+            }
             return Some(js_object_default_value_of(object));
         }
 

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -477,6 +477,8 @@ pub(super) unsafe fn dispatch_common(
             // internal value. The explicit Object.prototype.valueOf.call(x)
             // form uses object_prototype_value_of_thunk instead, where ToObject
             // intentionally produces a wrapper.
+            let object = object_handle.get_nanbox_f64();
+            let jsval = JSValue::from_bits(object.to_bits());
             if !jsval.is_pointer() {
                 return Some(object);
             }

--- a/crates/perry-runtime/src/symbol/gc_roots.rs
+++ b/crates/perry-runtime/src/symbol/gc_roots.rs
@@ -227,10 +227,23 @@ fn scan_symbol_side_table_root_slot(
             rewrite_symbol_property_owner_if_forwarded(visitor, owner);
         }
         SymbolSideTableRootSlot::SymbolPropertyEntry { owner, sym_key } => {
+            // The preceding budget slice may already have rekeyed this
+            // owner's map entry. Heal the snapshot's owner before looking up
+            // the entry, otherwise every later slice searches the stale key
+            // and skips both the symbol key and its value.
+            let mut healed_owner = owner;
+            visitor.visit_metadata_usize_slot(&mut healed_owner);
             let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
-            let Some((entry_sym, value_bits)) = guard
-                .as_mut()
-                .and_then(|map| map.get_mut(&owner))
+            let Some(map) = guard.as_mut() else {
+                return;
+            };
+            let lookup_owner = if map.contains_key(&healed_owner) {
+                healed_owner
+            } else {
+                owner
+            };
+            let Some((entry_sym, value_bits)) = map
+                .get_mut(&lookup_owner)
                 .and_then(|entries| entries.iter_mut().find(|entry| entry.0 == sym_key))
             else {
                 return;

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -524,11 +524,6 @@ unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
     if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
         return CustomToPrimitiveOutcome::TypeError;
     }
-    let method_ptr = (method_bits & POINTER_MASK) as usize;
-    if !crate::closure::is_closure_ptr(method_ptr) {
-        return CustomToPrimitiveOutcome::TypeError;
-    }
-
     let method_handle = scope.root_nanbox_f64(method);
     let hint_ptr = crate::string::js_string_from_bytes(b"number".as_ptr(), 6);
     let hint_handle = scope.root_string_ptr(hint_ptr);
@@ -538,9 +533,22 @@ unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
                 & POINTER_MASK),
     );
     let receiver = value_handle.get_nanbox_f64();
-    let prev_this = crate::object::js_implicit_this_set(receiver);
-    let result = crate::closure::js_native_call_value(method_handle.get_nanbox_f64(), &hint, 1);
-    crate::object::js_implicit_this_set(prev_this);
+    let method = method_handle.get_nanbox_f64();
+    let result = if crate::proxy::js_proxy_is_proxy(method) == 1 {
+        if !crate::proxy::proxy_wraps_callable(method) {
+            return CustomToPrimitiveOutcome::TypeError;
+        }
+        crate::proxy::call_proxy_value_with_this(method, receiver, &[hint])
+    } else {
+        let method_ptr = (method.to_bits() & POINTER_MASK) as usize;
+        if !crate::closure::is_closure_ptr(method_ptr) {
+            return CustomToPrimitiveOutcome::TypeError;
+        }
+        let prev_this = crate::object::js_implicit_this_set(receiver);
+        let result = crate::closure::js_native_call_value(method, &hint, 1);
+        crate::object::js_implicit_this_set(prev_this);
+        result
+    };
 
     if is_primitive_value(result) {
         CustomToPrimitiveOutcome::Primitive(result)

--- a/crates/perry-transform/src/aggregate_scalar.rs
+++ b/crates/perry-transform/src/aggregate_scalar.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 
 use perry_hir::types::{LocalId, Type};
-use perry_hir::{Expr, Module, Stmt};
+use perry_hir::{Expr, Function, Module, Stmt};
 
 const MAX_SCALAR_AGGREGATE_LEN: usize = 8;
 const MAX_SCALAR_AGGREGATE_FIELDS: usize = 16;
@@ -52,19 +52,70 @@ pub fn run(module: &mut Module) {
         })
         .collect();
 
+    // LocalIds are module-unique, but generated object/class methods live in
+    // separate HIR function bodies. A carrier declared in one body must stay
+    // materialized when another body references it, even if every use in the
+    // declaring body looks scalarizable. Count the distinct HIR regions that
+    // reference each local before mutating any of them.
+    let mut region_refs = vec![collect_stmt_refs(&module.init)];
+    region_refs.extend(module.functions.iter().map(collect_function_refs));
+    for class in &module.classes {
+        if let Some(constructor) = &class.constructor {
+            region_refs.push(collect_function_refs(constructor));
+        }
+        region_refs.extend(class.methods.iter().map(collect_function_refs));
+        region_refs.extend(
+            class
+                .getters
+                .iter()
+                .map(|(_, function)| collect_function_refs(function)),
+        );
+        region_refs.extend(
+            class
+                .setters
+                .iter()
+                .map(|(_, function)| collect_function_refs(function)),
+        );
+        region_refs.extend(class.static_methods.iter().map(collect_function_refs));
+    }
+    // Computed members are code-generated from their own retained Function
+    // bodies rather than passed through scalarize_stmts below. They still
+    // count as separate consumers of a carrier declared elsewhere.
+    for class in &module.classes {
+        region_refs.extend(
+            class
+                .computed_members
+                .iter()
+                .map(|member| collect_function_refs(&member.function)),
+        );
+    }
+    let mut reference_region_counts: HashMap<LocalId, usize> = HashMap::new();
+    for refs in &region_refs {
+        for id in refs {
+            *reference_region_counts.entry(*id).or_default() += 1;
+        }
+    }
+    let mut region_index = 0;
+
     scalarize_stmts(
         &mut module.init,
         &mut next_local_id,
         &mut source_span_remaps,
         &anon_shape_fields,
+        &region_refs[region_index],
+        &reference_region_counts,
     );
+    region_index += 1;
     for function in &mut module.functions {
         scalarize_stmts(
             &mut function.body,
             &mut next_local_id,
             &mut source_span_remaps,
             &anon_shape_fields,
+            &region_refs[region_index],
+            &reference_region_counts,
         );
+        region_index += 1;
     }
     for class in &mut module.classes {
         if let Some(constructor) = &mut class.constructor {
@@ -73,7 +124,10 @@ pub fn run(module: &mut Module) {
                 &mut next_local_id,
                 &mut source_span_remaps,
                 &anon_shape_fields,
+                &region_refs[region_index],
+                &reference_region_counts,
             );
+            region_index += 1;
         }
         for method in &mut class.methods {
             scalarize_stmts(
@@ -81,7 +135,10 @@ pub fn run(module: &mut Module) {
                 &mut next_local_id,
                 &mut source_span_remaps,
                 &anon_shape_fields,
+                &region_refs[region_index],
+                &reference_region_counts,
             );
+            region_index += 1;
         }
         for (_, getter) in &mut class.getters {
             scalarize_stmts(
@@ -89,7 +146,10 @@ pub fn run(module: &mut Module) {
                 &mut next_local_id,
                 &mut source_span_remaps,
                 &anon_shape_fields,
+                &region_refs[region_index],
+                &reference_region_counts,
             );
+            region_index += 1;
         }
         for (_, setter) in &mut class.setters {
             scalarize_stmts(
@@ -97,7 +157,10 @@ pub fn run(module: &mut Module) {
                 &mut next_local_id,
                 &mut source_span_remaps,
                 &anon_shape_fields,
+                &region_refs[region_index],
+                &reference_region_counts,
             );
+            region_index += 1;
         }
         for method in &mut class.static_methods {
             scalarize_stmts(
@@ -105,7 +168,10 @@ pub fn run(module: &mut Module) {
                 &mut next_local_id,
                 &mut source_span_remaps,
                 &anon_shape_fields,
+                &region_refs[region_index],
+                &reference_region_counts,
             );
+            region_index += 1;
         }
     }
 
@@ -116,11 +182,28 @@ pub fn run(module: &mut Module) {
     }
 }
 
+fn collect_stmt_refs(stmts: &[Stmt]) -> HashSet<LocalId> {
+    let mut refs = Vec::new();
+    let mut visited = HashSet::new();
+    for stmt in stmts {
+        perry_hir::collect_local_refs_stmt(stmt, &mut refs, &mut visited);
+    }
+    refs.into_iter().collect()
+}
+
+fn collect_function_refs(function: &Function) -> HashSet<LocalId> {
+    let mut refs = collect_stmt_refs(&function.body);
+    refs.extend(function.captures.iter().copied());
+    refs
+}
+
 fn scalarize_stmts(
     stmts: &mut Vec<Stmt>,
     next_local_id: &mut LocalId,
     source_span_remaps: &mut Vec<(LocalId, LocalId)>,
     anon_shape_fields: &AnonShapeFields,
+    region_refs: &HashSet<LocalId>,
+    reference_region_counts: &HashMap<LocalId, usize>,
 ) {
     let candidates: Vec<LocalId> = stmts
         .iter()
@@ -142,6 +225,8 @@ fn scalarize_stmts(
             next_local_id,
             source_span_remaps,
             anon_shape_fields,
+            region_refs,
+            reference_region_counts,
         );
     }
 
@@ -159,6 +244,8 @@ fn scalarize_stmts(
                     next_local_id,
                     source_span_remaps,
                     anon_shape_fields,
+                    region_refs,
+                    reference_region_counts,
                 );
                 if let Some(else_branch) = else_branch {
                     scalarize_stmts(
@@ -166,11 +253,20 @@ fn scalarize_stmts(
                         next_local_id,
                         source_span_remaps,
                         anon_shape_fields,
+                        region_refs,
+                        reference_region_counts,
                     );
                 }
             }
             Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
-                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+                scalarize_stmts(
+                    body,
+                    next_local_id,
+                    source_span_remaps,
+                    anon_shape_fields,
+                    region_refs,
+                    reference_region_counts,
+                );
             }
             Stmt::For { init, body, .. } => {
                 if let Some(init) = init {
@@ -180,25 +276,43 @@ fn scalarize_stmts(
                         next_local_id,
                         source_span_remaps,
                         anon_shape_fields,
+                        region_refs,
+                        reference_region_counts,
                     );
                     if init_vec.len() == 1 {
                         **init = init_vec.remove(0);
                     }
                 }
-                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+                scalarize_stmts(
+                    body,
+                    next_local_id,
+                    source_span_remaps,
+                    anon_shape_fields,
+                    region_refs,
+                    reference_region_counts,
+                );
             }
             Stmt::Try {
                 body,
                 catch,
                 finally,
             } => {
-                scalarize_stmts(body, next_local_id, source_span_remaps, anon_shape_fields);
+                scalarize_stmts(
+                    body,
+                    next_local_id,
+                    source_span_remaps,
+                    anon_shape_fields,
+                    region_refs,
+                    reference_region_counts,
+                );
                 if let Some(catch) = catch {
                     scalarize_stmts(
                         &mut catch.body,
                         next_local_id,
                         source_span_remaps,
                         anon_shape_fields,
+                        region_refs,
+                        reference_region_counts,
                     );
                 }
                 if let Some(finally) = finally {
@@ -207,6 +321,8 @@ fn scalarize_stmts(
                         next_local_id,
                         source_span_remaps,
                         anon_shape_fields,
+                        region_refs,
+                        reference_region_counts,
                     );
                 }
             }
@@ -217,6 +333,8 @@ fn scalarize_stmts(
                         next_local_id,
                         source_span_remaps,
                         anon_shape_fields,
+                        region_refs,
+                        reference_region_counts,
                     );
                 }
             }
@@ -301,7 +419,18 @@ fn scalarize_candidate(
     next_local_id: &mut LocalId,
     source_span_remaps: &mut Vec<(LocalId, LocalId)>,
     anon_shape_fields: &AnonShapeFields,
+    region_refs: &HashSet<LocalId>,
+    reference_region_counts: &HashMap<LocalId, usize>,
 ) -> bool {
+    let own_region_reference = usize::from(region_refs.contains(&array_id));
+    if reference_region_counts
+        .get(&array_id)
+        .copied()
+        .unwrap_or_default()
+        > own_region_reference
+    {
+        return false;
+    }
     let Some(elements) = stmts.iter().find_map(|stmt| match stmt {
         Stmt::Let {
             id,
@@ -880,5 +1009,39 @@ mod tests {
                 )
             }));
         }
+    }
+
+    #[test]
+    fn reference_from_generated_function_keeps_materialized_aggregate() {
+        let mut module = aggregate_fixture(false);
+        module.functions.push(Function {
+            id: 99,
+            name: "__obj_method_computed".to_string(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: Type::Any,
+            body: vec![Stmt::Return(Some(Expr::LocalGet(1)))],
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+
+        run(&mut module);
+
+        assert!(module.init.iter().any(|stmt| {
+            matches!(
+                stmt,
+                Stmt::Let {
+                    id: 1,
+                    init: Some(Expr::Array(_)),
+                    ..
+                }
+            )
+        }));
     }
 }

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1419,7 +1419,17 @@ fn inline_arg_needs_value_boundary(param: &Param, arg: &Expr) -> bool {
     // value semantics there: codegen materializes a managed copy for `any`
     // and copies exact POD layouts. Direct substitution would let later POD
     // recognition target the caller's native local from inside the callee.
-    matches!(arg, Expr::LocalGet(_)) && !param.ty.is_primitive()
+    if !matches!(arg, Expr::LocalGet(_)) || param.ty.is_primitive() {
+        return false;
+    }
+    // Typed arrays have reference semantics and cannot resolve to a PerryPod
+    // alias. Keeping a redundant parameter local for them hides their element
+    // reads from the canonical-i32 collector (the int-valued-TA liveness
+    // fixture loses two proven locals), with no value boundary to preserve.
+    !matches!(
+        &param.ty,
+        Type::Named(name) if perry_hir::typed_array_kind_for_name(name).is_some()
+    )
 }
 
 /// Try to inline a simple function or method call.

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -923,6 +923,32 @@ mod tests {
     }
 
     #[test]
+    fn typed_array_inline_argument_keeps_reference_substitution() {
+        let params = vec![Param {
+            id: 1,
+            name: "values".to_string(),
+            ty: Type::Named("Int32Array".to_string()),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }];
+        let mut next_local_id = 100;
+        let (setup, param_map) = call_inliner::build_inline_arg_bindings(
+            &params,
+            &[Expr::LocalGet(42)],
+            &HashSet::new(),
+            &HashSet::new(),
+            &mut next_local_id,
+        )
+        .unwrap();
+
+        assert!(setup.is_empty());
+        assert!(matches!(param_map.get(&1), Some(Expr::LocalGet(42))));
+        assert_eq!(next_local_id, 100);
+    }
+
+    #[test]
     fn cross_module_synthetic_imports_are_sorted() {
         let mut module = Module::new("dest");
         let mut extra_methods = HashMap::new();

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -1653,34 +1653,16 @@ pub(super) fn strip_bundled_shared_deps_from_well_known_lib(
             "failed to inspect stdlib symbols (empty set)"
         ));
     }
-    let empty = std::collections::HashSet::new();
-
     // Fixed-point loop: start by assuming every candidate is removable, then
     // repeatedly protect (un-mark) any candidate whose symbols are still
     // needed by the current kept-set (members - to_remove), until a round
     // protects nothing new.
-    let mut to_remove: std::collections::BTreeSet<String> = candidates.clone();
-    loop {
-        let kept_undefined: std::collections::HashSet<&String> = undefined_by_member
-            .iter()
-            .filter(|(m, _)| !to_remove.contains(m.as_str()))
-            .flat_map(|(_, syms)| syms.iter())
-            .collect();
-        let mut protected_this_round = false;
-        for c in to_remove.clone().iter() {
-            let defined = defined_by_member.get(c).unwrap_or(&empty);
-            let still_needed = kept_undefined
-                .iter()
-                .any(|s| defined.contains(*s) && !stdlib_defined.contains(*s));
-            if still_needed {
-                to_remove.remove(c);
-                protected_this_round = true;
-            }
-        }
-        if !protected_this_round {
-            break;
-        }
-    }
+    let to_remove = shared_dep_members_to_remove(
+        &candidates,
+        &defined_by_member,
+        &undefined_by_member,
+        &stdlib_defined,
+    );
     if to_remove.is_empty() {
         return Ok(lib_path.clone());
     }
@@ -1688,7 +1670,7 @@ pub(super) fn strip_bundled_shared_deps_from_well_known_lib(
         if !to_remove.contains(c) {
             eprintln!(
                 "[strip-dedup] {lib_name}: keeping bundled {c} — needed by a kept \
-                 sibling and not provided by stdlib"
+                 sibling and not safely replaceable by stdlib"
             );
         }
     }
@@ -1733,6 +1715,51 @@ pub(super) fn strip_bundled_shared_deps_from_well_known_lib(
     );
     let _ = std::fs::remove_dir_all(&extract_dir);
     Ok(trimmed_lib)
+}
+
+fn shared_dep_members_to_remove(
+    candidates: &std::collections::BTreeSet<String>,
+    defined_by_member: &std::collections::HashMap<String, std::collections::HashSet<String>>,
+    undefined_by_member: &std::collections::HashMap<String, std::collections::HashSet<String>>,
+    stdlib_defined: &std::collections::HashSet<String>,
+) -> std::collections::BTreeSet<String> {
+    let empty = std::collections::HashSet::new();
+    let mut to_remove = candidates.clone();
+    loop {
+        let kept_undefined: std::collections::HashSet<&String> = undefined_by_member
+            .iter()
+            .filter(|(m, _)| !to_remove.contains(m.as_str()))
+            .flat_map(|(_, syms)| syms.iter())
+            .collect();
+        let mut protected_this_round = false;
+        for c in to_remove.clone().iter() {
+            let defined = defined_by_member.get(c).unwrap_or(&empty);
+            let still_needed = kept_undefined.iter().any(|s| {
+                defined.contains(*s)
+                    && (!stdlib_defined.contains(*s) || requires_bundled_native_companion(s))
+            });
+            if still_needed {
+                to_remove.remove(c);
+                protected_this_round = true;
+            }
+        }
+        if !protected_this_round {
+            break;
+        }
+    }
+    to_remove
+}
+
+/// Native objects emitted by Ring's build script are one half of the Ring
+/// crate artifact. They are not interchangeable with a same-named object from
+/// another staticlib merely because both archives advertise the same stable
+/// `ring_core_<version>__*` C ABI in their symbol indexes. If fixed-point
+/// pruning has to keep a wrapper's Ring Rust CGU (for a wrapper-specific
+/// monomorphization), keep the C/assembly members that satisfy its Ring ABI as
+/// well. Otherwise the reduced wrapper contains the Rust half alone and ELF
+/// links fail with hundreds of undefined `ring_core_*` references.
+fn requires_bundled_native_companion(symbol: &str) -> bool {
+    symbol.trim_start_matches('_').starts_with("ring_core_")
 }
 
 mod stub_symbols;

--- a/crates/perry/src/commands/compile/strip_dedup/strip_dedup_tests.rs
+++ b/crates/perry/src/commands/compile/strip_dedup/strip_dedup_tests.rs
@@ -3,7 +3,10 @@
 //! evidence handling). Child module of `strip_dedup`, so `super::` sees its
 //! private items exactly as the inline `mod strip_dedup_tests` did.
 
-use super::{force_localize_symbol, is_panic_unwind_symbol, parse_nm_archive_output};
+use super::{
+    force_localize_symbol, is_panic_unwind_symbol, parse_nm_archive_output,
+    requires_bundled_native_companion, shared_dep_members_to_remove,
+};
 
 #[test]
 fn panic_unwind_classification_matches_dwref() {
@@ -127,6 +130,74 @@ empty_marker.o:
 
     // empty_marker.o → no entry; call site keeps it defensively.
     assert!(!by_member.contains_key("empty_marker.o"));
+}
+
+#[test]
+fn ring_core_symbols_require_the_bundled_native_companion() {
+    assert!(requires_bundled_native_companion(
+        "ring_core_0_17_14__p384_point_mul"
+    ));
+    // Mach-O's external-symbol spelling carries a leading underscore.
+    assert!(requires_bundled_native_companion(
+        "_ring_core_0_17_14__OPENSSL_cpuid_setup"
+    ));
+    assert!(!requires_bundled_native_companion(
+        "_RINvNtNtCsinkE3tyG5t6_4ring"
+    ));
+    assert!(!requires_bundled_native_companion("aws_lc_0_39_0_symbol"));
+}
+
+#[test]
+fn shared_dep_fixed_point_keeps_ring_native_half_with_kept_rust_half() {
+    use std::collections::{BTreeSet, HashMap, HashSet};
+
+    let candidates: BTreeSet<String> = ["ring-rust.o", "ring-native.o", "ordinary.o"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let defined_by_member: HashMap<String, HashSet<String>> = [
+        ("ring-rust.o", ["ring_wrapper_unique"]),
+        ("ring-native.o", ["ring_core_0_17_14__p384_point_mul"]),
+        ("ordinary.o", ["ordinary_shared"]),
+    ]
+    .into_iter()
+    .map(|(member, symbols)| {
+        (
+            member.to_string(),
+            symbols.into_iter().map(str::to_string).collect(),
+        )
+    })
+    .collect();
+    let undefined_by_member: HashMap<String, HashSet<String>> = [
+        (
+            "wrapper-entry.o",
+            vec!["ring_wrapper_unique", "ordinary_shared"],
+        ),
+        ("ring-rust.o", vec!["ring_core_0_17_14__p384_point_mul"]),
+    ]
+    .into_iter()
+    .map(|(member, symbols)| {
+        (
+            member.to_string(),
+            symbols.into_iter().map(str::to_string).collect(),
+        )
+    })
+    .collect();
+    let stdlib_defined: HashSet<String> = ["ring_core_0_17_14__p384_point_mul", "ordinary_shared"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+    let removed = shared_dep_members_to_remove(
+        &candidates,
+        &defined_by_member,
+        &undefined_by_member,
+        &stdlib_defined,
+    );
+
+    assert!(!removed.contains("ring-rust.o"));
+    assert!(!removed.contains("ring-native.o"));
+    assert!(removed.contains("ordinary.o"));
 }
 
 #[cfg(target_os = "windows")]

--- a/scripts/gc_rekeyed_key_tables.json
+++ b/scripts/gc_rekeyed_key_tables.json
@@ -230,6 +230,12 @@
       "why": "Registered prune retains on !is_dead_owner over the property owner (symbol.rs:530-539)."
     },
     {
+      "site": "crates/perry-runtime/src/symbol/gc_roots.rs::scan_symbol_side_table_root_slot",
+      "table": "SYMBOL_PROPERTIES (snapshot owner)",
+      "death": "dead_owner:prune_dead_symbol_property_owners",
+      "why": "The budgeted scanner heals the snapshot owner for lookup only; the underlying SYMBOL_PROPERTIES key is covered by the same registered owner prune as scan_symbol_property_roots_mut."
+    },
+    {
       "site": "crates/perry-runtime/src/weakref.rs::rewritten_holder_addr",
       "table": "WEAK_HOLDERS",
       "death": "self_pruned:prune_dead_weak_holders",

--- a/scripts/run_doc_tests.ps1
+++ b/scripts/run_doc_tests.ps1
@@ -12,7 +12,8 @@ $RepoRoot  = Resolve-Path (Join-Path $ScriptDir '..')
 Set-Location $RepoRoot
 
 # Build perry + UI backend + harness in release mode. Skipped transparently
-# if already built.
+# if already built. Keep the async database/mail wrappers in this same Cargo
+# graph as perry-stdlib so they share one tokio runtime compilation.
 cargo build --release `
     -p perry `
     -p perry-runtime `
@@ -20,7 +21,12 @@ cargo build --release `
     -p perry-runtime-static `
     -p perry-stdlib-static `
     -p perry-ui-windows `
-    -p perry-doc-tests
+    -p perry-doc-tests `
+    -p perry-ext-ioredis `
+    -p perry-ext-mongodb `
+    -p perry-ext-mysql2 `
+    -p perry-ext-pg `
+    -p perry-ext-nodemailer
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Host doc-tests can reuse the full prebuilt runtime/stdlib archives above.

--- a/scripts/run_doc_tests.sh
+++ b/scripts/run_doc_tests.sh
@@ -20,9 +20,13 @@ cd "$REPO_ROOT"
 # The runtime + stdlib are built with `--features full` so the prebuilt
 # `target/release/libperry_*.a` covers every doc-test's import surface,
 # letting PERRY_NO_AUTO_OPTIMIZE=1 below short-circuit the per-test
-# specialized rebuild (~30-200s saved per test).
+# specialized rebuild (~30-200s saved per test). Async wrappers used by the
+# database/mail examples must be in THIS invocation too: building one later
+# gives it a different tokio compilation from libperry_stdlib.a, and the
+# no-auto linker correctly refuses that unsafe archive pair.
 cargo build --release \
-    -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static -p perry-doc-tests
+    -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static -p perry-doc-tests \
+    -p perry-ext-ioredis -p perry-ext-mongodb -p perry-ext-mysql2 -p perry-ext-pg -p perry-ext-nodemailer
 
 # Disable per-test auto-optimize for HOST runs only. With this set,
 # `perry compile` short-circuits the cargo-rebuild step in


### PR DESCRIPTION
## Summary

- restore primitive valueOf, Error-subclass prototype, callable Proxy ToPrimitive, and cross-HIR aggregate semantics caught by the v0.5.1519-r2 full sweep
- preserve the #8782 POD boundary while allowing typed-array reference substitution, restoring the representation census floor
- heal budgeted symbol-side-table entry scans after owner rekeying
- keep Ring native C/assembly companions when archive reduction retains the matching Rust CGU
- build async doc-test wrappers in the same Cargo graph as perry-stdlib so their Tokio archives are coherent

## Release evidence

The r2 candidate is exact SHA 99e3abd6f5f5d32fea6d48b5624b5b3f012e03b3. Simulator Tests passed. The full Tests run exposed the regressions and CI build-coherence failures addressed here.

## Local checks

- cargo fmt --all
- cargo check -p perry-runtime
- cargo test -p perry-transform aggregate_scalar
- cargo test -p perry-transform inline::tests::typed_array_inline_argument_keeps_reference_substitution
- cargo test -p perry-runtime test_symbol_side_table_budgeted_scanner_heals_entries_after_owner_rekey
- cargo test --release -p perry --bin perry shared_dep_fixed_point_keeps_ring_native_half_with_kept_rust_half
- cargo test --release -p perry --bin perry ring_core_symbols_require_the_bundled_native_companion
- parity: test_gap_4100_primitive_proto_brand_check
- parity: test_gap_generic_class_constructor_name_7632
- parity: test_gap_array_iterator_next
- parity: test_gap_6320_proxy_closure_probes
- representation census: fixture_int_valued_ta canonical-i32 restored from 1 to floor 3
- bash and YAML syntax checks; unified doc-test package graph resolves one Tokio 1.53.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected prototype property lookup for built-in Error subclasses.
  * Fixed primitive `valueOf()` behavior and callable Proxy coercion.
  * Improved garbage-collection handling for symbol-linked properties.
  * Prevented incorrect scalarization across generated functions and improved typed-array inlining.
  * Preserved required native components during bundled dependency cleanup.

* **Tests**
  * Added regression coverage for prototype, symbol scanning, aggregate handling, and typed-array behavior.

* **Chores**
  * Improved cross-platform documentation test builds for database and email integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->