### PR TITLE
feat(hir): supply native parsers for static Zod schemas

### DIFF
--- a/changelog.d/9040-zod-compile-aot.md
+++ b/changelog.d/9040-zod-compile-aot.md
@@ -3,6 +3,11 @@
 - **Static Zod object schemas can now take a native `z.compile()` path.** Perry
   recognizes supported `z.object({...})` declarations and lowers string,
   finite-number, boolean, integer, and literal numeric-bound checks directly
-  to HIR. Successful parses no longer require Zod's `new Function` fast path;
-  failed checks delegate to the original Zod parser so its issue construction
-  remains authoritative. Unsupported schemas keep the regular Zod call.
+  to HIR. Perry supplies only the generated parser through Zod's
+  `compileFromParser()` integration API; Zod continues to own schema cloning,
+  parse-context bypasses, public methods, validation, and runtime fallbacks.
+  Successful parses no longer require `new Function`, while failed checks and
+  unsupported schemas remain authoritative in Zod.
+- `perry.compilePackages` can now resolve a package's TypeScript source tree
+  even when its published JavaScript export target is absent, enabling
+  reproducible source-only package pins for native compilation.

--- a/changelog.d/9040-zod-compile-aot.md
+++ b/changelog.d/9040-zod-compile-aot.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Static Zod object schemas can now take a native `z.compile()` path.** Perry
+  recognizes supported `z.object({...})` declarations and lowers string,
+  finite-number, boolean, integer, and literal numeric-bound checks directly
+  to HIR. Successful parses no longer require Zod's `new Function` fast path;
+  failed checks delegate to the original Zod parser so its issue construction
+  remains authoritative. Unsupported schemas keep the regular Zod call.

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -183,6 +183,7 @@ impl LoweringContext {
             namespace_import_locals: HashSet::new(),
             fetch_call_response_locals: HashSet::new(),
             namespace_import_sources: std::collections::HashMap::new(),
+            zod_schema_irs: HashMap::new(),
             generator_func_names: HashSet::new(),
             async_generator_func_names: HashSet::new(),
             nested_generator_forward_referenced: HashSet::new(),

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -220,9 +220,9 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
         return Ok(desugared);
     }
 
-    // Prototype schema-aware AOT path.  A supported static `z.compile(...)`
-    // becomes native Perry HIR here, before the npm call and Zod's
-    // `new Function` implementation are lowered.
+    // Prototype schema-aware AOT path. A supported static `z.compile(...)`
+    // becomes a native Perry parser passed into Zod's own installer, before
+    // the npm call reaches Zod's `new Function` implementation.
     if let Some(expr) = super::zod_aot::try_lower_zod_compile(ctx, call)? {
         return Ok(expr);
     }

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -220,6 +220,13 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
         return Ok(desugared);
     }
 
+    // Prototype schema-aware AOT path.  A supported static `z.compile(...)`
+    // becomes native Perry HIR here, before the npm call and Zod's
+    // `new Function` implementation are lowered.
+    if let Some(expr) = super::zod_aot::try_lower_zod_compile(ctx, call)? {
+        return Ok(expr);
+    }
+
     // Compile-time intrinsics + legacy CJS/UMD bare-callee shapes
     // (require/embedWasm/IIFE.call/Function('return this')/RegExp).
     if let Some(expr) = try_require_literal(ctx, call)? {

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -667,6 +667,10 @@ pub struct LoweringContext {
     /// symbol in the importer and drop every namespace member. Closes the zod
     /// `import { z }` breakage (zod's index does `import * as z; export { z }`).
     pub(crate) namespace_import_sources: std::collections::HashMap<String, String>,
+    /// Prototype Zod AOT schemas keyed by the local that holds the runtime
+    /// schema object.  The value is compiler-only: `z.compile(schema)` lowers
+    /// it directly to ordinary HIR and never exposes it to the executable.
+    pub(crate) zod_schema_irs: HashMap<LocalId, super::zod_aot::ZodSchemaIr>,
     /// Names of functions declared with `function*` — used to detect generator
     /// calls in `for...of` so the iterator protocol loop is emitted instead of
     /// the array-index loop.

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -85,6 +85,7 @@ mod template;
 pub(crate) use template::*;
 mod widget_decl;
 pub(crate) use widget_decl::*;
+mod zod_aot;
 
 // Newly-extracted topical siblings (split out from the previously
 // ~2,700-LOC `mod.rs` body). Each is re-exported by *explicit name*

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -458,12 +458,16 @@ pub(crate) fn lower_stmt(
                         // schema.  Its ordinary runtime initializer is still
                         // lowered below; this side table is consumed only if a
                         // later `z.compile(schema)` site can be specialized.
-                        let zod_schema_ir = match (&decl.name, &decl.init) {
-                            (ast::Pat::Ident(ident), Some(init)) => {
-                                super::zod_aot::extract_schema_ir(ctx, init)
-                                    .map(|ir| (ident.id.sym.to_string(), ir))
+                        let zod_schema_ir = if var_decl.kind == ast::VarDeclKind::Const {
+                            match (&decl.name, &decl.init) {
+                                (ast::Pat::Ident(ident), Some(init)) => {
+                                    super::zod_aot::extract_schema_ir(ctx, init)
+                                        .map(|ir| (ident.id.sym.to_string(), ir))
+                                }
+                                _ => None,
                             }
-                            _ => None,
+                        } else {
+                            None
                         };
                         // Check if this is a Widget({...}) call from perry/widget
                         if let Some(init) = &decl.init {

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -454,6 +454,17 @@ pub(crate) fn lower_stmt(
                     let mutable = var_decl.kind != ast::VarDeclKind::Const;
                     let is_var = var_decl.kind == ast::VarDeclKind::Var;
                     for decl in &var_decl.decls {
+                        // Retain a compiler-only description of a static Zod
+                        // schema.  Its ordinary runtime initializer is still
+                        // lowered below; this side table is consumed only if a
+                        // later `z.compile(schema)` site can be specialized.
+                        let zod_schema_ir = match (&decl.name, &decl.init) {
+                            (ast::Pat::Ident(ident), Some(init)) => {
+                                super::zod_aot::extract_schema_ir(ctx, init)
+                                    .map(|ir| (ident.id.sym.to_string(), ir))
+                            }
+                            _ => None,
+                        };
                         // Check if this is a Widget({...}) call from perry/widget
                         if let Some(init) = &decl.init {
                             if let ast::Expr::Call(call_expr) = init.as_ref() {
@@ -949,6 +960,11 @@ pub(crate) fn lower_stmt(
                         // not handled by the direct `class` fast path above.
                         record_chained_class_self_aliases(ctx, decl);
                         let stmts = lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
+                        if let Some((name, ir)) = zod_schema_ir {
+                            if let Some(id) = ctx.lookup_local(&name) {
+                                ctx.zod_schema_irs.insert(id, ir);
+                            }
+                        }
                         // `var` is function-scoped: mark defined locals so
                         // `pop_block_scope` preserves them when leaving an inner block.
                         if is_var {

--- a/crates/perry-hir/src/lower/zod_aot.rs
+++ b/crates/perry-hir/src/lower/zod_aot.rs
@@ -1,0 +1,588 @@
+//! Prototype Zod schema IR and direct HIR lowering.
+//!
+//! This deliberately does not compile Zod's generated JavaScript.  It reads a
+//! closed, static schema expression into [`ZodSchemaIr`] and emits the same
+//! happy-path contract as `z.compile`: a schema clone whose `_zod.run` first
+//! calls a native specialized parser and delegates failures to the original
+//! runtime parser.  The fallback preserves Zod's issue construction and keeps
+//! unsupported/error paths out of this proof of concept.
+
+use anyhow::Result;
+use swc_ecma_ast as ast;
+
+use crate::ir::{CompareOp, Expr, LogicalOp, Param, Stmt, UnaryOp};
+use crate::types::Type;
+
+use super::{lower_expr, LoweringContext};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ZodSchemaIr {
+    Object(Vec<ZodFieldIr>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ZodFieldIr {
+    pub(crate) key: String,
+    pub(crate) value: ZodValueIr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ZodValueIr {
+    String,
+    Number {
+        integer: bool,
+        minimum: Option<f64>,
+        maximum: Option<f64>,
+    },
+    Boolean,
+}
+
+fn peel_expr(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        expr = match expr {
+            ast::Expr::Paren(x) => &x.expr,
+            ast::Expr::TsAs(x) => &x.expr,
+            ast::Expr::TsNonNull(x) => &x.expr,
+            ast::Expr::TsSatisfies(x) => &x.expr,
+            ast::Expr::TsTypeAssertion(x) => &x.expr,
+            ast::Expr::TsConstAssertion(x) => &x.expr,
+            _ => return expr,
+        };
+    }
+}
+
+fn member_name(member: &ast::MemberExpr) -> Option<&str> {
+    match &member.prop {
+        ast::MemberProp::Ident(id) => Some(id.sym.as_ref()),
+        ast::MemberProp::Computed(c) => match peel_expr(&c.expr) {
+            ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+            _ => None,
+        },
+        ast::MemberProp::PrivateName(_) => None,
+    }
+}
+
+fn call_member(call: &ast::CallExpr) -> Option<(&ast::Expr, &str)> {
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let ast::Expr::Member(member) = peel_expr(callee) else {
+        return None;
+    };
+    Some((peel_expr(&member.obj), member_name(member)?))
+}
+
+fn is_zod_namespace(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    let ast::Expr::Ident(id) = peel_expr(expr) else {
+        return false;
+    };
+    matches!(
+        ctx.namespace_import_sources
+            .get(id.sym.as_ref())
+            .map(String::as_str),
+        Some("zod" | "zod/v4")
+    )
+}
+
+fn number_literal(expr: &ast::Expr) -> Option<f64> {
+    match peel_expr(expr) {
+        ast::Expr::Lit(ast::Lit::Num(n)) if n.value.is_finite() => Some(n.value),
+        ast::Expr::Unary(unary) if unary.op == ast::UnaryOp::Minus => {
+            let ast::Expr::Lit(ast::Lit::Num(n)) = peel_expr(&unary.arg) else {
+                return None;
+            };
+            let value = -n.value;
+            value.is_finite().then_some(value)
+        }
+        _ => None,
+    }
+}
+
+fn extract_value_ir(ctx: &LoweringContext, expr: &ast::Expr) -> Option<ZodValueIr> {
+    let ast::Expr::Call(call) = peel_expr(expr) else {
+        return None;
+    };
+    if call.args.iter().any(|arg| arg.spread.is_some()) {
+        return None;
+    }
+    let (receiver, method) = call_member(call)?;
+
+    if is_zod_namespace(ctx, receiver) {
+        if !call.args.is_empty() {
+            return None;
+        }
+        return match method {
+            "string" => Some(ZodValueIr::String),
+            "number" => Some(ZodValueIr::Number {
+                integer: false,
+                minimum: None,
+                maximum: None,
+            }),
+            "boolean" => Some(ZodValueIr::Boolean),
+            _ => None,
+        };
+    }
+
+    let mut inner = extract_value_ir(ctx, receiver)?;
+    match (&mut inner, method) {
+        (
+            ZodValueIr::Number {
+                integer,
+                minimum: _,
+                maximum: _,
+            },
+            "int",
+        ) if call.args.is_empty() => {
+            *integer = true;
+            Some(inner)
+        }
+        (ZodValueIr::Number { minimum, .. }, "min") if call.args.len() == 1 => {
+            *minimum = Some(number_literal(&call.args[0].expr)?);
+            Some(inner)
+        }
+        (ZodValueIr::Number { maximum, .. }, "max") if call.args.len() == 1 => {
+            *maximum = Some(number_literal(&call.args[0].expr)?);
+            Some(inner)
+        }
+        _ => None,
+    }
+}
+
+fn object_key(name: &ast::PropName) -> Option<String> {
+    match name {
+        ast::PropName::Ident(id) => Some(id.sym.to_string()),
+        ast::PropName::Str(s) => Some(s.value.to_string_lossy().to_string()),
+        ast::PropName::Num(n) => Some(n.value.to_string()),
+        _ => None,
+    }
+}
+
+pub(crate) fn extract_schema_ir(ctx: &LoweringContext, expr: &ast::Expr) -> Option<ZodSchemaIr> {
+    let ast::Expr::Call(call) = peel_expr(expr) else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let (receiver, method) = call_member(call)?;
+    if method != "object" || !is_zod_namespace(ctx, receiver) {
+        return None;
+    }
+    let ast::Expr::Object(shape) = peel_expr(&call.args[0].expr) else {
+        return None;
+    };
+
+    let mut fields = Vec::with_capacity(shape.props.len());
+    for property in &shape.props {
+        let ast::PropOrSpread::Prop(property) = property else {
+            return None;
+        };
+        let ast::Prop::KeyValue(kv) = property.as_ref() else {
+            return None;
+        };
+        let key = object_key(&kv.key)?;
+        if key == "__proto__" {
+            return None;
+        }
+        fields.push(ZodFieldIr {
+            key,
+            value: extract_value_ir(ctx, &kv.value)?,
+        });
+    }
+    Some(ZodSchemaIr::Object(fields))
+}
+
+fn property(object: Expr, name: impl Into<String>) -> Expr {
+    Expr::PropertyGet {
+        object: Box::new(object),
+        property: name.into(),
+        byte_offset: 0,
+    }
+}
+
+fn call(callee: Expr, args: Vec<Expr>) -> Expr {
+    Expr::Call {
+        callee: Box::new(callee),
+        args,
+        type_args: Vec::new(),
+        byte_offset: 0,
+    }
+}
+
+fn compare(op: CompareOp, left: Expr, right: Expr) -> Expr {
+    Expr::Compare {
+        op,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+fn logical(op: LogicalOp, left: Expr, right: Expr) -> Expr {
+    Expr::Logical {
+        op,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+fn not(expr: Expr) -> Expr {
+    Expr::Unary {
+        op: UnaryOp::Not,
+        operand: Box::new(expr),
+    }
+}
+
+fn return_undefined_if(condition: Expr) -> Stmt {
+    Stmt::If {
+        condition,
+        then_branch: vec![Stmt::Return(Some(Expr::Undefined))],
+        else_branch: None,
+    }
+}
+
+fn param(id: u32, name: &str) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty: Type::Any,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+fn closure(
+    func_id: u32,
+    params: Vec<Param>,
+    body: Vec<Stmt>,
+    captures: Vec<u32>,
+    strict: bool,
+) -> Expr {
+    Expr::Closure {
+        func_id,
+        params,
+        return_type: Type::Any,
+        body,
+        captures,
+        mutable_captures: Vec::new(),
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: true,
+        is_async: false,
+        is_generator: false,
+        is_strict: strict,
+    }
+}
+
+fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
+    let input_id = ctx.fresh_local();
+    let mut body = Vec::new();
+    let fields = match ir {
+        ZodSchemaIr::Object(fields) => fields,
+    };
+
+    let not_object = compare(
+        CompareOp::Ne,
+        Expr::TypeOf(Box::new(Expr::LocalGet(input_id))),
+        Expr::String("object".to_string()),
+    );
+    let null_input = compare(CompareOp::Eq, Expr::LocalGet(input_id), Expr::Null);
+    let array_input = Expr::ArrayIsArray(Box::new(Expr::LocalGet(input_id)));
+    body.push(return_undefined_if(logical(
+        LogicalOp::Or,
+        logical(LogicalOp::Or, not_object, null_input),
+        array_input,
+    )));
+
+    let mut output_fields = Vec::with_capacity(fields.len());
+    for field in fields {
+        let field_id = ctx.fresh_local();
+        body.push(Stmt::Let {
+            id: field_id,
+            name: format!("__zod_{}", field.key),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(property(Expr::LocalGet(input_id), field.key.clone())),
+        });
+
+        let type_name = match field.value {
+            ZodValueIr::String => "string",
+            ZodValueIr::Number { .. } => "number",
+            ZodValueIr::Boolean => "boolean",
+        };
+        let wrong_type = compare(
+            CompareOp::Ne,
+            Expr::TypeOf(Box::new(Expr::LocalGet(field_id))),
+            Expr::String(type_name.to_string()),
+        );
+        let invalid_type = match &field.value {
+            ZodValueIr::Number { .. } => logical(
+                LogicalOp::Or,
+                wrong_type,
+                not(Expr::NumberIsFinite(Box::new(Expr::LocalGet(field_id)))),
+            ),
+            _ => wrong_type,
+        };
+        body.push(return_undefined_if(invalid_type));
+
+        if let ZodValueIr::Number {
+            integer,
+            minimum,
+            maximum,
+        } = field.value
+        {
+            if integer {
+                body.push(return_undefined_if(not(Expr::NumberIsInteger(Box::new(
+                    Expr::LocalGet(field_id),
+                )))));
+            }
+            if let Some(minimum) = minimum {
+                body.push(return_undefined_if(compare(
+                    CompareOp::Lt,
+                    Expr::LocalGet(field_id),
+                    Expr::Number(minimum),
+                )));
+            }
+            if let Some(maximum) = maximum {
+                body.push(return_undefined_if(compare(
+                    CompareOp::Gt,
+                    Expr::LocalGet(field_id),
+                    Expr::Number(maximum),
+                )));
+            }
+        }
+
+        output_fields.push((field.key.clone(), Expr::LocalGet(field_id)));
+    }
+    body.push(Stmt::Return(Some(Expr::Object(output_fields))));
+
+    let func_id = ctx.fresh_func();
+    ctx.closure_display_names
+        .insert(func_id, "__perry_zod_native_parser".to_string());
+    closure(
+        func_id,
+        vec![param(input_id, "input")],
+        body,
+        Vec::new(),
+        ctx.current_strict_mode(),
+    )
+}
+
+fn lower_compiled_schema_wrapper(
+    ctx: &mut LoweringContext,
+    runtime_schema: Expr,
+    ir: &ZodSchemaIr,
+) -> Expr {
+    let strict = ctx.current_strict_mode();
+    let source_id = ctx.fresh_local();
+    let clone_id = ctx.fresh_local();
+    let original_run_id = ctx.fresh_local();
+    let parser_id = ctx.fresh_local();
+
+    let parser = lower_native_parser(ctx, ir);
+
+    let payload_id = ctx.fresh_local();
+    let parse_ctx_id = ctx.fresh_local();
+    let output_id = ctx.fresh_local();
+    let wrapper_body = vec![
+        Stmt::Let {
+            id: output_id,
+            name: "__zod_output".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(call(
+                Expr::LocalGet(parser_id),
+                vec![property(Expr::LocalGet(payload_id), "value")],
+            )),
+        },
+        Stmt::If {
+            condition: compare(CompareOp::Ne, Expr::LocalGet(output_id), Expr::Undefined),
+            then_branch: vec![
+                Stmt::Expr(Expr::PropertySet {
+                    object: Box::new(Expr::LocalGet(payload_id)),
+                    property: "value".to_string(),
+                    value: Box::new(Expr::LocalGet(output_id)),
+                }),
+                Stmt::Return(Some(Expr::LocalGet(payload_id))),
+            ],
+            else_branch: None,
+        },
+        Stmt::Return(Some(call(
+            Expr::LocalGet(original_run_id),
+            vec![Expr::LocalGet(payload_id), Expr::LocalGet(parse_ctx_id)],
+        ))),
+    ];
+    let wrapped_run_func = ctx.fresh_func();
+    ctx.closure_display_names
+        .insert(wrapped_run_func, "__perry_zod_wrapped_run".to_string());
+    let wrapped_run = closure(
+        wrapped_run_func,
+        vec![param(payload_id, "payload"), param(parse_ctx_id, "ctx")],
+        wrapper_body,
+        vec![parser_id, original_run_id],
+        strict,
+    );
+
+    let outer_body = vec![
+        Stmt::Let {
+            id: clone_id,
+            name: "__zod_clone".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(call(
+                property(Expr::LocalGet(source_id), "clone"),
+                Vec::new(),
+            )),
+        },
+        Stmt::Let {
+            id: original_run_id,
+            name: "__zod_original_run".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(property(property(Expr::LocalGet(source_id), "_zod"), "run")),
+        },
+        Stmt::Let {
+            id: parser_id,
+            name: "__zod_native_parser".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(parser),
+        },
+        Stmt::Expr(Expr::PropertySet {
+            object: Box::new(property(Expr::LocalGet(clone_id), "_zod")),
+            property: "run".to_string(),
+            value: Box::new(wrapped_run),
+        }),
+        Stmt::Return(Some(Expr::LocalGet(clone_id))),
+    ];
+    let outer_func = ctx.fresh_func();
+    ctx.closure_display_names
+        .insert(outer_func, "__perry_zod_compile".to_string());
+    let outer = closure(
+        outer_func,
+        vec![param(source_id, "schema")],
+        outer_body,
+        Vec::new(),
+        strict,
+    );
+    call(outer, vec![runtime_schema])
+}
+
+fn strict_options_only(call: &ast::CallExpr) -> bool {
+    if call.args.len() == 1 {
+        return true;
+    }
+    if call.args.len() != 2 || call.args[1].spread.is_some() {
+        return false;
+    }
+    let ast::Expr::Object(options) = peel_expr(&call.args[1].expr) else {
+        return false;
+    };
+    options.props.iter().all(|property| {
+        let ast::PropOrSpread::Prop(property) = property else {
+            return false;
+        };
+        let ast::Prop::KeyValue(kv) = property.as_ref() else {
+            return false;
+        };
+        object_key(&kv.key).as_deref() == Some("strict")
+            && matches!(peel_expr(&kv.value), ast::Expr::Lit(ast::Lit::Bool(_)))
+    })
+}
+
+pub(crate) fn try_lower_zod_compile(
+    ctx: &mut LoweringContext,
+    call_expr: &ast::CallExpr,
+) -> Result<Option<Expr>> {
+    if call_expr.args.is_empty()
+        || call_expr.args[0].spread.is_some()
+        || !strict_options_only(call_expr)
+    {
+        return Ok(None);
+    }
+    let Some((receiver, method)) = call_member(call_expr) else {
+        return Ok(None);
+    };
+    if method != "compile" || !is_zod_namespace(ctx, receiver) {
+        return Ok(None);
+    }
+
+    let schema_expr = peel_expr(&call_expr.args[0].expr);
+    let ir = match schema_expr {
+        ast::Expr::Ident(id) => ctx
+            .lookup_local(id.sym.as_ref())
+            .and_then(|local| ctx.zod_schema_irs.get(&local))
+            .cloned(),
+        _ => extract_schema_ir(ctx, schema_expr),
+    };
+    let Some(ir) = ir else {
+        return Ok(None);
+    };
+    let runtime_schema = lower_expr(ctx, schema_expr)?;
+    Ok(Some(lower_compiled_schema_wrapper(
+        ctx,
+        runtime_schema,
+        &ir,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn static_zod_compile_lowers_to_named_native_validator_hir() {
+        let source = r#"
+            import * as z from "zod";
+            const Player = z.object({
+                name: z.string(),
+                score: z.number().int().min(0).max(100),
+                active: z.boolean(),
+            });
+            export const CompiledPlayer = z.compile(Player, { strict: true });
+        "#;
+        let parsed = perry_parser::parse_typescript(source, "zod-aot.ts").expect("source parses");
+        let hir = crate::lower_module(&parsed, "zod-aot", "zod-aot.ts").expect("source lowers");
+
+        for expected in [
+            "__perry_zod_compile",
+            "__perry_zod_wrapped_run",
+            "__perry_zod_native_parser",
+        ] {
+            assert!(
+                hir.closure_display_names
+                    .values()
+                    .any(|name| name == expected),
+                "missing {expected}: {:#?}",
+                hir.closure_display_names
+            );
+        }
+
+        let dump = format!("{hir:#?}");
+        assert!(dump.contains("NumberIsFinite"), "{dump}");
+        assert!(dump.contains("NumberIsInteger"), "{dump}");
+        assert!(dump.contains("0.0"), "{dump}");
+        assert!(dump.contains("100.0"), "{dump}");
+    }
+
+    #[test]
+    fn unsupported_schema_keeps_the_regular_zod_call() {
+        let source = r#"
+            import * as z from "zod";
+            const Dynamic = z.array(z.string());
+            export const Compiled = z.compile(Dynamic, { strict: true });
+        "#;
+        let parsed =
+            perry_parser::parse_typescript(source, "zod-fallback.ts").expect("source parses");
+        let hir =
+            crate::lower_module(&parsed, "zod-fallback", "zod-fallback.ts").expect("source lowers");
+
+        assert!(
+            hir.closure_display_names
+                .values()
+                .all(|name| !name.starts_with("__perry_zod_")),
+            "unsupported schemas must not be partly specialized: {:#?}",
+            hir.closure_display_names
+        );
+    }
+}

--- a/crates/perry-hir/src/lower/zod_aot.rs
+++ b/crates/perry-hir/src/lower/zod_aot.rs
@@ -1,11 +1,10 @@
 //! Prototype Zod schema IR and direct HIR lowering.
 //!
-//! This deliberately does not compile Zod's generated JavaScript.  It reads a
-//! closed, static schema expression into [`ZodSchemaIr`] and emits the same
-//! happy-path contract as `z.compile`: a schema clone whose `_zod.run` first
-//! calls a native specialized parser and delegates failures to the original
-//! runtime parser.  The fallback preserves Zod's issue construction and keeps
-//! unsupported/error paths out of this proof of concept.
+//! This deliberately does not compile Zod's generated JavaScript. It reads a
+//! closed, static schema expression into [`ZodSchemaIr`] and emits only a
+//! native specialized parser. Zod's `compileFromParser` integration point owns
+//! the schema clone, parse-context bypasses, public methods, and runtime
+//! fallback. Unsupported/error paths stay entirely in Zod.
 
 use anyhow::Result;
 use swc_ecma_ast as ast;
@@ -76,6 +75,12 @@ fn is_zod_namespace(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     let ast::Expr::Ident(id) = peel_expr(expr) else {
         return false;
     };
+    // Namespace imports are not local-slot bindings in Perry's HIR. Any local
+    // with the same spelling therefore proves that this occurrence resolves
+    // to a shadowing user binding instead of the imported Zod namespace.
+    if ctx.lookup_local(id.sym.as_ref()).is_some() {
+        return false;
+    }
     matches!(
         ctx.namespace_import_sources
             .get(id.sym.as_ref())
@@ -173,6 +178,7 @@ pub(crate) fn extract_schema_ir(ctx: &LoweringContext, expr: &ast::Expr) -> Opti
     };
 
     let mut fields = Vec::with_capacity(shape.props.len());
+    let mut keys = std::collections::HashSet::with_capacity(shape.props.len());
     for property in &shape.props {
         let ast::PropOrSpread::Prop(property) = property else {
             return None;
@@ -181,7 +187,7 @@ pub(crate) fn extract_schema_ir(ctx: &LoweringContext, expr: &ast::Expr) -> Opti
             return None;
         };
         let key = object_key(&kv.key)?;
-        if key == "__proto__" {
+        if key == "__proto__" || !keys.insert(key.clone()) {
             return None;
         }
         fields.push(ZodFieldIr {
@@ -232,10 +238,10 @@ fn not(expr: Expr) -> Expr {
     }
 }
 
-fn return_undefined_if(condition: Expr) -> Stmt {
+fn return_invalid_if(condition: Expr, invalid_id: u32) -> Stmt {
     Stmt::If {
         condition,
-        then_branch: vec![Stmt::Return(Some(Expr::Undefined))],
+        then_branch: vec![Stmt::Return(Some(Expr::LocalGet(invalid_id)))],
         else_branch: None,
     }
 }
@@ -276,7 +282,7 @@ fn closure(
     }
 }
 
-fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
+fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr, invalid_id: u32) -> Expr {
     let input_id = ctx.fresh_local();
     let mut body = Vec::new();
     let fields = match ir {
@@ -290,11 +296,14 @@ fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
     );
     let null_input = compare(CompareOp::Eq, Expr::LocalGet(input_id), Expr::Null);
     let array_input = Expr::ArrayIsArray(Box::new(Expr::LocalGet(input_id)));
-    body.push(return_undefined_if(logical(
-        LogicalOp::Or,
-        logical(LogicalOp::Or, not_object, null_input),
-        array_input,
-    )));
+    body.push(return_invalid_if(
+        logical(
+            LogicalOp::Or,
+            logical(LogicalOp::Or, not_object, null_input),
+            array_input,
+        ),
+        invalid_id,
+    ));
 
     let mut output_fields = Vec::with_capacity(fields.len());
     for field in fields {
@@ -325,7 +334,7 @@ fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
             ),
             _ => wrong_type,
         };
-        body.push(return_undefined_if(invalid_type));
+        body.push(return_invalid_if(invalid_type, invalid_id));
 
         if let ZodValueIr::Number {
             integer,
@@ -334,23 +343,30 @@ fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
         } = field.value
         {
             if integer {
-                body.push(return_undefined_if(not(Expr::NumberIsInteger(Box::new(
-                    Expr::LocalGet(field_id),
-                )))));
+                body.push(return_invalid_if(
+                    not(Expr::NumberIsInteger(Box::new(Expr::LocalGet(field_id)))),
+                    invalid_id,
+                ));
             }
             if let Some(minimum) = minimum {
-                body.push(return_undefined_if(compare(
-                    CompareOp::Lt,
-                    Expr::LocalGet(field_id),
-                    Expr::Number(minimum),
-                )));
+                body.push(return_invalid_if(
+                    compare(
+                        CompareOp::Lt,
+                        Expr::LocalGet(field_id),
+                        Expr::Number(minimum),
+                    ),
+                    invalid_id,
+                ));
             }
             if let Some(maximum) = maximum {
-                body.push(return_undefined_if(compare(
-                    CompareOp::Gt,
-                    Expr::LocalGet(field_id),
-                    Expr::Number(maximum),
-                )));
+                body.push(return_invalid_if(
+                    compare(
+                        CompareOp::Gt,
+                        Expr::LocalGet(field_id),
+                        Expr::Number(maximum),
+                    ),
+                    invalid_id,
+                ));
             }
         }
 
@@ -365,83 +381,49 @@ fn lower_native_parser(ctx: &mut LoweringContext, ir: &ZodSchemaIr) -> Expr {
         func_id,
         vec![param(input_id, "input")],
         body,
-        Vec::new(),
+        vec![invalid_id],
         ctx.current_strict_mode(),
     )
 }
 
-fn lower_compiled_schema_wrapper(
+fn lower_compiled_schema_install(
     ctx: &mut LoweringContext,
+    runtime_namespace: Expr,
     runtime_schema: Expr,
+    runtime_options: Expr,
     ir: &ZodSchemaIr,
 ) -> Expr {
     let strict = ctx.current_strict_mode();
+    let namespace_id = ctx.fresh_local();
     let source_id = ctx.fresh_local();
-    let clone_id = ctx.fresh_local();
-    let original_run_id = ctx.fresh_local();
+    let options_id = ctx.fresh_local();
+    let invalid_id = ctx.fresh_local();
     let parser_id = ctx.fresh_local();
 
-    let parser = lower_native_parser(ctx, ir);
-
-    let payload_id = ctx.fresh_local();
-    let parse_ctx_id = ctx.fresh_local();
-    let output_id = ctx.fresh_local();
-    let wrapper_body = vec![
-        Stmt::Let {
-            id: output_id,
-            name: "__zod_output".to_string(),
-            ty: Type::Any,
-            mutable: false,
-            init: Some(call(
-                Expr::LocalGet(parser_id),
-                vec![property(Expr::LocalGet(payload_id), "value")],
-            )),
-        },
-        Stmt::If {
-            condition: compare(CompareOp::Ne, Expr::LocalGet(output_id), Expr::Undefined),
-            then_branch: vec![
-                Stmt::Expr(Expr::PropertySet {
-                    object: Box::new(Expr::LocalGet(payload_id)),
-                    property: "value".to_string(),
-                    value: Box::new(Expr::LocalGet(output_id)),
-                }),
-                Stmt::Return(Some(Expr::LocalGet(payload_id))),
-            ],
-            else_branch: None,
-        },
-        Stmt::Return(Some(call(
-            Expr::LocalGet(original_run_id),
-            vec![Expr::LocalGet(payload_id), Expr::LocalGet(parse_ctx_id)],
-        ))),
-    ];
-    let wrapped_run_func = ctx.fresh_func();
-    ctx.closure_display_names
-        .insert(wrapped_run_func, "__perry_zod_wrapped_run".to_string());
-    let wrapped_run = closure(
-        wrapped_run_func,
-        vec![param(payload_id, "payload"), param(parse_ctx_id, "ctx")],
-        wrapper_body,
-        vec![parser_id, original_run_id],
-        strict,
-    );
+    let parser = lower_native_parser(ctx, ir, invalid_id);
 
     let outer_body = vec![
-        Stmt::Let {
-            id: clone_id,
-            name: "__zod_clone".to_string(),
-            ty: Type::Any,
-            mutable: false,
-            init: Some(call(
-                property(Expr::LocalGet(source_id), "clone"),
-                Vec::new(),
-            )),
+        Stmt::If {
+            condition: compare(
+                CompareOp::Ne,
+                Expr::TypeOf(Box::new(property(
+                    Expr::LocalGet(namespace_id),
+                    "compileFromParser",
+                ))),
+                Expr::String("function".to_string()),
+            ),
+            then_branch: vec![Stmt::Return(Some(call(
+                property(Expr::LocalGet(namespace_id), "compile"),
+                vec![Expr::LocalGet(source_id), Expr::LocalGet(options_id)],
+            )))],
+            else_branch: None,
         },
         Stmt::Let {
-            id: original_run_id,
-            name: "__zod_original_run".to_string(),
+            id: invalid_id,
+            name: "__zod_invalid".to_string(),
             ty: Type::Any,
             mutable: false,
-            init: Some(property(property(Expr::LocalGet(source_id), "_zod"), "run")),
+            init: Some(property(Expr::LocalGet(namespace_id), "INVALID")),
         },
         Stmt::Let {
             id: parser_id,
@@ -450,24 +432,29 @@ fn lower_compiled_schema_wrapper(
             mutable: false,
             init: Some(parser),
         },
-        Stmt::Expr(Expr::PropertySet {
-            object: Box::new(property(Expr::LocalGet(clone_id), "_zod")),
-            property: "run".to_string(),
-            value: Box::new(wrapped_run),
-        }),
-        Stmt::Return(Some(Expr::LocalGet(clone_id))),
+        Stmt::Return(Some(call(
+            property(Expr::LocalGet(namespace_id), "compileFromParser"),
+            vec![Expr::LocalGet(source_id), Expr::LocalGet(parser_id)],
+        ))),
     ];
     let outer_func = ctx.fresh_func();
     ctx.closure_display_names
-        .insert(outer_func, "__perry_zod_compile".to_string());
+        .insert(outer_func, "__perry_zod_install_parser".to_string());
     let outer = closure(
         outer_func,
-        vec![param(source_id, "schema")],
+        vec![
+            param(namespace_id, "zod"),
+            param(source_id, "schema"),
+            param(options_id, "options"),
+        ],
         outer_body,
         Vec::new(),
         strict,
     );
-    call(outer, vec![runtime_schema])
+    call(
+        outer,
+        vec![runtime_namespace, runtime_schema, runtime_options],
+    )
 }
 
 fn strict_options_only(call: &ast::CallExpr) -> bool {
@@ -520,10 +507,17 @@ pub(crate) fn try_lower_zod_compile(
     let Some(ir) = ir else {
         return Ok(None);
     };
+    let runtime_namespace = lower_expr(ctx, receiver)?;
     let runtime_schema = lower_expr(ctx, schema_expr)?;
-    Ok(Some(lower_compiled_schema_wrapper(
+    let runtime_options = match call_expr.args.get(1) {
+        Some(options) => lower_expr(ctx, &options.expr)?,
+        None => Expr::Undefined,
+    };
+    Ok(Some(lower_compiled_schema_install(
         ctx,
+        runtime_namespace,
         runtime_schema,
+        runtime_options,
         &ir,
     )))
 }
@@ -544,11 +538,7 @@ mod tests {
         let parsed = perry_parser::parse_typescript(source, "zod-aot.ts").expect("source parses");
         let hir = crate::lower_module(&parsed, "zod-aot", "zod-aot.ts").expect("source lowers");
 
-        for expected in [
-            "__perry_zod_compile",
-            "__perry_zod_wrapped_run",
-            "__perry_zod_native_parser",
-        ] {
+        for expected in ["__perry_zod_install_parser", "__perry_zod_native_parser"] {
             assert!(
                 hir.closure_display_names
                     .values()
@@ -561,6 +551,9 @@ mod tests {
         let dump = format!("{hir:#?}");
         assert!(dump.contains("NumberIsFinite"), "{dump}");
         assert!(dump.contains("NumberIsInteger"), "{dump}");
+        assert!(dump.contains("compileFromParser"), "{dump}");
+        assert!(dump.contains("INVALID"), "{dump}");
+        assert!(!dump.contains("__perry_zod_wrapped_run"), "{dump}");
         assert!(dump.contains("0.0"), "{dump}");
         assert!(dump.contains("100.0"), "{dump}");
     }
@@ -582,6 +575,75 @@ mod tests {
                 .values()
                 .all(|name| !name.starts_with("__perry_zod_")),
             "unsupported schemas must not be partly specialized: {:#?}",
+            hir.closure_display_names
+        );
+    }
+
+    #[test]
+    fn mutable_schema_keeps_the_regular_zod_call() {
+        let source = r#"
+            import * as z from "zod";
+            let Player = z.object({ name: z.string() });
+            Player = z.object({ name: z.string() });
+            export const Compiled = z.compile(Player);
+        "#;
+        let parsed =
+            perry_parser::parse_typescript(source, "zod-mutable.ts").expect("source parses");
+        let hir =
+            crate::lower_module(&parsed, "zod-mutable", "zod-mutable.ts").expect("source lowers");
+
+        assert!(
+            hir.closure_display_names
+                .values()
+                .all(|name| !name.starts_with("__perry_zod_")),
+            "mutable schemas must not be specialized: {:#?}",
+            hir.closure_display_names
+        );
+    }
+
+    #[test]
+    fn shadowed_zod_namespace_keeps_the_regular_call() {
+        let source = r#"
+            import * as z from "zod";
+            function compileLocal() {
+                const z = makeLocalSchemaLibrary();
+                const Player = z.object({ name: z.string() });
+                return z.compile(Player);
+            }
+        "#;
+        let parsed =
+            perry_parser::parse_typescript(source, "zod-shadow.ts").expect("source parses");
+        let hir =
+            crate::lower_module(&parsed, "zod-shadow", "zod-shadow.ts").expect("source lowers");
+
+        assert!(
+            hir.closure_display_names
+                .values()
+                .all(|name| !name.starts_with("__perry_zod_")),
+            "shadowed namespace bindings must not be specialized: {:#?}",
+            hir.closure_display_names
+        );
+    }
+
+    #[test]
+    fn duplicate_object_keys_keep_the_regular_zod_call() {
+        let source = r#"
+            import * as z from "zod";
+            export const Compiled = z.compile(z.object({
+                name: z.string(),
+                name: z.string(),
+            }));
+        "#;
+        let parsed =
+            perry_parser::parse_typescript(source, "zod-duplicate.ts").expect("source parses");
+        let hir = crate::lower_module(&parsed, "zod-duplicate", "zod-duplicate.ts")
+            .expect("source lowers");
+
+        assert!(
+            hir.closure_display_names
+                .values()
+                .all(|name| !name.starts_with("__perry_zod_")),
+            "duplicate keys must not be specialized: {:#?}",
             hir.closure_display_names
         );
     }

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -1490,39 +1490,43 @@ pub(super) fn resolve_import(
             if !package_dir.is_dir() {
                 continue;
             }
-            let Some(entry) = resolve_package_entry(&package_dir, subpath.as_deref()) else {
-                continue;
-            };
+            let entry = resolve_package_entry(&package_dir, subpath.as_deref());
             // Packages with perry.nativeLibrary are compiled natively (Rust FFI)
             if has_perry_native_library(&package_dir) {
-                return Some((entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
+                if let Some(entry) = entry.as_ref() {
+                    return Some((entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
+                }
             }
             // Packages with perry.nativeModule: true contain Perry-compatible
             // TypeScript that must be compiled natively (e.g. perry-react).
             if has_perry_native_module(&package_dir) {
-                return Some((entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
+                if let Some(entry) = entry.as_ref() {
+                    return Some((entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
+                }
             }
             // Packages listed in perry.compilePackages are compiled natively
             if compile_packages.contains(&package_name) {
-                // Prefer TypeScript source over compiled JS
+                // Prefer TypeScript source over compiled JS. Do this even
+                // when the package's normal exports target is absent: source-
+                // only installs can deliberately ship `src/index.ts` while
+                // retaining published-package `import`/`require` metadata.
                 if let Some(src_entry) =
                     resolve_package_source_entry(&package_dir, subpath.as_deref())
                 {
                     return Some((src_entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
                 }
                 // Fall back to normal resolution but still mark as NativeCompiled
-                if let Some(fallback_entry) =
-                    resolve_package_entry(&package_dir, subpath.as_deref())
-                {
+                if let Some(fallback_entry) = entry {
                     return Some((
                         fallback_entry.canonicalize().ok()?,
                         ModuleKind::NativeCompiled,
                     ));
                 }
-                // The entry resolved above is the same package instance and is
-                // kept as the final fallback for unusual package metadata.
-                return Some((entry.canonicalize().ok()?, ModuleKind::NativeCompiled));
+                continue;
             }
+            let Some(entry) = entry else {
+                continue;
+            };
             // For other node_modules packages, classify by file
             // extension. `.ts` / `.tsx` sources are compiled natively.
             // `.js` / `.mjs` / `.cjs` and other shapes stay Interpreted;

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -1562,6 +1562,59 @@ mod declaration_sidecar_tests {
     }
 
     #[test]
+    fn compile_package_resolves_source_without_built_exports_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let package_dir = root.join("node_modules/source-only");
+        std::fs::create_dir_all(package_dir.join("src")).expect("mkdir package src");
+        std::fs::write(
+            package_dir.join("package.json"),
+            serde_json::json!({
+                "name": "source-only",
+                "type": "module",
+                "exports": {
+                    ".": {
+                        "import": "./index.js",
+                        "require": "./index.cjs"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write package.json");
+        let source = package_dir.join("src/index.ts");
+        std::fs::write(&source, "export const answer = 42;\n").expect("write source");
+        let importer = root.join("main.ts");
+        std::fs::write(&importer, "import { answer } from 'source-only';\n")
+            .expect("write importer");
+
+        assert!(
+            resolve_import(
+                "source-only",
+                &importer,
+                root,
+                &HashSet::new(),
+                &BTreeSet::new(),
+            )
+            .is_none(),
+            "normal package resolution must still honor its missing exports target"
+        );
+
+        let compile_packages = HashSet::from(["source-only".to_string()]);
+        let resolved = resolve_import(
+            "source-only",
+            &importer,
+            root,
+            &compile_packages,
+            &BTreeSet::new(),
+        )
+        .expect("compilePackages should admit the source tree directly");
+
+        assert_eq!(resolved.1, ModuleKind::NativeCompiled);
+        assert_eq!(resolved.0, source.canonicalize().expect("canonical source"));
+    }
+
+    #[test]
     fn compile_package_membership_uses_path_components() {
         let dir = tempfile::tempdir().expect("tempdir");
         let root = dir.path();

--- a/experiments/zod-compile-probe/README.md
+++ b/experiments/zod-compile-probe/README.md
@@ -2,12 +2,15 @@
 
 This probe exercises Perry's prototype schema-aware lowering for Zod. The
 compiler recognizes a closed `z.object({...})` schema, records a compiler-only
-schema IR, and replaces the matching `z.compile(schema)` call with ordinary
-Perry HIR closures. Zod's generated JavaScript is not evaluated.
+schema IR, and emits an ordinary Perry HIR parser. Zod's generated JavaScript
+is not evaluated.
 
-The generated schema clone uses a native happy path and delegates failures to
-the original Zod parser. That preserves Zod's normal issue construction while
-making successful parses independent of `new Function`/`dyn-eval`.
+Perry passes that parser to Zod's `compileFromParser()` integration API. Zod's
+own source remains responsible for cloning the schema, bypassing the native
+path for async/backward/skip-check contexts, installing public parse methods,
+and delegating failures to the original parser. Successful parses are
+independent of `new Function`/`dyn-eval` without duplicating Zod's wrapper
+contract in Perry.
 
 The current proof-of-concept subset is intentionally small:
 
@@ -16,9 +19,19 @@ The current proof-of-concept subset is intentionally small:
 - `z.string()`, `z.number()`, and `z.boolean()`
 - `z.number().int()`, `.min(<number literal>)`, and `.max(<number literal>)`
 - `z.compile(schema)` and the static `{ strict: <boolean> }` option
+- immutable `const` schema bindings with unshadowed Zod namespace imports
 
 Unsupported schemas keep the regular Zod call; they are never partially
-specialized.
+specialized. Zod versions without `compileFromParser()` also keep the regular
+`z.compile()` behavior.
+
+The dependency is temporarily pinned to the source-only package commit that
+backs the upstream Zod API proposal in
+[colinhacks/zod#6498](https://github.com/colinhacks/zod/issues/6498). Replace it
+with the first official Zod release containing `compileFromParser()` once that
+API lands. The probe explicitly opts `zod` into `perry.compilePackages`; Perry
+therefore resolves `src/index.ts` even though this temporary package has no
+built `index.js`, and compiles the complete reachable Zod graph natively.
 
 From this directory, install the pinned Zod dependency, then build and run on
 Windows with:

--- a/experiments/zod-compile-probe/README.md
+++ b/experiments/zod-compile-probe/README.md
@@ -1,0 +1,35 @@
+# Zod `z.compile()` AOT probe
+
+This probe exercises Perry's prototype schema-aware lowering for Zod. The
+compiler recognizes a closed `z.object({...})` schema, records a compiler-only
+schema IR, and replaces the matching `z.compile(schema)` call with ordinary
+Perry HIR closures. Zod's generated JavaScript is not evaluated.
+
+The generated schema clone uses a native happy path and delegates failures to
+the original Zod parser. That preserves Zod's normal issue construction while
+making successful parses independent of `new Function`/`dyn-eval`.
+
+The current proof-of-concept subset is intentionally small:
+
+- `import * as z from "zod"` or `"zod/v4"`
+- `z.object()` with static, non-computed fields
+- `z.string()`, `z.number()`, and `z.boolean()`
+- `z.number().int()`, `.min(<number literal>)`, and `.max(<number literal>)`
+- `z.compile(schema)` and the static `{ strict: <boolean> }` option
+
+Unsupported schemas keep the regular Zod call; they are never partially
+specialized.
+
+From this directory, install the pinned Zod dependency, then build and run on
+Windows with:
+
+```powershell
+npm ci
+$env:LLVM_SYS_221_PREFIX = "C:\llvm"
+$env:PERRY_RS4GC = "0"
+..\..\target\perry-dev\perry.exe compile .\index.ts -o .\zod-aot-poc.exe
+.\zod-aot-poc.exe
+```
+
+`PERRY_RS4GC=0` is a current Windows exception-handling workaround and is not
+part of the Zod AOT design.

--- a/experiments/zod-compile-probe/index.ts
+++ b/experiments/zod-compile-probe/index.ts
@@ -1,0 +1,102 @@
+import * as z from "zod";
+
+const Player = z.object({
+  username: z.string(),
+  displayName: z.string(),
+  email: z.string(),
+  country: z.string(),
+  language: z.string(),
+  team: z.string(),
+  role: z.string(),
+  status: z.string(),
+  bio: z.string(),
+  avatar: z.string(),
+  xp: z.number().int().min(0).max(1000),
+  level: z.number(),
+  rank: z.number(),
+  wins: z.number(),
+  losses: z.number(),
+  streak: z.number(),
+  coins: z.number(),
+  gems: z.number(),
+  active: z.boolean(),
+  verified: z.boolean(),
+});
+
+const originalRun = Player._zod.run;
+let fallbackRuns = 0;
+Player._zod.run = (payload, ctx) => {
+  fallbackRuns++;
+  return originalRun(payload, ctx);
+};
+
+// strict:true makes an unsupported compiler path throw instead of returning
+// the original interpreted schema.
+const CompiledPlayer = z.compile(Player, { strict: true });
+
+const validPlayer = {
+  username: "billie",
+  displayName: "Billie",
+  email: "billie@example.com",
+  country: "DE",
+  language: "de",
+  team: "blue",
+  role: "captain",
+  status: "online",
+  bio: "validator",
+  avatar: "avatar.png",
+  xp: 100,
+  level: 4,
+  rank: 12,
+  wins: 8,
+  losses: 2,
+  streak: 3,
+  coins: 500,
+  gems: 25,
+  active: true,
+  verified: true,
+  strippedByObjectSchema: "yes",
+};
+
+const invalidPlayer = {
+  username: "billie",
+  displayName: "Billie",
+  email: "billie@example.com",
+  country: "DE",
+  language: "de",
+  team: "blue",
+  role: "captain",
+  status: "online",
+  bio: "validator",
+  avatar: "avatar.png",
+  xp: "not-a-number",
+  level: 4,
+  rank: 12,
+  wins: 8,
+  losses: 2,
+  streak: 3,
+  coins: 500,
+  gems: 25,
+  active: true,
+  verified: true,
+};
+
+const valid = CompiledPlayer.safeParse(validPlayer);
+const fallbackRunsAfterValid = fallbackRuns;
+const invalid = CompiledPlayer.safeParse(invalidPlayer);
+
+console.log(`compiledClone=${CompiledPlayer !== Player}`);
+console.log(`compiledRunChanged=${CompiledPlayer._zod.run !== Player._zod.run}`);
+console.log(`validSuccess=${valid.success}`);
+console.log(`validAvoidedFallback=${fallbackRunsAfterValid === 0}`);
+console.log(
+  `validStrippedUnknown=${
+    valid.success && !("strippedByObjectSchema" in valid.data)
+  }`,
+);
+console.log(`invalidSuccess=${invalid.success}`);
+console.log(`invalidUsedFallback=${fallbackRuns === 1}`);
+if (!invalid.success) {
+  const issue = invalid.error.issues[0];
+  console.log(`invalidIssue=${issue.path.join(".")}:${issue.code}`);
+}

--- a/experiments/zod-compile-probe/index.ts
+++ b/experiments/zod-compile-probe/index.ts
@@ -1,5 +1,8 @@
 import * as z from "zod";
 
+// Isolate explicit z.compile() from Zod's older object-parser JIT.
+z.config({ jitless: true });
+
 const Player = z.object({
   username: z.string(),
   displayName: z.string(),

--- a/experiments/zod-compile-probe/index.ts
+++ b/experiments/zod-compile-probe/index.ts
@@ -90,6 +90,16 @@ const invalid = CompiledPlayer.safeParse(invalidPlayer);
 
 console.log(`compiledClone=${CompiledPlayer !== Player}`);
 console.log(`compiledRunChanged=${CompiledPlayer._zod.run !== Player._zod.run}`);
+console.log(
+  `wrapperOwnedByZod=${
+    (CompiledPlayer._zod.run as typeof Player._zod.run & {
+      __originalRun?: typeof Player._zod.run;
+    }).__originalRun === Player._zod.run
+  }`,
+);
+console.log(
+  `fallbackOwnedByZod=${CompiledPlayer._zod.bag.fallbackRun === Player._zod.run}`,
+);
 console.log(`validSuccess=${valid.success}`);
 console.log(`validAvoidedFallback=${fallbackRunsAfterValid === 0}`);
 console.log(

--- a/experiments/zod-compile-probe/package-lock.json
+++ b/experiments/zod-compile-probe/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "perry-zod-compile-probe",
       "dependencies": {
-        "zod": "4.5.2"
+        "zod": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49"
       }
     },
     "node_modules/zod": {
       "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
-      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
+      "resolved": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49",
+      "integrity": "sha512-JanZAPLNXhbqECBmRU+FBjnOy/d9DuaeWm8k/JaBck9Bo/Xt/1+BFGsryqgZl7wiYGNF+NorLn7j6HPPRK0qZA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/experiments/zod-compile-probe/package-lock.json
+++ b/experiments/zod-compile-probe/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "perry-zod-compile-probe",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-zod-compile-probe",
+      "dependencies": {
+        "zod": "4.5.0-canary.20260820T155656"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.0-canary.20260820T155656",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.0-canary.20260820T155656.tgz",
+      "integrity": "sha512-rZb3IWTKq3RpOggDaBtx4JgzSDZrYanBOEZF2g2ry8EhUwOOiRDGoC0Z2NkMLWmDBMd8acXa4V5uEG4cAYgAyQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/experiments/zod-compile-probe/package-lock.json
+++ b/experiments/zod-compile-probe/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "perry-zod-compile-probe",
       "dependencies": {
-        "zod": "4.5.0-canary.20260820T155656"
+        "zod": "4.5.2"
       }
     },
     "node_modules/zod": {
-      "version": "4.5.0-canary.20260820T155656",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.0-canary.20260820T155656.tgz",
-      "integrity": "sha512-rZb3IWTKq3RpOggDaBtx4JgzSDZrYanBOEZF2g2ry8EhUwOOiRDGoC0Z2NkMLWmDBMd8acXa4V5uEG4cAYgAyQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
+      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/experiments/zod-compile-probe/package.json
+++ b/experiments/zod-compile-probe/package.json
@@ -3,6 +3,12 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "zod": "4.5.2"
+    "zod": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49"
+  },
+  "perry": {
+    "compilePackages": ["zod"],
+    "allow": {
+      "compilePackages": ["zod"]
+    }
   }
 }

--- a/experiments/zod-compile-probe/package.json
+++ b/experiments/zod-compile-probe/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "zod": "4.5.0-canary.20260820T155656"
+    "zod": "4.5.2"
   }
 }

--- a/experiments/zod-compile-probe/package.json
+++ b/experiments/zod-compile-probe/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "perry-zod-compile-probe",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "zod": "4.5.0-canary.20260820T155656"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mongodb": "^7.0.0",
         "rate-limiter-flexible": "^11.2.0",
         "slugify": "^1.6.9",
-        "zod": "^4.5.0-canary.20260820T155656"
+        "zod": "^4.5.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.5.0-canary.20260820T155656",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.0-canary.20260820T155656.tgz",
-      "integrity": "sha512-rZb3IWTKq3RpOggDaBtx4JgzSDZrYanBOEZF2g2ry8EhUwOOiRDGoC0Z2NkMLWmDBMd8acXa4V5uEG4cAYgAyQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
+      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mongodb": "^7.0.0",
         "rate-limiter-flexible": "^11.2.0",
         "slugify": "^1.6.9",
-        "zod": "^4.5.2"
+        "zod": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -387,8 +387,8 @@
     },
     "node_modules/zod": {
       "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
-      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
+      "resolved": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49",
+      "integrity": "sha512-JanZAPLNXhbqECBmRU+FBjnOy/d9DuaeWm8k/JaBck9Bo/Xt/1+BFGsryqgZl7wiYGNF+NorLn7j6HPPRK0qZA==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "mongodb": "^7.0.0",
         "rate-limiter-flexible": "^11.2.0",
         "slugify": "^1.6.9",
-        "zod": "^4.3.5"
+        "zod": "^4.5.0-canary.20260820T155656"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "version": "4.5.0-canary.20260820T155656",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.0-canary.20260820T155656.tgz",
+      "integrity": "sha512-rZb3IWTKq3RpOggDaBtx4JgzSDZrYanBOEZF2g2ry8EhUwOOiRDGoC0Z2NkMLWmDBMd8acXa4V5uEG4cAYgAyQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mongodb": "^7.0.0",
     "rate-limiter-flexible": "^11.2.0",
     "slugify": "^1.6.9",
-    "zod": "^4.5.0-canary.20260820T155656"
+    "zod": "^4.5.2"
   },
   "dependencies": {
     "ethers": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,16 @@
     "mongodb": "^7.0.0",
     "rate-limiter-flexible": "^11.2.0",
     "slugify": "^1.6.9",
-    "zod": "^4.5.2"
+    "zod": "git+https://github.com/proggeramlug/zod.git#ee27e77ad86238199cfa0c262cfa2c7dfc125e49"
   },
   "dependencies": {
     "ethers": "^6.17.0",
     "node-cron": "^4.2.1"
+  },
+  "perry": {
+    "compilePackages": ["zod"],
+    "allow": {
+      "compilePackages": ["zod"]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mongodb": "^7.0.0",
     "rate-limiter-flexible": "^11.2.0",
     "slugify": "^1.6.9",
-    "zod": "^4.3.5"
+    "zod": "^4.5.0-canary.20260820T155656"
   },
   "dependencies": {
     "ethers": "^6.17.0",

--- a/test-files/test_gap_zod_compile_aot.ts
+++ b/test-files/test_gap_zod_compile_aot.ts
@@ -3,6 +3,10 @@
 // to Zod so its normal issue construction remains authoritative.
 import * as z from "zod";
 
+// Keep Zod's older object-parser JIT out of this test. The feature under test
+// is the explicit z.compile() call below, which Perry replaces before runtime.
+z.config({ jitless: true });
+
 const Player = z.object({
   name: z.string(),
   score: z.number().int().min(0).max(100),

--- a/test-files/test_gap_zod_compile_aot.ts
+++ b/test-files/test_gap_zod_compile_aot.ts
@@ -1,0 +1,42 @@
+// A static z.object schema should take Perry's schema-aware native path even
+// when the runtime was built without dyn-eval. Invalid input still delegates
+// to Zod so its normal issue construction remains authoritative.
+import * as z from "zod";
+
+const Player = z.object({
+  name: z.string(),
+  score: z.number().int().min(0).max(100),
+  active: z.boolean(),
+});
+
+const originalRun = Player._zod.run;
+let fallbackRuns = 0;
+Player._zod.run = (payload, ctx) => {
+  fallbackRuns++;
+  return originalRun(payload, ctx);
+};
+
+const CompiledPlayer = z.compile(Player, { strict: true });
+const valid = CompiledPlayer.safeParse({
+  name: "Billie",
+  score: 42,
+  active: true,
+  unknown: "strip me",
+});
+const fallbackRunsAfterValid = fallbackRuns;
+const invalid = CompiledPlayer.safeParse({
+  name: "Billie",
+  score: "not a number",
+  active: true,
+});
+
+console.log(CompiledPlayer !== Player);
+console.log(CompiledPlayer._zod.run !== Player._zod.run);
+console.log(valid.success);
+console.log(fallbackRunsAfterValid === 0);
+console.log(valid.success && !("unknown" in valid.data));
+console.log(invalid.success);
+console.log(fallbackRuns === 1);
+if (!invalid.success) {
+  console.log(`${invalid.error.issues[0].path.join(".")}:${invalid.error.issues[0].code}`);
+}

--- a/test-files/test_gap_zod_compile_aot.ts
+++ b/test-files/test_gap_zod_compile_aot.ts
@@ -36,6 +36,12 @@ const invalid = CompiledPlayer.safeParse({
 
 console.log(CompiledPlayer !== Player);
 console.log(CompiledPlayer._zod.run !== Player._zod.run);
+console.log(
+  (CompiledPlayer._zod.run as typeof Player._zod.run & {
+    __originalRun?: typeof Player._zod.run;
+  }).__originalRun === Player._zod.run,
+);
+console.log(CompiledPlayer._zod.bag.fallbackRun === Player._zod.run);
 console.log(valid.success);
 console.log(fallbackRunsAfterValid === 0);
 console.log(valid.success && !("unknown" in valid.data));


### PR DESCRIPTION
## Summary

AOT-compiles a conservative static subset of Zod `z.compile()` while keeping Zod?not Perry?as the owner of schema semantics.

Perry recognizes a closed `z.object({...})`, emits only a native parser, and passes that parser to the proposed Zod `compileFromParser()` API. Zod's own TypeScript remains responsible for cloning, async/backward/skip-check bypasses, recursion guards, public parse methods, validation, and authoritative runtime fallback.

This remains a draft because it depends on the upstream Zod integration API proposed in [colinhacks/zod#6498](https://github.com/colinhacks/zod/issues/6498).

## Architecture

```text
static schema source
       |
       v
Perry schema IR -> native parser (value | z.INVALID)
                              |
                              v
                 z.compileFromParser(schema, parser)
                              |
                              v
         Zod-owned clone / wrapper / fallback / public API
```

There is no Perry reimplementation of Zod's compiled wrapper contract. Unsupported schemas and Zod versions without `compileFromParser()` retain the ordinary `z.compile(schema, options)` call.

## Changes

- Extract compiler-only IR from immutable static `z.object({...})` declarations imported from `zod` / `zod/v4`.
- Lower string, finite-number, boolean, and number `int` / literal `min` / literal `max` checks to native Perry HIR.
- Return Zod's exported `INVALID` sentinel from the native parser and install it through Zod's `compileFromParser()`.
- Decline mutable schemas, shadowed Zod namespace bindings, duplicate keys, `__proto__`, unsupported schemas, and dynamic options rather than partially specializing them.
- Let `compilePackages` enter a TypeScript source tree even when the package's built exports target is absent. This makes the temporary source-only Zod pin reproducible.
- Pin the POC to the public source-only Zod commit `ee27e77ad86238199cfa0c262cfa2c7dfc125e49` and opt Zod into `perry.compilePackages`.
- Add HIR/resolver regressions, a conformance fixture, a real-Zod probe, and a changelog fragment.

## Current supported subset

- `import * as z from 'zod' or 'zod/v4'`
- immutable `const` schema bindings
- `z.object()` with static, unique, non-computed fields
- `z.string()`, `z.number()`, and `z.boolean()`
- `z.number().int()`, `.min(<number literal>)`, and `.max(<number literal>)`
- `z.compile(schema)` and static `{ strict: <boolean> }`

Everything else remains on Zod's normal runtime path.

## Upstream dependency / landing decision

The Zod-side API implementation is available at:

- issue: [colinhacks/zod#6498](https://github.com/colinhacks/zod/issues/6498)
- proposed branch comparison: [proggeramlug:zod:feat/aot-parser-install-api](https://github.com/colinhacks/zod/compare/main...proggeramlug:zod:feat/aot-parser-install-api?expand=1)

Before this Perry PR leaves draft, we should agree that:

1. Zod accepts an API equivalent to `compileFromParser(schema, parser, { validator? })` plus an exported failure sentinel.
2. The final Perry dependency uses the first official Zod release containing that API; the fork commit is only for this draft POC.
3. Perry continues to fail closed: only exact statically proven shapes specialize, and all other calls remain Zod-owned.

## Test plan

- [x] `npm ci --ignore-scripts --dry-run`
- [x] `cargo test -p perry-hir --lib` (360 passed, 1 pre-existing ignored before rebase)
- [x] `cargo test -p perry-hir zod_aot --lib` after rebasing onto current `main` (5 passed)
- [x] `cargo test -p perry --bin perry compile_package_resolves_source_without_built_exports_target`
- [x] `cargo build --profile perry-dev -p perry`
- [x] End-to-end compile after rebase: 95 Zod source modules native, 0 JavaScript
- [x] Auto-optimized runtime features: `async-runtime,web-fetch` (no `dyn-eval`)
- [x] 27.7 MB native executable; valid input avoids fallback, unknown keys strip, invalid input delegates to Zod
- [x] Wrapper `__originalRun` and `bag.fallbackRun` identities prove installation is Zod-owned
- [x] Zod targeted compile tests: 462 passed across all configured projects
- [x] Zod full compile suite: 2645 passed; 2 unrelated existing Windows esbuild path-escaping failures
- [x] Zod package build (`zshy`) passes
- [ ] Full Perry workspace CI

## Verified output

```text
true
true
true
true
true
true
true
false
true
score:invalid_type
```

The assertions cover schema cloning, replacement of `_zod.run`, Zod ownership of the wrapper and fallback, native valid parsing without fallback, unknown-key stripping, invalid fallback, and the final Zod issue.

## Checklist

- [x] No workspace version bump or direct `CHANGELOG.md` edit
- [x] Commits follow the repository prefix convention
- [x] Read `CONTRIBUTING.md` and agree to the Code of Conduct

