### PR TITLE
fix(transform): preserve exported aggregate carriers

### DIFF
--- a/changelog.d/9054-preserve-exported-aggregates.md
+++ b/changelog.d/9054-preserve-exported-aggregates.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Exported arrays of object literals now remain materialized across module
+  boundaries, preserving their identity, length, iteration behavior, and
+  element values instead of producing an `undefined` export getter.

--- a/crates/perry-transform/src/aggregate_scalar.rs
+++ b/crates/perry-transform/src/aggregate_scalar.rs
@@ -1726,7 +1726,7 @@ mod tests {
         }
     }
 
-    fn aggregate_fixture(observe_identity: bool) -> Module {
+    pub(super) fn aggregate_fixture(observe_identity: bool) -> Module {
         let mut module = Module::new("aggregate-scalar.ts");
         module.init = vec![
             Stmt::Let {
@@ -1802,44 +1802,6 @@ mod tests {
             .init
             .iter()
             .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })));
-    }
-
-    #[test]
-    fn exported_aggregate_keeps_materialized_carrier() {
-        for metadata_source in ["exports", "exported_objects"] {
-            let mut module = aggregate_fixture(false);
-            if metadata_source == "exports" {
-                module.exports.push(Export::Named {
-                    local: "values".to_string(),
-                    exported: "VALUES".to_string(),
-                });
-            } else {
-                module.exported_objects.push("values".to_string());
-            }
-
-            run(&mut module);
-
-            assert!(
-                module.init.iter().any(|stmt| {
-                    matches!(
-                        stmt,
-                        Stmt::Let {
-                            id: 1,
-                            init: Some(Expr::Array(_)),
-                            ..
-                        }
-                    )
-                }),
-                "{metadata_source} must keep the exported carrier"
-            );
-            assert!(
-                module
-                    .init
-                    .iter()
-                    .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })),
-                "{metadata_source} must keep element aliases"
-            );
-        }
     }
 
     #[test]
@@ -2026,3 +1988,7 @@ mod tests {
         assert!(format!("{stmts:?}").contains("__AnonShape_short"));
     }
 }
+
+#[cfg(test)]
+#[path = "aggregate_scalar_export_tests.rs"]
+mod export_tests;

--- a/crates/perry-transform/src/aggregate_scalar.rs
+++ b/crates/perry-transform/src/aggregate_scalar.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 
 use perry_hir::types::{LocalId, Type};
-use perry_hir::{Expr, Function, Module, Stmt};
+use perry_hir::{Export, Expr, Function, Module, Stmt};
 
 const MAX_SCALAR_AGGREGATE_LEN: usize = 8;
 const MAX_SCALAR_AGGREGATE_FIELDS: usize = 16;
@@ -89,6 +89,11 @@ pub fn run(module: &mut Module) {
                 .map(|member| collect_function_refs(&member.function)),
         );
     }
+    // An exported binding has consumers outside this module that cannot appear
+    // as LocalGet references in its HIR. Model that unknown consumer as one
+    // additional region so the existing cross-region escape barrier keeps the
+    // carrier materialized.
+    region_refs.push(collect_exported_local_ids(module));
     let mut reference_region_counts: HashMap<LocalId, usize> = HashMap::new();
     for refs in &region_refs {
         for id in refs {
@@ -195,6 +200,26 @@ fn collect_function_refs(function: &Function) -> HashSet<LocalId> {
     let mut refs = collect_stmt_refs(&function.body);
     refs.extend(function.captures.iter().copied());
     refs
+}
+
+fn collect_exported_local_ids(module: &Module) -> HashSet<LocalId> {
+    let mut exported_names: HashSet<&str> =
+        module.exported_objects.iter().map(String::as_str).collect();
+    exported_names.extend(module.exports.iter().filter_map(|export| match export {
+        Export::Named { local, .. } => Some(local.as_str()),
+        Export::ReExport { .. } | Export::ExportAll { .. } | Export::NamespaceReExport { .. } => {
+            None
+        }
+    }));
+
+    module
+        .init
+        .iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::Let { id, name, .. } if exported_names.contains(name.as_str()) => Some(*id),
+            _ => None,
+        })
+        .collect()
 }
 
 fn scalarize_stmts(
@@ -1777,6 +1802,44 @@ mod tests {
             .init
             .iter()
             .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })));
+    }
+
+    #[test]
+    fn exported_aggregate_keeps_materialized_carrier() {
+        for metadata_source in ["exports", "exported_objects"] {
+            let mut module = aggregate_fixture(false);
+            if metadata_source == "exports" {
+                module.exports.push(Export::Named {
+                    local: "values".to_string(),
+                    exported: "VALUES".to_string(),
+                });
+            } else {
+                module.exported_objects.push("values".to_string());
+            }
+
+            run(&mut module);
+
+            assert!(
+                module.init.iter().any(|stmt| {
+                    matches!(
+                        stmt,
+                        Stmt::Let {
+                            id: 1,
+                            init: Some(Expr::Array(_)),
+                            ..
+                        }
+                    )
+                }),
+                "{metadata_source} must keep the exported carrier"
+            );
+            assert!(
+                module
+                    .init
+                    .iter()
+                    .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })),
+                "{metadata_source} must keep element aliases"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry-transform/src/aggregate_scalar_export_tests.rs
+++ b/crates/perry-transform/src/aggregate_scalar_export_tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[test]
+fn exported_aggregate_keeps_materialized_carrier() {
+    for metadata_source in ["exports", "exported_objects"] {
+        let mut module = tests::aggregate_fixture(false);
+        if metadata_source == "exports" {
+            module.exports.push(Export::Named {
+                local: "values".to_string(),
+                exported: "VALUES".to_string(),
+            });
+        } else {
+            module.exported_objects.push("values".to_string());
+        }
+
+        run(&mut module);
+
+        assert!(
+            module.init.iter().any(|stmt| {
+                matches!(
+                    stmt,
+                    Stmt::Let {
+                        id: 1,
+                        init: Some(Expr::Array(_)),
+                        ..
+                    }
+                )
+            }),
+            "{metadata_source} must keep the exported carrier"
+        );
+        assert!(
+            module
+                .init
+                .iter()
+                .any(|stmt| matches!(stmt, Stmt::Let { id: 2, .. })),
+            "{metadata_source} must keep element aliases"
+        );
+    }
+}

--- a/crates/perry/tests/issue_9053_exported_aggregate.rs
+++ b/crates/perry/tests/issue_9053_exported_aggregate.rs
@@ -1,0 +1,69 @@
+//! Regression coverage for #9053: aggregate scalar replacement must not
+//! delete a carrier whose binding is consumed through another module.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn exported_array_of_objects_remains_materialized() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("values.js"),
+        r#"
+export const VALUES = [
+  { x: 1, label: "one" },
+  { x: 2, label: "two" },
+];
+"#,
+    )
+    .expect("write producer module");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import { VALUES } from "./values.js";
+
+console.log("length:", VALUES.length);
+console.log("identity:", VALUES === VALUES);
+for (const value of VALUES) {
+  console.log(value.x, value.label);
+}
+"#,
+    )
+    .expect("write entry module");
+
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg("main.ts")
+        .arg("--no-cache")
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "length: 2\nidentity: true\n1 one\n2 two\n"
+    );
+}


### PR DESCRIPTION
## Summary

Prevents aggregate scalar replacement from deleting arrays of object literals whose bindings are consumed from another module.

## Changes

- Treat local binding IDs recorded by `Module.exports` or `exported_objects` as references from a virtual external HIR region.
- Keep exported aggregate carriers materialized while preserving scalar replacement for genuinely local non-escaping aggregates.
- Add transform-level coverage for both export metadata paths and a native two-module compile/run regression covering length, iteration, property reads, and repeated-read identity.
- Add the required PR-numbered changelog fragment without changing version metadata.

## Related issue

Closes #9053

## Test plan

- [ ] `cargo build --release` clean (not run)
- [ ] Full workspace test command passes (not run)
- [x] `cargo fmt --all -- --check`
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `cargo test -p perry-transform` (120 passed)
- [x] `cargo test -p perry --test issue_9053_exported_aggregate -- --nocapture`
- [x] Added regression tests in the affected transform crate and Perry integration suite
- [x] Docs not required; no CLI, stdlib, or runtime API changed
- [x] Platform UI build not applicable

## Screenshots / output

The two-module fixture now prints:

```text
length: 2
identity: true
1 one
2 two
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose conventional prefix convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where exported arrays of objects could be incorrectly optimized away.
  * Preserved exported aggregate values and their object identities when consumed across modules.
  * Ensured exported arrays retain their length, iteration behavior, and element values.
  * Added regression coverage for cross-module exports, imports, array length, and object contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->