### PR TITLE
feat(gc): PERRY_GC_DIAG reports cumulative GC time and wall-clock share

### DIFF
--- a/changelog.d/9039-gc-time-share-diag.md
+++ b/changelog.d/9039-gc-time-share-diag.md
@@ -1,0 +1,16 @@
+`PERRY_GC_DIAG=1` now reports cumulative mutator-visible collection time and
+its wall-clock share at exit:
+
+    [gc-time] wall_us=… step_us=… remark_us=… minor_us=… full_sync_us=… share_permille=…
+
+The existing telemetry answers "how bad is the worst pause" (`step_max_us`,
+`final_remark_max_us`); this answers "what fraction of the run went to
+collection at all" — the measurement-first gate for any concurrent-marking
+work: if the share on real applications is single-digit percent, moving
+marking off the mutator thread has nothing worth hiding. Counters are
+always-on relaxed atomics (one `fetch_add` per GC event); the wall epoch is
+primed in `js_gc_init` so the denominator starts at program start, not at
+the first GC event. `share_permille` sums the three disjoint buckets
+(budgeted steps, atomic final remarks, copying minors); synchronous
+`gc()` calls are timed separately since they can internally drive budgeted
+steps.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1677,6 +1677,7 @@ pub(super) fn run_copied_minor_attempt(
     // #7592: this is the promotion the survivor-promotion handoff exists to
     // enable, so it releases the latch that suppressed a repeat handoff.
     note_copying_minor_completed();
+    super::instruments::note_copying_minor_pause_us(start.elapsed().as_micros() as u64);
     // #7604: the process-wide liveness counters. A copying minor ran, and this
     // is how much it actually relocated -- the only evidence that distinguishes
     // "the instrument was armed" from "the instrument fired".

--- a/crates/perry-runtime/src/gc/instruments.rs
+++ b/crates/perry-runtime/src/gc/instruments.rs
@@ -311,6 +311,7 @@ fn bump_max(slot: &AtomicU64, value: u64) {
 #[inline]
 pub(crate) fn note_budgeted_step_duration(us: u64) {
     bump_max(&STEP_MAX_US, us);
+    STEP_TOTAL_US.fetch_add(us, Ordering::Relaxed);
 }
 
 /// Record one atomic final-remark's wall duration.
@@ -318,6 +319,62 @@ pub(crate) fn note_budgeted_step_duration(us: u64) {
 pub(crate) fn note_final_remark_duration(us: u64) {
     bump_max(&REMARK_MAX_US, us);
     REMARK_COUNT.fetch_add(1, Ordering::Relaxed);
+    REMARK_TOTAL_US.fetch_add(us, Ordering::Relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// Cumulative mutator-visible GC time — the concurrent-GC decision number.
+//
+// The maxima above answer "how bad is the worst pause"; these answer "what
+// FRACTION of the run went to collection at all", which is the
+// measurement-first gate for taking marking off the mutator thread: if the
+// share on real workloads is single-digit percent, a concurrent collector
+// has nothing worth hiding. Relaxed atomics, always on — one fetch_add per
+// GC event is noise next to the event itself.
+//
+// `full_collect_total_us` measures the SYNCHRONOUS `js_gc_collect` entry
+// wall-clock; a forced full that internally drives budgeted steps also
+// charges those steps, so the sum of the four buckets can double-count that
+// path. Report the buckets separately and let the reader add what applies —
+// on the workloads this exists for (cc/pi), forced fulls are rare to absent.
+// ---------------------------------------------------------------------------
+
+/// Total microseconds spent in budgeted incremental steps.
+static STEP_TOTAL_US: AtomicU64 = AtomicU64::new(0);
+/// Total microseconds spent in atomic final remarks.
+static REMARK_TOTAL_US: AtomicU64 = AtomicU64::new(0);
+/// Total microseconds spent in copying minor scavenges.
+static MINOR_TOTAL_US: AtomicU64 = AtomicU64::new(0);
+/// Total microseconds spent inside synchronous `js_gc_collect` calls.
+static FULL_TOTAL_US: AtomicU64 = AtomicU64::new(0);
+
+/// Record one copying minor's pause duration.
+#[inline]
+pub(crate) fn note_copying_minor_pause_us(us: u64) {
+    MINOR_TOTAL_US.fetch_add(us, Ordering::Relaxed);
+}
+
+/// Record one synchronous full collection's wall duration.
+#[inline]
+pub(crate) fn note_full_collect_us(us: u64) {
+    FULL_TOTAL_US.fetch_add(us, Ordering::Relaxed);
+}
+
+/// (budgeted-step, final-remark, copying-minor, synchronous-full) cumulative
+/// microseconds since process start.
+pub fn gc_time_totals_us() -> (u64, u64, u64, u64) {
+    (
+        STEP_TOTAL_US.load(Ordering::Relaxed),
+        REMARK_TOTAL_US.load(Ordering::Relaxed),
+        MINOR_TOTAL_US.load(Ordering::Relaxed),
+        FULL_TOTAL_US.load(Ordering::Relaxed),
+    )
+}
+
+/// Microseconds since the first call in this process (the same epoch the
+/// mark-barrier timer uses) — the wall-clock denominator for the share line.
+pub(crate) fn wall_us_since_epoch() -> u64 {
+    process_epoch_us()
 }
 
 /// Record the FinalizationRegistry records one weak-processing step charged,

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -1128,6 +1128,11 @@ pub extern "C" fn js_gc_init() {
     // call lands. A host that loads several application images on several
     // threads gets one image per thread; a plain executable gets one.
     crate::object::class_image::enter_current_thread_image();
+    // Prime the process wall-clock epoch NOW: it lazily initializes on first
+    // read, and the first read is otherwise whatever GC event happens to
+    // consult it — which would make the exit-time GC-share denominator start
+    // at that event instead of at program start.
+    let _ = instruments::wall_us_since_epoch();
     // Parse LLVM stack-map metadata before the first collection. The parser
     // allocates its immutable index once; root scans themselves must remain
     // allocation-free while the collector owns the heap.
@@ -1245,6 +1250,23 @@ fn emit_incremental_liveness_diag() {
         poll_arm::poll_armed_count(),
     );
     emit_step_bounds_diag();
+    emit_gc_time_share_diag();
+}
+
+/// `PERRY_GC_DIAG=1`: cumulative mutator-visible collection time and its
+/// share of the wall clock — the measurement the concurrent-GC decision
+/// gates on. Buckets are reported separately (a forced synchronous full can
+/// internally drive budgeted steps, so summing all four may double-count
+/// that rare path); `share` sums steps+remarks+minors, the buckets that are
+/// disjoint by construction.
+fn emit_gc_time_share_diag() {
+    let (step_us, remark_us, minor_us, full_us) = instruments::gc_time_totals_us();
+    let wall_us = instruments::wall_us_since_epoch().max(1);
+    let pause_us = step_us + remark_us + minor_us;
+    eprintln!(
+        "[gc-time] wall_us={wall_us} step_us={step_us} remark_us={remark_us} minor_us={minor_us} full_sync_us={full_us} share_permille={}",
+        pause_us.saturating_mul(1000) / wall_us,
+    );
 }
 
 /// What the "time-budgeted" collector actually cost, as opposed to what it was

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -3617,7 +3617,9 @@ pub extern "C" fn js_gc_collect() {
     if defer_gc_request(DeferredGcRequest::Collect(GcTriggerKind::Manual)) {
         return;
     }
+    let start = std::time::Instant::now();
     manual_gc_collect_now();
+    super::instruments::note_full_collect_us(start.elapsed().as_micros() as u64);
 }
 
 /// Run an explicit (`gc()`) full collection, with **precise roots** — the same


### PR DESCRIPTION
Adds the measurement the concurrent-GC decision gates on (agreed direction: measure GC share on real workloads first — cc bundle, pi — and only write a concurrent-marking design doc if it's 15%+).

`PERRY_GC_DIAG=1` now prints at exit:

```
[gc-time] wall_us=172094 step_us=0 remark_us=0 minor_us=23626 full_sync_us=0 share_permille=137
```

- Cumulative counters for the three disjoint pause buckets (budgeted steps, atomic final remarks, copying minors) plus synchronous `gc()` wall time reported separately (it can internally drive budgeted steps, so it's not summed into the share).
- Always-on relaxed atomics — one `fetch_add` per GC **event**, noise next to the event itself; no new env knob.
- The wall epoch is primed in `js_gc_init`: it initialized lazily on first read, which would have silently started the denominator at the first GC event instead of program start.

973 gc:: tests green, fmt/gc-knob gates green. Runtime-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in GC diagnostic (`PERRY_GC_DIAG=1`) that reports cumulative garbage-collection time and its share of elapsed runtime.
  - Diagnostics include timings for incremental steps, final remarks, copying minor collections, and synchronous full collections.
- **Documentation**
  - Added changelog documentation describing the new diagnostic output and reported metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->