### PR TITLE
perf(codegen): for-of over a Map reads its entries inline (ECS round 4 follow-up)

### DIFF
--- a/changelog.d/8960-map-entry-inline.md
+++ b/changelog.d/8960-map-entry-inline.md
@@ -1,0 +1,1 @@
+- **codegen:** `for (const [k, v] of map)` reads each entry's key and value inline from the Map's flat buffer (a `GC_TYPE_MAP` header test, a live-size bounds check and one load) instead of two runtime calls that each re-resolved the receiver; subclass instances, plain objects and out-of-range indices keep the runtime helpers.

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -75,6 +75,117 @@ use super::{
 // unsound the moment one of them was edited.
 use super::index_get::numeric_index_has_integer_array_index_proof;
 
+/// `for (const [k, v] of map)` entry read, inline.
+///
+/// Each iteration of the desugared loop read its key and its value through
+/// `js_map_entry_key_at` / `js_map_entry_value_at`, and each of those
+/// resolved the receiver again (`clean_map_ptr`: tag, magnitude, header,
+/// subclass redirect) to read one word of a flat buffer — two calls and two
+/// resolutions per entry, 0.8% of an ECS frame on its per-frame grouping
+/// map. The lowering here decides the common receiver from the same facts the
+/// resolver would establish — a NaN-boxed heap pointer above the handle band
+/// whose header is `GC_TYPE_MAP` and not forwarded — re-reads `size` and
+/// `entries` on every read (the body may `set`/`delete` and grow or compact
+/// the buffer, and the receiver itself is re-read from its root by the
+/// rooted-operand group), bounds-checks the index, and loads the slot. Every
+/// other shape — a subclass instance, a plain object, an out-of-range or
+/// negative index, an unpublished handle — takes the runtime helper exactly
+/// as before, so the two paths are equivalent by construction.
+fn lower_map_entry_at_inline(
+    ctx: &mut FnCtx<'_>,
+    m_box: &str,
+    i_dbl: &str,
+    runtime_fn: &str,
+    value_slot: bool,
+) -> Result<String> {
+    use crate::nanbox::POINTER_TAG_TOP16_I64;
+    use crate::types::{I1, I8};
+    const HANDLE_BAND_TOP: &str = "1048575"; // 0x0FFFFF — heap objects are above
+    const GC_TYPE_MAP: &str = "8";
+    const GC_FLAG_FORWARDED: &str = "128";
+    let stem = if value_slot {
+        "map_entry_value"
+    } else {
+        "map_entry_key"
+    };
+    let head_idx = ctx.new_block(&format!("{stem}.head"));
+    let fast_idx = ctx.new_block(&format!("{stem}.fast"));
+    let slow_idx = ctx.new_block(&format!("{stem}.slow"));
+    let merge_idx = ctx.new_block(&format!("{stem}.merge"));
+    let head_label = ctx.block_label(head_idx);
+    let fast_label = ctx.block_label(fast_idx);
+    let slow_label = ctx.block_label(slow_idx);
+    let merge_label = ctx.block_label(merge_idx);
+
+    // A heap pointer above the handle band, before any header is read.
+    let (m_handle, i_i32) = {
+        let blk = ctx.block();
+        let m_handle = unbox_to_i64(blk, m_box);
+        let i_i32 = blk.fptosi(DOUBLE, i_dbl, I32);
+        let bits = blk.bitcast_double_to_i64(m_box);
+        let top16 = blk.lshr(I64, &bits, "48");
+        let is_pointer = blk.icmp_eq(I64, &top16, POINTER_TAG_TOP16_I64);
+        let above_band = blk.icmp_ugt(I64, &m_handle, HANDLE_BAND_TOP);
+        let plausible = blk.and(I1, &is_pointer, &above_band);
+        blk.cond_br(&plausible, &head_label, &slow_label);
+        (m_handle, i_i32)
+    };
+    // The header: a live (not forwarded) genuine Map; the index in range of
+    // the live size.
+    ctx.current_block = head_idx;
+    {
+        let blk = ctx.block();
+        let type_addr = blk.sub(I64, &m_handle, "8");
+        let type_ptr = blk.inttoptr(I64, &type_addr);
+        let obj_type = blk.load(I8, &type_ptr);
+        let is_map = blk.icmp_eq(I8, &obj_type, GC_TYPE_MAP);
+        let flags_addr = blk.sub(I64, &m_handle, "7");
+        let flags_ptr = blk.inttoptr(I64, &flags_addr);
+        let gc_flags = blk.load(I8, &flags_ptr);
+        let forwarded = blk.and(I8, &gc_flags, GC_FLAG_FORWARDED);
+        let live = blk.icmp_eq(I8, &forwarded, "0");
+        let size_ptr = blk.inttoptr(I64, &m_handle);
+        let size = blk.load(I32, &size_ptr);
+        let in_range = blk.icmp_ult(I32, &i_i32, &size);
+        let a = blk.and(I1, &is_map, &live);
+        let admitted = blk.and(I1, &a, &in_range);
+        blk.cond_br(&admitted, &fast_label, &slow_label);
+    }
+    ctx.current_block = fast_idx;
+    let (fast_value, fast_pred) = {
+        let blk = ctx.block();
+        let entries_addr = blk.add(I64, &m_handle, "8");
+        let entries_ptr = blk.inttoptr(I64, &entries_addr);
+        let entries = blk.load(I64, &entries_ptr);
+        let index = blk.zext(I32, &i_i32, I64);
+        let entry_offset = blk.shl(I64, &index, "4");
+        let key_addr = blk.add(I64, &entries, &entry_offset);
+        let slot_addr = if value_slot {
+            blk.add(I64, &key_addr, "8")
+        } else {
+            key_addr
+        };
+        let slot_ptr = blk.inttoptr(I64, &slot_addr);
+        let value = blk.load(DOUBLE, &slot_ptr);
+        let pred = blk.label.clone();
+        blk.br(&merge_label);
+        (value, pred)
+    };
+    ctx.current_block = slow_idx;
+    let (slow_value, slow_pred) = {
+        let blk = ctx.block();
+        let value = blk.call(DOUBLE, runtime_fn, &[(I64, &m_handle), (I32, &i_i32)]);
+        let pred = blk.label.clone();
+        blk.br(&merge_label);
+        (value, pred)
+    };
+    ctx.current_block = merge_idx;
+    Ok(ctx.block().phi(
+        DOUBLE,
+        &[(&fast_value, &fast_pred), (&slow_value, &slow_pred)],
+    ))
+}
+
 fn lower_index_i32(ctx: &mut FnCtx<'_>, index: &Expr) -> Result<String> {
     if can_lower_expr_as_i32(
         index,
@@ -462,18 +573,15 @@ pub(crate) fn lower(
         // entries straight out of the Map's internal buffer instead of
         // calling `js_map_entries` (which materializes N+1 small Arrays).
         Expr::MapEntryKeyAt { map, idx } | Expr::MapEntryValueAt { map, idx } => {
-            let runtime_fn = match expr {
-                Expr::MapEntryKeyAt { .. } => "js_map_entry_key_at",
-                Expr::MapEntryValueAt { .. } => "js_map_entry_value_at",
+            let (runtime_fn, value_slot) = match expr {
+                Expr::MapEntryKeyAt { .. } => ("js_map_entry_key_at", false),
+                Expr::MapEntryValueAt { .. } => ("js_map_entry_value_at", true),
                 _ => unreachable!(),
             };
             rooting::with_operands_rooted(ctx, &[map, idx], |ctx, vals| {
                 let m_box = vals[0].clone();
                 let i_dbl = vals[1].clone();
-                let blk = ctx.block();
-                let m_handle = unbox_to_i64(blk, &m_box);
-                let i_i32 = blk.fptosi(DOUBLE, &i_dbl, I32);
-                Ok(blk.call(DOUBLE, runtime_fn, &[(I64, &m_handle), (I32, &i_i32)]))
+                lower_map_entry_at_inline(ctx, &m_box, &i_dbl, runtime_fn, value_slot)
             })
         }
 

--- a/crates/perry-codegen/src/expr/map_entry_at_tests.rs
+++ b/crates/perry-codegen/src/expr/map_entry_at_tests.rs
@@ -1,0 +1,82 @@
+//! The inline `for (const [k, v] of map)` entry read (`lower_map_entry_at_inline`).
+
+use crate::{compile_module, CompileOptions};
+use perry_hir::types::Type;
+use perry_hir::{Expr, Function, Module, Param, Stmt};
+
+fn param(id: u32, name: &str) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn entry_read_ir(value_slot: bool) -> String {
+    let read = if value_slot {
+        Expr::MapEntryValueAt {
+            map: Box::new(Expr::LocalGet(10)),
+            idx: Box::new(Expr::LocalGet(11)),
+        }
+    } else {
+        Expr::MapEntryKeyAt {
+            map: Box::new(Expr::LocalGet(10)),
+            idx: Box::new(Expr::LocalGet(11)),
+        }
+    };
+    let f = Function {
+        id: 1,
+        name: "read".to_string(),
+        type_params: Vec::new(),
+        params: vec![param(10, "m"), param(11, "i")],
+        return_type: Type::Any,
+        body: vec![Stmt::Return(Some(read))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    };
+    let mut module = Module::new("map_entry_at_test.ts");
+    module.functions = vec![f];
+    let opts = CompileOptions {
+        emit_ir_only: true,
+        ..Default::default()
+    };
+    String::from_utf8(compile_module(&module, opts).expect("fixture must compile"))
+        .expect("LLVM IR is UTF-8")
+}
+
+/// The admitted receiver reads the slot inline — a `GC_TYPE_MAP` header test,
+/// a live-size bounds check, the `entries` buffer re-read — and the runtime
+/// helper is kept as the fallback for every miss.
+#[test]
+fn map_entry_reads_are_inline_with_the_helper_as_the_fallback() {
+    let key_ir = entry_read_ir(false);
+    assert!(
+        key_ir.contains("map_entry_key.head")
+            && key_ir.contains("map_entry_key.fast")
+            && key_ir.contains("icmp eq i8")
+            && key_ir.contains("load double")
+            && key_ir.contains("call double @js_map_entry_key_at("),
+        "the key read should be inline with the helper as fallback:\n{key_ir}"
+    );
+    let value_ir = entry_read_ir(true);
+    assert!(
+        value_ir.contains("map_entry_value.fast")
+            && value_ir.contains("call double @js_map_entry_value_at("),
+        "the value read should be inline with the helper as fallback:\n{value_ir}"
+    );
+    // The value slot is the second word of the 16-byte entry.
+    assert!(
+        value_ir.contains("add i64 %") && value_ir.contains(", 8\n") || value_ir.contains(", 8 "),
+        "the value read should offset by one word within the entry:\n{value_ir}"
+    );
+}

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -33,6 +33,8 @@ use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR};
 // existing `crate::expr::X` paths resolve unchanged.
 mod array_literal;
 mod bitset_test;
+#[cfg(test)]
+mod map_entry_at_tests;
 pub(crate) use bitset_test::is_u32_bitset_test;
 mod buffer_access;
 mod buffer_views;


### PR DESCRIPTION
One codegen mechanism (the second of the two follow-ups agreed after round 4), cut from current main. Suites on the isolated perrymaster gate: codegen lib (1338, incl. the new `map_entry_reads_are_inline_with_the_helper_as_the_fallback`) + `native_proof_regressions` (280). Paired measurement on the `codehz/ecs` "5k entities: 3 commands each + sync" row (idle Mac mini, alternating pairs, control = the branch's merge base) follows in a comment.

- **`for (const [k, v] of map)` reads its entries inline.** Each iteration of the desugared loop read its key and its value through `js_map_entry_key_at` / `js_map_entry_value_at`, and each of those resolved the receiver again (`clean_map_ptr`: tag, magnitude, header, subclass redirect) to read one word of a flat buffer — two calls and two resolutions per entry, 0.8% of the ECS frame on its per-frame grouping map. `lower_map_entry_at_inline` decides the common receiver from the same facts the resolver would establish — a NaN-boxed heap pointer above the handle band whose header is `GC_TYPE_MAP` and not forwarded — re-reads `size` and `entries` on every read (the body may `set`/`delete` and grow or compact the buffer; the receiver itself is re-read from its root by the rooted-operand group), bounds-checks the index and loads the slot. Every other shape — a `class X extends Map` instance, a plain object, an out-of-range or negative index, a handle — takes the runtime helper exactly as before, so the two paths are equivalent by construction.

https://claude.ai/code/session_01FUvFrRNZyc5qknBiJbYbby


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Map iteration performance by reading keys and values more efficiently during entry access.
  * Added safe fallback behavior for unsupported Map shapes and invalid indexes.

* **Tests**
  * Added coverage validating optimized Map entry reads, bounds checking, and fallback behavior.

* **Documentation**
  * Added a changelog entry describing the Map iteration performance improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->