### PR TITLE
ci: shard the GC representation matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -653,6 +653,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           ./scripts/gc_repsel_matrix.sh --self-test-liveness-parser
+          python3 scripts/gc_repsel_matrix_merge.py --self-test
           python3 scripts/gc_matrix_liveness_check.py --self-test
           python3 scripts/gc_matrix_liveness_check.py --check-registry
 
@@ -1712,91 +1713,40 @@ jobs:
           }
 
   # ---------------------------------------------------------------------------
-  # GC write-barrier stress (optional / non-blocking)
+  # GC x representation-selection stress matrix
   #
-  # `crates/perry/tests/gc_write_barrier_stress.rs` runs compiled binaries
-  # under the slowest GC configuration (PERRY_GC_FORCE_EVACUATE +
-  # PERRY_GC_VERIFY_EVACUATION) to hunt a *rare* corruption window (#5029).
-  # Those tests are ~200s each and nondeterministic by nature, so they are a
-  # poor fit for the blocking per-PR `cargo-test` gate (one flake blocked
-  # every unrelated PR). They are `#[ignore]`d there and run here instead.
+  # This is the only CI execution of the requires=move allocation-point arms
+  # over the representation corpus. PRs run the high-signal subset; sweep and
+  # full tiers run every arm. The final job id remains `gc-stress`, a blocking
+  # input to the tier fan-in; scripts/gc_gate_wiring_check.py asserts it stays
+  # main-line reachable and able to fail (#7194).
   #
-  # The write-barrier stress tests stay opt-in + informational
-  # (`continue-on-error` on THEIR step, so a flake never fails the workflow).
-  #
-  # The job itself is no longer informational. It also runs the GC x
-  # representation-selection stress matrix (`scripts/gc_repsel_matrix.sh`),
-  # which IS a gate: until it existed, a representation could regress GC
-  # correctness and no CI job would say a word. Three weaknesses were fixed
-  # deliberately, and re-introducing any of them re-opens that hole:
-  #   1. job-level `continue-on-error: true` is gone (a gate that cannot fail
-  #      is not a gate); it now sits on the legacy write-barrier step only;
-  #   2. the `if:` no longer requires a `run-extended-tests` label, which is
-  #      why this job "skipped" on the representation PRs (#6911, #6925);
-  #   3. it no longer runs write-barrier stress *only* — nothing about the
-  #      representation corpus was covered before.
-  #
-  # Cost split: a PR runs the 4-arm subset, whose arms all share one
-  # compile-time environment, so the corpus is compiled ONCE and run four
-  # times. push / schedule / workflow_dispatch run the full arm list as the
-  # deeper net. NOTE: this job is not yet in branch protection's required
-  # contexts — adding it there is what makes the gate blocking.
-  #
-  # ***`schedule` IS LOAD-BEARING IN THE `if:` BELOW (#7194).*** Without it this
-  # job had NO main-line execution at all, and the hole is invisible from either
-  # end on its own:
-  #
-  #   * this workflow's `push:` trigger is TAGS ONLY — "Direct pushes to main do
-  #     NOT trigger tests", stated at the top of this file — so `push` in the
-  #     `if:` only ever means a release tag;
-  #   * the nightly cron, which the concurrency comment above calls "the only
-  #     backstop for integration-suite regressions a scoped PR run can't see",
-  #     fires as `schedule`, which the `if:` did not list. Measured: twelve
-  #     consecutive nightly `main` runs, `gc-stress` reported `skipped` in every
-  #     one.
-  #
-  # So between release tags, nothing in CI ran scripts/gc_repsel_matrix.sh on
-  # `main` — and the matrix is the only place the `requires=move`
-  # allocation-point arms execute over the representation corpus. That is how
-  # test_gap_repsel_p4a3_ptr_numarray stayed red on ten arms for over a week
-  # with no CI event to say so, forcing three separate PRs (#7193, #7233, #7196)
-  # to hand-exonerate the same seventy cells. This is CLAUDE.md hazard 4 in its
-  # purest form: the job existed, was correctly written, and its subject never
-  # ran. scripts/gc_gate_wiring_check.py asserts this from `lint` so it cannot
-  # silently come back.
+  # The legacy write-barrier corruption-window hunts remain in the final job as
+  # an informational continue-on-error step. Only that nondeterministic step is
+  # soft; matrix coverage, parity, liveness, and the GC instrument smoke gate.
   # ---------------------------------------------------------------------------
-  gc-stress:
+  # Build the base compiler/runtime once and share it with every matrix shard.
+  # Release run 33123474583 spent 11m41s here before the unsharded matrix even
+  # started; repeating that fixed cost in each worker would erase much of the
+  # sharding win (#8915).
+  gc-stress-build:
     needs: plan
     if: fromJSON(needs.plan.outputs.plan).jobs.gc_stress
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
       - name: Install Rust toolchain
         run: rustup toolchain install nightly-2026-08-20 --profile minimal
       - uses: ./.github/actions/setup-llvm22
-
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: "${{ runner.os }}-perry"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
       - name: Install clang
         run: |
           sudo apt-get update
           sudo apt-get install -y clang
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          # Single source of truth: .node-version at the repo root. Node is the
-          # matrix oracle (we byte-diff against it), so the version is a
-          # correctness input. scripts/gc_repsel_matrix.sh refuses to run when
-          # the running node disagrees with the pin — a test the oracle cannot
-          # run would drop out of the gate silently.
-          node-version-file: .node-version
-
       - name: Build perry + runtime staticlibs (release)
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
@@ -1804,37 +1754,141 @@ jobs:
           cargo build --release \
             -p perry -p perry-runtime -p perry-stdlib \
             -p perry-runtime-static -p perry-stdlib-static
+      - name: Upload shared GC matrix build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gc-repsel-release-build
+          path: |
+            target/release/perry
+            target/release/libperry_runtime.a
+            target/release/libperry_stdlib.a
+          if-no-files-found: error
+          retention-days: 1
 
-      # GATING. Fails the job on any new untriaged red cell. Cells whose GC arm
-      # was measurably inert are reported UNVERIFIED, never green (#6942,
-      # #6946, #6950) — the script asserts liveness from the collector's own
-      # PERRY_GC_TRACE / PERRY_GC_DIAG output rather than trusting the env var.
-      - name: GC x representation-selection matrix (PR subset)
-        if: fromJSON(needs.plan.outputs.plan).gc_stress_mode == 'pr'
-        run: ./scripts/gc_repsel_matrix.sh --no-build --arms pr --json gc-repsel-matrix.json
+  # Stable round-robin slices of test-parity/gc_repsel_corpus.txt. Full/sweep
+  # tiers use four shards; the PR subset uses one (scripts/ci_plan.py). Every
+  # shard still runs every selected arm, so the complete cross-product remains
+  # covered. fail-fast:false preserves evidence from all shards after a red.
+  gc-stress-shard:
+    name: gc-stress matrix (${{ matrix.shard }}/${{ fromJSON(needs.plan.outputs.plan).gc_stress.total }})
+    needs: [plan, gc-stress-build]
+    if: >-
+      always() &&
+      fromJSON(needs.plan.outputs.plan).jobs.gc_stress &&
+      needs.gc-stress-build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.plan).gc_stress.shards }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Per-shard auto-optimize archives are compile-environment-specific and
+      # stay local; the shared artifact supplies the base release build.
+      - name: Install Rust toolchain
+        run: rustup toolchain install nightly-2026-08-20 --profile minimal
+      - uses: ./.github/actions/setup-llvm22
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: false
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          # Node is the byte-exact oracle; the script refuses a version that
+          # differs from the repository's single source of truth.
+          node-version-file: .node-version
+      - name: Download shared GC matrix build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: gc-repsel-release-build
+          path: target/release
+      - name: Ensure the downloaded compiler is executable
+        run: chmod +x target/release/perry
 
-      - name: GC x representation-selection matrix (full)
-        if: fromJSON(needs.plan.outputs.plan).gc_stress_mode == 'full'
-        run: ./scripts/gc_repsel_matrix.sh --no-build --arms all --json gc-repsel-matrix.json
+      # Liveness is corpus-wide, so a shard defers only that verdict to the
+      # strict fan-in below. GNU timeout fires before the job cap: TERM lets
+      # the harness record the active file/environment and completed cells,
+      # leaving time for the always() artifact upload.
+      - name: GC x representation-selection matrix shard ${{ matrix.shard }}
+        env:
+          MODE: ${{ fromJSON(needs.plan.outputs.plan).gc_stress.mode }}
+          SHARD: ${{ matrix.shard }}
+          TOTAL: ${{ fromJSON(needs.plan.outputs.plan).gc_stress.total }}
+        run: |
+          set -euo pipefail
+          timeout --signal=TERM --kill-after=1m 75m \
+            ./scripts/gc_repsel_matrix.sh \
+              --no-build \
+              --arms "$MODE" \
+              --shard "$SHARD/$TOTAL" \
+              --defer-liveness \
+              --json "gc-repsel-matrix-$SHARD.json"
+      - name: Upload shard report and interruption progress
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gc-repsel-matrix-shard-${{ matrix.shard }}
+          path: gc-repsel-matrix-${{ matrix.shard }}.json*
+          if-no-files-found: error
 
-      # GATING, and deliberately so. CLAUDE.md's GC knob kill-policy requires
-      # every GC knob to have an arm that exercises it; the #7154 instruments
-      # (PERRY_GC_PROTECT_FROMSPACE, PERRY_GC_SCHEDULE_SEED)
-      # would otherwise be dark knobs on the subsystem with this repo's worst
-      # history of configuration rot. This asserts BOTH defaults — inert with
-      # the knobs unset, live with them set — and refuses to pass unless the
-      # stress arms (the rate-1 seeded schedule, and the #7254 RATE=1 +
-      # VERIFY_EVACUATION pairing)
-      # forced strictly more collections than the pressure-only arm, so it
-      # cannot go green having run zero copying minors (the #6942 / #7024 /
-      # #7025 failure mode).
-      # The detection property itself is a required-gate unit test:
-      # gc/tests/fromspace_protect.rs::quarantine_catches_a_planted_stale_from_space_deref.
-      # Arms 1-3/5 use a fixture sized for ~1200 back-edge polls (not #7154's
-      # 240k), pinned to every-poll candidacy
-      # (PERRY_GC_SCHEDULE_ALLOC_KB=0). Arm 6 (#7728) is the budgeted one:
-      # a realistic poll count at the SHIPPED default, which is the axis that
-      # a ~1200-poll fixture structurally cannot see.
+  # Strict fan-in, retaining the historical job id that full-suite-gate needs.
+  # It rejects missing/duplicate/interrupted shards, proves every expected cell
+  # appears exactly once, then applies liveness to the reconstructed corpus.
+  gc-stress:
+    needs: [plan, gc-stress-build, gc-stress-shard]
+    if: ${{ always() && fromJSON(needs.plan.outputs.plan).jobs.gc_stress }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Download GC matrix shard evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: gc-repsel-matrix-shard-*
+          path: gc-repsel-shards
+      - name: Merge shards and enforce complete coverage + liveness
+        env:
+          EXPECT: ${{ fromJSON(needs.plan.outputs.plan).gc_stress.total }}
+          MODE: ${{ fromJSON(needs.plan.outputs.plan).gc_stress.mode }}
+        run: |
+          set -euo pipefail
+          python3 scripts/gc_repsel_matrix_merge.py --self-test
+          python3 scripts/gc_repsel_matrix_merge.py \
+            --expect "$EXPECT" \
+            --mode "$MODE" \
+            --output gc-repsel-matrix.json \
+            gc-repsel-shards/gc-repsel-matrix-shard-*/gc-repsel-matrix-*.json
+
+      # The remaining GC stress arms are aggregate-only. Repeating them in
+      # every matrix shard would add cost without increasing their coverage.
+      - name: Install Rust toolchain
+        run: rustup toolchain install nightly-2026-08-20 --profile minimal
+      - uses: ./.github/actions/setup-llvm22
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: false
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+      - name: Download shared GC matrix build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: gc-repsel-release-build
+          path: target/release
+      - name: Ensure the downloaded compiler is executable
+        run: chmod +x target/release/perry
+
+      # GATING. The kill-policy requires every GC knob to have a live arm;
+      # gc_instrument_smoke asserts both the default-inert and stressed-live
+      # sides of the from-space/schedule instruments.
       - name: GC rooting-bug instruments (inert-when-off, live-when-on)
         run: ./scripts/gc_instrument_smoke.sh target/release/perry
 
@@ -1843,12 +1897,10 @@ jobs:
         # hunts (#5029). Kept out of the gate so a flake never blocks a PR.
         continue-on-error: true
         env:
-          # Match the cargo-test gate's linker workaround (lld SIGBUS on the
-          # shared runner during large test links).
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
         run: cargo test -p perry --test gc_write_barrier_stress -- --ignored
 
-      - name: Upload matrix report
+      - name: Upload merged matrix report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/docs/src/testing/ci-tiers.md
+++ b/docs/src/testing/ci-tiers.md
@@ -29,7 +29,7 @@ copy is current.
 | `cargo-test` | yes | yes | yes |
 | `cargo-test-perry` |  |  | yes |
 | `gap-suite` | 6x fast | 3x fast | 8x full |
-| `gc-stress` | yes | yes | yes |
+| `gc-stress` | 1x pr | 4x all | 4x all |
 | `e2e-scoped` | yes |  |  |
 | `security-audit` | deps only | yes | yes |
 | `windows-build` |  | yes | yes |

--- a/scripts/ci_plan.py
+++ b/scripts/ci_plan.py
@@ -138,6 +138,14 @@ PARITY_SHARDS = 12
 # package; this matrix owns only `perry` integration targets.
 PERRY_INTEGRATION_SHARDS = 8
 
+# GC x representation-selection matrix. The PR subset remains one bounded job;
+# sweep/full runs retain every corpus file and every arm but partition the 80
+# files four ways. The previous single runner spent its remaining 78 minutes
+# compiling 80 files across ten compile environments and never reached a
+# verdict (#8915). Four stable round-robin slices leave ample room below the
+# 90-minute release bound without consuming the org's full 20-runner pool.
+GC_STRESS_SHARDS = {"pr": 1, "sweep": 4, "full": 4}
+
 EXTENDED_LABEL = "run-extended-tests"
 
 # The nightly (full-tier) cron in test.yml `on.schedule`. Any OTHER cron firing
@@ -310,6 +318,7 @@ def plan(
         gap = {"mode": "fast", "total": 1}
     gap["shards"] = list(range(1, gap["total"] + 1))
     gap["update_snapshot"] = bool(update_gap_snapshot)
+    gc_stress_total = GC_STRESS_SHARDS[tier]
 
     return {
         "tier": tier,
@@ -327,8 +336,14 @@ def plan(
             "total": PERRY_INTEGRATION_SHARDS,
             "shards": list(range(1, PERRY_INTEGRATION_SHARDS + 1)),
         },
-        # gc-stress: the PR subset of the GC x repsel matrix vs the full one.
-        "gc_stress_mode": "pr" if tier == "pr" else "full",
+        # gc-stress: one PR-subset runner or a sharded all-arms run. The
+        # gc-stress fan-in validates exact coverage and applies liveness once
+        # across the reconstructed whole-corpus report.
+        "gc_stress": {
+            "mode": "pr" if tier == "pr" else "all",
+            "total": gc_stress_total,
+            "shards": list(range(1, gc_stress_total + 1)),
+        },
     }
 
 
@@ -348,6 +363,8 @@ def table() -> str:
             if job == "gap_suite" and mark:
                 g = GAP_SUITE[t]
                 mark = f"{g['total']}x {g['mode']}"
+            if job == "gc_stress" and mark:
+                mark = f"{GC_STRESS_SHARDS[t]}x {'pr' if t == 'pr' else 'all'}"
             cells.append(mark)
         lines.append(f"| `{job.replace('_', '-')}` | " + " | ".join(cells) + " |")
     return "\n".join(lines)
@@ -388,6 +405,7 @@ def _self_test() -> int:
     core = plan("pull_request", "refs/pull/1/merge", changed=["crates/perry-runtime/src/gc/mod.rs"])
     check("core PR: gap suite on", core["jobs"]["gap_suite"])
     check("core PR: gc-stress on", core["jobs"]["gc_stress"])
+    check("core PR: gc-stress is one PR-subset shard", core["gc_stress"] == {"mode": "pr", "total": 1, "shards": [1]})
     check("core PR: e2e-scoped on", core["jobs"]["e2e_scoped"])
     check("core PR: windows off", not core["jobs"]["windows_build"])
     check("core PR: parity off", not core["jobs"]["parity"])
@@ -423,6 +441,7 @@ def _self_test() -> int:
     check("sweep: 3 fast gap shards", sweep["gap"]["total"] == 3 and sweep["gap"]["mode"] == "fast")
     check("sweep: cargo-test full", sweep["cargo_test_scope"] == "full")
     check("sweep: security-audit on", sweep["jobs"]["security_audit"])
+    check("sweep: full GC matrix has four shards", sweep["gc_stress"] == {"mode": "all", "total": 4, "shards": [1, 2, 3, 4]})
 
     full = plan("schedule", "refs/heads/main")
     check("full: every job except e2e-scoped", all(v for k, v in full["jobs"].items() if k != "e2e_scoped"))
@@ -436,6 +455,7 @@ def _self_test() -> int:
     )
     check("full: 8 auto-optimize gap shards", full["gap"]["total"] == 8 and full["gap"]["mode"] == "full")
     check("full: parity sharded (6h-cap kill, 2026-08-16)", full["parity"]["total"] >= 2 and full["parity"]["shards"][0] == 1)
+    check("full: full GC matrix has four shards", full["gc_stress"] == {"mode": "all", "total": 4, "shards": [1, 2, 3, 4]})
 
     labelled = plan("pull_request", "refs/pull/1/merge", labels=[EXTENDED_LABEL], changed=["README.md"])
     check("labelled PR runs the full tier regardless of scope", labelled["jobs"]["parity"] and labelled["jobs"]["gap_suite"])
@@ -450,8 +470,8 @@ def _self_test() -> int:
     #    moving-GC gate and MUST be main-line reachable (push:main or
     #    schedule). The checker cannot see through fromJSON(plan), so this is
     #    where that guarantee lives.
-    check("gc-stress reachable on push:main", sweep["jobs"]["gc_stress"] and sweep["gc_stress_mode"] == "full")
-    check("gc-stress reachable on schedule", full["jobs"]["gc_stress"] and full["gc_stress_mode"] == "full")
+    check("gc-stress reachable on push:main", sweep["jobs"]["gc_stress"] and sweep["gc_stress"]["mode"] == "all")
+    check("gc-stress reachable on schedule", full["jobs"]["gc_stress"] and full["gc_stress"]["mode"] == "all")
 
     # 5. Sabotage: the checker can fail.
     check("sabotage: a job cannot be in no tier", all(JOBS.values()))

--- a/scripts/gc_gate_wiring_check.py
+++ b/scripts/gc_gate_wiring_check.py
@@ -53,10 +53,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 GATES = [
     (
         ".github/workflows/test.yml",
-        "gc-stress",
+        "gc-stress-shard",
         "scripts/gc_repsel_matrix.sh — the GC x representation-selection matrix, "
         "and the only CI execution of the requires=move allocation-point arms "
         "over the representation corpus",
+    ),
+    (
+        ".github/workflows/test.yml",
+        "gc-stress",
+        "scripts/gc_repsel_matrix_merge.py — the strict matrix fan-in that "
+        "rejects missing shards and enforces corpus-wide liveness before "
+        "full-suite-gate can pass",
     ),
     (
         ".github/workflows/gc-moving-witnesses.yml",

--- a/scripts/gc_repsel_matrix.sh
+++ b/scripts/gc_repsel_matrix.sh
@@ -70,6 +70,7 @@
 #   scripts/gc_repsel_matrix.sh [--arms pr|all|<csv>] [--filter <substr>]
 #                               [--pressure <MB>] [--jobs N] [--no-build]
 #                               [--profile <cargo profile>] [--json <path>]
+#                               [--shard N/M] [--defer-liveness]
 #                               [--list-arms] [--liveness-report-only]
 #                               [--self-test-liveness-parser]
 set -uo pipefail
@@ -112,6 +113,9 @@ JSON_OUT=""
 PROFILE="release"
 LIVENESS_REPORT_ONLY=0
 SELF_TEST_LIVENESS_PARSER=0
+SHARD_INDEX=1
+SHARD_COUNT=1
+DEFER_LIVENESS=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -122,6 +126,21 @@ while [ $# -gt 0 ]; do
         --profile) PROFILE="$2"; shift 2 ;;
         --no-build) DO_BUILD=0; shift ;;
         --json) JSON_OUT="$2"; shift 2 ;;
+        --shard)
+            shard_spec="$2"
+            SHARD_INDEX="${shard_spec%%/*}"
+            SHARD_COUNT="${shard_spec#*/}"
+            if [ "$shard_spec" != "$SHARD_INDEX/$SHARD_COUNT" ]; then
+                echo "invalid --shard '$shard_spec' (expected N/M)" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        # A shard cannot make a corpus-wide liveness claim: the few tests on
+        # it may legitimately be inert for an arm that bites elsewhere. CI
+        # passes this on every shard and runs the gate once on the strict
+        # fan-in report produced by gc_repsel_matrix_merge.py.
+        --defer-liveness) DEFER_LIVENESS=1; shift ;;
         --list-arms) ARMS_SEL="__list__"; shift ;;
         --self-test-liveness-parser) SELF_TEST_LIVENESS_PARSER=1; shift ;;
         # Local exploration only (e.g. a `--filter` narrow enough that an arm
@@ -132,6 +151,58 @@ while [ $# -gt 0 ]; do
         *) echo "unknown flag: $1" >&2; exit 2 ;;
     esac
 done
+
+case "$SHARD_INDEX:$SHARD_COUNT" in
+    *[!0-9:]*|:*|*:)
+        echo "invalid --shard '$SHARD_INDEX/$SHARD_COUNT' (expected positive integers)" >&2
+        exit 2
+        ;;
+esac
+if [ "$SHARD_INDEX" -lt 1 ] || [ "$SHARD_COUNT" -lt 1 ] || [ "$SHARD_INDEX" -gt "$SHARD_COUNT" ]; then
+    echo "invalid --shard '$SHARD_INDEX/$SHARD_COUNT' (require 1 <= N <= M)" >&2
+    exit 2
+fi
+if [ "$DEFER_LIVENESS" = 1 ] && [ -z "$JSON_OUT" ]; then
+    echo "--defer-liveness requires --json so the fan-in has evidence to check" >&2
+    exit 2
+fi
+
+# Keep a durable, append-only breadcrumb beside the final JSON. The report is
+# intentionally written only when complete (the fan-in rejects a missing one),
+# while this file survives a TERM/INT and tells an interrupted CI shard exactly
+# which file/environment was active plus every completed cell's counters.
+PROGRESS_OUT=""
+if [ -n "$JSON_OUT" ]; then
+    PROGRESS_OUT="$JSON_OUT.progress.log"
+    : > "$PROGRESS_OUT"
+fi
+progress() {
+    [ -n "$PROGRESS_OUT" ] || return 0
+    printf '%s shard=%s/%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$SHARD_INDEX" "$SHARD_COUNT" "$*" >> "$PROGRESS_OUT"
+}
+progress "start arms=$ARMS_SEL filter=${FILTER:-<none>}"
+
+WORK=""
+cleanup() {
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        progress "exit status=$rc (final JSON may be absent; this log is the partial evidence)"
+    fi
+    # WORK is assigned only from mktemp below. Keep the empty guard explicit:
+    # this trap is intentionally armed before registration/oracle checks so an
+    # early interruption is preserved too.
+    [ -z "$WORK" ] || rm -rf "$WORK"
+}
+on_signal() {
+    signal="$1"; status="$2"
+    progress "interrupted signal=$signal"
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'on_signal INT 130' INT
+trap 'on_signal TERM 143' TERM
+trap 'on_signal HUP 129' HUP
 
 if [ "$SELF_TEST_LIVENESS_PARSER" = 1 ]; then
     got="$(sum_copy_minor_moved <<'EOF'
@@ -368,6 +439,22 @@ if [ -n "$FILTER" ]; then
 fi
 [ "${#CORPUS[@]}" -gt 0 ] || { echo "empty corpus after filter" >&2; exit 2; }
 
+CORPUS_TOTAL="${#CORPUS[@]}"
+if [ "$SHARD_COUNT" -gt 1 ]; then
+    SHARDED=()
+    corpus_i=0
+    for b in "${CORPUS[@]}"; do
+        if [ $((corpus_i % SHARD_COUNT + 1)) -eq "$SHARD_INDEX" ]; then
+            SHARDED+=("$b")
+        fi
+        corpus_i=$((corpus_i+1))
+    done
+    CORPUS=(${SHARDED[@]+"${SHARDED[@]}"})
+fi
+[ "${#CORPUS[@]}" -gt 0 ] || { echo "empty corpus in shard $SHARD_INDEX/$SHARD_COUNT" >&2; exit 2; }
+echo "==> shard $SHARD_INDEX/$SHARD_COUNT: ${#CORPUS[@]}/$CORPUS_TOTAL corpus files (stable manifest round-robin)"
+progress "selected files=${#CORPUS[@]} corpus_total=$CORPUS_TOTAL"
+
 # ---------------------------------------------------------------------------
 # Oracle + compiler.  THE ORACLE VERSION IS LOAD-BEARING: a test the oracle
 # cannot run would drop out of the gate silently, so refuse to run at all.
@@ -392,15 +479,21 @@ fi
 [ -x "$PERRY_BIN" ] || { echo "${RED}missing $PERRY_BIN${NC}" >&2; exit 2; }
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/perry-gcmatrix.XXXXXX")"
-trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/oracle" "$WORK/bin" "$WORK/out"
 
 echo "==> oracle: node $NODE_V x ${#CORPUS[@]} corpus files"
 oracle_fail=0
+oracle_i=0
 for b in "${CORPUS[@]}"; do
+    oracle_i=$((oracle_i+1))
+    echo "  oracle [$oracle_i/${#CORPUS[@]}] $b"
+    progress "oracle-start test=$b"
     if ! node --experimental-strip-types "test-files/$b.ts" > "$WORK/oracle/$b.out" 2>/dev/null; then
         echo "${RED}ORACLE FAIL${NC} node cannot run test-files/$b.ts -- it would drop out of the gate" >&2
         oracle_fail=1
+        progress "oracle-result test=$b result=FAIL"
+    else
+        progress "oracle-result test=$b result=PASS"
     fi
 done
 [ "$oracle_fail" = 0 ] || exit 2
@@ -434,8 +527,10 @@ NARMS="${#ARM_IDS[@]}"
 # are handled below).
 echo "==> warming the auto-optimize archive"
 mkdir -p "$WORK/bin/_warm"
+progress "compile-start env=_warm test=${CORPUS[0]}"
 "$PERRY_BIN" "test-files/${CORPUS[0]}.ts" -o "$WORK/bin/_warm/warm" > "$WORK/bin/_warm/warm.log" 2>&1 \
     || { echo "${RED}warm-up compile failed${NC} (see $WORK/bin/_warm/warm.log)" >&2; }
+progress "compile-result env=_warm test=${CORPUS[0]} result=$([ -x "$WORK/bin/_warm/warm" ] && echo PASS || echo FAIL)"
 
 echo "==> compiling ${#CORPUS[@]} files x ${#GROUP_SLUGS[@]} compile-env groups (jobs=$JOBS)"
 gi=0
@@ -443,8 +538,9 @@ while [ "$gi" -lt "${#GROUP_SLUGS[@]}" ]; do
     slug="${GROUP_SLUGS[$gi]}"; cenv="${GROUP_ENVS[$gi]}"
     mkdir -p "$WORK/bin/$slug"
     printf '%s\n' "${CORPUS[@]}" | WORK="$WORK" PERRY_BIN="$PERRY_BIN" CENV="$cenv" SLUG="$slug" \
+        PROGRESS_OUT="$PROGRESS_OUT" SHARD_INDEX="$SHARD_INDEX" SHARD_COUNT="$SHARD_COUNT" \
         xargs -P "$JOBS" -I{} sh -c \
-        'env $CENV "$PERRY_BIN" "test-files/$1.ts" -o "$WORK/bin/$SLUG/$1" > "$WORK/bin/$SLUG/$1.log" 2>&1 || echo "COMPILEFAIL $SLUG $1"' _ {}
+        'echo "  compile env=$SLUG test=$1"; [ -z "$PROGRESS_OUT" ] || printf "%s shard=%s/%s compile-start env=%s test=%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SHARD_INDEX" "$SHARD_COUNT" "$SLUG" "$1" >> "$PROGRESS_OUT"; if env $CENV "$PERRY_BIN" "test-files/$1.ts" -o "$WORK/bin/$SLUG/$1" > "$WORK/bin/$SLUG/$1.log" 2>&1; then [ -z "$PROGRESS_OUT" ] || printf "%s shard=%s/%s compile-result env=%s test=%s result=PASS\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SHARD_INDEX" "$SHARD_COUNT" "$SLUG" "$1" >> "$PROGRESS_OUT"; else echo "COMPILEFAIL $SLUG $1"; [ -z "$PROGRESS_OUT" ] || printf "%s shard=%s/%s compile-result env=%s test=%s result=FAIL\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SHARD_INDEX" "$SHARD_COUNT" "$SLUG" "$1" >> "$PROGRESS_OUT"; fi' _ {}
     gi=$((gi+1))
 done
 
@@ -477,6 +573,8 @@ while [ "$ai" -lt "$NARMS" ]; do
     ti=0
     while [ "$ti" -lt "${#CORPUS[@]}" ]; do
         b="${CORPUS[$ti]}"; bin="$WORK/bin/$slug/$b"; idx=$((ti*NARMS+ai))
+        echo "  run [$((ti+1))/${#CORPUS[@]}] test=$b env=$slug arm=$id"
+        progress "cell-start test=$b env=$slug arm=$id"
         cycles=0; evacuated=0; scavenged=0
         if [ ! -x "$bin" ]; then
             result="FAIL"; ev="compile-failed"
@@ -590,6 +688,7 @@ while [ "$ai" -lt "$NARMS" ]; do
             XFAIL) n_xfail=$((n_xfail+1)); echo "  ${YELLOW}XFAIL${NC} $b" ;;
             FAIL)  n_fail=$((n_fail+1)); echo "  ${RED}FAIL${NC} $b ($ev)" ;;
         esac
+        progress "cell-result test=$b env=$slug arm=$id result=$result $ev"
         ti=$((ti+1))
     done
     ai=$((ai+1))
@@ -675,7 +774,8 @@ echo "  UNVER = output matched but the arm was inert here; see #6942 / #6946 / #
 # A gate that runs only when someone remembered a flag is not a gate.
 JSON_REPORT="${JSON_OUT:-$WORK/matrix.json}"
 {
-    printf '{"node":"%s","pressure_mb":"%s","arms":[' "$NODE_V" "$PRESSURE_MB"
+    printf '{"node":"%s","pressure_mb":"%s","complete":true,"shard":{"index":%d,"count":%d,"corpus_total":%d,"corpus_selected":%d},"arms":[' \
+        "$NODE_V" "$PRESSURE_MB" "$SHARD_INDEX" "$SHARD_COUNT" "$CORPUS_TOTAL" "${#CORPUS[@]}"
     ai=0
     while [ "$ai" -lt "$NARMS" ]; do
         [ "$ai" = 0 ] || printf ','
@@ -704,6 +804,7 @@ JSON_REPORT="${JSON_OUT:-$WORK/matrix.json}"
         "$n_pass" "$n_unver" "$n_xfail" "$n_fail"
 } > "$JSON_REPORT"
 [ -n "$JSON_OUT" ] && echo "json: $JSON_OUT"
+progress "report-complete cells=$n_cells pass=$n_pass unver=$n_unver xfail=$n_xfail fail=$n_fail path=$JSON_REPORT"
 
 # ---------------------------------------------------------------------------
 # LIVENESS GATE (#7255). Half of this script's exit status.
@@ -717,7 +818,10 @@ JSON_REPORT="${JSON_OUT:-$WORK/matrix.json}"
 # ---------------------------------------------------------------------------
 echo
 liveness_rc=0
-if command -v python3 > /dev/null 2>&1; then
+if [ "$DEFER_LIVENESS" = 1 ]; then
+    echo "liveness gate: deferred to gc_repsel_matrix_merge.py over all $SHARD_COUNT shard report(s)"
+    progress "liveness-deferred"
+elif command -v python3 > /dev/null 2>&1; then
     liveness_args=""
     [ "$LIVENESS_REPORT_ONLY" = 1 ] && liveness_args="--report-only"
     # shellcheck disable=SC2086

--- a/scripts/gc_repsel_matrix_merge.py
+++ b/scripts/gc_repsel_matrix_merge.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Strict fan-in for sharded gc_repsel_matrix.sh reports.
+
+The matrix is sharded by corpus file, so no individual shard is allowed to
+make a corpus-wide liveness claim. This merger proves that every deterministic
+slice arrived, that every expected test/arm cell appears exactly once, and then
+runs the existing liveness gate over the reconstructed whole-suite report.
+
+Usage:
+  scripts/gc_repsel_matrix_merge.py --expect 4 --mode all \
+      --output gc-repsel-matrix.json shard-*/gc-repsel-matrix.json
+  scripts/gc_repsel_matrix_merge.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from gc_matrix_liveness_check import (
+    MATRIX,
+    REGISTRY,
+    Violation,
+    check_report,
+    matrix_arms,
+    matrix_pr_arms,
+    parse_registry,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "test-parity" / "gc_repsel_corpus.txt"
+RESULTS = ("PASS", "UNVER", "XFAIL", "FAIL")
+
+
+def corpus_from_manifest(text: str) -> list[str]:
+    corpus = []
+    for raw in text.splitlines():
+        value = raw.split("#", 1)[0].strip()
+        if value:
+            corpus.append("".join(value.split()))
+    if not corpus:
+        raise Violation(f"{MANIFEST.name}: corpus is empty")
+    return corpus
+
+
+def expected_arms(mode: str, matrix_text: str) -> list[dict[str, str]]:
+    declared = matrix_arms(matrix_text)
+    ids = list(declared) if mode == "all" else matrix_pr_arms(matrix_text)
+    return [{"id": arm_id, "requires": declared[arm_id]} for arm_id in ids]
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            report = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise Violation(f"{path}: cannot read a complete matrix report: {exc}") from exc
+    if not isinstance(report, dict):
+        raise Violation(f"{path}: matrix report root must be an object")
+    return report
+
+
+def merge(
+    reports: list[dict[str, Any]],
+    sources: list[str],
+    expect: int,
+    arms: list[dict[str, str]],
+    corpus: list[str],
+) -> dict[str, Any]:
+    if len(reports) != expect:
+        raise Violation(
+            f"expected exactly {expect} shard reports, got {len(reports)} — "
+            "a missing artifact must fail the matrix, not shrink it"
+        )
+
+    arm_ids = [arm["id"] for arm in arms]
+    expected_arm_set = set(arm_ids)
+    expected_by_shard = {
+        shard: corpus[shard - 1 :: expect] for shard in range(1, expect + 1)
+    }
+    by_shard: dict[int, tuple[dict[str, Any], str]] = {}
+    node = None
+    pressure = None
+
+    for report, source in zip(reports, sources):
+        if report.get("complete") is not True:
+            raise Violation(f"{source}: report is not marked complete")
+        shard = report.get("shard")
+        if not isinstance(shard, dict):
+            raise Violation(f"{source}: missing shard metadata")
+        index, count = shard.get("index"), shard.get("count")
+        if not isinstance(index, int) or not isinstance(count, int):
+            raise Violation(f"{source}: shard index/count must be integers")
+        if count != expect or index not in expected_by_shard:
+            raise Violation(
+                f"{source}: declares shard {index}/{count}, expected one of 1/{expect}..{expect}/{expect}"
+            )
+        if index in by_shard:
+            raise Violation(
+                f"shard {index}/{expect} appears in both {by_shard[index][1]} and {source}"
+            )
+        by_shard[index] = (report, source)
+
+        if shard.get("corpus_total") != len(corpus):
+            raise Violation(
+                f"{source}: corpus_total={shard.get('corpus_total')!r}, expected {len(corpus)}"
+            )
+        if shard.get("corpus_selected") != len(expected_by_shard[index]):
+            raise Violation(
+                f"{source}: corpus_selected={shard.get('corpus_selected')!r}, "
+                f"expected {len(expected_by_shard[index])} for shard {index}/{expect}"
+            )
+        if report.get("arms") != arms:
+            raise Violation(
+                f"{source}: arm inventory/order does not match the current matrix's expected selection"
+            )
+        if node is None:
+            node, pressure = report.get("node"), report.get("pressure_mb")
+        elif report.get("node") != node or report.get("pressure_mb") != pressure:
+            raise Violation(f"{source}: node/pressure configuration differs across shards")
+
+    missing_shards = sorted(set(expected_by_shard) - set(by_shard))
+    if missing_shards:
+        raise Violation(f"missing shard reports: {missing_shards}")
+
+    merged_cells: list[dict[str, Any]] = []
+    for shard_index in range(1, expect + 1):
+        report, source = by_shard[shard_index]
+        cells = report.get("cells")
+        if not isinstance(cells, list):
+            raise Violation(f"{source}: cells must be an array")
+        wanted_tests = set(expected_by_shard[shard_index])
+        # The historical manifest currently repeats three witnesses. Preserve
+        # that exact workload: cells are a multiset, not a set, and each listed
+        # occurrence must arrive once from its deterministic shard.
+        wanted_keys = Counter(
+            (test, arm)
+            for test in expected_by_shard[shard_index]
+            for arm in arm_ids
+        )
+        found_keys: Counter[tuple[str, str]] = Counter()
+        for cell in cells:
+            if not isinstance(cell, dict):
+                raise Violation(f"{source}: every cells[] entry must be an object")
+            test, arm, result = cell.get("test"), cell.get("arm"), cell.get("result")
+            key = (test, arm)
+            if test not in wanted_tests:
+                raise Violation(
+                    f"{source}: test {test!r} does not belong to deterministic shard {shard_index}/{expect}"
+                )
+            if arm not in expected_arm_set:
+                raise Violation(f"{source}: unexpected arm {arm!r}")
+            if result not in RESULTS:
+                raise Violation(f"{source}: invalid result {result!r} for {test}/{arm}")
+            found_keys[key] += 1
+            merged_cells.append(cell)
+        missing_cells = sorted((wanted_keys - found_keys).elements())
+        extra_cells = sorted((found_keys - wanted_keys).elements())
+        if missing_cells or extra_cells:
+            detail = []
+            if missing_cells:
+                detail.append(f"missing {len(missing_cells)} cells (first: {missing_cells[:3]})")
+            if extra_cells:
+                detail.append(f"unexpected {len(extra_cells)} cells (first: {extra_cells[:3]})")
+            raise Violation(f"{source}: incomplete shard coverage: {'; '.join(detail)}")
+
+        counts = Counter(cell["result"] for cell in cells)
+        declared_summary = report.get("summary")
+        expected_summary = {
+            "pass": counts["PASS"],
+            "unverified": counts["UNVER"],
+            "xfail": counts["XFAIL"],
+            "fail": counts["FAIL"],
+        }
+        if declared_summary != expected_summary:
+            raise Violation(
+                f"{source}: summary {declared_summary!r} does not match its cells {expected_summary!r}"
+            )
+
+    expected_cells = len(corpus) * len(arms)
+    if len(merged_cells) != expected_cells:
+        raise Violation(f"merged {len(merged_cells)} cells, expected {expected_cells}")
+    expected_keys = Counter((test, arm) for test in corpus for arm in arm_ids)
+    merged_keys = Counter((cell["test"], cell["arm"]) for cell in merged_cells)
+    if merged_keys != expected_keys:
+        raise Violation("merged cell multiset does not match the manifest x arm cross-product")
+
+    counts = Counter(cell["result"] for cell in merged_cells)
+    return {
+        "node": node,
+        "pressure_mb": pressure,
+        "complete": True,
+        "merged_from": expect,
+        "arms": arms,
+        "cells": merged_cells,
+        "summary": {
+            "pass": counts["PASS"],
+            "unverified": counts["UNVER"],
+            "xfail": counts["XFAIL"],
+            "fail": counts["FAIL"],
+        },
+    }
+
+
+def _fixture_report(
+    shard: int,
+    total: int,
+    corpus: list[str],
+    arms: list[dict[str, str]],
+) -> dict[str, Any]:
+    tests = corpus[shard - 1 :: total]
+    cells = []
+    for test in tests:
+        for arm in arms:
+            cells.append(
+                {
+                    "test": test,
+                    "arm": arm["id"],
+                    "result": "PASS",
+                    "cycles": 1,
+                    "evacuated": 1 if arm["requires"] == "move" else 0,
+                    "scavenged": 0,
+                    "reclaimed": 0,
+                    "evidence": "fixture",
+                }
+            )
+    return {
+        "node": "26.5.1",
+        "pressure_mb": "8",
+        "complete": True,
+        "shard": {
+            "index": shard,
+            "count": total,
+            "corpus_total": len(corpus),
+            "corpus_selected": len(tests),
+        },
+        "arms": arms,
+        "cells": cells,
+        "summary": {"pass": len(cells), "unverified": 0, "xfail": 0, "fail": 0},
+    }
+
+
+def self_test() -> int:
+    failures = []
+    # `a` is intentionally repeated, matching the real manifest's historical
+    # repeated witnesses and exercising multiset coverage across shards.
+    corpus = ["a", "b", "c", "a", "d"]
+    arms = [{"id": "move", "requires": "move"}, {"id": "control", "requires": "none"}]
+    good = [_fixture_report(1, 2, corpus, arms), _fixture_report(2, 2, corpus, arms)]
+
+    def expect(name: str, reports: list[dict[str, Any]], should_fail: bool) -> None:
+        try:
+            merge(reports, [f"s{i + 1}" for i in range(len(reports))], 2, arms, corpus)
+            failed = False
+        except Violation:
+            failed = True
+        if failed != should_fail:
+            failures.append(name)
+
+    expect("complete two-shard merge", good, False)
+    expect("missing shard rejected", good[:1], True)
+    duplicate = [json.loads(json.dumps(good[0])), json.loads(json.dumps(good[0]))]
+    expect("duplicate shard rejected", duplicate, True)
+    incomplete = json.loads(json.dumps(good))
+    incomplete[0]["complete"] = False
+    expect("incomplete report rejected", incomplete, True)
+    missing_cell = json.loads(json.dumps(good))
+    missing_cell[0]["cells"].pop()
+    expect("missing cell rejected", missing_cell, True)
+    wrong_slice = json.loads(json.dumps(good))
+    wrong_slice[0]["cells"][0]["test"] = "b"
+    expect("wrong deterministic slice rejected", wrong_slice, True)
+    bad_summary = json.loads(json.dumps(good))
+    bad_summary[0]["summary"]["pass"] -= 1
+    expect("dishonest summary rejected", bad_summary, True)
+
+    if failures:
+        print("gc_repsel_matrix_merge --self-test FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("gc_repsel_matrix_merge --self-test: OK (7 cases)")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("inputs", nargs="*", type=Path)
+    parser.add_argument("--expect", type=int)
+    parser.add_argument("--mode", choices=("pr", "all"))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if not args.expect or not args.mode or not args.output or not args.inputs:
+        parser.error("--expect, --mode, --output and at least one input are required")
+
+    try:
+        arms = expected_arms(args.mode, MATRIX.read_text(encoding="utf-8"))
+        corpus = corpus_from_manifest(MANIFEST.read_text(encoding="utf-8"))
+        reports = [load(path) for path in args.inputs]
+        merged = merge(reports, [str(path) for path in args.inputs], args.expect, arms, corpus)
+        registry = parse_registry(REGISTRY.read_text(encoding="utf-8")) if REGISTRY.exists() else {}
+        liveness_violations = check_report(merged, registry)
+    except Violation as exc:
+        print(f"GC MATRIX FAN-IN: {exc}", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(merged, handle, indent=1)
+        handle.write("\n")
+
+    for violation in liveness_violations:
+        print(f"LIVENESS GATE: {violation}", file=sys.stderr)
+    summary = merged["summary"]
+    print(
+        f"merged {args.expect} complete shard report(s) -> {args.output}: "
+        f"PASS={summary['pass']} UNVER={summary['unverified']} "
+        f"XFAIL={summary['xfail']} FAIL={summary['fail']}"
+    )
+    if liveness_violations or summary["fail"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- build the release compiler/runtime once and reuse the artifact across GC matrix workers
- split sweep/full runs into four stable 20-entry corpus shards while retaining all 22 arms; keep the PR subset as one shard
- add a strict fan-in that rejects missing, duplicate, interrupted, or incomplete shard coverage before applying corpus-wide liveness
- report the active file/environment and preserve an append-only progress journal when a shard is interrupted
- keep gc-stress as a blocking dependency of full-suite-gate

No package or crate version is bumped.

## Validation

- cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static
- filtered end-to-end matrix witness: evac_minor and shipped_default both PASS with complete JSON/progress evidence
- forced TERM: interruption journal preserved and complete JSON correctly withheld
- ci_plan, merge, liveness, and GC wiring self-tests
- actionlint .github/workflows/test.yml
- bash syntax and git diff checks

Closes #8915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - GC stress testing now runs across parallel shards for sweep and full validation tiers.
  - Shared build artifacts reduce repeated compilation during stress-test runs.
  - Sharded test reports are combined into a single validated report.
  - Coverage, duplicate results, configuration consistency, and liveness are checked before results are accepted.
  - Progress information and partial evidence are preserved when interrupted or unsuccessful.
- **Documentation**
  - Updated CI tier documentation to reflect the new GC stress-test frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->