### PR TITLE
docs: regenerate qs API reference

### DIFF
--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2065 entries across 135 modules
+// Coverage: 2067 entries across 136 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -3590,6 +3590,13 @@ declare module "punycode" {
   export function toASCII(...args: any[]): any;
   /** stdlib */
   export function toUnicode(...args: any[]): any;
+}
+
+declare module "qs" {
+  /** stdlib */
+  export function parse(input: string, options: any): any;
+  /** stdlib */
+  export function stringify(value: any, options: any): string;
 }
 
 declare module "querystring" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3017 entries across 137 modules.
+Total: 3019 entries across 138 modules.
 
 ## Modules
 
@@ -107,6 +107,7 @@ Total: 3017 entries across 137 modules.
 - [`pg`](#pg)
 - [`process`](#process)
 - [`punycode`](#punycode)
+- [`qs`](#qs)
 - [`querystring`](#querystring)
 - [`rate-limiter-flexible`](#rate-limiter-flexible)
 - [`readline`](#readline)
@@ -3156,6 +3157,13 @@ Total: 3017 entries across 137 modules.
 - `default`
 - `ucs2`
 - `version`
+
+## `qs`
+
+### Methods
+
+- `parse` — module
+- `stringify` — module
 
 ## `querystring`
 


### PR DESCRIPTION
## Summary

Regenerate the committed API reference and TypeScript declarations for the newly merged `qs` manifest entries.

## Release blocker

Full CI run 32862086005 failed `Check for API docs drift`; its generated diff is reproduced exactly here: 17 insertions and 2 count updates across the two generated files.

## Validation

- diff matches the generator output captured by the failed CI job byte-for-byte
- whitespace check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API reference documentation for the `qs` module.
  * Documented `parse` and `stringify` methods, including their parameters and return values.
  * Updated API coverage and module indexes to include the new entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->