### PR TITLE
test(compile): cover builtin imports in compiled packages

### DIFF
--- a/changelog.d/8817-compiled-package-builtin-import.md
+++ b/changelog.d/8817-compiled-package-builtin-import.md
@@ -1,0 +1,6 @@
+Added regression coverage for Node builtin named imports used from natively
+compiled dependencies. The exact `@hono/node-server` fallback from
+`options.createServer` to its module-scope `http.createServer` import now has an
+offline compiler fixture and a real-package listen/fetch/close release smoke,
+covering both `http` and `node:http` spellings without relying on app-level
+imports.

--- a/crates/perry/tests/issue_8749_compiled_package_builtin_import.rs
+++ b/crates/perry/tests/issue_8749_compiled_package_builtin_import.rs
@@ -1,0 +1,114 @@
+//! Regression test for #8749: a Node builtin named import used from a
+//! `compilePackages` dependency must retain its runtime binding.
+//!
+//! `@hono/node-server` imports `createServer` from `http`, selects it through a
+//! module-scope fallback (`options.createServer || createServerHTTP`), and calls
+//! the selected function later from `serve()`. App-level imports already
+//! worked; the binding was lost specifically while compiling the dependency.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn builtin_named_import_survives_module_scope_fallback_in_compiled_package() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "compiled-builtin-import-consumer",
+  "private": true,
+  "type": "module",
+  "perry": {
+    "compilePackages": ["fake-node-server"],
+    "allow": { "compilePackages": ["fake-node-server"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("fake-node-server");
+    std::fs::create_dir_all(&pkg).expect("mkdir fake-node-server");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{
+  "name": "fake-node-server",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}"#,
+    )
+    .expect("write dependency package.json");
+    std::fs::write(
+        pkg.join("index.mjs"),
+        r#"
+import { createServer as createServerHTTP } from "http";
+import { createServer as createServerNodeHTTP } from "node:http";
+
+const options = {};
+const selectedHTTP = options.createServer || createServerHTTP;
+const selectedNodeHTTP = options.createServer || createServerNodeHTTP;
+
+export function inspectBindings() {
+  const serverHTTP = selectedHTTP({}, () => {});
+  const serverNodeHTTP = selectedNodeHTTP({}, () => {});
+  return [
+    typeof createServerHTTP,
+    typeof createServerNodeHTTP,
+    typeof selectedHTTP,
+    typeof selectedNodeHTTP,
+    typeof serverHTTP.listen,
+    typeof serverNodeHTTP.listen,
+  ].join(",");
+}
+"#,
+    )
+    .expect("write compiled dependency");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { inspectBindings } from "fake-node-server";
+console.log(inspectBindings());
+process.exit(0);
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "function,function,function,function,function,function\n",
+        "both builtin spellings must stay bound through the dependency's module global"
+    );
+}

--- a/tests/release/packages/hono-node-server/entry.ts
+++ b/tests/release/packages/hono-node-server/entry.ts
@@ -1,0 +1,16 @@
+// Issue #8749: @hono/node-server selects its imported node:http factory
+// through `options.createServer || createServerHTTP` inside compiled package
+// code. Exercise the real package through listen, fetch, response, and close.
+import { serve } from "@hono/node-server";
+
+const port = 38139;
+const server = serve({
+  fetch: () => new Response("ok"),
+  port,
+}, async () => {
+  const response = await fetch(`http://127.0.0.1:${port}/`);
+  console.log(`status=${response.status}`);
+  console.log(`body=${await response.text()}`);
+  server.close();
+  process.exit(0);
+});

--- a/tests/release/packages/hono-node-server/expected.txt
+++ b/tests/release/packages/hono-node-server/expected.txt
@@ -1,0 +1,2 @@
+status=200
+body=ok

--- a/tests/release/packages/hono-node-server/fixture.sh
+++ b/tests/release/packages/hono-node-server/fixture.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Issue #8749: real-package smoke for @hono/node-server's module-scope
+# `options.createServer || createServerHTTP` binding under compilePackages.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+. "$(dirname "$0")/../_fixture_lib.sh"
+
+fixture_setup "hono-node-server" || exit 1
+fixture_compile_run_diff "hono-node-server"

--- a/tests/release/packages/hono-node-server/package-lock.json
+++ b/tests/release/packages/hono-node-server/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "perry-release-fixture-hono-node-server",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-release-fixture-hono-node-server",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hono/node-server": "1.19.17",
+        "hono": "4.13.4"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
+      "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    }
+  }
+}

--- a/tests/release/packages/hono-node-server/package.json
+++ b/tests/release/packages/hono-node-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "perry-release-fixture-hono-node-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tier-3 fixture for @hono/node-server's compiled-package Node builtin imports.",
+  "dependencies": {
+    "@hono/node-server": "1.19.17",
+    "hono": "4.13.4"
+  },
+  "perry": {
+    "compilePackages": ["@hono/node-server", "hono"],
+    "allow": {
+      "compilePackages": ["@hono/node-server", "hono"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The report was captured against `main@6173ff9f6`. On current `main`, the focused compiled-package reproducer and the exact published `@hono/node-server` adapter path both succeed. This PR locks that behavior down with offline and real-package regression coverage so module-scope Node builtin imports cannot silently regress to `undefined` inside compiled dependencies.

## Changes

- Add an offline `compilePackages` integration test that exercises `options.createServer || createServerHTTP`, calls the selected factories, and covers both `http` and `node:http` named imports.
- Add a tier-3 release fixture pinned to `@hono/node-server@1.19.17` and `hono@4.13.4` that listens, self-fetches, verifies the response, and closes cleanly from the package's listening callback.
- Add the required changelog fragment; no workspace version bump or release-metadata edits.

## Related issue

Closes #8749

## Test plan

- [ ] `cargo build --release` clean (not run; focused integration target built successfully)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run; focused integration test below passes)
- [x] `cargo test -p perry --test issue_8749_compiled_package_builtin_import --no-fail-fast`
- [x] `rustfmt --edition 2021 --check crates/perry/tests/issue_8749_compiled_package_builtin_import.rs`
- [x] `py -3 scripts/check_test_registration.py`
- [x] Node oracle run for the pinned release fixture produced `status=200` and `body=ok`
- [x] Committed pinned release fixture compiled and ran under Perry with the same output (`PERRY_RS4GC=0` on Windows to avoid the separate known #7354 WinEH limitation)
- [x] `bash -n tests/release/packages/hono-node-server/fixture.sh`
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` (not applicable)
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform (not applicable)

`cargo fmt --all -- --check` could not complete in this Windows worktree because rustfmt hit the existing maximum-path-length limit; the changed Rust test was checked directly and passed. The broader `pre-tag-check.sh --quick` also expects `python3` on Git Bash's PATH; the relevant registration check passed via the installed Windows Python launcher.

## Screenshots / output

```text
status=200
body=ok
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)