### PR TITLE
test(parity): prune stale release suppressions

### DIFF
--- a/changelog.d/8841-release-parity-budget.md
+++ b/changelog.d/8841-release-parity-budget.md
@@ -1,1 +1,1 @@
-- Keep release-grade parity CI viable as the corpus grows by spreading it over twelve shards, adding timeout margin, and ratcheting the Linux Parcel watcher and HTTP Agent lifecycle gaps surfaced by the v0.5.1519 candidates.
+- Keep release-grade parity CI viable as the corpus grows by spreading it over twelve shards, adding timeout margin, pruning two stale Linux suppressions, and ratcheting the Parcel watcher and HTTP Agent lifecycle gaps surfaced by the v0.5.1519 candidates.

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -637,15 +637,6 @@
       "linux"
     ]
   },
-  "test_issue_806_curried_mixin_outer_capture": {
-    "issue": "8271",
-    "added": "2026-08-17",
-    "category": "untriaged",
-    "reason": "First complete parity run since 2026-07-04 (suite dark behind tag-gating + continue-on-error; #8187/#8244). Needs bisect over the six-week window. 2026-08-17 parity-debt audit (#8271).",
-    "platforms": [
-      "linux"
-    ]
-  },
   "test_issue_859_native_promise_pin": {
     "issue": "8271",
     "added": "2026-08-17",
@@ -882,12 +873,6 @@
     "platforms": [
       "linux"
     ]
-  },
-  "test_parity_stream": {
-    "issue": "793",
-    "added": "2026-05-15",
-    "category": "module-inventory",
-    "reason": "Tracking issue #793 (roadmap umbrella) is CLOSED — this needs a live surface tracker (audited 2026-08-07, #7582). Node.js module inventory — `node:stream` surface not fully implemented. Tracker for surface coverage; flips to PASS as each API lands. Not a regression."
   },
   "test_parity_stream_web": {
     "issue": "793",


### PR DESCRIPTION
## Summary
- remove the two stale Linux parity suppressions reported by release candidate r18
- keep the v0.5.1519 parity-budget changelog accurate

## Evidence
- Release CI run 32949659037, parity shard 8 job 98120735010
- Artifact: https://github.com/PerryTS/perry/actions/runs/32949659037/artifacts/9602879801
- `test_issue_806_curried_mixin_outer_capture` passed
- `test_parity_stream` passed

## Local checks
- `jq empty test-parity/known_failures.json`
- `python3 scripts/parity_known_failures.py --self-test`
- `python3 scripts/parity_known_failures.py --audit`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved parity testing by distributing CI coverage across twelve shards.
  - Added timeout margin to improve reliability during test runs.
  - Expanded coverage for file-watching and HTTP connection lifecycle behavior.
  - Removed obsolete Linux suppressions and outdated known-failure entries, making test results more accurate.

- **Documentation**
  - Updated release notes to reflect the latest parity testing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->