### PR TITLE
fix: clear v0.5.1519 r14 release blockers

### DIFF
--- a/changelog.d/8842-release-r14-blockers.md
+++ b/changelog.d/8842-release-r14-blockers.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Kept caught property-read `TypeError` throws unwind-capable across the runtime FFI boundary, made the regression test build the static runtime archive it actually links, and reconciled the Linux parity ratchet with the r14 release evidence.

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -719,7 +719,7 @@ pub(crate) fn string_coerce_is_inert(value: f64) -> bool {
 /// `js_string_coerce` used for `String(x)` / `'' + x`. `prop_name_*` carries
 /// the static method name for the diagnostic.
 #[no_mangle]
-pub extern "C" fn js_string_coerce_method_this(
+pub extern "C-unwind" fn js_string_coerce_method_this(
     value: f64,
     prop_name_ptr: *const u8,
     prop_name_len: usize,

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -1630,8 +1630,10 @@ pub extern "C" fn js_error_get_kind(error: *mut ErrorHeader) -> u32 {
 /// `receiver_is_null` distinguishes "Cannot read properties of null"
 /// from "Cannot read properties of undefined" (matches V8's wording).
 /// `prop_name_ptr` / `prop_name_len` carry the static property name.
+/// `C-unwind` is required because `js_throw` may use the system-unwinder
+/// fallback to reach generated code's landing pad.
 #[no_mangle]
-pub extern "C" fn js_throw_type_error_property_access(
+pub extern "C-unwind" fn js_throw_type_error_property_access(
     receiver_is_null: u32,
     prop_name_ptr: *const u8,
     prop_name_len: usize,

--- a/crates/perry/tests/issue_5247_property_read_source_location.rs
+++ b/crates/perry/tests/issue_5247_property_read_source_location.rs
@@ -53,12 +53,12 @@ fn ensure_runtime_archive() {
             .current_dir(workspace_root())
             .arg("build")
             .arg("-p")
-            .arg("perry-runtime")
+            .arg("perry-runtime-static")
             .output()
-            .expect("run cargo build -p perry-runtime");
+            .expect("run cargo build -p perry-runtime-static");
         assert!(
             build.status.success(),
-            "cargo build -p perry-runtime failed\nstdout:\n{}\nstderr:\n{}",
+            "cargo build -p perry-runtime-static failed\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&build.stdout),
             String::from_utf8_lossy(&build.stderr)
         );

--- a/test-files/test_parcel_watcher_idle.ts
+++ b/test-files/test_parcel_watcher_idle.ts
@@ -1,3 +1,4 @@
+// parity-skip: benchmark fixture requires PERRY_WATCH_ROOT/PERRY_WATCH_READY and the dedicated Parcel watcher harness
 import { subscribe, unsubscribe } from "@parcel/watcher";
 import fs from "fs";
 import path from "path";

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -39,7 +39,7 @@
   },
   "test_class_field_layout": {
     "issue": "8841",
-    "added": "2026-08-26",
+    "added": "2026-08-25",
     "category": "bug-open",
     "reason": "Reproduces 5/5 on pre-#8835 r13 and in r14 Full CI: both runtimes exit 0 but their class-field layout output differs. Tracked in #8841.",
     "platforms": [
@@ -243,7 +243,7 @@
   },
   "test_issue_3199_3200_tls_server_tlssocket": {
     "issue": "8841",
-    "added": "2026-08-26",
+    "added": "2026-08-25",
     "category": "bug-open",
     "reason": "Reproduces 5/5 on both pre-#8835 r13 and r14: Perry exits 1 after the initial TLS server-address line while Node completes with exit 0. Tracked in #8841.",
     "platforms": [
@@ -960,7 +960,7 @@
   },
   "test_stress_promises": {
     "issue": "8841",
-    "added": "2026-08-26",
+    "added": "2026-08-25",
     "category": "bug-open",
     "reason": "Reproduces 5/5 on both pre-#8835 r13 and r14: Perry dies with SIGSEGV (exit 139) after six output lines while Node exits 0. Tracked in #8841.",
     "platforms": [

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -106,15 +106,6 @@
       "linux"
     ]
   },
-  "test_harness_class_mixins": {
-    "issue": "8271",
-    "added": "2026-08-17",
-    "category": "untriaged",
-    "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
-    "platforms": [
-      "linux"
-    ]
-  },
   "test_hono_bundle": {
     "issue": "8271",
     "added": "2026-08-17",
@@ -471,15 +462,6 @@
     "added": "2026-08-17",
     "category": "ci-env",
     "reason": "Compile fails on the Linux CI host (libperry_ui_gtk4.a family — same class as #8224 item 3). 2026-08-17 parity-debt audit (#8271).",
-    "platforms": [
-      "linux"
-    ]
-  },
-  "test_issue_562_stream_subclass": {
-    "issue": "8271",
-    "added": "2026-08-17",
-    "category": "untriaged",
-    "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
     "platforms": [
       "linux"
     ]

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -37,6 +37,15 @@
       "linux"
     ]
   },
+  "test_class_field_layout": {
+    "issue": "8841",
+    "added": "2026-08-26",
+    "category": "bug-open",
+    "reason": "Reproduces 5/5 on pre-#8835 r13 and in r14 Full CI: both runtimes exit 0 but their class-field layout output differs. Tracked in #8841.",
+    "platforms": [
+      "linux"
+    ]
+  },
   "test_date_fns_format": {
     "issue": "8271",
     "added": "2026-08-17",
@@ -228,6 +237,15 @@
     "added": "2026-08-17",
     "category": "untriaged",
     "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
+    "platforms": [
+      "linux"
+    ]
+  },
+  "test_issue_3199_3200_tls_server_tlssocket": {
+    "issue": "8841",
+    "added": "2026-08-26",
+    "category": "bug-open",
+    "reason": "Reproduces 5/5 on both pre-#8835 r13 and r14: Perry exits 1 after the initial TLS server-address line while Node completes with exit 0. Tracked in #8841.",
     "platforms": [
       "linux"
     ]
@@ -936,6 +954,15 @@
     "added": "2026-08-17",
     "category": "untriaged",
     "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
+    "platforms": [
+      "linux"
+    ]
+  },
+  "test_stress_promises": {
+    "issue": "8841",
+    "added": "2026-08-26",
+    "category": "bug-open",
+    "reason": "Reproduces 5/5 on both pre-#8835 r13 and r14: Perry dies with SIGSEGV (exit 139) after six output lines while Node exits 0. Tracked in #8841.",
     "platforms": [
       "linux"
     ]


### PR DESCRIPTION
## Summary\n\n- make js_throw_type_error_property_access use the C-unwind ABI so a caught property-read TypeError can reach generated landing pads without panic_cannot_unwind\n- make the #5247 integration test build perry-runtime-static, the archive it actually links\n- remove the two parity entries that r14 proved stale\n- track three repeatedly reproduced pre-existing Linux parity failures in #8841\n- mark the Parcel watcher idle benchmark as orchestrated rather than standalone parity\n\n## Release evidence\n\n- Failed r14 Full CI: https://github.com/PerryTS/perry/actions/runs/32898410858\n- Property-read abort backtrace identifies js_throw_type_error_property_access as the non-unwind ABI boundary: https://github.com/PerryTS/perry/actions/runs/32912059523\n- Promise stress reproduces 5/5 on r13 and r14:\n  - https://github.com/PerryTS/perry/actions/runs/32911025459\n  - https://github.com/PerryTS/perry/actions/runs/32911028305\n- Class layout reproduces 5/5 on r13: https://github.com/PerryTS/perry/actions/runs/32911407743\n- TLS lifecycle reproduces 5/5 on r13 and r14:\n  - https://github.com/PerryTS/perry/actions/runs/32911412179\n  - https://github.com/PerryTS/perry/actions/runs/32911414409\n\n## Validation\n\n- focused cargo regression on fix commit 508efe6674a6df4d4a548148ab759eef8d100d1e: 3 passed, 0 failed in the dedicated release-cargo-diagnostic job: https://github.com/PerryTS/perry/actions/runs/32912212569\n- jq empty test-parity/known_failures.json\n- python3 scripts/parity_known_failures.py --audit\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain caught property-access errors could fail to unwind correctly, improving runtime reliability.
* **Testing**
  * Corrected regression-test setup for property-access error handling.
  * Improved environment-specific test coverage and updated tracking for known Linux test results.
* **Documentation**
  * Added release documentation covering the resolved error-handling regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->