### PR TITLE
fix(runtime): preserve async unwind depth across longjmp

### DIFF
--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -50,6 +50,15 @@ crate::perry_thread_local! {
     /// (Node runs ESM evaluation as a job inside a microtask checkpoint, so
     /// ticks queued at top level wait for the checkpoint to finish; #788).
     static ESM_EVAL_CHECKPOINT_PENDING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// Saved `ASYNC_BOX_EXECUTION_REFS` depths for nested microtask runners.
+    /// This state must not live in a Rust stack local: `longjmp` re-enters the
+    /// runner at `setjmp`, and optimized Linux builds may have reused that
+    /// local's stack slot while the protected callback was running (#8937).
+    /// Keeping the boundary out of the jumped-over frame also preserves the
+    /// distinct owner boundary of each re-entrant runner.
+    static ASYNC_BOX_EXECUTION_REF_BASES: std::cell::RefCell<Vec<u32>> =
+        const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// Whether this thread is already executing a microtask pump, including its
@@ -204,7 +213,9 @@ fn rooted_closure(h: &crate::gc::RuntimeHandle<'_>) -> ClosurePtr {
 fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
     mt_profile_register();
     bump(&MT_DRAIN_COUNT);
-    let async_box_ref_depth = async_box_execution_ref_depth();
+    let async_box_ref_depth = u32::try_from(async_box_execution_ref_depth())
+        .expect("microtask execution-ref depth overflow");
+    ASYNC_BOX_EXECUTION_REF_BASES.with(|bases| bases.borrow_mut().push(async_box_ref_depth));
     let reentrant = MICROTASK_RUN_DEPTH.with(|depth| {
         let mut current = depth.get();
         let reentrant = current.pump > 0;
@@ -308,6 +319,16 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
         // exactly the activation references acquired since THIS (possibly
         // re-entrant) runner began; an enclosing activation is below the saved
         // depth and must remain owned when this runner returns.
+        // Re-read the boundary from TLS after the non-local jump. A Rust local
+        // captured before `setjmp` is not stable here in optimized builds: its
+        // storage can be reused on the ordinary path before `longjmp` resumes
+        // this branch (#8937).
+        let async_box_ref_depth = ASYNC_BOX_EXECUTION_REF_BASES.with(|bases| {
+            *bases
+                .borrow()
+                .last()
+                .expect("microtask execution-ref boundary")
+        }) as usize;
         unwind_async_box_execution_refs(async_box_ref_depth);
         if !cur.is_null() {
             unsafe {
@@ -1104,6 +1125,14 @@ fn run_microtasks(mode: MicrotaskDrainMode) -> i32 {
     {
         crate::r#box::flush_released_boxes();
     }
+
+    ASYNC_BOX_EXECUTION_REF_BASES.with(|bases| {
+        let base = bases
+            .borrow_mut()
+            .pop()
+            .expect("microtask execution-ref boundary");
+        debug_assert_eq!(async_box_execution_ref_depth(), base as usize);
+    });
 
     MICROTASK_RUN_DEPTH.with(|depth| {
         let mut current = depth.get();

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -305,6 +305,12 @@
     },
     {
       "file": "crates/perry-runtime/src/promise/microtasks.rs",
+      "name": "ASYNC_BOX_EXECUTION_REF_BASES",
+      "verdict": "not_a_gc_pointer",
+      "why": "Vec<u32> of checked length snapshots from ASYNC_BOX_EXECUTION_REFS. Every entry comes only from Vec::len() and is used only as a later Vec drain boundary; no address or JS value can enter this vector, and entries are never dereferenced or decoded."
+    },
+    {
+      "file": "crates/perry-runtime/src/promise/microtasks.rs",
       "name": "CURRENT_MICROTASK_VALUE",
       "verdict": "covered_elsewhere",
       "scanner": "promise::scan_promise_roots_mut (promise/scanners.rs:66, visit_cell_f64_slot) plus its budgeted step twin scan_current_microtask_value_step (scanners.rs:420); registered via reg_budgeted_scanner! at gc/mod.rs:833-838",


### PR DESCRIPTION
## Summary

- keep each microtask runner's async-box execution-ref boundary in thread-local state instead of a Rust stack local read after `longjmp`
- preserve distinct boundaries for re-entrant microtask drains and assert execution refs are balanced at runner exit
- store the checked boundary as pointer-free `u32` data and document that GC-root-holder verdict
- fix the Linux x86_64 `node_stream` error-path harness abort from #8937

No version bump is included.

## Testing

On `root@perrymaster.skelpo.net` (Linux x86_64, rustc 1.100.0-nightly):

- Before the fix, `cargo test --release -p perry-runtime --lib node_stream:: -- --test-threads=1` aborted in `unwind_async_box_execution_refs` with a garbage range start (`5281019308720`)
- After the final fix, the same suite passed: 85 passed, 0 failed
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: 2744 passed, 0 failed, 4 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check_thread_locals.py`
- `python3 scripts/gc_runtime_root_holders.py`
- `python3 scripts/check_gc_scanner_latches.py`