### PR TITLE
batch: land #8860, #8862

### DIFF
--- a/crates/perry-runtime/src/gc/copying_pointer_set.rs
+++ b/crates/perry-runtime/src/gc/copying_pointer_set.rs
@@ -304,10 +304,13 @@ pub(super) unsafe fn plausible_gc_header(header: *mut GcHeader, arena: bool) -> 
 /// ~1024 (the top 32 bits of the address), which never matches the
 /// fixed total.
 fn fixed_layout_total_size(info: &GcTypeInfo) -> Option<usize> {
-    // MapHeader { size: u32, capacity: u32, entries: *mut f64 } = 16 B.
-    // SetHeader { size: u32, capacity: u32, elements: *mut f64 } = 16 B.
     match info.type_id {
-        crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => Some(GC_HEADER_SIZE + 16),
+        crate::gc::GC_TYPE_MAP => {
+            Some(GC_HEADER_SIZE + std::mem::size_of::<crate::map::MapHeader>())
+        }
+        crate::gc::GC_TYPE_SET => {
+            Some(GC_HEADER_SIZE + std::mem::size_of::<crate::set::SetHeader>())
+        }
         _ => None,
     }
 }

--- a/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/fabricated_map_rejection.rs
@@ -15,24 +15,22 @@
 //!   * `gc_flags` = second byte, needs `GC_FLAG_ARENA` (0x02) — ~coin flip
 //!
 //! The size check rejects the observed `size ≈ 1024` corruption, but payload
-//! bytes can also encode the genuine Map total of 24. The complete fix is the
+//! bytes can also encode the genuine fixed Map total. The complete fix is the
 //! arena's allocation-authored object-start bitmap: `classify_arena` requires
 //! a candidate Map header address to be recorded there before dispatching its
 //! rewrite descriptor. Other arena types do not need to stamp the bitmap.
 
 use super::*;
 
-/// Size of `MapHeader` (and `SetHeader`): `{ size: u32, capacity: u32,
-/// entries/elements: *mut f64 }` = 16 bytes.
-const MAP_HEADER_PAYLOAD: usize = 16;
-const MAP_FIXED_TOTAL: usize = GC_HEADER_SIZE + MAP_HEADER_PAYLOAD;
+const MAP_FIXED_TOTAL: usize = GC_HEADER_SIZE + std::mem::size_of::<crate::map::MapHeader>();
+const SET_FIXED_TOTAL: usize = GC_HEADER_SIZE + std::mem::size_of::<crate::set::SetHeader>();
 
 /// Directly test that `plausible_gc_header` rejects a fabricated Map
 /// header with the ~1024-byte size that an interior arena pointer
-/// produces, while accepting a genuine Map header with size = 24.
+/// produces, while accepting a genuine fixed-size Map header.
 #[test]
 fn test_plausible_gc_header_rejects_fabricated_map_size() {
-    // A genuine Map header: obj_type = MAP, size = 24, GC_FLAG_ARENA set.
+    // A genuine Map header has the exact fixed payload size.
     let mut genuine = GcHeader {
         obj_type: GC_TYPE_MAP,
         gc_flags: GC_FLAG_ARENA,
@@ -59,18 +57,18 @@ fn test_plausible_gc_header_rejects_fabricated_map_size() {
         "fabricated Map header (size=1024) must be rejected"
     );
 
-    // Edge: size = 24 + 8 = 32 (what free-list reuse into a larger slot
+    // Edge: fixed size + 8 (what free-list reuse into a larger slot
     // would produce) must also be rejected — only the exact fixed total
     // is accepted.
     let mut wrong_size = GcHeader {
         obj_type: GC_TYPE_MAP,
         gc_flags: GC_FLAG_ARENA,
         _reserved: 0,
-        size: 32,
+        size: (MAP_FIXED_TOTAL + 8) as u32,
     };
     assert!(
         !unsafe { plausible_gc_header(&mut wrong_size as *mut GcHeader, true) },
-        "Map header with non-fixed size (32) must be rejected"
+        "Map header with non-fixed size must be rejected"
     );
 }
 
@@ -84,11 +82,11 @@ fn test_plausible_gc_header_rejects_fabricated_set_size() {
         obj_type: GC_TYPE_SET,
         gc_flags: GC_FLAG_ARENA,
         _reserved: 0,
-        size: MAP_FIXED_TOTAL as u32,
+        size: SET_FIXED_TOTAL as u32,
     };
     assert!(
         unsafe { plausible_gc_header(&mut genuine as *mut GcHeader, true) },
-        "genuine Set header (size={MAP_FIXED_TOTAL}) must be plausible"
+        "genuine Set header (size={SET_FIXED_TOTAL}) must be plausible"
     );
 
     let mut fabricated = GcHeader {
@@ -151,7 +149,7 @@ fn test_plausible_gc_header_rejects_malloc_only_type_in_arena() {
 fn test_classify_arena_rejects_interior_pointer_as_map() {
     let _guard = CopyingNurseryTestGuard::new(1);
 
-    // Allocate a genuine Map. Its GcHeader.size must be 24.
+    // Allocate a genuine Map. Its GcHeader.size must match the fixed layout.
     let map_ptr = crate::map::js_map_alloc(4) as *mut u8;
     assert!(!map_ptr.is_null(), "Map allocation must succeed");
 

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -124,11 +124,16 @@ pub(crate) fn test_map_side_deallocation_snapshot() -> (u64, u64) {
 struct MapSideAllocation {
     entries: *mut f64,
     capacity: usize,
+    numeric_index: Box<NumericIndex>,
 }
 
 impl MapSideAllocation {
     fn new(entries: *mut f64, capacity: usize) -> Self {
-        Self { entries, capacity }
+        Self {
+            entries,
+            capacity,
+            numeric_index: Box::new(crate::fast_hash::new_ptr_hash_map()),
+        }
     }
 
     fn byte_len(&self) -> usize {
@@ -187,7 +192,11 @@ fn register_map(ptr: *mut MapHeader, entries: *mut f64, capacity: usize) {
             !registry.contains_key(&(ptr as usize)),
             "Map side allocation registered twice for the same header"
         );
-        registry.insert(ptr as usize, MapSideAllocation::new(entries, capacity));
+        let mut allocation = MapSideAllocation::new(entries, capacity);
+        unsafe {
+            (*ptr).numeric_index = allocation.numeric_index.as_mut();
+        }
+        registry.insert(ptr as usize, allocation);
     });
 }
 
@@ -298,6 +307,8 @@ impl PartialEq for NumericKey {
 }
 impl Eq for NumericKey {}
 
+type NumericIndex = crate::fast_hash::PtrHashMap<NumericKey, u32>;
+
 /// `true` if `bits` is a non-pointer JSValue (number, bool, undefined,
 /// null, or any NaN-tagged value that is NOT a string/heap pointer).
 /// We index only these in the side-table.
@@ -336,26 +347,19 @@ fn is_safe_numeric_key(bits: u64) -> bool {
     true
 }
 
-// Side-table mapping `map_ptr -> (NumericKey-bits -> entries-array-index)`.
-// O(1) `find_key_index` for numeric keys; pointer keys still take the
-// linear-scan path so they remain correct under gen-GC string forwarding.
+// O(1) index from numeric key bits to entries-array index. The owning Box is
+// kept in `MapSideAllocation`; `MapHeader::numeric_index` points directly at
+// it so a lookup does not first hash the MapHeader address through a second
+// thread-local table. The Box address stays stable when MAP_REGISTRY rehashes
+// or a moving GC rekeys the owning allocation.
 //
-// Both nesting levels use `PtrHasher` (Fibonacci-multiplicative + xorshift
-// avalanche, see `crate::fast_hash`). The xorshift step is essential here
-// because `NumericKey(u64)` holds f64 bit-patterns — small whole-number
-// EntityIds have mantissa-zero, so pure multiplicative hashing would
-// collapse hundreds of keys into bucket 0 (caught by a 2x regression
-// the first time around). With the avalanche step, even the worst-case
-// integer-f64 inputs distribute across buckets normally.
-crate::perry_thread_local! {
-    static MAP_INDEX: RefCell<
-        crate::fast_hash::PtrHashMap<usize, crate::fast_hash::PtrHashMap<NumericKey, u32>>,
-    > = RefCell::new(crate::fast_hash::new_ptr_hash_map());
-}
+// `PtrHasher`'s xorshift avalanche is essential because `NumericKey(u64)`
+// holds f64 bit patterns: small whole-number EntityIds have mantissa-zero, so
+// pure multiplicative hashing would collapse hundreds of keys into bucket 0.
 
 // Side-table mapping `map_ptr -> (FNV-1a 64-bit content hash -> Vec<entries-array-index>)`
 // for STRING keys. Bypasses the gen-GC-stale-bits constraint that keeps
-// `MAP_INDEX` numeric-only by hashing the string's CONTENT, not its
+// the numeric index numeric-only by hashing the string's CONTENT, not its
 // pointer bits — so a forwarded heap-string and an SSO inline string
 // with the same bytes share the same bucket. Stored values are u32
 // indexes into the entries array (not pointers), which survive
@@ -471,7 +475,7 @@ fn is_ptr_index_key(bits: u64) -> bool {
 }
 
 // Side-table mapping `map_ptr -> (MapPtrKey -> entries-array-index)` for
-// pointer keys — the third index alongside `MAP_INDEX` (numeric bits) and
+// pointer keys — the third index alongside the direct numeric index and
 // `MAP_STRING_INDEX` (string content). Before #6084 object/bigint keys took
 // a full linear scan per operation (measured 1,793x slower than string keys
 // on a 20k-entry map). GC-move safety mirrors `set.rs`'s SET_INDEX: the
@@ -501,9 +505,6 @@ crate::perry_thread_local! {
 /// `processCommands` iterated `commands[i]` over an Array whose memory
 /// had been a Map a few collections earlier.
 pub fn drop_map_index(addr: usize) {
-    MAP_INDEX.with(|idx| {
-        idx.borrow_mut().remove(&addr);
-    });
     MAP_STRING_INDEX.with(|idx| {
         idx.borrow_mut().remove(&addr);
     });
@@ -533,13 +534,6 @@ pub(crate) fn map_header_moved_for_gc(old_addr: usize, new_addr: usize) {
         }
         registry.insert(new_addr, allocation);
     });
-    MAP_INDEX.with(|idx| {
-        let mut idx = idx.borrow_mut();
-        idx.remove(&new_addr);
-        if let Some(slot) = idx.remove(&old_addr) {
-            idx.insert(new_addr, slot);
-        }
-    });
     MAP_STRING_INDEX.with(|idx| {
         let mut idx = idx.borrow_mut();
         idx.remove(&new_addr);
@@ -562,9 +556,6 @@ pub(crate) unsafe fn finalize_map_side_allocation_for_gc(map: *mut MapHeader) {
     }
     let addr = map as usize;
     let allocation = MAP_REGISTRY.with(|r| r.borrow_mut().remove(&addr));
-    MAP_INDEX.with(|idx| {
-        idx.borrow_mut().remove(&addr);
-    });
     MAP_STRING_INDEX.with(|idx| {
         idx.borrow_mut().remove(&addr);
     });
@@ -579,6 +570,7 @@ pub(crate) unsafe fn finalize_map_side_allocation_for_gc(map: *mut MapHeader) {
     drop(allocation);
     // GC_STORE_AUDIT(POINTER_FREE): finalizer clears external entries side-allocation pointer after deregistration/deallocation.
     (*map).entries = std::ptr::null_mut();
+    (*map).numeric_index = std::ptr::null_mut();
     (*map).capacity = 0;
     (*map).size = 0;
 }
@@ -688,11 +680,12 @@ pub(crate) fn test_map_numeric_index_contains(map: *const MapHeader, key: f64) -
     if !is_safe_numeric_key(bits) {
         return false;
     }
-    MAP_INDEX.with(|idx| {
-        idx.borrow()
-            .get(&(map as usize))
-            .is_some_and(|slot| slot.contains_key(&NumericKey(bits)))
-    })
+    unsafe {
+        (*map)
+            .numeric_index
+            .as_ref()
+            .is_some_and(|index| index.contains_key(&NumericKey(bits)))
+    }
 }
 
 #[cfg(test)]
@@ -716,7 +709,6 @@ pub(crate) fn release_current_thread_map_side_allocations() {
         crate::gc::gc_note_external_side_free(allocation.byte_len());
         drop(allocation);
     }
-    MAP_INDEX.with(|idx| idx.borrow_mut().clear());
     MAP_STRING_INDEX.with(|idx| idx.borrow_mut().clear());
     MAP_PTR_INDEX.with(|idx| idx.borrow_mut().clear());
 }
@@ -834,6 +826,8 @@ pub struct MapHeader {
     pub capacity: u32,
     /// Pointer to entries array (separately allocated)
     pub entries: *mut f64,
+    /// Direct pointer to the stable numeric-key index owned by MAP_REGISTRY.
+    numeric_index: *mut NumericIndex,
 }
 
 /// Each map entry is 16 bytes (key + value, both as f64/JSValue)
@@ -1065,17 +1059,14 @@ pub extern "C" fn js_map_alloc(capacity: u32) -> *mut MapHeader {
         (*ptr).capacity = cap;
         // GC_STORE_AUDIT(INIT): map entries buffer is external storage; element stores are barriered separately.
         (*ptr).entries = entries;
+        (*ptr).numeric_index = std::ptr::null_mut();
 
         // Register in map registry for runtime type detection
         register_map(ptr, entries, cap as usize);
 
-        // Initialize / reset the O(1) lookup side-table for this address.
-        // Arena reuse may recycle a freed Map's GC slot, so a stale index
-        // entry from the prior occupant must be cleared here.
-        MAP_INDEX.with(|idx| {
-            idx.borrow_mut()
-                .insert(ptr as usize, crate::fast_hash::new_ptr_hash_map());
-        });
+        // Initialize / reset the pointer/string lookup side-tables for this
+        // address. The numeric index is owned by the registered allocation
+        // and reached directly through the header above.
         MAP_STRING_INDEX.with(|idx| {
             idx.borrow_mut()
                 .insert(ptr as usize, std::collections::HashMap::new());
@@ -1107,7 +1098,7 @@ pub extern "C" fn js_map_size(map: *const MapHeader) -> u32 {
 }
 
 /// Find the index of a key in the map, or -1 if not found.
-/// Uses the O(1) MAP_INDEX side-table; falls back to a linear scan only
+/// Uses the O(1) numeric side index; falls back to a linear scan only
 /// when no side-table entry exists (e.g. a Map produced by a path that
 /// bypassed `js_map_alloc`).
 /// Below this size, linear scan over the entries buffer beats the
@@ -1153,20 +1144,13 @@ pub(crate) unsafe fn find_key_index(map: *const MapHeader, key: f64) -> i32 {
     // Numeric-key fast path: bits-stable values (numbers, bools,
     // undefined/null) hash by raw bits — no pointers, immune to GC moves.
     if is_safe_numeric_key(key_bits) {
-        let hit = MAP_INDEX.with(|idx| {
-            let idx = idx.borrow();
-            if let Some(slot) = idx.get(&(map as usize)) {
-                if let Some(&i) = slot.get(&NumericKey(key_bits)) {
-                    if i < size {
-                        return Some(i as i32);
-                    }
+        if let Some(index) = (*map).numeric_index.as_ref() {
+            if let Some(&i) = index.get(&NumericKey(key_bits)) {
+                if i < size {
+                    return i as i32;
                 }
-                return Some(-1i32);
             }
-            None
-        });
-        if let Some(v) = hit {
-            return v;
+            return -1;
         }
     }
 
@@ -1443,7 +1427,7 @@ pub extern "C" fn js_map_set(map: *mut MapHeader, key: f64, value: f64) -> *mut 
 fn map_set_resolved(map: *mut MapHeader, key: f64, value: f64) {
     let key = normalize_zero(key);
     unsafe {
-        // Check if key already exists (O(1) via MAP_INDEX)
+        // Check if key already exists (O(1) via the numeric side index)
         let idx = find_key_index(map, key);
 
         if idx >= 0 {
@@ -1502,13 +1486,9 @@ fn map_set_resolved(map: *mut MapHeader, key: f64, value: f64) {
         // GC-rebuilt pointer index (#6084).
         let key_bits = key.to_bits();
         if is_safe_numeric_key(key_bits) {
-            MAP_INDEX.with(|idx| {
-                let mut idx = idx.borrow_mut();
-                let slot = idx
-                    .entry(map as usize)
-                    .or_insert_with(crate::fast_hash::new_ptr_hash_map);
-                slot.insert(NumericKey(key_bits), size);
-            });
+            if let Some(index) = (*map).numeric_index.as_mut() {
+                index.insert(NumericKey(key_bits), size);
+            }
         } else if is_string_like(key_bits) {
             // String key: content-hashed index bypasses the gen-GC stale-bits
             // constraint by storing entry indexes (not pointers) keyed by
@@ -1926,19 +1906,16 @@ unsafe fn repair_map_indices_after_ordered_delete(
     let map_addr = map as usize;
     let deleted_bits = deleted_key.to_bits();
 
-    MAP_INDEX.with(|indexes| {
-        let mut indexes = indexes.borrow_mut();
-        if let Some(index) = indexes.get_mut(&map_addr) {
-            if is_safe_numeric_key(deleted_bits) {
-                index.remove(&NumericKey(deleted_bits));
-            }
-            for entry_idx in index.values_mut() {
-                if *entry_idx > deleted_idx {
-                    *entry_idx -= 1;
-                }
+    if let Some(index) = (*map).numeric_index.as_mut() {
+        if is_safe_numeric_key(deleted_bits) {
+            index.remove(&NumericKey(deleted_bits));
+        }
+        for entry_idx in index.values_mut() {
+            if *entry_idx > deleted_idx {
+                *entry_idx -= 1;
             }
         }
-    });
+    }
 
     MAP_STRING_INDEX.with(|indexes| {
         let mut indexes = indexes.borrow_mut();
@@ -2020,12 +1997,11 @@ pub extern "C" fn js_map_clear(map: *mut MapHeader) {
     unsafe {
         (*map).size = 0;
     }
-    MAP_INDEX.with(|idx| {
-        let mut idx = idx.borrow_mut();
-        if let Some(slot) = idx.get_mut(&(map as usize)) {
-            slot.clear();
+    unsafe {
+        if let Some(index) = (*map).numeric_index.as_mut() {
+            index.clear();
         }
-    });
+    }
     MAP_STRING_INDEX.with(|idx| {
         let mut idx = idx.borrow_mut();
         if let Some(slot) = idx.get_mut(&(map as usize)) {
@@ -2738,6 +2714,23 @@ mod tests {
         );
         assert_eq!(js_map_delete_number_key(map, boxed_string_key), 1);
         assert_eq!(js_map_has(map, boxed_string_key), 0);
+    }
+
+    #[test]
+    fn numeric_index_is_direct_and_stable_across_entries_growth() {
+        let map = js_map_alloc(4);
+        let initial_index = unsafe { (*map).numeric_index };
+        assert!(!initial_index.is_null());
+
+        for i in 0..64 {
+            js_map_set(map, i as f64, (i * 10) as f64);
+        }
+
+        assert_eq!(unsafe { (*map).numeric_index }, initial_index);
+        for i in 0..64 {
+            assert_eq!(js_map_get(map, i as f64), (i * 10) as f64);
+            assert!(test_map_numeric_index_contains(map, i as f64));
+        }
     }
 
     #[test]

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -269,7 +269,8 @@ fn object_alloc_class_inline_keys_impl(
     parent_class_id: u32,
     field_count: u32,
     keys_array: *mut ArrayHeader,
-) -> (*mut ObjectHeader, u32) {
+    preinstalled_shape_id: u32,
+) -> (*mut ObjectHeader, u32, bool) {
     if parent_class_id != 0 {
         register_class(class_id, parent_class_id);
     }
@@ -290,14 +291,29 @@ fn object_alloc_class_inline_keys_impl(
 
     let ptr = arena_alloc_gc(total_size, 8, crate::gc::GC_TYPE_OBJECT) as *mut ObjectHeader;
 
-    unsafe {
+    let used_preinstalled_shape = unsafe {
         (*ptr).class_id = class_id;
         (*ptr).parent_class_id = parent_class_id;
         // GC_STORE_AUDIT(INIT): fresh object starts with no per-object meta record (#6759 B).
         (*ptr).meta = ptr::null_mut();
-        // #8113: the birth live-slot bound is a PARAMETER now — it used to be
-        // read back out of the `(*ptr).field_count` store that stood here.
-        set_object_keys_array_with_live(ptr, keys_array, logical_field_count as u32);
+        // The compiled entry point passes the ShapeId installed beside this
+        // canonical keys global at module initialization. Reuse that immutable
+        // descriptor directly when its live-slot bound still matches; learned
+        // instance widening and worker-local first installs retain the exact
+        // mint-and-validate fallback.
+        let used_preinstalled_shape = preinstalled_shape_id != 0
+            && crate::object::shapes::try_birth_stamp_preinstalled_shape(
+                ptr,
+                preinstalled_shape_id,
+                keys_array,
+                logical_field_count as u32,
+            );
+        if !used_preinstalled_shape {
+            // #8113: the birth live-slot bound is a PARAMETER now — it used to
+            // be read back out of the `(*ptr).field_count` store that stood
+            // here.
+            set_object_keys_array_with_live(ptr, keys_array, logical_field_count as u32);
+        }
 
         // PerryTS/perry#4717: initialize ALL `max(field_count, 8)` field slots to
         // `undefined`, mirroring `js_object_alloc_with_parent`. The arena hands back
@@ -314,8 +330,9 @@ fn object_alloc_class_inline_keys_impl(
             ptr::write(fields_ptr.add(i), JSValue::undefined());
         }
         crate::gc::layout_init_pointer_free(ptr as *mut u8);
-    }
-    (ptr, logical_field_count as u32)
+        used_preinstalled_shape
+    };
+    (ptr, logical_field_count as u32, used_preinstalled_shape)
 }
 
 /// Compatibility entry point for runtime callers that do not have a
@@ -335,8 +352,8 @@ pub extern "C" fn js_object_alloc_class_inline_keys(
     field_count: u32,
     keys_array: *mut ArrayHeader,
 ) -> *mut ObjectHeader {
-    let (ptr, birth_slots) =
-        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array);
+    let (ptr, birth_slots, _) =
+        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array, 0);
     unsafe {
         let key_count = if keys_array.is_null() {
             0
@@ -368,10 +385,17 @@ pub extern "C" fn js_object_alloc_class_inline_keys_stamped(
     keys_array: *mut ArrayHeader,
     shape_id: u32,
 ) -> *mut ObjectHeader {
-    let (ptr, birth_slots) =
-        object_alloc_class_inline_keys_impl(class_id, parent_class_id, field_count, keys_array);
-    unsafe {
-        crate::object::shapes::birth_stamp_object_shape(ptr, shape_id, birth_slots);
+    let (ptr, birth_slots, used_preinstalled_shape) = object_alloc_class_inline_keys_impl(
+        class_id,
+        parent_class_id,
+        field_count,
+        keys_array,
+        shape_id,
+    );
+    if !used_preinstalled_shape {
+        unsafe {
+            crate::object::shapes::birth_stamp_object_shape(ptr, shape_id, birth_slots);
+        }
     }
     ptr
 }

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -823,6 +823,50 @@ pub(crate) unsafe fn birth_stamp_object_shape(
     }
 }
 
+/// Stamp a newborn compiled-class allocation from the ShapeId installed at
+/// module initialization, without re-canonicalizing the same shape facts.
+///
+/// A hit proves the immutable ordered-keys edge and live inline-slot bound
+/// directly from the agent-local descriptor. Canonical class keys never mutate
+/// in place: structural growth forks a new keys array and mints a new ShapeId,
+/// so exact `(ShapeId, keys pointer)` identity also carries the descriptor's
+/// logical key count. Missing worker-local ids and learned-width mismatches
+/// return `false` for the existing mint-and-validate path to handle.
+///
+/// # Safety
+///
+/// `obj` must be a freshly allocated, unpublished `ObjectHeader` and `keys`
+/// must be the module-init canonical keys pointer paired with
+/// `runtime_shape_id`. No allocation or collection may occur between this
+/// function returning `true` and initialization of the newborn's fields.
+#[inline]
+pub(crate) unsafe fn try_birth_stamp_preinstalled_shape(
+    obj: *mut crate::object::ObjectHeader,
+    runtime_shape_id: u32,
+    keys: *mut ArrayHeader,
+    live_inline_slot_count: u32,
+) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    let Some(descriptor) = shape_descriptor_by_id(runtime_shape_id) else {
+        return false;
+    };
+    if descriptor.keys != keys as u64
+        || descriptor.live_inline_slot_count != live_inline_slot_count
+        || descriptor.semantic_generation != 0
+        || descriptor.object_kind != ShapeObjectKind::Ordinary
+    {
+        return false;
+    }
+    (*obj).parent_class_id = runtime_shape_id;
+    if !crate::arena::pointer_in_nursery(obj as usize) {
+        note_old_generation_carrier(Some(descriptor));
+    }
+    debug_assert_object_shape_parity(obj);
+    true
+}
+
 /// Publish the exact descriptor for a FRESHLY ALLOCATED header. #8113: the
 /// birth live-slot bound must be supplied because no header word carries it.
 ///

--- a/crates/perry-runtime/src/object/shapes_tests.rs
+++ b/crates/perry-runtime/src/object/shapes_tests.rs
@@ -90,6 +90,8 @@ mod c3c_tests {
             (*obj).meta = std::ptr::null_mut();
             let fields = (obj as *mut u8).add(std::mem::size_of::<crate::object::ObjectHeader>())
                 as *mut crate::value::JSValue;
+            // GC_STORE_AUDIT(INIT): freshly allocated inline slots, filled with a
+            // non-pointer immediate before the object is reachable from anything.
             for index in 0..crate::object::INLINE_SLOT_FLOOR {
                 std::ptr::write(fields.add(index), crate::value::JSValue::undefined());
             }

--- a/crates/perry-runtime/src/object/shapes_tests.rs
+++ b/crates/perry-runtime/src/object/shapes_tests.rs
@@ -67,6 +67,69 @@ mod c3c_tests {
         );
     }
 
+    /// A module-init ShapeId is already a complete proof of the immutable
+    /// keys edge and live inline bound. The allocation fast path must be able
+    /// to install that proof directly on a newborn without publishing the
+    /// same facts through the reverse shape index again.
+    #[test]
+    fn preinstalled_shape_fast_path_stamps_matching_newborn() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const CID: u32 = 0x0C3C_7903;
+        let packed = b"direct_a\0direct_b";
+        let keys =
+            crate::object::js_build_class_keys_array(CID, 2, packed.as_ptr(), packed.len() as u32);
+        let shape_id = js_object_shape_id_for_keys(keys as usize as u64, 2);
+        let payload = std::mem::size_of::<crate::object::ObjectHeader>()
+            + crate::object::INLINE_SLOT_FLOOR * std::mem::size_of::<crate::value::JSValue>();
+        let obj = crate::arena::arena_alloc_gc(payload, 8, crate::gc::GC_TYPE_OBJECT)
+            as *mut crate::object::ObjectHeader;
+
+        unsafe {
+            (*obj).class_id = CID;
+            (*obj).parent_class_id = 0;
+            (*obj).meta = std::ptr::null_mut();
+            let fields = (obj as *mut u8).add(std::mem::size_of::<crate::object::ObjectHeader>())
+                as *mut crate::value::JSValue;
+            for index in 0..crate::object::INLINE_SLOT_FLOOR {
+                std::ptr::write(fields.add(index), crate::value::JSValue::undefined());
+            }
+            crate::gc::layout_init_pointer_free(obj as *mut u8);
+
+            assert!(try_birth_stamp_preinstalled_shape(obj, shape_id, keys, 2));
+            assert_eq!((*obj).parent_class_id, shape_id);
+            assert_eq!(crate::object::object_keys_array(obj), keys);
+            debug_assert_object_shape_parity(obj);
+        }
+    }
+
+    /// Learned/hidden inline capacity can legitimately exceed the public key
+    /// count. A module-init id for the narrow shape must fail closed, and the
+    /// existing allocator fallback must publish and retain the exact wider
+    /// descriptor rather than stamping the supplied id anyway.
+    #[test]
+    fn preinstalled_shape_live_bound_mismatch_uses_exact_fallback() {
+        let _lock = crate::gc::global_side_table_test_lock();
+        const CID: u32 = 0x0C3C_7904;
+        let packed = b"wide_a\0wide_b";
+        let keys =
+            crate::object::js_build_class_keys_array(CID, 2, packed.as_ptr(), packed.len() as u32);
+        let narrow_id = js_object_shape_id_for_keys(keys as usize as u64, 2);
+
+        let obj =
+            crate::object::js_object_alloc_class_inline_keys_stamped(CID, 0, 3, keys, narrow_id);
+        let actual_id = unsafe { (*obj).parent_class_id };
+        assert_ne!(
+            actual_id, narrow_id,
+            "a narrow module ShapeId must not describe a wider allocation"
+        );
+        let descriptor = shape_descriptor_by_id(actual_id)
+            .expect("the widened fallback must publish an exact descriptor");
+        assert_eq!(descriptor.keys, keys as u64);
+        assert_eq!(descriptor.logical_key_count, 2);
+        assert_eq!(descriptor.live_inline_slot_count, 3);
+        unsafe { debug_assert_object_shape_parity(obj) };
+    }
+
     /// #6759 C3c stamp invariant on a REAL object through the real
     /// write/read paths: a read resolution stamps a shape id into the
     /// plain object's `parent_class_id`; after further appends any surviving

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -1430,13 +1430,11 @@ fn class_capture_value_or_rejects_tag_stripped_fallback() {
 /// Reading `.size` on a `Map` *by name* — the shape a minified bundle produces
 /// when the receiver's `Map` type is erased to `any` (`map.size` dispatched
 /// through `js_object_get_field_by_name`) — reaches the `.size` fast path,
-/// which calls `own_key_present(map, "size")`. A `MapHeader` is 16 bytes
-/// (`size`/`capacity`/`entries`) with no `keys_array` field at offset 16, so
-/// `crate::object::object_keys_array(obj)` used to read 8 bytes past the header into the adjacent
-/// allocation; that stray word cleared the keys-pointer alignment/range guard
-/// and then SIGBUS'd on the `[keys-8]` GC-type-tag load. `own_key_present` now
-/// answers `false` for a non-`GC_TYPE_OBJECT` receiver, so the read falls
-/// through to the `Map.size` tail instead of dereferencing garbage.
+/// which calls `own_key_present(map, "size")`. A `MapHeader` is not an
+/// `ObjectHeader` and has no `keys_array` field; treating it as one used to
+/// read unrelated bytes and then SIGBUS on the derived GC-type-tag load.
+/// `own_key_present` now answers `false` for a non-`GC_TYPE_OBJECT` receiver,
+/// so the read falls through to the `Map.size` tail.
 #[test]
 fn map_size_by_name_does_not_oob_read_keys_array() {
     unsafe {
@@ -1446,8 +1444,8 @@ fn map_size_by_name_does_not_oob_read_keys_array() {
         let empty = crate::map::js_map_alloc(4);
         assert!(!empty.is_null());
         // The precise frame that faulted: a Map is not an object, so it has no
-        // own string key. This must answer false without dereferencing
-        // `[obj+16]` past the 16-byte MapHeader.
+        // own string key. This must answer false without interpreting Map
+        // metadata as an ObjectHeader field.
         assert!(!own_key_present(empty as *mut ObjectHeader, size_key));
         let v0 = crate::object::js_object_get_field_by_name(empty as *const ObjectHeader, size_key);
         assert!(v0.is_number(), "empty Map .size must be a number");

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -1991,10 +1991,6 @@
     },
     {
       "file": "crates/perry-runtime/src/map.rs",
-      "name": "MAP_INDEX"
-    },
-    {
-      "file": "crates/perry-runtime/src/map.rs",
       "name": "MAP_PTR_INDEX"
     },
     {


### PR DESCRIPTION
Batch landing of two reviewed PRs, validated once as a single merged tree.

| PR | |
|---|---|
| #8860 | perf(map): remove outer hash from numeric-key lookups |
| #8862 | perf(object): reuse preinstalled birth shapes |

### #8860 — audit of the raw pointer inside a GC header

This stores a direct, non-owning `*mut NumericIndex` **inside `MapHeader`**, which is the shape that caused #8393 (a side table keyed by a raw heap address going stale after a copying minor). Two properties had to hold, and both do:

- **The pointer is never traced or rewritten.** `GcRewriteDescriptorKind::Map` in `gc/layout_slot_visit.rs` is *field-explicit* — it reads `size`, `capacity`, `entries` and derives the entries slot range. It does not scan all pointer-sized words, and never mentions `numeric_index`. That is correct: the pointee is a `Box` (malloc), not GC heap, so tracing it would be the bug.
- **The fixed-layout size check was updated with the header.** `fixed_layout_total_size` moved from a hardcoded `Some(GC_HEADER_SIZE + 16)` to `size_of::<MapHeader>()` / `size_of::<SetHeader>()`. This is the load-bearing one: the header grew, and a stale constant would make `plausible_gc_header` reject genuine Map headers — rendering them invisible to the collector, exactly the hazard that function's own comment warns about ("entries reachable only through a >cap map would be swept while live and never rewritten after a move"). Deriving the size means the next field addition cannot silently break it.

`gc_runtime_root_holders` flagged a **stale** `MAP_INDEX` frontier pin rather than a new holder — because this PR removes the thread-local hash that was the unrooted holder. Deleted the pin, which is the receipt the gate asks for.

### #8862 — one store site

`gc_store_site_inventory` flagged `object/shapes_tests.rs:94`: a test writing `JSValue::undefined()` into freshly allocated inline slots, before the object is reachable from anything and immediately before `layout_init_pointer_free`. Marked `GC_STORE_AUDIT(INIT)`.

### Validation (merged tree)

- all 30 lint-job gates pass
- `perry-runtime` 2705, `perry-codegen` 1270, `perry-stdlib` 122 — all 0 failed
- moving-GC arm (`PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`): **16 failed on the batch and 16 on clean `main`** — same-commit A/B, none introduced. Run deliberately here because both PRs change collector-visible structure.
- `df` checked before and after; no result produced under ENOSPC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Map numeric-key indexing reliability during growth, deletion, clearing, garbage collection, and cleanup.
  * Corrected Map and Set memory-layout validation using their actual header sizes.
  * Improved compiled-class allocation by reusing compatible preinstalled object shapes when available.

* **Tests**
  * Added coverage for Map and Set size validation, index stability, mixed-index deletion behavior, and preinstalled shape reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->