### PR TITLE
test(parser): cover Unicode whitespace regex literals (#8902)

### DIFF
--- a/changelog.d/8989-regex-literal-unicode-whitespace.md
+++ b/changelog.d/8989-regex-literal-unicode-whitespace.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Regex literals containing raw no-break space (U+00A0) or narrow no-break
+  space (U+202F) match the same way as their escaped forms. Parser and runtime
+  parity coverage now guards both standalone and character-class patterns
+  (#8902).

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -1737,6 +1737,14 @@ class C {
             "const re = /schön/i;\n",
             "const re = /Maß/;\n",
             "const re = /\\s*(\\d+)\\s+([\\d.,]+)\\s*€/;\n",
+            // #8902: whitespace code points are pattern characters too. The
+            // report used both literal and character-class forms of NBSP and
+            // narrow NBSP; keep them raw here (the Rust escapes decode before
+            // this source reaches the TypeScript parser).
+            "const re = /\u{00a0}/g;\n",
+            "const re = /[\u{00a0}]/g;\n",
+            "const re = /\u{202f}/g;\n",
+            "const re = /[\u{202f}]/g;\n",
             // A non-ASCII character immediately after a backslash (identity
             // escape) took the other corrupting arm of the same match.
             "const re = /\\€/;\n",
@@ -1755,26 +1763,31 @@ class C {
 
     #[test]
     fn test_regex_literal_non_ascii_survives_to_the_ast() {
-        // End-to-end through SWC: the pattern SWC reports must be the source text.
-        let module = parse_typescript("const re = /a€b/;\n", "re.ts").unwrap();
-        let mut seen = None;
-        for item in &module.body {
-            let swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Var(
-                var,
-            ))) = item
-            else {
-                continue;
-            };
-            for decl in &var.decls {
-                if let Some(init) = decl.init.as_deref() {
-                    if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Regex(re)) = init {
-                        seen = Some(re.exp.to_string());
+        // End-to-end through SWC: the pattern SWC reports must be the source
+        // text, including Unicode whitespace that is invisible in a diff
+        // (#8902).
+        for expected in ["a€b", "\u{00a0}", "\u{202f}"] {
+            let source = format!("const re = /{expected}/;\n");
+            let module = parse_typescript(&source, "re.ts").unwrap();
+            let mut seen = None;
+            for item in &module.body {
+                let swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(
+                    swc_ecma_ast::Decl::Var(var),
+                )) = item
+                else {
+                    continue;
+                };
+                for decl in &var.decls {
+                    if let Some(init) = decl.init.as_deref() {
+                        if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Regex(re)) = init {
+                            seen = Some(re.exp.to_string());
+                        }
                     }
                 }
             }
+            assert_eq!(seen.as_deref(), Some(expected));
+            assert_eq!(seen.unwrap().chars().count(), expected.chars().count());
         }
-        assert_eq!(seen.as_deref(), Some("a€b"));
-        assert_eq!(seen.unwrap().chars().count(), 3);
     }
 
     #[test]

--- a/test-files/test_issue_8902_regex_literal_unicode_whitespace.ts
+++ b/test-files/test_issue_8902_regex_literal_unicode_whitespace.ts
@@ -1,0 +1,20 @@
+// Regression test for #8902: raw Unicode whitespace in a regex literal must
+// remain part of the pattern instead of being discarded by source parsing.
+
+function codePoints(value: string): string {
+  return [...value]
+    .map((character) => character.codePointAt(0)!.toString(16).padStart(4, "0"))
+    .join(" ");
+}
+
+const nbsp = `x${String.fromCharCode(0x00a0)}y`;
+const narrowNbsp = `x${String.fromCharCode(0x202f)}y`;
+
+console.log(codePoints(nbsp.replace(/ /g, " ")));
+console.log(codePoints(nbsp.replace(/[ ]/g, " ")));
+console.log(codePoints(narrowNbsp.replace(/ /g, " ")));
+console.log(codePoints(narrowNbsp.replace(/[ ]/g, " ")));
+
+// Controls: escaped literals and constructor patterns already worked.
+console.log(codePoints(nbsp.replace(/\u00a0/g, " ")));
+console.log(codePoints(nbsp.replace(new RegExp("[\\u00a0]", "g"), " ")));


### PR DESCRIPTION
Closes #8902.

## Summary

#8902 was reported against 0.5.1220. The underlying raw-non-ASCII regex-literal parser bug was fixed later by #7431 (at workspace version 0.5.1280), so current `main` already preserves and matches the reported U+00A0 and U+202F characters.

This PR adds the exact missing regression coverage:

- parser pre-pass tests for raw NBSP and narrow NBSP, both standalone and in character classes
- SWC AST checks proving both whitespace code points survive unchanged
- an end-to-end parity fixture covering literal, character-class, escaped, and `RegExp` constructor forms

No production code or version metadata changes are needed.

## Validation

Run on `root@perrymaster.skelpo.net` from the isolated worktree:

- `cargo test -p perry-parser` — 40 passed
- fresh worktree compiler output for the new fixture is byte-identical to Node (six code-point lines)
- `cargo fmt --all -- --check`
- `scripts/check_file_size.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regular expressions containing non-breaking spaces and narrow non-breaking spaces so raw and escaped forms now behave consistently.
  * Corrected matching for these characters both as standalone patterns and within character classes.

* **Tests**
  * Added coverage for literal regex patterns and `RegExp` constructor patterns involving Unicode whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->