### PR TITLE
test: prevent Windows direct-call fixture folding

### DIFF
--- a/changelog.d/8844-windows-icf-test-identity.md
+++ b/changelog.d/8844-windows-icf-test-identity.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Prevented MSVC identical-code folding from collapsing distinct typed-feedback test fixtures and causing spurious Windows pointer-identity failures.

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -4,6 +4,13 @@ static CLASS_FIELD_SETTER_CALLS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 static CLASS_FIELD_SETTER_VALUE_BITS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
+// Keep the two direct-call fixtures distinguishable under MSVC's identical
+// COMDAT folding: their different Rust signatures otherwise lower to the same
+// x64 machine code, which makes pointer-identity guard tests spuriously fail.
+static TEST_DIRECT_METHOD_CALLS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+static TEST_DIRECT_CLOSURE_CALLS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 extern "C" fn test_class_field_setter(_this: f64, value: f64) -> f64 {
     CLASS_FIELD_SETTER_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -12,10 +19,12 @@ extern "C" fn test_class_field_setter(_this: f64, value: f64) -> f64 {
 }
 
 extern "C" fn test_direct_method(_this: f64, value: f64) -> f64 {
+    TEST_DIRECT_METHOD_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     value
 }
 
 extern "C" fn test_direct_closure(_closure: *const crate::closure::ClosureHeader, arg: f64) -> f64 {
+    TEST_DIRECT_CLOSURE_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     arg
 }
 


### PR DESCRIPTION
## Summary
- keep the two typed-feedback direct-call test fixtures distinct under MSVC identical COMDAT folding
- preserve the production pointer-identity checks unchanged

## Release evidence
- r15 Full CI Windows job failed only because the two test fixtures received the same folded address
- failed job: https://github.com/PerryTS/perry/actions/runs/32916479366/job/98023193327
- r15 remains running to surface any additional blockers

## Validation
- cargo fmt --all -- --check
- git diff --check
- focused Windows validation will be attached before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows test failures caused by distinct typed-feedback fixtures being incorrectly merged.
  * Added execution tracking to improve the reliability of direct method and closure call tests.

* **Documentation**
  * Documented the Windows test fix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->