### PR TITLE
fix(compile): omit erased names from module namespaces

### DIFF
--- a/changelog.d/8994-namespace-erased-names.md
+++ b/changelog.d/8994-namespace-erased-names.md
@@ -1,0 +1,3 @@
+Module namespaces omit erased and non-consumer-visible names.
+
+Namespace keys are derived from consumer-visible export names, so a private backing function such as `_null` no longer appears beside its public alias, and erased TypeScript interfaces and type aliases are excluded when materializing dynamic and nested namespace objects. Includes a Zod-shaped regression for `import * as z`.

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -67,6 +67,45 @@ fn configured_module_codegen_jobs(total_modules: usize) -> (usize, usize) {
     (module_jobs, llvm_unit_jobs)
 }
 
+/// Whether `name` is metadata for an erased TypeScript declaration rather
+/// than a JavaScript binding in `module`.
+///
+/// Interfaces and type aliases remain in `Module::exports` so cross-module
+/// type resolution can follow re-export chains. Runtime namespace builders
+/// must filter them back out, while preserving declaration-merged names that
+/// also have a value binding.
+fn is_type_only_export_binding(module: &perry_hir::Module, name: &str) -> bool {
+    let has_type_declaration = module
+        .interfaces
+        .iter()
+        .any(|interface| interface.name == name)
+        || module.type_aliases.iter().any(|alias| alias.name == name);
+    if !has_type_declaration {
+        return false;
+    }
+
+    let has_runtime_value = module
+        .functions
+        .iter()
+        .any(|function| function.name == name)
+        || module
+            .exported_functions
+            .iter()
+            .any(|(exported, _)| exported == name)
+        || module
+            .exported_objects
+            .iter()
+            .any(|exported| exported == name)
+        || module.classes.iter().any(|class| class.name == name)
+        || module
+            .enums
+            .iter()
+            .any(|enumeration| enumeration.name == name)
+        || module.globals.iter().any(|global| global.name == name);
+
+    !has_runtime_value
+}
+
 // OpenCode's 0.5--1.0 MiB generated chunks routinely lower to 20--45 MiB of
 // LLVM input even with fewer than 1,000 HIR callables. Treat that observed
 // range as memory-heavy too: ordinary modules still use outer parallelism,
@@ -1626,25 +1665,40 @@ pub fn run_with_parse_cache(
     for (path, hir_module) in &ctx.native_modules {
         let path_str = path.to_string_lossy().to_string();
         let exports = all_module_exports.entry(path_str.clone()).or_default();
+        // `is_exported` and `exported_objects` also mark PRIVATE backing names
+        // that need cross-module symbols. For `function _null() {}; export {
+        // _null as null }`, `_null` is link-visible but is not a public module
+        // export. Derive the namespace surface from the consumer-visible side
+        // of `Export::Named` so an alias does not publish both names (#8904).
+        let public_named_exports: std::collections::HashSet<&str> = hir_module
+            .exports
+            .iter()
+            .filter_map(|export| match export {
+                perry_hir::Export::Named { exported, .. } => Some(exported.as_str()),
+                _ => None,
+            })
+            .collect();
         // Exported functions
         for func in &hir_module.functions {
-            if func.is_exported {
+            if func.is_exported && public_named_exports.contains(func.name.as_str()) {
                 exports.insert(func.name.clone(), path_str.clone());
             }
         }
         // Exported objects (export const x = { ... })
         for obj_name in &hir_module.exported_objects {
-            exports.insert(obj_name.clone(), path_str.clone());
+            if public_named_exports.contains(obj_name.as_str()) {
+                exports.insert(obj_name.clone(), path_str.clone());
+            }
         }
         // Exported classes
         for class in &hir_module.classes {
-            if class.is_exported {
+            if class.is_exported && public_named_exports.contains(class.name.as_str()) {
                 exports.insert(class.name.clone(), path_str.clone());
             }
         }
         // Exported enums
         for en in &hir_module.enums {
-            if en.is_exported {
+            if en.is_exported && public_named_exports.contains(en.name.as_str()) {
                 exports.insert(en.name.clone(), path_str.clone());
             }
         }
@@ -1656,40 +1710,10 @@ pub fn run_with_parse_cache(
         // resolves to a bogus closure value that breaks consumers enumerating
         // the namespace (drizzle's `drizzle(pool, { schema })`, where the schema
         // module also `export type Customer = …` alongside the real tables).
-        // A name that is ALSO a value export (declaration merging, a class)
-        // stays — only names that are exclusively types are dropped.
-        let value_export_names: std::collections::HashSet<&str> = hir_module
-            .functions
-            .iter()
-            .filter(|f| f.is_exported)
-            .map(|f| f.name.as_str())
-            .chain(hir_module.exported_objects.iter().map(|s| s.as_str()))
-            .chain(
-                hir_module
-                    .classes
-                    .iter()
-                    .filter(|c| c.is_exported)
-                    .map(|c| c.name.as_str()),
-            )
-            .chain(
-                hir_module
-                    .enums
-                    .iter()
-                    .filter(|e| e.is_exported)
-                    .map(|e| e.name.as_str()),
-            )
-            .collect();
-        let type_only_export_names: std::collections::HashSet<String> = hir_module
-            .type_aliases
-            .iter()
-            .map(|t| t.name.clone())
-            .chain(hir_module.interfaces.iter().map(|i| i.name.clone()))
-            .filter(|n| !value_export_names.contains(n.as_str()))
-            .collect();
         // Named exports (export { foo, bar as baz })
         for export in &hir_module.exports {
             if let perry_hir::Export::Named { local, exported } = export {
-                if type_only_export_names.contains(exported) {
+                if is_type_only_export_binding(hir_module, local) {
                     continue;
                 }
                 exports.insert(exported.clone(), path_str.clone());
@@ -2660,6 +2684,18 @@ pub fn run_with_parse_cache(
         for fe in flat {
             // Locate source module's HIR (where the binding lives).
             let source_mod = module_name_to_module.get(&fe.source_module);
+            // `flatten_exports` intentionally retains interfaces and aliases
+            // so the type resolver can follow their barrel chains. A dynamic
+            // import or nested namespace re-export is a JavaScript object,
+            // though, and must not expose those erased declarations as own
+            // enumerable properties with `undefined` values (#8904).
+            if fe.nested_namespace_of.is_none()
+                && source_mod
+                    .map(|module| is_type_only_export_binding(module, &fe.source_local))
+                    .unwrap_or(false)
+            {
+                continue;
+            }
             let source_prefix = source_mod
                 .map(|m| sanitize_module_name(&m.name))
                 .unwrap_or_else(|| sanitize_module_name(&fe.source_module));

--- a/test-files/issue_8904_namespace_materialization/coerce.ts
+++ b/test-files/issue_8904_namespace_materialization/coerce.ts
@@ -1,0 +1,11 @@
+export interface CoercedNumber<T = unknown> {
+  readonly input: T;
+}
+
+export type CoerceInput = string | number;
+
+function _number(): (value: CoerceInput) => number {
+  return (value: CoerceInput): number => Number(value);
+}
+
+export { _number as number };

--- a/test-files/issue_8904_namespace_materialization/external.ts
+++ b/test-files/issue_8904_namespace_materialization/external.ts
@@ -1,0 +1,13 @@
+export interface SchemaShape {
+  readonly kind: string;
+}
+
+export type SchemaInput = Record<string, unknown>;
+
+function _object(): string {
+  return "object";
+}
+
+export { _object as object };
+
+export * as coerce from "./coerce.ts";

--- a/test-files/issue_8904_namespace_materialization/index.ts
+++ b/test-files/issue_8904_namespace_materialization/index.ts
@@ -1,0 +1,3 @@
+import * as z from "./external.ts";
+
+export { z };

--- a/test-files/test_gap_namespace_type_erasure_8904.ts
+++ b/test-files/test_gap_namespace_type_erasure_8904.ts
@@ -1,0 +1,16 @@
+// #8904: Zod exposes `z` through `import * as z; export { z }`, and `z.coerce`
+// through `export * as coerce`. Both namespace objects must contain all of
+// their runtime values and none of their erased TypeScript declarations.
+import { z } from "./issue_8904_namespace_materialization/index.ts";
+
+console.log("typeof z:", typeof z);
+console.log("typeof z.object:", typeof z.object);
+console.log("typeof z.coerce:", typeof z.coerce);
+console.log("z keys:", JSON.stringify(Object.keys(z).sort()));
+console.log("coerce in z:", "coerce" in z);
+console.log(
+  "coerce enumerable:",
+  Object.getOwnPropertyDescriptor(z, "coerce")?.enumerable,
+);
+console.log("coerce keys:", JSON.stringify(Object.keys(z.coerce).sort()));
+console.log("coerced number:", z.coerce.number()("42"));


### PR DESCRIPTION
## Summary

- derive module namespace keys from consumer-visible export names so private backing functions such as `_null` do not leak beside their public aliases
- exclude erased TypeScript interfaces and type aliases when materializing dynamic and nested namespace objects
- add a Zod-shaped regression for `import * as z; export { z }`, nested `export * as coerce`, reflection, alias-only exports, and type erasure

## Verification

On `root@perrymaster.skelpo.net`:

- `cargo fmt --all -- --check`
- `cargo build --release -p perry`
- `cargo build --release -p perry-runtime-static -p perry-stdlib-static`
- `./run_parity_tests.sh --filter namespace_type_erasure_8904`
- `./run_parity_tests.sh --filter export_star_as_namespace_object`
- `./run_parity_tests.sh --filter namespace_import_enumerable`
- real Zod 4.3.5 no-cache compile: `Object.keys(z).length === 236` in both Node and Perry, `z.coerce` is owned/enumerable, and `z.coerce.number()("42") === 42`

No version bump.

Fixes #8904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace exports so type-only declarations are excluded from runtime namespace objects.
  * Prevented private backing names from appearing as public exports.
  * Ensured nested and dynamically imported namespaces expose only valid runtime values.

* **Tests**
  * Added coverage for namespace re-exports, enumerable properties, runtime keys, and numeric coercion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->