### PR TITLE
fix(eval): restore global var declaration checks and descriptors

### DIFF
--- a/changelog.d/9031-eval-global-var-declarations.md
+++ b/changelog.d/9031-eval-global-var-declarations.md
@@ -1,0 +1,1 @@
+Fixed global-script `eval` variable declarations to reject new bindings on non-extensible globals and preserve existing Script `var` property descriptors.

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -231,25 +231,17 @@ fn emit_script_global_function_decls(ctx: &mut FnCtx<'_>, hir: &HirModule) {
     }
 }
 
-/// #5848: emit the global-object reflection of a Script's Annex B
-/// block-nested top-level `function` declarations (`{ function f(){} }` /
-/// `if (c) function f(){}` / `switch (x) { case 1: function f(){} }`
-/// directly in sloppy global code) — `globalThis[name] = undefined`, as a
-/// non-configurable own property.
+/// Emit the early global-object bindings for Script-level `var`s and Annex B
+/// block-nested top-level function declarations —
+/// `globalThis[name] = undefined`, as a non-configurable own property.
 ///
 /// GlobalDeclarationInstantiation's `CreateGlobalVarBinding` (B.3.3.2 step
 /// 5.b.i) runs for these names before any top-level statement executes, so
 /// the property must already be observable — with value `undefined` — ahead
-/// of the block that later assigns the real function (test262 `annexB/
-/// language/global-code/*-global-init.js`). The block's own execution still
-/// writes the real function into the module-level local slot
-/// (`annexb_block_fn_var_ids`) as today; this only seeds the *object*
-/// property so pre-block `Object.getOwnPropertyDescriptor`/`hasOwnProperty`
-/// checks see it — a one-time snapshot, not a live-synced mirror, matching
-/// `emit_script_global_function_decls`'s existing precedent. Unlike that
-/// function, not gated on `hir.references_global_this`: this Annex B pattern
-/// is rare enough that the extra reflection call is not a meaningful
-/// per-program cost, and the spec creates the property unconditionally.
+/// of the statement that later assigns the real value. The HIR reflection
+/// pass keeps subsequent writes synchronized; this prelude establishes the
+/// descriptor it must preserve (test262 `language/eval-code/*/
+/// var-env-var-init-global-exstng` and Annex B global-init cases).
 fn emit_annexb_global_undefined_decls(ctx: &mut FnCtx<'_>, hir: &HirModule) {
     if hir.annexb_global_undefined_names.is_empty() {
         return;

--- a/crates/perry-hir/src/ir/module.rs
+++ b/crates/perry-hir/src/ir/module.rs
@@ -54,19 +54,14 @@ pub struct Module {
     /// add dynamic-property-helper calls to module init for pure programs. Set
     /// at lowering from the installed module source.
     pub references_global_this: bool,
-    /// #5848: names of Annex B block-nested top-level `function`
-    /// declarations (`{ function f(){} }`, `if (c) function f(){}`,
-    /// `switch (x) { case 1: function f(){} }`, directly in sloppy global
-    /// code) that need an early `undefined`-valued, non-configurable global
-    /// property — GlobalDeclarationInstantiation's `CreateGlobalVarBinding`
-    /// (B.3.3.2 step 5.b.i) runs before any top-level statement executes, so
-    /// the property must already exist (as `undefined`) ahead of the block
-    /// that later assigns the real function. Excludes names already covered
-    /// by a same-named bare top-level function declaration (already
-    /// reflected with its real value via `script_global_functions`). Codegen
-    /// emits these unconditionally for a non-ESM entry program (not gated on
-    /// `references_global_this`: the pattern is rare enough that the extra
-    /// reflection call is not a meaningful per-program cost).
+    /// Script-level `var` bindings and Annex B block-nested top-level function
+    /// declarations that need an early `undefined`-valued, non-configurable
+    /// global property. GlobalDeclarationInstantiation's
+    /// `CreateGlobalVarBinding` runs before any top-level statement executes;
+    /// later value mirrors must update this property without creating it with
+    /// the ordinary assignment attributes. Excludes names covered by a
+    /// same-named bare top-level function declaration, whose entry value is
+    /// emitted separately through `script_global_functions`.
     pub annexb_global_undefined_names: Vec<String>,
     /// Top-level statements to execute
     pub init: Vec<Stmt>,

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -1173,6 +1173,16 @@ fn parse_eval_literal(src: &str) -> Option<Expr> {
 fn try_direct_eval_simple_assignment_fold(ctx: &mut LoweringContext, body: &str) -> Option<Expr> {
     let src = body.trim().trim_end_matches(';').trim();
     let is_var_assignment = src.starts_with("var ");
+    // A sloppy direct eval at global-script top level performs
+    // GlobalDeclarationInstantiation. Even the tiny `eval("var x")` shape
+    // must run CanDeclareGlobalVar: it throws when `globalThis` is
+    // non-extensible and `x` is absent. Leave every `var` form to the general
+    // eval fold below, which publishes through `apply_global_eval_hoist` and
+    // preserves the global property's descriptor. The shortcut remains valid
+    // for strict eval (fresh eval var environment) and for function-local eval.
+    if is_var_assignment && !ctx.current_strict && eval_is_module_top_global(ctx) {
+        return None;
+    }
     let assignment = src.strip_prefix("var ").unwrap_or(src);
     let (name_raw, value_raw) = match assignment.split_once('=') {
         Some(parts) => parts,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -1508,6 +1508,30 @@ pub fn lower_module_full(
     let is_esm_entry =
         !module.imports.is_empty() || !module.exports.is_empty() || module.has_top_level_await;
     if ctx.is_entry_module && !is_esm_entry && module.references_global_this {
+        // GlobalDeclarationInstantiation creates every Script-level `var`
+        // property before user code, with configurable=false. The late
+        // reflection pass below mirrors declaration/assignment values with an
+        // ordinary property write; if that write creates the property itself,
+        // it gets configurable=true and a later eval can no longer preserve
+        // the Script binding's descriptor (#5841). Reuse the existing early
+        // non-configurable-undefined codegen list. A same-named top-level
+        // function owns the entry value and is emitted separately, so do not
+        // overwrite it with undefined.
+        let script_function_names: HashSet<&str> = module
+            .script_global_functions
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect();
+        module.annexb_global_undefined_names.extend(
+            ctx.script_var_decl_names
+                .iter()
+                .filter(|name| !script_function_names.contains(name.as_str()))
+                .cloned(),
+        );
+        module.annexb_global_undefined_names.sort();
+        module.annexb_global_undefined_names.dedup();
+    }
+    if ctx.is_entry_module && !is_esm_entry && module.references_global_this {
         let script_vars: HashMap<_, _> = ctx
             .script_var_decl_names
             .iter()

--- a/crates/perry-hir/tests/issue_5833_global_code_cluster.rs
+++ b/crates/perry-hir/tests/issue_5833_global_code_cluster.rs
@@ -23,7 +23,8 @@ fn lower_src(src: &str) -> anyhow::Result<perry_hir::Module> {
 fn lower_entry_src(src: &str) -> anyhow::Result<perry_hir::Module> {
     let mut cache = SourceCache::new();
     let parsed = parse_typescript_with_cache(src, "issue_5833_entry.ts", &mut cache)?;
-    lower_module_with_class_id_types_seed_and_entry(
+    perry_hir::set_current_module_source(src.to_string());
+    let lowered = lower_module_with_class_id_types_seed_and_entry(
         &parsed.module,
         "test",
         "issue_5833_entry.ts",
@@ -33,7 +34,9 @@ fn lower_entry_src(src: &str) -> anyhow::Result<perry_hir::Module> {
         None,
         true,
     )
-    .map(|(module, _)| module)
+    .map(|(module, _)| module);
+    perry_hir::clear_current_module_source();
+    lowered
 }
 
 fn class_local_let<'a>(module: &'a perry_hir::Module, name: &str) -> Option<&'a Expr> {
@@ -132,5 +135,28 @@ fn restricted_global_check_only_applies_to_the_entry_script() {
     lower_src("let undefined;").expect(
         "a non-entry module's `let undefined` must not be rejected \
          (it never binds against the real global object)",
+    );
+}
+
+#[test]
+fn reflected_script_var_gets_an_early_nonconfigurable_global_slot() {
+    // The later HIR mirror uses an ordinary property write. Seed the Script
+    // binding first so that write preserves GlobalDeclarationInstantiation's
+    // configurable=false descriptor (#5841 / #5903).
+    let module = lower_entry_src(
+        r#"
+        var existing = 23;
+        globalThis.existing;
+        "#,
+    )
+    .expect("entry Script var should lower");
+
+    assert!(
+        module
+            .annexb_global_undefined_names
+            .iter()
+            .any(|name| name == "existing"),
+        "the Script var must be created before its reflected initializer: {:?}",
+        module.annexb_global_undefined_names
     );
 }


### PR DESCRIPTION
## Summary
- route sloppy module-top `eval("var …")` through global declaration instantiation instead of the simple-expression shortcut
- seed reflected Script `var` bindings as non-configurable properties before ordinary mirror writes
- preserve top-level function-owned entry values and deduplicate the early global slots

## Release blockers fixed
- `direct_eval_non_definable_global_var_throws` no longer skips `CanDeclareGlobalVar` on a non-extensible global
- direct and indirect eval preserve `configurable:false` when reusing an existing Script `var`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perry-hir`
- Linux parity server: `issue_5579_non_definable_global_eval` — 7/7
- Linux parity server: `issue_5841_eval_global_descriptor` — 6/6
- Linux parity server: `issue_5579_indirect_eval_global_completion` — 8/8
- Linux parity server: `test_issue_611_globalthis.ts` matches the committed expected output

Closes #5579
Closes #5841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global-script `eval` variable declarations on non-extensible global objects.
  * Preserved existing global property descriptors when declaring Script-level variables.
  * Ensured reflected global bindings are initialized correctly and remain synchronized.
* **Tests**
  * Added coverage for global `var` bindings and descriptor preservation during entry-script evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->