### PR TITLE
test(parity): wait for cron ticks with deadline

### DIFF
--- a/test-files/test_gap_cron_cronjob.ts
+++ b/test-files/test_gap_cron_cronjob.ts
@@ -33,7 +33,10 @@ async function main() {
   );
 
   job.start();
-  await new Promise((resolve) => setTimeout(resolve, 3200));
+  const tickDeadline = Date.now() + 10_000;
+  while ((ticks < 2 || autoTicks < 2) && Date.now() < tickDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
   job.stop();
   auto.stop();
 


### PR DESCRIPTION
Stabilizes the release-blocking cron parity test by waiting up to 10 seconds for the two expected ticks instead of assuming a loaded hosted runner schedules them within 3.2 seconds. Semantics remain unchanged: missing callbacks still produce false and fail parity. Verified with 10/10 exact Node-vs-Perry runs on perrymaster (100%, zero compile failures or crashes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing reliability for CronJob behavior tests by polling for expected job executions instead of relying on a fixed delay.
  * Preserved existing assertions and output while allowing up to 10 seconds for scheduled jobs to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->