### PR TITLE
fix(net): reject non-string listen hosts

### DIFF
--- a/changelog.d/8920-net-listen-host-boundary.md
+++ b/changelog.d/8920-net-listen-host-boundary.md
@@ -1,0 +1,4 @@
+Prevent `net.Server.listen(port, callback)` from reading callback/object storage
+as a native hostname. Address conversion now accepts only actual JS strings and
+copies their logical byte length, restoring Linux listen parity without
+changing IPv4, IPv6, or unspecified-host behavior.

--- a/crates/perry-ext-net/src/ipc.rs
+++ b/crates/perry-ext-net/src/ipc.rs
@@ -62,10 +62,7 @@ fn allocate_socket() -> (i64, mpsc::UnboundedReceiver<SocketCommand>) {
 /// Read a JS string without coercing closures or option objects through a
 /// StringHeader layout.
 pub(crate) unsafe fn string_value(value: f64) -> Option<String> {
-    let value = perry_ffi::JsValue::from_bits(value.to_bits());
-    value
-        .is_string()
-        .then(|| crate::string_from_header_i64(value.as_string_ptr() as i64))?
+    crate::jsvalue_to_owned_string(value)
 }
 
 pub(crate) fn register_connect_cb(handle: i64, cb_f64: f64) {

--- a/crates/perry-ext-net/src/jsvalue.rs
+++ b/crates/perry-ext-net/src/jsvalue.rs
@@ -51,6 +51,23 @@ extern "C" {
     fn js_get_string_pointer_unified(value: f64) -> i64;
 }
 
+/// Read an actual NaN-boxed JS string using its logical byte length.
+///
+/// `js_get_string_pointer_unified` also accepts `POINTER_TAG` values for
+/// historical callers that pass raw string pointers. That permissive fallback
+/// is unsafe at typed JS-value boundaries: closures and ordinary objects use
+/// the same tag, and interpreting their storage as a `StringHeader` can leak
+/// header bytes (including NULs) into a native hostname or path. Check the JS
+/// tag first, then materialize heap and SSO strings through the shared runtime
+/// helper and copy exactly `StringHeader::byte_len` bytes via `read_string`.
+pub(crate) unsafe fn jsvalue_to_owned_string(value: f64) -> Option<String> {
+    let value_kind = JsValue::from_bits(value.to_bits());
+    if !value_kind.is_any_string() {
+        return None;
+    }
+    string_from_header_i64(js_get_string_pointer_unified(value))
+}
+
 /// Issue #1131 — read a NaN-boxed JS value as the raw bytes to put on
 /// the wire for `socket.write(chunk)`. Outbound mirror of
 /// `perry-ext-http`'s `jsvalue_to_body_bytes` (#1124): a JS
@@ -178,8 +195,8 @@ pub(crate) unsafe fn get_object_string_field(obj_f64: f64, field_name: &str) -> 
     if val.is_undefined() || val.is_null() {
         return None;
     }
-    if val.is_string() {
-        return string_from_header_i64(val.as_string_ptr() as i64);
+    if val.is_any_string() {
+        return jsvalue_to_owned_string(val_f64);
     }
     if val.is_number() {
         return Some(format!("{}", val.to_number() as i64));
@@ -221,8 +238,8 @@ pub(crate) unsafe fn get_object_number_field(obj_f64: f64, field_name: &str) -> 
         return Some(val.to_number());
     }
     // Some npm code passes `port` as a string — accept that too.
-    if val.is_string() {
-        if let Some(s) = string_from_header_i64(val.as_string_ptr() as i64) {
+    if val.is_any_string() {
+        if let Some(s) = jsvalue_to_owned_string(val_f64) {
             if let Ok(n) = s.parse::<f64>() {
                 return Some(n);
             }
@@ -364,6 +381,36 @@ mod tests {
         let v = JsValue::from_string_ptr(s.as_raw());
         let bytes = unsafe { jsvalue_to_socket_bytes(f64::from_bits(v.bits())) };
         assert_eq!(bytes.as_deref(), Some(&b"longer-than-sso"[..]));
+    }
+
+    /// #8909 — native address conversion must copy only the logical string
+    /// payload and must never treat a callback/object pointer's storage as a
+    /// `StringHeader`. `listen(port, callback)` puts the callback in the same
+    /// positional slot used by `listen(port, host, callback)`; accepting its
+    /// POINTER_TAG used to feed closure-header NUL bytes to `TcpListener::bind`.
+    #[test]
+    fn address_string_boundary_accepts_strings_and_rejects_pointer_storage() {
+        let host = alloc_string("127.0.0.1");
+        let heap_string = f64::from_bits(JsValue::from_string_ptr(host.as_raw()).bits());
+        let converted = unsafe { jsvalue_to_owned_string(heap_string) };
+        assert_eq!(converted.as_deref(), Some("127.0.0.1"));
+        assert!(!converted.unwrap().contains('\0'));
+
+        assert_eq!(
+            unsafe { jsvalue_to_owned_string(sso(b"::1")) }.as_deref(),
+            Some("::1"),
+            "short inline host strings must retain their logical length"
+        );
+
+        // Use a valid allocation behind the wrong tag so this regression test
+        // safely proves the tag check. The pre-fix listen conversion accepted
+        // every POINTER_TAG (including a real closure) and read its storage as
+        // a string header.
+        let pointer_tagged_storage = f64::from_bits(JsValue::from_object_ptr(host.as_raw()).bits());
+        assert!(unsafe { jsvalue_to_owned_string(pointer_tagged_storage) }.is_none());
+        assert!(
+            unsafe { jsvalue_to_owned_string(f64::from_bits(JsValue::UNDEFINED.bits())) }.is_none()
+        );
     }
 
     /// The clean non-string reject must still hold: a `POINTER_TAG`

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -116,8 +116,8 @@ pub use server_state::*;
 mod jsvalue;
 pub(crate) use jsvalue::{
     build_error_object, get_object_bool_field, get_object_number_field, get_object_string_field,
-    get_object_value_field, is_nanboxed_pointer, jsvalue_to_socket_bytes, string_from_header_i64,
-    unbox_pointer,
+    get_object_value_field, is_nanboxed_pointer, jsvalue_to_owned_string, jsvalue_to_socket_bytes,
+    string_from_header_i64, unbox_pointer,
 };
 
 use crate::tls::{do_tls_handshake, record_tls_handshake, TlsClientConfigData};
@@ -380,7 +380,6 @@ enum PendingNetEvent {
 // callback pointer with it.
 extern "C" {
     fn js_net_callback_ptr(value: f64) -> i64;
-    fn js_get_string_pointer_unified(value: f64) -> i64;
     fn js_async_hooks_provider_init(type_ptr: *const u8, type_len: usize) -> u64;
     fn js_async_hooks_provider_init_with_trigger(
         type_ptr: *const u8,
@@ -494,14 +493,10 @@ pub unsafe extern "C" fn js_net_socket_connect(arg1_f64: f64, arg2_f64: f64, arg
         return handle;
     }
     // Positional overload: arg1 is the port number, arg2 is the host
-    // string (NaN-boxed), arg3 is the optional connectListener. Reuse
-    // the runtime's string-pointer unifier (handles STRING_TAG and
-    // POINTER_TAG strings the same way).
-    extern "C" {
-        fn js_get_string_pointer_unified(value: f64) -> i64;
-    }
-    let host_ptr = js_get_string_pointer_unified(arg2_f64);
-    let (host, listener_f64) = match string_from_header_i64(host_ptr) {
+    // string (NaN-boxed), arg3 is the optional connectListener. Accept only
+    // actual JS string tags: arg2 may instead be the connectListener closure,
+    // whose POINTER_TAG storage must never be read as a StringHeader (#8909).
+    let (host, listener_f64) = match jsvalue_to_owned_string(arg2_f64) {
         Some(h) => (h, arg3_f64),
         // #4905: `connect(port)` / `connect(port, connectListener)` —
         // Node defaults the host to localhost when arg2 isn't a string
@@ -662,8 +657,10 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
         // #2013: a numeric `port` must be an integer in [0, 65536); Node throws
         // RangeError [ERR_SOCKET_BAD_PORT] otherwise.
         js_net_validate_listen_port(port);
-        let host = string_from_header_i64(js_get_string_pointer_unified(arg2.get()))
-            .unwrap_or_else(|| "0.0.0.0".to_string());
+        // `listen(port, callback)` places the callback in arg2. Keep the host
+        // boundary strict so closure/object storage cannot become a hostname;
+        // real heap and SSO strings are copied at their logical byte length.
+        let host = jsvalue_to_owned_string(arg2.get()).unwrap_or_else(|| "0.0.0.0".to_string());
         (port as u16, host)
     };
     let server_async_id = init_provider(b"TCPSERVERWRAP");

--- a/crates/perry-ext-net/src/tls.rs
+++ b/crates/perry-ext-net/src/tls.rs
@@ -667,14 +667,13 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
     use crate::option_setters::js_net_validate_connect_port;
     use crate::{
         get_object_bool_field, get_object_number_field, get_object_string_field,
-        is_nanboxed_pointer, spawn_socket_task_initialized, statics, string_from_header_i64,
+        is_nanboxed_pointer, jsvalue_to_owned_string, spawn_socket_task_initialized, statics,
         unbox_pointer,
     };
     use perry_ffi::JsValue;
 
     extern "C" {
         fn js_value_is_closure(value_bits: i64) -> i32;
-        fn js_get_string_pointer_unified(value: f64) -> i64;
     }
     let is_closure =
         |v: f64| is_nanboxed_pointer(v) && js_value_is_closure(v.to_bits() as i64) != 0;
@@ -687,7 +686,7 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
         if !JsValue::from_bits(v.to_bits()).is_any_string() {
             return None;
         }
-        string_from_header_i64(js_get_string_pointer_unified(v))
+        jsvalue_to_owned_string(v)
     };
     // Cert verification only goes off when the caller says so explicitly —
     // a missing/undefined flag keeps it on.


### PR DESCRIPTION
## Summary

Prevent `net.Server.listen(port, callback)` from interpreting callback/object storage as a native host string. Address conversion now accepts only real heap or inline JS string tags and copies the logical string payload length.

## Changes

- Add a strict NaN-boxed JS-string conversion helper shared by TCP, IPC, option-field, and TLS address paths.
- Default `listen(port, callback)` to the unspecified host instead of reading closure-header bytes as a `StringHeader`.
- Apply the same strict boundary to positional `net.connect` hosts.
- Add a lower-level regression test covering heap IPv4, inline IPv6, logical-length/NUL cleanliness, and rejection of pointer-tagged callback/object storage.

## Related issue

Fixes #8909

## Test plan

- `cargo test -p perry-ext-net` (33 passed)
- `./run_parity_tests.sh --filter test_issue_1123_listen` (100% parity)
- `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --filter test_issue_1131_socket_write_types` (100% parity)

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output

Both focused parity fixtures pass with their expected output and no compile failures or crashes.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server listening when a callback or object is provided, preventing it from being misinterpreted as a hostname.
  * Improved handling of string values across networking and TLS connections.
  * Restored consistent Linux listen behavior while preserving IPv4, IPv6, and default-host behavior.
  * Improved support for short and long strings, including correct handling of string boundaries and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->