### PR TITLE
test(perry): short-spread integration tests assert the inline receiver probe (#8947 follow-up)

### DIFF
--- a/crates/perry/tests/issue_8772_short_packed_spread.rs
+++ b/crates/perry/tests/issue_8772_short_packed_spread.rs
@@ -226,7 +226,12 @@ fn repro_has_direct_empty_and_one_arms_and_matches_node_under_moving_gc() {
         .expect("read main LLVM IR");
     let invoke = function_ir(&ir, "__invoke(");
     assert!(invoke.contains("call i32 @js_short_packed_spread_values("));
-    assert!(invoke.contains("call i32 @js_method_direct_shape_class("));
+    // #8947: the receiver's (class_id, ShapeId) probe is emitted INLINE
+    // (`method_probe.*`) instead of calling `js_method_direct_shape_class`.
+    assert!(
+        invoke.contains("method_probe.read") && !invoke.contains("@js_method_direct_shape_class("),
+        "the short-spread method probe must be inline:\n{invoke}"
+    );
     let direct = named_blocks(
         invoke,
         &[
@@ -276,7 +281,12 @@ fn reverse_dependency_has_direct_arms_and_matches_node_under_moving_gc() {
         .expect("read generic consumer LLVM IR");
     let invoke = function_ir(&ir, "__invoke(");
     assert!(invoke.contains("call i32 @js_short_packed_spread_values("));
-    assert!(invoke.contains("call i32 @js_method_direct_shape_class("));
+    // #8947: the receiver's (class_id, ShapeId) probe is emitted INLINE
+    // (`method_probe.*`) instead of calling `js_method_direct_shape_class`.
+    assert!(
+        invoke.contains("method_probe.read") && !invoke.contains("@js_method_direct_shape_class("),
+        "the short-spread method probe must be inline:\n{invoke}"
+    );
     assert!(invoke.contains("@perry_method_reverse_ts__Position__reset("));
     assert!(invoke.contains("@perry_method_reverse_ts__Velocity__reset("));
     assert!(ir.contains("@perry_class_shape_id_reverse_ts__Position = external global i32"));


### PR DESCRIPTION
Main is red on `issue_8772_short_packed_spread`: two assertions still require `call i32 @js_method_direct_shape_class(`, which #8947 replaced with the inline `method_probe.*` sequence at that site. #8947 updated the codegen unit tests (`call_spread_short_tests.rs`) but missed these two integration assertions — my miss, sorry.

They now assert the same property on the new shape: `method_probe.read` present and no `@js_method_direct_shape_class(` call. Everything else in the file (node-identical output under both GC modes, the direct target blocks, the class-shape globals) is untouched.

Verified: `cargo test -p perry --test issue_8772_short_packed_spread` → 5 passed / 0 failed (it fails 2/5 on main without this).

https://claude.ai/code/session_019WVcWKmYsUBnnFB7nBgbBJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for short packed spread scenarios.
  * Tests now verify that receiver method probes are emitted using the expected inline representation, helping detect regressions in generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->