### PR TITLE
perf(runtime): decide builtin iterator .next() first in the handle ladder

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -67,6 +67,51 @@ pub(super) unsafe fn dispatch_handle(
     let refreshed_args = || crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(arg_handles);
     let _ = (root_scope, object_handle, &refreshed_args, raw_bits, jsval);
     let _ = (method_name_ptr, method_name_len);
+
+    // Builtin collection / array iterators, decided first.
+    //
+    // `for…of` calls `.next()` once PER ELEMENT, and every one of those calls
+    // used to walk the whole ladder below — hundreds of lines of receiver
+    // classification — before reaching the `class_id` compare that actually
+    // answers it. On a 4k-entity ECS archetype-migration frame the Map and Set
+    // iterator dispatchers were 8.6% of the row, nearly all of it spent
+    // getting to them.
+    //
+    // The test hoisted here is byte-identical to the one further down; only its
+    // position changes. These class ids are dedicated to the builtin iterators,
+    // so no earlier arm of the ladder can legitimately claim such a receiver.
+    // A user override of `.next()` is still honoured: the override lookup lives
+    // INSIDE each dispatcher (`call_overridden_iterator_next`), not in the
+    // ladder that precedes it.
+    if jsval.is_pointer() {
+        let raw = jsval.as_pointer::<u8>() as usize;
+        if !crate::value::addr_class::is_small_handle(raw) && raw != 0 {
+            if let Some(header) = crate::value::addr_class::try_read_gc_header(raw) {
+                if header.obj_type == crate::gc::GC_TYPE_OBJECT {
+                    let obj = raw as *mut ObjectHeader;
+                    let class_id = (*obj).class_id;
+                    if class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID {
+                        return Some(crate::collection_iter_object::dispatch_map_iterator_method(
+                            obj,
+                            method_name,
+                        ));
+                    }
+                    if class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
+                        return Some(crate::collection_iter_object::dispatch_set_iterator_method(
+                            obj,
+                            method_name,
+                        ));
+                    }
+                    if class_id == crate::array::ARRAY_ITERATOR_CLASS_ID {
+                        return Some(crate::array::dispatch_array_iterator_method(
+                            obj,
+                            method_name,
+                        ));
+                    }
+                }
+            }
+        }
+    }
     // Check if this is a handle-based object (small integer, not a real heap pointer)
     // Handles are used by Fastify, ioredis, and other native modules that store
     // objects in a registry and use integer IDs to reference them.


### PR DESCRIPTION
`for…of` calls `.next()` once **per element**, and each of those calls walked the whole receiver-classification ladder in `dispatch_handle` — several hundred lines of small-handle, buffer, node-module, class-id and prototype checks — before reaching the `class_id` compare that actually answers it.

On a 4k-entity ECS archetype-migration frame the Map and Set iterator dispatchers were **8.6% of the row**, nearly all of it spent getting to them:

```
dispatch_handle  inclusive 41.4%
   73.3%  js_native_call_value        (the ECS closure — unrelated)
   10.4%  dispatch_map_iterator_method
   10.3%  dispatch_set_iterator_method
    1.3%  <self>
```

## The change

Hoist the three builtin-iterator `class_id` tests to the top of the ladder. They are **byte-identical** to the ones they shadow further down; only their position changes.

Safety:
- These ids are dedicated to the builtin array/Map/Set iterators, so no earlier arm of the ladder can legitimately claim such a receiver.
- The gate reads the GC header first, so a small handle or a non-object pointer never reaches the `ObjectHeader` field read.
- **A user override of `.next()` still wins**: the override lookup lives *inside* each dispatcher (`call_overridden_iterator_next`), not in the ladder that precedes it, so moving the entry point does not move the override check.

## Tests

No new test — the change is positional and every existing assertion about iterator dispatch still pins the behaviour. Local gate on the Linux build host: **perry-runtime serial 2767 passed / 0 failed**; `iterator` 32/32, `map` 108/108, `set` 201/201, array-iterator 1/1.

Paired measurement on the quiet host follows in a comment; if it does not move the row this gets closed rather than merged.

Claude-Session: https://claude.ai/code/session_01FUvFrRNZyc5qknBiJbYbby

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved method dispatch for Map, Set, and Array iterators through an earlier optimized path.
  * Iterator operations retain their existing behavior while potentially completing more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->