### PR TITLE
fix(ci): restore native-region compiler-output proof

### DIFF
--- a/benchmarks/compiler_output/fixtures/h1_buffer_alias_negative.ts
+++ b/benchmarks/compiler_output/fixtures/h1_buffer_alias_negative.ts
@@ -1,4 +1,5 @@
 const SIZE = 32;
+let escapedRead: ((i: number) => number) | undefined;
 
 function aliasLocal(): number {
   const owned = Buffer.alloc(SIZE);
@@ -40,6 +41,10 @@ function unknownCallEscape(): number {
 function closureCapture(): number {
   const owned = Buffer.alloc(SIZE);
   const read = (i: number) => owned[i];
+  // Keep the closure observable so HIR cannot erase the capture before the
+  // native-region proof sees it. The captured Buffer must remain a denied
+  // unchecked-native candidate even though the direct call below is exact.
+  escapedRead = read;
   let total = read(0) | 0;
   closure_capture:
   for (let i = 0; i < owned.length; i++) {
@@ -144,7 +149,8 @@ console.log(
       mutatedWhileIndex(mutationBuf) +
       staleNativeAlias() +
       staleAllocationLength() +
-      arrayBufferViews()
+      arrayBufferViews() +
+      (escapedRead ? 0 : 1)
     ) |
       0),
 );

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -90,7 +90,11 @@ required = true
 no_runtime_calls = true
 
 [[workloads.image_convolution.named_regions.selectors]]
-label_prefix_any = ["for.body.36", "while.body.40"]
+counter_min = { store_i8 = 1 }
+counter_equals = { load_i8 = 0 }
+
+[[workloads.image_convolution.named_regions.selectors]]
+counter_min = { load_i8 = 1, store_i8 = 1, xor_i32 = 1 }
 
 [[workloads.image_convolution.named_regions.checks]]
 name = "named_region_input_generation_byte_writes"
@@ -101,6 +105,24 @@ detail = "input_generation byte writes and xor shape"
 name = "named_region_input_generation_to_int32_conversion_budget"
 max = { fptosi = 1, sitofp = 1, inttoptr = 0, ptrtoint = 0 }
 detail = "input_generation JS division ToInt32 conversion budget"
+
+# Native record requirements use these structural regions rather than LLVM's
+# ordinal block suffixes. The latter shift whenever an earlier lowering grows
+# its CFG even when these loops and their checked guarantees are unchanged.
+[[workloads.image_convolution.named_regions]]
+name = "input_gradient_native"
+exclusive = false
+
+[[workloads.image_convolution.named_regions.selectors]]
+counter_min = { store_i8 = 1 }
+counter_equals = { load_i8 = 0 }
+
+[[workloads.image_convolution.named_regions]]
+name = "input_noise_native"
+exclusive = false
+
+[[workloads.image_convolution.named_regions.selectors]]
+counter_min = { load_i8 = 1, store_i8 = 1, xor_i32 = 1 }
 
 [[workloads.image_convolution.named_regions]]
 name = "blur"
@@ -127,9 +149,6 @@ no_runtime_calls = true
 no_conversions = true
 
 [[workloads.image_convolution.named_regions.selectors]]
-label_prefix_any = ["for.body.64"]
-
-[[workloads.image_convolution.named_regions.selectors]]
 counter_min = { load_i8 = 1, xor_i32 = 1, mul_i32 = 1 }
 counter_equals = { store_i8 = 0 }
 
@@ -145,7 +164,7 @@ allow_materialization_reasons = ["function_abi", "return_abi"]
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_input_generation_buffer_view"
-block_label = "for.body.36"
+named_region = "input_gradient_native"
 expr_kind = "Uint8ArraySet.array"
 consumer = "Uint8ArraySet.BufferView"
 native_rep_name = "buffer_view"
@@ -155,7 +174,7 @@ min = 3
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_input_generation_byte_store"
-block_label = "for.body.36"
+named_region = "input_gradient_native"
 expr_kind = "Uint8ArraySet"
 consumer = "u8_store_trunc_i32"
 native_rep_name = "u8"
@@ -165,7 +184,7 @@ min = 3
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_noise_byte_load"
-block_label = "while.body.40"
+named_region = "input_noise_native"
 expr_kind = "Uint8ArrayGet"
 consumer = "u8_load_zext_i32"
 native_rep_name = "u8"
@@ -174,7 +193,7 @@ bounds_state = "proven_or_guarded"
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_noise_byte_store"
-block_label = "while.body.40"
+named_region = "input_noise_native"
 expr_kind = "Uint8ArraySet"
 consumer = "u8_store_trunc_i32"
 native_rep_name = "u8"
@@ -183,7 +202,7 @@ bounds_state = "proven_or_guarded"
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_blur_byte_load"
-block_label = "for.body.56"
+named_region = "blur"
 expr_kind = "Uint8ArrayGet"
 consumer = "u8_load_zext_i32"
 native_rep_name = "u8"
@@ -194,7 +213,7 @@ min = 3
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_blur_byte_store"
-block_label = "for.body.56"
+named_region = "blur"
 expr_kind = "Uint8ArraySet"
 consumer = "u8_store_trunc_i32"
 native_rep_name = "u8"
@@ -204,7 +223,7 @@ alias_state = "no_alias_proven_or_guarded"
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_fnv_byte_load"
-block_label = "for.body.64"
+named_region = "fnv_hash"
 expr_kind = "Uint8ArrayGet"
 consumer = "u8_load_zext_i32"
 native_rep_name = "u8"
@@ -214,7 +233,7 @@ alias_state = "no_alias_proven_or_guarded"
 
 [[workloads.image_convolution.native_rep_checks.require_records]]
 name = "image_fnv_i32_hash"
-block_label = "for.body.64"
+named_region = "fnv_hash"
 expr_kind = "MathImul"
 consumer = "lower_expr_native_i32.structural"
 native_rep_name = "i32"

--- a/scripts/compiler_output_harness/spec.py
+++ b/scripts/compiler_output_harness/spec.py
@@ -92,6 +92,22 @@ def validate_workload_spec(data: dict[str, Any]) -> None:
                     raise HarnessError(
                         f"workload {name!r} native_rep_checks require_records need names"
                     )
+                named_region = required.get("named_region")
+                if named_region is not None:
+                    known_regions = {
+                        region.get("name")
+                        for region in workload.get("named_regions", []) or []
+                    }
+                    if not isinstance(named_region, str) or not named_region:
+                        raise HarnessError(
+                            f"workload {name!r} native_rep_checks require_records "
+                            "named_region must be a non-empty string"
+                        )
+                    if named_region not in known_regions:
+                        raise HarnessError(
+                            f"workload {name!r} native_rep_checks require_records "
+                            f"references unknown named region {named_region!r}"
+                        )
         for region in workload.get("named_regions", []) or []:
             if not region.get("name"):
                 raise HarnessError(f"workload {name!r} has a named region without name")

--- a/scripts/compiler_output_harness/verification.py
+++ b/scripts/compiler_output_harness/verification.py
@@ -640,7 +640,15 @@ def generic_native_rep_contract_results(
     )
 
     for required in check_spec.get("require_records", []) or []:
-        matches = [r for r in records if _record_matches_required(r, required)]
+        candidate_records = records
+        named_region = required.get("named_region")
+        if named_region:
+            candidate_records = _records_for_native_region(
+                records, named_regions or {}, workload_info, str(named_region)
+            )
+        matches = [
+            r for r in candidate_records if _record_matches_required(r, required)
+        ]
         min_count = int(required.get("min", 1) or 1)
         name = str(required.get("name") or required.get("consumer") or "record")
         add(
@@ -1130,6 +1138,11 @@ def verify_artifacts(
     clang_args = clang_args or []
     workload_info = workloads.get(workload, {})
     named_regions = named_hot_regions(workload_info, ir_after)
+    # Native-representation records describe lowering blocks before LLVM's
+    # optimization and vectorization passes. Resolve their structural regions
+    # against the matching IR phase, while optimized-shape checks keep using
+    # the post-optimization regions above.
+    native_named_regions = named_hot_regions(workload_info, ir_before)
     counters = counters or {}
     native_records = _flatten_native_records(native_reps)
 
@@ -1331,7 +1344,11 @@ def verify_artifacts(
         add(result["name"], bool(result["passed"]), result["detail"])
 
     for result in native_rep_contract_results(
-        workload, native_records, named_regions, len(native_reps or []), workloads
+        workload,
+        native_records,
+        native_named_regions,
+        len(native_reps or []),
+        workloads,
     ):
         add(result["name"], bool(result["passed"]), result["detail"])
 
@@ -1351,10 +1368,15 @@ def verify_artifacts(
         "vectorization_expectation": vector_expectation,
         "runtime_budget_results": runtime_budget_results(workload, runtime_summary, workloads),
         "named_regions": named_regions,
+        "native_named_regions": native_named_regions,
         "named_region_contract_results": named_region_contract_results(
             workload, named_regions, workloads
         ),
         "native_rep_contract_results": native_rep_contract_results(
-            workload, native_records, named_regions, len(native_reps or []), workloads
+            workload,
+            native_records,
+            native_named_regions,
+            len(native_reps or []),
+            workloads,
         ),
     }

--- a/tests/test_compiler_output_regression.py
+++ b/tests/test_compiler_output_regression.py
@@ -657,6 +657,90 @@ entry:
         )
         self.assertEqual(report["status"], "pass", report["errors"])
 
+    def test_image_convolution_native_proof_survives_block_renumbering(self):
+        replacements = {
+            "for.body.36": "for.body.48",
+            "while.body.40": "while.body.52",
+            "for.body.56": "for.body.68",
+            "for.body.64": "for.body.76",
+        }
+        renamed_ir = GOOD_IR
+        for old_label, new_label in replacements.items():
+            renamed_ir = renamed_ir.replace(old_label, new_label)
+        records = image_native_records()
+        for record in records:
+            record["block_label"] = replacements.get(
+                record["block_label"], record["block_label"]
+            )
+            record["lowering_block"] = record["block_label"]
+
+        report = HARNESS.verify_artifacts(
+            workload="image_convolution",
+            ir_before=renamed_ir,
+            ir_after=renamed_ir,
+            assembly=GOOD_ASM,
+            benchmark={"runs": [{"exit_code": 0}]},
+            vectorization={
+                "vectorized_count": 0,
+                "missed_count": 0,
+                "analysis_count": 0,
+            },
+            native_reps=[{"records": records}],
+        )
+        self.assertEqual(report["status"], "pass", report["errors"])
+
+    def test_image_native_regions_use_pre_optimization_ir(self):
+        optimized_ir = GOOD_IR.replace("for.body.36", "vector.body")
+        report = HARNESS.verify_artifacts(
+            workload="image_convolution",
+            ir_before=GOOD_IR,
+            ir_after=optimized_ir,
+            assembly=GOOD_ASM,
+            benchmark={"runs": [{"exit_code": 0}]},
+            vectorization={
+                "vectorized_count": 1,
+                "missed_count": 0,
+                "analysis_count": 0,
+            },
+            native_reps=[{"records": image_native_records()}],
+        )
+        self.assertEqual(report["status"], "pass", report["errors"])
+        self.assertEqual(
+            report["native_named_regions"]["input_gradient_native"]["labels"],
+            ["for.body.36"],
+        )
+        self.assertEqual(
+            report["named_regions"]["input_gradient_native"]["labels"],
+            ["vector.body"],
+        )
+
+    def test_image_convolution_rejects_native_proof_from_wrong_named_region(self):
+        records = image_native_records()
+        fnv_record = next(
+            record for record in records if record.get("expr_kind") == "MathImul"
+        )
+        fnv_record["block_label"] = "for.body.56"
+        fnv_record["lowering_block"] = "for.body.56"
+
+        report = HARNESS.verify_artifacts(
+            workload="image_convolution",
+            ir_before=GOOD_IR,
+            ir_after=GOOD_IR,
+            assembly=GOOD_ASM,
+            benchmark={"runs": [{"exit_code": 0}]},
+            vectorization={
+                "vectorized_count": 0,
+                "missed_count": 0,
+                "analysis_count": 0,
+            },
+            native_reps=[{"records": records}],
+        )
+        self.assertEqual(report["status"], "fail")
+        self.assertTrue(
+            any("image_fnv_i32_hash" in error for error in report["errors"]),
+            report["errors"],
+        )
+
     def test_hot_loop_runtime_call_fails_gate(self):
         bad_ir = GOOD_IR.replace(
             "  %p0 = getelementptr inbounds i8, ptr %base, i64 %i\n",
@@ -1552,6 +1636,34 @@ idxset.bounded_numeric_merge.5:
                                     "contains": "25",
                                 }
                             ],
+                        }
+                    },
+                }
+            )
+
+    def test_workload_spec_rejects_unknown_required_record_region(self):
+        with self.assertRaises(HARNESS.HarnessError):
+            HARNESS.validate_workload_spec(
+                {
+                    "schema_version": 1,
+                    "workloads": {
+                        "bad": {
+                            "source": "fixture.ts",
+                            "kind": "numeric_loop",
+                            "vectorization": {
+                                "min_vectorized_loops": 0,
+                                "allowed_missed_reason_kinds": [],
+                            },
+                            "runtime_budgets": {},
+                            "named_regions": [{"name": "known"}],
+                            "native_rep_checks": {
+                                "require_records": [
+                                    {
+                                        "name": "bad_region",
+                                        "named_region": "missing",
+                                    }
+                                ]
+                            },
                         }
                     },
                 }


### PR DESCRIPTION
## Summary

- scope native-representation requirements through structurally discovered named regions instead of brittle ordinal LLVM block labels
- resolve those native regions from pre-optimization IR, matching the phase that emits native-representation records while preserving optimized-IR shape gates
- keep the negative Buffer closure observable so `closure_capture` denial remains exercised
- add validation and regression coverage for block renumbering, phase separation, and wrong-region evidence

No version bump is included.

## Testing

- `cargo build --release -p perry`
- `python -m py_compile scripts/compiler_output_harness/spec.py scripts/compiler_output_harness/verification.py tests/test_compiler_output_regression.py`
- targeted compiler-output harness regression tests (5 passed)
- `compiler_output_regression.py capture --workload image_convolution ... --verify-native-regions --gate` (passed)
- `compiler_output_regression.py capture --workload h1_buffer_alias_negative ... --verify-native-regions --gate` (passed, including `closure_capture`)
- `compiler_output_regression.py suite --suite native-region-proof ... --gate` (all 11 workloads passed)

Closes #8912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler-output validation so checks remain reliable when internal IR block labels change.
  * Corrected native proof-record matching to use the appropriate pre-optimization regions.
  * Added safeguards against records being associated with the wrong named region.
* **Validation**
  * Workload specifications now reject empty or unknown named-region references with clear errors.
  * Expanded regression coverage for region mapping, label renumbering, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->