### PR TITLE
fix(gc): restore the census-pinned carrier expression in the shape scanner

### DIFF
--- a/changelog.d/8917-census-carrier-pin.md
+++ b/changelog.d/8917-census-carrier-pin.md
@@ -1,0 +1,7 @@
+Restored the literal `if descriptor.old_carrier || descriptor.cache_carrier` two-armed expression in `scan_shape_table_rekey_mut`.
+
+#8899 lifted that condition into a `let is_carrier = …` binding for its memo key. The change was semantically inert, but `scripts/shape_descriptor_census.py` deliberately pins the *whole* two-armed expression — so that a sabotage which widens the gate or swaps the arms has to be red — and the refactor stopped matching that pin. `lint` has been red on `main` since #8899 landed.
+
+It also silently disarmed the census's own self-test: that test sabotages this exact literal via `str.replace(old, new, 1)`, which does nothing when the string is absent, so the "un-gated into an unconditional table root" case was being replaced into nothing and proving nothing.
+
+The condition is now written out at the decision site, with a comment saying why it must stay literal; `is_carrier` remains and still keys the memo.

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -1771,7 +1771,13 @@ pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVis
                 continue;
             }
             let probe_addr = addr;
-            let moved = if is_carrier {
+            // Written out rather than reusing `is_carrier` on purpose: the
+            // census gate (`scripts/shape_descriptor_census.py`) pins this exact
+            // two-armed expression so that a sabotage which widens the gate or
+            // swaps the arms is red, and its own self-test sabotages this very
+            // literal. `is_carrier` above is the same predicate, and is what
+            // keys the memo.
+            let moved = if descriptor.old_carrier || descriptor.cache_carrier {
                 visitor.visit_usize_slot(&mut addr)
             } else {
                 visitor.visit_metadata_usize_slot(&mut addr)


### PR DESCRIPTION
`lint` has been red on `main` since #8899 landed, and stayed red across #8900 and #8901. This restores it.

## What broke

#8899 lifted `descriptor.old_carrier || descriptor.cache_carrier` out of the `if` in `scan_shape_table_rekey_mut` into a `let is_carrier = …` binding, so the memo could key on it. The change is semantically inert — `is_carrier` *is* that expression.

But `scripts/shape_descriptor_census.py` pins the **whole two-armed expression** on purpose, and says so:

> Pin the whole two-armed expression, not just the set of APIs called: a sabotage that widens the gate, or that swaps the arms, has to be red.

So the pin stopped matching and the census started raising `CensusError: descriptor rooting is not gated on 'old_carrier || cache_carrier'`.

## The second-order damage

The census's own self-test sabotages that exact literal:

```python
ungated_root[shapes_path] = ungated_root[shapes_path].replace(
    "let moved = if descriptor.old_carrier || descriptor.cache_carrier {",
    "let moved = if true {", 1,
)
```

`str.replace` does nothing when the string is absent. After #8899 that sabotage replaced nothing, so the "un-gated into an unconditional table root" case was passing without testing anything. **A sabotage test that patches a string literal goes vacuous the moment the source is reworded**, and nothing reports it.

## The fix

The condition is written out again at the decision site, with a comment saying why it must stay literal. `is_carrier` remains and still keys the memo. One line of behaviour change: none.

## Attribution

```
f9890759c exit=1   bench: dynamic property keys (#8901)
e18b24c42 exit=1   gc(shapes): transition cache weak target (#8900)
d02892491 exit=1   perf(gc): memoise the shape scanner probe (#8899)   <-- broke here
2a6dcd344 exit=0   perf: ECS command path round 3 (#8897)
7c9f60169 exit=0   fix(hir): preserve shared cells (#8896)
```

## Validation

`scripts/run_lint_gates.sh` — **all 53 gates pass** (compile tier skipped). Runtime 2759/0 under `RUST_TEST_THREADS=1`. Census exits 0, and its self-test sabotage is non-vacuous again.

## How this got merged

I audited #8899 by running the five gates that looked topically relevant to a GC diff and merged on that. `run_lint_gates.sh` exists precisely to stop this, derives its list from `test.yml` at run time, and its header documents the same failure mode taking down five gates in one day on 2026-08-17. I should have run it; I now do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored carrier detection logic required for shape census validation.
  * Fixed the census self-test and lint checks so string-pinning operates correctly.
  * Preserved existing memoization behavior while improving validation reliability.

* **Documentation**
  * Added a changelog entry explaining the required literal condition and validation safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->