### PR TITLE
fix(codegen): escape a scalar-replaced object when an undeclared field is written

### DIFF
--- a/changelog.d/9028-scalar-replace-new-field.md
+++ b/changelog.d/9028-scalar-replace-new-field.md
@@ -1,0 +1,29 @@
+Reading a property before its first write no longer makes every later read
+answer `undefined`.
+
+```ts
+const c: any = {};
+const b = c["k"];   // read before the key exists
+c["k"] = 7;
+c["k"]              // was undefined, now 7
+```
+
+Scalar replacement gives each DECLARED field of a non-escaping `new` its own
+alloca (`stored_fields = all_fields ∩ used_fields`). An object literal lowers to
+a synthetic `__AnonShape_` class whose `all_fields` is exactly the literal's
+keys, so a write to a key the literal does not have had nowhere to go: the store
+was dropped and the reads saw the alloca's initial `undefined`.
+
+`escape_check.rs` escaped such a receiver for a class setter and for a
+self-referential value, but neither the `PropertySet` nor the `PutValueSet` arm
+checked that the written property is a declared field. Both now do, via
+`class_chain_has_field`, which fails toward "has it" for an unmodeled base and
+for a class carrying computed members — so it can only escape more
+conservatively than the declared list justifies, never less.
+
+Not specific to object literals: a user class took the same path, so
+`class C { x = 1 }` followed by `(new C() as any)["k"] = 7` read back wrong too.
+
+The failure was silent rather than a crash, on an ordinary shape:
+`if (!cache["v"]) cache["v"] = compute(); return cache["v"];` returned
+`undefined`. Covered by `test-files/test_gap_scalar_replace_new_field.ts`.

--- a/crates/perry-codegen/src/collectors/class_accessors.rs
+++ b/crates/perry-codegen/src/collectors/class_accessors.rs
@@ -36,6 +36,44 @@ pub fn is_class_getter(
 /// Mirror of `is_class_getter` for setters — used on the PropertySet/
 /// PropertyUpdate paths where a setter dispatch (vs. a plain field write)
 /// likewise needs a real `this` pointer.
+/// Does `class_name` (or an ancestor) declare `property` as a FIELD?
+///
+/// Scalar replacement gives each declared field its own alloca, so a write to a
+/// property the class does not declare has nowhere to go: the store is silently
+/// dropped and every later read answers `undefined` (#9024). Callers use this to
+/// escape such a receiver instead, so it takes the ordinary heap path.
+pub fn class_chain_has_field(
+    classes: &std::collections::HashMap<String, &perry_hir::Class>,
+    class_name: &str,
+    property: &str,
+) -> bool {
+    let mut cur = Some(class_name.to_string());
+    let mut seen = std::collections::HashSet::new();
+    let mut depth = 0usize;
+    while let Some(name) = cur {
+        if !seen.insert(name.clone()) || depth > 64 {
+            break;
+        }
+        depth += 1;
+        let Some(class) = classes.get(&name) else {
+            // An unmodeled base: cannot prove the field is absent, so do not
+            // claim it is. Fail toward "has it" and leave escaping to the
+            // unmodeled-base check that already exists.
+            return true;
+        };
+        if class.fields.iter().any(|f| f.name == property) {
+            return true;
+        }
+        // A computed or dynamically-keyed member means the declared list is not
+        // authoritative for this class.
+        if !class.computed_members.is_empty() || class.fields.iter().any(|f| f.key_expr.is_some()) {
+            return true;
+        }
+        cur = class.extends_name.clone();
+    }
+    false
+}
+
 pub fn is_class_setter(
     classes: &std::collections::HashMap<String, &perry_hir::Class>,
     class_name: &str,

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -246,6 +246,14 @@ pub fn check_escapes_in_expr(
                         check_escapes_in_expr(value, candidates, classes, escaped);
                         return;
                     }
+                    // #9024: same rule as the `PutValueSet` arm below — a
+                    // write to an UNDECLARED property has no scalar slot, so the
+                    // store would be dropped and later reads answer `undefined`.
+                    if !crate::collectors::class_accessors::class_chain_has_field(
+                        classes, class_name, property,
+                    ) {
+                        escaped.insert(*id);
+                    }
                     // Object position is safe. But check if value contains
                     // LocalGet(id) — that would be self-referential escape.
                     if expr_contains_local_get(value, *id) {
@@ -275,6 +283,15 @@ pub fn check_escapes_in_expr(
                             escaped.insert(*id);
                             check_escapes_in_expr(value, candidates, classes, escaped);
                             return;
+                        }
+                        // #9024: scalar replacement gives each DECLARED field
+                        // an alloca. A write to a property the class does not
+                        // declare has no slot, so the store is dropped and every
+                        // later read answers `undefined`. Escape instead.
+                        if !crate::collectors::class_accessors::class_chain_has_field(
+                            classes, class_name, property,
+                        ) {
+                            escaped.insert(*id);
                         }
                         if expr_contains_local_get(value, *id) {
                             escaped.insert(*id);

--- a/test-files/test_gap_scalar_replace_new_field.ts
+++ b/test-files/test_gap_scalar_replace_new_field.ts
@@ -1,0 +1,41 @@
+// #9024: a scalar-replaced non-escaping object gives each DECLARED field an
+// alloca. Writing a property the class does not declare has no slot, so the
+// store was dropped and every later read answered `undefined`.
+const a: any = {};
+const a0 = a["k"];
+a["k"] = 7;
+console.log(a0, a["k"]);
+
+const b: any = {};
+const b0 = b.k;
+b.k = 8;
+console.log(b0, b.k);
+
+class C {
+  x = 1;
+}
+const c: any = new C();
+const c0 = c["k"];
+c["k"] = 9;
+console.log(c0, c["k"], c.x);
+
+// declared fields must still scalar-replace and read correctly
+const d: any = { k: 0 };
+const d0 = d["k"];
+d["k"] = 10;
+console.log(d0, d["k"]);
+
+// read twice after the write
+const e: any = {};
+const e0 = e["k"];
+e["k"] = 11;
+const e1 = e["k"];
+console.log(e0, e1, e["k"]);
+
+// the ordinary cache shape this bug breaks
+const cache: any = {};
+function memo(n: number) {
+  if (!cache["v"]) cache["v"] = n * 2;
+  return cache["v"];
+}
+console.log(memo(21), memo(99));


### PR DESCRIPTION
Fixes #9024 — a **silent wrong value** on an ordinary pattern:

```ts
const c: any = {};
const b = c["k"];   // read before the key exists
c["k"] = 7;
c["k"]              // node: 7    perry: undefined
```

## Root cause

Scalar replacement gives each **declared** field of a non-escaping `new` its own alloca — `stored_fields = all_fields ∩ used_fields` in `stmt/let_stmt.rs`. An object literal lowers to a synthetic `__AnonShape_` class whose `all_fields` is exactly the literal's keys, so a write to a key the literal does not have has nowhere to go: the store is dropped, and every later read returns the alloca's initial `undefined`.

`escape_check.rs` already escapes such a receiver for a class **setter** and for a self-referential value, but neither the `PropertySet` nor the `PutValueSet` arm checked that the written property is a declared **field**.

## How I narrowed it

The variant table is what identified the mechanism, so it is worth recording — each row flips exactly one thing:

| variant | before |
|---|---|
| `c["k"]` read-before-write | **`undefined`** |
| `c.k` (static syntax) | **`undefined`** |
| `{ other: 1 }` receiver | **`undefined`** |
| `class C { x = 1 }`, undeclared key | **`undefined`** |
| `{ k: 0 }` — key IS declared | `7` ✅ |
| `Object.create(null)` | `7` ✅ |
| read moved into a function | `7` ✅ |
| write moved into a function | `7` ✅ |

Escaping via a function call fixing it, and a declared key being fine, is what pointed at scalar replacement rather than a runtime cache — `PERRY_PTR_SHAPE_LOCALS=0` also does *not* fix it, which ruled out the ptr-shape locals path and left `escape_news`/`escape_check`. The HIR then showed `{}` lowering to `New __AnonShape_… (fields: 0)` with the write as `PutValueSet`.

## The fix

A new `class_chain_has_field` in `class_accessors.rs`, mirroring `is_class_setter`'s chain walk, used by both arms. It is deliberately **fail-open**: an unmodeled base, or a class carrying computed members / `key_expr` fields, answers "has it", so the declared list is only trusted where it is authoritative. The check can therefore only escape *more* conservatively than the declared list justifies — never less.

This is not object-literal-specific: a user class hits the same path, so `class C { x = 1 }` then `(new C() as any)["k"] = 7` was equally wrong, and is fixed too.

## Verification

- **Sabotage**: removing the `PutValueSet` guard returns the gap test to `undefined undefined`; restoring it gives `undefined 7`.
- New gap test `test_gap_scalar_replace_new_field.ts` — computed and static syntax, user class, declared-field control, read-twice-after-write, and the `if (!cache["v"]) cache["v"] = …` memo shape. **Byte-identical to node 26.5.1.** (A new *passing* test needs no snapshot entry; `gap_snapshot.py` treats only a not-in-snapshot **failing** test as a regression.)
- `perry-codegen` 1343/0, `perry-runtime --lib` 2804/0, `perry-hir` 355/0, `fmt --check`.
- `run_lint_gates.sh` **all 60 gates passed; 2 CI-only skipped**.

I have not measured the perf effect. The change escapes strictly more receivers, so a workload that writes undeclared properties to a hot short-lived object loses scalar replacement there — that is the price of the store not being silently dropped, but it is worth a benchmark eye before this rides into a release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect `undefined` results when optimized objects receive writes to declared or dynamically accessed properties.
  - Improved handling of property access across class inheritance, computed properties, and object literals.
  - Preserved repeated property reads and writes in memoization-style code.

- **Tests**
  - Added regression coverage for dot and bracket property access, class instances, undeclared fields, and repeated reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->