### PR TITLE
perf(runtime): closure_is_arrow from the dispatch cache; ReadonlySet.has leaf; Set.clear empty exit (ECS round 4)

### DIFF
--- a/changelog.d/8952-closure-arrow-set-leaf.md
+++ b/changelog.d/8952-closure-arrow-set-leaf.md
@@ -1,0 +1,1 @@
+- **runtime:** `closure_is_arrow` takes its answer from the memoised dispatch strategy instead of a second thread-local registry probe per receiver rebind; `ReadonlySet.has` outlines its structural fallback so the genuine-`Set` arm is a leaf; `Set.clear()` on an already-empty set returns before the side-table probe.

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -658,7 +658,13 @@ pub fn closure_is_arrow(closure: *const ClosureHeader) -> bool {
     if func_ptr.is_null() {
         return false;
     }
-    is_registered_arrow_function(func_ptr)
+    // The unified dispatch strategy already carries arrow-ness (the same
+    // registry answer, memoised per body and kept coherent by
+    // `js_register_closure_arrow_function`'s invalidation), and the call
+    // that follows a receiver rebind resolves it anyway — so answer from the
+    // recent-bodies cache instead of a second thread-local hash probe per
+    // call. (`this.handler(a, b)` on a closure-typed field paid both.)
+    resolve_strategy(func_ptr).is_arrow()
 }
 
 /// True if `closure` is a bound-method / bound-function value (its body is the

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -1194,10 +1194,18 @@ pub unsafe extern "C-unwind" fn js_readonly_set_has(receiver: f64, value: f64) -
         }
     }
 
-    // The structural fallback can allocate and re-enter generated code. Root
-    // both operands before crossing that boundary, then pass refreshed values
-    // into the existing dispatcher (which establishes its own roots before
-    // the first collecting probe).
+    readonly_set_has_structural(receiver, value)
+}
+
+/// The structural fallback of [`js_readonly_set_has`]: it can allocate and
+/// re-enter generated code, so it roots both operands before crossing that
+/// boundary and passes refreshed values into the existing dispatcher (which
+/// establishes its own roots before the first collecting probe). Out of line
+/// so the genuine-`Set` arm above is a leaf: with the handle scope inlined,
+/// every `componentTypeSet.has(type)` paid the fallback's full frame.
+#[cold]
+#[inline(never)]
+unsafe fn readonly_set_has_structural(receiver: f64, value: f64) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let receiver_handle = scope.root_nanbox_f64(receiver);
     let value_handle = scope.root_nanbox_f64(value);
@@ -1452,6 +1460,12 @@ pub extern "C" fn js_set_clear(set: *mut SetHeader) {
         return;
     }
     unsafe {
+        // The side-table mirrors the elements exactly, so an already-empty
+        // set has nothing to reset — half of a change set's per-entity
+        // `adds.clear(); removes.clear()` — and skips the table probe.
+        if (*set).size == 0 {
+            return;
+        }
         (*set).size = 0;
     }
     SET_INDEX.with(|idx| {
@@ -2137,6 +2151,23 @@ mod tests {
         let size = js_set_size(set);
         js_set_add(set, 3.0);
         assert_eq!(js_set_size(set), size);
+        // Clearing an empty set is a no-op that leaves it usable; clearing a
+        // populated one resets the side-table (the re-added value is found,
+        // the removed ones are not).
+        let empty = js_set_alloc(2);
+        js_set_clear(empty);
+        js_set_add(empty, 3.0);
+        assert_eq!(js_set_has(empty, 3.0), 1);
+        js_set_clear(set);
+        assert_eq!(js_set_size(set), 0);
+        assert_eq!(js_set_has(set, 1.0), 0);
+        js_set_add(set, 1.0);
+        assert_eq!(js_set_has(set, 1.0), 1);
+        js_set_clear(set);
+        // Restore the members the tail below expects (2 was deleted above).
+        for value in [1.0, 3.0, 4.0] {
+            js_set_add(set, value);
+        }
         // Growing past the scan bound hands every lookup to the side-table.
         for value in 100..120 {
             js_set_add(set, value as f64);


### PR DESCRIPTION
Three small runtime mechanisms from the ECS round-4 chain, cut from current main (`23a211383`). Suites on the isolated perrymaster gate: `set::` (54, serial) + runtime (2752). Paired measurement on the `codehz/ecs` "5k entities: 3 commands each + sync" row (idle Mac mini, alternating pairs) follows in a comment.

- **`closure_is_arrow` answers from the dispatch cache.** It probed the arrow registry — a thread-local hash lookup — on every receiver rebind, i.e. on every `this.handler(a, b)` call through a closure-typed field (`CommandBuffer.execute`'s `this.executeEntityCommands(entityId, commands)`, 5k/frame: `closure_is_arrow` 0.8% + the rebind helper 0.9%), while the `DispatchStrategy` the call resolves right after already carries `is_arrow`, memoised per body in the recent-bodies cache and kept coherent by `js_register_closure_arrow_function`'s invalidation (#6475). Answer from that cache instead. (Stamping such facts into the closure header at allocation was considered and rejected: late registration during cyclic module init purges the strategy caches, and a stamped header cannot be purged.)
- **`js_readonly_set_has` is a leaf.** It inlined its structural fallback (a handle scope and the generic method dispatch), so the genuine-`Set` arm — `componentTypeSet.has(type)` on every command, 1.4% self — paid the fallback's frame. The fallback is outlined and cold.
- **`js_set_clear` exits on an already-empty set** before the side-table probe (the table mirrors the elements, so there is nothing to reset) — half of a change set's per-entity `adds.clear(); removes.clear()`; the small-Set lane test now also pins clear-on-empty and clear-then-reuse.

https://claude.ai/code/session_01FUvFrRNZyc5qknBiJbYbby


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime efficiency for closure checks and set operations.
  * Optimized membership checks and clearing already-empty sets, with no change to expected behavior.
* **Reliability**
  * Expanded coverage for set clearing and subsequent member re-addition scenarios.
* **Documentation**
  * Added changelog details covering the runtime performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->