### PR TITLE
perf(codegen): elide length-only arguments objects

### DIFF
--- a/changelog.d/8807-arguments-length-only.md
+++ b/changelog.d/8807-arguments-length-only.md
@@ -1,0 +1,1 @@
+Functions and methods that only read `arguments.length` now reuse the already-bundled raw argument array instead of allocating a full Arguments object. Any other observation keeps the existing fail-closed materialization path.

--- a/crates/perry-codegen/src/codegen/arguments.rs
+++ b/crates/perry-codegen/src/codegen/arguments.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use perry_hir::Param;
+use perry_hir::{Expr, Param, Stmt};
 
 use crate::block::LlBlock;
 use crate::expr::{nanbox_pointer_inline, FnCtx};
@@ -40,11 +40,21 @@ pub(crate) fn store_param_slot(
 pub(crate) fn materialize_arguments_object(
     ctx: &mut FnCtx<'_>,
     params: &[Param],
+    body: Option<&[Stmt]>,
     callee: ArgumentsCallee<'_>,
 ) {
     let Some(synth_param) = params.iter().find(|p| p.arguments_object.is_some()) else {
         return;
     };
+    // Call lowering has already bundled every supplied argument into the
+    // synthesized slot as a marked Array. When the only observable operation
+    // is `arguments.length`, that bundle has exactly the required value and a
+    // full ECMAScript Arguments object would only add allocation, mapped-index
+    // setup, and GC pressure. Keep the existing conservative materialization
+    // path for every other use (including callers that cannot provide a body).
+    if body.is_some_and(|body| arguments_used_only_for_length(body, synth_param.id)) {
+        return;
+    }
     let Some(meta) = synth_param.arguments_object.as_ref() else {
         return;
     };
@@ -102,12 +112,100 @@ pub(crate) fn materialize_arguments_object(
     ctx.block().store(DOUBLE, &boxed_args, &arguments_slot);
 }
 
+/// Prove that replacing the synthesized Arguments object with its raw argument
+/// bundle cannot be observed. The proof is deliberately fail-closed: HIR's
+/// canonical local-reference collector counts every use of the synthetic local,
+/// including specialized local-bearing expressions such as `ArrayPop(id)`.
+/// Every one of those uses must correspond to an exact `arguments.length` read
+/// found by the generic expression traversal.
+fn arguments_used_only_for_length(body: &[Stmt], arguments_id: u32) -> bool {
+    let mut refs = Vec::new();
+    let mut visited_closures = HashSet::new();
+    for stmt in body {
+        perry_hir::collect_local_refs_stmt(stmt, &mut refs, &mut visited_closures);
+    }
+
+    let total_uses = refs.iter().filter(|id| **id == arguments_id).count();
+    let mut length_reads = 0usize;
+    crate::collectors::for_each_expr_in_stmts(body, &mut |expr| {
+        if matches!(
+            expr,
+            Expr::PropertyGet {
+                object,
+                property,
+                ..
+            } if property == "length"
+                && matches!(object.as_ref(), Expr::LocalGet(id) if *id == arguments_id)
+        ) {
+            length_reads += 1;
+        }
+    });
+    length_reads > 0 && total_uses == length_reads
+}
+
 fn mapped_arguments_params(params: &[Param]) -> Vec<(u32, u32)> {
     params
         .iter()
         .filter_map(|p| p.arguments_object.as_ref())
         .flat_map(|meta| meta.mapped_parameter_ids.iter().copied())
         .collect()
+}
+
+#[cfg(test)]
+mod length_only_tests {
+    use super::arguments_used_only_for_length;
+    use perry_hir::{Expr, Stmt};
+
+    const ARGUMENTS: u32 = 17;
+
+    fn length() -> Expr {
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(ARGUMENTS)),
+            property: "length".to_string(),
+            byte_offset: 0,
+        }
+    }
+
+    #[test]
+    fn accepts_exact_length_reads_at_arbitrary_depth() {
+        let body = vec![Stmt::Return(Some(Expr::Binary {
+            op: perry_hir::BinaryOp::Add,
+            left: Box::new(Expr::Integer(1)),
+            right: Box::new(length()),
+        }))];
+        assert!(arguments_used_only_for_length(&body, ARGUMENTS));
+    }
+
+    #[test]
+    fn rejects_identity_index_and_mixed_uses() {
+        assert!(!arguments_used_only_for_length(
+            &[Stmt::Return(Some(Expr::LocalGet(ARGUMENTS)))],
+            ARGUMENTS
+        ));
+        assert!(!arguments_used_only_for_length(
+            &[Stmt::Return(Some(Expr::IndexGet {
+                object: Box::new(Expr::LocalGet(ARGUMENTS)),
+                index: Box::new(Expr::Integer(0)),
+            }))],
+            ARGUMENTS
+        ));
+        assert!(!arguments_used_only_for_length(
+            &[
+                Stmt::Expr(length()),
+                Stmt::Return(Some(Expr::LocalGet(ARGUMENTS))),
+            ],
+            ARGUMENTS
+        ));
+    }
+
+    #[test]
+    fn rejects_specialized_local_bearing_operations() {
+        let body = vec![
+            Stmt::Expr(length()),
+            Stmt::Return(Some(Expr::ArrayPop(ARGUMENTS))),
+        ];
+        assert!(!arguments_used_only_for_length(&body, ARGUMENTS));
+    }
 }
 
 /// Does `property`, resolved against `class_name`'s ancestry, declare a USER

--- a/crates/perry-codegen/src/codegen/closure.rs
+++ b/crates/perry-codegen/src/codegen/closure.rs
@@ -1201,6 +1201,7 @@ pub(super) fn compile_closure(
     super::arguments::materialize_arguments_object(
         &mut ctx,
         params,
+        Some(body),
         super::arguments::ArgumentsCallee::CurrentClosure,
     );
 

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -1252,6 +1252,7 @@ pub(super) fn compile_function(
     super::arguments::materialize_arguments_object(
         &mut ctx,
         &f.params,
+        Some(&f.body),
         super::arguments::ArgumentsCallee::FunctionWrapper(&wrapper_name),
     );
 

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -630,6 +630,7 @@ pub(super) fn compile_method(
     super::arguments::materialize_arguments_object(
         &mut ctx,
         &method.params,
+        Some(&method.body),
         super::arguments::ArgumentsCallee::Undefined,
     );
 
@@ -1856,6 +1857,7 @@ pub(super) fn compile_static_method(
     super::arguments::materialize_arguments_object(
         &mut ctx,
         &f.params,
+        Some(&f.body),
         super::arguments::ArgumentsCallee::Undefined,
     );
     if f.is_async {

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -107,7 +107,8 @@ pub(crate) use refs::{
 };
 pub(crate) use safepoint_sites::count_safepoint_sites;
 pub(crate) use scalar_method_dispatch::{
-    collect_module_dispatch_facts, mark_unstable_scalar_method_receivers, ModuleDispatchFacts,
+    collect_module_dispatch_facts, for_each_expr_in_stmts, mark_unstable_scalar_method_receivers,
+    ModuleDispatchFacts,
 };
 pub(crate) use scalar_methods::simple_scalar_method_summary;
 pub(crate) use shadow_slots::{

--- a/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
+++ b/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
@@ -559,7 +559,7 @@ pub(super) fn for_each_expr(expr: &Expr, f: &mut dyn FnMut(&Expr)) {
     }
 }
 
-pub(super) fn for_each_expr_in_stmts(stmts: &[Stmt], f: &mut dyn FnMut(&Expr)) {
+pub(crate) fn for_each_expr_in_stmts(stmts: &[Stmt], f: &mut dyn FnMut(&Expr)) {
     for stmt in stmts {
         for_each_expr_in_stmt(stmt, f);
     }

--- a/crates/perry-codegen/src/lower_call/new_ctor_args.rs
+++ b/crates/perry-codegen/src/lower_call/new_ctor_args.rs
@@ -106,6 +106,7 @@ pub(crate) fn bind_inline_constructor_params(
     crate::codegen::arguments::materialize_arguments_object(
         ctx,
         params,
+        None,
         crate::codegen::arguments::ArgumentsCallee::Undefined,
     );
 

--- a/crates/perry/tests/arguments_length_only.rs
+++ b/crates/perry/tests/arguments_length_only.rs
@@ -1,0 +1,101 @@
+//! Regression coverage for eliding full Arguments-object materialization when
+//! a function observes only `arguments.length`.
+//!
+//! Call lowering already supplies a marked raw-argument Array containing every
+//! actual argument. Its length is therefore exact for ordinary functions,
+//! methods, function expressions, and captured outer `arguments`. Any other
+//! observation must retain the full ECMAScript Arguments object.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn length_only_works_across_callable_kinds_and_arities() {
+    let stdout = compile_and_run(
+        r#"
+function declared(a?: any, b?: any) { return arguments.length; }
+const expression = function (a?: any) { return arguments.length; };
+class Probe {
+  method(a?: any) { return arguments.length; }
+  static method(a?: any) { return arguments.length; }
+}
+function captured(a?: any) {
+  return () => arguments.length;
+}
+
+const probe = new Probe();
+console.log(declared(), declared(1), declared(1, 2, 3));
+console.log(expression(), expression(1, 2));
+console.log(probe.method(), probe.method(1, 2));
+console.log(Probe.method(), Probe.method(1, 2, 3));
+console.log(captured(1, 2, 3, 4)());
+"#,
+    );
+    assert_eq!(stdout, "0 1 3\n0 2\n0 2\n0 3\n4\n");
+}
+
+#[test]
+fn observable_and_mixed_arguments_uses_still_materialize() {
+    let stdout = compile_and_run(
+        r#"
+import { types } from "node:util";
+
+function observable(a?: any) {
+  return types.isArgumentsObject(arguments);
+}
+function mixed(a?: any) {
+  return arguments.length + ":" + arguments[0] + ":" +
+    types.isArgumentsObject(arguments);
+}
+function writesLength() {
+  arguments.length = 7;
+  return arguments.length;
+}
+
+console.log(observable(1));
+console.log(mixed("first", "second"));
+console.log(writesLength(1, 2));
+"#,
+    );
+    assert_eq!(stdout, "true\n2:first:true\n7\n");
+}


### PR DESCRIPTION
## Summary

- prove when every use of a synthesized `arguments` binding is exactly `arguments.length`
- retain the already-bundled raw argument array in that case instead of allocating a full ECMAScript Arguments object
- keep the existing materialization path for index access, identity/prototype observation, assignment, specialized local operations, and callers without a function body

The proof is fail-closed: Perry's canonical HIR local-reference collector counts every use (including specialized local-bearing expressions), and every counted use must correspond to an exact `.length` read found by the generic expression traversal.

## Motivation and measured effect

A symbolized Mac mini profile of codehz/ecs showed `World.set()` allocating an Arguments object on every command only to read `arguments.length`. The resulting ephemeral object/descriptor churn dominated minor GC.

On the exact M2 integration control, with auto-opt disabled, a short 3-sample interleaved Mac mini A/B produced:

| ECS row | control Perry | candidate Perry | Perry speedup |
|---|---:|---:|---:|
| 10k single update + sync | 225.77 ms | 58.13 ms | 3.88x |
| 10k two updates + sync | 574.33 ms | 97.27 ms | 5.91x |
| mixed update/spawn/delete + sync | 133.70 ms | 43.29 ms | 3.09x |
| 15k commands + sync | 359.42 ms | 67.21 ms | 5.35x |
| read-only query | 0.0782 ms | 0.0697 ms | 1.12x |

All Node and Perry assertions passed in every sample. The generated `World.set` LLVM function changed from one `js_arguments_object_alloc` call to zero. A fresh 15k-command diagnostic profile reduced minor-GC pause sum from 1,020,535 us / 6 events to 62,597 us / 4 events; the residual profile is now dominated by numeric Map mutation rather than Arguments-object descriptor churn.

The A/B above is intentionally labeled development evidence (3 samples, no quiet-host gate); it establishes the mechanism and effect size, not a parity claim.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p perry-codegen --lib` (1,241 passed, 0 failed, 1 ignored)
- `cargo test -p perry --test arguments_length_only -- --test-threads=2` (2 passed)
- focused existing Arguments-object regressions on the integration base: 9 passed after pinning the matching runtime archive
- codehz/ecs Mac mini A/B with all correctness oracles passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of code that only reads `arguments.length`, reducing unnecessary runtime work.

* **Bug Fixes**
  * Preserved full `arguments` behavior for indexing, identity checks, property writes, and other observable uses.
  * Improved handling across functions, closures, and instance or static methods.

* **Tests**
  * Added coverage for nested, captured, mixed, and observable `arguments` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->