### PR TITLE
perf(object): reuse preinstalled birth shapes

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -269,7 +269,8 @@ fn object_alloc_class_inline_keys_impl(
     parent_class_id: u32,
     field_count: u32,
     keys_array: *mut ArrayHeader,
-) -> (*mut ObjectHeader, u32) {
+    preinstalled_shape_id: u32,
+) -> (*mut ObjectHeader, u32, bool) {
     if parent_class_id != 0 {
         register_class(class_id, parent_class_id);
     }
@@ -290,14 +291,29 @@ fn object_alloc_class_inline_keys_impl(
 
     let ptr = arena_alloc_gc(total_size, 8, crate::gc::GC_TYPE_OBJECT) as *mut ObjectHeader;
 
-    unsafe {
+    let used_preinstalled_shape = unsafe {
         (*ptr).class_id = class_id;
         (*ptr).parent_class_id = parent_class_id;
         // GC_STORE_AUDIT(INIT): fresh object starts with no per-object meta record (#6759 B).
         (*ptr).meta = ptr::null_mut();
-        // #8113: the birth live-slot bound is a PARAMETER now — it used to be
-        // read back out of the `(*ptr).field_count` store that stood here.
-        set_object_keys_array_with_live(ptr, keys_array, logical_field_count as u32);
+        // The compiled entry point passes the ShapeId installed beside this
+        // canonical keys global at module initialization. Reuse that immutable
+        // descriptor directly when its live-slot bound still matches; learned
+        // instance widening and worker-local first installs retain the exact
+        // mint-and-validate fallback.
+        let used_preinstalled_shape = preinstalled_shape_id != 0
+            && crate::object::shapes::try_birth_stamp_preinstalled_shape(
+                ptr,
+                preinstalled_shape_id,
+                keys_array,
+                logical_field_count as u32,
+            );
+        if !used_preinstalled_shape {
+            // #8113: the birth live-slot bound is a PARAMETER now — it used to
+            // be read back out of the `(*ptr).field_count` store that stood
+            // here.
+            set_object_keys_array_with_live(ptr, keys_array, logical_field_count as u32);
+        }
 
         // PerryTS/perry#4717: initialize ALL `max(field_count, 8)` field slots to
         // `undefined`, mirroring `js_object_alloc_with_parent`. The arena hands back
@@ -314,8 +330,9 @@ fn object_alloc_class_inline_keys_impl(
             ptr::write(fields_ptr.add(i), JSValue::undefined());
         }
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
-    }
-    (ptr, logical_field_count as u32)
+        used_preinstalled_shape
+    };
+    (ptr, logical_field_count as u32, used_preinstalled_shape)
 }
 
 /// Compatibility entry point for runtime callers that do not have a
@@ -335,8 +352,8 @@ pub extern "C" fn js_object_alloc_class_inline_keys(
     field_count: u32,
     keys_array: *mut ArrayHeader,
 ) -> *mut ObjectHeader {
-    let (ptr, birth_slots) =
-        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array);
+    let (ptr, birth_slots, _) =
+        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array, 0);
     unsafe {
         let key_count = if keys_array.is_null() {
             0
@@ -368,10 +385,17 @@ pub extern "C" fn js_object_alloc_class_inline_keys_stamped(
     keys_array: *mut ArrayHeader,
     shape_id: u32,
 ) -> *mut ObjectHeader {
-    let (ptr, birth_slots) =
-        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array);
-    unsafe {
-        crate::object::shapes::birth_stamp_object_shape(ptr, shape_id, birth_slots);
+    let (ptr, birth_slots, used_preinstalled_shape) = object_alloc_class_inline_keys_impl(
+        class_id,
+        parent_class_id,
+        field_count,
+        keys_array,
+        shape_id,
+    );
+    if !used_preinstalled_shape {
+        unsafe {
+            crate::object::shapes::birth_stamp_object_shape(ptr, shape_id, birth_slots);
+        }
     }
     ptr
 }

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -823,6 +823,50 @@ pub(crate) unsafe fn birth_stamp_object_shape(
     }
 }
 
+/// Stamp a newborn compiled-class allocation from the ShapeId installed at
+/// module initialization, without re-canonicalizing the same shape facts.
+///
+/// A hit proves the immutable ordered-keys edge and live inline-slot bound
+/// directly from the agent-local descriptor. Canonical class keys never mutate
+/// in place: structural growth forks a new keys array and mints a new ShapeId,
+/// so exact `(ShapeId, keys pointer)` identity also carries the descriptor's
+/// logical key count. Missing worker-local ids and learned-width mismatches
+/// return `false` for the existing mint-and-validate path to handle.
+///
+/// # Safety
+///
+/// `obj` must be a freshly allocated, unpublished `ObjectHeader` and `keys`
+/// must be the module-init canonical keys pointer paired with
+/// `runtime_shape_id`. No allocation or collection may occur between this
+/// function returning `true` and initialization of the newborn's fields.
+#[inline]
+pub(crate) unsafe fn try_birth_stamp_preinstalled_shape(
+    obj: *mut crate::object::ObjectHeader,
+    runtime_shape_id: u32,
+    keys: *mut ArrayHeader,
+    live_inline_slot_count: u32,
+) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    let Some(descriptor) = shape_descriptor_by_id(runtime_shape_id) else {
+        return false;
+    };
+    if descriptor.keys != keys as u64
+        || descriptor.live_inline_slot_count != live_inline_slot_count
+        || descriptor.semantic_generation != 0
+        || descriptor.object_kind != ShapeObjectKind::Ordinary
+    {
+        return false;
+    }
+    (*obj).parent_class_id = runtime_shape_id;
+    if !crate::arena::pointer_in_nursery(obj as usize) {
+        note_old_generation_carrier(Some(descriptor));
+    }
+    debug_assert_object_shape_parity(obj);
+    true
+}
+
 /// Publish the exact descriptor for a FRESHLY ALLOCATED header. #8113: the
 /// birth live-slot bound must be supplied because no header word carries it.
 ///

--- a/crates/perry-runtime/src/object/shapes_tests.rs
+++ b/crates/perry-runtime/src/object/shapes_tests.rs
@@ -67,6 +67,69 @@ mod c3c_tests {
         );
     }
 
+    /// A module-init ShapeId is already a complete proof of the immutable
+    /// keys edge and live inline bound. The allocation fast path must be able
+    /// to install that proof directly on a newborn without publishing the
+    /// same facts through the reverse shape index again.
+    #[test]
+    fn preinstalled_shape_fast_path_stamps_matching_newborn() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const CID: u32 = 0x0C3C_7903;
+        let packed = b"direct_a\0direct_b";
+        let keys =
+            crate::object::js_build_class_keys_array(CID, 2, packed.as_ptr(), packed.len() as u32);
+        let shape_id = js_object_shape_id_for_keys(keys as usize as u64, 2);
+        let payload = std::mem::size_of::<crate::object::ObjectHeader>()
+            + crate::object::INLINE_SLOT_FLOOR * std::mem::size_of::<crate::value::JSValue>();
+        let obj = crate::arena::arena_alloc_gc(payload, 8, crate::gc::GC_TYPE_OBJECT)
+            as *mut crate::object::ObjectHeader;
+
+        unsafe {
+            (*obj).class_id = CID;
+            (*obj).parent_class_id = 0;
+            (*obj).meta = std::ptr::null_mut();
+            let fields = (obj as *mut u8).add(std::mem::size_of::<crate::object::ObjectHeader>())
+                as *mut crate::value::JSValue;
+            for index in 0..crate::object::INLINE_SLOT_FLOOR {
+                std::ptr::write(fields.add(index), crate::value::JSValue::undefined());
+            }
+            crate::gc::layout_init_pointer_free(obj as *mut u8);
+
+            assert!(try_birth_stamp_preinstalled_shape(obj, shape_id, keys, 2));
+            assert_eq!((*obj).parent_class_id, shape_id);
+            assert_eq!(crate::object::object_keys_array(obj), keys);
+            debug_assert_object_shape_parity(obj);
+        }
+    }
+
+    /// Learned/hidden inline capacity can legitimately exceed the public key
+    /// count. A module-init id for the narrow shape must fail closed, and the
+    /// existing allocator fallback must publish and retain the exact wider
+    /// descriptor rather than stamping the supplied id anyway.
+    #[test]
+    fn preinstalled_shape_live_bound_mismatch_uses_exact_fallback() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const CID: u32 = 0x0C3C_7904;
+        let packed = b"wide_a\0wide_b";
+        let keys =
+            crate::object::js_build_class_keys_array(CID, 2, packed.as_ptr(), packed.len() as u32);
+        let narrow_id = js_object_shape_id_for_keys(keys as usize as u64, 2);
+
+        let obj =
+            crate::object::js_object_alloc_class_inline_keys_stamped(CID, 0, 3, keys, narrow_id);
+        let actual_id = unsafe { (*obj).parent_class_id };
+        assert_ne!(
+            actual_id, narrow_id,
+            "a narrow module ShapeId must not describe a wider allocation"
+        );
+        let descriptor = shape_descriptor_by_id(actual_id)
+            .expect("the widened fallback must publish an exact descriptor");
+        assert_eq!(descriptor.keys, keys as u64);
+        assert_eq!(descriptor.logical_key_count, 2);
+        assert_eq!(descriptor.live_inline_slot_count, 3);
+        unsafe { debug_assert_object_shape_parity(obj) };
+    }
+
     /// #6759 C3c stamp invariant on a REAL object through the real
     /// write/read paths: a read resolution stamps a shape id into the
     /// plain object's `parent_class_id`; after further appends any surviving


### PR DESCRIPTION
## Summary

- reuse the module-init ShapeId when allocating a compiled class whose canonical keys pointer and live inline-slot bound still match
- avoid publishing and hashing the same `ShapeFacts` again during every matching object birth
- preserve the existing exact mint-and-validate fallback for learned-width changes, missing worker-local descriptors, foreign ids, and semantic/class shapes
- retain old-generation carrier bookkeeping when a directly stamped allocation is not in the nursery

## Correctness

Two new runtime regressions cover the direct matching-id path and a widened live-slot mismatch that must fail closed into an exact wider descriptor.

Mac-mini release runtime suite: **2704 passed, 0 failed, 4 ignored**.

## Performance

Unchanged `codehz/ecs` command benchmark (`5k entities: 3 commands each + sync`, 15k commands), M3 Mac mini, 11 alternating control/candidate pairs. Each process used 2 warmups, 6 measured rounds, and 64 operations per timed batch.

- control median: **25.612 ms**
- candidate median: **21.649 ms**
- median paired improvement: **15.61%**
- candidate wins: **11/11**
- semantic oracles: **22/22**
- paired range: **14.88% to 16.08% faster**

This PR is independent of the Map-header optimization in #8860; the measurement above uses current `main` as its control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved object allocation when a compatible preinstalled shape is available.
  - Added validation to ensure shape metadata matches object keys, slot counts, generations, and object types.
  - Automatically falls back to an exact compatible shape when the supplied shape is unavailable or mismatched.
  - Prevented duplicate shape stamping during allocation.

- **Tests**
  - Added coverage for successful preinstalled-shape allocation and mismatch fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->