### PR TITLE
codegen: inline the multi-arm direct-method receiver probe

### DIFF
--- a/changelog.d/0000-inline-method-shape-probe.md
+++ b/changelog.d/0000-inline-method-shape-probe.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Multi-arm direct method call sites (the subclass-arm compare chain, the indexed-dispatch shape probe and the short-spread method probe) resolve the receiver's `(class_id, ShapeId)` inline instead of through the runtime probe `js_method_direct_shape_class`: the same prototype-latch, pointer/heap-band, header-word and non-zero tests, ending in two `select`s so the zero-on-decline convention the chains rely on is unchanged. On the wolf-ecs cycle the probe was 2.2–2.6% of self time.

--- a/crates/perry-codegen/src/expr/call_spread_short.rs
+++ b/crates/perry-codegen/src/expr/call_spread_short.rs
@@ -268,17 +268,12 @@ pub(crate) fn try_lower<'f, 'e>(
     let key_idx = ctx.strings.intern(property);
     let entry = ctx.strings.entry(key_idx);
     let method_guard_slot = (entry.dispatch_hash & 0xffff).to_string();
-    let shape_out = ctx.func.alloca_entry(I32);
-    let live_class = ctx.block().call(
-        I32,
-        "js_method_direct_shape_class",
-        &[
-            (DOUBLE, &fast_recv),
-            (PTR, &shape_out),
-            (I32, &method_guard_slot),
-        ],
-    );
-    let live_shape = ctx.block().load(I32, &shape_out);
+    let (live_class, live_shape) =
+        crate::lower_call::method_override::emit_inline_direct_method_shape_probe(
+            ctx,
+            &fast_recv,
+            &method_guard_slot,
+        );
 
     let candidate_test_idxs: Vec<usize> = (0..candidates.len())
         .map(|index| ctx.new_block(&format!("short_spread.target_test{index}")))

--- a/crates/perry-codegen/src/expr/call_spread_short_tests.rs
+++ b/crates/perry-codegen/src/expr/call_spread_short_tests.rs
@@ -166,7 +166,11 @@ fn every_short_packed_arity_calls_reset_directly_without_apply() {
     let ir = emit();
     let invoke = function_body(&ir, "__invoke(");
     assert!(invoke.contains("call i32 @js_short_packed_spread_values("));
-    assert!(invoke.contains("call i32 @js_method_direct_shape_class("));
+    // The receiver probe is inline (`method_probe.*`): no runtime call.
+    assert!(
+        invoke.contains("method_probe.read") && !invoke.contains("@js_method_direct_shape_class("),
+        "the class/shape probe must be inline:\n{invoke}"
+    );
     let fast_prefix = &invoke[..invoke
         .find("\nshort_spread.method_probe")
         .expect("method-probe block")];
@@ -223,7 +227,11 @@ fn reverse_dependency_capabilities_activate_in_a_generic_consumer() {
         invoke.contains("call i32 @js_short_packed_spread_values("),
         "the generic consumer has no local concrete class, so activation proves the producer-to-consumer capability flow\n{invoke}"
     );
-    assert!(invoke.contains("call i32 @js_method_direct_shape_class("));
+    // The receiver probe is inline (`method_probe.*`): no runtime call.
+    assert!(
+        invoke.contains("method_probe.read") && !invoke.contains("@js_method_direct_shape_class("),
+        "the class/shape probe must be inline:\n{invoke}"
+    );
     assert!(invoke.contains("@perry_method_issue_8772_short_spread_ts__Position__reset("));
     assert!(invoke.contains("@perry_method_issue_8772_short_spread_ts__Velocity__reset("));
     assert!(ir.contains(

--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -295,6 +295,109 @@ pub(crate) fn emit_inline_direct_method_shape_guard(
     }
 }
 
+/// Inline form of the runtime probe `js_method_direct_shape_class`: resolve
+/// the live receiver's `(class_id, ShapeId)` for a multi-arm compare chain,
+/// or `(0, 0)` wherever the probe would decline — a non-pointer, an address
+/// outside the heap band, a non-`GC_TYPE_OBJECT` / forwarded /
+/// descriptor-bearing / packed-numeric-proof header, a tripped prototype
+/// latch (process-wide or for this method's dispatch slot), a zero class id
+/// or a zero ShapeId. The chains only ever compare both words against
+/// compiler-published non-zero pairs, so the zero convention is preserved by
+/// two `select`s rather than extra blocks.
+///
+/// The header word and the packed `class_id | ShapeId << 32` load are the
+/// ones [`emit_inline_direct_method_shape_guard`] already uses for the
+/// single-arm form; this is the same sequence without the comparison baked
+/// in. On the wolf-ecs cycle the runtime probe was 2.2–2.6% of self time on
+/// call, address classification and flag resolution for a few loads.
+pub(crate) fn emit_inline_direct_method_shape_probe(
+    ctx: &mut FnCtx<'_>,
+    recv_box: &str,
+    method_guard_slot: &str,
+) -> (String, String) {
+    let deref_idx = ctx.new_block("method_probe.deref");
+    let read_idx = ctx.new_block("method_probe.read");
+    let merge_idx = ctx.new_block("method_probe.merge");
+    let deref_label = ctx.block_label(deref_idx);
+    let read_label = ctx.block_label(read_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    let heap_floor =
+        crate::target_layout::heap_addr_lower_bound_inclusive(ctx.target_triple).to_string();
+    let heap_ceiling =
+        crate::target_layout::heap_addr_upper_bound_exclusive(ctx.target_triple).to_string();
+    let check_end = {
+        let blk = ctx.block();
+        let invalidated =
+            blk.load_atomic_acquire(I8, "@PERRY_CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED", 1);
+        let all_methods_ok = blk.icmp_eq(I8, &invalidated, "0");
+        let method_slot_ptr = blk.gep(
+            I8,
+            "@PERRY_CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED_BY_METHOD",
+            &[(I64, method_guard_slot)],
+        );
+        let method_invalidated = blk.load_atomic_acquire(I8, &method_slot_ptr, 1);
+        let method_ok = blk.icmp_eq(I8, &method_invalidated, "0");
+        let prototype_ok = blk.and(I1, &all_methods_ok, &method_ok);
+        let recv_bits = blk.bitcast_double_to_i64(recv_box);
+        let recv_handle = blk.and(I64, &recv_bits, crate::nanbox::POINTER_MASK_I64);
+        let tag = blk.lshr(I64, &recv_bits, "48");
+        let is_tagged_ptr = blk.icmp_eq(I64, &tag, POINTER_TAG_HI16);
+        // `normalize_raw_object_addr` also accepts the top-word-zero raw
+        // address form internal method ABIs carry.
+        let is_raw_ptr = blk.icmp_eq(I64, &tag, "0");
+        let is_ptr = blk.or(I1, &is_tagged_ptr, &is_raw_ptr);
+        let above_floor = blk.icmp_uge(I64, &recv_handle, &heap_floor);
+        let below_ceiling = blk.icmp_ult(I64, &recv_handle, &heap_ceiling);
+        let in_heap_range = blk.and(I1, &above_floor, &below_ceiling);
+        let ptr_safe = blk.and(I1, &is_ptr, &in_heap_range);
+        let can_deref = blk.and(I1, &prototype_ok, &ptr_safe);
+        blk.cond_br(&can_deref, &deref_label, &merge_label);
+        blk.label.clone()
+    };
+    ctx.current_block = deref_idx;
+    let deref_end = {
+        let blk = ctx.block();
+        let recv_bits = blk.bitcast_double_to_i64(recv_box);
+        let recv_handle = blk.and(I64, &recv_bits, crate::nanbox::POINTER_MASK_I64);
+        let obj_ptr = blk.inttoptr(I64, &recv_handle);
+        let gc_header_ptr = blk.gep(I8, &obj_ptr, &[(I64, "-8")]);
+        let gc_header = blk.load(I32, &gc_header_ptr);
+        let guarded_gc_bits = blk.and(I32, &gc_header, GC_OBJECT_METHOD_GUARD_MASK_I32);
+        let gc_header_ok = blk.icmp_eq(I32, &guarded_gc_bits, GC_TYPE_OBJECT);
+        blk.cond_br(&gc_header_ok, &read_label, &merge_label);
+        blk.label.clone()
+    };
+    ctx.current_block = read_idx;
+    let (cid, shape_id, read_end) = {
+        let blk = ctx.block();
+        let recv_bits = blk.bitcast_double_to_i64(recv_box);
+        let recv_handle = blk.and(I64, &recv_bits, crate::nanbox::POINTER_MASK_I64);
+        let obj_ptr = blk.inttoptr(I64, &recv_handle);
+        // ObjectHeader: `class_id: u32` @0, authoritative ShapeId @4.
+        let class_id = blk.load(I32, &obj_ptr);
+        let shape_ptr = blk.gep(I8, &obj_ptr, &[(I64, "4")]);
+        let shape_id = blk.load(I32, &shape_ptr);
+        let class_nonzero = blk.icmp_ne(I32, &class_id, "0");
+        let shape_nonzero = blk.icmp_ne(I32, &shape_id, "0");
+        let both = blk.and(I1, &class_nonzero, &shape_nonzero);
+        let cid = blk.select(I1, &both, I32, &class_id, "0");
+        let shape = blk.select(I1, &both, I32, &shape_id, "0");
+        blk.br(&merge_label);
+        (cid, shape, blk.label.clone())
+    };
+    ctx.current_block = merge_idx;
+    let blk = ctx.block();
+    let cid_out = blk.phi(
+        I32,
+        &[("0", &check_end), ("0", &deref_end), (&cid, &read_end)],
+    );
+    let shape_out = blk.phi(
+        I32,
+        &[("0", &check_end), ("0", &deref_end), (&shape_id, &read_end)],
+    );
+    (cid_out, shape_out)
+}
+
 /// Emit the exact ordinary-object `(class_id, ShapeId)` guard used by a
 /// `$pshape_args` route.  Unlike the method-receiver guard above this does not
 /// consult prototype-method invalidation state: it proves field offsets only.
@@ -877,17 +980,8 @@ pub(super) fn emit_guarded_direct_method_call(
     let multi_arm = !subclass_arms.is_empty();
     let inline_single_arm = shape_only_guard && !multi_arm;
     if multi_arm {
-        let shape_slot = ctx.func.alloca_entry(I32);
-        let cid = ctx.block().call(
-            I32,
-            "js_method_direct_shape_class",
-            &[
-                (DOUBLE, recv_box),
-                (crate::types::PTR, &shape_slot),
-                (I32, &method_guard_slot_str),
-            ],
-        );
-        let shape_id = ctx.block().load(I32, &shape_slot);
+        let (cid, shape_id) =
+            emit_inline_direct_method_shape_probe(ctx, recv_box, &method_guard_slot_str);
         {
             let next = sub_test_labels[0].clone();
             let blk = ctx.block();

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -69,7 +69,7 @@ pub(crate) use func_ref::{
     guarded_path_type,
 };
 mod jsx;
-mod method_override;
+pub(crate) mod method_override;
 pub(crate) use method_override::emit_inline_direct_method_shape_guard;
 mod namespace_call;
 mod native;

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -435,17 +435,12 @@ pub(crate) fn try_lower_instance_method_call(
             };
             let mut shape_probe_cid: Option<String> = None;
             if !shape_probe_arms.is_empty() {
-                let shape_slot = ctx.func.alloca_entry(I32);
-                let cid = ctx.block().call(
-                    I32,
-                    "js_method_direct_shape_class",
-                    &[
-                        (DOUBLE, &recv_box),
-                        (crate::types::PTR, &shape_slot),
-                        (I32, &method_guard_slot_str),
-                    ],
-                );
-                let shape_id = ctx.block().load(I32, &shape_slot);
+                let (cid, shape_id) =
+                    crate::lower_call::method_override::emit_inline_direct_method_shape_probe(
+                        ctx,
+                        &recv_box,
+                        &method_guard_slot_str,
+                    );
                 shape_probe_cid = Some(cid.clone());
                 let own_idx = ctx.new_block("idisp.own_probe");
                 let test_idxs: Vec<usize> = (1..shape_probe_arms.len())


### PR DESCRIPTION
## What

Multi-arm direct method call sites resolve the live receiver's `(class_id, ShapeId)` before their compare chain. Three of them still did it through the runtime probe `js_method_direct_shape_class` — the subclass-arm form of `emit_guarded_direct_method_call`, the indexed-dispatch shape probe (`dynamic_dispatch.rs`) and the short-spread method probe (`call_spread_short.rs`) — i.e. a call, a heap-address classification and the flag resolution for what is a handful of loads.

`emit_inline_direct_method_shape_probe` (`lower_call/method_override.rs`) emits the same decision inline: the process-wide and per-method prototype latches, the tagged-or-raw pointer test against the target's heap band, the packed header word masked to `GC_TYPE_OBJECT` / not forwarded / no descriptors / no packed-numeric proof (the mask the single-arm inline guard `emit_inline_direct_method_shape_guard` already uses), then the `class_id` and ShapeId loads with two `select`s that keep the runtime's zero-on-decline contract — `dynamic_dispatch.rs` relies on the zero to route declined receivers to the runtime fallback. The compare chains after the probe are untouched. No runtime changes.

## Why

Fresh symbol-level profile of the wolf-ecs twins (Linux `perf`, 10 s): `js_method_direct_shape_class` is 2.2% (entity cycle) / 2.6% (add/remove) of self time; `addComponent$pshape`, `removeComponent$pshape` and `destroyEntity$pshape` each carry the probe on their `sset.add`/`sset.remove` sites (36 sites in the module).

## Verification (local, per the campaign rule)

- `call_spread_short_tests` now pins `method_probe.read` present and no `@js_method_direct_shape_class(` call at the short-spread site; `proven_this_routing_tests` unchanged. `cargo test -p perry-codegen`: 1813 passed / 0 failed.
- Full gate run (`-D warnings`, transform/hir suites, file size, GC store inventory, raw-handle debt, census, local-binding, addr-class) and the Mac-mini paired screens (current main `6d10e8a1d` → this PR, 2 s + 50 ms, 11 pairs) are running; posting both as comments.

https://claude.ai/code/session_019WVcWKmYsUBnnFB7nBgbBJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved direct method dispatch by resolving receiver information inline, reducing reliance on runtime probing.
  - May improve execution speed for subclass calls, indexed dispatch, and short-spread method calls.

- **Bug Fixes**
  - Preserved existing dispatch behavior, including prototype checks, shape validation, and fallback handling.

- **Tests**
  - Updated coverage to verify inline method probing and ensure equivalent behavior across local and reverse-dependency scenarios.

- **Documentation**
  - Added a changelog entry describing the dispatch performance improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->