### PR TITLE
perf(runtime): reject non-private property names without validating UTF-8 (read −10.5%)

### DIFF
--- a/changelog.d/8970-private-member-name-fast-reject.md
+++ b/changelog.d/8970-private-member-name-fast-reject.md
@@ -1,0 +1,22 @@
+The generic property read and write no longer UTF-8-validate every key to
+discover it isn't a private class member.
+
+`private_member_storage_name` sits at the top of both `js_object_get_field_by_name`
+and `field_set_by_name`, so every property operation in the program pays it —
+and it reached its verdict through `str_from_string_header`, which validates
+the WHOLE key as UTF-8 before the prefix compare can reject it. In a
+computed-key read loop that measured ~7.5% self time (plus its share of
+`from_utf8`), all of it spent proving that `"k123"` does not begin with `#`.
+
+A storage name always starts with `#` and is longer than the
+`#<perry:private-member:` prefix, so a length compare and one byte settle it
+for every ordinary key. Keys that pass the filter still take the original
+path, so private members — and the rare `#`-prefixed ordinary key — behave
+exactly as before.
+
+Interleaved A/B, min-of-15 at quiet load: read loop 38 → 34 ms (−10.5%),
+combined overwrite loop 82 → 76 ms (−7.3%), write loop 44 → 43 ms; means move
+the same direction on all three. Output on a private-member differential
+(fields, static private counters, private methods, private getters, `#x in o`,
+subclassing, and an ordinary key named `#<perry:private-member:1:x>`) is
+byte-identical to pre-change perry.

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss/private_member_access.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss/private_member_access.rs
@@ -40,13 +40,50 @@ pub(crate) fn take_private_method_owner_hint(method_name: &str) -> Option<u32> {
     })
 }
 
+/// The prefix every private class member's storage name carries.
+const PRIVATE_MEMBER_PREFIX: &str = "#<perry:private-member:";
+
+/// Cheap rejection for the overwhelmingly common case: an ordinary property
+/// name is not a private-member storage name.
+///
+/// [`private_member_storage_name`] runs at the TOP of both the generic
+/// property read (`js_object_get_field_by_name`) and the generic write
+/// (`field_set_by_name`), so every property operation in the program pays it.
+/// It reaches that verdict via `str_from_string_header`, which UTF-8-validates
+/// the WHOLE key before the prefix compare can reject it — measured at ~7.5%
+/// self time in a computed-key read loop, plus its share of `from_utf8`, all
+/// of it spent proving that `"k123"` does not begin with `#`.
+///
+/// A storage name always starts with `#` and is at least `PRIVATE_MEMBER_PREFIX`
+/// long, so a length compare and one byte settle it for every ordinary key
+/// without validating anything. Only keys that pass this filter — private
+/// members and the rare `#`-prefixed user key — go on to the real check, so
+/// the slow path's behaviour is unchanged.
+#[inline(always)]
+fn cannot_be_private_member_name(key: *const crate::StringHeader) -> bool {
+    if key.is_null() {
+        return true;
+    }
+    // SAFETY: same reads `string_header_as_str` already performs on this
+    // pointer (null-checked header, then its payload); no new dereference.
+    unsafe {
+        if (*key).byte_len as usize <= PRIVATE_MEMBER_PREFIX.len() {
+            return true;
+        }
+        *crate::object::string_header_payload(key) != b'#'
+    }
+}
+
 fn private_member_storage_name(key: *const crate::StringHeader) -> Option<String> {
+    if cannot_be_private_member_name(key) {
+        return None;
+    }
     let key = unsafe { super::super::has_own_helpers::str_from_string_header(key) }?;
     private_member_storage_name_str(key).map(str::to_string)
 }
 
 fn private_member_storage_name_str(key: &str) -> Option<&str> {
-    let rest = key.strip_prefix("#<perry:private-member:")?;
+    let rest = key.strip_prefix(PRIVATE_MEMBER_PREFIX)?;
     let (_, name) = rest.split_once(':')?;
     name.strip_suffix('>')
 }


### PR DESCRIPTION
`private_member_storage_name` runs at the top of **both** the generic property read (`js_object_get_field_by_name`) and the generic write (`field_set_by_name`), so every property operation in the program pays it. It reached its verdict via `str_from_string_header`, which UTF-8-validates the *entire* key before the prefix compare can reject it.

In a computed-key read loop that is **~7.5% self time** (plus its share of `from_utf8`) — all of it spent proving that `"k123"` does not begin with `#`.

A private-member storage name always starts with `#` and is longer than the `#<perry:private-member:` prefix, so a length compare plus one byte settles it for every ordinary key, with no validation and no slice. Keys that pass the filter still take the original path, so private members and `#`-prefixed ordinary keys are untouched.

### Measurement

Interleaved A/B pairs, min-of-15, quiet load (~1.9), 16-core Linux host:

| loop | main | this PR | |
|---|---|---|---|
| read only | 38 ms | **34 ms** | −10.5% |
| combined overwrite | 82 ms | **76 ms** | −7.3% |
| write only | 44 ms | 43 ms | −2.3% |

Means move the same direction on all three (45→43, 93→85, 47→46). An earlier 6-pair run was inconclusive — the spread exceeded the effect — so this is the tightened measurement.

### Correctness

- `perry-runtime`: **2779 passed / 0 failed**.
- Differential against pre-change perry on a private-member exercise — instance fields, `static #instances`, private methods, private getters, `#x in obj`, subclassing, and an ordinary property literally named `#<perry:private-member:1:x>` — is **byte-identical**, including on the cases where perry currently diverges from node.
- The guard performs no dereference the previous path didn't already perform (null check, then `byte_len`, then the payload's first byte via the shared `string_header_payload` helper).

### Note

Building that differential surfaced three pre-existing correctness bugs in private class members on `main` (compound assignment on a private field yields `NaN`; private fields are enumerable own properties; an ordinary key matching the internal prefix is silently dropped). They are **not** affected by this PR — same output before and after — and are filed separately as #8969.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved property access performance by quickly filtering keys that cannot reference private members.
  * Reduced overhead in read and overwrite operations while preserving existing behavior.
* **Bug Fixes**
  * Maintained correct handling for private members and specially formatted keys.
* **Validation**
  * Confirmed output remains identical to the previous implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->