### PR TITLE
fix(runtime): preserve untyped Uint8Array stores

### DIFF
--- a/changelog.d/9015-untyped-uint8array-store.md
+++ b/changelog.d/9015-untyped-uint8array-store.md
@@ -1,0 +1,13 @@
+Stores through an untyped helper now preserve Buffer-backed `Uint8Array` values.
+
+Perry's function inliner can specialize an `any`-typed index helper at a
+`Uint8Array` call site and route the write through the generic typed-array
+setter. That setter assumed every receiver had `TypedArrayHeader` layout, while
+Perry represents `Uint8Array` with `BufferHeader`; the different data offsets
+made the write disappear. The setter now validates the runtime receiver just
+like the getter and dispatches Buffer-backed or reassigned receivers through
+ordinary dynamic set semantics.
+
+The Buffer path also performs ToNumber and Uint8 modulo narrowing before its
+integer-only ABI, so NaN-boxed `any` values such as `257` and `-1` store as `1`
+and `255` rather than `0`.

--- a/crates/perry-runtime/src/typedarray/access.rs
+++ b/crates/perry-runtime/src/typedarray/access.rs
@@ -263,10 +263,19 @@ fn value_needs_coercion_side_effect(value: f64) -> bool {
 /// `ta[i] = value`.
 #[no_mangle]
 pub extern "C" fn js_typed_array_set(ta: *mut TypedArrayHeader, index: i32, value: f64) {
-    let ta = clean_ta_ptr(ta) as *mut TypedArrayHeader;
-    if ta.is_null() {
-        return;
-    }
+    // Mirror `js_typed_array_get`'s receiver validation. TypeScript's erased
+    // declarations and the function-inlining pass can route a Buffer-backed
+    // Uint8Array (or a reassigned plain receiver) through this generic helper.
+    // BufferHeader has data at +8 while TypedArrayHeader has data at +16, so
+    // interpreting the former as the latter silently drops/corrupts stores.
+    let ta = match classify_element_read_receiver(ta as u64) {
+        ElementReadReceiver::TypedArray(addr) => addr as *mut TypedArrayHeader,
+        ElementReadReceiver::Ordinary(receiver) => {
+            crate::value::js_dyn_index_set(receiver, f64::from(index), value);
+            return;
+        }
+        ElementReadReceiver::Absent => return,
+    };
     unsafe {
         if crate::native_arena::is_native_typed_view(ta as *const TypedArrayHeader) {
             crate::native_arena::validate_view_alive(

--- a/crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs
+++ b/crates/perry-runtime/src/typedarray/element_read_receiver_tests.rs
@@ -510,6 +510,25 @@ fn js_typed_array_index_get_dynamic_still_reads_a_uint8array_buffer_owner() {
     assert!(is_undefined(js_typed_array_index_get_dynamic(recv, 3.0)));
 }
 
+#[test]
+fn js_typed_array_set_dispatches_a_uint8array_buffer_owner() {
+    // Function inlining can specialize an `any` helper at a Uint8Array call
+    // site and emit this generic typed-array setter. The receiver remains a
+    // BufferHeader, so the setter must dispatch instead of assuming the +16
+    // TypedArrayHeader data offset. Keep the value NaN-boxed to match the
+    // erased `any` parameter ABI that exposed the release blocker.
+    let buf = crate::buffer::js_uint8array_alloc(2);
+    let recv = ((buf as u64) & POINTER_MASK) as *mut TypedArrayHeader;
+    let boxed_257 = f64::from_bits(crate::value::INT32_TAG | 257);
+    let boxed_minus_one = f64::from_bits(crate::value::INT32_TAG | u64::from((-1_i32) as u32));
+
+    js_typed_array_set(recv, 0, boxed_257);
+    js_typed_array_set(recv, 1, boxed_minus_one);
+
+    assert_eq!(js_typed_array_get(recv, 0), 1.0);
+    assert_eq!(js_typed_array_get(recv, 1), 255.0);
+}
+
 /// The generic Array element read routes a registered %TypedArray% receiver
 /// off its managed header tag BEFORE the tracked-allocation resolver (which
 /// can only miss for a typed array), and answers exactly what the typed read

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -1093,6 +1093,16 @@ fn to_uint32_bits(value: f64) -> u32 {
     m as u32
 }
 
+/// Coerce a NaN-boxed JS value for a Uint8Array/Buffer element store.
+///
+/// Perry represents `Uint8Array` with `BufferHeader`, outside the generic
+/// `TypedArrayHeader` registry. Dynamic stores still receive a full JS value,
+/// so they must perform the same ToNumber + modulo narrowing as the generic
+/// typed-array path before calling the integer-only buffer accessor.
+pub(crate) fn jsvalue_to_uint8(value: f64) -> u8 {
+    to_uint32_bits(jsvalue_to_f64(value)) as u8
+}
+
 /// Store a number into the typed array slot, performing the per-kind cast.
 pub(crate) unsafe fn store_at(ta: *mut TypedArrayHeader, idx: usize, value: f64) {
     let kind = (*ta).kind;

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -692,10 +692,11 @@ pub extern "C" fn js_dyn_index_set_strict(obj: f64, index: f64, value: f64, stri
     }
     if crate::buffer::is_registered_buffer(raw_ptr) {
         if let Some(idx_i32) = finite_nonnegative_i32_index(index) {
+            let byte = crate::typedarray::jsvalue_to_uint8(value);
             crate::buffer::js_buffer_set(
                 raw_ptr as *mut crate::buffer::BufferHeader,
                 idx_i32,
-                value as i32,
+                i32::from(byte),
             );
         }
         return value;
@@ -845,3 +846,7 @@ static KEEP_JS_IS_UNDEFINED_OR_BARE_NAN: extern "C" fn(f64) -> i32 = js_is_undef
 #[cfg(test)]
 #[path = "dyn_index_collection_tag_tests.rs"]
 mod collection_tag_tests;
+
+#[cfg(test)]
+#[path = "dyn_index_uint8array_tests.rs"]
+mod uint8array_tests;

--- a/crates/perry-runtime/src/value/dyn_index_uint8array_tests.rs
+++ b/crates/perry-runtime/src/value/dyn_index_uint8array_tests.rs
@@ -1,0 +1,26 @@
+//! Dynamic-index regression coverage for Perry's Buffer-backed Uint8Array.
+
+use super::{js_dyn_index_get, js_dyn_index_set_strict};
+
+fn boxed_i32(value: i32) -> f64 {
+    f64::from_bits(crate::value::INT32_TAG | u64::from(value as u32))
+}
+
+#[test]
+fn dynamic_uint8array_set_coerces_nanboxed_values_before_narrowing() {
+    let array = crate::buffer::js_uint8array_alloc(2);
+    let receiver = crate::value::js_nanbox_pointer(array as i64);
+    let index_zero = boxed_i32(0);
+    let index_one = boxed_i32(1);
+
+    let wrapped_one = boxed_i32(257);
+    assert_eq!(
+        js_dyn_index_set_strict(receiver, index_zero, wrapped_one, 1).to_bits(),
+        wrapped_one.to_bits(),
+        "an assignment expression still yields its original boxed value"
+    );
+    assert_eq!(js_dyn_index_get(receiver, index_zero), 1.0);
+
+    js_dyn_index_set_strict(receiver, index_one, boxed_i32(-1), 1);
+    assert_eq!(js_dyn_index_get(receiver, index_one), 255.0);
+}


### PR DESCRIPTION
Fixes the v0.5.1519 Full-CI blocker where stores through an erased/inlined `any` helper wrote zero to Perry's Buffer-backed `Uint8Array`.

- validate the receiver in `js_typed_array_set`, symmetric with the getter
- dispatch Buffer-backed/reassigned receivers through ordinary dynamic set semantics
- coerce NaN-boxed values with ToNumber/ToUint8 before the integer Buffer ABI
- add focused runtime coverage for both entry paths

Validated on `perrymaster.skelpo.net`:
- `cargo test -p perry-runtime js_typed_array_set_dispatches_a_uint8array_buffer_owner --lib`
- `cargo test -p perry-runtime dynamic_uint8array_set_coerces_nanboxed_values_before_narrowing --lib`
- `PERRY_WORKSPACE_ROOT=/root/perry-release-fix-array-probe-kind cargo test -p perry --test issue_5525_typed_array_untyped_index -- --nocapture` (4/4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed writes to Buffer-backed `Uint8Array` values accessed through generic helpers.
  * Ensured numeric values are correctly converted and narrowed when storing bytes (for example, `257` becomes `1` and `-1` becomes `255`).
  * Preserved the assigned value returned by dynamic indexed assignments.

* **Tests**
  * Added regression coverage for Buffer-backed `Uint8Array` writes and numeric conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->