### PR TITLE
runtime: allocate native async-resolution promises in malloc space

### DIFF
--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -307,7 +307,8 @@ pub use object::{
 };
 pub use promise::{js_is_promise, js_promise_run_microtasks, js_promise_state, js_promise_value};
 pub use promise::{
-    js_promise_mark_internally_handled, js_promise_new, js_promise_reject, js_promise_rejected,
+    js_promise_mark_internally_handled, js_promise_new, js_promise_new_cross_thread,
+    js_promise_reject, js_promise_rejected,
     js_promise_resolve, js_promise_resolved,
 };
 pub use string::js_string_from_bytes;

--- a/crates/perry-stdlib/src/argon2.rs
+++ b/crates/perry-stdlib/src/argon2.rs
@@ -9,14 +9,14 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
-use perry_runtime::{js_promise_new, js_string_from_bytes, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, js_string_from_bytes, Promise, StringHeader};
 
 /// argon2.hash(password) -> Promise<string>
 ///
 /// Hash a password using Argon2id with default parameters.
 #[no_mangle]
 pub unsafe extern "C" fn js_argon2_hash(password_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let password = match string_from_header(password_ptr) {
         Some(p) => p,
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn js_argon2_verify(
     hash_ptr: *const StringHeader,
     password_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let hash_str = match string_from_header(hash_ptr) {
         Some(h) => h,

--- a/crates/perry-stdlib/src/axios.rs
+++ b/crates/perry-stdlib/src/axios.rs
@@ -7,7 +7,7 @@ use crate::common::{
     get_handle, register_handle, spawn_for_promise, string_from_header_lossy as string_from_header,
     Handle,
 };
-use perry_runtime::{js_promise_new, js_string_from_bytes, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, js_string_from_bytes, Promise, StringHeader};
 
 /// #598: read the body argument as a JSON string. Strings pass
 /// through as-is; everything else is JSON.stringify'd via the
@@ -49,7 +49,7 @@ unsafe fn request_without_body(
     url_ptr: *const StringHeader,
     method: reqwest::Method,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let url = match string_from_header(url_ptr) {
         Some(u) => u,
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn js_axios_options(url_ptr: *const StringHeader) -> *mut 
 /// axios.post(url, data) -> Promise<AxiosResponse>
 #[no_mangle]
 pub unsafe extern "C" fn js_axios_post(url_ptr: *const StringHeader, data: f64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let url = match string_from_header(url_ptr) {
         Some(u) => u,
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn js_axios_post(url_ptr: *const StringHeader, data: f64) 
 /// axios.put(url, data) -> Promise<AxiosResponse>
 #[no_mangle]
 pub unsafe extern "C" fn js_axios_put(url_ptr: *const StringHeader, data: f64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let url = match string_from_header(url_ptr) {
         Some(u) => u,
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn js_axios_put(url_ptr: *const StringHeader, data: f64) -
 /// axios.delete(url) -> Promise<AxiosResponse>
 #[no_mangle]
 pub unsafe extern "C" fn js_axios_delete(url_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let url = match string_from_header(url_ptr) {
         Some(u) => u,
@@ -305,7 +305,7 @@ pub unsafe extern "C" fn js_axios_delete(url_ptr: *const StringHeader) -> *mut P
 /// axios.patch(url, data) -> Promise<AxiosResponse>
 #[no_mangle]
 pub unsafe extern "C" fn js_axios_patch(url_ptr: *const StringHeader, data: f64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let url = match string_from_header(url_ptr) {
         Some(u) => u,

--- a/crates/perry-stdlib/src/bcrypt.rs
+++ b/crates/perry-stdlib/src/bcrypt.rs
@@ -15,7 +15,7 @@ pub unsafe extern "C" fn js_bcrypt_hash(
     password_ptr: *const StringHeader,
     salt_rounds: f64,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let password = match string_from_header(password_ptr) {
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn js_bcrypt_compare(
     password_ptr: *const StringHeader,
     hash_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let password = match string_from_header(password_ptr) {
@@ -142,7 +142,7 @@ pub unsafe extern "C" fn js_bcrypt_compare(
 /// bcrypt.genSalt(rounds) -> Promise<string>
 #[no_mangle]
 pub unsafe extern "C" fn js_bcrypt_gen_salt(rounds: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
     let cost = rounds as u32;
 

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -83,7 +83,18 @@ unsafe fn unpin_promise_after_native_resolution(promise_ptr: usize) {
 #[inline]
 pub unsafe fn js_promise_new_for_native_resolution() -> *mut perry_runtime::Promise {
     ensure_gc_scanner_registered();
-    let p = perry_runtime::js_promise_new();
+    // #8770: allocate in MALLOC space (non-moving), not the nursery arena. A
+    // native-resolution promise is handed to a tokio worker as a raw `usize` and,
+    // until its resolution is queued into PENDING_RESOLUTIONS (which the root
+    // scanner visits), it is reachable only through that worker-thread capture —
+    // invisible to the main-thread copying minor. A nursery resident in that
+    // window is wiped by the from-space flip REGARDLESS of its PIN flag (the flip
+    // resets eden/survivor blocks wholesale; only root-reachable pins force the
+    // fallback — see `js_promise_new_cross_thread`). Then `js_stdlib_process_
+    // pending` unpins/resolves through the stale pointer and faults on the
+    // reclaimed header. Malloc space is non-moving and both sweep paths honor
+    // GC_FLAG_PINNED, so the pin actually protects it there.
+    let p = perry_runtime::js_promise_new_cross_thread();
     pin_promise_for_native_resolution(p as usize);
     p
 }

--- a/crates/perry-stdlib/src/container/backend_ctl.rs
+++ b/crates/perry-stdlib/src/container/backend_ctl.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn js_container_getBackend() -> *const StringHeader {
 /// FFI: js_container_detectBackend() -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_detectBackend() -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     crate::common::spawn_for_promise_deferred(
         promise as *mut u8,
         async move {
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn js_container_selectBackendFor(
 ///   await setBackends(ready.map(b => b.name));
 #[no_mangle]
 pub unsafe extern "C" fn js_container_getAvailableBackends() -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     crate::common::spawn_for_promise_deferred(
         promise as *mut u8,
         async move {
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn js_container_getBackendPriority() -> *const StringHeade
 /// - `"backend probe failed: <reason>"`
 #[no_mangle]
 pub unsafe extern "C" fn js_container_setBackend(name_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let name = match string_from_header(name_ptr) {
         Some(s) => s,
         None => {
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn js_container_setBackend(name_ptr: *const StringHeader) 
 pub unsafe extern "C" fn js_container_setBackends(
     names_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let names_json = match string_from_header(names_json_ptr) {
         Some(s) => s,
         None => {

--- a/crates/perry-stdlib/src/container/compose_ffi.rs
+++ b/crates/perry-stdlib/src/container/compose_ffi.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn js_container_compose_start(
     handle: f64,
     services_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn js_container_compose_stop(
     handle: f64,
     services_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn js_container_compose_restart(
     handle: f64,
     services_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn js_container_compose_restart(
 /// FFI: `js_container_compose_config(handle: f64) -> *mut Promise`
 #[no_mangle]
 pub unsafe extern "C" fn js_container_compose_config(handle: f64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn js_container_compose_config(handle: f64) -> *mut Promis
 pub unsafe extern "C" fn js_container_composeUp(
     spec_ptr: *const perry_runtime::StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let spec = match types::parse_compose_spec(spec_ptr) {
         Ok(s) => s,
@@ -283,7 +283,7 @@ pub unsafe extern "C" fn js_container_compose_down(
     handle: f64,
     opts_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let opts_json = unsafe { string_from_header(opts_ptr) };
@@ -330,7 +330,7 @@ pub unsafe extern "C" fn js_container_compose_down(
 /// FFI: `js_container_compose_ps(handle: f64) -> *mut Promise`
 #[no_mangle]
 pub unsafe extern "C" fn js_container_compose_ps(handle: f64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn js_container_compose_logs(
     service_ptr: *const StringHeader,
     tail: f64,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn js_container_compose_exec(
     service_ptr: *const StringHeader,
     cmd_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let handle_id = handle_id_from_f64(handle);
 
     let engine = match types::get_compose_handle(handle_id as u64) {

--- a/crates/perry-stdlib/src/container/images.rs
+++ b/crates/perry-stdlib/src/container/images.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -19,7 +19,7 @@ use std::sync::OnceLock;
 pub unsafe extern "C" fn js_container_pullImage(
     reference_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let reference = match string_from_header(reference_ptr) {
         Some(s) => s,
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn js_container_pullImage(
 /// FFI: js_container_listImages() -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_listImages() -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Resolves with a JSON-encoded `ImageInfo[]` string.
     crate::common::spawn_for_promise_deferred(
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn js_container_build(
     spec_ptr: *const StringHeader,
     image_name_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let spec_json = string_from_header(spec_ptr).unwrap_or_else(|| "{}".to_string());
     let image_name = string_from_header(image_name_ptr).unwrap_or_default();
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn js_container_removeImage(
     reference_ptr: *const StringHeader,
     force: i32,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let reference = match string_from_header(reference_ptr) {
         Some(s) => s,

--- a/crates/perry-stdlib/src/container/lifecycle.rs
+++ b/crates/perry-stdlib/src/container/lifecycle.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 /// FFI: js_container_run(spec_json: *const StringHeader) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_run(spec_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let spec = match types::parse_container_spec(spec_ptr) {
         Ok(s) => s,
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn js_container_run(spec_ptr: *const StringHeader) -> *mut
 /// FFI: js_container_create(spec_json: *const StringHeader) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_create(spec_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let spec = match types::parse_container_spec(spec_ptr) {
         Ok(s) => s,
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn js_container_create(spec_ptr: *const StringHeader) -> *
 /// FFI: js_container_start(id: *const StringHeader) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_start(id_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn js_container_stop(
     id_ptr: *const StringHeader,
     timeout: i32,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn js_container_remove(
     id_ptr: *const StringHeader,
     force: i32,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn js_container_downByProject(
     project_ptr: *const StringHeader,
     opts_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let project = match string_from_header(project_ptr) {
         Some(s) if !s.is_empty() => s,
         _ => {
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn js_container_downByProject(
 /// FFI: `js_container_downAll(opts_json: *const StringHeader) -> *mut Promise`
 #[no_mangle]
 pub unsafe extern "C" fn js_container_downAll(opts_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let opts_json = string_from_header(opts_ptr);
 
     crate::common::spawn_for_promise_deferred(
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn js_container_removeIfExists(
     id_ptr: *const StringHeader,
     force: i32,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = match string_from_header(id_ptr) {
         Some(s) if !s.is_empty() => s,
         _ => {
@@ -363,7 +363,7 @@ pub(crate) fn parse_cleanup_options(
 /// `JSON.parse(await list(true))` to recover the array.
 #[no_mangle]
 pub unsafe extern "C" fn js_container_list(all: i32) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise_deferred(
         promise as *mut u8,
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn js_container_list(all: i32) -> *mut Promise {
 /// FFI: js_container_inspect(id: *const StringHeader) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_inspect(id_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,

--- a/crates/perry-stdlib/src/container/logs_exec.rs
+++ b/crates/perry-stdlib/src/container/logs_exec.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 /// FFI: js_container_logs(id: *const StringHeader, tail: i32) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_container_logs(id_ptr: *const StringHeader, tail: i32) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn js_container_exec(
     env_json_ptr: *const StringHeader,
     workdir_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let id = match string_from_header(id_ptr) {
         Some(s) => s,

--- a/crates/perry-stdlib/src/container/workload.rs
+++ b/crates/perry-stdlib/src/container/workload.rs
@@ -6,7 +6,7 @@ pub use types::{
 };
 
 pub use backend::{detect_backend, ContainerBackend};
-use perry_runtime::{js_promise_new, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, Promise, StringHeader};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn js_workload_runGraph(
     graph_json_ptr: *const StringHeader,
     opts_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let graph_json = string_from_header(graph_json_ptr).unwrap_or_else(|| "{}".to_string());
     let opts_json = string_from_header(opts_json_ptr).unwrap_or_else(|| "{}".to_string());
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn js_workload_runGraph(
 /// FFI: js_workload_inspectGraph(handle_id: i64) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_workload_inspectGraph(handle_id: i64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
 
     crate::common::spawn_for_promise_deferred(
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn js_workload_inspectGraph(handle_id: i64) -> *mut Promis
 /// FFI: js_workload_handle_down(handle_id: i64, force: i32) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_workload_handle_down(handle_id: i64, force: i32) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn js_workload_handle_down(handle_id: i64, force: i32) -> 
 /// FFI: js_workload_handle_status(handle_id: i64) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_workload_handle_status(handle_id: i64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
 
     crate::common::spawn_for_promise_deferred(
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn js_workload_handle_logs(
     node_id_ptr: *const StringHeader,
     tail: i32,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
     let node_id = string_from_header(node_id_ptr).unwrap_or_default();
     let tail_opt = if tail >= 0 { Some(tail as u32) } else { None };
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn js_workload_handle_exec(
     node_id_ptr: *const StringHeader,
     cmd_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
     let node_id = string_from_header(node_id_ptr).unwrap_or_default();
     let cmd_json = string_from_header(cmd_json_ptr).unwrap_or_else(|| "[]".to_string());
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn js_workload_handle_exec(
 /// FFI: js_workload_handle_ps(handle_id: i64) -> *mut Promise
 #[no_mangle]
 pub unsafe extern "C" fn js_workload_handle_ps(handle_id: i64) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
     let id = handle_id as u64;
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -380,7 +380,7 @@ fn tagged_bool(value: bool) -> f64 {
 /// fetch(url) -> Promise<Response>
 #[no_mangle]
 pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
     url_ptr: *const StringHeader,
     auth_header_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -526,7 +526,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
     auth_header_ptr: *const StringHeader,
     body_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -604,7 +604,7 @@ pub unsafe extern "C" fn js_fetch_post(
     body_ptr: *const StringHeader,
     content_type_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -696,7 +696,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
     // allocation can't move the still-TLS-stashed signal before we read it.
     let abort_state = abort_bridge::take_pending_signal_watch();
 
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     // An already-aborted signal rejects the request up front; otherwise keep the
@@ -824,7 +824,7 @@ fn consume_response_body(handle: f64) -> Result<Vec<u8>, &'static str> {
 /// `Expr::Await` for the rationale).
 #[no_mangle]
 pub unsafe extern "C" fn js_fetch_response_text(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let body = match consume_response_body(handle) {
         Ok(body) => body,
         Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
@@ -893,7 +893,7 @@ unsafe fn json_value_to_jsvalue(value: &serde_json::Value) -> JSValue {
 /// response.json() -> Promise<object>
 #[no_mangle]
 pub unsafe extern "C" fn js_fetch_response_json(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let body = match consume_response_body(handle) {
         Ok(body) => body,
         Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
@@ -932,7 +932,7 @@ pub unsafe extern "C" fn js_fetch_response_json(handle: f64) -> *mut perry_runti
 pub unsafe extern "C" fn js_fetch_text(
     url_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -1284,7 +1284,7 @@ fn alloc_headers(store: HeadersStore) -> usize {
 /// doesn't hang. See `js_fetch_response_text` for rationale.
 #[no_mangle]
 pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let body = match consume_response_body(handle) {
         Ok(body) => body,
         Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
@@ -1322,7 +1322,7 @@ pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut perry_run
 /// `.slice()` / `.size` / `.type` to the FFIs below.
 #[no_mangle]
 pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let id = handle_id(handle);
     let content_type = {
         let guard = FETCH_RESPONSES.lock().unwrap();
@@ -1391,7 +1391,7 @@ pub unsafe extern "C" fn js_blob_type(handle: f64) -> *mut StringHeader {
 /// property dispatch in `value.rs`. Resolved synchronously.
 #[no_mangle]
 pub unsafe extern "C" fn js_blob_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let id = handle_id(handle);
     let body: Vec<u8> = BLOB_REGISTRY
         .lock()
@@ -1427,7 +1427,7 @@ pub unsafe extern "C" fn js_blob_bytes(handle: f64) -> *mut perry_runtime::Promi
 /// characters; lossy_utf8 produces U+FFFD identically).
 #[no_mangle]
 pub unsafe extern "C" fn js_blob_text(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let id = handle_id(handle);
     let body: Vec<u8> = BLOB_REGISTRY
         .lock()
@@ -1850,7 +1850,7 @@ fn consume_request_body(handle: f64) -> Result<Vec<u8>, &'static str> {
 /// (#1688)
 #[no_mangle]
 pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     match consume_request_body(handle) {
         Ok(body) => {
             let text = String::from_utf8_lossy(&body).to_string();
@@ -1873,7 +1873,7 @@ pub unsafe extern "C" fn js_request_text(handle: f64) -> *mut perry_runtime::Pro
 /// `js_fetch_response_json`. (#1688)
 #[no_mangle]
 pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let body = match consume_request_body(handle) {
         Ok(b) => b,
         Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {
@@ -1904,7 +1904,7 @@ pub unsafe extern "C" fn js_request_json(handle: f64) -> *mut perry_runtime::Pro
 /// BufferHeader over the body bytes, mirroring `js_response_array_buffer`. (#1688)
 #[no_mangle]
 pub unsafe extern "C" fn js_request_array_buffer(handle: f64) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let body = match consume_request_body(handle) {
         Ok(b) => b,
         Err(err_msg) if err_msg == BODY_ALREADY_USED_MESSAGE => {

--- a/crates/perry-stdlib/src/ioredis.rs
+++ b/crates/perry-stdlib/src/ioredis.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn js_ioredis_set(
     key_ptr: *const StringHeader,
     value_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn js_ioredis_get(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn js_ioredis_del(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn js_ioredis_exists(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -354,7 +354,7 @@ pub unsafe extern "C" fn js_ioredis_incr(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -411,7 +411,7 @@ pub unsafe extern "C" fn js_ioredis_decr(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -469,7 +469,7 @@ pub unsafe extern "C" fn js_ioredis_expire(
     key_ptr: *const StringHeader,
     seconds: f64,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -525,7 +525,7 @@ pub unsafe extern "C" fn js_ioredis_expire(
 /// redis.connect() -> Promise<void>
 #[no_mangle]
 pub unsafe extern "C" fn js_ioredis_connect(handle: Handle) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     spawn(async move {
@@ -554,7 +554,7 @@ pub unsafe extern "C" fn js_ioredis_setex(
     seconds: f64,
     value_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -632,7 +632,7 @@ pub unsafe extern "C" fn js_ioredis_disconnect(handle: Handle) {
 /// redis.ping() -> Promise<"PONG">
 #[no_mangle]
 pub unsafe extern "C" fn js_ioredis_ping(handle: Handle) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     spawn(async move {
@@ -683,7 +683,7 @@ pub unsafe extern "C" fn js_ioredis_hget(
     key_ptr: *const StringHeader,
     field_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -755,7 +755,7 @@ pub unsafe extern "C" fn js_ioredis_hset(
     field_ptr: *const StringHeader,
     value_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -826,7 +826,7 @@ pub unsafe extern "C" fn js_ioredis_hgetall(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -903,7 +903,7 @@ pub unsafe extern "C" fn js_ioredis_hdel(
     key_ptr: *const StringHeader,
     field_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -966,7 +966,7 @@ pub unsafe extern "C" fn js_ioredis_hlen(
     handle: Handle,
     key_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let key = match string_from_header(key_ptr) {
@@ -1018,7 +1018,7 @@ pub unsafe extern "C" fn js_ioredis_hlen(
 /// redis.quit() -> Promise<"OK">
 #[no_mangle]
 pub unsafe extern "C" fn js_ioredis_quit(handle: Handle) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     // Remove connection from cache

--- a/crates/perry-stdlib/src/mongodb.rs
+++ b/crates/perry-stdlib/src/mongodb.rs
@@ -11,7 +11,7 @@ use bson::{doc, Document};
 use mongodb::{Client, Collection, Database};
 use perry_runtime::json::js_json_stringify;
 use perry_runtime::{
-    js_object_alloc, js_object_set_field, js_promise_new, js_string_from_bytes, JSValue,
+    js_object_alloc, js_object_set_field, js_promise_new_cross_thread, js_string_from_bytes, JSValue,
     ObjectHeader, Promise, StringHeader,
 };
 
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn js_mongodb_client_new(uri_ptr: *const StringHeader) -> 
 pub unsafe extern "C" fn js_mongodb_client_connect(client_handle: Handle) -> *mut Promise {
     use crate::common::get_handle_mut;
 
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let pending = if let Some(h) = get_handle_mut::<MongoClientHandle>(client_handle) {
         h.pending_uri.take()
@@ -186,7 +186,7 @@ unsafe fn bson_to_jsvalue(doc: &Document) -> *mut ObjectHeader {
 /// MongoClient.connect(uri) -> Promise<MongoClient>
 #[no_mangle]
 pub unsafe extern "C" fn js_mongodb_connect(uri_ptr: *const StringHeader) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let uri = match string_from_header(uri_ptr) {
         Some(u) => u,
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn js_mongodb_collection_find_one(
     collection_handle: Handle,
     filter_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
 
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn js_mongodb_collection_find(
     collection_handle: Handle,
     filter_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
 
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn js_mongodb_collection_insert_one(
     collection_handle: Handle,
     doc_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let doc_json = match string_from_header(doc_json_ptr) {
         Some(j) => j,
@@ -418,7 +418,7 @@ pub unsafe extern "C" fn js_mongodb_collection_insert_many(
     collection_handle: Handle,
     docs_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let docs_json = match string_from_header(docs_json_ptr) {
         Some(j) => j,
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn js_mongodb_collection_update_one(
     filter_json_ptr: *const StringHeader,
     update_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
     let update_json = match string_from_header(update_json_ptr) {
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn js_mongodb_collection_update_many(
     filter_json_ptr: *const StringHeader,
     update_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
     let update_json = match string_from_header(update_json_ptr) {
@@ -532,7 +532,7 @@ pub unsafe extern "C" fn js_mongodb_collection_delete_one(
     collection_handle: Handle,
     filter_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
 
@@ -558,7 +558,7 @@ pub unsafe extern "C" fn js_mongodb_collection_delete_many(
     collection_handle: Handle,
     filter_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
 
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn js_mongodb_collection_count(
     collection_handle: Handle,
     filter_json_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let filter_json = string_from_header(filter_json_ptr).unwrap_or_else(|| "{}".to_string());
 
@@ -714,7 +714,7 @@ pub unsafe extern "C" fn js_mongodb_collection_count_value(
 /// client.close() -> Promise<void>
 #[no_mangle]
 pub unsafe extern "C" fn js_mongodb_client_close(_client_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     spawn_for_promise(promise as *mut u8, async move {
         // MongoDB client doesn't need explicit close in Rust driver
@@ -728,7 +728,7 @@ pub unsafe extern "C" fn js_mongodb_client_close(_client_handle: Handle) -> *mut
 /// client.listDatabases() -> Promise<string> (JSON array of database names)
 #[no_mangle]
 pub unsafe extern "C" fn js_mongodb_client_list_databases(client_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     spawn_for_promise_deferred(
         promise as *mut u8,
@@ -759,7 +759,7 @@ pub unsafe extern "C" fn js_mongodb_client_list_databases(client_handle: Handle)
 /// db.listCollections() -> Promise<string> (JSON array of collection names)
 #[no_mangle]
 pub unsafe extern "C" fn js_mongodb_db_list_collections(db_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     spawn_for_promise_deferred(
         promise as *mut u8,

--- a/crates/perry-stdlib/src/mysql2/connection.rs
+++ b/crates/perry-stdlib/src/mysql2/connection.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use perry_runtime::{js_promise_new, JSValue, Promise};
+use perry_runtime::{js_promise_new_cross_thread, JSValue, Promise};
 use sqlx::mysql::MySqlConnection;
 use sqlx::Connection;
 
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn js_mysql2_create_connection(config_f: f64) -> *mut Prom
     // Take f64 at the FFI boundary to avoid SysV AMD64 ABI mismatch
     // (see js_mysql2_create_pool for details).
     let config = JSValue::from_bits(config_f.to_bits());
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Parse the config
     let mysql_config = parse_mysql_config(config);
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn js_mysql2_create_connection(config_f: f64) -> *mut Prom
 /// Closes the MySQL connection.
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_connection_end(conn_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::take_handle;
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn js_mysql2_connection_query(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn js_mysql2_connection_execute(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let sql = if sql_ptr.is_null() {
         String::new()
@@ -415,7 +415,7 @@ pub unsafe extern "C" fn js_mysql2_connection_execute(
 pub unsafe extern "C" fn js_mysql2_connection_begin_transaction(
     conn_handle: Handle,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::get_handle_mut;
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn js_mysql2_connection_begin_transaction(
 /// connection.commit() -> Promise<void>
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_connection_commit(conn_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::get_handle_mut;
@@ -487,7 +487,7 @@ pub unsafe extern "C" fn js_mysql2_connection_commit(conn_handle: Handle) -> *mu
 /// connection.rollback() -> Promise<void>
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_connection_rollback(conn_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::get_handle_mut;

--- a/crates/perry-stdlib/src/mysql2/pool.rs
+++ b/crates/perry-stdlib/src/mysql2/pool.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use perry_runtime::{js_array_get_jsvalue, js_array_length, js_promise_new, JSValue, Promise};
+use perry_runtime::{js_array_get_jsvalue, js_array_length, js_promise_new_cross_thread, JSValue, Promise};
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
 use sqlx::pool::PoolConnection;
 use sqlx::MySql;
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn js_mysql2_create_pool(config_f: f64) -> Handle {
 /// Closes all connections in the pool.
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_pool_end(pool_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::take_handle;
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn js_mysql2_pool_query(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn js_mysql2_pool_execute(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -432,7 +432,7 @@ pub(crate) unsafe fn extract_params_from_jsvalue(params: JSValue) -> Vec<ParamVa
 /// Gets a connection from the pool.
 #[no_mangle]
 pub unsafe extern "C" fn js_mysql2_pool_get_connection(pool_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::get_handle;
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn js_mysql2_pool_connection_query(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -589,7 +589,7 @@ pub unsafe extern "C" fn js_mysql2_pool_connection_execute(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {

--- a/crates/perry-stdlib/src/net/mod.rs
+++ b/crates/perry-stdlib/src/net/mod.rs
@@ -1695,7 +1695,7 @@ pub unsafe extern "C" fn js_net_socket_upgrade_tls(
     servername_ptr: i64,
     verify: f64,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as *mut u8;
 
     let servername = match string_from_header_i64(servername_ptr) {

--- a/crates/perry-stdlib/src/nodemailer.rs
+++ b/crates/perry-stdlib/src/nodemailer.rs
@@ -7,7 +7,7 @@ use lettre::message::header::ContentType;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use perry_runtime::{
-    js_promise_new, js_string_from_bytes, JSValue, ObjectHeader, Promise, StringHeader,
+    js_promise_new_cross_thread, js_string_from_bytes, JSValue, ObjectHeader, Promise, StringHeader,
 };
 
 use crate::common::{register_handle, Handle};
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn js_nodemailer_send_mail(
     transporter_handle: Handle,
     options: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Parse mail options
     let mail_opts = match parse_mail_options(options) {
@@ -298,7 +298,7 @@ pub unsafe extern "C" fn js_nodemailer_send_mail(
 /// Verifies that the transporter can connect to the SMTP server.
 #[no_mangle]
 pub unsafe extern "C" fn js_nodemailer_verify(transporter_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::get_handle;

--- a/crates/perry-stdlib/src/pg/connection.rs
+++ b/crates/perry-stdlib/src/pg/connection.rs
@@ -1,6 +1,6 @@
 //! PostgreSQL connection implementation
 
-use perry_runtime::{js_array_get_jsvalue, js_array_length, js_promise_new, JSValue, Promise};
+use perry_runtime::{js_array_get_jsvalue, js_array_length, js_promise_new_cross_thread, JSValue, Promise};
 use sqlx::postgres::PgConnection;
 use sqlx::{Connection, Row};
 
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn js_pg_client_new(config_f: f64) -> Handle {
 pub unsafe extern "C" fn js_pg_client_connect(client_handle: Handle) -> *mut Promise {
     use crate::common::get_handle_mut;
 
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Snapshot the pending config out of the handle BEFORE entering the
     // async block — `get_handle_mut` returns a `&mut` that we can't keep
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn js_pg_connect(config_f: f64) -> *mut Promise {
     // Take f64 at the FFI boundary to avoid SysV AMD64 ABI mismatch
     // (see js_mysql2_create_pool for details).
     let config = JSValue::from_bits(config_f.to_bits());
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Parse the config
     let pg_config = parse_pg_config(config);
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn js_pg_connect(config_f: f64) -> *mut Promise {
 /// Closes the PostgreSQL connection.
 #[no_mangle]
 pub unsafe extern "C" fn js_pg_client_end(client_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::take_handle;
@@ -178,7 +178,7 @@ pub unsafe extern "C" fn js_pg_client_query(
     client_handle: Handle,
     sql_ptr: *const u8,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn js_pg_client_query_params(
     sql_ptr: *const u8,
     params: JSValue,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let sql = if sql_ptr.is_null() {
         String::new()

--- a/crates/perry-stdlib/src/pg/pool.rs
+++ b/crates/perry-stdlib/src/pg/pool.rs
@@ -1,6 +1,6 @@
 //! PostgreSQL connection pool implementation
 
-use perry_runtime::{js_promise_new, JSValue, Promise};
+use perry_runtime::{js_promise_new_cross_thread, JSValue, Promise};
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::Row;
 
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn js_pg_create_pool(config_f: f64) -> *mut Promise {
     // Take f64 at the FFI boundary to avoid SysV AMD64 ABI mismatch
     // (see js_mysql2_create_pool for details).
     let config = JSValue::from_bits(config_f.to_bits());
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Parse the config
     let pg_config = parse_pg_config(config);
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn js_pg_create_pool(config_f: f64) -> *mut Promise {
 /// Executes a query on the pool.
 #[no_mangle]
 pub unsafe extern "C" fn js_pg_pool_query(pool_handle: Handle, sql_ptr: *const u8) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     // Extract the SQL string
     let sql = if sql_ptr.is_null() {
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn js_pg_pool_query(pool_handle: Handle, sql_ptr: *const u
 /// Closes all connections in the pool.
 #[no_mangle]
 pub unsafe extern "C" fn js_pg_pool_end(pool_handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     crate::common::spawn_for_promise(promise as *mut u8, async move {
         use crate::common::take_handle;

--- a/crates/perry-stdlib/src/sharp.rs
+++ b/crates/perry-stdlib/src/sharp.rs
@@ -8,7 +8,7 @@ use crate::common::{
     string_from_header_lossy as string_from_header, Handle,
 };
 use image::{imageops::FilterType, DynamicImage, GenericImageView, ImageFormat};
-use perry_runtime::{js_promise_new, js_string_from_bytes, JSValue, Promise, StringHeader};
+use perry_runtime::{js_promise_new_cross_thread, js_string_from_bytes, JSValue, Promise, StringHeader};
 use std::io::Cursor;
 
 /// Sharp image handle with pending operations
@@ -269,7 +269,7 @@ pub unsafe extern "C" fn js_sharp_to_file(
     handle: Handle,
     path_ptr: *const StringHeader,
 ) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     let path = match string_from_header(path_ptr) {
         Some(p) => p,
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn js_sharp_to_file(
 /// Get the image as a buffer.
 #[no_mangle]
 pub unsafe extern "C" fn js_sharp_to_buffer(handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     spawn_for_promise(promise as *mut u8, async move {
         if let Some(sharp) = get_handle::<SharpHandle>(handle) {
@@ -346,7 +346,7 @@ pub unsafe extern "C" fn js_sharp_to_buffer(handle: Handle) -> *mut Promise {
 /// Get image metadata.
 #[no_mangle]
 pub unsafe extern "C" fn js_sharp_metadata(handle: Handle) -> *mut Promise {
-    let promise = js_promise_new();
+    let promise = js_promise_new_cross_thread();
 
     spawn_for_promise(promise as *mut u8, async move {
         if let Some(sharp) = get_handle::<SharpHandle>(handle) {

--- a/crates/perry-stdlib/src/worker_threads/async_shim.rs
+++ b/crates/perry-stdlib/src/worker_threads/async_shim.rs
@@ -28,7 +28,7 @@
 //! The pinning `js_promise_new_for_native_resolution` performs is likewise a
 //! consequence of deferral — it keeps the promise alive across the window
 //! between creation and the pump's resolution — and an inline settle spans no
-//! collection point, so a plain `js_promise_new` is the correct counterpart.
+//! collection point, so a plain `js_promise_new_cross_thread` is the correct counterpart.
 
 #[cfg(feature = "async-runtime")]
 pub(crate) use crate::common::async_bridge::{
@@ -46,7 +46,7 @@ mod inline {
     ///
     /// No pinning: pinning guards the deferral window, and there is none here.
     pub(crate) unsafe fn js_promise_new_for_native_resolution() -> *mut perry_runtime::Promise {
-        perry_runtime::js_promise_new()
+        perry_runtime::js_promise_new_cross_thread()
     }
 
     /// Settle now rather than queueing for a pump that does not exist.

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn js_ws_connect(
         }
         __android_log_print(3, b"PerryWS\0".as_ptr(), b"js_ws_connect called\0".as_ptr());
     }
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
 
     let url = match string_from_header(url_ptr) {
@@ -657,7 +657,7 @@ pub unsafe extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
 pub unsafe extern "C" fn js_ws_connect(
     url_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let handle = perry_native_ws_connect(url_ptr as *const u8);
     let result_bits = handle.to_bits();
     // Resolve immediately with the handle (connection happens async in native)
@@ -858,7 +858,7 @@ pub unsafe extern "C" fn js_ws_wait_for_message(
     handle: i64,
     timeout_ms: f64,
 ) -> *mut perry_runtime::Promise {
-    let promise = perry_runtime::js_promise_new();
+    let promise = perry_runtime::js_promise_new_cross_thread();
     let promise_ptr = promise as usize;
     let ws_id = handle as usize;
     let timeout = std::time::Duration::from_millis(timeout_ms as u64);


### PR DESCRIPTION
## Summary
Native async resolutions (`fetch`, DB drivers, WebSocket, argon2/bcrypt, containers, etc. — the `spawn_for_promise`-style bindings) created their `Promise` via the **nursery arena** (`js_promise_new`), pinned it, and handed the raw pointer to a tokio worker thread. Until the worker completes and queues the resolution into `PENDING_RESOLUTIONS`, the promise is reachable **only** via the worker-thread capture — invisible to the main-thread copying minor.

A copying-minor from-space flip destroys a nursery resident **regardless of its `GC_FLAG_PINNED`** (the flip resets eden/survivor blocks wholesale; only root-reachable pins force the pinned-young fallback — see the `js_promise_new_cross_thread` doc comment in `promise/then.rs`). So the promise is reclaimed, and when the worker's resolution later reaches `js_stdlib_process_pending`, it roots/unpins/resolves through the **reclaimed** promise header → `EXC_BAD_ACCESS` in `js_stdlib_process_pending` (clearing `GC_FLAG_PINNED` on a from-space header), or `(number).get is not a function` downstream.

Fix: allocate these promises via `js_promise_new_cross_thread` (malloc space — non-moving, and both sweep paths honor `GC_FLAG_PINNED`), the design-intended allocator for exactly this cross-thread hand-off. Re-export the symbol from `perry-runtime` and switch every native-binding caller.

## How it was found / confirmed
The `#8770` GC-corruption campaign (getting the compiled Claude Code CLI to run natively). On a symbolicated build under `PERRY_GC_PROTECT_FROMSPACE=1`, the SIGSEGV was 12/12 in `js_stdlib_process_pending` on a **protected from-space** promise header; after this change that fault is gone (the nursery-pin path for native resolutions never fires — all such promises are malloc).

## Files
`perry-runtime/src/lib.rs` (re-export `js_promise_new_cross_thread`) + `perry-stdlib/src/common/async_bridge.rs` (the helper) + 21 native-binding callers (`fetch/mod.rs`, `ws`, `ioredis`, `bcrypt`, `argon2`, `axios`, `mongodb`, `nodemailer`, `sharp`, `pg/*`, `mysql2/*`, `net/mod`, `container/*`, `worker_threads/async_shim`).

## Testing
`cargo check -p perry-runtime -p perry-stdlib` clean on current `main`. Malloc promises are valid everywhere they're used (non-moving; sweep honors the pin), so the switch is safe at every call site.

https://claude.ai/code/session_01TwxRkALrR9HKSF1zKLSTAF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for asynchronous operations across networking, databases, containers, file processing, messaging, and security APIs.
  * Promises created by background tasks are now handled more safely, reducing the risk of lost or invalid results.
  * WebSocket, fetch, HTTP, and worker-based operations receive more consistent cross-thread behavior.
  * MySQL query timeout errors now provide clearer guidance when the server may be unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->