### PR TITLE
perf(runtime): keep the migrated key index instead of dropping it (populated delete −36.2%)

### DIFF
--- a/changelog.d/9005-keep-migrated-index.md
+++ b/changelog.d/9005-keep-migrated-index.md
@@ -1,0 +1,20 @@
+`delete obj[k]` stops rebuilding the shape key index — for real this time.
+
+#9002 shifted the index onto the post-delete keys array, but the delete tail
+ends with `shape_drop` on that same array, so the migrated index was discarded
+immediately and the next lookup rebuilt it by re-hashing every surviving key
+name. (#9002's own measured win came from pruning the STALE old entry, not
+from preserving a usable index; its description has been corrected.)
+
+A migrated index is *shifted to match* the compacted array, so it is current,
+not stale. Skipping the drop when the migration succeeded is what actually
+stops the rebuild. Everything else is unchanged: a partially built index, or a
+delete that took another path, still drops exactly as before.
+
+Interleaved A/B, min-of-15 at quiet load (~1.0): `bench_populated_delete`
+4361 → **2781 ms, −36.2%** (mean −36.2%). Combined overwrite and
+realistic-name read unchanged.
+
+Cumulative across #9000–#9003 and this: **5938 → 2781 ms, −53.2%** on perry's
+worst object-model gap. Suite 2787 passed, no warnings; adversarial property
+differential byte-identical to node.

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -375,7 +375,7 @@ pub extern "C" fn js_object_delete_field(
         // property name. On a 500-key object that rebuild ran on EVERY delete.
         // A wrong index can only cause a miss — `shape_slot_lookup` validates
         // the stored key against the requested bytes before returning a slot.
-        super::shapes::shape_index_migrate_after_delete(
+        let index_migrated = super::shapes::shape_index_migrate_after_delete(
             keys as usize,
             keys_cloned as usize,
             i as u32,
@@ -458,7 +458,13 @@ pub extern "C" fn js_object_delete_field(
         //    not eagerly deleted because a sibling may still name one; exact
         //    new facts are published below and weak post-trace pruning retires
         //    dead historical descriptors.
-        crate::object::shapes::shape_drop(crate::object::object_keys_array(obj));
+        // ...unless the migration above already shifted it to match the
+        // compacted array, in which case it is CURRENT, not stale, and
+        // dropping it would throw away the rebuild this is meant to avoid —
+        // the next lookup would re-hash every surviving key name.
+        if !index_migrated {
+            crate::object::shapes::shape_drop(crate::object::object_keys_array(obj));
+        }
         1
     }
 }

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -126,23 +126,27 @@ pub(crate) fn record_shape_scan_outcome(
 /// index that is wrong produces a MISS and the caller's own fallback, never a
 /// wrong property. Only a fully-built index is carried over; a partially built
 /// one is dropped and rebuilt as before.
+///
+/// Returns whether the index was actually carried over: the delete tail uses
+/// that to skip the `shape_drop` that would otherwise discard it immediately.
+#[must_use]
 pub(crate) fn shape_index_migrate_after_delete(
     old_keys_id: usize,
     new_keys_id: usize,
     removed_slot: u32,
     old_key_count: u32,
-) {
+) -> bool {
     if old_keys_id == 0 || new_keys_id == 0 || old_keys_id == new_keys_id {
-        return;
+        return false;
     }
     let mut inner = crate::state::state().shapes.inner.borrow_mut();
     let Some(mut index) = inner.indices.remove(&old_keys_id) else {
-        return;
+        return false;
     };
     if index.indexed_len < old_key_count {
         // Partially built: shifting it would leave the un-indexed tail
         // misaligned. Dropping it preserves the previous behaviour exactly.
-        return;
+        return false;
     }
     index.slots.retain(|_, list| {
         list.retain_shift(removed_slot);
@@ -150,4 +154,5 @@ pub(crate) fn shape_index_migrate_after_delete(
     });
     index.indexed_len = old_key_count - 1;
     inner.indices.insert(new_keys_id, index);
+    true
 }


### PR DESCRIPTION
Fifth in the populated-delete series, and it corrects #9002 as well as building on it.

**What #9002 got wrong.** It shifts the key index onto the post-delete keys array — but the delete tail ends with `shape_drop(object_keys_array(obj))`, which removes `indices[keys]` for *exactly that array*. So the migrated index was discarded immediately and the next lookup rebuilt it anyway, by re-hashing every surviving key name. #9002's measured −7.6% is real, but it came from the other half of that function: pruning the **stale old** entry, which the previous code left behind on every delete. I have corrected that PR's description.

**What this does.** A migrated index is *shifted to match* the compacted array, so it is **current, not stale** — dropping it throws away the rebuild the migration exists to prevent. The drop is now skipped when the migration succeeded. Where migration does not apply (a partially built index, or a delete taking another path), the drop happens exactly as before.

### Measurement

Interleaved A/B, min-of-15, quiet load (~1.0), base and branch from exact SHAs in one run:

| | base | this PR | |
|---|---|---|---|
| `bench_populated_delete` | 4361 ms | **2781 ms** | **−36.2%** (mean −36.2%) |
| combined overwrite | 38 ms | 38 ms | unchanged |
| realistic-name read | 14 ms | 14 ms | unchanged |

Cumulative across #9000, #9001, #9002, #9003 and this: **5938 → 2781 ms, −53.2%**.

### Correctness

- `perry-runtime`: **2787 passed / 0 failed**, no warnings (`--all-targets`).
- Adversarial property differential — delete-then-reread under a cached slot, accessor over a cached data slot, prototype fallback after delete, `Object.freeze`, same keys in opposite orders, 300-key object in the overflow store — **byte-identical to node**. The delete-heavy cases are the ones a stale index would break, and they pass.

The index's own safety net still applies underneath all of this: `shape_slot_lookup` re-validates the stored key against the requested bytes before returning a slot, so even a wrong index yields a miss and the caller's fallback, never a wrong property.

### Still on the table

The per-delete keys-array clone remains. `GC_FLAG_SHAPE_SHARED` is stamped when the transition cache publishes an array, and `object_ops::keys_array` already treats it as authoritative for this exact decision — so an **owned** array could be compacted in place, removing the allocation entirely. That is the next one and wants care, since it mutates an array other objects could reference if the flag were ever incomplete.

https://claude.ai/code/session_01Ay8VyLkKbm8Hkc1xmvTEsP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved object property deletion performance by reducing redundant index rebuilding and descriptor checks.
  - Preserved optimized property lookup indexes when deletion succeeds, avoiding unnecessary rehashing.
  - Added faster handling for compacting object keys during deletion.

- **Documentation**
  - Added release documentation covering index preservation after property deletion and benchmark improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->