### PR TITLE
fix(codegen): parse typed inline assembly

### DIFF
--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -780,7 +780,7 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
     }
 
     /// Calls: direct `@f(...)`, indirect `%fp(...)` (with or without a
-    /// pre-opaque `(sig)*` type), and the inline-asm barrier.
+    /// pre-opaque `(sig)*` type), and Perry-emitted inline asm.
     fn call(&mut self, dst: Option<&str>, rest: &str) -> Result<Option<BasicValueEnum<'ctx>>> {
         // Optional fast-math prefix tokens on float-returning calls.
         let rest = rest
@@ -788,16 +788,21 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
             .trim_start_matches("contract ")
             .trim_start();
 
-        // Inline asm: `void asm sideeffect "ASM", "CONSTRAINTS"(ARGS)`
-        if let Some(asm_rest) = rest.strip_prefix("void asm ") {
-            return self.call_asm(asm_rest).map(|_| None);
-        }
-
         // #8175: explicit calling-convention token before the return type.
         let (rest, preserve_none) = match rest.strip_prefix(crate::inst::PRESERVE_NONE_CC) {
             Some(tail) => (tail.trim_start(), true),
             None => (rest, false),
         };
+
+        // Inline asm: `RET asm sideeffect "ASM", "CONSTRAINTS"(ARGS)`.
+        // Validate the whole prefix as a return type before committing to
+        // this branch: an ordinary quoted callee or operand may itself
+        // contain the substring ` asm `.
+        if let Some((ret_tok, asm_rest)) = rest.split_once(" asm ") {
+            if ret_tok == "void" || basic_type(self.ctx, ret_tok).is_ok() {
+                return self.call_asm(dst, ret_tok, asm_rest, preserve_none);
+            }
+        }
 
         // Return type is the first top-level token; everything from the
         // callee marker on is `CALLEE(ARGS)[ #attrs]`.
@@ -889,29 +894,86 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
         }
     }
 
-    fn call_asm(&mut self, rest: &str) -> Result<()> {
-        // `sideeffect "ASM", "CONSTR"()` — the only asm perry emits is the
-        // empty barrier, but parse the strings properly anyway.
-        let sideeffect = rest.trim_start().starts_with("sideeffect");
-        let mut strings = rest.split('"');
-        let asm = strings.nth(1).unwrap_or("").to_string();
-        let constraints = strings.nth(1).unwrap_or("").to_string();
-        let void_fn = self.ctx.void_type().fn_type(&[], false);
+    fn call_asm(
+        &mut self,
+        dst: Option<&str>,
+        ret_tok: &str,
+        rest: &str,
+        preserve_none: bool,
+    ) -> Result<Option<BasicValueEnum<'ctx>>> {
+        let rest = rest.trim_start();
+        let (sideeffect, rest) = match rest.strip_prefix("sideeffect") {
+            Some(tail) if tail.starts_with(char::is_whitespace) => (true, tail.trim_start()),
+            _ => (false, rest),
+        };
+        let (asm, rest) = take_quoted(rest, "inline-asm template")?;
+        let rest = rest
+            .trim_start()
+            .strip_prefix(',')
+            .ok_or_else(|| anyhow!("inline asm missing constraint separator"))?;
+        let (constraints, rest) = take_quoted(rest, "inline-asm constraints")?;
+        let args_and_attrs = rest.trim_start();
+        if !args_and_attrs.starts_with('(') {
+            bail!("inline asm missing argument list");
+        }
+        let close = rmatch_paren(args_and_attrs, 0)?;
+        let args_str = &args_and_attrs[1..close];
+        let trailing_attr = args_and_attrs[close + 1..].trim();
+
+        let mut args: Vec<BasicMetadataValueEnum> = Vec::new();
+        let mut arg_types: Vec<inkwell::types::BasicMetadataTypeEnum> = Vec::new();
+        for arg in split_top_level(args_str) {
+            let (aty, atok) = ty_and_val(&arg)?;
+            let ty = basic_type(self.ctx, aty)?;
+            args.push(self.val(ty, atok)?.into());
+            arg_types.push(ty.into());
+        }
+
+        let fn_ty = fn_type_of(self.ctx, ret_tok, &arg_types)?;
         let ptr =
             self.ctx
-                .create_inline_asm(void_fn, asm, constraints, sideeffect, false, None, false);
+                .create_inline_asm(fn_ty, asm, constraints, sideeffect, false, None, false);
+        let name = dst.map(|d| d.trim_start_matches('%')).unwrap_or("");
         let site = self
             .builder
-            .build_indirect_call(void_fn, ptr, &[], "")
+            .build_indirect_call(fn_ty, ptr, &args, name)
             .map_err(be)?;
+        if preserve_none {
+            site.set_call_convention(LLVM_CC_PRESERVE_NONE);
+        }
+
+        let mut has_gc_leaf = false;
+        match trailing_attr {
+            "" => {}
+            other if other.starts_with('"') => {
+                let (k, v) = match other.split_once("\"=\"") {
+                    Some((k, v)) => (k.trim_matches('"'), v.trim_matches('"')),
+                    None => (other.trim_matches('"'), ""),
+                };
+                if k.is_empty() {
+                    bail!("malformed inline-asm callsite string attribute `{other}`");
+                }
+                has_gc_leaf = k == "gc-leaf-function";
+                site.add_attribute(
+                    inkwell::attributes::AttributeLoc::Function,
+                    self.ctx.create_string_attribute(k, v),
+                );
+            }
+            other => bail!("unknown inline-asm callsite attribute `{other}`"),
+        }
         // Perry-emitted inline asm never calls back into the runtime, so it
         // can never reach a safepoint. Without this, RS4GC statepoint-wraps
         // the call and produces IR the verifier rejects (#8121).
-        site.add_attribute(
-            inkwell::attributes::AttributeLoc::Function,
-            self.ctx.create_string_attribute("gc-leaf-function", ""),
-        );
-        Ok(())
+        if !has_gc_leaf {
+            site.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                self.ctx.create_string_attribute("gc-leaf-function", ""),
+            );
+        }
+        match site.try_as_basic_value() {
+            inkwell::values::ValueKind::Basic(v) => Ok(Some(v)),
+            _ => Ok(None),
+        }
     }
 
     fn binary_or_cast(&mut self, dst: &str, op: &str, rest: &str) -> Result<BasicValueEnum<'ctx>> {
@@ -1787,6 +1849,21 @@ fn be(e: inkwell::builder::BuilderError) -> anyhow::Error {
 
 fn unquote(s: &str) -> String {
     s.trim_matches('"').to_string()
+}
+
+/// Consume one LLVM quoted string. Perry's emitted templates and constraint
+/// strings use LLVM's `\XX` byte escapes rather than embedded quote
+/// characters, so the next quote is the structural terminator and the bytes
+/// between can be passed to `create_inline_asm` unchanged.
+fn take_quoted<'a>(s: &'a str, what: &str) -> Result<(String, &'a str)> {
+    let s = s.trim_start();
+    let body = s
+        .strip_prefix('"')
+        .ok_or_else(|| anyhow!("{what} is not quoted"))?;
+    let end = body
+        .find('"')
+        .ok_or_else(|| anyhow!("unterminated {what}"))?;
+    Ok((body[..end].to_string(), &body[end + 1..]))
 }
 
 /// Find the matching `)` for the `(` at `open` in `s`.

--- a/crates/perry-codegen/src/dialect/tests.rs
+++ b/crates/perry-codegen/src/dialect/tests.rs
@@ -417,3 +417,81 @@ fn gc_leaf_attribute_constructs_on_invoke() {
         "invoke lost its gc-leaf-function call-site attribute:\n{printed}"
     );
 }
+
+/// #9050: Apple arm64's hot-TLS reader is value-returning inline asm, not the
+/// void-only loop barrier that originally defined this parser branch. Keep
+/// both forms live, plus an operand-bearing form that proves the constructed
+/// function signature follows the inline-asm argument list.
+#[test]
+fn typed_and_void_inline_asm_round_trip_with_gc_leaf_attributes() {
+    let ir = r#"
+declare i64 @"ordinary asm callee"()
+
+define i64 @read_tpidrro() {
+entry:
+  %r = call i64 asm sideeffect "mrs $0, tpidrro_el0", "=r"() "gc-leaf-function"
+  ret i64 %r
+}
+
+define i64 @asm_with_operand(i64 %x) {
+entry:
+  %r = call i64 asm sideeffect "", "=r,r"(i64 %x) "gc-leaf-function"
+  ret i64 %r
+}
+
+define void @barrier() {
+entry:
+  call void asm sideeffect "", ""() "gc-leaf-function"
+  ret void
+}
+
+define i64 @ordinary_call() {
+entry:
+  %r = call i64 @"ordinary asm callee"()
+  ret i64 %r
+}
+"#;
+    let (skeleton, fns) = split_corpus(ir);
+    let ctx = Context::create();
+    let module = crate::inprocess::parse_ir_text(&ctx, &skeleton, "typed_inline_asm_skel")
+        .expect("skeleton parses");
+    for function in &fns {
+        predeclare_function_from_text(&ctx, &module, function).expect("predeclare");
+    }
+    for function in &fns {
+        add_function_from_text(&ctx, &module, function).unwrap_or_else(|e| panic!("{e:#}"));
+    }
+    module
+        .verify()
+        .unwrap_or_else(|e| panic!("verifier rejected native module:\n{}", e.to_string()));
+
+    let printed = module.print_to_string().to_string();
+    let typed = printed
+        .lines()
+        .find(|line| line.contains("mrs $0, tpidrro_el0"))
+        .unwrap_or_else(|| panic!("typed inline asm was not constructed:\n{printed}"));
+    assert!(
+        typed.contains("call i64 asm sideeffect") && typed.contains("#0"),
+        "typed inline asm lost its result type, sideeffect flag, or leaf attribute:\n{printed}"
+    );
+    assert!(
+        printed.contains("ret i64 %r"),
+        "typed inline asm result is not returned:\n{printed}"
+    );
+    assert!(
+        printed.contains("\"=r,r\"(i64 %x)"),
+        "inline-asm argument list did not survive construction:\n{printed}"
+    );
+    assert!(
+        printed.contains("call void asm sideeffect"),
+        "void inline-asm barrier regressed:\n{printed}"
+    );
+    assert!(
+        printed.contains("call i64 @\"ordinary asm callee\"()"),
+        "ordinary call containing ` asm ` was misclassified:\n{printed}"
+    );
+    assert!(
+        printed.contains("attributes #0 = { \"gc-leaf-function\" }"),
+        "inline asm lost its structural gc-leaf-function attribute:\n{printed}"
+    );
+}

--- a/crates/perry-codegen/src/native_emit.rs
+++ b/crates/perry-codegen/src/native_emit.rs
@@ -1056,6 +1056,47 @@ mod tests {
         );
     }
 
+    /// #9050: exercise the exact Apple arm64 hot-TLS instruction through the
+    /// migration harness's real verdict: object bytes from text parsing and
+    /// native dialect construction must match. The void barrier remains in
+    /// the same fixture as a control for the original inline-asm form.
+    #[test]
+    fn typed_inline_asm_matches_text_object_on_apple_arm64() {
+        const TARGET: &str = "arm64-apple-darwin";
+        let _shadow = crate::codegen::helpers::NativeRootsPin::shadow();
+        let mut module = LlModule::new(TARGET);
+        let function = module.define_function("read_tpidrro", I64, vec![]);
+        let entry = function.create_block("entry");
+        entry.emit_raw(
+            "%r = call i64 asm sideeffect \"mrs $0, tpidrro_el0\", \"=r\"() \
+             \"gc-leaf-function\"",
+        );
+        entry.emit_raw("call void asm sideeffect \"\", \"\"() \"gc-leaf-function\"");
+        entry.ret(I64, "%r");
+
+        let text_ir = module.to_ir();
+        assert!(
+            text_ir.contains(
+                "call i64 asm sideeffect \"mrs $0, tpidrro_el0\", \"=r\"() \
+                 \"gc-leaf-function\""
+            ),
+            "fixture lost the exact hot-TLS inline asm:\n{text_ir}"
+        );
+        assert!(
+            text_ir.contains("call void asm sideeffect \"\", \"\"() \"gc-leaf-function\""),
+            "fixture lost the void barrier control:\n{text_ir}"
+        );
+
+        let text = crate::linker::compile_ll_to_object(&text_ir, Some(TARGET))
+            .expect("trusted text arm emits an Apple arm64 object");
+        let native = compile_module_native(&mut module, Some(TARGET), "typed_inline_asm_fixture")
+            .expect("native reader emits an Apple arm64 object");
+        assert_eq!(
+            native, text,
+            "typed inline asm must emit byte-identical objects through text and native readers"
+        );
+    }
+
     /// #8596: whole-module generated-callee effects must reach both emission
     /// transports. The text path spells the string attribute inline; LLVM's
     /// C API prints it through an attribute group. RS4GC is the final arbiter:


### PR DESCRIPTION
Fixes #9050

## Summary

- recognize typed inline assembly only when the complete pre-asm prefix is a valid return type
- parse inline-asm arguments into the matching function signature, preserve side effects, and return non-void call values
- structurally preserve the GC-leaf call-site attribute while keeping the existing void barrier path covered
- verify the exact Apple arm64 hot-TLS instruction emits byte-identical objects through the text and native readers

## Testing

Run on root@perrymaster.skelpo.net with LLVM 22:

- cargo fmt --all -- --check
- cargo test -p perry-codegen typed_and_void_inline_asm_round_trip_with_gc_leaf_attributes -- --nocapture
- cargo test -p perry-codegen typed_inline_asm_matches_text_object_on_apple_arm64 -- --nocapture
- cargo test -p perry-codegen --lib (1345 passed, 1 ignored)

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline assembly handling for typed return values, void barriers, side effects, operands, and calling conventions.
  * Preserved required `gc-leaf-function` attributes during inline assembly processing.
  * Correctly distinguishes ordinary calls from inline assembly when similar text appears in call expressions.

* **Tests**
  * Added coverage for inline assembly round trips and Apple ARM64 compilation output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->