### PR TITLE
fix(inline): keep module-relative loads in source module

### DIFF
--- a/changelog.d/8879-release-r24-module-relative-inline.md
+++ b/changelog.d/8879-release-r24-module-relative-inline.md
@@ -1,0 +1,3 @@
+Prevent cross-module function inlining from moving dynamic `require`, dynamic
+`import`, or Worker paths into an importing module, where their relative target
+map belongs to a different source file and can produce `MODULE_NOT_FOUND`.

--- a/crates/perry-transform/src/inline/cross_module.rs
+++ b/crates/perry-transform/src/inline/cross_module.rs
@@ -351,7 +351,15 @@ fn cross_function_expr_is_safe(
             extern_names.push(name.clone());
             true
         }
-        Expr::GlobalGet(_) | Expr::GlobalSet(_, _) | Expr::NativeModuleRef(_) => false,
+        Expr::GlobalGet(_)
+        | Expr::GlobalSet(_, _)
+        | Expr::NativeModuleRef(_)
+        // These nodes carry source-module-relative path sets. Codegen resolves
+        // those sets through the current module's dynamic-target map, so a
+        // clone installed in an importer would silently use the wrong map and
+        // fall through to ambient require/import handling.
+        | Expr::DynamicImport { .. }
+        | Expr::WorkerNew { .. } => false,
         // Capture-free zero-argument closures are self-contained after their
         // FuncId is refreshed in the destination. This admits default thunks
         // such as `exists = () => true` without allowing a source local to

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -1254,6 +1254,49 @@ mod tests {
     }
 
     #[test]
+    fn cross_module_free_function_with_dynamic_require_is_rejected() {
+        let mut source = Module::new("/src/package/index.ts");
+        let mut loads_relative_module = function(
+            1,
+            vec![Stmt::Return(Some(Expr::DynamicImport {
+                paths: vec!["./alpha".to_string()],
+                arg: Box::new(Expr::String("./alpha".to_string())),
+                byte_offset: 0,
+                deferred_error: None,
+                synchronous: true,
+            }))],
+        );
+        loads_relative_module.name = "loadAlpha".to_string();
+        loads_relative_module.is_exported = true;
+        source.functions.push(loads_relative_module);
+        source.exported_functions.push(("loadAlpha".to_string(), 1));
+
+        assert!(gather_cross_module_functions(&source).is_empty());
+    }
+
+    #[test]
+    fn cross_module_free_function_with_worker_target_is_rejected() {
+        let mut source = Module::new("/src/package/index.ts");
+        let mut starts_relative_worker = function(
+            1,
+            vec![Stmt::Return(Some(Expr::WorkerNew {
+                paths: vec!["./worker.ts".to_string()],
+                filename: Box::new(Expr::String("./worker.ts".to_string())),
+                options: None,
+                is_eval: false,
+            }))],
+        );
+        starts_relative_worker.name = "startWorker".to_string();
+        starts_relative_worker.is_exported = true;
+        source.functions.push(starts_relative_worker);
+        source
+            .exported_functions
+            .push(("startWorker".to_string(), 1));
+
+        assert!(gather_cross_module_functions(&source).is_empty());
+    }
+
+    #[test]
     fn cross_module_runtime_import_does_not_reuse_type_only_import() {
         let mut root = function(
             1,


### PR DESCRIPTION
Release blocker found by exact-SHA Full CI run 33063034439.

Cross-module free-function localization copied DynamicImport nodes, including synchronous computed require, into the importer, but their resolved relative paths are keyed in the source module's dynamic-target map. The importer therefore missed ./alpha and fell through to ambient require with MODULE_NOT_FOUND.

This conservatively rejects dynamic import/require and Worker target nodes from cross-module free-function candidates.

Validated locally:
- cargo test -p perry-transform cross_module_free_function_with_ -- --nocapture
- cargo test -p perry --test create_require_package computed_require_const_folds_to_compiled_package_modules -- --exact --nocapture
- cargo fmt --all -- --check
- ./scripts/check_file_size.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause dynamic `require`/`import` and Worker paths to resolve against the wrong module during cross-module function inlining.
  - Prevented affected functions from being inlined, avoiding potential `MODULE_NOT_FOUND` errors.

- **Tests**
  - Added coverage for dynamic module loading and Worker targets to ensure they remain safely handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->