### PR TITLE
ci: restore parity release margin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2401,7 +2401,9 @@ jobs:
   #
   # Sharded 2026-08-16: the unsharded job was killed by GitHub's 6-hour job
   # cap (run 31935729773, 11:44 -> 17:45) — the release gate could not
-  # complete even in principle. Each shard runs `run_parity_tests.sh
+  # complete even in principle. Increased 8 -> 12 shards after release run
+  # 32922022811 reached only 152/173 tests in shard 8 before the old
+  # 150-minute cap. Each shard runs `run_parity_tests.sh
   # --shard N/M` (round-robin partition, same mechanism as gap-suite) plus
   # `parity_known_failures.py`, which is shard-safe by design ("not in this
   # shard is never flagged"). The AGGREGATE gates — the threshold minimums
@@ -2426,7 +2428,10 @@ jobs:
       matrix:
         shard: ${{ fromJSON(needs.plan.outputs.plan).parity.shards }}
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    # A healthy shard must finish well below this cap after the 12-way split.
+    # 210 is a hang backstop with cold-cache/host-contention margin, not a
+    # performance budget; a cancelled shard makes full-suite-gate fail.
+    timeout-minutes: 210
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Rust toolchain

--- a/changelog.d/8841-release-parity-budget.md
+++ b/changelog.d/8841-release-parity-budget.md
@@ -1,0 +1,1 @@
+- Keep release-grade parity CI viable as the corpus grows by spreading it over twelve shards, adding timeout margin, and tracking the Linux Parcel watcher facade mismatch surfaced by the v0.5.1519 candidate.

--- a/scripts/ci_plan.py
+++ b/scripts/ci_plan.py
@@ -121,10 +121,13 @@ GAP_SUITE = {
 }
 
 # Parity: full tier only, sharded. The unsharded job was killed by GitHub's
-# 6-hour job cap on 2026-08-16 (run 31935729773) — 8 shards puts each around
-# 45-75 min. `parity-aggregate` (not in JOBS: it keys off `jobs.parity`)
-# merges the shard reports and runs the aggregate-only gates.
-PARITY_SHARDS = 8
+# 6-hour job cap on 2026-08-16 (run 31935729773). The corpus subsequently
+# outgrew the original 8-way split: release run 32922022811 reached only
+# 152/173 tests in shard 8 before its 150-minute cap. Twelve shards restore
+# wall-time margin without exceeding the org's 20-runner pool once the other
+# full-tier jobs drain. `parity-aggregate` (not in JOBS: it keys off
+# `jobs.parity`) merges the shard reports and runs the aggregate-only gates.
+PARITY_SHARDS = 12
 
 EXTENDED_LABEL = "run-extended-tests"
 

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -745,6 +745,15 @@
       "linux"
     ]
   },
+  "test_parcel_watcher_facade": {
+    "issue": "8841",
+    "added": "2026-08-26",
+    "category": "ci-env",
+    "reason": "Release run 32922022811: the Linux Node oracle exits in package_json_reader while Perry's native watcher sees events but times out waiting for the nested create event. Track the CI-dependent facade mismatch without weakening the dedicated Parcel watcher integration tests.",
+    "platforms": [
+      "linux"
+    ]
+  },
   "test_parity_cluster": {
     "issue": "8271",
     "added": "2026-08-17",


### PR DESCRIPTION
## Summary

- spread release-grade parity over 12 shards instead of 8
- raise the parity job hang backstop from 150 to 210 minutes
- track the Linux-only `test_parcel_watcher_facade` CI mismatch surfaced by the release candidate

## Release evidence

Full candidate run 32922022811 cancelled parity shard 8 at the exact 150-minute cap while it was still making progress (152/173 tests completed). The shard was not hung. All other observed mismatches in the partial report were already present in `test-parity/known_failures.json`; the Parcel watcher facade mismatch was the only untracked result.

No publisher was dispatched, and no npm package, tag, or GitHub Release was created.

## Validation

- `python3 scripts/ci_plan.py --self-test`
- full dispatch plan emits parity shards 1-12
- `python3 scripts/parity_report_merge.py --self-test`
- `python3 scripts/parity_known_failures.py --self-test`
- `python3 scripts/parity_known_failures.py --audit`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Release-parity checks now run across 12 parallel shards for improved execution capacity.
  * Increased the parity check timeout to provide additional completion time.

* **Known Issues**
  * Documented a Linux-specific Parcel watcher mismatch in the tracked known-failures list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->