### PR TITLE
perf(map): remove outer hash from numeric-key lookups

### DIFF
--- a/crates/perry-runtime/src/gc/copying_pointer_set.rs
+++ b/crates/perry-runtime/src/gc/copying_pointer_set.rs
@@ -304,10 +304,13 @@ pub(super) unsafe fn plausible_gc_header(header: *mut GcHeader, arena: bool) -> 
 /// ~1024 (the top 32 bits of the address), which never matches the
 /// fixed total.
 fn fixed_layout_total_size(info: &GcTypeInfo) -> Option<usize> {
-    // MapHeader { size: u32, capacity: u32, entries: *mut f64 } = 16 B.
-    // SetHeader { size: u32, capacity: u32, elements: *mut f64 } = 16 B.
     match info.type_id {
-        crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => Some(GC_HEADER_SIZE + 16),
+        crate::gc::GC_TYPE_MAP => {
+            Some(GC_HEADER_SIZE + std::mem::size_of::<crate::map::MapHeader>())
+        }
+        crate::gc::GC_TYPE_SET => {
+            Some(GC_HEADER_SIZE + std::mem::size_of::<crate::set::SetHeader>())
+        }
         _ => None,
     }
 }

--- a/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
@@ -15,24 +15,22 @@
 //!   * `gc_flags` = second byte, needs `GC_FLAG_ARENA` (0x02) — ~coin flip
 //!
 //! The size check rejects the observed `size ≈ 1024` corruption, but payload
-//! bytes can also encode the genuine Map total of 24. The complete fix is the
+//! bytes can also encode the genuine fixed Map total. The complete fix is the
 //! arena's allocation-authored object-start bitmap: `classify_arena` requires
 //! a candidate Map header address to be recorded there before dispatching its
 //! rewrite descriptor. Other arena types do not need to stamp the bitmap.
 
 use super::*;
 
-/// Size of `MapHeader` (and `SetHeader`): `{ size: u32, capacity: u32,
-/// entries/elements: *mut f64 }` = 16 bytes.
-const MAP_HEADER_PAYLOAD: usize = 16;
-const MAP_FIXED_TOTAL: usize = GC_HEADER_SIZE + MAP_HEADER_PAYLOAD;
+const MAP_FIXED_TOTAL: usize = GC_HEADER_SIZE + std::mem::size_of::<crate::map::MapHeader>();
+const SET_FIXED_TOTAL: usize = GC_HEADER_SIZE + std::mem::size_of::<crate::set::SetHeader>();
 
 /// Directly test that `plausible_gc_header` rejects a fabricated Map
 /// header with the ~1024-byte size that an interior arena pointer
-/// produces, while accepting a genuine Map header with size = 24.
+/// produces, while accepting a genuine fixed-size Map header.
 #[test]
 fn test_plausible_gc_header_rejects_fabricated_map_size() {
-    // A genuine Map header: obj_type = MAP, size = 24, GC_FLAG_ARENA set.
+    // A genuine Map header has the exact fixed payload size.
     let mut genuine = GcHeader {
         obj_type: GC_TYPE_MAP,
         gc_flags: GC_FLAG_ARENA,
@@ -59,18 +57,18 @@ fn test_plausible_gc_header_rejects_fabricated_map_size() {
         "fabricated Map header (size=1024) must be rejected"
     );
 
-    // Edge: size = 24 + 8 = 32 (what free-list reuse into a larger slot
+    // Edge: fixed size + 8 (what free-list reuse into a larger slot
     // would produce) must also be rejected — only the exact fixed total
     // is accepted.
     let mut wrong_size = GcHeader {
         obj_type: GC_TYPE_MAP,
         gc_flags: GC_FLAG_ARENA,
         _reserved: 0,
-        size: 32,
+        size: (MAP_FIXED_TOTAL + 8) as u32,
     };
     assert!(
         !unsafe { plausible_gc_header(&mut wrong_size as *mut GcHeader, true) },
-        "Map header with non-fixed size (32) must be rejected"
+        "Map header with non-fixed size must be rejected"
     );
 }
 
@@ -84,11 +82,11 @@ fn test_plausible_gc_header_rejects_fabricated_set_size() {
         obj_type: GC_TYPE_SET,
         gc_flags: GC_FLAG_ARENA,
         _reserved: 0,
-        size: MAP_FIXED_TOTAL as u32,
+        size: SET_FIXED_TOTAL as u32,
     };
     assert!(
         unsafe { plausible_gc_header(&mut genuine as *mut GcHeader, true) },
-        "genuine Set header (size={MAP_FIXED_TOTAL}) must be plausible"
+        "genuine Set header (size={SET_FIXED_TOTAL}) must be plausible"
     );
 
     let mut fabricated = GcHeader {
@@ -151,7 +149,7 @@ fn test_plausible_gc_header_rejects_malloc_only_type_in_arena() {
 fn test_classify_arena_rejects_interior_pointer_as_map() {
     let _guard = CopyingNurseryTestGuard::new(1);
 
-    // Allocate a genuine Map. Its GcHeader.size must be 24.
+    // Allocate a genuine Map. Its GcHeader.size must match the fixed layout.
     let map_ptr = crate::map::js_map_alloc(4) as *mut u8;
     assert!(!map_ptr.is_null(), "Map allocation must succeed");
 

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -124,11 +124,16 @@ pub(crate) fn test_map_side_deallocation_snapshot() -> (u64, u64) {
 struct MapSideAllocation {
     entries: *mut f64,
     capacity: usize,
+    numeric_index: Box<NumericIndex>,
 }
 
 impl MapSideAllocation {
     fn new(entries: *mut f64, capacity: usize) -> Self {
-        Self { entries, capacity }
+        Self {
+            entries,
+            capacity,
+            numeric_index: Box::new(crate::fast_hash::new_ptr_hash_map()),
+        }
     }
 
     fn byte_len(&self) -> usize {
@@ -187,7 +192,11 @@ fn register_map(ptr: *mut MapHeader, entries: *mut f64, capacity: usize) {
             !registry.contains_key(&(ptr as usize)),
             "Map side allocation registered twice for the same header"
         );
-        registry.insert(ptr as usize, MapSideAllocation::new(entries, capacity));
+        let mut allocation = MapSideAllocation::new(entries, capacity);
+        unsafe {
+            (*ptr).numeric_index = allocation.numeric_index.as_mut();
+        }
+        registry.insert(ptr as usize, allocation);
     });
 }
 
@@ -298,6 +307,8 @@ impl PartialEq for NumericKey {
 }
 impl Eq for NumericKey {}
 
+type NumericIndex = crate::fast_hash::PtrHashMap<NumericKey, u32>;
+
 /// `true` if `bits` is a non-pointer JSValue (number, bool, undefined,
 /// null, or any NaN-tagged value that is NOT a string/heap pointer).
 /// We index only these in the side-table.
@@ -336,26 +347,19 @@ fn is_safe_numeric_key(bits: u64) -> bool {
     true
 }
 
-// Side-table mapping `map_ptr -> (NumericKey-bits -> entries-array-index)`.
-// O(1) `find_key_index` for numeric keys; pointer keys still take the
-// linear-scan path so they remain correct under gen-GC string forwarding.
+// O(1) index from numeric key bits to entries-array index. The owning Box is
+// kept in `MapSideAllocation`; `MapHeader::numeric_index` points directly at
+// it so a lookup does not first hash the MapHeader address through a second
+// thread-local table. The Box address stays stable when MAP_REGISTRY rehashes
+// or a moving GC rekeys the owning allocation.
 //
-// Both nesting levels use `PtrHasher` (Fibonacci-multiplicative + xorshift
-// avalanche, see `crate::fast_hash`). The xorshift step is essential here
-// because `NumericKey(u64)` holds f64 bit-patterns — small whole-number
-// EntityIds have mantissa-zero, so pure multiplicative hashing would
-// collapse hundreds of keys into bucket 0 (caught by a 2x regression
-// the first time around). With the avalanche step, even the worst-case
-// integer-f64 inputs distribute across buckets normally.
-crate::perry_thread_local! {
-    static MAP_INDEX: RefCell<
-        crate::fast_hash::PtrHashMap<usize, crate::fast_hash::PtrHashMap<NumericKey, u32>>,
-    > = RefCell::new(crate::fast_hash::new_ptr_hash_map());
-}
+// `PtrHasher`'s xorshift avalanche is essential because `NumericKey(u64)`
+// holds f64 bit patterns: small whole-number EntityIds have mantissa-zero, so
+// pure multiplicative hashing would collapse hundreds of keys into bucket 0.
 
 // Side-table mapping `map_ptr -> (FNV-1a 64-bit content hash -> Vec<entries-array-index>)`
 // for STRING keys. Bypasses the gen-GC-stale-bits constraint that keeps
-// `MAP_INDEX` numeric-only by hashing the string's CONTENT, not its
+// the numeric index numeric-only by hashing the string's CONTENT, not its
 // pointer bits — so a forwarded heap-string and an SSO inline string
 // with the same bytes share the same bucket. Stored values are u32
 // indexes into the entries array (not pointers), which survive
@@ -471,7 +475,7 @@ fn is_ptr_index_key(bits: u64) -> bool {
 }
 
 // Side-table mapping `map_ptr -> (MapPtrKey -> entries-array-index)` for
-// pointer keys — the third index alongside `MAP_INDEX` (numeric bits) and
+// pointer keys — the third index alongside the direct numeric index and
 // `MAP_STRING_INDEX` (string content). Before #6084 object/bigint keys took
 // a full linear scan per operation (measured 1,793x slower than string keys
 // on a 20k-entry map). GC-move safety mirrors `set.rs`'s SET_INDEX: the
@@ -501,9 +505,6 @@ crate::perry_thread_local! {
 /// `processCommands` iterated `commands[i]` over an Array whose memory
 /// had been a Map a few collections earlier.
 pub fn drop_map_index(addr: usize) {
-    MAP_INDEX.with(|idx| {
-        idx.borrow_mut().remove(&addr);
-    });
     MAP_STRING_INDEX.with(|idx| {
         idx.borrow_mut().remove(&addr);
     });
@@ -533,13 +534,6 @@ pub(crate) fn map_header_moved_for_gc(old_addr: usize, new_addr: usize) {
         }
         registry.insert(new_addr, allocation);
     });
-    MAP_INDEX.with(|idx| {
-        let mut idx = idx.borrow_mut();
-        idx.remove(&new_addr);
-        if let Some(slot) = idx.remove(&old_addr) {
-            idx.insert(new_addr, slot);
-        }
-    });
     MAP_STRING_INDEX.with(|idx| {
         let mut idx = idx.borrow_mut();
         idx.remove(&new_addr);
@@ -562,9 +556,6 @@ pub(crate) unsafe fn finalize_map_side_allocation_for_gc(map: *mut MapHeader) {
     }
     let addr = map as usize;
     let allocation = MAP_REGISTRY.with(|r| r.borrow_mut().remove(&addr));
-    MAP_INDEX.with(|idx| {
-        idx.borrow_mut().remove(&addr);
-    });
     MAP_STRING_INDEX.with(|idx| {
         idx.borrow_mut().remove(&addr);
     });
@@ -579,6 +570,7 @@ pub(crate) unsafe fn finalize_map_side_allocation_for_gc(map: *mut MapHeader) {
     drop(allocation);
     // GC_STORE_AUDIT(POINTER_FREE): finalizer clears external entries side-allocation pointer after deregistration/deallocation.
     (*map).entries = std::ptr::null_mut();
+    (*map).numeric_index = std::ptr::null_mut();
     (*map).capacity = 0;
     (*map).size = 0;
 }
@@ -688,11 +680,12 @@ pub(crate) fn test_map_numeric_index_contains(map: *const MapHeader, key: f64) -
     if !is_safe_numeric_key(bits) {
         return false;
     }
-    MAP_INDEX.with(|idx| {
-        idx.borrow()
-            .get(&(map as usize))
-            .is_some_and(|slot| slot.contains_key(&NumericKey(bits)))
-    })
+    unsafe {
+        (*map)
+            .numeric_index
+            .as_ref()
+            .is_some_and(|index| index.contains_key(&NumericKey(bits)))
+    }
 }
 
 #[cfg(test)]
@@ -716,7 +709,6 @@ pub(crate) fn release_current_thread_map_side_allocations() {
         crate::gc::gc_note_external_side_free(allocation.byte_len());
         drop(allocation);
     }
-    MAP_INDEX.with(|idx| idx.borrow_mut().clear());
     MAP_STRING_INDEX.with(|idx| idx.borrow_mut().clear());
     MAP_PTR_INDEX.with(|idx| idx.borrow_mut().clear());
 }
@@ -834,6 +826,8 @@ pub struct MapHeader {
     pub capacity: u32,
     /// Pointer to entries array (separately allocated)
     pub entries: *mut f64,
+    /// Direct pointer to the stable numeric-key index owned by MAP_REGISTRY.
+    numeric_index: *mut NumericIndex,
 }
 
 /// Each map entry is 16 bytes (key + value, both as f64/JSValue)
@@ -1065,17 +1059,14 @@ pub extern "C" fn js_map_alloc(capacity: u32) -> *mut MapHeader {
         (*ptr).capacity = cap;
         // GC_STORE_AUDIT(INIT): map entries buffer is external storage; element stores are barriered separately.
         (*ptr).entries = entries;
+        (*ptr).numeric_index = std::ptr::null_mut();
 
         // Register in map registry for runtime type detection
         register_map(ptr, entries, cap as usize);
 
-        // Initialize / reset the O(1) lookup side-table for this address.
-        // Arena reuse may recycle a freed Map's GC slot, so a stale index
-        // entry from the prior occupant must be cleared here.
-        MAP_INDEX.with(|idx| {
-            idx.borrow_mut()
-                .insert(ptr as usize, crate::fast_hash::new_ptr_hash_map());
-        });
+        // Initialize / reset the pointer/string lookup side-tables for this
+        // address. The numeric index is owned by the registered allocation
+        // and reached directly through the header above.
         MAP_STRING_INDEX.with(|idx| {
             idx.borrow_mut()
                 .insert(ptr as usize, std::collections::HashMap::new());
@@ -1107,7 +1098,7 @@ pub extern "C" fn js_map_size(map: *const MapHeader) -> u32 {
 }
 
 /// Find the index of a key in the map, or -1 if not found.
-/// Uses the O(1) MAP_INDEX side-table; falls back to a linear scan only
+/// Uses the O(1) numeric side index; falls back to a linear scan only
 /// when no side-table entry exists (e.g. a Map produced by a path that
 /// bypassed `js_map_alloc`).
 /// Below this size, linear scan over the entries buffer beats the
@@ -1153,20 +1144,13 @@ pub(crate) unsafe fn find_key_index(map: *const MapHeader, key: f64) -> i32 {
     // Numeric-key fast path: bits-stable values (numbers, bools,
     // undefined/null) hash by raw bits — no pointers, immune to GC moves.
     if is_safe_numeric_key(key_bits) {
-        let hit = MAP_INDEX.with(|idx| {
-            let idx = idx.borrow();
-            if let Some(slot) = idx.get(&(map as usize)) {
-                if let Some(&i) = slot.get(&NumericKey(key_bits)) {
-                    if i < size {
-                        return Some(i as i32);
-                    }
+        if let Some(index) = (*map).numeric_index.as_ref() {
+            if let Some(&i) = index.get(&NumericKey(key_bits)) {
+                if i < size {
+                    return i as i32;
                 }
-                return Some(-1i32);
             }
-            None
-        });
-        if let Some(v) = hit {
-            return v;
+            return -1;
         }
     }
 
@@ -1443,7 +1427,7 @@ pub extern "C" fn js_map_set(map: *mut MapHeader, key: f64, value: f64) -> *mut 
 fn map_set_resolved(map: *mut MapHeader, key: f64, value: f64) {
     let key = normalize_zero(key);
     unsafe {
-        // Check if key already exists (O(1) via MAP_INDEX)
+        // Check if key already exists (O(1) via the numeric side index)
         let idx = find_key_index(map, key);
 
         if idx >= 0 {
@@ -1502,13 +1486,9 @@ fn map_set_resolved(map: *mut MapHeader, key: f64, value: f64) {
         // GC-rebuilt pointer index (#6084).
         let key_bits = key.to_bits();
         if is_safe_numeric_key(key_bits) {
-            MAP_INDEX.with(|idx| {
-                let mut idx = idx.borrow_mut();
-                let slot = idx
-                    .entry(map as usize)
-                    .or_insert_with(crate::fast_hash::new_ptr_hash_map);
-                slot.insert(NumericKey(key_bits), size);
-            });
+            if let Some(index) = (*map).numeric_index.as_mut() {
+                index.insert(NumericKey(key_bits), size);
+            }
         } else if is_string_like(key_bits) {
             // String key: content-hashed index bypasses the gen-GC stale-bits
             // constraint by storing entry indexes (not pointers) keyed by
@@ -1926,19 +1906,16 @@ unsafe fn repair_map_indices_after_ordered_delete(
     let map_addr = map as usize;
     let deleted_bits = deleted_key.to_bits();
 
-    MAP_INDEX.with(|indexes| {
-        let mut indexes = indexes.borrow_mut();
-        if let Some(index) = indexes.get_mut(&map_addr) {
-            if is_safe_numeric_key(deleted_bits) {
-                index.remove(&NumericKey(deleted_bits));
-            }
-            for entry_idx in index.values_mut() {
-                if *entry_idx > deleted_idx {
-                    *entry_idx -= 1;
-                }
+    if let Some(index) = (*map).numeric_index.as_mut() {
+        if is_safe_numeric_key(deleted_bits) {
+            index.remove(&NumericKey(deleted_bits));
+        }
+        for entry_idx in index.values_mut() {
+            if *entry_idx > deleted_idx {
+                *entry_idx -= 1;
             }
         }
-    });
+    }
 
     MAP_STRING_INDEX.with(|indexes| {
         let mut indexes = indexes.borrow_mut();
@@ -2020,12 +1997,11 @@ pub extern "C" fn js_map_clear(map: *mut MapHeader) {
     unsafe {
         (*map).size = 0;
     }
-    MAP_INDEX.with(|idx| {
-        let mut idx = idx.borrow_mut();
-        if let Some(slot) = idx.get_mut(&(map as usize)) {
-            slot.clear();
+    unsafe {
+        if let Some(index) = (*map).numeric_index.as_mut() {
+            index.clear();
         }
-    });
+    }
     MAP_STRING_INDEX.with(|idx| {
         let mut idx = idx.borrow_mut();
         if let Some(slot) = idx.get_mut(&(map as usize)) {
@@ -2738,6 +2714,23 @@ mod tests {
         );
         assert_eq!(js_map_delete_number_key(map, boxed_string_key), 1);
         assert_eq!(js_map_has(map, boxed_string_key), 0);
+    }
+
+    #[test]
+    fn numeric_index_is_direct_and_stable_across_entries_growth() {
+        let map = js_map_alloc(4);
+        let initial_index = unsafe { (*map).numeric_index };
+        assert!(!initial_index.is_null());
+
+        for i in 0..64 {
+            js_map_set(map, i as f64, (i * 10) as f64);
+        }
+
+        assert_eq!(unsafe { (*map).numeric_index }, initial_index);
+        for i in 0..64 {
+            assert_eq!(js_map_get(map, i as f64), (i * 10) as f64);
+            assert!(test_map_numeric_index_contains(map, i as f64));
+        }
     }
 
     #[test]

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -1430,13 +1430,11 @@ fn class_capture_value_or_rejects_tag_stripped_fallback() {
 /// Reading `.size` on a `Map` *by name* — the shape a minified bundle produces
 /// when the receiver's `Map` type is erased to `any` (`map.size` dispatched
 /// through `js_object_get_field_by_name`) — reaches the `.size` fast path,
-/// which calls `own_key_present(map, "size")`. A `MapHeader` is 16 bytes
-/// (`size`/`capacity`/`entries`) with no `keys_array` field at offset 16, so
-/// `crate::object::object_keys_array(obj)` used to read 8 bytes past the header into the adjacent
-/// allocation; that stray word cleared the keys-pointer alignment/range guard
-/// and then SIGBUS'd on the `[keys-8]` GC-type-tag load. `own_key_present` now
-/// answers `false` for a non-`GC_TYPE_OBJECT` receiver, so the read falls
-/// through to the `Map.size` tail instead of dereferencing garbage.
+/// which calls `own_key_present(map, "size")`. A `MapHeader` is not an
+/// `ObjectHeader` and has no `keys_array` field; treating it as one used to
+/// read unrelated bytes and then SIGBUS on the derived GC-type-tag load.
+/// `own_key_present` now answers `false` for a non-`GC_TYPE_OBJECT` receiver,
+/// so the read falls through to the `Map.size` tail.
 #[test]
 fn map_size_by_name_does_not_oob_read_keys_array() {
     unsafe {
@@ -1446,8 +1444,8 @@ fn map_size_by_name_does_not_oob_read_keys_array() {
         let empty = crate::map::js_map_alloc(4);
         assert!(!empty.is_null());
         // The precise frame that faulted: a Map is not an object, so it has no
-        // own string key. This must answer false without dereferencing
-        // `[obj+16]` past the 16-byte MapHeader.
+        // own string key. This must answer false without interpreting Map
+        // metadata as an ObjectHeader field.
         assert!(!own_key_present(empty as *mut ObjectHeader, size_key));
         let v0 = crate::object::js_object_get_field_by_name(empty as *const ObjectHeader, size_key);
         assert!(v0.is_number(), "empty Map .size must be a number");


### PR DESCRIPTION
## Summary

- keep each Map's numeric-key index in its existing `MapSideAllocation` owner
- store a direct, non-owning pointer to that stable index in `MapHeader`
- remove the thread-local outer `MapHeader* -> numeric index` hash lookup from numeric `Map.get`/`has`/`set`
- derive fixed GC layout sizes from `MapHeader` and `SetHeader` after the Map header grows

The index remains owned and freed with the Map's registered side allocation. Its `Box` address is stable across entries-buffer growth, registry rehashes, and moving-GC registry rekeys.

## Validation

- `cargo test -p perry-runtime --lib`: 2,703 passed, 0 failed, 4 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- exact release compiler/runtime builds for latest `main` (`926d95782`) and this commit (`d4e53d579`)
- existing copying-minor Map relocation test verifies numeric lookup/index survival after `MapHeader` movement
- new regression verifies the direct index pointer stays stable while the entries buffer grows from 4 to 64 keys

## Performance

Mac mini, Apple M1, unchanged upstream `@codehz/ecs` comprehensive command-buffer row (`5k entities: 3 commands each + sync`, 15k commands), alternating exact control/candidate processes, 2 warmups + 6 measured rounds per process:

- control median: **28.5104 ms**
- candidate median: **27.5947 ms**
- median paired improvement: **3.188%**
- candidate wins: **11/11**
- paired range: **2.967% to 3.639% faster**
- semantic oracles: **22/22 passed**

Binary SHA-256:

- control: `76389e4f9f9bf0172cfbb4e8b4806fde3389ca0317012ab56b3aa6ff5cf3c191`
- candidate: `b035ec1fc595abfc3b395f20ac914a2315561c4f36b10f57338a1b722c7ae483`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Map and Set memory-size calculations across different layouts.
  * Improved Map numeric-key indexing reliability during growth, deletion, garbage collection, and memory relocation.
  * Preserved numeric-index stability as Map storage expands.
  * Strengthened Map validation and size handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->