### PR TITLE
fix(codegen): forward default ctor through dynamic ancestor

### DIFF
--- a/changelog.d/9043-default-derived-dynamic-ancestor.md
+++ b/changelog.d/9043-default-derived-dynamic-ancestor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Default-derived constructors now forward their user arguments through a dynamic heritage edge owned by an intermediate constructor-free class. Both direct `new Leaf(...)` lowering and class-value construction call the captured base constructor and then initialize intermediate and leaf fields in order, instead of returning an uninitialized instance.

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -736,6 +736,12 @@ pub(super) fn compile_method(
     // as uninitialized register values (read as NaN-boxed undefined).
     let is_constructor_method = method.name == format!("{}_constructor", class.name);
     if is_constructor_method {
+        // #9043: a default-derived chain can reach a dynamic parent through a
+        // constructor-free static ancestor (`Leaf -> Mid -> <captured Base>`).
+        // Keep the owner of that dynamic edge so this standalone Leaf symbol
+        // dispatches through Mid's registered parent, just like direct `new`.
+        let dynamic_parent_owner =
+            crate::lower_call::default_ctor_dynamic_parent_owner(&ctx, class);
         if class.extends.is_some()
             || class.extends_name.is_some()
             || class.native_extends.is_some()
@@ -768,21 +774,23 @@ pub(super) fn compile_method(
         // no `extends_name`) now emits a synthesized dynamic super below —
         // stage its self fields AFTER that call (tail SelfOnly), like any
         // other heritage class, instead of applying them twice.
-        let no_ctor_dynamic_parent = class.constructor.is_none()
-            && class.extends_name.is_none()
-            && class.extends_expr.is_some();
-        let init_mode = if class.extends_name.is_some() || no_ctor_dynamic_parent {
-            crate::lower_call::FieldInitMode::AncestorsOnly
-        } else {
-            crate::lower_call::FieldInitMode::All
-        };
-        crate::lower_call::apply_field_initializers_recursive(&mut ctx, &class.name, init_mode)
-            .with_context(|| {
-                format!(
-                    "applying field initializers for '{}' constructor",
-                    class.name
-                )
-            })?;
+        // The runtime parent constructor initializes everything above its
+        // dynamic edge. Classes from that edge's owner through this leaf are
+        // derived and must wait until the synthesized super call below.
+        if dynamic_parent_owner.is_none() {
+            let init_mode = if class.extends_name.is_some() {
+                crate::lower_call::FieldInitMode::AncestorsOnly
+            } else {
+                crate::lower_call::FieldInitMode::All
+            };
+            crate::lower_call::apply_field_initializers_recursive(&mut ctx, &class.name, init_mode)
+                .with_context(|| {
+                    format!(
+                        "applying field initializers for '{}' constructor",
+                        class.name
+                    )
+                })?;
+        }
         // Refs #420: when a class has no own constructor but extends a parent
         // that DOES have a body, JS spec requires a default ctor that calls
         // `super(...args)` — implicit forward. perry's standalone ctor for
@@ -819,6 +827,9 @@ pub(super) fn compile_method(
                 if has_local_body || has_imported_ctor {
                     break;
                 }
+                if pc.extends_expr.is_some() {
+                    break;
+                }
                 effective_parent = pc.extends_name.as_deref();
             }
             // Wall 51: a class with a DYNAMIC parent (`extends_expr`, e.g.
@@ -830,7 +841,7 @@ pub(super) fn compile_method(
             // the static call would target the wrong/empty symbol, so the parent
             // ctor never ran and inherited fields stayed undefined. Skip the
             // inline path for dynamic-parent classes.
-            if let Some(pname) = effective_parent.filter(|_| class.extends_expr.is_none()) {
+            if let Some(pname) = effective_parent.filter(|_| dynamic_parent_owner.is_none()) {
                 let pname_owned = pname.to_string();
                 let node_stream_kind = if pname_owned == "Readable" {
                     node_stream_parent_kind(ctx.classes, class)
@@ -1052,17 +1063,27 @@ pub(super) fn compile_method(
             // .pathname` threw. Forward this synthesized ctor's params to the
             // runtime dynamic-parent super dispatcher, mirroring the explicit
             // `Expr::SuperCall` dynamic-parent path in `expr/this_super_call.rs`.
-            let parent_is_uncallable_builtin = class
-                .extends_name
+            let parent_is_uncallable_builtin = dynamic_parent_owner
                 .as_deref()
+                .and_then(|owner| ctx.classes.get(owner).copied())
+                .and_then(|owner| owner.extends_name.as_deref())
                 .map(crate::expr::is_other_builtin_constructor_name)
                 .unwrap_or(false)
-                && class.extends_name.as_deref() != Some("SharedArrayBuffer");
+                && dynamic_parent_owner
+                    .as_deref()
+                    .and_then(|owner| ctx.classes.get(owner).copied())
+                    .and_then(|owner| owner.extends_name.as_deref())
+                    != Some("SharedArrayBuffer");
             if builtin_parent_runtime.is_none()
-                && class.extends_expr.is_some()
+                && dynamic_parent_owner.is_some()
                 && !parent_is_uncallable_builtin
             {
-                if let Some(cid) = ctx.class_ids.get(&class.name).copied().filter(|c| *c != 0) {
+                if let Some(cid) = dynamic_parent_owner
+                    .as_deref()
+                    .and_then(|owner| ctx.class_ids.get(owner))
+                    .copied()
+                    .filter(|c| *c != 0)
+                {
                     let undef_lit =
                         crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
                     let mut lowered_args: Vec<String> = Vec::with_capacity(method.params.len());
@@ -1137,10 +1158,13 @@ pub(super) fn compile_method(
             // run, so they can read state set by the parent body (e.g. drizzle's
             // PgText.enumValues = this.config.enumValues — this.config is set
             // in Column body via super-chain). Refs #420.
+            let post_init_mode = dynamic_parent_owner
+                .map(crate::lower_call::FieldInitMode::FromInclusive)
+                .unwrap_or(crate::lower_call::FieldInitMode::SelfOnly);
             crate::lower_call::apply_field_initializers_recursive(
                 &mut ctx,
                 &class.name,
-                crate::lower_call::FieldInitMode::SelfOnly,
+                post_init_mode,
             )
             .with_context(|| {
                 format!(

--- a/crates/perry-codegen/src/lower_call/field_init.rs
+++ b/crates/perry-codegen/src/lower_call/field_init.rs
@@ -461,6 +461,12 @@ pub(crate) enum FieldInitMode {
     /// constructor body, so there is no SuperCall site to apply intermediate
     /// class fields.
     AfterRoot,
+    /// Apply the named class and every descendant through the leaf. Used when
+    /// a constructor-free static chain reaches a dynamic-parent edge: the
+    /// runtime parent constructor initializes everything above `start_at`, and
+    /// the local default-derived chain must then initialize the dynamic-edge
+    /// owner and its descendants in order.
+    FromInclusive(String),
 }
 
 /// Whether a named public field initializer can populate the allocation's
@@ -529,6 +535,7 @@ pub(crate) fn apply_field_initializers_recursive(
     //   UpToInclusive(stop_at): keep chain[0..=index_of(stop_at)]
     //   BetweenExclusiveTo(stop_at): keep chain[index_of(stop_at)+1..]
     //   AfterRoot: keep chain[1..]
+    //   FromInclusive(start_at): keep chain[index_of(start_at)..]
     let chain: Vec<String> = match &mode {
         FieldInitMode::All => chain,
         FieldInitMode::AncestorsOnly => {
@@ -590,6 +597,13 @@ pub(crate) fn apply_field_initializers_recursive(
                 // `this.arr.includes(x)` on an unset field threw
                 // `Cannot read properties of undefined`.
                 chain
+            }
+        }
+        FieldInitMode::FromInclusive(start_at) => {
+            if let Some(idx) = chain.iter().position(|n| n == start_at) {
+                chain[idx..].to_vec()
+            } else {
+                Vec::new()
             }
         }
     };

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -162,7 +162,7 @@ pub(crate) use new_ctor_args::{
 // super-must-be-called.
 pub(crate) use new_helpers::{
     ctor_body_calls_super, ctor_body_closure_calls_super, ctor_body_has_value_return,
-    ctor_body_uses_this, ctor_chain_can_replace_this,
+    ctor_body_uses_this, ctor_chain_can_replace_this, default_ctor_dynamic_parent_owner,
 };
 // #6325 / #6326: the class-chain walk to a native base whose surface perry
 // stamps onto the instance, plus its init emitter. Shared by the implicit

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -18,7 +18,8 @@ use super::new_ctor_args::{
 use super::new_helpers::{
     collect_decl_local_ids, ctor_body_calls_super, ctor_body_closure_calls_super,
     ctor_body_has_value_return, ctor_body_uses_this, ctor_chain_uses_new_target,
-    emit_promise_subclass_init, local_constructor_symbol_exists, node_stream_parent_kind,
+    default_ctor_dynamic_parent_owner, emit_promise_subclass_init, local_constructor_symbol_exists,
+    node_stream_parent_kind,
 };
 use crate::expr::{lower_expr, lower_js_args_array, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
@@ -1036,7 +1037,18 @@ fn lower_new_impl_inner<'a>(
     // name and a runtime heritage value must construct through that runtime
     // value. The source module's standalone ctor owns all imported-parent
     // field initialization; this module must only replay the local leaf.
-    let defer_to_dynamic_parent = class.extends_expr.is_some() && !has_imported_ctor;
+    // #9043: the dynamic heritage edge may belong to a constructor-free
+    // ANCESTOR rather than the leaf itself (`Leaf -> Mid -> <captured Base>`).
+    // The registered runtime parent is keyed by that edge's owner (`Mid`), and
+    // the edge remains authoritative across every static default-ctor hop below
+    // it. Keep the owner name for the dispatch and use the boolean everywhere
+    // the old direct-leaf-only path deferred static/imported construction.
+    let dynamic_parent_owner = if has_imported_ctor {
+        None
+    } else {
+        default_ctor_dynamic_parent_owner(ctx, class)
+    };
+    let defer_to_dynamic_parent = dynamic_parent_owner.is_some();
     let builtin_parent_runtime = if !has_own_ctor && !has_imported_ctor {
         match class.extends_name.as_deref() {
             Some("Writable") => Some("js_node_stream_writable_subclass_init"),
@@ -1081,6 +1093,9 @@ fn lower_new_impl_inner<'a>(
                     found = Some(pname.to_string());
                     break;
                 }
+                if parent_class.extends_expr.is_some() {
+                    break;
+                }
                 walker = parent_class.extends_name.as_deref();
             } else {
                 break;
@@ -1111,12 +1126,21 @@ fn lower_new_impl_inner<'a>(
         bind_inline_constructor_params(ctx, &ctor.params, &lowered_args, args, ctor_capture_fill)
     });
 
-    if let Some(stop_at) = inherited_ctor_class.clone() {
-        apply_field_initializers_recursive(ctx, class_name, FieldInitMode::UpToInclusive(stop_at))?;
-    } else {
-        apply_field_initializers_recursive(ctx, class_name, FieldInitMode::AncestorsOnly)?;
+    // A dynamic parent constructor owns the fields above its registered edge.
+    // Every local class from the edge owner through the leaf is derived, so
+    // their fields run only after that runtime `super(...args)` returns.
+    if dynamic_parent_owner.is_none() {
+        if let Some(stop_at) = inherited_ctor_class.clone() {
+            apply_field_initializers_recursive(
+                ctx,
+                class_name,
+                FieldInitMode::UpToInclusive(stop_at),
+            )?;
+        } else {
+            apply_field_initializers_recursive(ctx, class_name, FieldInitMode::AncestorsOnly)?;
+        }
     }
-    if !has_extends {
+    if !has_extends && class.extends_expr.is_none() {
         // Base class — no super(), apply own fields now (before body).
         apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;
     }
@@ -1290,6 +1314,12 @@ fn lower_new_impl_inner<'a>(
                     // duplicate private-element installation.
                     found_inherited_ctor = true;
                     break; // Found and inlined the parent ctor.
+                }
+                // A dynamic heritage expression is the authoritative next
+                // edge. Following its optional static metadata would skip the
+                // runtime class value and can call the wrong constructor.
+                if parent_class.extends_expr.is_some() {
+                    break;
                 }
                 parent_name = parent_class.extends_name.as_deref();
             } else {
@@ -1757,18 +1787,29 @@ fn lower_new_impl_inner<'a>(
         // builtin still emits the call, but the runtime backstops it by value —
         // `js_fetch_or_value_super` no-ops the same builtin set via
         // `is_uncallable_builtin_super_parent` (perry-runtime, kept in lockstep).
-        let parent_is_uncallable_builtin = class
-            .extends_name
+        let parent_is_uncallable_builtin = dynamic_parent_owner
             .as_deref()
+            .and_then(|owner| ctx.classes.get(owner).copied())
+            .and_then(|owner| owner.extends_name.as_deref())
             .map(crate::expr::is_other_builtin_constructor_name)
             .unwrap_or(false)
             // SharedArrayBuffer construction now returns a real branded
             // buffer and honors the subclass newTarget/prototype in the
             // runtime dispatcher. It must run rather than retaining Perry's
             // provisional plain-object receiver.
-            && class.extends_name.as_deref() != Some("SharedArrayBuffer");
-        if !found_inherited_ctor && class.extends_expr.is_some() && !parent_is_uncallable_builtin {
-            if let Some(cid) = ctx.class_ids.get(class_name).copied().filter(|c| *c != 0) {
+            && dynamic_parent_owner
+                .as_deref()
+                .and_then(|owner| ctx.classes.get(owner).copied())
+                .and_then(|owner| owner.extends_name.as_deref())
+                != Some("SharedArrayBuffer");
+        if !found_inherited_ctor && dynamic_parent_owner.is_some() && !parent_is_uncallable_builtin
+        {
+            if let Some(cid) = dynamic_parent_owner
+                .as_deref()
+                .and_then(|owner| ctx.class_ids.get(owner))
+                .copied()
+                .filter(|c| *c != 0)
+            {
                 let parent_val = ctx.block().call(
                     DOUBLE,
                     "js_get_dynamic_parent_value",
@@ -1858,8 +1899,13 @@ fn lower_new_impl_inner<'a>(
     // static `extends_name`, so include the `extends_expr` case (SelfOnly,
     // mirroring the explicit-`SuperCall` dynamic-parent arm in this_super_call.rs).
     if !has_own_ctor && (has_extends || class.extends_expr.is_some()) && !has_imported_ctor {
-        if defer_to_dynamic_parent
-            || builtin_parent_runtime.is_some()
+        if let Some(owner) = dynamic_parent_owner {
+            apply_field_initializers_recursive(
+                ctx,
+                class_name,
+                FieldInitMode::FromInclusive(owner),
+            )?;
+        } else if builtin_parent_runtime.is_some()
             || fetch_parent_runtime.is_some()
             || promise_parent_runtime
             || usp_parent_runtime

--- a/crates/perry-codegen/src/lower_call/new_helpers.rs
+++ b/crates/perry-codegen/src/lower_call/new_helpers.rs
@@ -11,6 +11,47 @@ use perry_hir::{Class, Expr};
 use crate::expr::FnCtx;
 use crate::types::{DOUBLE, I32};
 
+/// The class whose registered runtime parent must receive a synthesized
+/// default-constructor call for `class Leaf extends ... {}`.
+///
+/// A dynamic heritage edge can sit above one or more constructor-free static
+/// edges: `Leaf extends Mid`, while `Mid extends <captured value>`. Walking only
+/// `extends_name` reaches `Mid` and then silently stops, because the
+/// authoritative parent of `Mid` lives in `extends_expr`. Return the owner of
+/// that first dynamic edge so both inline `new` lowering and standalone
+/// constructor generation can dispatch through its registered parent value.
+/// Any real local/imported constructor encountered first owns the remaining
+/// `super()` chain and therefore stops this search.
+pub(crate) fn default_ctor_dynamic_parent_owner(ctx: &FnCtx<'_>, class: &Class) -> Option<String> {
+    if class.constructor.is_some() {
+        return None;
+    }
+    if class.extends_expr.is_some() {
+        return Some(class.name.clone());
+    }
+
+    let mut parent = class.extends_name.as_deref();
+    for _ in 0..64 {
+        let parent_name = parent?;
+        if ctx
+            .imported_class_ctors
+            .get(parent_name)
+            .is_some_and(|ctor| ctor.stops_constructor_walk())
+        {
+            return None;
+        }
+        let parent_class = ctx.classes.get(parent_name).copied()?;
+        if parent_class.constructor.is_some() {
+            return None;
+        }
+        if parent_class.extends_expr.is_some() {
+            return Some(parent_class.name.clone());
+        }
+        parent = parent_class.extends_name.as_deref();
+    }
+    None
+}
+
 /// The native base classes perry models by STAMPING state onto the INSTANCE at
 /// construction time instead of giving it a real builtin prototype: the instance
 /// is a plain `ObjectHeader`, and `super()` installs the base's surface on it —

--- a/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
+++ b/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
@@ -159,6 +159,42 @@ console.log(build("T"));
     assert_eq!(out, "T/one/two\n");
 }
 
+/// The same dynamic-ancestor barrier must work when the leaf class escapes its
+/// factory and construction goes through the standalone `Leaf_constructor`
+/// symbol. Intermediate derived fields run after the dynamic Base constructor,
+/// in root-to-leaf order.
+#[test]
+fn two_hop_dynamic_construct_forwards_args_and_orders_fields() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function make(tag: string) {
+  class Base {
+    s: string;
+    constructor(a: string, b: string) {
+      this.s = tag + "/" + a + "/" + b;
+    }
+  }
+  class Mid extends Base {
+    mid = this.s + "/mid";
+  }
+  class Leaf extends Mid {
+    leaf = this.mid + "/leaf";
+  }
+  return Leaf;
+}
+
+const C = make("T");
+const value = new C("one", "two");
+console.log(value.s);
+console.log(value.mid);
+console.log(value.leaf);
+"#,
+    );
+    assert_eq!(out, "T/one/two\nT/one/two/mid\nT/one/two/mid/leaf\n");
+}
+
 /// Guard the CAPTURING-leaf path (zod chains): a capturing subclass gets a
 /// synthesized forwarding ctor and takes the own-ctor path, whose tail-split
 /// derives from its own appended caps. Both the subclass's snapshot and the


### PR DESCRIPTION
Closes #9043.

A constructor-free static chain can terminate at an ancestor whose authoritative parent is stored in extends_expr. Both direct new lowering and the standalone constructor walk previously stopped there without invoking the captured base constructor.

This resolves the registered dynamic parent using the edge-owning ancestor class ID, forwards all user arguments, and applies intermediate/leaf fields after the dynamic super call.

Local verification:
- cargo check -p perry-codegen -p perry
- cargo fmt --all -- --check
- product Clippy scope
- issue_806_default_derived_ctor_forwarding: 6/6 with PERRY_NO_AUTO_OPTIMIZE=1
- issue_806_default_derived_ctor_forwarding: 6/6 with default auto-optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default-derived class construction when inheritance includes dynamically generated parent classes.
  * Constructor arguments are now forwarded correctly, with inherited and subclass fields initialized in the proper order.
  * Improved construction through both direct class instantiation and class values.

* **Tests**
  * Added regression coverage for multi-level dynamic inheritance, argument forwarding, and field initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->