### PR TITLE
test(sharp): root object fixtures across allocation

### DIFF
--- a/crates/perry-ext-sharp/src/lib.rs
+++ b/crates/perry-ext-sharp/src/lib.rs
@@ -909,6 +909,11 @@ mod tests {
     use image::{ImageBuffer, Rgba};
 
     unsafe fn object(fields: &[(&str, JsValue)]) -> JsValue {
+        let scope = TransientRootScope::enter();
+        let rooted_fields: Vec<_> = fields
+            .iter()
+            .map(|(_, value)| scope.root_nanbox(f64::from_bits(value.bits())))
+            .collect();
         let keys: Vec<&str> = fields.iter().map(|(key, _)| *key).collect();
         let (packed, shape_id) = build_object_shape(&keys);
         let obj = js_object_alloc_with_shape(
@@ -917,10 +922,16 @@ mod tests {
             packed.as_ptr(),
             packed.len() as u32,
         );
-        for (index, (_, value)) in fields.iter().enumerate() {
-            js_object_set_field(obj, index as u32, *value);
+        let rooted_obj = scope.root_nanbox(f64::from_bits(JsValue::from_object_ptr(obj).bits()));
+        for (index, value) in rooted_fields.iter().enumerate() {
+            let current_obj = JsValue::from_bits(rooted_obj.get().to_bits()).as_pointer();
+            js_object_set_field(
+                current_obj,
+                index as u32,
+                JsValue::from_bits(value.get().to_bits()),
+            );
         }
-        JsValue::from_object_ptr(obj)
+        JsValue::from_bits(rooted_obj.get().to_bits())
     }
 
     unsafe fn create_input(


### PR DESCRIPTION
## Summary

- root pointer-valued Sharp fixture fields before allocating an object
- re-read the rooted object before every field write
- return the post-collection object value

## Release blocker

Full CI run 32861049819 failed the mandatory unrooted-local shape ratchet on the new Sharp create-input test helper. This fixes the unsafe shape instead of raising the baseline.

## Validation

- unrooted-local shape self-test passed
- unrooted-local shape ratchet passed and exposure dropped from 568 to 567
- formatting and diff checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object construction in tests to preserve valid references and prevent invalid values when populating fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->