### PR TITLE
fix(runtime): permit catchable throw bridges to unwind

### DIFF
--- a/changelog.d/8869-release-throw-abi.md
+++ b/changelog.d/8869-release-throw-abi.md
@@ -1,0 +1,1 @@
+Fix catchable constructor and unresolved-global errors aborting across their runtime ABI boundaries.

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -1017,15 +1017,20 @@ pub extern "C" fn js_throw_reference_error_unresolved_get() -> f64 {
 ///-only callee; see project_auto_optimize_keepalive_3320).
 #[cfg(feature = "keepalive-anchors")]
 #[used]
-static KEEP_JS_GLOBAL_GET_OR_THROW_UNRESOLVED: extern "C" fn(f64) -> f64 =
+static KEEP_JS_GLOBAL_GET_OR_THROW_UNRESOLVED: extern "C-unwind" fn(f64) -> f64 =
     js_global_get_or_throw_unresolved;
 
 /// Read a compile-time-unresolved identifier off `globalThis` (a global the
 /// program created dynamically — `Function("this.y = 2")()` — exists only at
 /// runtime), throwing the spec ReferenceError when no such global property
 /// exists.
+///
+/// `C-unwind` is required because the missing-global path raises a Perry
+/// exception through the system unwinder to generated code's landing pad. A
+/// plain `extern "C"` boundary aborts before a surrounding JavaScript `catch`
+/// can run when the debug runtime is linked.
 #[no_mangle]
-pub extern "C" fn js_global_get_or_throw_unresolved(name_value: f64) -> f64 {
+pub extern "C-unwind" fn js_global_get_or_throw_unresolved(name_value: f64) -> f64 {
     let g = crate::object::js_get_global_this();
     let gj = crate::value::JSValue::from_bits(g.to_bits());
     if gj.is_pointer() {
@@ -1066,6 +1071,8 @@ pub extern "C" fn js_global_get_or_throw_unresolved(name_value: f64) -> f64 {
     let err_ptr = js_referenceerror_new(msg_str);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err_ptr as i64))
 }
+
+const _: extern "C-unwind" fn(f64) -> f64 = js_global_get_or_throw_unresolved;
 
 /// Keepalive anchor for the auto-optimize whole-program build (generated-code
 ///-only callee; see project_auto_optimize_keepalive_3320).
@@ -1732,14 +1739,20 @@ pub extern "C-unwind" fn js_throw_type_error_not_a_function(
 /// importantly plain `f64` numbers, whose bit pattern overlaps the raw pointer
 /// encoding (`new 1`, `new 1.5`). The thrown TypeError is catchable via Perry's
 /// exception machinery, matching `try { new 1 } catch (e) { … }`.
+///
+/// `C-unwind` is required because this generated-code boundary can propagate
+/// that catchable exception through the system unwinder. Plain `extern "C"`
+/// turns the throw into `panic_cannot_unwind` with the debug runtime.
 #[no_mangle]
-pub extern "C" fn js_throw_not_a_constructor() -> f64 {
+pub extern "C-unwind" fn js_throw_not_a_constructor() -> f64 {
     let msg = b"is not a constructor";
     let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
     let err_ptr = js_typeerror_new(msg_str);
     let err_value = crate::value::JSValue::pointer(err_ptr as *const u8).bits();
     crate::exception::js_throw(f64::from_bits(err_value))
 }
+
+const _: extern "C-unwind" fn() -> f64 = js_throw_not_a_constructor;
 
 /// Issue #615: writes to read-only / frozen / sealed / non-extensible
 /// objects must throw a TypeError under strict mode (per spec). TS files

--- a/crates/perry/tests/issue_5253_construct_reference_source_location.rs
+++ b/crates/perry/tests/issue_5253_construct_reference_source_location.rs
@@ -97,6 +97,16 @@ fn run_fixture(fixture: &str, extra_args: &[&str]) -> String {
 
     let bin = root.join("main_bin");
     let run = Command::new(&bin).output().expect("run compiled binary");
+    // Both fixtures catch the throw and log it, so the program must exit
+    // cleanly. Preserve stderr here so an ABI abort cannot masquerade as an
+    // empty-output assertion failure.
+    assert!(
+        run.status.success(),
+        "compiled binary must exit successfully; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
     String::from_utf8_lossy(&run.stdout).into_owned()
 }
 


### PR DESCRIPTION
## Summary

- mark the unresolved-global and not-a-constructor throw bridges as `C-unwind`
- keep the generated-only unresolved-global anchor ABI in sync
- make the #5253 regression harness surface child-process aborts

## Release evidence

Release-candidate CI run 32988311861 reached `issue_5253_construct_reference_source_location` after the #5247 value-call tests passed. All four #5253 cases produced empty stdout because their child binaries aborted before the JavaScript catch handlers ran. Both failing runtime entry points were plain `extern "C"` even though they call `js_throw`; this applies the same direct-boundary fix validated by the preceding #5247 test.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- compile-time `extern "C-unwind"` ABI guards

Release blocker for v0.5.1519.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so constructor and unresolved-global errors can be caught reliably across runtime boundaries.
  * Enhanced test failure diagnostics with process status and captured output when compiled fixtures do not exit successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->