### PR TITLE
test(gc): make extension root rewrite checks deterministic

### DIFF
--- a/changelog.d/9004-deterministic-ext-gc-root-tests.md
+++ b/changelog.d/9004-deterministic-ext-gc-root-tests.md
@@ -1,0 +1,21 @@
+Extension-crate GC root-rewrite tests now select a moving collection through
+`perry_runtime::gc::js_gc_force_evacuation_test_override` instead of mutating
+`PERRY_GC_FORCE_EVACUATE` process-wide.
+
+These tests assert that a scanner **rewrote** a root, which is only observable
+if the collection actually moved the object — and whether a minor evacuates is
+a policy decision that legitimately declines under quiet unit-test heaps. Full
+CI run 33227701945 failed exactly that way in
+`perry-ext-commander::gc_mutable_scanner_rewrites_action_callback_root`: the
+scanner was fine, the collection simply stayed non-moving.
+
+The env-var approach it replaces was process-wide, so the forcing window was
+visible to every other libtest thread in the binary — the same shape #7946
+removed from `perry-runtime`'s own suite, where it silently turned in-place
+promotion off underneath `gc::tests::promote_in_place`. The override is
+thread-local and tri-state (`1` on, `0` off, negative clears), and each guard
+restores the previous state, so a thread that had no override keeps none.
+
+`perry-ext-commander`, `-cron`, `-fastify`, `-streams` and `-ws` were not
+forcing at all before this; they now assert against a guaranteed-moving
+collection rather than whichever policy the heap happened to pick.

--- a/crates/perry-ext-commander/src/lib.rs
+++ b/crates/perry-ext-commander/src/lib.rs
@@ -662,6 +662,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -670,9 +671,15 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(0);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -680,6 +687,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 

--- a/crates/perry-ext-cron/src/lib.rs
+++ b/crates/perry-ext-cron/src/lib.rs
@@ -467,6 +467,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -475,9 +476,15 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(0);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -485,6 +492,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -166,6 +166,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -174,9 +175,15 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(0);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -184,6 +191,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 

--- a/crates/perry-ext-http/src/server/mod.rs
+++ b/crates/perry-ext-http/src/server/mod.rs
@@ -202,6 +202,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -214,19 +215,18 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            // Force evacuation for the guard's lifetime: these tests assert a
-            // root was REWRITTEN, which is only observable if the object
-            // actually moved, and whether a minor evacuates is a C4b policy
-            // decision that legitimately declines under unit-test conditions
-            // (at which point the assertions fail with nothing wrong in the
-            // code under test). See the twin guard in `crate::tests`.
-            //
-            // SAFETY: `GC_TEST_LOCK` is held for the guard's whole lifetime,
-            // so no other GC test in this binary observes the mutation window.
-            unsafe { std::env::set_var("PERRY_GC_FORCE_EVACUATE", "1") };
+            // Rewriting is observable only when the collector moves the root.
+            // Keep that test policy thread-local so unrelated test threads do
+            // not observe a process-wide environment mutation.
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(slot_count);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -234,8 +234,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
-            // SAFETY: still under `GC_TEST_LOCK` (dropped after this body).
-            unsafe { std::env::remove_var("PERRY_GC_FORCE_EVACUATE") };
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -7,6 +7,7 @@ static GC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 struct GcTestGuard {
     frame: u64,
+    previous_force_evacuation: i32,
     _lock: MutexGuard<'static, ()>,
 }
 
@@ -15,24 +16,17 @@ impl GcTestGuard {
         let lock = GC_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // These tests assert that a scanner REWROTE a root, which only has an
-        // observable answer if the collection actually MOVED the object. That
-        // is a policy decision (C4b weighs nursery/RSS pressure against
-        // measured movable candidates), and under unit-test conditions the
-        // policy legitimately declines — at which point the assertions read
-        // "the address did not change" and fail, with nothing wrong in the
-        // code under test. Force evacuation for the duration of the guard so
-        // the subject is guaranteed live; `perry-runtime`'s own
-        // `ForcedEvacuationTestGuard` is `#[cfg(test)]`-internal and cannot be
-        // reached from this crate's test binary, but the env knob is read
-        // fresh on every query and the guard already serializes these tests.
-        //
-        // SAFETY: `GC_TEST_LOCK` is held for the guard's whole lifetime, so no
-        // other GC test in this binary observes the mutation window.
-        unsafe { std::env::set_var("PERRY_GC_FORCE_EVACUATE", "1") };
+        // Rewriting is observable only when the collector moves the root.
+        // Keep that test policy thread-local so unrelated test threads do not
+        // observe a process-wide environment mutation.
+        let previous_force_evacuation = perry_runtime::gc::js_gc_force_evacuation_test_override(1);
         perry_runtime::gc::js_gc_write_barriers_emitted(1);
         let frame = perry_runtime::gc::js_shadow_frame_push(0);
-        Self { frame, _lock: lock }
+        Self {
+            frame,
+            previous_force_evacuation,
+            _lock: lock,
+        }
     }
 }
 
@@ -40,8 +34,7 @@ impl Drop for GcTestGuard {
     fn drop(&mut self) {
         perry_runtime::gc::js_shadow_frame_pop(self.frame);
         perry_runtime::gc::js_gc_write_barriers_emitted(0);
-        // SAFETY: still under `GC_TEST_LOCK` (dropped after this body).
-        unsafe { std::env::remove_var("PERRY_GC_FORCE_EVACUATE") };
+        perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
     }
 }
 

--- a/crates/perry-ext-net/src/tests.rs
+++ b/crates/perry-ext-net/src/tests.rs
@@ -5,7 +5,7 @@ static GC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 struct GcTestGuard {
     frame: u64,
-    previous_force_evacuation: Option<std::ffi::OsString>,
+    previous_force_evacuation: i32,
     _lock: MutexGuard<'static, ()>,
 }
 
@@ -15,15 +15,9 @@ impl GcTestGuard {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Rewriting is observable only when the collector moves the root.
-        // Unit-test heaps are normally too quiet for the evacuation policy to
-        // choose that path, so make the test's collection deterministic. The
-        // lock serializes this crate's GC tests, and Drop restores any value
-        // supplied by the test runner.
-        let previous_force_evacuation = std::env::var_os("PERRY_GC_FORCE_EVACUATE");
-        // SAFETY: GC_TEST_LOCK is held until this guard is dropped, so no
-        // other GC test in this binary observes the temporary environment
-        // value.
-        unsafe { std::env::set_var("PERRY_GC_FORCE_EVACUATE", "1") };
+        // Keep that test policy thread-local so unrelated test threads do not
+        // observe a process-wide environment mutation.
+        let previous_force_evacuation = perry_runtime::gc::js_gc_force_evacuation_test_override(1);
         perry_runtime::gc::js_gc_write_barriers_emitted(1);
         let frame = perry_runtime::gc::js_shadow_frame_push(1);
         Self {
@@ -38,14 +32,7 @@ impl Drop for GcTestGuard {
     fn drop(&mut self) {
         perry_runtime::gc::js_shadow_frame_pop(self.frame);
         perry_runtime::gc::js_gc_write_barriers_emitted(0);
-        // SAFETY: GC_TEST_LOCK is still held here and is released only after
-        // this Drop implementation returns.
-        unsafe {
-            match self.previous_force_evacuation.take() {
-                Some(value) => std::env::set_var("PERRY_GC_FORCE_EVACUATE", value),
-                None => std::env::remove_var("PERRY_GC_FORCE_EVACUATE"),
-            }
-        }
+        perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
     }
 }
 

--- a/crates/perry-ext-streams/src/lib.rs
+++ b/crates/perry-ext-streams/src/lib.rs
@@ -1449,6 +1449,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -1457,9 +1458,15 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(0);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -1467,6 +1474,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -1300,6 +1300,7 @@ mod tests {
 
     struct GcTestGuard {
         frame: u64,
+        previous_force_evacuation: i32,
         _lock: MutexGuard<'static, ()>,
     }
 
@@ -1308,9 +1309,15 @@ mod tests {
             let lock = GC_TEST_LOCK
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let previous_force_evacuation =
+                perry_runtime::gc::js_gc_force_evacuation_test_override(1);
             perry_runtime::gc::js_gc_write_barriers_emitted(1);
             let frame = perry_runtime::gc::js_shadow_frame_push(0);
-            Self { frame, _lock: lock }
+            Self {
+                frame,
+                previous_force_evacuation,
+                _lock: lock,
+            }
         }
     }
 
@@ -1318,6 +1325,7 @@ mod tests {
         fn drop(&mut self) {
             perry_runtime::gc::js_shadow_frame_pop(self.frame);
             perry_runtime::gc::js_gc_write_barriers_emitted(0);
+            perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
         }
     }
 


### PR DESCRIPTION
## Summary

- force the moving-GC policy with the runtime thread-local test override in every extension test that asserts root addresses are rewritten
- restore the previous per-thread override in each guard
- replace remaining process-wide `PERRY_GC_FORCE_EVACUATE` mutations

## Release blocker

Full CI run 33227701945 failed in `perry-ext-commander::gc_mutable_scanner_rewrites_action_callback_root` because the collection legitimately stayed non-moving. The scanner itself was not broken; the test asserted address movement without selecting a moving collection.

## Verification

- all 13 affected `gc_` tests pass locally
- all 13 still pass with ambient `PERRY_GC_FORCE_EVACUATE=0`, proving the thread-local override controls the test
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved garbage-collection test coverage by consistently exercising memory evacuation scenarios across extensions.
  - Test settings are now isolated to the active runtime context and automatically restored afterward.
  - Reduced cross-test interference and improved reliability when validating callback, timer, networking, and stream behavior.
  - Replaced process-wide configuration changes with safer temporary test controls.

- **Documentation**
  - Added changelog documentation covering deterministic garbage-collection root-rewrite tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->