### PR TITLE
fix(runtime): narrow the collection-iterator latch to Map/Set receivers

### DIFF
--- a/changelog.d/8998-narrow-iterator-latch.md
+++ b/changelog.d/8998-narrow-iterator-latch.md
@@ -1,0 +1,5 @@
+The collection-iterator latch is keyed to Map/Set receivers instead of any `@@iterator` write.
+
+`ITERATOR_PROTOCOL_TOUCHED` previously flipped on any `@@iterator` symbol write anywhere in the process, so an ordinary class merely *defining* `[Symbol.iterator]` disabled the plain-collection iteration lane (#8991) process-wide — which is to say the lane did not run in any realistic program.
+
+Narrowing to registered Map/Set receivers is sound because perry models no `Map.prototype` object to patch: `symbol::get` emulates `Map.prototype[Symbol.iterator]` by binding (#2856), so an own write on the instance is the only override path.

--- a/crates/perry-runtime/src/object/map_set_subclass.rs
+++ b/crates/perry-runtime/src/object/map_set_subclass.rs
@@ -84,8 +84,8 @@ unsafe fn instance_object_ptr(this: f64) -> Option<*mut ObjectHeader> {
 /// hidden backing field), return its backing collection. Returns `None` for
 /// real Maps/Sets, ordinary objects, and non-objects — so callers fall through
 /// to their existing handling.
-/// Set once any `[Symbol.iterator]` symbol-keyed write or delete is observed,
-/// anywhere in the process.
+/// Set once an own `[Symbol.iterator]` write or delete is observed on a
+/// registered `Map` or `Set`.
 ///
 /// [`plain_collection_default_iteration`] answers a plain `Map`/`Set` with its
 /// builtin iterator WITHOUT consulting the symbol tables, so it must not run
@@ -93,21 +93,39 @@ unsafe fn instance_object_ptr(this: f64) -> Option<*mut ObjectHeader> {
 /// `Map.prototype[Symbol.iterator]`, or an own `@@iterator` installed on one
 /// instance, both have to be observable.
 ///
-/// Deliberately coarse: the flag is not keyed to the collection prototypes,
-/// because a plain `Map` has no prototype OBJECT to compare against the way
-/// `Array.prototype` does (its surface is served by redirecting the operation
-/// at each dispatch point). Any `@@iterator` write in the program disables the
-/// lane process-wide. That is the conservative direction — it can only cost
-/// speed, never correctness — and the overwhelming majority of programs never
-/// write `@@iterator` at all, so they keep the lane for free.
+/// Keyed to the RECEIVER, not to a prototype: perry models no `Map.prototype`
+/// object at all — `symbol::get` emulates `Map.prototype[Symbol.iterator]` by
+/// binding `entries` inside the resolver (#2856) — so an own symbol property
+/// on the instance is the only channel that can override default iteration,
+/// and that is what [`note_iterator_symbol_write`] watches.
 pub static ITERATOR_PROTOCOL_TOUCHED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-/// Record (if `sym_key` is the well-known `Symbol.iterator`) that the
-/// iteration protocol has been tampered with. Called from the same symbol
-/// set/delete paths that already feed `note_array_proto_iterator_write`.
-pub fn note_iterator_symbol_write(sym_key: usize) {
-    if sym_key == 0 || ITERATOR_PROTOCOL_TOUCHED.load(std::sync::atomic::Ordering::Relaxed) {
+/// Record that a plain collection's own `[Symbol.iterator]` has been written,
+/// so [`plain_collection_default_iteration`] stops claiming receivers.
+///
+/// Narrowed to writes whose RECEIVER is a registered `Map` or `Set`. The first
+/// version flipped on any `@@iterator` write anywhere, which made the lane
+/// dead code in practice: a class that merely *defines* `[Symbol.iterator]` as
+/// a method — an ordinary iterable class, and the ECS corpus has two — tripped
+/// it at class-definition time and disabled the lane process-wide.
+///
+/// Receiver-narrowing is sound here because perry models no `Map.prototype`
+/// OBJECT: `symbol::get` emulates `Map.prototype[Symbol.iterator]` by binding
+/// `entries` (and `Set`'s by binding `values`) inside the resolver itself
+/// (#2856). There is therefore nothing to patch on a prototype, and the only
+/// channel that can override a plain collection's default iteration is an OWN
+/// symbol property on that instance — which is exactly what this hook sees.
+/// A Map/Set SUBCLASS instance is an ordinary object, not a registered
+/// collection, so the lane already declines it and the subclass arm decides.
+pub fn note_iterator_symbol_write(obj_key: usize, sym_key: usize) {
+    if sym_key == 0
+        || obj_key == 0
+        || ITERATOR_PROTOCOL_TOUCHED.load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return;
+    }
+    if !crate::map::is_registered_map(obj_key) && !crate::set::is_registered_set(obj_key) {
         return;
     }
     if sym_key == crate::symbol::well_known_symbol("iterator") as usize {
@@ -684,10 +702,13 @@ mod plain_collection_lane_tests {
         let map_value = crate::value::js_nanbox_pointer(map as i64);
         assert!(plain_collection_default_iteration(map_value).is_some());
 
-        note_iterator_symbol_write(crate::symbol::well_known_symbol("iterator") as usize);
+        note_iterator_symbol_write(
+            map as usize,
+            crate::symbol::well_known_symbol("iterator") as usize,
+        );
         assert!(
             ITERATOR_PROTOCOL_TOUCHED.load(std::sync::atomic::Ordering::Relaxed),
-            "an @@iterator write must flip the latch"
+            "an own @@iterator write on a Map must flip the latch"
         );
         assert!(
             plain_collection_default_iteration(map_value).is_none(),
@@ -697,10 +718,32 @@ mod plain_collection_lane_tests {
 
         // An unrelated symbol must not flip it (checked from the clean state).
         ITERATOR_PROTOCOL_TOUCHED.store(false, std::sync::atomic::Ordering::Relaxed);
-        note_iterator_symbol_write(crate::symbol::well_known_symbol("asyncIterator") as usize);
+        note_iterator_symbol_write(
+            map as usize,
+            crate::symbol::well_known_symbol("asyncIterator") as usize,
+        );
         assert!(
             !ITERATOR_PROTOCOL_TOUCHED.load(std::sync::atomic::Ordering::Relaxed),
             "only @@iterator disables the lane"
+        );
+
+        // The regression this narrowing fixes: an ORDINARY class that merely
+        // DEFINES `[Symbol.iterator]` as a method must not disable the lane.
+        // Its receiver is a class prototype object, not a registered
+        // collection. The first version flipped on any receiver, which made
+        // the lane dead code in every program containing an iterable class.
+        let ordinary = crate::object::js_object_alloc(0, 0);
+        note_iterator_symbol_write(
+            ordinary as usize,
+            crate::symbol::well_known_symbol("iterator") as usize,
+        );
+        assert!(
+            !ITERATOR_PROTOCOL_TOUCHED.load(std::sync::atomic::Ordering::Relaxed),
+            "defining @@iterator on a non-collection must leave the lane armed"
+        );
+        assert!(
+            plain_collection_default_iteration(map_value).is_some(),
+            "and the lane must still claim a plain Map afterwards"
         );
         ITERATOR_PROTOCOL_TOUCHED.store(false, std::sync::atomic::Ordering::Relaxed);
     }

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -111,7 +111,7 @@ pub(crate) unsafe fn js_object_delete_symbol_property(obj_f64: f64, sym_f64: f64
     // virtual (native dispatch, not in the side table), so the delete must
     // still flip the modified flag for `js_get_iterator` to throw per spec.
     crate::array::note_array_proto_iterator_write(obj_key, sym_key);
-    crate::object::map_set_subclass::note_iterator_symbol_write(sym_key);
+    crate::object::map_set_subclass::note_iterator_symbol_write(obj_key, sym_key);
 
     accessors::clear_symbol_accessor_property(obj_key, sym_key);
     {
@@ -390,7 +390,7 @@ unsafe fn set_symbol_property(obj_f64: f64, sym_f64: f64, value_f64: f64) -> f64
     // `Array.prototype[Symbol.iterator] = fn` disables the array fast path in
     // `js_get_iterator` so destructuring / GetIterator see the patched method.
     crate::array::note_array_proto_iterator_write(obj_key, sym_key);
-    crate::object::map_set_subclass::note_iterator_symbol_write(sym_key);
+    crate::object::map_set_subclass::note_iterator_symbol_write(obj_key, sym_key);
     let has_own_data = object_symbol_data_property_exists(obj_key, sym_key);
     // Frozen / sealed / non-extensible receivers reject symbol-keyed writes
     // like string-keyed ones: an existing prop is non-writable when frozen


### PR DESCRIPTION
Follow-up to #8991, which I measured **after** it merged: as shipped it is **+0.07%, 5/9** on the ECS archetype-migration row — a null, because **the lane never runs**.

## Why it never runs

The `ITERATOR_PROTOCOL_TOUCHED` latch flips on *any* `@@iterator` symbol write anywhere in the process. A class that merely **defines** `[Symbol.iterator]` as a method trips it — an ordinary iterable class, and the ECS corpus has two (`utils/multi-map.ts`, `utils/bit-set.ts`). So the latch fires at class-definition time and disables the lane process-wide, in essentially any real program.

I described the latch as "deliberately coarse … it can only cost speed, never correctness" in #8991. That was accurate, and it cost all of the speed.

## The fix, and why it is sound

Flip only when the write's **receiver** is a registered `Map` or `Set`.

Receiver-narrowing is safe here for a specific reason: **perry models no `Map.prototype` object at all.** `symbol::get` emulates `Map.prototype[Symbol.iterator]` by binding `entries`, and `Set`'s by binding `values`, inside the resolver itself (#2856). There is therefore nothing to patch on a prototype, and the only channel that can override a plain collection's default iteration is an **own** symbol property on that instance — which is exactly what this hook observes.

A Map/Set *subclass* instance is an ordinary object rather than a registered collection, so the lane already declines it and the subclass arm decides; that is unchanged.

## Tests

The added assertion is the regression itself: defining `@@iterator` on a non-collection must leave the lane armed, and a plain `Map` must still be claimed afterwards. The existing assertions still pin that an own `@@iterator` write **on a Map** does disarm it, and that `@@asyncIterator` does not.

Local gate on the Linux build host: **perry-runtime serial 2766 passed / 0 failed**; `iterator` 32/32, `symbol` 49/49, lane tests 2/2.

Paired measurement on the quiet host follows in a comment. If the narrowed lane still does not move the row, the right outcome is to revert #8991 rather than keep inert machinery on a correctness-sensitive path — I will open that revert myself if so.

Claude-Session: https://claude.ai/code/session_01FUvFrRNZyc5qknBiJbYbby

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed collection iteration behavior so `[Symbol.iterator]` changes on unrelated classes no longer affect Map and Set iteration.
  - Map and Set iteration now responds only to iterator changes made directly on registered Map or Set subclasses.
  - Improved default collection iteration in applications that define custom iterators elsewhere.
- **Tests**
  - Added regression coverage to prevent unrelated iterator definitions from disabling default collection iteration.
- **Documentation**
  - Documented the updated iterator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->