### PR TITLE
fix(hir): preserve prototype-intercepted builder writes

### DIFF
--- a/changelog.d/9035-builder-fold-prototype-descriptors.md
+++ b/changelog.d/9035-builder-fold-prototype-descriptors.md
@@ -1,0 +1,1 @@
+Fixed straight-line object-builder assignments so inherited setters and non-writable properties on `Object.prototype` still intercept writes.

--- a/crates/perry-hir/src/lower/builder_fold.rs
+++ b/crates/perry-hir/src/lower/builder_fold.rs
@@ -28,6 +28,12 @@
 //!   differ). Literals already containing accessor/spread/computed/method
 //!   props are left untouched entirely — an appended key could otherwise
 //!   turn a setter invocation into a redefinition.
+//! - A module that mutates `Object.prototype` through the standard descriptor
+//!   APIs is excluded. An inherited setter or non-writable data descriptor
+//!   makes `o.k = v` observably different from `{ k: v }`: the former performs
+//!   `[[Set]]`, while the latter defines an own data property. Runtime write
+//!   guards cannot protect a fold because the assignment no longer exists in
+//!   HIR (#9034).
 //! - Only `Pat::Ident` bindings qualify; the declarator may carry any type
 //!   annotation. Exported declarations are skipped (scope kept tight).
 //!
@@ -35,6 +41,7 @@
 //! exactly as before.
 
 use swc_ecma_ast as ast;
+use swc_ecma_visit::{Visit, VisitWith};
 
 /// Fold cap per literal — beyond this the object is dictionary-like and the
 /// literal machinery's inline-slot benefits taper off anyway.
@@ -43,13 +50,107 @@ const MAX_FOLDED_PROPS: usize = 64;
 /// Returns a folded clone when at least one builder sequence was folded;
 /// `None` means "nothing to do — lower the original".
 pub(crate) fn fold_builder_sequences(module: &ast::Module) -> Option<ast::Module> {
-    if !module_has_candidate(module) {
+    if !module_has_candidate(module) || module_mutates_object_prototype_descriptors(module) {
         return None;
     }
     let mut folded = module.clone();
     let mut changed = false;
     process_module_items(&mut folded.body, &mut changed);
     changed.then_some(folded)
+}
+
+/// Whether this module can make assignment to a fresh ordinary object invoke
+/// inherited descriptor semantics on the canonical `Object.prototype`.
+///
+/// This is deliberately module-wide and conservative. Descriptor mutation is
+/// rare, while trying to prove source ordering across nested closures and
+/// static-import execution would be brittle. A false positive only preserves
+/// the original dynamic writes; a false negative changes JavaScript behavior.
+fn module_mutates_object_prototype_descriptors(module: &ast::Module) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_call_expr(&mut self, call: &ast::CallExpr) {
+            if self.found {
+                return;
+            }
+            if call_mutates_object_prototype_descriptors(call) {
+                self.found = true;
+                return;
+            }
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    module.visit_with(&mut finder);
+    finder.found
+}
+
+fn call_mutates_object_prototype_descriptors(call: &ast::CallExpr) -> bool {
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let ast::Expr::Member(member) = strip_transparent_expr(callee) else {
+        return false;
+    };
+    let Some(method) = static_member_name(member) else {
+        return false;
+    };
+
+    // Legacy Annex-B mutation APIs operate directly on Object.prototype.
+    if matches!(method, "__defineGetter__" | "__defineSetter__")
+        && is_object_prototype_expr(&member.obj)
+    {
+        return true;
+    }
+
+    let descriptor_api = (is_ident_expr(&member.obj, "Object")
+        && matches!(method, "defineProperty" | "defineProperties"))
+        || (is_ident_expr(&member.obj, "Reflect") && method == "defineProperty");
+    descriptor_api
+        && call
+            .args
+            .first()
+            .is_some_and(|arg| arg.spread.is_none() && is_object_prototype_expr(&arg.expr))
+}
+
+fn strip_transparent_expr(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        expr = match expr {
+            ast::Expr::Paren(v) => &v.expr,
+            ast::Expr::TsAs(v) => &v.expr,
+            ast::Expr::TsNonNull(v) => &v.expr,
+            ast::Expr::TsTypeAssertion(v) => &v.expr,
+            ast::Expr::TsConstAssertion(v) => &v.expr,
+            ast::Expr::TsSatisfies(v) => &v.expr,
+            _ => return expr,
+        };
+    }
+}
+
+fn static_member_name(member: &ast::MemberExpr) -> Option<&str> {
+    match &member.prop {
+        ast::MemberProp::Ident(name) => Some(name.sym.as_ref()),
+        ast::MemberProp::Computed(key) => match strip_transparent_expr(&key.expr) {
+            ast::Expr::Lit(ast::Lit::Str(value)) => value.value.as_str(),
+            _ => None,
+        },
+        ast::MemberProp::PrivateName(_) => None,
+    }
+}
+
+fn is_ident_expr(expr: &ast::Expr, expected: &str) -> bool {
+    matches!(strip_transparent_expr(expr), ast::Expr::Ident(id) if id.sym.as_ref() == expected)
+}
+
+fn is_object_prototype_expr(expr: &ast::Expr) -> bool {
+    let ast::Expr::Member(member) = strip_transparent_expr(expr) else {
+        return false;
+    };
+    static_member_name(member) == Some("prototype") && is_ident_expr(&member.obj, "Object")
 }
 
 /// Cheap read-only pre-scan: is any statement list anywhere (including

--- a/crates/perry-hir/tests/builder_fold_prototype_descriptor.rs
+++ b/crates/perry-hir/tests/builder_fold_prototype_descriptor.rs
@@ -1,0 +1,97 @@
+//! Regression coverage for #9034: straight-line builder folding must preserve
+//! assignment `[[Set]]` semantics when `Object.prototype` can intercept a key.
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Expr, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> perry_hir::Module {
+    let mut cache = SourceCache::new();
+    let parsed =
+        parse_typescript_with_cache(src, "builder_fold_prototype_descriptor.ts", &mut cache)
+            .expect("parse should succeed");
+    lower_module(
+        &parsed.module,
+        "test",
+        "builder_fold_prototype_descriptor.ts",
+    )
+    .expect("lower should succeed")
+}
+
+fn binding_init<'a>(module: &'a perry_hir::Module, name: &str) -> &'a Expr {
+    module
+        .init
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let {
+                name: binding,
+                init: Some(init),
+                ..
+            } if binding == name => Some(init),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("top-level binding `{name}` not found"))
+}
+
+fn has_runtime_set(module: &perry_hir::Module, key: &str) -> bool {
+    module.init.iter().any(|stmt| {
+        matches!(
+            stmt,
+            Stmt::Expr(Expr::PutValueSet { key: hir_key, .. })
+                if matches!(hir_key.as_ref(), Expr::String(actual) if actual == key)
+        )
+    })
+}
+
+#[test]
+fn object_prototype_descriptor_mutation_blocks_builder_folding() {
+    let module = lower_src(
+        r#"
+        Object.defineProperty(Object.prototype, "hook", {
+            set(v: any) { (this as any).seen = v },
+            configurable: true,
+        });
+        const built: any = {};
+        built.hook = 42;
+        "#,
+    );
+
+    assert!(
+        matches!(
+            binding_init(&module, "built"),
+            Expr::New { class_name, args, .. }
+                if class_name.starts_with("__AnonShape_") && args.is_empty()
+        ),
+        "the empty allocation must not absorb the later assignment: {:?}",
+        binding_init(&module, "built")
+    );
+    assert!(
+        has_runtime_set(&module, "hook"),
+        "the assignment must survive as runtime [[Set]]: {:?}",
+        module.init
+    );
+}
+
+#[test]
+fn ordinary_builder_sequence_still_folds_without_a_prototype_barrier() {
+    let module = lower_src(
+        r#"
+        const built: any = {};
+        built.hook = 42;
+        "#,
+    );
+
+    assert!(
+        matches!(
+            binding_init(&module, "built"),
+            Expr::New { class_name, args, .. }
+                if class_name.starts_with("__AnonShape_") && args.len() == 1
+        ),
+        "the ordinary builder optimization should remain enabled: {:?}",
+        binding_init(&module, "built")
+    );
+    assert!(
+        !has_runtime_set(&module, "hook"),
+        "the folded assignment should be absorbed into the allocation"
+    );
+}


### PR DESCRIPTION
Fixes #9034.

The #6812 straight-line builder fold changed assignment [[Set]] semantics into object-literal own-property definition semantics after Object.prototype descriptor mutation.

This adds a conservative module-wide AST barrier for Object.defineProperty, Object.defineProperties, Reflect.defineProperty, and Annex-B getter/setter mutation targeting Object.prototype. Ordinary modules retain the fold.

Validated:
- exact release-blocking issue_6084 case on the dedicated server
- all four issue_6084 integration tests
- complete perry-hir and perry-transform suites
- focused HIR regression confirms the barrier and confirms ordinary folding remains enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved JavaScript assignment behavior when `Object.prototype` defines setters or non-writable properties.
  * Prevented an optimization from changing how assignments are intercepted by inherited prototype descriptors.
* **Tests**
  * Added regression coverage for prototype setters and standard object-building scenarios.
* **Documentation**
  * Added a changelog entry describing the behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->