### PR TITLE
fix(tooling): stop run_lint_gates reporting a permanent false failure

### DIFF
--- a/changelog.d/9009-lint-gate-ci-only-expressions.md
+++ b/changelog.d/9009-lint-gate-ci-only-expressions.md
@@ -1,0 +1,25 @@
+`scripts/run_lint_gates.sh` no longer reports a permanent false failure.
+
+The extractor read each `run:` block line by line, so a backslash-continued
+gate was emitted as its first line only and then executed that way. #8928's
+step ran as `python3 scripts/ci_cargo_test_shard.py --package perry \`, with
+`--total-shards` and `--validate` stranded on the continuation lines, and
+failed on a missing argument for everyone on every run — `1 of 58 FAILED`.
+
+Backslash continuations are now joined before matching, and a command carrying
+a GitHub Actions expression is skipped: it is substituted in CI and never
+locally, so running it passes an empty value and fails for reasons unrelated to
+the tree. Skipped gates are named in the output and subtracted from the total
+rather than dropped — a gate that quietly disappears is worse than one that is
+permanently red, which is the subject of this script.
+
+The join leaves the derived list otherwise identical (56 commands, the two
+ratchet steps still extracted — their `git cat-file … || git fetch …` prelude
+is a separate logical command from the gate below it). Sabotage checks both
+ways: an expression injected into an unrelated gate becomes a second named
+skip, and a genuinely broken gate still reports `FAIL` and exits 1.
+
+The expression is built by concatenation, not written literally, because this
+heredoc sits inside a process substitution and bash 3.2 (macOS) treats a
+literal `${{` in the body as an unterminated parameter expansion — which kills
+the script before it runs anything, and would do so only on macOS.

--- a/scripts/run_lint_gates.sh
+++ b/scripts/run_lint_gates.sh
@@ -66,7 +66,14 @@ for step in steps:
     run = step.get("run")
     if not run:
         continue
-    for line in run.split("\n"):
+    # Join backslash continuations FIRST. Without this a multi-line gate is
+    # extracted as its first line only and then RUN that way -- truncated, with
+    # a trailing backslash -- which is #8929: the ci_cargo_test_shard.py step
+    # failed for everyone. Joining is safe for the ratchet steps, whose
+    # "git cat-file ... || git fetch ..." prelude is a SEPARATE logical command
+    # from the "python3 scripts/..." gate on the line below it.
+    joined = re.sub(r"\\\n[ \t]*", " ", run)
+    for line in joined.split("\n"):
         line = line.strip()
         if not re.match(r"^(python3 scripts/|\./scripts/|cargo fmt)", line):
             continue
@@ -76,12 +83,33 @@ for step in steps:
         if line in seen:
             continue
         seen.add(line)
-        print(line)
+        # A GitHub Actions expression is substituted in CI and never locally,
+        # so running such a gate here passes an empty value and fails for
+        # reasons that say nothing about the tree. Report it as SKIPPED and
+        # name it -- a gate silently dropped from the list would be worse than
+        # one that is permanently red.
+        #
+        # Built by concatenation on purpose, and NOT written literally: this
+        # heredoc sits inside a process substitution, and bash 3.2 (macOS)
+        # parses the body far enough to treat a literal dollar-brace-brace as
+        # an unterminated parameter expansion -- the whole script then dies
+        # with "unexpected EOF while looking for matching quote".
+        gha_expr = "$" + "{" + "{"
+        if gha_expr in line:
+            print("#skip# " + line)
+        else:
+            print(line)
 PY
 )
 
 if [[ "${1:-}" == "--list" ]]; then
-    printf '%s\n' "${CMDS[@]}"
+    for _c in "${CMDS[@]}"; do
+        if [[ "$_c" == "#skip# "* ]]; then
+            printf 'SKIP (CI-only expression, not run locally): %s\n' "${_c#\#skip\# }"
+        else
+            printf '%s\n' "$_c"
+        fi
+    done
     echo "(${#CMDS[@]} gate commands, derived from .github/workflows/test.yml)"
     exit 0
 fi
@@ -90,7 +118,14 @@ echo "run_lint_gates: ${#CMDS[@]} gate commands derived from the lint job"
 echo
 
 failed=()
+skipped=0
 for cmd in "${CMDS[@]}"; do
+    if [[ "$cmd" == "#skip# "* ]]; then
+        skipped=$((skipped + 1))
+        printf '  skip  %s\n' "${cmd#\#skip\# }"
+        printf '        (carries a CI-only expression; substituted by GitHub Actions, not here)\n'
+        continue
+    fi
     if out="$(eval "$cmd" 2>&1)"; then
         printf '  ok    %s\n' "$cmd"
     else
@@ -133,10 +168,11 @@ else
     fi
 fi
 
-total=${#CMDS[@]}
+total=$(( ${#CMDS[@]} - skipped ))
 ((compile_ran)) && total=$((total + 2))
 suffix=""
 ((compile_ran)) || suffix=" (compile tier SKIPPED)"
+((skipped)) && suffix="${suffix}; ${skipped} CI-only skipped"
 
 echo
 if ((${#failed[@]})); then


### PR DESCRIPTION
Closes #8929 — `scripts/run_lint_gates.sh` has been reporting `1 of 58 FAILED` for everyone, permanently.

## Root cause

The extractor walked each `run:` block **line by line**, so a backslash-continued gate was emitted as its first line only — and then executed that way. #8928's step became:

```
python3 scripts/ci_cargo_test_shard.py --package perry \
```

with `--total-shards` and `--validate` left behind on the continuation lines, so it failed on a missing argument. The gate itself was fine.

## Fix

Join backslash continuations *before* matching, then skip commands that carry a GitHub Actions expression — substituted in CI, never locally, so running one here passes an empty value and fails for reasons that say nothing about the tree.

Skipped gates are **named in the output and subtracted from the total**, not dropped. A gate that silently vanishes from the list is worse than one that is permanently red, which is the whole subject of this script.

## Why the join is safe

The two ratchet steps look like they would break, since their `run:` blocks *begin* with `git cat-file -e "$BASE_SHA^{commit}" ... || git fetch ...` — a line that does not match the gate regex. But that prelude is a **separate logical command** from the `python3 scripts/...` gate on the line below it, so joining leaves both ratchets extracted exactly as before.

Confirmed empirically rather than argued: the derived list is byte-identical before and after except for the one command, and the count stays 56. The join neither loses nor invents a gate.

```
-python3 scripts/ci_cargo_test_shard.py --package perry \
+SKIP (CI-only expression, not run locally): python3 scripts/ci_cargo_test_shard.py --package perry  --total-shards "${{ ... }}"  --validate
```

## Verification

Full run, both tiers: **`all 57 gates passed; 1 CI-only skipped`** (was `1 of 58 FAILED`).

Sabotaged both directions, because a skip mechanism that skipped too much would be the exact failure this script guards against:

- **injected** a CI-only expression into an unrelated gate (`check_test_registration.py --self-test`) → reported as a *second* skip, `all 54 gates passed; 2 CI-only skipped`
- **broke** a real gate (`--definitely-not-a-flag`) → `FAIL`, `1 of 55 FAILED`, **exit 1**

So the runner still goes red on a genuine failure, and no real gate can be misrouted into the skip branch — extracted commands must start with `python3 scripts/`, `./scripts/` or `cargo fmt`, so none can begin with the `#skip#` marker.

## One trap worth flagging for future editors

The expression is built by concatenation (`"$" + "{" + "{"`) rather than written literally, and there is a comment saying why. This heredoc sits inside a process substitution, and **bash 3.2 (macOS)** parses far enough into the body to treat a literal `${{` as an unterminated parameter expansion — the script then dies with `unexpected EOF while looking for matching quote` before running anything. It would still work on CI's newer bash, so "simplifying" it back would break only macOS. #8929 notes the author hit this fragility and backed out rather than ship it unverified.

This matters a little more than a convenience script: `run_lint_gates.sh` is invoked by `scripts/pre-tag-check.sh` and the release runbook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lint checks that use multi-line commands so all command arguments are processed correctly.
  * Prevented CI-only checks from causing false failures when run locally.
  * Corrected the reported total so skipped CI-only checks are excluded from results.

* **Improvements**
  * Lint listings now clearly identify checks skipped outside CI.
  * Summaries report how many checks were skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->