### PR TITLE
fix(runtime): remove stale native async unsafe

### DIFF
--- a/changelog.d/8812-native-async-warnings.md
+++ b/changelog.d/8812-native-async-warnings.md
@@ -1,0 +1,1 @@
+fix(runtime): remove a stale `unsafe` block from native async rejection handling so the mandatory `-D warnings` release gate passes on the pinned nightly toolchain.

--- a/crates/perry-runtime/src/promise/native_async.rs
+++ b/crates/perry-runtime/src/promise/native_async.rs
@@ -202,7 +202,7 @@ fn error_value_bits(message: &[u8]) -> u64 {
     // `js_error_new_with_message` -> `alloc_error` roots its `message`
     // argument in its own handle scope before its first allocation, so a
     // scoped raw argument is sound here (#7341 self-rooting entry point).
-    let error = message.with_mut_ptr::<crate::string::StringHeader, _>(|ptr| unsafe {
+    let error = message.with_mut_ptr::<crate::string::StringHeader, _>(|ptr| {
         crate::error::js_error_new_with_message(ptr)
     });
     crate::value::js_nanbox_pointer(error as i64).to_bits()


### PR DESCRIPTION
Summary:
- remove an unnecessary unsafe block in native async rejection handling
- unblock the mandatory pinned-nightly warnings release gate
- add the required changelog fragment

Validation:
- cargo fmt with nightly-2026-08-20
- cargo check -p perry-runtime with RUSTFLAGS=-D warnings

Required to retry v0.5.1519 after warnings failed in run 32830955822.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a native async warning that could block release builds.
  * Improved compatibility with strict compiler warning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->