### PR TITLE
fix(ci): refresh diagnostics thread-local inventory

### DIFF
--- a/scripts/thread_local_cold_allowlist.json
+++ b/scripts/thread_local_cold_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Files still declaring raw `thread_local!`. Every entry is a declaration that pays `_tlv_get_addr` on Darwin; the count is a ratchet, so adding one to an already-listed file fails too. New code should use `crate::perry_thread_local!` \u2014 see crates/perry-runtime/src/tls_hot.rs. Regenerate with scripts/check_thread_locals.py --update.",
-  "_hot_declarations": 269,
+  "_hot_declarations": 271,
   "files": {
     "crates/perry-runtime/src/agent.rs": 1,
     "crates/perry-runtime/src/arena/block.rs": 2,
@@ -60,7 +60,7 @@
     "crates/perry-runtime/src/node_stream_constructors.rs": 2,
     "crates/perry-runtime/src/node_stream_tests.rs": 1,
     "crates/perry-runtime/src/node_submodules/blob.rs": 1,
-    "crates/perry-runtime/src/node_submodules/diagnostics.rs": 6,
+    "crates/perry-runtime/src/node_submodules/diagnostics.rs": 5,
     "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs": 1,
     "crates/perry-runtime/src/node_submodules/mod.rs": 1,
     "crates/perry-runtime/src/node_submodules/test.rs": 1,


### PR DESCRIPTION
## Summary
- reconcile the cold thread-local allowlist with the five shipping raw blocks in diagnostics.rs
- preserve the intentional #8891 move of ERROR_USER_PROPS from a raw thread-local side table to GC-managed error metadata
- refresh the generated hot-declaration total from 269 to 271 for current main

No version bump.

Fixes #8911

## Testing
- py -3 scripts/check_thread_locals.py --self-test
- py -3 scripts/check_thread_locals.py
- Windows GC structural audit scripts and structural baseline validation
- py -3 -m unittest discover -s tests -p test_gc_ratchet.py -v (98 passed, 12 platform-expected skips)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal thread-local cold allowlist tracking to reflect current declaration counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->