### PR TITLE
fix(ci): reject the 0000- changelog placeholder and warn on a wrong number

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,29 +180,17 @@ jobs:
       # `pr-gate` is the single required context, so a red step here is as
       # blocking as a red job was -- and one fewer job is one fewer runner
       # slot on a 20-slot org.
+      # Runs on every tier, not just PRs, so the gate's own logic is exercised
+      # even when the enforcement step below is inapplicable.
+      - name: Changeset gate self-test
+        if: ${{ !cancelled() }}
+        run: ./scripts/check_changeset_fragment.sh --self-test
+
       - name: Require a changelog.d/ fragment for crates/ changes
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate > files.json
-          # jq -e, no pipes: `lint` is a registered gate (gc_gate_wiring_check)
-          # and `jq | grep -q` under pipefail can fail on SIGPIPE when grep
-          # closes early on the first match.
-          # `-s` + `[.[][]]`: --paginate emits one JSON array per page, and
-          # `jq -e` reports only the LAST array's verdict without the slurp.
-          if ! jq -s -e '[.[][]] | any(.filename | startswith("crates/"))' files.json > /dev/null; then
-            echo "No crates/ changes — gate not applicable."; exit 0
-          fi
-          # The fragment must be ADDED in this PR (editing a leftover file
-          # doesn't count) and match the root-level <digits>-<slug>.md shape
-          # cut_release_notes.sh folds at release time.
-          if jq -s -e '[.[][]] | any(.status == "added" and (.filename | test("^changelog\\.d/[0-9]+-[^/]+\\.md$")))' files.json > /dev/null; then
-            exit 0
-          fi
-          echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/<PR>-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
-          exit 1
+        run: ./scripts/check_changeset_fragment.sh "${{ github.repository }}" "${{ github.event.pull_request.number }}"
 
       - name: Setup Node.js for benchmark harness tests
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/changelog.d/9010-changeset-fragment-number.md
+++ b/changelog.d/9010-changeset-fragment-number.md
@@ -1,0 +1,20 @@
+The changeset gate now rejects the `0000-` changelog placeholder and warns when
+an added fragment carries neither this PR's number nor a plausible backfill's.
+
+It previously accepted any `changelog.d/<digits>-<slug>.md` — *some* digits, not
+this PR's number — so both the unfilled placeholder and another PR's number
+passed. Nothing reads a fragment until a release is cut, at which point the
+change is attributed to the wrong PR; #8978 recorded four in one day, every one
+caught by eye rather than by a gate.
+
+An all-zero prefix is a hard failure: no PR is ever number 0, so it is always
+the placeholder. A mismatched real number is only a warning, because a backfill
+(#8973 renamed three fragments to numbers that were not its own) and a stacked
+PR naming its parent both legitimately carry one — a strict rule would block the
+PR that repairs the problem.
+
+The logic moved out of inline YAML into `scripts/check_changeset_fragment.sh`,
+whose `--self-test` exercises the same function the gate calls rather than a
+copy, and runs on every tier instead of only on `pull_request`. The enforcement
+invocation takes `${{ }}` arguments, so `run_lint_gates.sh` skips it locally via
+the mechanism added in #9009 while still running the self-test.

--- a/scripts/check_changeset_fragment.sh
+++ b/scripts/check_changeset_fragment.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Changeset gate: a PR touching `crates/` must ADD a `changelog.d/<PR>-<slug>.md`
+# fragment (see `changelog.d/README.md`; fragments fold into the GitHub Release
+# notes at tag time via `scripts/cut_release_notes.sh`, and `CHANGELOG.md` is
+# frozen).
+#
+# Fragment names are PR-keyed so in-flight PRs cannot collide. Getting the
+# number wrong is SILENT: nothing reads the fragment until a release is cut,
+# and it then attributes the change to a different PR. #8978 recorded four in
+# one day, all caught by eye rather than by any gate.
+#
+# WHY THE NUMBER IS NOT ENFORCED STRICTLY
+# ---------------------------------------
+# "The fragment must carry this PR's number" is a false positive on two
+# legitimate shapes:
+#
+#   * a backfill -- #8973 renamed three fragments to `8944-`, `8947-` and
+#     `8291-`, none of them its own number, so a strict rule would block the
+#     very PR that repairs the problem;
+#   * a stacked PR whose fragment names the parent change.
+#
+# So a mismatched real number is a WARNING. An all-zero prefix is different and
+# is a hard failure: no PR is ever number 0, so `0000-` is always the unfilled
+# placeholder, never a deliberate choice. That alone would have caught three of
+# #8978's four cases.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <owner/repo> <pr-number>" >&2
+    echo "       $0 --self-test" >&2
+}
+
+# Verdict over a `pulls/<n>/files` payload. `--paginate` emits one JSON array
+# per page, so every read slurps (`-s`) and flattens (`[.[][]]`).
+#
+# `jq -e` with no pipe, and `grep` reading a FILE: `jq | grep -q` under
+# `pipefail` can fail on SIGPIPE when grep closes early on its first match.
+changeset_verdict() {
+    local files="$1" pr="$2" added
+    added="$(dirname "$files")/added-fragments.txt"
+
+    if ! jq -s -e '[.[][]] | any(.filename | startswith("crates/"))' "$files" >/dev/null; then
+        echo "No crates/ changes - gate not applicable."
+        return 0
+    fi
+
+    jq -s -r '[.[][]]
+              | map(select(.status == "added"
+                           and (.filename | test("^changelog\\.d/[0-9]+-[^/]+\\.md$"))))
+              | .[].filename' "$files" > "$added"
+
+    if grep -Eq '^changelog\.d/0+-' "$added"; then
+        echo "::error::A changelog.d fragment still carries the 0000- placeholder. Rename it to changelog.d/${pr}-<slug>.md (see changelog.d/README.md)."
+        return 1
+    fi
+
+    if [ ! -s "$added" ]; then
+        echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/${pr}-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
+        return 1
+    fi
+
+    if ! grep -Eq "^changelog\.d/0*${pr}-" "$added"; then
+        echo "::warning::No added changelog.d fragment is numbered ${pr}. That is expected for a backfill or a stacked PR; otherwise rename it, because a wrong number is invisible until a release is cut."
+    fi
+    return 0
+}
+
+# Exercises `changeset_verdict` itself, not a copy of it, so the check and its
+# test cannot drift apart.
+self_test() {
+    local dir rc fails=0 out
+    dir="$(mktemp -d)"
+    trap 'rm -rf "$dir"' RETURN
+
+    _case() { # name expected_rc expected_grep json [must_not_contain]
+        local name="$1" want_rc="$2" want="$3" json="$4" reject="${5:-}"
+        printf '%s\n' "$json" > "$dir/files.json"
+        set +e
+        out="$(changeset_verdict "$dir/files.json" 9010 2>&1)"
+        rc=$?
+        set -e
+        if [ "$rc" != "$want_rc" ]; then
+            echo "  FAIL  $name: rc=$rc want=$want_rc"; echo "$out" | sed 's/^/        /'
+            fails=$((fails + 1)); return
+        fi
+        if [ -n "$want" ] && ! printf '%s' "$out" | grep -q "$want"; then
+            echo "  FAIL  $name: output missing '$want'"; echo "$out" | sed 's/^/        /'
+            fails=$((fails + 1)); return
+        fi
+        if [ -z "$want" ] && printf '%s' "$out" | grep -q '::warning::'; then
+            echo "  FAIL  $name: unexpected warning"; echo "$out" | sed 's/^/        /'
+            fails=$((fails + 1)); return
+        fi
+        if [ -n "$reject" ] && printf '%s' "$out" | grep -q "$reject"; then
+            echo "  FAIL  $name: output should not contain '$reject'"; echo "$out" | sed 's/^/        /'
+            fails=$((fails + 1)); return
+        fi
+        echo "  ok    $name"
+    }
+
+    _case "no crates/ change is not applicable" 0 "not applicable" \
+        '[{"filename":"docs/src/x.md","status":"modified"}]'
+    _case "crates/ change with the right number passes silently" 0 "" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/9010-x.md","status":"added"}]'
+    _case "crates/ change with no fragment fails" 1 "adds no changelog.d" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"}]'
+    _case "0000- placeholder is a hard failure" 1 "0000- placeholder" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/0000-x.md","status":"added"}]'
+    _case "0000- fails even alongside a correct fragment" 1 "0000- placeholder" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/0000-x.md","status":"added"},{"filename":"changelog.d/9010-y.md","status":"added"}]'
+    _case "a backfill number warns but passes" 0 "::warning::" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/8944-x.md","status":"added"}]'
+    _case "an EDITED fragment does not satisfy the gate" 1 "adds no changelog.d" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/9010-x.md","status":"modified"}]'
+    _case "a nested path does not satisfy the gate" 1 "adds no changelog.d" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"},{"filename":"changelog.d/sub/9010-x.md","status":"added"}]'
+    # --paginate emits one array per page; the slurp must see every page, not
+    # just the last (the bug the `-s` + `[.[][]]` form was written for).
+    _case "a fragment on a later page still counts" 0 "" \
+        '[{"filename":"crates/a/src/l.rs","status":"modified"}]
+[{"filename":"changelog.d/9010-x.md","status":"added"}]' \
+        "not applicable"
+    # Mirror image: crates/ on the LAST page. Without the slurp, `jq -e`
+    # reports only the last array and this one would pass by accident.
+    _case "crates/ on a later page is still gated" 1 "adds no changelog.d" \
+        '[{"filename":"docs/src/x.md","status":"modified"}]
+[{"filename":"crates/a/src/l.rs","status":"modified"}]'
+
+    if [ "$fails" -ne 0 ]; then
+        echo "check_changeset_fragment: $fails self-test case(s) FAILED"
+        return 1
+    fi
+    echo "check_changeset_fragment: self-test passed"
+    return 0
+}
+
+case "${1:-}" in
+    --self-test) self_test ;;
+    -h|--help|"") usage; exit 2 ;;
+    *)
+        if [ "$#" -ne 2 ]; then usage; exit 2; fi
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+        gh api "repos/$1/pulls/$2/files" --paginate > "$tmp/files.json"
+        changeset_verdict "$tmp/files.json" "$2"
+        ;;
+esac


### PR DESCRIPTION
Closes #8978.

The changeset gate accepted any `changelog.d/<digits>-<slug>.md` — *some* digits, not **this PR's** number — so both the unfilled `0000-` placeholder and another PR's number passed. It is a silent failure: nothing reads a fragment until a release is cut, and it then attributes the change to the wrong PR. The issue records four in one day, all caught by eye.

## Scope, and why it is deliberately not stricter

`0000-` is now a **hard failure**. No PR is ever number 0, so it is always the unfilled placeholder and never a deliberate choice — that alone covers three of the issue's four cases.

A mismatched **real** number is only a **warning**, because two legitimate shapes carry one: a backfill (#8973 renamed three fragments to `8944-`, `8947-` and `8291-`, none its own number) and a stacked PR naming its parent. A strict rule would block exactly the PR that repairs the problem. This is the minimum the issue itself argued for.

## Made testable rather than left inline

The logic moves into `scripts/check_changeset_fragment.sh`. `--self-test` exercises `changeset_verdict` itself, not a reimplementation, so the check and its test cannot drift — a frozen copy would only test the copy. It runs on **every tier** via its own step, where the enforcement step is `pull_request`-only.

Nine cases: not-applicable, correct number, missing fragment, `0000-` alone, `0000-` alongside a correct fragment, backfill-warns-but-passes, edited-not-added, nested path, and both pagination orders.

## Sabotage-verified, including one case that was passing for the wrong reason

- removing the `0000-` check → 2 cases fail ✅
- dropping the slurp on the `crates/` detection → caught ✅ — **but only after I fixed my own test.** The multi-page case originally asserted rc=0 with no warning, which "gate not applicable" satisfies just as well as "gate passed", so an un-slurped `jq -e` seeing only the last page slipped through. It now also rejects the string `not applicable`, and there is a mirror case with `crates/` on the last page.
- dropping the slurp on the fragment *extraction* → still passes, and that is correct rather than a blind spot: without `-s`, jq emits filenames from every array anyway, so that slurp is stylistic consistency, not load-bearing.

## Local behaviour

The enforcement call takes `${{ }}` arguments, so `run_lint_gates.sh` skips it locally through the mechanism added in #9009, while still running the self-test:

```
  ok    ./scripts/check_changeset_fragment.sh --self-test
  skip  ./scripts/check_changeset_fragment.sh "${{ github.repository }}" "${{ ... }}"
run_lint_gates: all 58 gates passed; 2 CI-only skipped
```

Full gate run green; `test.yml` parses.

Note this PR touches no `crates/`, so the gate is not applicable to it — it cannot self-demonstrate, which is why the self-test carries the evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated checks for changes affecting the project’s crates.
  * Changelog entries are now required for applicable changes and validated more consistently.
  * Placeholder changelog entries are rejected, while mismatched pull request numbers generate warnings.
  * Added automated self-checks to verify changelog validation and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->