### PR TITLE
perf: field-value call arguments keep the proven-this clone; subclass push arm ahead of the tracked resolver (wolf-ecs −11.2% / −11.9%)

### DIFF
--- a/changelog.d/8921-proven-this-call-args-subclass-push.md
+++ b/changelog.d/8921-proven-this-call-args-subclass-push.md
@@ -1,0 +1,8 @@
+Compiler and Array performance: a method that passes a declared field's value
+to a sibling method (`this.m(this.items[i])`) keeps its proven-receiver clone
+instead of re-proving `this` at every site of its public body; and the
+generic and spec Array push entries append to an object-backed Array
+subclass through its dense fast path before consulting the tracked
+allocator resolver. wolf-ecs (noctjs/ecs-benchmark) on the Mac mini
+reference box, 2-second window: add/remove -11.2%, entity-cycle -11.9%,
+11/11 paired wins each; semantics probes byte-identical to Node.

--- a/crates/perry-codegen/src/collectors/proven_this_routing_tests.rs
+++ b/crates/perry-codegen/src/collectors/proven_this_routing_tests.rs
@@ -1014,6 +1014,90 @@ fn guarded_pshape_call_site_is_preceded_by_a_shape_id_guard() {
     }
 }
 
+/// A method that hands a declared field's VALUE to a sibling method
+/// (`this.scale(this.value)`) passes nothing but that value: the receiver is
+/// not leaked, so the caller keeps its proven-`this` clone. Before, any
+/// mention of `this` inside an internal call's arguments rejected the caller
+/// outright — wolf-ecs `addComponent(this._ent[id], i)`-style calls lost their
+/// clone and re-proved `this` at every site of the public body.
+#[test]
+fn field_value_arguments_to_sibling_methods_keep_the_proven_this_clone() {
+    let mut counter = counter_class();
+    counter.methods.push(func(
+        92,
+        "scaleByValue",
+        Vec::new(),
+        Type::Number,
+        vec![Stmt::Return(Some(call(
+            Expr::This,
+            "scale",
+            vec![this_get("value")],
+        )))],
+    ));
+    let mut m = Module::new("pshape_field_value_args.ts");
+    m.classes = vec![counter];
+    m.functions = vec![func(
+        1,
+        "probe",
+        vec![param(2, "c", Type::Named("Counter".to_string()))],
+        Type::Number,
+        vec![Stmt::Return(Some(call(
+            Expr::LocalGet(2),
+            "scaleByValue",
+            Vec::new(),
+        )))],
+    )];
+    m.init_kind = ModuleInitKind::Eager;
+    let ir = emit(&m, false);
+    let clones = pshape_definitions(&ir);
+    assert!(
+        clones.iter().any(|d| d.contains("__scaleByValue$pshape")),
+        "a field-value argument to a sibling method must not reject the clone:\n{clones:#?}"
+    );
+
+    // A bare `this` argument still leaks the receiver and must still reject.
+    let mut counter = counter_class();
+    counter.methods.push(func(
+        93,
+        "leak",
+        vec![param(94, "other", Type::Any)],
+        Type::Number,
+        vec![Stmt::Return(Some(Expr::Number(1.0)))],
+    ));
+    counter.methods.push(func(
+        95,
+        "leakSelf",
+        Vec::new(),
+        Type::Number,
+        vec![Stmt::Return(Some(call(
+            Expr::This,
+            "leak",
+            vec![Expr::This],
+        )))],
+    ));
+    let mut m = Module::new("pshape_this_value_arg.ts");
+    m.classes = vec![counter];
+    m.functions = vec![func(
+        1,
+        "probeLeak",
+        vec![param(2, "c", Type::Named("Counter".to_string()))],
+        Type::Number,
+        vec![Stmt::Return(Some(call(
+            Expr::LocalGet(2),
+            "leakSelf",
+            Vec::new(),
+        )))],
+    )];
+    m.init_kind = ModuleInitKind::Eager;
+    let ir = emit(&m, false);
+    assert!(
+        !pshape_definitions(&ir)
+            .iter()
+            .any(|d| d.contains("__leakSelf$pshape")),
+        "a bare `this` argument leaks the receiver and must reject the clone:\n{ir}"
+    );
+}
+
 /// The single-pair shape-only arm is small enough to inline at the call site.
 /// Pin the complete safety gate: acquire both the all-method escape latch and
 /// the FNV-indexed method-name latch, accept both the boxed-pointer and

--- a/crates/perry-codegen/src/collectors/ptr_shape.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape.rs
@@ -1758,8 +1758,15 @@ impl<'a, 'b> ThisFlowAnalysis<'a, 'b> {
                 if !self.function_this_safe(&owner, property, func, false) {
                     return false;
                 }
-                args.iter()
-                    .all(|a| !expr_mentions_this(a) && self.expr_this_safe(a, ctx))
+                // Arguments are vetted as ordinary expressions: a bare `this`
+                // in value position, a `this`-capturing closure and a
+                // non-field `this.x` read all reject there already. A declared
+                // field READ passed along (`this.m(this.ents[id])`) hands the
+                // callee a field's value, never the receiver, and must not
+                // disqualify the caller — wolf-ecs `addComponent` /
+                // `removeComponent` / `createEntity` each call a sibling
+                // method with such an argument.
+                args.iter().all(|a| self.expr_this_safe(a, ctx))
             }
             // `super(...)`: the parent constructor body was already vetted by
             // `ctor_chain_safe` (whole chain). Args must not leak `this`; in
@@ -1788,8 +1795,7 @@ impl<'a, 'b> ThisFlowAnalysis<'a, 'b> {
                 if !self.function_this_safe(&owner, method, func, false) {
                     return false;
                 }
-                args.iter()
-                    .all(|a| !expr_mentions_this(a) && self.expr_this_safe(a, ctx))
+                args.iter().all(|a| self.expr_this_safe(a, ctx))
             }
             // Shape barriers on `this` inside a method body (the module-wide
             // kill already covers these; kept as defense in depth).

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -670,6 +670,15 @@ pub extern "C" fn js_array_push_f64(arr: *mut ArrayHeader, value: f64) -> *mut A
         }
         return arr;
     }
+    // An object-backed Array subclass carries `GC_TYPE_OBJECT`, so the tracked
+    // resolver below is a guaranteed miss for it. Ask the dense subclass append
+    // first, off the header tag the guarded element tiers already read; every
+    // rejected case (no dense proof, integrity flags, tail not learned) keeps
+    // the complete route below. wolf-ecs `packed.push(id)` on an `Archetype`
+    // paid the resolver twice per push once #8897 routed field pushes here.
+    if object_backed_push_fast(arr, value) {
+        return arr;
+    }
     let cleaned = clean_arr_ptr_mut(arr);
     if cleaned.is_null() {
         // #7574: a `class X extends Array` instance (or any array-like object)
@@ -690,6 +699,17 @@ pub extern "C" fn js_array_push_f64(arr: *mut ArrayHeader, value: f64) -> *mut A
         return js_array_alloc(0);
     }
     unsafe { js_array_push_f64_resolved(cleaned, value) }
+}
+
+/// The dense object-backed Array-subclass append, dispatched off the receiver's
+/// `GC_TYPE_OBJECT` header tag before any allocator/registry resolution. The
+/// caller has already demoted a uniquely-owned heap string in `value`.
+#[inline]
+fn object_backed_push_fast(arr: *mut ArrayHeader, value: f64) -> bool {
+    if crate::array::array_receiver_gc_tag(arr).0 != crate::gc::GC_TYPE_OBJECT {
+        return false;
+    }
+    crate::array::subclass::array_subclass_fast_push_one_raw(arr, value).is_some()
 }
 
 /// Push into a live, forwarding-resolved plain Array. The caller owns all
@@ -831,6 +851,16 @@ static KEEP_JS_ARRAY_PUSH_U31_WITH_LENGTH: extern "C" fn(
 pub extern "C" fn js_array_push_f64_spec(arr: *mut ArrayHeader, value: f64) -> *mut ArrayHeader {
     if array_ptr_as_proxy(arr).is_some() {
         return js_array_push_f64(arr, value);
+    }
+    // Object-backed Array subclass: the dense append needs neither the tracked
+    // resolver nor the exotic probe (both are classification misses for an
+    // OBJECT header); the string demote precedes the store as in
+    // `js_array_push_f64`.
+    if crate::array::array_receiver_gc_tag(arr).0 == crate::gc::GC_TYPE_OBJECT {
+        crate::string::js_string_addref_if_heap_string(value);
+        if crate::array::subclass::array_subclass_fast_push_one_raw(arr, value).is_some() {
+            return arr;
+        }
     }
     let cleaned = clean_arr_ptr_mut(arr);
     if cleaned.is_null() {

--- a/crates/perry-runtime/src/array/subclass_tests.rs
+++ b/crates/perry-runtime/src/array/subclass_tests.rs
@@ -571,6 +571,62 @@ fn transition_cache_carrier_bits_follow_live_occupancy_across_full_trace_recompu
     );
 }
 
+/// The spec push entry (the typed field-push lowering's complete fallback)
+/// and the generic entry both append to an object-backed Array subclass
+/// through the dense fast arm, off the header tag, without the tracked
+/// resolver: the receiver pointer is returned unchanged and the element is
+/// readable through the dense read.
+#[test]
+fn spec_and_generic_push_entries_append_to_an_object_backed_subclass_densely() {
+    let _global = crate::gc::global_side_table_test_lock();
+    crate::object::array_tail_transition::test_clear();
+    let class_id = 0x0074_8696;
+    crate::object::js_register_class_parent(class_id, CLASS_ID_ARRAY);
+    let obj = js_object_alloc(class_id, 2);
+    assert!(!obj.is_null());
+    let receiver = crate::value::js_nanbox_pointer(obj as i64);
+    crate::node_stream::js_array_subclass_init(receiver, 0.0);
+    // Learn the tail edge once through the generic route.
+    assert_eq!(
+        js_array_push_f64(obj as *mut ArrayHeader, 1.0),
+        obj as *mut ArrayHeader
+    );
+    assert_eq!(array_subclass_fast_pop(receiver), Some(1.0));
+    // Reference: the fused u31 entry's dense arm. Whatever tracked-resolver
+    // probes the arm itself needs, the spec and generic entries must need the
+    // same number — none of their own before reaching it.
+    let probes = crate::value::addr_class::tracked_header_probe_count_for_tests;
+    let mut length = u32::MAX;
+    let before = probes();
+    assert_eq!(
+        js_array_push_u31_with_length(obj as *mut ArrayHeader, 5, &mut length),
+        obj as *mut ArrayHeader
+    );
+    let u31_probes = probes() - before;
+    assert_eq!(array_subclass_fast_pop(receiver), Some(5.0));
+    let before = probes();
+    assert_eq!(
+        crate::array::js_array_push_f64_spec(obj as *mut ArrayHeader, 7.0),
+        obj as *mut ArrayHeader
+    );
+    let spec_probes = probes() - before;
+    // Back to the learned edge (length 0 -> 1) before the generic entry.
+    assert_eq!(array_subclass_fast_pop(receiver), Some(7.0));
+    let before = probes();
+    assert_eq!(
+        js_array_push_f64(obj as *mut ArrayHeader, 9.0),
+        obj as *mut ArrayHeader
+    );
+    let generic_probes = probes() - before;
+    assert_eq!(
+        (spec_probes, generic_probes),
+        (u31_probes, u31_probes),
+        "the spec and generic entries must reach the dense arm without tracked probes of their own"
+    );
+    assert_eq!(array_subclass_fast_length(receiver), Some(1.0));
+    assert_eq!(array_subclass_fast_index_get(receiver, 0), Some(9.0));
+}
+
 #[test]
 fn array_subclass_named_prefix_token_survives_only_exact_numeric_tail_transitions() {
     let _global = crate::gc::global_side_table_test_lock();

--- a/crates/perry-runtime/src/gc/layout_tables.rs
+++ b/crates/perry-runtime/src/gc/layout_tables.rs
@@ -226,17 +226,6 @@ pub(in crate::gc) fn prune_dead_per_object_layout_owners(is_dead_owner: &dyn Fn(
     }
 }
 
-#[cfg(test)]
-pub(in crate::gc) fn test_per_object_layout_present(user_ptr: usize) -> bool {
-    hot_layout_slot_masks().borrow().contains_key(&user_ptr)
-        || hot_typed_layouts().borrow().contains_key(&user_ptr)
-}
-
-#[cfg(test)]
-pub(in crate::gc) fn test_young_layout_records() -> u32 {
-    PERRY_YOUNG_LAYOUT_RECORDS.load(std::sync::atomic::Ordering::SeqCst)
-}
-
 /// Bits in the per-object address filter (see [`layout_addr_filter_may_hold`]).
 /// 4096 bits is 512 B of thread-local storage, held INLINE in
 /// [`PerObjectLayoutHint`] so the flag and the filter share one hot slot. One

--- a/crates/perry-runtime/src/gc/layout_tables.rs
+++ b/crates/perry-runtime/src/gc/layout_tables.rs
@@ -226,6 +226,17 @@ pub(in crate::gc) fn prune_dead_per_object_layout_owners(is_dead_owner: &dyn Fn(
     }
 }
 
+#[cfg(test)]
+pub(in crate::gc) fn test_per_object_layout_present(user_ptr: usize) -> bool {
+    hot_layout_slot_masks().borrow().contains_key(&user_ptr)
+        || hot_typed_layouts().borrow().contains_key(&user_ptr)
+}
+
+#[cfg(test)]
+pub(in crate::gc) fn test_young_layout_records() -> u32 {
+    PERRY_YOUNG_LAYOUT_RECORDS.load(std::sync::atomic::Ordering::SeqCst)
+}
+
 /// Bits in the per-object address filter (see [`layout_addr_filter_may_hold`]).
 /// 4096 bits is 512 B of thread-local storage, held INLINE in
 /// [`PerObjectLayoutHint`] so the flag and the filter share one hot slot. One

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1783,7 +1783,9 @@ pub(crate) unsafe fn cell_meta_slot(user_ptr: usize) -> Option<*mut *mut ObjectM
     }
 }
 
-/// Does `user_ptr` name a cell that can own an `ObjectMeta`?
+/// Does `user_ptr` name a cell that can own an `ObjectMeta`? (Exercised by
+/// the error-cell tests; production code asks `cell_meta_slot` directly.)
+#[cfg(test)]
 pub(crate) unsafe fn cell_has_meta_edge(user_ptr: usize) -> bool {
     cell_meta_slot(user_ptr).is_some()
 }

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -1671,11 +1671,6 @@ pub(crate) fn prune_dead_shape_keys(is_dead_owner: &dyn Fn(usize) -> bool) {
     }
 }
 
-/// Metadata-only forwarding repair for the weak descriptor table and
-/// pointer-keyed slot indices. Mark/copy mode does not root anything; live
-/// object scans provide descriptor reachability, and post-copy rewrite follows
-/// only forwarding records those live edges already created.
-
 crate::perry_thread_local! {
     /// Scratch memo for [`scan_shape_table_rekey_mut`]'s per-address probe,
     /// reused across collections so the scan allocates nothing.

--- a/crates/perry-runtime/src/value/addr_class.rs
+++ b/crates/perry-runtime/src/value/addr_class.rs
@@ -265,6 +265,16 @@ fn classify_tracked_gc_header_with(
         .then_some((header_addr, TrackedGcStorage::Malloc))
 }
 
+/// Test-only count of tracked-resolver probes, so a fast path can pin that
+/// it answered without one.
+#[cfg(test)]
+static TRACKED_HEADER_PROBES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn tracked_header_probe_count_for_tests() -> u64 {
+    TRACKED_HEADER_PROBES.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Locate a `GcHeader` only after allocator-owned metadata proves that `addr`
 /// is a Perry GC allocation. Unlike [`try_read_gc_header`], this does not use
 /// an address-magnitude window as evidence of ownership: arena page membership
@@ -285,6 +295,8 @@ fn classify_tracked_gc_header_with(
 pub(crate) unsafe fn try_read_tracked_gc_header(
     addr: usize,
 ) -> Option<std::ptr::NonNull<GcHeader>> {
+    #[cfg(test)]
+    TRACKED_HEADER_PROBES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let (header_addr, storage) = classify_tracked_gc_header_with(
         addr,
         |candidate| crate::arena::classify_heap_space_in_range(candidate).map(|(_, base, _)| base),


### PR DESCRIPTION
## Summary

Two changes, measured on the Mac mini reference box (`taskpolicy -t 0 -l 0`, 11 alternating process pairs, wolf-ecs add/remove and entity-cycle from noctjs/ecs-benchmark, semantics probe byte-identical to Node):

1. **Field-value arguments to sibling methods keep the proven-`this` clone** (`collectors/ptr_shape.rs`). The this-flow walker rejected a method as a `$pshape` candidate whenever an internal `this.m(...)` call's *arguments* mentioned `this` at all — so `this._archChange(this._ent[id], i)`, `this._hasComponent(this._ent[id].mask, i)` and `this._crEnt(this.entID)` disqualified wolf-ecs `addComponent`, `removeComponent` and `createEntity`, which then ran their public bodies re-proving `this` at every property/element/method site (≈14k instructions for ~20 source lines; a flat 54% of the add/remove profile). A declared-field read hands the callee a value, never the receiver, and `expr_this_safe` already rejects a bare `this`, a `this`-capturing closure and a non-field read on its own; arguments are now vetted by it alone. Test pins both directions (field value admitted, bare `this` still rejected).
2. **Object-backed subclass push arm ahead of the tracked resolver** (`array/push_pop.rs`). #8897's `field_push_local_bind` turns `this.packed.push(x)` into a local `ArrayPush` whose complete fallback is `js_array_push_f64_spec`; for an object-backed `class Archetype extends Array` that entry paid the tracked resolver (a guaranteed miss on a `GC_TYPE_OBJECT` header) and then `js_array_push_f64`, which paid it again before reaching the dense subclass arm. Both entries now ask the dense arm first, off the header tag; a test-only probe counter on `try_read_tracked_gc_header` pins that they reach it with exactly the fused u31 entry's probes (none).

| window | baseline | add/remove | entity-cycle |
|---|---|---:|---:|
| 2 s (`targetMs = 2000`) | main `77b994f6b` (#8890's base, pre-#8897) | 0.4594 → 0.4081 **−11.2%** (11/11) | 0.3843 → 0.3388 **−11.9%** (11/11) |
| 50 ms (harness tail) | main `f9890759c` | 0.4701 → 0.4080 **−13.2%** (11/11) | 0.9421 → 0.3390 −64% (11/11; warm-up dominated, see below) |

Note on methodology: the 50 ms tail window is dominated by warm-up. #8897 introduced a cold-start ramp on entity-cycle (steady state unchanged, but calls 2…N run ~3× slower for thousands of calls; `PERRY_GC_DIAG` shows ~224k allocations / 9.4 MB per 300 calls where the previous main allocated nothing) — reported on #8897 with probes; this PR does not address it, which is why the 2 s window against the pre-#8897 main is the number to read.

## Verification
- rebased onto main `82c961f99` (#8923 carries the `-D warnings` cleanups this PR had briefly included)
- codegen 1330/1330 (`cargo test -p perry-codegen --lib`); runtime `array::` / `typed_feedback::` 320/320 (`--test-threads=1`); workspace `cargo check --all-targets` under `-D warnings` with the host-compatible exclusions; file-size, GC store-site inventory, addr-class, raw-handle (`--no-raise-vs origin/main`), local-binding audits all green.
- `addComponent$pshape` / `removeComponent$pshape` / `createEntity$pshape` now exist in the compiled wolf-ecs module and are the hot bodies in the profile.

https://claude.ai/code/session_019WVcWKmYsUBnnFB7nBgbBJ
