### PR TITLE
perf(runtime): one shape-descriptor lookup per dynamic write IC hit, not two

### DIFF
--- a/changelog.d/8975-single-shape-lookup-per-ic-hit.md
+++ b/changelog.d/8975-single-shape-lookup-per-ic-hit.md
@@ -1,0 +1,24 @@
+The dynamic write IC does one shape-descriptor lookup per hit instead of two.
+
+`object_shape_id` runs a full shape-table lookup — and copies the whole
+`ShapeDescriptor` out of the table — purely to prove the stamped id is live,
+then discards it. `dyn_ic_try_store` called it for the token compare and then
+looked the SAME id up again for the slot bound; both write re-prime sites did
+the same while already holding a descriptor.
+
+It now reads the stamp off the header. In `dyn_ic_try_store` the token compare
+runs first, so a wrong-shape receiver costs a load and a compare with no table
+work at all, and the single lookup that supplies the slot bound doubles as the
+liveness proof: a stamp with no live descriptor returns `None` exactly where
+`object_shape_id`'s 0 made the token compare fail before.
+
+Verified by profile rather than by wall clock, because the effect is close to
+the noise floor of the benchmark. In a computed-key write loop
+`shape_descriptor_by_id` falls **7.01% → 3.49%** of self time and
+`object_shape_id` (1.32%) leaves the profile entirely.
+
+Wall clock, interleaved A/B min-of-21 at quiet load, against the exact parent
+commit: write-only loop 42 → 40 ms min (−4.8%), mean 46 → 45. The combined
+overwrite loop and the read loop are unchanged, as expected for a change
+confined to the write IC. Computed-key differential output is byte-identical
+to node; suite 2779 passed, 0 failed.

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -451,8 +451,11 @@ pub extern "C" fn js_put_value_set_ic_miss(
             return result;
         }
 
+        // The descriptor above already proves this stamp is live, so the
+        // token comes from the header word rather than from a second full
+        // lookup-and-copy of the same id (see `dyn_ic_try_store`).
         let shape_token = crate::object::shapes::PIC_ID_TOKEN_BIT
-            | crate::object::shapes::object_shape_id(obj) as u64;
+            | crate::object::shapes::object_shape_stamp(obj) as u64;
 
         // Publish the token last conceptually: a zero-initialized or stale
         // token cannot hit this slot until it matches this receiver's current
@@ -712,12 +715,23 @@ unsafe fn dyn_ic_try_store(target: f64, token: u64, slot: u32, value: f64) -> Op
     {
         return None;
     }
-    let current_token = crate::object::shapes::PIC_ID_TOKEN_BIT
-        | crate::object::shapes::object_shape_id(obj) as u64;
-    if current_token != token {
+    // ONE descriptor lookup, not two. `object_shape_id` runs a full lookup —
+    // and copies the whole `ShapeDescriptor` out of the table — purely to
+    // prove the stamped id is live, then throws the descriptor away; the bound
+    // check below then looked the SAME id up again. `shape_descriptor_by_id`
+    // was 10.5% of self time in a computed-key write loop, the single largest
+    // item, and half of that was this duplicate.
+    //
+    // Read the stamp straight off the header, reject on the token first (a
+    // load and a compare, so a wrong-shape receiver costs no table work at
+    // all), and let the one lookup that supplies the bound double as the
+    // liveness proof: a stamp with no live descriptor returns `None` here,
+    // exactly as `object_shape_id`'s 0 made the token compare fail before.
+    let stamp = crate::object::shapes::object_shape_stamp(obj);
+    if (crate::object::shapes::PIC_ID_TOKEN_BIT | stamp as u64) != token {
         return None;
     }
-    let shape = crate::object::shapes::object_shape_descriptor(obj)?;
+    let shape = crate::object::shapes::shape_descriptor_by_id(stamp)?;
     if slot >= shape.live_inline_slot_count {
         // Overflow slot. The token compare above already proved the receiver
         // is in the exact shape the (key → slot) pair was learned in, so the
@@ -877,8 +891,11 @@ pub extern "C" fn js_put_value_set_dyn_ic_miss(
         let Some(idx) = own_idx else {
             return result;
         };
+        // The descriptor above already proves this stamp is live, so the
+        // token comes from the header word rather than from a second full
+        // lookup-and-copy of the same id (see `dyn_ic_try_store`).
         let shape_token = crate::object::shapes::PIC_ID_TOKEN_BIT
-            | crate::object::shapes::object_shape_id(obj) as u64;
+            | crate::object::shapes::object_shape_stamp(obj) as u64;
         let key_bits = key.to_bits() as i64;
         // Preserve the empty-way sentinel invariant: never prime bits 0
         // (only the JS number 0 has them, and numeric keys cannot prime


### PR DESCRIPTION
`object_shape_id` runs a full shape-table lookup — and copies the whole `ShapeDescriptor` out of the table — purely to prove the stamped id is live, then throws the descriptor away. `dyn_ic_try_store` called it for the token compare and then looked the **same id up again** for the slot bound; both write re-prime sites did the same while already holding a descriptor.

It now reads the stamp straight off the header. In `dyn_ic_try_store` the token compare runs first, so a wrong-shape receiver costs a load and a compare with no table work at all, and the one lookup that supplies the slot bound doubles as the liveness proof: a stamp with no live descriptor returns `None` exactly where `object_shape_id`'s `0` made the token compare fail before.

### Measurement — and what it does not show

`shape_descriptor_by_id` was the largest single item in a computed-key write profile (10.5% at the time it was found). The **mechanism is verified directly**: in that loop it falls **7.01% → 3.49%** of self time, and `object_shape_id` (1.32%) leaves the profile entirely.

The wall clock is a smaller story, and I would rather state it than round it up. Interleaved A/B, min-of-21, quiet load (~1.15), built from the exact parent commit and this commit in one run:

| loop | base | this PR | |
|---|---|---|---|
| write only | 42 ms | **40 ms** | −4.8% min, −2% mean |
| combined overwrite | 71 ms | 72 ms | unchanged |
| read only | 31 ms | 31 ms | unchanged (write-only change) |

So: a small, mechanically-confirmed reduction on the loop it targets, and neutral elsewhere. It is worth having because it is strictly less work for identical semantics, not because it moves a headline number.

An earlier comparison of mine suggested −7% to −12%; that was against binaries built before #8970 and #8971 merged, so it was crediting this change with their gains. The table above is against the correct parent.

### Correctness

- `perry-runtime`: **2779 passed / 0 failed**.
- `scripts/run_lint_gates.sh`: all gates pass (`ci_cargo_test_shard.py` needs `--total-shards 8`, which passes when supplied).
- Computed-key differential vs node — delete/re-add ordering, `Map`/`Set` keys, the SSO boundary, non-ASCII, floats, negatives, 1e21: **byte-identical**.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dynamic property writes by reducing shape lookups during inline-cache hits.
  * Wrong-shape writes now avoid unnecessary table work.
  * Write-only workloads show a measurable performance improvement, while overwrite and read performance remain unchanged.
* **Reliability**
  * Preserved computed-key output with byte-identical results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->