### PR TITLE
fix(build-cache): register the two unkeyed codegen env vars (main CI is red)

### DIFF
--- a/changelog.d/9044-build-cache-codegen-env-vars.md
+++ b/changelog.d/9044-build-cache-codegen-env-vars.md
@@ -1,0 +1,14 @@
+`PERRY_BOX_CAPTURE_ENTRY_CELLS` and `PERRY_GUARDED_PREINLINE_MAX_IR_BYTES` are
+now build-cache inputs.
+
+Both landed without build-cache registration, so
+`codegen_env_vars_are_build_cache_inputs` failed on `main` — and because it is a
+`perry` bin-crate unit test, the whole `perry` test binary failed to compile,
+turning every open PR's cargo-test job red.
+
+Both are inputs rather than exclusions because both change emitted code: the
+capture-cell knob changes every closure body that qualifies for entry-resolved
+box cells, and the preinline ceiling changes which functions inline, so a run
+with a raised ceiling must not be served objects a default run produced. That
+is #6394's rule — a codegen env var keys the cache or carries a written reason
+it cannot affect output.

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -49,6 +49,14 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // `disable-tail-calls` before the optimizer. It changes the generated
     // code of the functions it trips on, so it is a cache input.
     "PERRY_LL_TRE_MAX_ALLOCA_WALK",
+    // #9026: gates the once-per-closure-entry resolution of read-only boxed
+    // capture cells — flipping it changes every closure body that qualifies.
+    "PERRY_BOX_CAPTURE_ENTRY_CELLS",
+    // The guarded-preinline IR-size ceiling: functions on either side of the
+    // budget inline differently, so a run with a raised ceiling must not be
+    // served objects a default run produced (same rule as the RS4GC budget
+    // above).
+    "PERRY_GUARDED_PREINLINE_MAX_IR_BYTES",
     // #8583: the relocation estimate above which a function spills its GC roots
     // to a shadow frame. It changes which functions carry statepoints, so it
     // changes the generated code and must be a cache input.


### PR DESCRIPTION
`codegen_env_vars_are_build_cache_inputs` fails on current main — `PERRY_BOX_CAPTURE_ENTRY_CELLS` (#9026) and `PERRY_GUARDED_PREINLINE_MAX_IR_BYTES` landed without build-cache registration, so **every open PR's cargo-test job is red** (that's how I found it, on #9042). Both change emitted code, so they're cache inputs, not exclusions — same rationale as the RS4GC/TRE budgets beside them. The four build_cache tests pass locally with the registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build-cache accuracy when code-generation settings change.
  - Prevented stale cached builds by ensuring relevant compilation options trigger fresh builds.
  - Resolved test and build failures related to untracked code-generation settings.

- **Documentation**
  - Added changelog information describing the updated build-cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->