### PR TITLE
ci: unblock release parity and current-main warnings

### DIFF
--- a/changelog.d/8841-release-parity-budget.md
+++ b/changelog.d/8841-release-parity-budget.md
@@ -1,1 +1,1 @@
-- Keep release-grade parity CI viable as the corpus grows by spreading it over twelve shards, adding timeout margin, and tracking the Linux Parcel watcher facade mismatch surfaced by the v0.5.1519 candidate.
+- Keep release-grade parity CI viable as the corpus grows by spreading it over twelve shards, adding timeout margin, and ratcheting the Linux Parcel watcher and HTTP Agent lifecycle gaps surfaced by the v0.5.1519 candidates.

--- a/changelog.d/8851-release-main-warnings.md
+++ b/changelog.d/8851-release-main-warnings.md
@@ -1,0 +1,1 @@
+- Restore warning-clean compiler builds after the packed-loop index-store lowering was split into its own module.

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -39,20 +39,17 @@ use crate::rooting;
 use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
 use crate::types::{DOUBLE, I32, I64};
 
-use super::index_set_packed_loop::{
-    lower_packed_f64_range_loop_index_set, lower_packed_numeric_loop_index_set,
-};
+use super::index_set_packed_loop::lower_packed_numeric_loop_index_set;
 use super::index_set_typed_array::lower_inline_dyn_typed_array_set;
 use super::{
-    array_kind_fact, array_store_needs_layout_note, array_store_needs_write_barrier,
+    array_store_needs_layout_note, array_store_needs_write_barrier,
     attach_buffer_view_pointer_state_for_expr, buffer_access_materialization_reason,
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_root_nanbox_store_on_block, emit_typed_feedback_register_site, emit_write_barrier,
     expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_store, lower_expr,
-    lower_expr_as_i32, lower_expr_native, lower_index_set_fast, lower_typed_array_store,
-    materialize_js_value, nanbox_pointer_inline, raw_f64_layout_fact, unbox_str_handle,
-    unbox_to_i64, BufferAccessSpec, FnCtx, PackedF64LoopFact, PackedNumericLoopKind,
-    TypedFeedbackContract, TypedFeedbackKind,
+    lower_expr_native, lower_index_set_fast, lower_typed_array_store, materialize_js_value,
+    nanbox_pointer_inline, raw_f64_layout_fact, unbox_str_handle, unbox_to_i64, BufferAccessSpec,
+    FnCtx, PackedF64LoopFact, PackedNumericLoopKind, TypedFeedbackContract, TypedFeedbackKind,
 };
 
 pub(super) fn canonicalize_raw_f64_numeric_store_value(

--- a/crates/perry-codegen/src/expr/index_set_packed_loop.rs
+++ b/crates/perry-codegen/src/expr/index_set_packed_loop.rs
@@ -4,30 +4,18 @@
 //! Split out of `index_set.rs` to keep it under the 2,000-line file gate.
 
 use anyhow::Result;
-use perry_hir::{BinaryOp, Expr};
+use perry_hir::Expr;
 
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
-    BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
-    NativeRep, SemanticKind,
+    BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
-use crate::rooting;
-use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
 use crate::types::{DOUBLE, I32, I64};
 
 use super::index_set::{canonicalize_raw_f64_numeric_store_value, packed_f64_loop_fact};
-use super::index_set_typed_array::lower_inline_dyn_typed_array_set;
-use super::*;
 use super::{
-    array_kind_fact, array_store_needs_layout_note, array_store_needs_write_barrier,
-    attach_buffer_view_pointer_state_for_expr, buffer_access_materialization_reason,
-    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
-    emit_root_nanbox_store_on_block, emit_typed_feedback_register_site, emit_write_barrier,
-    expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_store, lower_expr,
-    lower_expr_as_i32, lower_expr_native, lower_index_set_fast, lower_typed_array_store,
-    materialize_js_value, nanbox_pointer_inline, raw_f64_layout_fact, unbox_str_handle,
-    unbox_to_i64, BufferAccessSpec, FnCtx, PackedF64LoopFact, PackedNumericLoopKind,
-    TypedFeedbackContract, TypedFeedbackKind,
+    array_kind_fact, emit_typed_feedback_register_site, lower_expr, lower_expr_as_i32,
+    raw_f64_layout_fact, FnCtx, PackedNumericLoopKind, TypedFeedbackContract, TypedFeedbackKind,
 };
 
 fn lower_packed_f64_loop_store_value(

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -430,6 +430,15 @@
       "linux"
     ]
   },
+  "test_issue_4975_http_agent_keep_alive_connection_options": {
+    "issue": "8841",
+    "added": "2026-08-26",
+    "category": "bug-open",
+    "reason": "Release run 32935157745: Node exits 0, while Perry prints the expected keepAlive and keepAliveInitialDelay values but does not terminate before the 10s harness deadline. Track the Agent/socket lifecycle gap after server.close(); remove this entry with the fix tracked in #8841.",
+    "platforms": [
+      "linux"
+    ]
+  },
   "test_issue_4977_gc_toplevel_locals": {
     "issue": "8271",
     "added": "2026-08-17",


### PR DESCRIPTION
## What

- Record the r17 Linux failure of `test_issue_4975_http_agent_keep_alive_connection_options` in the parity ratchet.
- Classify it as `bug-open`, scoped to Linux, and track the lifecycle fix in #8841.
- Restore warning-clean current-main builds after the packed-loop module split in #8847 by removing only rustc-reported unused imports.
- Update the release changelog fragments.

## Evidence

r17 Full: https://github.com/PerryTS/perry/actions/runs/32935157745
Parity job: https://github.com/PerryTS/perry/actions/runs/32935157745/job/98076809981
Parity artifact: https://github.com/PerryTS/perry/actions/runs/32935157745/artifacts/9597975431

Node exits 0. Perry prints the expected `true` and `1250`, then does not terminate before the harness deadline. The ratchet will fail stale once the fixture passes and require this entry to be removed with the product fix.

The first PR run also exposed ten unused-import errors already present on current `main` after #8847: https://github.com/PerryTS/perry/actions/runs/32945577563/job/98105537416. The follow-up commit removes exactly those unused imports; executable compiler logic is unchanged.

## Local checks

- `cargo fmt --all -- --check`
- `python3 scripts/parity_known_failures.py --self-test`
- `python3 scripts/parity_known_failures.py --audit`
- `jq empty test-parity/known_failures.json`
- `git diff --check`

No publisher was dispatched and no npm/tag side effects occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to reflect Linux Parcel watcher and HTTP Agent lifecycle gaps.
  * Added information about restored warning-free compiler builds.
* **Tests**
  * Documented a Linux-specific known test failure involving HTTP Agent connection cleanup after server shutdown.
* **Bug Fixes**
  * Improved compiler output by addressing warnings in packed numeric loop processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->