### PR TITLE
perf(runtime): inline the single-slot case in the shape key index (populated delete −13.9%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6348,6 +6348,7 @@ dependencies = [
  "taffy",
  "temporal_rs",
  "thiserror 1.0.69",
+ "timezone_provider",
  "unicode-normalization",
  "unicode-segmentation",
  "url",

--- a/changelog.d/8998-delete-path-hasher-memcpy.md
+++ b/changelog.d/8998-delete-path-hasher-memcpy.md
@@ -1,0 +1,28 @@
+Two costs removed from the populated-delete path — perry's worst object-model
+gap against node (`bench_populated_delete.ts`, ~280×).
+
+**1. The shape key index no longer hashes a hash.** `ShapeIndex::slots` was a
+std `HashMap<u64, Vec<u32>>` whose key is ALREADY an FNV-1a content hash, so
+every probe ran SipHash over it — no added distribution, real time.
+`hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of self time** in
+that benchmark, second only to `shape_slot_lookup`, which is what performs the
+probes. It now uses the `PtrHasher` the runtime's other id-keyed registries
+already use.
+
+**2. The keys-array clone is a memcpy.** Each delete allocates a fresh keys
+array and previously copied the surviving keys one `f64` at a time; it is now
+two `copy_nonoverlapping` runs. Safe by the code's own existing argument: the
+destination is a freshly allocated, still-unpublished array whose layout is
+rebuilt before publish — which is why the per-element writes carried no GC
+barrier either — and the two allocations cannot overlap.
+
+Interleaved A/B, min-of-15 at quiet load: 5938 → 5847 ms (−1.5% min, −2.2%
+mean). Smaller than the profile share suggests, because the delete path is
+dominated by allocator and page churn (`clear_page_erms` 5.6%, `mi_free` 4.2%,
+`RawVecInner::finish_grow` 2.9%) rather than by hashing — the index is rebuilt
+per delete, and each of its ~500 buckets is a separate `Vec<u32>`. That is the
+next target and is untouched here.
+
+Suite 2787 passed, 0 failed, no warnings. Adversarial property differential
+(delete-then-reread, accessor over a cached slot, prototype fallback, freeze,
+key-order shapes, overflow slots) is byte-identical to node.

--- a/changelog.d/8999-release-receiver-probe-kinds.md
+++ b/changelog.d/8999-release-receiver-probe-kinds.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Dynamic indexed reads now inspect `ObjectMeta.elements` only for receivers whose GC kind is an object. Array, string, Error, and other layouts can no longer be interpreted as an object metadata pointer, eliminating the release parity crashes introduced with Array-subclass elements storage.
+- Managed heap cells are classified as closures only when their authoritative GC kind is `GC_TYPE_CLOSURE`. Reused `Error` storage whose padding retained the closure magic marker no longer loses `.message` or custom fields during property lookup.
+- Removed the stale Linux parity allowance for `test_class_field_layout`, which now matches Node, and recorded the timezone-provider dependency added to the runtime in `Cargo.lock`.

--- a/changelog.d/9000-delete-path-hasher-memcpy.md
+++ b/changelog.d/9000-delete-path-hasher-memcpy.md
@@ -1,0 +1,28 @@
+Two costs removed from the populated-delete path — perry's worst object-model
+gap against node (`bench_populated_delete.ts`, ~280×).
+
+**1. The shape key index no longer hashes a hash.** `ShapeIndex::slots` was a
+std `HashMap<u64, Vec<u32>>` whose key is ALREADY an FNV-1a content hash, so
+every probe ran SipHash over it — no added distribution, real time.
+`hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of self time** in
+that benchmark, second only to `shape_slot_lookup`, which is what performs the
+probes. It now uses the `PtrHasher` the runtime's other id-keyed registries
+already use.
+
+**2. The keys-array clone is a memcpy.** Each delete allocates a fresh keys
+array and previously copied the surviving keys one `f64` at a time; it is now
+two `copy_nonoverlapping` runs. Safe by the code's own existing argument: the
+destination is a freshly allocated, still-unpublished array whose layout is
+rebuilt before publish — which is why the per-element writes carried no GC
+barrier either — and the two allocations cannot overlap.
+
+Interleaved A/B, min-of-15 at quiet load: 5938 → 5847 ms (−1.5% min, −2.2%
+mean). Smaller than the profile share suggests, because the delete path is
+dominated by allocator and page churn (`clear_page_erms` 5.6%, `mi_free` 4.2%,
+`RawVecInner::finish_grow` 2.9%) rather than by hashing — the index is rebuilt
+per delete, and each of its ~500 buckets is a separate `Vec<u32>`. That is the
+next target and is untouched here.
+
+Suite 2787 passed, 0 failed, no warnings. Adversarial property differential
+(delete-then-reread, accessor over a cached slot, prototype fallback, freeze,
+key-order shapes, overflow slots) is byte-identical to node.

--- a/changelog.d/9001-shape-index-inline-slot.md
+++ b/changelog.d/9001-shape-index-inline-slot.md
@@ -1,0 +1,20 @@
+The shape key index stops allocating once per key.
+
+`ShapeIndex::slots` mapped each content hash to a `Vec<u32>`, so every index
+build made one heap allocation PER KEY — and the index is rebuilt on every
+populated delete, so a 500-key object was making ~500 `Vec` allocations per
+`delete`. Allocator and page churn dominates that benchmark (`clear_page_erms`
+5.6%, `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9%), well above the lookup
+work the index exists to do.
+
+A bucket holds more than one slot only on a genuine FNV-1a collision between
+two distinct property names, so the common case is exactly one. Store it
+inline and promote to a `Vec` only when a collision actually occurs.
+
+Interleaved A/B, min-of-15 at quiet load (~1.0): `bench_populated_delete`
+**5810 → 5004 ms, −13.9%** (mean −13.9%, the two agree). The combined
+overwrite loop and realistic-name read are unchanged, as expected for a change
+confined to index construction.
+
+Suite 2787 passed, no warnings. Adversarial property differential is
+byte-identical to node.

--- a/crates/perry-codegen/src/expr/index_get/inline_dyn_typed_array.rs
+++ b/crates/perry-codegen/src/expr/index_get/inline_dyn_typed_array.rs
@@ -444,11 +444,13 @@ pub(super) fn lower_inline_dyn_typed_array_get(
     // of this probe (no meta, no store) is the shape-carried form and keeps
     // the IC below; an out-of-bounds index or a hole goes to the complete
     // dispatcher (prototype chain).
+    let elem_kind_idx = ctx.new_block("arrlike.elem.kind");
     let elem_meta_idx = ctx.new_block("arrlike.elem.meta");
     let elem_store_idx = ctx.new_block("arrlike.elem.store");
     let elem_bounds_idx = ctx.new_block("arrlike.elem.bounds");
     let elem_load_idx = ctx.new_block("arrlike.elem.load");
     let elem_value_idx = ctx.new_block("arrlike.elem.value");
+    let elem_kind_label = ctx.block_label(elem_kind_idx);
     let elem_meta_label = ctx.block_label(elem_meta_idx);
     let elem_store_label = ctx.block_label(elem_store_idx);
     let elem_bounds_label = ctx.block_label(elem_bounds_idx);
@@ -456,7 +458,11 @@ pub(super) fn lower_inline_dyn_typed_array_get(
     let elem_value_label = ctx.block_label(elem_value_idx);
     ctx.current_block = object_brand_idx;
     ctx.block()
-        .cond_br(&is_array, &object_array_guard_label, &elem_meta_label);
+        .cond_br(&is_array, &object_array_guard_label, &elem_kind_label);
+    ctx.current_block = elem_kind_idx;
+    let elem_is_object = ctx.block().icmp_eq(I8, &gc_type, "2");
+    ctx.block()
+        .cond_br(&elem_is_object, &elem_meta_label, &object_miss_label);
     ctx.current_block = elem_meta_idx;
     let elem_meta_addr = ctx.block().add(I64, &object_raw, &meta_offset);
     let elem_meta_slot_ptr = ctx.block().inttoptr(I64, &elem_meta_addr);

--- a/crates/perry-codegen/src/expr/index_get_claim_tests.rs
+++ b/crates/perry-codegen/src/expr/index_get_claim_tests.rs
@@ -409,6 +409,19 @@ fn any_typed_dynamic_key_takes_the_numeric_tiers_when_it_is_an_array_index() {
         ir.contains("tav.get.brand") && ir.contains("arrlike.ic.family_token"),
         "an integer key must reach the inline typed-array and dense-subclass tiers:\n{ir}"
     );
+    // Only an ordinary ObjectHeader has the `meta` slot used by the
+    // elements-backed Array-subclass probe. Native Buffers and other exotic
+    // managed cells must leave through the complete dispatcher before that
+    // load; interpreting their header word at offset 8 as ObjectMeta crashes.
+    let kind = super::class_field_barrier_tests::block_body(&ir, "arrlike.elem.kind.")
+        .expect("the elements-store object-kind guard exists");
+    assert!(
+        kind.contains("icmp eq i8")
+            && kind.contains(", 2")
+            && kind.contains("arrlike.elem.meta")
+            && kind.contains("arrlike.ic.miss"),
+        "only GC_TYPE_OBJECT may reach the ObjectMeta.elements load:\n{kind}"
+    );
     // The elements-backed subclass probe sits ahead of the shape IC: meta
     // word → `ObjectMeta.elements` (word 12) → inner-array bounds → slot.
     let store = super::class_field_barrier_tests::block_body(&ir, "arrlike.elem.store.")

--- a/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
+++ b/crates/perry-codegen/tests/temp_root_operand_temporaries.rs
@@ -530,7 +530,7 @@ fn registered_root_operands_are_reloaded_rather_than_rooted() {
 // concat read the string's pre-move address: an empty line, exit code 0.
 
 /// An operand that is statically NUMERIC *and* can collect, so `"lit" + it`
-/// takes the fused `js_string_concat_value` path — the exact expression form
+/// takes the fused `js_string_concat_value_box` path — the exact expression form
 /// #7114 was reported against.
 ///
 /// A non-`Add` `Expr::Binary` is numeric by construction (`is_numeric_expr`),
@@ -641,7 +641,8 @@ fn string_literal_concat_operand_is_re_derived_below_the_allocating_sibling() {
     let f = init_ir(&ir);
     let handle = "load double, ptr @concat_reload_ts_.str.";
     assert_eq!(
-        f.matches("call i64 @js_string_concat_value(").count(),
+        f.matches("call double @js_string_concat_value_box(")
+            .count(),
         1,
         "exactly one fused string+value concat in @main:\n{f}"
     );
@@ -659,7 +660,7 @@ fn string_literal_concat_operand_is_re_derived_below_the_allocating_sibling() {
          it:\n{f}"
     );
 
-    let concat = f.find("call i64 @js_string_concat_value(").unwrap();
+    let concat = f.find("call double @js_string_concat_value_box(").unwrap();
     let alloc = f[..concat]
         .rfind("call i64 @js_object_alloc(")
         .unwrap_or_else(|| panic!("the sibling must allocate before the concat:\n{f}"));

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -187,7 +187,7 @@ fn scalar_object_literal_skips_pure_unobserved_initializers() {
         "non-escaping object literal should stay scalar-replaced"
     );
     assert!(
-        !ir.contains("call i64 @js_string_concat"),
+        !ir.contains("call double @js_string_concat_value_box("),
         "pure unobserved field initializer should not be lowered"
     );
 }
@@ -226,7 +226,7 @@ fn scalar_array_literal_skips_pure_unobserved_initializers() {
         "non-escaping array literal should stay scalar-replaced"
     );
     assert!(
-        !ir.contains("call i64 @js_string_concat"),
+        !ir.contains("call double @js_string_concat_value_box("),
         "pure unobserved array initializer should not be lowered"
     );
 }
@@ -294,7 +294,7 @@ fn scalar_object_literal_keeps_initializers_read_by_update() {
 
     let ir = ir_for(module);
     assert!(
-        ir.contains("call i64 @js_string_concat"),
+        ir.contains("call double @js_string_concat_value_box("),
         "field initializer read by obj.field++ must still be lowered"
     );
 }

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -419,6 +419,24 @@ pub fn is_closure_ptr(ptr: usize) -> bool {
     if !ptr.is_multiple_of(std::mem::align_of::<ClosureHeader>()) {
         return false;
     }
+    // Arena ownership gives us an authoritative discriminator. Do not let a
+    // coincidental CLOSURE_MAGIC in another managed cell's payload win: in
+    // particular, ErrorHeader has padding at the closure tag offset and an
+    // arena slot reused after a closure can retain "CLOS" in those bytes.
+    // Headerless/external allocations remain on the exact-magic fallback.
+    if !matches!(
+        crate::arena::classify_heap_generation(ptr),
+        crate::arena::HeapGeneration::Unknown
+    ) {
+        let Some(header) = (unsafe { crate::value::addr_class::try_read_gc_header(ptr) }) else {
+            return false;
+        };
+        if header.obj_type != crate::gc::GC_TYPE_CLOSURE
+            || header.gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
+        {
+            return false;
+        }
+    }
     unsafe {
         let type_tag = *((ptr as *const u8).add(CLOSURE_TYPE_TAG_OFFSET) as *const u32);
         type_tag == CLOSURE_MAGIC
@@ -1009,6 +1027,36 @@ mod tests_1802 {
                 !is_closure_ptr(handle),
                 "is_closure_ptr({handle:#x}) must be false (small-handle band) \
                  without dereferencing the handle as a pointer",
+            );
+        }
+    }
+
+    /// A managed cell's GC kind must outrank bytes that merely look like a
+    /// closure tag. ErrorHeader's bytes 12..16 are padding on 64-bit targets;
+    /// reused arena storage can therefore retain CLOSURE_MAGIC there.
+    #[test]
+    fn managed_error_with_closure_magic_in_padding_is_not_a_closure() {
+        unsafe {
+            let message = crate::string::js_string_from_bytes(b"survives".as_ptr(), 8);
+            let error = crate::error::js_error_new_with_message(message);
+            // GC_STORE_AUDIT(POINTER_FREE): writes the u32 magic constant into
+            // an ErrorHeader's padding on purpose, so the assertion below proves
+            // the GC kind outranks look-alike bytes. No heap pointer is stored,
+            // so there is nothing for a barrier to track.
+            std::ptr::write_unaligned(
+                (error as *mut u8).add(CLOSURE_TYPE_TAG_OFFSET) as *mut u32,
+                CLOSURE_MAGIC,
+            );
+
+            assert!(!is_closure_ptr(error as usize));
+            assert_eq!((*error).message, message);
+
+            let key = crate::string::js_string_from_bytes(b"message".as_ptr(), 7);
+            let value = crate::object::js_object_get_field_by_name(error.cast(), key);
+            assert_eq!(
+                value.bits() & crate::value::POINTER_MASK,
+                message as usize as u64,
+                "property lookup must reach Error handling, not the closure path",
             );
         }
     }

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -343,14 +343,27 @@ pub extern "C" fn js_object_delete_field(
             (keys as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
         let dst_elements =
             (keys_cloned as *mut u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *mut f64;
-        // Copy keys [0..i) ++ [i+1..N) into [0..new_count).
-        for j in 0..i {
-            // GC_STORE_AUDIT(INIT): cloned keys array is unpublished; layout is rebuilt before publication.
-            *dst_elements.add(j) = *src_elements.add(j);
+        // Copy keys [0..i) ++ [i+1..N) into [0..new_count) as two contiguous
+        // runs. These were scalar element loops, which is O(resident keys) of
+        // load/store pairs on a path that already allocates and rebuilds a
+        // layout per delete — and `delete obj[k]` on a populated object is
+        // perry's worst object-model gap against node (~200x on
+        // `bench_populated_delete.ts`).
+        //
+        // GC_STORE_AUDIT(INIT): the destination is a freshly allocated, still
+        // UNPUBLISHED keys array whose layout is rebuilt before it is
+        // published — which is why the per-element writes carried no barrier
+        // either. Source and destination are distinct allocations, so the
+        // copies cannot overlap.
+        if i > 0 {
+            std::ptr::copy_nonoverlapping(src_elements, dst_elements, i);
         }
-        for j in i..new_count {
-            // GC_STORE_AUDIT(INIT): cloned keys array is unpublished; layout is rebuilt before publication.
-            *dst_elements.add(j) = *src_elements.add(j + 1);
+        if new_count > i {
+            std::ptr::copy_nonoverlapping(
+                src_elements.add(i + 1),
+                dst_elements.add(i),
+                new_count - i,
+            );
         }
         (*keys_cloned).length = new_count as u32;
         super::rebuild_array_layout_from_slots(keys_cloned);

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -343,14 +343,30 @@ pub extern "C" fn js_object_delete_field(
             (keys as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
         let dst_elements =
             (keys_cloned as *mut u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *mut f64;
-        // Copy keys [0..i) ++ [i+1..N) into [0..new_count).
-        for j in 0..i {
-            // GC_STORE_AUDIT(INIT): cloned keys array is unpublished; layout is rebuilt before publication.
-            *dst_elements.add(j) = *src_elements.add(j);
+        // Copy keys [0..i) ++ [i+1..N) into [0..new_count) as two contiguous
+        // runs. These were scalar element loops, which is O(resident keys) of
+        // load/store pairs on a path that already allocates and rebuilds a
+        // layout per delete — and `delete obj[k]` on a populated object is
+        // perry's worst object-model gap against node (~200x on
+        // `bench_populated_delete.ts`).
+        //
+        // GC_STORE_AUDIT(INIT): the destination is a freshly allocated, still
+        // UNPUBLISHED keys array whose layout is rebuilt before it is
+        // published — which is why the per-element writes carried no barrier
+        // either. Source and destination are distinct allocations, so the
+        // copies cannot overlap.
+        if i > 0 {
+            std::ptr::copy_nonoverlapping(src_elements, dst_elements, i);
         }
-        for j in i..new_count {
-            // GC_STORE_AUDIT(INIT): cloned keys array is unpublished; layout is rebuilt before publication.
-            *dst_elements.add(j) = *src_elements.add(j + 1);
+        if new_count > i {
+            // GC_STORE_AUDIT(INIT): same unpublished destination as the run
+            // above — freshly allocated keys array, layout rebuilt before
+            // `set_object_keys_array` publishes it, distinct allocations.
+            std::ptr::copy_nonoverlapping(
+                src_elements.add(i + 1),
+                dst_elements.add(i),
+                new_count - i,
+            );
         }
         (*keys_cloned).length = new_count as u32;
         super::rebuild_array_layout_from_slots(keys_cloned);

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -31,6 +31,42 @@
 use crate::array::ArrayHeader;
 use std::cell::RefCell;
 
+/// Slots sharing one content hash.
+///
+/// Almost always exactly one: the key is an FNV-1a hash of distinct property
+/// names, so a bucket with two entries is a genuine hash collision. Storing
+/// that common case inline removes a heap allocation PER KEY from every index
+/// build — and the index is rebuilt on every populated delete, so a 500-key
+/// object was making ~500 `Vec` allocations per `delete`. Allocator and page
+/// churn is the dominant cost on that benchmark (`clear_page_erms` 5.6%,
+/// `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9%), well above the lookup
+/// work itself.
+#[derive(Clone, Debug)]
+pub(crate) enum SlotList {
+    One(u32),
+    Many(Vec<u32>),
+}
+
+impl SlotList {
+    #[inline]
+    fn push(&mut self, slot: u32) {
+        match self {
+            SlotList::One(existing) => {
+                *self = SlotList::Many(vec![*existing, slot]);
+            }
+            SlotList::Many(v) => v.push(slot),
+        }
+    }
+
+    #[inline]
+    fn iter(&self) -> impl Iterator<Item = &u32> {
+        match self {
+            SlotList::One(slot) => std::slice::from_ref(slot).iter(),
+            SlotList::Many(v) => v.iter(),
+        }
+    }
+}
+
 pub(crate) struct ShapeIndex {
     /// Key count covered by `slots`. Longer live array ⟹ catch up
     /// incrementally (append-only while shared); shorter ⟹ a delete
@@ -45,7 +81,7 @@ pub(crate) struct ShapeIndex {
     /// `bench_populated_delete.ts` — perry's worst object-model gap against
     /// node — `hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of
     /// self time**, second only to the lookup that performs them.
-    slots: crate::fast_hash::PtrHashMap<u64, Vec<u32>>,
+    slots: crate::fast_hash::PtrHashMap<u64, SlotList>,
 }
 
 /// Immutable facts named by one ShapeId.
@@ -1601,7 +1637,12 @@ unsafe fn index_range(shape: &mut ShapeIndex, keys: *const ArrayHeader, key_coun
         let v = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
         if let Some(b) = crate::string::js_string_key_bytes(v, &mut sso) {
             let h = super::key_bytes_hash(b.as_ptr(), b.len());
-            shape.slots.entry(h).or_default().push(i);
+            match shape.slots.entry(h) {
+                std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(i),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(SlotList::One(i));
+                }
+            }
         }
     }
     shape.indexed_len = key_count;
@@ -1649,7 +1690,7 @@ pub(crate) unsafe fn shape_slot_lookup(
     let candidates = shape.slots.get(&key_hash)?;
     let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
     let (slots, slot_len) = super::keys_array_dense_slots(keys);
-    for &i in candidates {
+    for &i in candidates.iter() {
         if (i as usize) >= slot_len || i >= key_count {
             continue;
         }
@@ -1676,7 +1717,12 @@ pub(crate) fn shape_note_append(
     if let Some(shape) = inner.indices.get_mut(&(keys as usize)) {
         if shape.indexed_len + 1 == new_count {
             shape.indexed_len = new_count;
-            shape.slots.entry(key_hash).or_default().push(slot);
+            match shape.slots.entry(key_hash) {
+                std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(slot),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(SlotList::One(slot));
+                }
+            }
         }
     }
 }
@@ -1686,7 +1732,12 @@ pub(crate) fn shape_note_append(
 pub(crate) fn shape_note_hit(keys: *const ArrayHeader, key_hash: u64, slot: u32) {
     let mut inner = crate::state::state().shapes.inner.borrow_mut();
     if let Some(shape) = inner.indices.get_mut(&(keys as usize)) {
-        shape.slots.entry(key_hash).or_default().push(slot);
+        match shape.slots.entry(key_hash) {
+            std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(slot),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(SlotList::One(slot));
+            }
+        }
     }
 }
 

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -31,41 +31,9 @@
 use crate::array::ArrayHeader;
 use std::cell::RefCell;
 
-/// Slots sharing one content hash.
-///
-/// Almost always exactly one: the key is an FNV-1a hash of distinct property
-/// names, so a bucket with two entries is a genuine hash collision. Storing
-/// that common case inline removes a heap allocation PER KEY from every index
-/// build — and the index is rebuilt on every populated delete, so a 500-key
-/// object was making ~500 `Vec` allocations per `delete`. Allocator and page
-/// churn is the dominant cost on that benchmark (`clear_page_erms` 5.6%,
-/// `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9%), well above the lookup
-/// work itself.
-#[derive(Clone, Debug)]
-pub(crate) enum SlotList {
-    One(u32),
-    Many(Vec<u32>),
-}
-
-impl SlotList {
-    #[inline]
-    fn push(&mut self, slot: u32) {
-        match self {
-            SlotList::One(existing) => {
-                *self = SlotList::Many(vec![*existing, slot]);
-            }
-            SlotList::Many(v) => v.push(slot),
-        }
-    }
-
-    #[inline]
-    fn iter(&self) -> impl Iterator<Item = &u32> {
-        match self {
-            SlotList::One(slot) => std::slice::from_ref(slot).iter(),
-            SlotList::Many(v) => v.iter(),
-        }
-    }
-}
+#[path = "shapes_slot_list.rs"]
+mod shapes_slot_list;
+pub(crate) use shapes_slot_list::{record_shape_scan_outcome, SlotList};
 
 pub(crate) struct ShapeIndex {
     /// Key count covered by `slots`. Longer live array ⟹ catch up
@@ -1843,37 +1811,6 @@ crate::perry_thread_local! {
     /// single-word shape `PtrHasher` is built for.
     static PROBE_MEMO: std::cell::RefCell<crate::fast_hash::PtrHashMap<usize, (bool, usize)>> =
         std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_map());
-}
-
-/// Per-descriptor bookkeeping after its keys address has been probed.
-///
-/// Lifted out of `scan_shape_table_rekey_mut`'s loop so the memoised path and
-/// the probing path cannot drift apart — the probe is what is deduplicated,
-/// never the bookkeeping, which still runs once per descriptor.
-#[inline]
-fn record_shape_scan_outcome(
-    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
-    id: &u32,
-    descriptor: &mut ShapeDescriptor,
-    addr: usize,
-    moved: bool,
-    dead_descriptor_ids: &mut Vec<u32>,
-    descriptor_rekeys: &mut Vec<u32>,
-) {
-    // Validate the POST-visit address. A stale shape key can follow the
-    // forwarding record of the non-array tenant that recycled its address;
-    // checking only an unmoved old address misses that case.
-    if visitor.is_metadata_rewrite_phase() && shape_keys_address_is_recycled(addr) {
-        dead_descriptor_ids.push(*id);
-    } else if moved {
-        descriptor.keys = addr as u64;
-    }
-    // A live-object edge can rewrite the boxed `keys` slot before this metadata
-    // pass. Comparing against the address represented in the reverse maps
-    // catches both that ordering and a move observed here.
-    if descriptor.keys != descriptor.indexed_keys {
-        descriptor_rekeys.push(*id);
-    }
 }
 
 /// Metadata-only forwarding repair for the weak descriptor table and

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -30,7 +30,6 @@
 
 use crate::array::ArrayHeader;
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 pub(crate) struct ShapeIndex {
     /// Key count covered by `slots`. Longer live array ⟹ catch up
@@ -39,7 +38,14 @@ pub(crate) struct ShapeIndex {
     indexed_len: u32,
     /// FNV-1a content hash of key bytes → candidate slots (collisions
     /// resolved by the per-hit content validation).
-    slots: HashMap<u64, Vec<u32>>,
+    ///
+    /// Keyed with [`crate::fast_hash::PtrHasher`], not the std default: the
+    /// key is ALREADY a well-distributed FNV-1a hash, so running SipHash over
+    /// it again buys no distribution and costs real time. On
+    /// `bench_populated_delete.ts` — perry's worst object-model gap against
+    /// node — `hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of
+    /// self time**, second only to the lookup that performs them.
+    slots: crate::fast_hash::PtrHashMap<u64, Vec<u32>>,
 }
 
 /// Immutable facts named by one ShapeId.
@@ -1633,7 +1639,7 @@ pub(crate) unsafe fn shape_slot_lookup(
             }
             inner.indices.entry(keys_id).or_insert(ShapeIndex {
                 indexed_len: 0,
-                slots: HashMap::with_capacity(key_count as usize),
+                slots: crate::fast_hash::new_ptr_hash_map(),
             })
         }
     };

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -30,8 +30,6 @@
 
 use crate::array::ArrayHeader;
 use std::cell::RefCell;
-<<<<<<< HEAD
-=======
 
 /// Slots sharing one content hash.
 ///
@@ -68,7 +66,6 @@ impl SlotList {
         }
     }
 }
->>>>>>> refs/tmp/pr9001
 
 pub(crate) struct ShapeIndex {
     /// Key count covered by `slots`. Longer live array ⟹ catch up
@@ -84,11 +81,7 @@ pub(crate) struct ShapeIndex {
     /// `bench_populated_delete.ts` — perry's worst object-model gap against
     /// node — `hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of
     /// self time**, second only to the lookup that performs them.
-<<<<<<< HEAD
-    slots: crate::fast_hash::PtrHashMap<u64, Vec<u32>>,
-=======
     slots: crate::fast_hash::PtrHashMap<u64, SlotList>,
->>>>>>> refs/tmp/pr9001
 }
 
 /// Immutable facts named by one ShapeId.

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -1,0 +1,74 @@
+//! `SlotList` — the shape key index's per-hash slot list, in a sibling file.
+//!
+//! Extracted from `shapes.rs` to keep it under the repo's 2000-line cap.
+//! Also carries `record_shape_scan_outcome`, the shape scanner's
+//! per-descriptor bookkeeping, to keep `shapes.rs` under that cap.
+
+/// Slots sharing one content hash.
+///
+/// Almost always exactly one: the key is an FNV-1a hash of distinct property
+/// names, so a bucket with two entries is a genuine hash collision. Storing
+/// that common case inline removes a heap allocation PER KEY from every index
+/// build — and the index is rebuilt on every populated delete, so a 500-key
+/// object was making ~500 `Vec` allocations per `delete`. Allocator and page
+/// churn is the dominant cost on that benchmark (`clear_page_erms` 5.6%,
+/// `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9%), well above the lookup
+/// work itself.
+#[derive(Clone, Debug)]
+pub(crate) enum SlotList {
+    One(u32),
+    Many(Vec<u32>),
+}
+
+impl SlotList {
+    #[inline]
+    pub(crate) fn push(&mut self, slot: u32) {
+        match self {
+            SlotList::One(existing) => {
+                *self = SlotList::Many(vec![*existing, slot]);
+            }
+            SlotList::Many(v) => v.push(slot),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &u32> {
+        match self {
+            SlotList::One(slot) => std::slice::from_ref(slot).iter(),
+            SlotList::Many(v) => v.iter(),
+        }
+    }
+}
+
+use super::{shape_keys_address_is_recycled, ShapeDescriptor};
+
+/// Per-descriptor bookkeeping after its keys address has been probed.
+///
+/// Lifted out of `scan_shape_table_rekey_mut`'s loop so the memoised path and
+/// the probing path cannot drift apart — the probe is what is deduplicated,
+/// never the bookkeeping, which still runs once per descriptor.
+#[inline]
+pub(crate) fn record_shape_scan_outcome(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    id: &u32,
+    descriptor: &mut ShapeDescriptor,
+    addr: usize,
+    moved: bool,
+    dead_descriptor_ids: &mut Vec<u32>,
+    descriptor_rekeys: &mut Vec<u32>,
+) {
+    // Validate the POST-visit address. A stale shape key can follow the
+    // forwarding record of the non-array tenant that recycled its address;
+    // checking only an unmoved old address misses that case.
+    if visitor.is_metadata_rewrite_phase() && shape_keys_address_is_recycled(addr) {
+        dead_descriptor_ids.push(*id);
+    } else if moved {
+        descriptor.keys = addr as u64;
+    }
+    // A live-object edge can rewrite the boxed `keys` slot before this metadata
+    // pass. Comparing against the address represented in the reverse maps
+    // catches both that ordering and a move observed here.
+    if descriptor.keys != descriptor.indexed_keys {
+        descriptor_rekeys.push(*id);
+    }
+}

--- a/crates/perry-runtime/src/object/shapes_test_support.rs
+++ b/crates/perry-runtime/src/object/shapes_test_support.rs
@@ -119,7 +119,7 @@ pub(crate) fn test_seed_shape_entry(keys_id: usize) {
             keys_id,
             ShapeIndex {
                 indexed_len: 0,
-                slots: HashMap::new(),
+                slots: crate::fast_hash::new_ptr_hash_map(),
             },
         );
     let _ = shape_descriptor_ensure(keys_id as *const ArrayHeader, 0, 0)

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -37,15 +37,6 @@
       "linux"
     ]
   },
-  "test_class_field_layout": {
-    "issue": "8841",
-    "added": "2026-08-25",
-    "category": "bug-open",
-    "reason": "Reproduces 5/5 on pre-#8835 r13 and in r14 Full CI: both runtimes exit 0 but their class-field layout output differs. Tracked in #8841.",
-    "platforms": [
-      "linux"
-    ]
-  },
   "test_date_fns_format": {
     "issue": "8271",
     "added": "2026-08-17",


### PR DESCRIPTION
Builds on #9000, and goes after what that PR's profiling identified as the real cost on this path rather than the one that merely looked biggest.

`ShapeIndex::slots` mapped each content hash to a `Vec<u32>`, so an index build allocated **once per key**. The index is rebuilt on every populated delete, so a 500-key object was making **~500 `Vec` allocations per `delete`**. That is why allocator and page churn dominates this benchmark — `clear_page_erms` 5.6%, `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9% — well above the lookup work the index exists to perform.

A bucket holds more than one slot only on a genuine FNV-1a collision between two distinct property names, so the common case is exactly one. It is now stored inline, promoting to a `Vec` only when a collision actually occurs.

### Measurement

Interleaved A/B, min-of-15, quiet load (~1.0), built from the exact parent commit and this commit in one run:

| | base | this PR | |
|---|---|---|---|
| `bench_populated_delete` | 5810 ms | **5004 ms** | **−13.9%** |
| combined overwrite | 38 ms | 38 ms | unchanged |
| realistic-name read | 14 ms | 14 ms | unchanged |

Mean moves identically to min (5862 → 5046), which is the check that this is a real reduction in work rather than a lucky floor on a GC-heavy benchmark.

For contrast, #9000 removed a **14.7%** profile share from this same benchmark and bought ~2% wall clock. This one removes an allocation and buys 13.9%. On an allocation-bound path, what a profile ranks by self time is not what costs time.

### Correctness

- `perry-runtime`: **2787 passed / 0 failed**, no warnings (`--all-targets`).
- Adversarial property differential — delete-then-reread under a cached slot, an accessor over a cached data slot, prototype fallback after delete, `Object.freeze`, the same keys in opposite orders, a 300-key object in the overflow store — **byte-identical to node**.

### Still on the table

The index is rebuilt from scratch on every delete. Not rebuilding it — updating it in place, or keying it so a delete does not invalidate it — is the larger remaining win here, and this PR does not attempt it.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic indexed reads for array-like and typed-array values, avoiding incorrect fast-path handling.
  - Corrected closure detection so ordinary objects and error values are no longer misclassified as closures.
  - Removed a known parity failure related to class field layouts.
  - Updated runtime behavior and platform expectations for release receivers and timezone handling.

- **Performance**
  - Reduced overhead during populated-property deletion and shape lookup operations, improving benchmarked deletion performance by approximately 14%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->