### PR TITLE
fix(runtime): require verified Node-API addon entries

### DIFF
--- a/changelog.d/8992-node-api-entry-verification.md
+++ b/changelog.d/8992-node-api-entry-verification.md
@@ -1,0 +1,7 @@
+Node-API sidecar loading now rejects an addon entry unless its canonical path
+is one of the payload files whose size and SHA-256 were successfully verified.
+This keeps the runtime authorization boundary self-contained even if sidecar
+staging changes in the future.
+
+The sidecar contract now also documents the accepted pathname-reopen TOCTOU
+window and requires deployments to protect sidecars from concurrent writers.

--- a/crates/perry-runtime/src/node_api_host/loader.rs
+++ b/crates/perry-runtime/src/node_api_host/loader.rs
@@ -202,6 +202,8 @@ fn verify_addon_payload(root: &Path, addon: &ManifestAddon) -> Result<PathBuf, S
             addon.logical_id
         ));
     }
+    let entry = safe_payload_path(root, &addon.entry)?;
+    let mut entry_verified = false;
     for file in &addon.files {
         let path = safe_payload_path(root, &file.path)?;
         let bytes = std::fs::read(&path).map_err(|error| {
@@ -225,8 +227,18 @@ fn verify_addon_payload(root: &Path, addon: &ManifestAddon) -> Result<PathBuf, S
                 path.display()
             ));
         }
+        if path == entry {
+            entry_verified = true;
+        }
     }
-    safe_payload_path(root, &addon.entry)
+    if !entry_verified {
+        return Err(format!(
+            "Node-API addon `{}` entry {} is not listed among its verified payload files",
+            addon.logical_id,
+            entry.display()
+        ));
+    }
+    Ok(entry)
 }
 
 #[cfg(unix)]
@@ -434,6 +446,10 @@ pub fn load_addon(request: &str) -> Result<f64, String> {
     }
     let load_result = (|| {
         begin_legacy_capture(&path)?;
+        // Platform dynamic loaders accept a pathname, not the bytes or a
+        // portable file handle retained by verification. A local writer can
+        // therefore race this open after hashing; the accepted trust boundary
+        // and deployment mitigation are documented in node-api-host.md.
         let handle = match unsafe { open_library(&path) } {
             Ok(handle) => handle,
             Err(error) => {

--- a/crates/perry/tests/node_api_host_e2e.rs
+++ b/crates/perry/tests/node_api_host_e2e.rs
@@ -368,7 +368,7 @@ console.log("node-api-cache", direct.exports === addon)
     ));
     let manifest_bytes =
         std::fs::read(sidecar.join("manifest.json")).expect("read Node-API sidecar manifest");
-    let manifest: serde_json::Value =
+    let mut manifest: serde_json::Value =
         serde_json::from_slice(&manifest_bytes).expect("parse sidecar manifest");
     assert_eq!(manifest["napi_version"], 8);
     assert_eq!(
@@ -427,6 +427,42 @@ console.log("node-api-cache", direct.exports === addon)
     assert!(stdout.contains("node-api-answer 8523"), "stdout: {stdout}");
     assert!(stdout.contains("node-api-add 42"), "stdout: {stdout}");
     assert!(stdout.contains("node-api-cache true"), "stdout: {stdout}");
+
+    let entry_parent = relative_entry
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or(".");
+    let unverified_relative = format!("{entry_parent}/unverified.node");
+    let unverified_addon = unverified_relative
+        .split('/')
+        .fold(sidecar.clone(), |path, part| path.join(part));
+    std::fs::write(&unverified_addon, &staged_bytes).expect("write unverified addon entry");
+    manifest["addons"][0]["entry"] = serde_json::Value::String(unverified_relative.clone());
+    std::fs::write(
+        sidecar.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).expect("serialize manifest with unverified entry"),
+    )
+    .expect("point manifest at unverified addon entry");
+    let unverified_run = Command::new(&executable)
+        .output()
+        .expect("run Node-API host with unverified entry");
+    assert!(
+        !unverified_run.status.success(),
+        "unverified addon entry unexpectedly ran"
+    );
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&unverified_run.stdout),
+        String::from_utf8_lossy(&unverified_run.stderr)
+    );
+    assert!(diagnostic.contains("ERR_DLOPEN_FAILED"), "{diagnostic}");
+    assert!(
+        diagnostic.contains("not listed among its verified payload files"),
+        "unverified entry diagnostic did not identify missing authentication: {diagnostic}"
+    );
+    std::fs::write(sidecar.join("manifest.json"), &manifest_bytes)
+        .expect("restore original Node-API manifest");
+    std::fs::remove_file(unverified_addon).expect("remove unverified addon entry");
 
     let mut tampered = staged_bytes;
     tampered.push(0xA5);

--- a/docs/src/internals/node-api-host.md
+++ b/docs/src/internals/node-api-host.md
@@ -455,6 +455,20 @@ never consults the build machine's `node_modules` tree.
 This sidecar model has no first-run write, so read-only install directories are
 supported. Moving the executable requires moving its `.perry-native` sibling.
 Missing or hash-mismatched files fail before `dlopen` with a packaging error.
+The loader also requires the canonical entry path passed to the dynamic loader
+to equal the canonical path of a payload file whose size and hash were just
+verified. An existing file that is selected only by `entry`, but omitted from
+`files`, is rejected.
+
+The platform dynamic-loader APIs reopen that canonical pathname; they do not
+provide one portable way to load from the file handle used for verification.
+There is consequently an accepted time-of-check/time-of-use window between the
+last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires write
+access to the installed sidecar directory, which is outside this loader's
+integrity boundary. Deployments must protect the executable and its sidecar
+with the same ownership and write permissions (and platform signing where
+applicable). The manifest checks detect packaging damage and tampering before
+the first load; they are not a defense against a concurrent local writer.
 
 For a macOS app bundle the directory is placed under `Contents/Frameworks`.
 Every Mach-O sidecar and nested dylib is signed before the outer executable or


### PR DESCRIPTION
## Summary

Require a Node-API addon's canonical entry path to match a payload file whose size and SHA-256 were successfully verified before loading it.

## Changes

- Reject manifest entries that resolve to an existing but unlisted payload file.
- Extend the real Node-API loader end-to-end gate with an unverified-entry tampering case.
- Document the accepted hash-to-dynamic-loader TOCTOU boundary and deployment mitigation.

## Related issue

Fixes #8871

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `PERRY_REQUIRE_NODE_API_E2E=1 cargo test -p perry --test node_api_host_e2e real_node_api_addon_resolves_from_host_and_authenticates_sidecar -- --nocapture`
- [x] `cargo test -p perry-runtime --features node-api-host node_api_host:: -- --nocapture`
- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] Added or updated a test in the affected crate
- [x] Updated `docs/src/`

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Node-API sidecar loading now rejects addon entries not included among payload files with successfully verified size and SHA-256 values.
  * Canonical path matching ensures only the verified addon entry is loaded.
  * Clearer errors are provided when an addon entry fails integrity verification.
* **Documentation**
  * Updated sidecar integrity guidance, including verification requirements and limitations involving concurrent file changes.
* **Tests**
  * Added coverage confirming unverified addon entries are rejected before loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->