### PR TITLE
fix(link): keep stdlib authoritative on archive fallback

### DIFF
--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -102,10 +102,14 @@ runs:
         # `full-suite-gate` and blocked the release (run 32298711372).
         # `--connect-timeout`/`--max-time` turn that into a fast, retryable
         # failure; `--retry-all-errors` makes the retries actually cover
-        # transport stalls.
+        # transport stalls. Keep each attempt to five minutes and the retry
+        # window to twenty: `--max-time` resets for every retry, so the former
+        # 25-minute value could take 150+ minutes across six attempts and
+        # outlive this job's 120-minute cap without reaching any tests.
         $archive = "$env:RUNNER_TEMP\llvm.tar.xz"
         curl.exe -sSL --retry 5 --retry-all-errors --retry-delay 10 `
-          --connect-timeout 30 --max-time 1500 -o "$archive" $url
+          --connect-timeout 30 --max-time 300 --retry-max-time 1200 `
+          -o "$archive" $url
         # A native command's non-zero exit does NOT trip
         # $ErrorActionPreference, so check it explicitly — otherwise a failed
         # download fell through to `tar` and surfaced as a confusing archive

--- a/changelog.d/8827-safe-wrapper-link-fallback.md
+++ b/changelog.d/8827-safe-wrapper-link-fallback.md
@@ -1,0 +1,1 @@
+- Fix packaged and no-auto builds when the available LLVM tools cannot inspect Rust's native wrapper archives: Perry now keeps the full stdlib's allocator and runtime authoritative instead of producing binaries that can abort on an invalid free.

--- a/crates/perry/src/commands/compile/link/archive_cache.rs
+++ b/crates/perry/src/commands/compile/link/archive_cache.rs
@@ -33,6 +33,15 @@ pub(super) struct PreparedArchiveInputs<'a> {
     pub well_known_libs: &'a [PathBuf],
 }
 
+pub(super) struct PreparedArchives {
+    pub paths: Vec<PathBuf>,
+    /// Cached entries are only written after every required archive transform
+    /// succeeds. A false value means at least one original wrapper was kept
+    /// as a non-fatal fallback and must not precede the full stdlib at link
+    /// time: its bundled allocator/runtime objects could otherwise win.
+    pub safe_to_precede_stdlib: bool,
+}
+
 /// Cache the expensive, deterministic strip/dedup pass over well-known native
 /// archives. This is an intermediate-artifact cache: application objects and
 /// linker flags remain covered by the final-link cache and are deliberately
@@ -41,7 +50,7 @@ pub(super) struct PreparedArchiveInputs<'a> {
 pub(super) fn prepare_well_known_archives<F>(
     inputs: PreparedArchiveInputs<'_>,
     prepare: F,
-) -> Vec<PathBuf>
+) -> PreparedArchives
 where
     F: FnOnce() -> (Vec<PathBuf>, bool),
 {
@@ -49,7 +58,11 @@ where
         || std::env::var("PERRY_NO_CACHE").as_deref() == Ok("1")
     {
         debug_cache("MISS", "disabled");
-        return prepare().0;
+        let (paths, safe_to_precede_stdlib) = prepare();
+        return PreparedArchives {
+            paths,
+            safe_to_precede_stdlib,
+        };
     }
 
     let compiler = std::env::current_exe().ok();
@@ -66,7 +79,11 @@ where
         Ok(key) => key,
         Err(error) => {
             debug_cache("MISS", &format!("could not fingerprint inputs: {error}"));
-            return prepare().0;
+            let (paths, safe_to_precede_stdlib) = prepare();
+            return PreparedArchives {
+                paths,
+                safe_to_precede_stdlib,
+            };
         }
     };
     let entry_dir = inputs
@@ -77,18 +94,28 @@ where
 
     if let Some(paths) = load_cached_archives(&entry_dir, &key, inputs.well_known_libs) {
         debug_cache("HIT", &key);
-        return paths;
+        return PreparedArchives {
+            paths,
+            safe_to_precede_stdlib: true,
+        };
     }
 
     debug_cache("MISS", &key);
     let (prepared, cacheable) = prepare();
     if !cacheable {
         debug_cache("MISS", "archive preparation used a non-fatal fallback");
-        return prepared;
+        return PreparedArchives {
+            paths: prepared,
+            safe_to_precede_stdlib: false,
+        };
     }
-    match store_cached_archives(&entry_dir, &key, inputs.well_known_libs, &prepared) {
+    let paths = match store_cached_archives(&entry_dir, &key, inputs.well_known_libs, &prepared) {
         Some(paths) => paths,
         None => prepared,
+    };
+    PreparedArchives {
+        paths,
+        safe_to_precede_stdlib: true,
     }
 }
 
@@ -369,5 +396,48 @@ mod tests {
         assert!(load_cached_archives(&entry, key, &archives).is_some());
         fs::write(&stored[0], b"corrupt").unwrap();
         assert!(load_cached_archives(&entry, key, &archives).is_none());
+    }
+
+    #[test]
+    fn preparation_safety_survives_fallback_and_cache_hit() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let runtime = root.join("runtime.a");
+        let stdlib = root.join("stdlib.a");
+        let wrapper = root.join("wrapper.a");
+        let prepared = root.join("prepared.a");
+        for (path, bytes) in [
+            (&runtime, b"runtime".as_slice()),
+            (&stdlib, b"stdlib".as_slice()),
+            (&wrapper, b"wrapper".as_slice()),
+            (&prepared, b"prepared".as_slice()),
+        ] {
+            fs::write(path, bytes).unwrap();
+        }
+        let archives = vec![wrapper.clone()];
+        let make_inputs = || PreparedArchiveInputs {
+            cache_dir: root,
+            target: Some("test-target"),
+            target_triple: Some("test-target"),
+            compiled_features: &[],
+            runtime_lib: &runtime,
+            stdlib_lib: Some(&stdlib),
+            well_known_libs: &archives,
+        };
+
+        let fallback =
+            prepare_well_known_archives(make_inputs(), || (vec![wrapper.clone()], false));
+        assert_eq!(fallback.paths, vec![wrapper]);
+        assert!(!fallback.safe_to_precede_stdlib);
+
+        let stored = prepare_well_known_archives(make_inputs(), || (vec![prepared.clone()], true));
+        assert!(stored.safe_to_precede_stdlib);
+        assert_eq!(fs::read(&stored.paths[0]).unwrap(), b"prepared");
+
+        let cached = prepare_well_known_archives(make_inputs(), || -> (Vec<PathBuf>, bool) {
+            panic!("a valid cache hit must not prepare the archives again")
+        });
+        assert!(cached.safe_to_precede_stdlib);
+        assert_eq!(cached.paths, stored.paths);
     }
 }

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -32,7 +32,8 @@ pub(crate) fn build_and_run_link(
     // No-auto / auto-fallback keeps the full prebuilt stdlib, so the
     // matching perry-stdlib feature was not stripped. Put wrappers first
     // in that shape so wrapper-only handles keep using their own surface
-    // symbols instead of the bundled stdlib copies.
+    // symbols instead of the bundled stdlib copies, but only after archive
+    // preparation has removed unsafe duplicate allocator/runtime objects.
     prefer_well_known_before_stdlib: bool,
     // Issue #76 — `libperry_wasm_host.a` (wasmi-backed WebAssembly host
     // runtime). Only `Some(...)` when the user passed `--enable-wasm-runtime`
@@ -397,9 +398,9 @@ pub(crate) fn build_and_run_link(
             .collect();
         (paths, cacheable.get())
     };
-    let well_known_libs: Vec<PathBuf> =
+    let (well_known_libs, wrappers_may_precede_stdlib): (Vec<PathBuf>, bool) =
         if prefer_well_known_before_stdlib && !source_well_known_libs.is_empty() {
-            prepare_well_known_archives(
+            let prepared = prepare_well_known_archives(
                 PreparedArchiveInputs {
                     cache_dir: &ctx.cache_dir,
                     target,
@@ -410,10 +411,17 @@ pub(crate) fn build_and_run_link(
                     well_known_libs: &source_well_known_libs,
                 },
                 prepare_well_known,
-            )
+            );
+            (prepared.paths, prepared.safe_to_precede_stdlib)
         } else {
-            source_well_known_libs
+            (source_well_known_libs, true)
         };
+    let wrappers_precede_stdlib = prefer_well_known_before_stdlib && wrappers_may_precede_stdlib;
+    if prefer_well_known_before_stdlib && !wrappers_may_precede_stdlib {
+        eprintln!(
+            "[strip-dedup] warning: archive preparation was incomplete; linking the full stdlib before wrappers to keep its allocator and runtime authoritative"
+        );
+    }
     // Multiple specifiers can route to the same native archive (`http` and
     // `https` both select perry_ext_http). They were de-duplicated before the
     // archive-preparation pass so the expensive transform also runs once.
@@ -427,7 +435,7 @@ pub(crate) fn build_and_run_link(
                 // graph. Put selected wrappers first, then let stdlib fill the
                 // unresolved surface. The stdlib staticlib already bundles
                 // perry-runtime, so Windows must not add it again.
-                if prefer_well_known_before_stdlib {
+                if wrappers_precede_stdlib {
                     for wk in &well_known_libs {
                         cmd.arg(wk);
                     }
@@ -442,7 +450,7 @@ pub(crate) fn build_and_run_link(
                 // Non-Windows archive linkers retain the historical repeat for
                 // stdlib bridge references. On Windows each wrapper appears
                 // exactly once; if there was no wrapper-first pass, put it here.
-                if !is_windows || !prefer_well_known_before_stdlib {
+                if !is_windows || !wrappers_precede_stdlib {
                     for wk in &well_known_libs {
                         cmd.arg(wk);
                     }
@@ -515,7 +523,7 @@ pub(crate) fn build_and_run_link(
         // Android + UI: runtime is provided by UI lib, but stdlib must still be linked
         // separately (UI lib does not bundle perry-stdlib).
         if let Some(ref stdlib) = stdlib_lib {
-            if prefer_well_known_before_stdlib {
+            if wrappers_precede_stdlib {
                 for wk in &well_known_libs {
                     cmd.arg(wk);
                 }


### PR DESCRIPTION
## Summary

- preserve whether well-known archive preparation completed safely through the archive cache
- fall back to full-stdlib-first linking when LLVM cannot inspect Rust wrapper bitcode
- bound Windows LLVM download retries so a stalled transfer cannot consume the full two-hour doc-test job

## Release blocker

The v0.5.1519 macOS doc test aborted with an invalid free after LLVM 22 failed to inspect LLVM 23 wrapper archives. The old non-fatal fallback kept wrappers before stdlib, allowing a wrapper allocator shim to become authoritative.

## Validation

- archive cache unit tests: 3 passed
- formatting and diff checks passed
- focused macOS 14 run 32859262825 reproduced the LLVM inspection failure and passed normal plus Guard Malloc execution at both -Os and -O3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linking reliability for packaged and no-auto builds when native wrapper archives cannot be inspected.
  - Prevented potential runtime failures caused by unsafe allocator and runtime selection.
  - Added safer fallback behavior and warnings when archive preparation is incomplete.
  - Updated wrapper ordering across supported platforms to produce more reliable binaries.

- **Chores**
  - Improved Windows LLVM downloads with shorter per-attempt timeouts and a bounded overall retry period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->