### PR TITLE
fix(transform): preserve resumed values in generator loop conditions

### DIFF
--- a/changelog.d/9027-generator-loop-resume-temporary.md
+++ b/changelog.d/9027-generator-loop-resume-temporary.md
@@ -1,0 +1,13 @@
+Generator loop conditions now preserve values passed to `.next(value)`.
+
+The generator linearizer creates temporary locals when a `yield` appears inside
+a loop condition. Those locals were already preallocated and captured across
+resume states, but their state-local declarations still created shadow boxes.
+The resumed value was written to the shadow while the condition read the
+untouched captured box, so `while ((value = yield n) !== "stop")` observed
+`undefined`, completed early, or accumulated the wrong values.
+
+Linearizer-created locals now use the same declaration-to-assignment rewrite as
+ordinary hoisted generator bindings, keeping every state on the preallocated
+capture. The eight-case #5933 loop-condition suite passes byte-for-byte against
+Node, including repeated yields and a terminating `.next("stop")`.

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -480,6 +480,14 @@ pub fn transform_generator_function_with_extra_captures(
         .collect();
     let mut hoisted_ids: std::collections::HashSet<LocalId> =
         hoisted_for_rewrite.iter().map(|(id, _, _)| *id).collect();
+    // Linearization allocates additional locals for state-spanning values
+    // (including the resume and condition temporaries for a `yield` in a loop
+    // condition). They are preallocated and captured below just like ordinary
+    // hoisted bindings, so a `Let` left inside a resume state would allocate a
+    // shadow box: the state writes the shadow, while later `LocalGet`s read the
+    // untouched captured box. Rewrite those declarations to assignments to
+    // the preallocated capture too.
+    hoisted_ids.extend(extra_local_ids.iter().copied());
     // The lifted param prologue defines locals (destructured targets + temps)
     // that the state machine reads; treat them as hoisted so their `Let`s route
     // through the prealloc box (`js_box_set`) instead of shadowing the capture.


### PR DESCRIPTION
Fixes #5933.

Linearizer-created generator temporaries were preallocated and captured, but their state-local `Let` declarations were not rewritten to assignments. Resume states therefore wrote a shadow box and later read the untouched captured box, turning `.next(value)` into `undefined` inside yielded loop conditions.

This includes every linearizer-created local in the existing hoisted-let rewrite, matching how those locals are already preallocated and captured.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p perry-transform` (119 passed; 6 doc-tests ignored)
- dedicated Linux server: `cargo test -p perry --test issue_5933_loop_condition_await` (8 passed)
- standalone exact probe: yields 0, 1, 2 and completes with `ab`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generator loops containing `yield` in their conditions.
  * Resumed values are now preserved correctly across repeated yields.
  * Loop conditions now terminate and accumulate values consistently, matching expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->