### PR TITLE
land #8761: honor exotic indices in Array shift

### DIFF
--- a/changelog.d/8761-array-shift-exotic-indices.md
+++ b/changelog.d/8761-array-shift-exotic-indices.md
@@ -1,0 +1,11 @@
+Fixed `Array.prototype.shift` on arrays whose indexed operations are
+observable. The dense `memmove` fast path is kept for ordinary arrays, but a
+receiver carrying index accessors / custom-attribute descriptors, sparse
+storage past the dense backing store, or an indexed property inherited from
+`Array.prototype` / `Object.prototype` now runs the specified live
+`HasProperty` / `Get` / `Set` / `Delete` sequence, so inherited indices,
+holes and getter side effects (freezing the receiver, or making `length`
+non-writable before the final `Set(O, "length", …)`) are all observed in spec
+order. The dense path additionally translates the internal `TAG_HOLE`
+sentinel to `undefined`, and the spec path roots the receiver and the carried
+values across every accessor that can allocate or move them.

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -1110,8 +1110,19 @@ pub extern "C" fn js_array_shift_f64(arr: *mut ArrayHeader) -> f64 {
             return TAG_UNDEFINED_F64;
         }
 
+        // A raw memmove is only equivalent to Shift when every observable
+        // indexed operation is an ordinary dense-array access. Indexed
+        // descriptors and prototype properties require the specified live
+        // HasProperty/Get/Set/Delete order; their accessors can also freeze the
+        // receiver or make `length` non-writable before the final length Set.
+        if crate::array::array_iteration_is_exotic(arr) {
+            return shift_array_spec_path(arr);
+        }
+
+        // `TAG_HOLE` is an internal storage sentinel. Even on the dense path,
+        // Get(O, "0") must expose it as `undefined`.
+        let value = crate::array::js_array_get_f64(arr, 0);
         let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-        let value = *elements_ptr;
 
         // Shift all elements down
         // GC_STORE_AUDIT(BARRIERED): shift memmove is followed by layout/barrier rebuild.
@@ -1119,6 +1130,77 @@ pub extern "C" fn js_array_shift_f64(arr: *mut ArrayHeader) -> f64 {
         (*arr).length = length - 1;
         rebuild_array_layout(arr);
         value
+    }
+}
+
+/// ECMA-262 Array.prototype.shift for a real array whose indexed operations
+/// are observable. The loop keeps the original length while consulting live
+/// presence and values, and roots both the receiver and carried values across
+/// accessors which may allocate or move either one.
+unsafe fn shift_array_spec_path(arr: *mut ArrayHeader) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    let first_handle = scope.root_nanbox_f64(f64::from_bits(crate::value::TAG_UNDEFINED));
+    let from_value_handle = scope.root_nanbox_f64(f64::from_bits(crate::value::TAG_UNDEFINED));
+    let len = (*arr).length;
+
+    let (first, _) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+        arr_handle.with_mut_ptr(|current| crate::array::array_spec_get(current, 0))
+    });
+    first_handle.set_nanbox_f64(first);
+
+    for from in 1..len {
+        let from_present = arr_handle.with_mut_ptr::<ArrayHeader, _>(|current| {
+            crate::array::array_spec_has_index(current, from)
+        });
+        let to = from - 1;
+        if from_present {
+            let (value, _) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+                arr_handle.with_mut_ptr(|current| crate::array::array_spec_get(current, from))
+            });
+            from_value_handle.set_nanbox_f64(value);
+            shift_array_spec_set(&arr_handle, to, &from_value_handle);
+        } else {
+            shift_array_spec_delete(&arr_handle, to);
+        }
+    }
+
+    shift_array_spec_delete(&arr_handle, len - 1);
+
+    // Set(O, "length", len - 1, true) occurs after every indexed operation.
+    // Re-read the receiver state because any getter/setter above may have
+    // frozen it or replaced `length` with a non-writable descriptor.
+    arr_handle.with_mut_ptr::<ArrayHeader, _>(|current| {
+        let current = clean_arr_ptr_mut(current);
+        if array_is_frozen(current) {
+            throw_frozen_array_mutation();
+        }
+        guard_writable_length(current);
+        (*current).length = len - 1;
+        rebuild_array_layout(current);
+    });
+    first_handle.get_nanbox_f64()
+}
+
+fn shift_array_spec_set(
+    arr_handle: &crate::gc::RuntimeHandle<'_>,
+    index: u32,
+    value_handle: &crate::gc::RuntimeHandle<'_>,
+) {
+    let _ = arr_handle.across_mut::<ArrayHeader, _>(|| {
+        let value = value_handle.get_nanbox_f64();
+        arr_handle.with_mut_ptr(|current| {
+            crate::array::js_array_set_f64_extend(current, index, value);
+        });
+    });
+}
+
+fn shift_array_spec_delete(arr_handle: &crate::gc::RuntimeHandle<'_>, index: u32) {
+    let (deleted, _) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+        arr_handle.with_mut_ptr(|current| crate::array::js_array_delete(current, index))
+    });
+    if deleted == 0 {
+        throw_cannot_delete_array_index(index);
     }
 }
 

--- a/crates/perry/tests/issue_5898_array_shift_exotic.rs
+++ b/crates/perry/tests/issue_5898_array_shift_exotic.rs
@@ -1,0 +1,118 @@
+//! Regression coverage for the Array.prototype.shift exotic-index cluster in
+//! #5898. Shift must use live ordinary-property operations and observe indexed
+//! getter side effects before setting the final array length.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn shift_observes_inherited_indices_holes_and_length_side_effects() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    let runtime_dir = perry_bin()
+        .parent()
+        .expect("perry binary directory")
+        .to_path_buf();
+    std::fs::write(
+        &entry,
+        r#"
+(Array.prototype as any)[1] = 1;
+const inherited = [0];
+inherited.length = 2;
+console.log("inherited", inherited.shift(), inherited[0], inherited[1]);
+delete (Array.prototype as any)[1];
+
+const holey: any[] = [];
+holey[0] = 0;
+holey[3] = 3;
+console.log("holey-first", holey.shift(), holey.length, holey[0], holey[2]);
+holey.length = 1;
+console.log("holey-second", holey.shift(), holey.length);
+
+const frozen: any[] = new Array(1);
+let frozenGetterCalls = 0;
+Object.defineProperty(Array.prototype, "0", {
+  configurable: true,
+  get() {
+    Object.freeze(frozen);
+    frozenGetterCalls++;
+  }
+});
+try {
+  frozen.shift();
+  console.log("frozen no throw");
+} catch (error) {
+  console.log("frozen", error instanceof TypeError, frozen.length, frozenGetterCalls);
+}
+delete (Array.prototype as any)[0];
+
+const readonlyLength: any[] = new Array(1);
+let readonlyGetterCalls = 0;
+Object.defineProperty(Array.prototype, "0", {
+  configurable: true,
+  get() {
+    Object.defineProperty(readonlyLength, "length", { writable: false });
+    readonlyGetterCalls++;
+  }
+});
+try {
+  readonlyLength.shift();
+  console.log("readonly no throw");
+} catch (error) {
+  console.log(
+    "readonly",
+    error instanceof TypeError,
+    readonlyLength.length,
+    readonlyGetterCalls
+  );
+}
+delete (Array.prototype as any)[0];
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_LIB_DIR", &runtime_dir)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RS4GC", "0")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "inherited 0 1 1\n",
+            "holey-first 0 3 undefined 3\n",
+            "holey-second undefined 0\n",
+            "frozen true 1 1\n",
+            "readonly true 1 1\n",
+        )
+    );
+}


### PR DESCRIPTION
Lands #8761 (fix(runtime): honor exotic indices in Array shift), original author's commit preserved.

## I held this PR on regressions it did not cause

I blocked #8761 on four gap-suite parity regressions and asked the author not to re-baseline. That was the right instinct about baselines, but the wrong attribution — **the PR caused none of them.**

#8761's CI ran 2026-08-24 17:03–17:25 UTC against `main` tip `20a388974`, and actually reported **eight** regressions across five shards, not the four I quoted. Two *unrelated* sibling PRs on the same `main` window — #8771 and #8776 — report the **identical** failure set. The cluster is class-instance prototype-chain breakage that `main` carried at that moment, and it was fixed within hours by #8766 (17:41), #8778 (18:26) and #8780/#8781 (19:27) — #8781's own body names `String(new C())`, i.e. `test_gap_string_coercion_tostring`, one of the eight.

So the "shared helper" I suspected was `main`, not this PR. CLAUDE.md's own guidance is to attribute a red via a sibling PR on the same base; I did not do that, and the PR sat blocked as a result.

## Evidence

Full 580-test gap sweep on both arms — clean `main` @ `e043aa294` vs `main` + PR — identical toolchain, identical `-p` set, same target dir, sequential, byte-compared against Node 26.5.1 (matching `.node-version`):

| | pass | compile_fail | parity_fail |
|---|---|---|---|
| clean main | 546 | 12 | 22 |
| main + PR | 546 | 12 | 22 |

**Divergences across all 580 tests: zero.** All four originally-named tests pass on both arms, as do the four additional ones from the other shards. Arm A was verified genuinely PR-free (`nm` finds 0 `shift_array_spec_path` symbols in its `libperry_runtime.a`); arm B's `.a` mtimes were confirmed to move after each edit, so neither arm was measuring a stale archive.

## The actual blocker

A `lint` failure: "This PR changes crates/ but adds no changelog.d/ fragment." This branch adds `changelog.d/8761-array-shift-exotic-indices.md`. No baseline was touched, no test deleted, no `#[ignore]`, no version bump.

## Validation

- all 30 lint-job gates pass
- `perry-runtime` 2690, `perry-codegen` 1252, `perry-stdlib` 120 — all 0 failed

## Known coverage gap

15 ext-routed gap tests (http/http2/net/ws/zlib/events) were **not** compared against Node in either arm — they need `perry-ext-*` wrappers built in the same cargo invocation. This matters for this PR specifically, because `js_array_shift_f64` is called from `node_stream*` and `events_on.rs`. Their status is identical in both arms (`compile_fail`, same missing-wrapper reason), so nothing is attributable to the PR, but CI is the authority for those paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Array.prototype.shift` behavior for sparse arrays, inherited indexed properties, accessors, custom descriptors, and holes.
  * Ensured getter side effects and property operations occur in the specified order.
  * Correctly converts internal array holes to `undefined` when shifting.

* **Tests**
  * Added coverage for exotic index scenarios, inherited properties, frozen arrays, and non-writable lengths.

* **Documentation**
  * Documented the corrected `Array.prototype.shift` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->