### PR TITLE
fix(codegen): native IR reader accepts value-returning inline asm (macOS ARM64 app builds die without it)

### DIFF
--- a/changelog.d/9049-native-reader-value-asm.md
+++ b/changelog.d/9049-native-reader-value-asm.md
@@ -1,0 +1,22 @@
+The native IR reader accepts value-returning inline asm.
+
+It handled only the void inline-asm barrier; the value-returning form fell
+through to the ordinary-call callee search and failed with `call without
+callee`. The hot-TLS thread-pointer read emits exactly that form —
+
+    %r = call i64 asm sideeffect "mrs $0, tpidrro_el0", "=r"() "gc-leaf-function"
+
+— so on macOS aarch64 any function taking the inline allocation fast path failed
+native IR construction, killing the build. The textual transport compiles the
+same IR fine, and small modules use it by default, which is why no suite saw
+this: only large codegen-unit-split modules (or an explicit
+`PERRY_LLVM_INPROCESS=native`) reach the reader. That is the dialect reader's
+closed-set design working as intended — a new emission form fails loudly at
+construction — but the form had no arm.
+
+Two parsing details the reader test pins: the arg list is found after the
+CONSTRAINTS' closing quote (the 4th quote), not the last quote on the line,
+because the emitter appends a quoted `"gc-leaf-function"` attribute after the
+args; and the rebuilt callsite carries the same structural `gc-leaf-function`
+marking as the void barrier, since perry-emitted asm never re-enters the runtime
+and RS4GC must not statepoint-wrap it (#8121).

--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -793,6 +793,17 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
             return self.call_asm(asm_rest).map(|_| None);
         }
 
+        // Value-returning inline asm: `TY asm sideeffect "ASM", "CONSTR"(ARGS)`
+        // — the hot-TLS thread-pointer read (`mrs $0, tpidrro_el0`). The type
+        // token before ` asm ` must be a bare type, not a callee or signature,
+        // or an ordinary call to a function whose name contains "asm" would be
+        // misparsed.
+        if let Some((ty_tok, asm_rest)) = rest.split_once(" asm ") {
+            if !ty_tok.contains(['@', '%', '(']) {
+                return self.call_asm_value(dst, ty_tok.trim(), asm_rest).map(Some);
+            }
+        }
+
         // #8175: explicit calling-convention token before the return type.
         let (rest, preserve_none) = match rest.strip_prefix(crate::inst::PRESERVE_NONE_CC) {
             Some(tail) => (tail.trim_start(), true),
@@ -912,6 +923,66 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
             self.ctx.create_string_attribute("gc-leaf-function", ""),
         );
         Ok(())
+    }
+
+    /// Value-returning inline asm, the register-read twin of [`Self::call_asm`]:
+    /// `%dst = call TY asm sideeffect "ASM", "CONSTR"(ARGS)`. Same
+    /// `gc-leaf-function` marking — perry-emitted asm never re-enters the
+    /// runtime, so RS4GC must not statepoint-wrap it (#8121).
+    fn call_asm_value(
+        &mut self,
+        dst: Option<&str>,
+        ty_tok: &str,
+        rest: &str,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        let sideeffect = rest.trim_start().starts_with("sideeffect");
+        let mut strings = rest.split('"');
+        let asm = strings.nth(1).unwrap_or("").to_string();
+        let constraints = strings.nth(1).unwrap_or("").to_string();
+        // Arguments live after the CONSTRAINTS' closing quote (the 4th quote
+        // in the line) — not after the last quote in the line, because the
+        // emitter appends a quoted `"gc-leaf-function"` attribute after the
+        // arg list. That attribute is dropped here and re-added structurally
+        // below, like the void barrier's.
+        let mut quote_iter = rest
+            .char_indices()
+            .filter(|(_, c)| *c == '"')
+            .map(|(i, _)| i);
+        let after_constraints = quote_iter
+            .nth(3)
+            .map(|i| i + 1)
+            .ok_or_else(|| anyhow!("asm call missing constraint string"))?;
+        let tail = &rest[after_constraints..];
+        let paren = tail
+            .find('(')
+            .ok_or_else(|| anyhow!("asm call missing arg list"))?;
+        let close = rmatch_paren(tail, paren)?;
+        let args_str = &tail[paren + 1..close];
+        let mut args: Vec<BasicMetadataValueEnum> = Vec::new();
+        let mut arg_types: Vec<inkwell::types::BasicMetadataTypeEnum> = Vec::new();
+        for a in split_top_level(args_str) {
+            let (aty, atok) = ty_and_val(&a)?;
+            let ty = basic_type(self.ctx, aty)?;
+            args.push(self.val(ty, atok)?.into());
+            arg_types.push(ty.into());
+        }
+        let fn_ty = indirect_fn_type(self.ctx, ty_tok, &arg_types)?;
+        let ptr =
+            self.ctx
+                .create_inline_asm(fn_ty, asm, constraints, sideeffect, false, None, false);
+        let name = dst.map(|d| d.trim_start_matches('%')).unwrap_or("");
+        let site = self
+            .builder
+            .build_indirect_call(fn_ty, ptr, &args, name)
+            .map_err(be)?;
+        site.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            self.ctx.create_string_attribute("gc-leaf-function", ""),
+        );
+        match site.try_as_basic_value() {
+            inkwell::values::ValueKind::Basic(v) => Ok(v),
+            other => bail!("value asm call produced no value: {other:?}"),
+        }
     }
 
     fn binary_or_cast(&mut self, dst: &str, op: &str, rest: &str) -> Result<BasicValueEnum<'ctx>> {

--- a/crates/perry-codegen/src/dialect/tests.rs
+++ b/crates/perry-codegen/src/dialect/tests.rs
@@ -417,3 +417,23 @@ fn gc_leaf_attribute_constructs_on_invoke() {
         "invoke lost its gc-leaf-function call-site attribute:\n{printed}"
     );
 }
+
+/// Value-returning inline asm — the hot-TLS thread-pointer read
+/// (`mrs $0, tpidrro_el0`). The reader handled only the VOID asm barrier;
+/// the value form fell through to the callee search and failed with
+/// "call without callee", which killed whole application builds (pi's
+/// bundle) at native codegen. The void barrier rides along to pin both.
+#[test]
+fn value_returning_inline_asm() {
+    let text = r#"
+define i64 @tls_read() {
+entry:
+  %tsd = call i64 asm sideeffect "mrs $0, tpidrro_el0", "=r"() "gc-leaf-function"
+  call void asm sideeffect "", ""()
+  %base = and i64 %tsd, -8
+  ret i64 %base
+}
+"#;
+    let n = roundtrip_ir(text, "asm_value");
+    assert!(n >= 4, "built only {n} instructions");
+}


### PR DESCRIPTION
The native IR reader handled only the **void** inline-asm barrier; a value-returning form fell through to the ordinary-call callee search and failed with `call without callee`. The hot-TLS thread-pointer read emits exactly that form —

```llvm
%r = call i64 asm sideeffect "mrs $0, tpidrro_el0", "=r"() "gc-leaf-function"
```

— so **any function that takes the inline allocation fast path fails native IR construction on macOS aarch64**, killing the whole build. pi's 13MB bundle dies in its `__rest` helper; the textual pipeline compiles the same IR fine, which is why the suites never saw it.

Two parsing subtleties, both pinned by the new reader test:
- the arg list is found after the **4th quote** (the constraints' closing quote), not the last quote in the line — the emitter appends a quoted `"gc-leaf-function"` attribute after the args, which the first version of this fix tripped over;
- the callsite is rebuilt with the same structural `gc-leaf-function` marking as the void barrier (#8121 — perry-emitted asm never re-enters the runtime, so RS4GC must not statepoint-wrap it).

Reader test round-trips both forms (with the trailing attribute exactly as emitted) through the verifier. perry-codegen lib 1344/0. Verified end-to-end: pi's bundle now compiles past the previously-fatal unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for value-returning inline assembly calls when reading LLVM IR.
  * Inline assembly results are now correctly typed and returned for downstream use.

* **Bug Fixes**
  * Fixed failures when processing LLVM IR containing inline assembly that returns a value.
  * Added coverage for value-returning assembly and assembly barriers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->