### PR TITLE
perf(runtime): delete's value shift stops re-resolving the slot bound per slot (−6.0%)

### DIFF
--- a/changelog.d/9003-delete-shift-bound.md
+++ b/changelog.d/9003-delete-shift-bound.md
@@ -1,0 +1,30 @@
+The post-delete value shift stops re-resolving the receiver's slot bound once
+per moved slot.
+
+`js_object_get_field` resolves the live inline-slot bound itself, and that
+bound is a shape-table probe — so shifting N values down after a delete paid N
+shape-descriptor lookups. A 500-key object did ~499 of them per `delete`. The
+loop already holds that exact bound in `field_count`, and nothing in it changes
+the receiver's shape.
+
+`object_field_at_with_live` exists for precisely this case (#8122) and is
+otherwise the identical body, inline-vs-overflow split included, so the values
+read are unchanged.
+
+This is also why `shape_descriptor_by_id` and `shape_slot_lookup` ranked so
+high in the delete profile: a large share was this loop, not the index lookups
+they exist to serve.
+
+Interleaved A/B, min-of-15 at quiet load (~1.0): `bench_populated_delete`
+4651 → **4371 ms, −6.0%** (mean −6.1%). Combined overwrite and realistic-name
+read unchanged.
+
+Cumulative with #9000/#9001/#9002: 5938 → 4371 ms, **−26.4%**. Suite 2787
+passed, no warnings; adversarial property differential byte-identical to node.
+
+Not done here: the shift still moves values one at a time through barriered
+stores. The deferred-layout batching helper (#7630) would remove the per-slot
+layout note, but its settle step marks the object layout-UNKNOWN whenever a
+pointer was stored — trading a precise pointer mask for scan-all-slots on an
+object that already had one. That is a GC-cost regression on an existing
+object, so it was deliberately not used.

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -394,7 +394,18 @@ pub extern "C" fn js_object_delete_field(
             // written under. Reading by NAME here would invoke a getter and store its
             // result as a data property, silently collapsing accessors (Next's module
             // exports are `Object.defineProperty(..., {get})`).
-            let next = js_object_get_field(obj, (j + 1) as u32);
+            // `js_object_get_field` resolves the live-slot bound itself, and
+            // that bound is a shape-table probe — so shifting N values paid N
+            // descriptor lookups per delete. This loop already holds the same
+            // bound in `field_count`, and nothing in it changes the receiver's
+            // shape, so pass it in. `object_field_at_with_live` exists for
+            // exactly this (#8122) and is otherwise the identical body,
+            // including the inline-vs-overflow split.
+            let next = crate::object::field_get_set::object_field_at_with_live(
+                obj,
+                (j + 1) as u32,
+                field_count,
+            );
             // Inline write if target slot < alloc_limit, else overflow.
             if j < alloc_limit {
                 let fields_ptr =

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -250,7 +250,7 @@ pub(crate) use accessors::{
     accessor_receiver_override_begin, accessor_receiver_override_end,
     array_prototype_property_value, builtin_reflection_accessor_read, class_getter_this,
     invoke_accessor_getter, invoke_accessor_setter, is_typed_array_prototype,
-    ordinary_object_prototype_property_value, own_data_field_by_name,
+    object_field_at_with_live, ordinary_object_prototype_property_value, own_data_field_by_name,
     primitive_builtin_prototype_property, primitive_object_prototype_accessor, string_index_value,
 };
 pub(crate) use class_object_props::class_object_prototype_value;


### PR DESCRIPTION
Fourth in the populated-delete series (#9000, #9001, #9002).

`js_object_get_field` resolves the receiver's live inline-slot bound itself, and that bound is a **shape-table probe**. So shifting N values down after a delete paid N shape-descriptor lookups — ~499 per `delete` on a 500-key object. The loop already holds that exact bound in `field_count`, and nothing in it changes the receiver's shape.

`object_field_at_with_live` exists for precisely this case (#8122) and is otherwise the identical body, inline-vs-overflow split included, so the values read are unchanged.

This also explains why `shape_descriptor_by_id` and `shape_slot_lookup` ranked so high in the delete profile: a large share of them was *this loop*, not the index lookups they exist to serve.

### Measurement

Interleaved A/B, min-of-15, quiet load (~1.0), base and branch from exact SHAs in one run:

| | base | this PR | |
|---|---|---|---|
| `bench_populated_delete` | 4651 ms | **4371 ms** | **−6.0%** (mean −6.1%) |
| combined overwrite | 37 ms | 38 ms | unchanged |
| realistic-name read | 14 ms | 14 ms | unchanged |

Cumulative across the series: **5938 → 4371 ms, −26.4%**.

### One optimisation deliberately NOT taken

The shift still moves values individually through barriered stores. The deferred-layout batching helper (#7630) would remove the per-slot layout note — but its settle step (`layout_finish_deferred_boxed_object`) marks the object **layout-UNKNOWN** whenever a pointer was stored, degrading a precise pointer mask to scan-all-slots. That is correct and valuable for the freshly-built objects it was designed for, and a bad trade here: it buys CPU on the delete by making every later GC scan the whole payload of an object that already had a precise mask. Left alone deliberately.

### Correctness

- `perry-runtime`: **2787 passed / 0 failed**, no warnings (`--all-targets`).
- Adversarial property differential — delete-then-reread under a cached slot, accessor over a cached data slot, prototype fallback after delete, `Object.freeze`, same keys in opposite orders, 300-key object in the overflow store — **byte-identical to node**.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved object property deletion performance, especially for objects with multiple properties.
  * Reduced overhead when shifting remaining property values after deletion.
  * Preserved existing read behavior while delivering cumulative benchmark improvements.

* **Bug Fixes**
  * Ensured surviving properties retain their correct positions and values after deletion.

* **Documentation**
  * Added changelog details covering performance improvements, testing, and benchmark results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->