### PR TITLE
fix(ci): read flattened GC matrix shard downloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1851,6 +1851,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: gc-repsel-matrix-shard-*
+          merge-multiple: true
           path: gc-repsel-shards
       - name: Merge shards and enforce complete coverage + liveness
         env:
@@ -1863,7 +1864,7 @@ jobs:
             --expect "$EXPECT" \
             --mode "$MODE" \
             --output gc-repsel-matrix.json \
-            gc-repsel-shards/gc-repsel-matrix-shard-*/gc-repsel-matrix-*.json
+            gc-repsel-shards/gc-repsel-matrix-*.json
 
       # The remaining GC stress arms are aggregate-only. Repeating them in
       # every matrix shard would add cost without increasing their coverage.

--- a/changelog.d/9007-gc-matrix-fanin-layout.md
+++ b/changelog.d/9007-gc-matrix-fanin-layout.md
@@ -1,0 +1,16 @@
+The `gc-stress` fan-in now downloads the GC representation-matrix shards with
+`merge-multiple: true` and reads them from a flat directory.
+
+`actions/download-artifact@v8` extracted a single matching artifact directly
+into `gc-repsel-shards/` rather than into a per-artifact subdirectory, so the
+nested glob `gc-repsel-shards/gc-repsel-matrix-shard-*/gc-repsel-matrix-*.json`
+matched nothing and the step died on the literal pattern under `set -euo
+pipefail`. #9004's run 33228890420 produced a complete one-shard matrix
+(`PASS=436 FAIL=0`) and still failed the fan-in.
+
+Flattening makes the one-shard PR tier and the multi-shard Full tier use the
+same layout. Shards write distinct filenames (`gc-repsel-matrix-$SHARD.json`),
+so merging into one directory cannot collide, and the merge itself is unchanged:
+`--expect` still requires exactly the planned number of reports, rejects a
+duplicated or missing shard index, and verifies each test belongs to its
+deterministic shard — a flattened layout cannot quietly reduce coverage.


### PR DESCRIPTION
## Summary

- flatten all GC matrix shard artifacts into one directory in the fan-in job
- merge reports from that consistent layout for both the one-shard PR tier and multi-shard Full tier

## Release blocker

PR #9004 run 33228890420 produced a complete one-shard matrix (`PASS=436`, `FAIL=0`), but `actions/download-artifact@v8` extracted the single matching artifact directly into `gc-repsel-shards/`. The fan-in only searched a nested artifact-name directory and failed with `No such file or directory`.

## Verification

- downloaded the exact `gc-repsel-matrix-shard-1` artifact from run 33228890420
- merged it successfully from the flattened path: `PASS=436 UNVER=124 XFAIL=0 FAIL=0`
- `python3 scripts/gc_repsel_matrix_merge.py --self-test`
- `python3 scripts/gc_gate_wiring_check.py --self-test`
- `python3 scripts/gc_gate_wiring_check.py`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection stress test result processing by correctly combining reports from parallel test shards.
  * Prevented report-merging failures caused by artifacts being extracted into nested directories.
  * Preserved validation of expected report counts, unique shard indices, and deterministic test-to-shard assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->