### PR TITLE
fix(runtime): permit dynamic construct throws to unwind

### DIFF
--- a/changelog.d/8873-release-construct-unwind.md
+++ b/changelog.d/8873-release-construct-unwind.md
@@ -1,0 +1,1 @@
+Fix catchable dynamic-constructor TypeErrors aborting at the runtime construct boundary.

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -230,7 +230,11 @@ pub(crate) unsafe fn nm_ctor_stream(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn js_new_function_construct(
+// This is a generated-code boundary whose TypeError paths unwind to the
+// caller's JavaScript catch landing pad. A plain `extern "C"` installs an
+// abort-on-unwind guard in the debug/static runtime, so `new <primitive>()`
+// aborts instead of remaining catchable.
+pub unsafe extern "C-unwind" fn js_new_function_construct(
     func_value: f64,
     args_ptr: *const f64,
     args_len: usize,
@@ -1159,6 +1163,8 @@ pub unsafe extern "C" fn js_new_function_construct(
     // Reflect()`, `new Error.prototype()` and `new sym()` silently succeed.
     super::super::object_ops::throw_object_type_error(b"is not a constructor")
 }
+
+const _: unsafe extern "C-unwind" fn(f64, *const f64, usize) -> f64 = js_new_function_construct;
 
 /// `new <callee>(...spread)` — spread-bearing construction. Codegen builds a
 /// single JS array containing every argument in evaluation order (regular args

--- a/crates/perry/tests/issue_5253_construct_reference_source_location.rs
+++ b/crates/perry/tests/issue_5253_construct_reference_source_location.rs
@@ -98,11 +98,13 @@ fn run_fixture(fixture: &str, extra_args: &[&str]) -> String {
     let bin = root.join("main_bin");
     let run = Command::new(&bin).output().expect("run compiled binary");
     // Both fixtures catch the throw and log it, so the program must exit
-    // cleanly. Preserve stderr here so an ABI abort cannot masquerade as an
-    // empty-output assertion failure.
+    // cleanly. This is also the ABI regression assertion: every runtime
+    // boundary between the throw helper and generated code's catch landing
+    // pad must permit unwinding. Preserve stderr so an ABI abort cannot
+    // masquerade as an empty-output assertion failure.
     assert!(
         run.status.success(),
-        "compiled binary must exit successfully; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        "compiled binary must catch the runtime throw and exit successfully; status: {:?}\nstdout:\n{}\nstderr:\n{}",
         run.status,
         String::from_utf8_lossy(&run.stdout),
         String::from_utf8_lossy(&run.stderr),


### PR DESCRIPTION
## Summary
- mark the generated dynamic-construction boundary as `C-unwind`
- assert the exported ABI at compile time
- prevent catchable `new <primitive>()` TypeErrors from aborting the debug/static runtime

## Release blocker evidence
Full release candidate r20 failed both issue #5253 constructor cases with exit 134 and `panic in a function that cannot unwind`; the reference-error cases passed after #8869. The remaining throw crosses `js_new_function_construct`, which was still plain `extern "C"`.

## Local checks
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p perry-runtime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic-constructor TypeErrors so they can be caught by JavaScript `try...catch` handlers instead of terminating the application.
  * Improved runtime handling of errors raised during dynamically generated object construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->