### PR TITLE
bench: populated-object delete churn — the ~200× gap, and why a memo cannot fix it

### DIFF
--- a/benchmarks/bench_populated_delete.ts
+++ b/benchmarks/bench_populated_delete.ts
@@ -1,0 +1,38 @@
+// Benchmark: delete/re-add churn on a POPULATED object — the cache/dictionary
+// pattern (`delete obj[k]; obj[k] = v` with k rotating over resident keys).
+//
+// Measured 2026-08-29 (16-core Linux host, node v26.8.1, N = 200_000,
+// 500 resident keys):
+//
+//   node        37 ms
+//   perry   ~8_000 ms        (~200x)
+//
+// This is EIGHT TIMES worse than the 0<->1-key delete oscillation
+// (`bench_dynamic_property_keys`' delete loop, ~25x after #8936), because the
+// churn cost scales with the RESIDENT key count: every iteration pays a
+// 500-element keys-array clone on the delete, a second clone on the re-add
+// (appending to a shared array), two layout rebuilds, two shape-descriptor
+// mints (with `ShapeFacts` hashing and reverse-index maintenance), and a
+// 500-slot value shift. O(resident keys) per delete, with large constants.
+//
+// A delete-transition memo (V8-style back-transitions keyed on the keys
+// array's ADDRESS) was built and measured against this benchmark: it was a
+// WASH, twice, in drift-cancelling interleaved A/B pairs — with rotating keys
+// each delete+re-add changes the shape, so the next delete is a fresh
+// (shape, key) pair and address-keyed memoisation never converges. It was
+// deleted rather than shipped. The structural fix needs a content-stable
+// shape identity (facts independent of the keys array's address), so that
+// equal key-sets reuse one canonical shape regardless of which clone produced
+// them — that is a shape-interning change, not a cache.
+const o: Record<string, number> = {};
+for (let i = 0; i < 500; i++) o["k" + i] = i;
+let s = 0;
+const N = 200000;
+const t = Date.now();
+for (let i = 0; i < N; i++) {
+  const k = "k" + (i % 500);
+  delete o[k];
+  o[k] = i;
+  s += o[k];
+}
+console.log("popdel_ms=" + (Date.now() - t) + " chk=" + (s % 7));


### PR DESCRIPTION
Adds `benchmarks/bench_populated_delete.ts`: `delete obj[k]; obj[k] = v` with `k` rotating over 500 resident keys — the cache/dictionary pattern.

| engine | time |
|---|---:|
| node | 37 ms |
| perry | ~8 000 ms (**~200×**) |

Eight times worse than the 0↔1-key delete oscillation (~25× after #8936), because the churn cost scales with the **resident** key count: per operation, two 500-element keys-array clones (delete + re-add-to-shared), two layout rebuilds, two shape-descriptor mints with `ShapeFacts` hashing and reverse-index maintenance, and a 500-slot value shift.

### The negative result this PR preserves

A V8-style **delete-transition memo** (back-transitions keyed on the keys array's address, with the inverse edge recorded at the add-transition funnel so cycles converge) was built for this, GC-integrated on the weak+reap model from #8900, and passed the full 2762-test suite.

It was then measured as a **wash — twice** — in drift-cancelling interleaved A/B pairs, and deleted rather than shipped. The reason is structural, and worth having on record so it is not rebuilt: with rotating keys, every delete+re-add changes the shape, so the next delete is a fresh `(shape, key)` pair. Address-keyed memoisation only converges for same-key churn, which is not what real workloads do.

### What the fix actually is

**Content-stable shape identity**: `ShapeFacts` currently includes the keys array's *address*, so equal key-sets produced by different clones get different shapes. Interning shapes by content would let every clone of the same key-set land on one canonical shape — no mint, no reap, no reverse-index churn — and it subsumes the unbounded shape-table growth measured in #8899 (786 k descriptors for <400 live objects). This benchmark is the acceptance test for that work.

First measured on the ~25× overwrite path's residue; the 200× here makes populated delete the worst known gap to node in the object model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone benchmark for measuring delete-and-readd performance on populated objects.
  * Reports elapsed time and a checksum for consistent performance comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->