### PR TITLE
fix(release): avoid changelog preflight pipefail

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -136,7 +136,7 @@ jobs:
               echo "::error::tag $TAG already exists — the version in Cargo.toml was already released. Land a version bump or use existing_tag to re-publish."
               exit 1
             fi
-            if ! find changelog.d -maxdepth 1 -type f -name '[0-9]*.md' | grep -q .; then
+            if [ -z "$(find changelog.d -maxdepth 1 -type f -name '[0-9]*.md' -print -quit)" ]; then
               echo "::error::no fragments in changelog.d/ — the release notes are cut from them; nothing to release."
               exit 1
             fi

--- a/scripts/publish/publish.test.mts
+++ b/scripts/publish/publish.test.mts
@@ -367,6 +367,8 @@ test('pipeline.mts: OIDC publication and release receipt are pinned to one commi
   assert.match(workflow, /\[ "\$REF_NAME" = "main" \]/)
   assert.match(workflow, /"\$REF" != refs\/heads\/\*/)
   assert.match(workflow, /\[ "\$CANDIDATE_SHA" != "\$SHA" \]/)
+  assert.match(workflow, /find changelog\.d[^\n]+-print -quit/)
+  assert.doesNotMatch(workflow, /find changelog\.d[^\n]+\|\s*grep -q/)
   assert.match(workflow, /needs: \[preflight, build, build-cross, npm-publish\]/)
   assert.match(workflow, /needs\.npm-publish\.result == 'success'/)
 })


### PR DESCRIPTION
The v0.5.1519 release preflight failed before any publish because find piped into grep -q under pipefail sees SIGPIPE when the repository has many changelog fragments. Resolve at most one matching path with find -print -quit instead, and regression-test that the unsafe pipeline does not return.

Validation:
- preflight shell reproduction passes with 1,171 fragments
- actionlint workflow syntax passes
- publish script tests: 26 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to reliably detect numbered changelog fragments.
  * Preserved the existing error message when no changelog fragments are found.

* **Tests**
  * Updated release workflow checks to verify changelog detection behavior and maintain validation of branch, reference, and candidate commit safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->