### PR TITLE
test(release): align any split regression with runtime dispatch

### DIFF
--- a/changelog.d/8886-release-r25-split-coercion-test.md
+++ b/changelog.d/8886-release-r25-split-coercion-test.md
@@ -1,0 +1,3 @@
+Correct the stale split regression expectation so an unproven `any` numeric
+receiver is checked for ordinary missing-method `TypeError` semantics, while
+the existing runtime string-dispatch coverage remains intact.

--- a/crates/perry/tests/issue_5271_string_method_nonstring_receiver.rs
+++ b/crates/perry/tests/issue_5271_string_method_nonstring_receiver.rs
@@ -159,13 +159,12 @@ console.log(t.trim());
     );
 }
 
-/// Scalar replacement of a non-escaping split result must preserve the
-/// `ToString(this)` coercion used by the normal String-method lowering. This
-/// receiver is deliberately `any`-typed and numeric: treating its boxed number
-/// as a StringHeader would otherwise produce `undefined` instead of the first
-/// split component.
+/// An unproven `any` receiver must keep ordinary runtime method semantics. The
+/// genuine `any`-typed string case above exercises the runtime string arm; a
+/// numeric value has no `split` method and must throw instead of being silently
+/// coerced to a string. This is the non-string half of the #7673 dispatch gate.
 #[test]
-fn scalar_split_on_any_receiver_keeps_string_coercion() {
+fn split_on_any_numeric_receiver_throws_type_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let entry = dir.path().join("main.ts");
     std::fs::write(
@@ -179,10 +178,31 @@ console.log(first);
     )
     .expect("write entry");
 
-    let stdout = compile_and_run(dir.path(), &entry);
-    assert_eq!(
-        stdout.trim(),
-        "1",
-        "split must coerce an any receiver to string"
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        !run.status.success(),
+        "a numeric receiver must not be String-coerced (stdout: {})",
+        String::from_utf8_lossy(&run.stdout)
+    );
+    assert!(
+        stderr.contains("TypeError") && stderr.contains("split is not a function"),
+        "expected the runtime missing-method TypeError, got: {stderr}"
     );
 }


### PR DESCRIPTION
Release r24 reached this stale assertion after nearly three hours of Full CI. Since #7673, an unproven any receiver takes runtime method dispatch: a genuine string uses the runtime string arm, while a number has no split method and throws TypeError.

This updates the old scalar-coercion expectation to assert the intended non-string runtime behavior. Production code is unchanged.

Local verification:
- focused corrected regression: passed
- complete issue_5271 test target: 4 passed
- cargo fmt --all -- --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `split` behavior for numeric values typed as `any`.
  * These values now correctly raise a runtime `TypeError` instead of being implicitly converted to strings.

* **Tests**
  * Added regression coverage to verify the corrected error behavior and preserved string-dispatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->