### PR TITLE
test(parity): baseline expected-output matrix diffs

### DIFF
--- a/test-parity/parity_matrix_baseline.json
+++ b/test-parity/parity_matrix_baseline.json
@@ -1,6 +1,6 @@
 {
   "_schema": {
-    "description": "Baseline for scripts/parity_matrix_trend.py. Modules absent from `modules` must pass with zero diff lines. Entries here are existing module-inventory gaps that may fail until their top-level parity smoke tests are retired or narrowed.",
+    "description": "Baseline for scripts/parity_matrix_trend.py. Modules absent from `modules` must pass with zero diff lines. Entries here are existing module-inventory gaps that may fail until their top-level parity smoke tests are retired or narrowed, or passing tests whose explicit expected-output oracle intentionally differs from Node.",
     "max_diff_lines": "Integer maximum accepted unified-diff changed-line count, or null when the current broad inventory test has not been converted to an exact diff baseline yet.",
     "allowed_statuses": "Statuses accepted for the module. `pass` is always accepted as an improvement."
   },
@@ -141,6 +141,31 @@
       "max_diff_lines": 28,
       "issue": "8271"
     },
+    "namespace_const_cross_module": {
+      "test_id": "test_parity_namespace_const_cross_module",
+      "max_diff_lines": 28,
+      "issue": "8956"
+    },
+    "native_value_profile": {
+      "test_id": "test_parity_native_value_profile",
+      "max_diff_lines": 20,
+      "issue": "8956"
+    },
+    "numeric_enum_reverse_mapping_4509": {
+      "test_id": "test_parity_numeric_enum_reverse_mapping_4509",
+      "max_diff_lines": 25,
+      "issue": "8956"
+    },
+    "regex_replace_fn_lookahead": {
+      "test_id": "test_parity_regex_replace_fn_lookahead",
+      "max_diff_lines": 12,
+      "issue": "8956"
+    },
+    "request_subclass_stream_body": {
+      "test_id": "test_parity_request_subclass_stream_body",
+      "max_diff_lines": 11,
+      "issue": "8956"
+    },
     "sqlite": {
       "test_id": "test_parity_sqlite",
       "issue": "812",
@@ -205,6 +230,11 @@
       ],
       "max_diff_lines": 21,
       "issue": "8271"
+    },
+    "webassembly_graceful_fail_default": {
+      "test_id": "test_parity_webassembly_graceful_fail_default",
+      "max_diff_lines": 11,
+      "issue": "8956"
     },
     "zlib": {
       "test_id": "test_parity_zlib",

--- a/tests/test_parity_matrix_trend.py
+++ b/tests/test_parity_matrix_trend.py
@@ -82,6 +82,36 @@ class ParityMatrixTrendTests(unittest.TestCase):
             self.assertTrue(zlib["known"])
             self.assertEqual(zlib["diff_lines"], 2)
 
+    def test_passing_expected_output_difference_needs_explicit_baseline(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            test_id = "test_parity_expected_output"
+            self.write_json(root / "report.json", {
+                "results": [{"id": test_id, "status": "pass"}],
+            })
+            self.write_json(root / "known_failures.json", {})
+            self.write_json(root / "baseline.json", {"modules": {}})
+            self.write_output(root, test_id, "node\n", "expected\n")
+
+            result = self.run_checker(root)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("diff_lines 2 exceeds baseline 0", result.stdout)
+
+            self.write_json(root / "baseline.json", {
+                "modules": {
+                    "expected_output": {
+                        "test_id": test_id,
+                        "max_diff_lines": 2,
+                        "issue": "8956",
+                    }
+                }
+            })
+
+            result = self.run_checker(root)
+
+            self.assertEqual(result.returncode, 0, result.stdout)
+
     def test_new_untriaged_failure_fails(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Summary

The parity matrix treated every passing module as a Node-oracle test, so six tests that intentionally use explicit expected output exceeded the absent-module zero-diff default. This adds explicit, measured baselines for those six modules without changing their pass-only status requirement.

## Changes

- Add the six measured `max_diff_lines` ceilings to `test-parity/parity_matrix_baseline.json`, each with #8956 provenance.
- Keep `allowed_statuses` unset so only `pass` remains accepted.
- Document expected-output entries in the baseline schema description.
- Add a self-test proving an expected-output difference fails under the absent-module zero-diff default and passes with an explicit baseline.

## Related issue

Closes #8956

## Test plan

- [x] `python3 -m unittest discover -s tests -p "test_parity_matrix_trend.py" -v` (5 tests pass)
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Rechecked both archived 12-shard aggregate reports (`49279e99` and `a1e44c5d`): the six expected-output modules produce no matrix problems; only the semantic failures tracked by #8954 and #8955 remain.
- [x] `git diff --check`
- [ ] `cargo build --release` clean (not needed for JSON/Python test-only changes)
- [ ] Full workspace tests (not needed for JSON/Python test-only changes)
- [x] Added focused regression coverage in `tests/test_parity_matrix_trend.py`
- [ ] Docs update (not user-facing)
- [ ] Platform UI build (not applicable)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md.
- [x] My commit follows the repository's conventional prefix style.
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parity tracking for tests that pass while intentionally differing from Node’s expected output.
  * Added baseline coverage for six additional module scenarios.

* **Tests**
  * Added validation that output differences require an explicit baseline before parity checks pass.
  * Confirmed parity checks succeed once an approved difference is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->