### PR TITLE
perf(hir): keep the array type through methods chained on new Array<T>(n)

### DIFF
--- a/changelog.d/9036-chained-array-ctor-type.md
+++ b/changelog.d/9036-chained-array-ctor-type.md
@@ -1,0 +1,1 @@
+Kept the inferred array type through builtin methods chained on `new Array<T>(n)` — `new Array<number>(n).fill(0)` now infers `number[]` instead of `Any`, so index stores on such arrays take the inline guarded lane (34.6 → 3.4 ns per store).

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -1236,6 +1236,25 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
                     return Type::Any;
                 }
                 let obj_ty = infer_type_from_expr(&member.obj, ctx);
+                // `new Array<T>(n)` types as `Generic { base: "Array", [T] }`
+                // (the explicit-type-args early return above) — the same array
+                // `T[]` denotes, and downstream consumers already treat the
+                // two as one (`typed_parse.rs`, `stmt_loops.rs`,
+                // `element_shape_loop.rs`). This table must too: without the
+                // rebind, `new Array<number>(n).fill(0)` inferred `Any`, the
+                // binding lost its array type, and every later `a[i] = v` on
+                // it took the generic feedback store instead of the inline
+                // guarded lane — 34.6 vs 3.7 ns per store, for the array's
+                // whole life.
+                let obj_ty = match obj_ty {
+                    Type::Generic {
+                        ref base,
+                        ref type_args,
+                    } if base == "Array" && type_args.len() == 1 => {
+                        Type::Array(Box::new(type_args[0].clone()))
+                    }
+                    other => other,
+                };
 
                 // Phase 4.1: user class methods. When the receiver is typed
                 // as `Type::Named(C)` (e.g., a local declared as `p: Point` or

--- a/crates/perry-hir/tests/chained_array_ctor_method_types.rs
+++ b/crates/perry-hir/tests/chained_array_ctor_method_types.rs
@@ -1,0 +1,70 @@
+//! `new Array<T>(n)` types as `Generic { base: "Array", type_args: [T] }`
+//! (the explicit-type-args early return in `infer_type_from_expr`), while the
+//! builtin array method-return table matched only `Type::Array`. A chained
+//! receiver-returning method — `new Array<number>(n).fill(0)`, the canonical
+//! preallocation idiom — therefore inferred `Any`, the binding lost its array
+//! type, and every later `a[i] = v` on it took the generic feedback store
+//! instead of the inline guarded lane: 34.6 vs 3.7 ns per store, for the
+//! array's whole life. The rebind in `lower_types.rs` normalizes the Generic
+//! spelling to `Type::Array` before the method tables; these tests pin it.
+
+use perry_diagnostics::SourceCache;
+use perry_hir::types::Type;
+use perry_hir::{lower_module, Module, Stmt};
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_src(src: &str) -> Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "test.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "test.ts").expect("lower should succeed")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn find_local_type<'m>(module: &'m Module, name: &str) -> &'m Type {
+    for s in &module.init {
+        if let Stmt::Let { name: n, ty, .. } = s {
+            if n == name {
+                return ty;
+            }
+        }
+    }
+    panic!("binding {name} not found in module.init");
+}
+
+#[test]
+fn chained_fill_keeps_number_array_type() {
+    let module = lower_src("const a = new Array<number>(8192).fill(0);");
+    assert_eq!(
+        find_local_type(&module, "a"),
+        &Type::Array(Box::new(Type::Number)),
+        "new Array<number>(n).fill(0) must infer number[], not Any"
+    );
+}
+
+#[test]
+fn double_chain_through_receiver_returning_methods() {
+    let module = lower_src("const b = new Array<number>(4).fill(1).reverse();");
+    assert_eq!(
+        find_local_type(&module, "b"),
+        &Type::Array(Box::new(Type::Number)),
+        "receiver-returning chains off new Array<T> must keep T[]"
+    );
+}
+
+#[test]
+fn element_returning_method_sees_element_type() {
+    let module = lower_src("const c = new Array<number>(4).fill(2).at(0);");
+    assert_eq!(
+        find_local_type(&module, "c"),
+        &Type::Number,
+        ".at() on a new Array<number> chain must return the element type"
+    );
+}


### PR DESCRIPTION
## What

`new Array<T>(n)` infers as `Generic { base: "Array", type_args: [T] }` (the explicit-type-args early return in `infer_type_from_expr`), but the builtin array method-return table matched only `Type::Array`. A chained receiver-returning method — **`new Array<number>(n).fill(0)`, the canonical preallocation idiom** — therefore inferred `Any`: the binding lost its array type and every subsequent `a[i] = v` on it took the generic feedback store instead of the inline guarded lane, for the array's whole life.

## Fix

Rebind `Generic { base: "Array", [T] } -> Type::Array(T)` right after the receiver type is inferred, before the method tables — the same normalization every downstream consumer already applies (`typed_parse.rs`, `stmt_loops.rs`, `element_shape_loop.rs`).

## Numbers (isolated store loop over such an array, dev box)

| shape | before | after | node |
|---|---|---|---|
| `const a = new Array<number>(8192).fill(0)` + store loop | 34.6 ns | **3.4 ns** | 0.7 |
| same code with explicit `: number[]` annotation | 3.7 ns | 3.7 ns | 0.7 |

The discriminator that found it: identical code ± the annotation.

## Interaction note

Complementary to #9033: this fix makes more receivers statically numeric; without #9033's `LocalGet` canonical-value arm those would have routed pushes into the slower guarded tier. Order-independent now that both exist.

## Tests

3 new HIR regression tests (`chained_array_ctor_method_types.rs`) pinning `number[]` through `.fill`, a double chain (`.fill().reverse()`), and element-type extraction (`.at()`). Full gate on the build host: suites green (one known-flaky parallel-only GC stack_maps test passes in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for chained methods on typed array constructors.
  * Array-returning chains such as `.fill().reverse()` now preserve the correct element type.
  * Element access methods such as `.at()` now infer the correct element type.

* **Tests**
  * Added coverage for single and multi-step array method chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->