### PR TITLE
fix(ui): distinguish Text style and id overloads

### DIFF
--- a/changelog.d/8790-text-style-overload.md
+++ b/changelog.d/8790-text-style-overload.md
@@ -1,0 +1,11 @@
+Fixed the `Text(content, style)` overload in `perry/ui`. Two-argument `Text`
+calls were unconditionally routed through the reactive `Text(content, id)`
+constructor, so a style object was passed to native UI backends as a string
+pointer. Styled text examples consequently crashed on macOS while decoding the
+bogus id. Codegen now distinguishes option objects from string ids, sends
+styled text through the regular widget constructor plus inline-style setters,
+and preserves the reactive-id route for `Text(content, id)`.
+
+Doc-test failures now also retain the Unix signal number instead of reporting
+every signal termination as the indistinguishable `exit=-1`, so release-gate
+reports identify crashes and resource kills directly.

--- a/crates/perry-codegen/src/lower_call/native/native_ui_widgets_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_ui_widgets_branch.rs
@@ -1,9 +1,16 @@
 {
-    // perry/ui Text(content, id) — 2-arg form registers the widget in the
-    // per-platform text registry so setText(id, val) can update it later.
-    // The 1-arg form `Text(content)` routes through the PERRY_UI_TABLE entry
-    // (perry_ui_text_create) as normal; only the 2-arg form is intercepted here.
-    if module == "perry/ui" && method == "Text" && object.is_none() && args.len() == 2 {
+    // perry/ui Text(content, id) — the 2-string form registers the widget in
+    // the per-platform text registry so setText(id, val) can update it later.
+    // A two-argument call is also used for `Text(content, { ...style })`.
+    // Only intercept the reactive-id overload when the second argument is not
+    // an options object; styled Text must reach the generic widget table so it
+    // creates the regular text widget and applies each inline-style setter.
+    if module == "perry/ui"
+        && method == "Text"
+        && object.is_none()
+        && args.len() == 2
+        && extract_options_fields(ctx, &args[1]).is_none()
+    {
         let text_ptr = get_raw_string_ptr(ctx, &args[0])?;
         let id_ptr = get_raw_string_ptr(ctx, &args[1])?;
         ctx.pending_declares.push((
@@ -17,10 +24,6 @@
             "perry_ui_text_create_with_id",
             &[(I64, &text_ptr), (I64, &id_ptr)],
         );
-        // Optional trailing style arg (position 2) — same pattern as Button.
-        if let Some(style_arg) = args.get(2).cloned() {
-            apply_inline_style(ctx, &handle, &style_arg)?;
-        }
         let blk = ctx.block();
         return Ok(nanbox_pointer_inline(blk, &handle));
     }
@@ -401,47 +404,6 @@
             method,
             args.len()
         );
-    }
-
-    // Phase 2 v3.3: `Text(content, id)` reactive form. The 1-arg
-    // `Text(content)` row in PERRY_UI_TABLE doesn't know about the
-    // optional `id` second arg — pre-fix the table-call's "if args.len()
-    // == sig.args.len() + 1 ⇒ inline_style_arg" path absorbed it as a
-    // would-be style object, then `apply_inline_style` silently no-op'd
-    // because strings aren't object literals. Effect: id was dropped on
-    // the floor and `setText("counter", ...)` had nothing to look up.
-    //
-    // Fix: detect Text-with-id BEFORE the table lookup, lower the
-    // create call manually (mirroring the table-call shape), then
-    // emit `perry_arkts_register_text_id(handle, id)` so the platform
-    // UI lib can map id → widget handle. On harmonyos, codegen-arkts
-    // emits `@State text_<id>` directly into the .ets and the
-    // register_text_id call is a runtime no-op (see
-    // perry-runtime/src/ui_text_registry.rs).
-    if module == "perry/ui" && method == "Text" && object.is_none() && args.len() == 2 {
-        let content_ptr = get_raw_string_ptr(ctx, &args[0])?;
-        ctx.pending_declares
-            .push(("perry_ui_text_create".to_string(), I64, vec![I64]));
-        let handle = {
-            let blk = ctx.block();
-            blk.call(I64, "perry_ui_text_create", &[(I64, &content_ptr)])
-        };
-        // Lower the id arg as a regular NaN-boxed JS value so the
-        // runtime's `decode_jsvalue_string` can read it through the
-        // standard StringHeader path (handles SSO + heap strings the
-        // same way, and matches the harmonyos drain-queue contract).
-        let id_d = lower_expr(ctx, &args[1])?;
-        ctx.pending_declares.push((
-            "perry_arkts_register_text_id".to_string(),
-            crate::types::VOID,
-            vec![I64, DOUBLE],
-        ));
-        let blk = ctx.block();
-        blk.call_void(
-            "perry_arkts_register_text_id",
-            &[(I64, &handle), (DOUBLE, &id_d)],
-        );
-        return Ok(nanbox_pointer_inline(blk, &handle));
     }
 
     if module == "perry/ui"

--- a/crates/perry-codegen/tests/app_window_config_options.rs
+++ b/crates/perry-codegen/tests/app_window_config_options.rs
@@ -132,6 +132,16 @@ fn app_call(config: Vec<(&str, Expr)>) -> Stmt {
     })
 }
 
+fn text_call(second_arg: Expr) -> Stmt {
+    Stmt::Expr(Expr::NativeMethodCall {
+        module: "perry/ui".to_string(),
+        class_name: None,
+        object: None,
+        method: "Text".to_string(),
+        args: vec![Expr::String("hello".to_string()), second_arg],
+    })
+}
+
 fn compile_ir(name: &str, body: Vec<Stmt>) -> String {
     String::from_utf8(compile_module(&module(name, body), empty_opts()).unwrap()).unwrap()
 }
@@ -194,4 +204,45 @@ fn app_config_without_window_options_emits_no_setter_calls() {
             "omitted App() config key must not emit `{setter}`. IR:\n{ir}"
         );
     }
+}
+
+#[test]
+fn text_options_object_routes_to_inline_style_not_reactive_id() {
+    let ir = compile_ir(
+        "text_inline_style_overload",
+        vec![text_call(Expr::Object(vec![(
+            "borderRadius".to_string(),
+            Expr::Number(6.0),
+        )]))],
+    );
+
+    assert!(
+        ir.contains("call i64 @perry_ui_text_create("),
+        "styled Text must use the regular one-string constructor; IR:\n{ir}"
+    );
+    assert!(
+        ir.contains("call void @perry_ui_widget_set_corner_radius("),
+        "styled Text must apply its inline-style setters; IR:\n{ir}"
+    );
+    assert!(
+        !ir.contains("perry_ui_text_create_with_id"),
+        "a style object must never be decoded as a reactive string id; IR:\n{ir}"
+    );
+}
+
+#[test]
+fn text_string_id_keeps_reactive_constructor_route() {
+    let ir = compile_ir(
+        "text_reactive_id_overload",
+        vec![text_call(Expr::String("counter".to_string()))],
+    );
+
+    assert!(
+        ir.contains("call i64 @perry_ui_text_create_with_id("),
+        "Text(content, id) must keep registering its reactive id; IR:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call void @perry_ui_widget_set_corner_radius("),
+        "a reactive string id must not be treated as an inline style; IR:\n{ir}"
+    );
 }

--- a/crates/perry-doc-tests/src/main.rs
+++ b/crates/perry-doc-tests/src/main.rs
@@ -551,8 +551,8 @@ fn run_one(
                     kind: ex.kind,
                     status: Status::RunFail,
                     detail: format!(
-                        "exit={} {}",
-                        out.status.code().unwrap_or(-1),
+                        "{} {}",
+                        exit_description(&out.status),
                         combine_stdio(&out.stdout, &out.stderr),
                     ),
                     duration_ms: 0,
@@ -762,8 +762,8 @@ fn cross_compile_one(
             kind: ex.kind,
             status: Status::CrossCompileFail,
             detail: format!(
-                "target=`{target}`: perry exit {}: {}",
-                output.status.code().unwrap_or(-1),
+                "target=`{target}`: perry {}: {}",
+                exit_description(&output.status),
                 combine_stdio(&output.stdout, &output.stderr),
             ),
             duration_ms: 0,
@@ -816,12 +816,28 @@ fn compile(perry_bin: &Path, src: &Path, out: &Path) -> Result<()> {
         .with_context(|| format!("launching perry for {}", src.display()))?;
     if !out_status.status.success() {
         return Err(anyhow!(
-            "perry exit {}: {}",
-            out_status.status.code().unwrap_or(-1),
+            "perry {}: {}",
+            exit_description(&out_status.status),
             combine_stdio(&out_status.stdout, &out_status.stderr),
         ));
     }
     Ok(())
+}
+
+/// Preserve the actual termination reason on Unix instead of collapsing every
+/// signal to the indistinguishable sentinel `exit=-1`.
+fn exit_description(status: &std::process::ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("exit={code}");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return format!("signal={signal}");
+        }
+    }
+    "exit=unknown".to_string()
 }
 
 /// Merge child stdout + stderr for error reporting. MSVC `link.exe` on


### PR DESCRIPTION
## Summary
- route `Text(content, { ...style })` through the regular widget constructor and inline-style setters instead of decoding the options object as a reactive string id
- preserve `Text(content, id)` registration and remove the duplicate unreachable lowering branch
- report Unix child signals in doc-test failures instead of collapsing them to `exit=-1`

## Release blocker
The v0.5.1519 full release candidate run reproduced macOS segfaults in `cross_widget_inline_style.ts`, `hex_gradient.ts`, and `visual_test.ts`. LLDB resolved the crash to `perry_ui_text_create_with_id` decoding the style object as UTF-8.

## Local verification
- `cargo fmt --all -- --check`
- `cargo test -p perry-codegen --test app_window_config_options` (4 passed)
- `cargo test -p perry-doc-tests` (10 passed)
- exact release compiler + macOS UI archive: all 10 `ui/styling/` doc examples passed
- `stdlib/utilities/snippets.ts` passed plus 100 `--no-compile` harness repetitions

The source version remains `0.5.1519`; no tag or GitHub Release is created by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Text` overload handling so passing a style object correctly creates a regular text widget and applies inline styles.
  - Preserved reactive ID behavior when a string ID is provided to `Text`.
  - Improved documentation test failure messages by reporting the Unix signal that terminated a process instead of a generic exit code.

- **Documentation**
  - Added changelog coverage for the text styling and process termination reporting fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->