### PR TITLE
perf(runtime): carry the key index across a delete instead of rebuilding it (−7.6%)

### DIFF
--- a/changelog.d/9002-index-migrate-on-delete.md
+++ b/changelog.d/9002-index-migrate-on-delete.md
@@ -1,0 +1,24 @@
+`delete obj[k]` no longer rebuilds the shape key index.
+
+The delete clones the keys array, so the clone has a new address, misses
+`indices`, and rebuilt the whole index — decoding and FNV-hashing all ~500
+surviving property names on EVERY delete of a 500-key object.
+
+The survivors are the same strings in the same order minus one, so the index
+is shifted instead of recomputed: drop the removed slot, decrement every slot
+above it, touch no key bytes. Only a fully-built index is carried over; a
+partially built one is dropped exactly as before, since shifting it would
+misalign the un-indexed tail.
+
+Safe by construction rather than by argument: `shape_slot_lookup` re-validates
+the stored key against the requested bytes before returning a slot, so an
+index that is wrong yields a MISS and the caller's existing fallback, never a
+wrong property.
+
+Interleaved A/B, min-of-15 at quiet load (~1.0): `bench_populated_delete`
+5023 → **4641 ms, −7.6%** (mean −7.4%). Combined overwrite and realistic-name
+read unchanged.
+
+With #9000 and #9001 this brings the benchmark from 5938 to 4641 ms (−21.8%).
+Suite 2787 passed, no warnings; adversarial property differential byte-identical
+to node.

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -370,6 +370,17 @@ pub extern "C" fn js_object_delete_field(
         }
         (*keys_cloned).length = new_count as u32;
         super::rebuild_array_layout_from_slots(keys_cloned);
+        // Carry the key index onto the clone by shifting slots, instead of
+        // letting the new address miss `indices` and re-hash every surviving
+        // property name. On a 500-key object that rebuild ran on EVERY delete.
+        // A wrong index can only cause a miss — `shape_slot_lookup` validates
+        // the stored key against the requested bytes before returning a slot.
+        super::shapes::shape_index_migrate_after_delete(
+            keys as usize,
+            keys_cloned as usize,
+            i as u32,
+            key_count as u32,
+        );
         // `set_object_keys_array` publishes the cloned edge while preserving
         // the predecessor's semantic generation and object kind.
         set_object_keys_array(obj, keys_cloned);

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -33,7 +33,9 @@ use std::cell::RefCell;
 
 #[path = "shapes_slot_list.rs"]
 mod shapes_slot_list;
-pub(crate) use shapes_slot_list::{record_shape_scan_outcome, SlotList};
+pub(crate) use shapes_slot_list::{
+    record_shape_scan_outcome, shape_index_migrate_after_delete, SlotList,
+};
 
 pub(crate) struct ShapeIndex {
     /// Key count covered by `slots`. Longer live array ⟹ catch up
@@ -1595,46 +1597,6 @@ pub(crate) unsafe fn clear_object_shape_stamp(obj: *mut crate::object::ObjectHea
     } else {
         false
     }
-}
-
-/// Carry a key index across a delete, instead of re-hashing every key name.
-///
-/// `delete obj[k]` clones the keys array, so the result has a new address and
-/// misses `indices` — which meant a 500-key object rebuilt its whole index on
-/// every delete, decoding and FNV-hashing all ~500 property names each time.
-/// The surviving keys are the same strings in the same order minus one, so the
-/// index can be shifted rather than recomputed: drop the removed slot and
-/// decrement every slot above it. No key bytes are touched.
-///
-/// Safe against a mistake by construction: [`shape_slot_lookup`] re-validates
-/// the stored key against the requested bytes before returning a slot, so an
-/// index that is wrong produces a MISS and the caller's own fallback, never a
-/// wrong property. Only a fully-built index is carried over; a partially built
-/// one is dropped and rebuilt as before.
-pub(crate) fn shape_index_migrate_after_delete(
-    old_keys_id: usize,
-    new_keys_id: usize,
-    removed_slot: u32,
-    old_key_count: u32,
-) {
-    if old_keys_id == 0 || new_keys_id == 0 || old_keys_id == new_keys_id {
-        return;
-    }
-    let mut inner = crate::state::state().shapes.inner.borrow_mut();
-    let Some(mut index) = inner.indices.remove(&old_keys_id) else {
-        return;
-    };
-    if index.indexed_len < old_key_count {
-        // Partially built: shifting it would leave the un-indexed tail
-        // misaligned. Dropping it preserves the previous behaviour exactly.
-        return;
-    }
-    index.slots.retain(|_, list| {
-        list.retain_shift(removed_slot);
-        !list.is_empty()
-    });
-    index.indexed_len = old_key_count - 1;
-    inner.indices.insert(new_keys_id, index);
 }
 
 /// Build (or extend) the slot map for `keys` covering `key_count` keys.

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -1597,6 +1597,46 @@ pub(crate) unsafe fn clear_object_shape_stamp(obj: *mut crate::object::ObjectHea
     }
 }
 
+/// Carry a key index across a delete, instead of re-hashing every key name.
+///
+/// `delete obj[k]` clones the keys array, so the result has a new address and
+/// misses `indices` — which meant a 500-key object rebuilt its whole index on
+/// every delete, decoding and FNV-hashing all ~500 property names each time.
+/// The surviving keys are the same strings in the same order minus one, so the
+/// index can be shifted rather than recomputed: drop the removed slot and
+/// decrement every slot above it. No key bytes are touched.
+///
+/// Safe against a mistake by construction: [`shape_slot_lookup`] re-validates
+/// the stored key against the requested bytes before returning a slot, so an
+/// index that is wrong produces a MISS and the caller's own fallback, never a
+/// wrong property. Only a fully-built index is carried over; a partially built
+/// one is dropped and rebuilt as before.
+pub(crate) fn shape_index_migrate_after_delete(
+    old_keys_id: usize,
+    new_keys_id: usize,
+    removed_slot: u32,
+    old_key_count: u32,
+) {
+    if old_keys_id == 0 || new_keys_id == 0 || old_keys_id == new_keys_id {
+        return;
+    }
+    let mut inner = crate::state::state().shapes.inner.borrow_mut();
+    let Some(mut index) = inner.indices.remove(&old_keys_id) else {
+        return;
+    };
+    if index.indexed_len < old_key_count {
+        // Partially built: shifting it would leave the un-indexed tail
+        // misaligned. Dropping it preserves the previous behaviour exactly.
+        return;
+    }
+    index.slots.retain(|_, list| {
+        list.retain_shift(removed_slot);
+        !list.is_empty()
+    });
+    index.indexed_len = old_key_count - 1;
+    inner.indices.insert(new_keys_id, index);
+}
+
 /// Build (or extend) the slot map for `keys` covering `key_count` keys.
 unsafe fn index_range(shape: &mut ShapeIndex, keys: *const ArrayHeader, key_count: u32) {
     let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -31,6 +31,44 @@ impl SlotList {
         }
     }
 
+    /// Drop `removed` and shift every slot above it down by one.
+    #[inline]
+    pub(crate) fn retain_shift(&mut self, removed: u32) {
+        let shift = |s: u32| -> Option<u32> {
+            match s.cmp(&removed) {
+                std::cmp::Ordering::Equal => None,
+                std::cmp::Ordering::Less => Some(s),
+                std::cmp::Ordering::Greater => Some(s - 1),
+            }
+        };
+        match self {
+            SlotList::One(slot) => match shift(*slot) {
+                Some(s) => *slot = s,
+                None => *self = SlotList::Many(Vec::new()),
+            },
+            SlotList::Many(v) => {
+                v.retain_mut(|s| match shift(*s) {
+                    Some(n) => {
+                        *s = n;
+                        true
+                    }
+                    None => false,
+                });
+                if v.len() == 1 {
+                    *self = SlotList::One(v[0]);
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            SlotList::One(_) => false,
+            SlotList::Many(v) => v.is_empty(),
+        }
+    }
+
     #[inline]
     pub(crate) fn iter(&self) -> impl Iterator<Item = &u32> {
         match self {

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -1,8 +1,9 @@
 //! `SlotList` — the shape key index's per-hash slot list, in a sibling file.
 //!
 //! Extracted from `shapes.rs` to keep it under the repo's 2000-line cap.
-//! Also carries `record_shape_scan_outcome`, the shape scanner's
-//! per-descriptor bookkeeping, to keep `shapes.rs` under that cap.
+//! Also carries the two helpers that are mostly `SlotList` manipulation:
+//! `record_shape_scan_outcome` (the shape scanner's per-descriptor
+//! bookkeeping) and `shape_index_migrate_after_delete`.
 
 /// Slots sharing one content hash.
 ///
@@ -109,4 +110,44 @@ pub(crate) fn record_shape_scan_outcome(
     if descriptor.keys != descriptor.indexed_keys {
         descriptor_rekeys.push(*id);
     }
+}
+
+/// Carry a key index across a delete, instead of re-hashing every key name.
+///
+/// `delete obj[k]` clones the keys array, so the result has a new address and
+/// misses `indices` — which meant a 500-key object rebuilt its whole index on
+/// every delete, decoding and FNV-hashing all ~500 property names each time.
+/// The surviving keys are the same strings in the same order minus one, so the
+/// index can be shifted rather than recomputed: drop the removed slot and
+/// decrement every slot above it. No key bytes are touched.
+///
+/// Safe against a mistake by construction: [`shape_slot_lookup`] re-validates
+/// the stored key against the requested bytes before returning a slot, so an
+/// index that is wrong produces a MISS and the caller's own fallback, never a
+/// wrong property. Only a fully-built index is carried over; a partially built
+/// one is dropped and rebuilt as before.
+pub(crate) fn shape_index_migrate_after_delete(
+    old_keys_id: usize,
+    new_keys_id: usize,
+    removed_slot: u32,
+    old_key_count: u32,
+) {
+    if old_keys_id == 0 || new_keys_id == 0 || old_keys_id == new_keys_id {
+        return;
+    }
+    let mut inner = crate::state::state().shapes.inner.borrow_mut();
+    let Some(mut index) = inner.indices.remove(&old_keys_id) else {
+        return;
+    };
+    if index.indexed_len < old_key_count {
+        // Partially built: shifting it would leave the un-indexed tail
+        // misaligned. Dropping it preserves the previous behaviour exactly.
+        return;
+    }
+    index.slots.retain(|_, list| {
+        list.retain_shift(removed_slot);
+        !list.is_empty()
+    });
+    index.indexed_len = old_key_count - 1;
+    inner.indices.insert(new_keys_id, index);
 }


### PR DESCRIPTION
Third in the populated-delete series, after #9000 and #9001. This one removes the rebuild rather than making it cheaper.

`delete obj[k]` clones the keys array. The clone has a **new address**, so it misses `indices` and the whole index is rebuilt — decoding and FNV-hashing all ~500 surviving property names, on every single delete of a 500-key object.

The survivors are the same strings in the same order minus one, so the index can be **shifted instead of recomputed**: drop the removed slot, decrement every slot above it, touch no key bytes at all.

### Safety

By construction, not by argument: `shape_slot_lookup` already re-validates the stored key against the requested bytes before returning a slot. An index that is wrong therefore produces a **miss** and the caller's existing fallback — it cannot resolve to a different property. Only a fully-built index is migrated; a partially built one is dropped exactly as before, since shifting it would misalign the un-indexed tail.

### Measurement

Interleaved A/B, min-of-15, quiet load (~1.0), base and branch built from exact SHAs in one run:

| | base | this PR | |
|---|---|---|---|
| `bench_populated_delete` | 5023 ms | **4641 ms** | **−7.6%** (mean −7.4%) |
| combined overwrite | 38 ms | 38 ms | unchanged |
| realistic-name read | 14 ms | 14 ms | unchanged |

Cumulative across #9000 + #9001 + this: **5938 → 4641 ms, −21.8%** on perry's worst object-model gap.

### Correctness

- `perry-runtime`: **2787 passed / 0 failed**, no warnings (`--all-targets`).
- Adversarial property differential — delete-then-reread under a cached slot, accessor over a cached data slot, prototype fallback after delete, `Object.freeze`, same keys in opposite orders, 300-key object in the overflow store — **byte-identical to node**. The delete-heavy cases in that fixture are the ones this PR could plausibly break, and they pass.

### Remaining on this path

The per-delete value shift still moves ~499 values one at a time through barriered setters, and the keys-array clone still allocates per delete. The shift is the larger of the two and needs a bulk write-barrier story before it can become a memmove.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved property deletion speed by avoiding unnecessary reprocessing of remaining property names.
  * Reduced benchmark time for populated-object deletion by approximately 7.6%.

* **Reliability**
  * Preserved correct property lookup behavior after deletions, including for edge cases and adversarial scenarios.
  * All 2,787 tests pass without warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->