### PR TITLE
fix(compiler): retain extracted Math methods (#9051)

### DIFF
--- a/changelog.d/9051-extracted-math.md
+++ b/changelog.d/9051-extracted-math.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Auto-optimized binaries now retain callable `Math` namespace members when methods such as `Math.cos` are captured as values, including inside class bodies.

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -68,6 +68,25 @@ fn debug_hir_uses_string_normalization(hir_debug: &str) -> bool {
         || hir_debug.contains("property: \"Collator\"")
 }
 
+fn debug_hir_uses_global_math_member(hir_debug: &str) -> bool {
+    // Value-form reads such as `const cos = Math.cos` lose the `Math`
+    // receiver during lowering and reach final HIR as a property read from
+    // the shared GlobalGet(0) builtin sentinel. Match every member reified by
+    // `install_math_namespace`. A same-named property on another object is a
+    // benign false positive (a slightly larger runtime), while a false
+    // negative leaves the extracted function undefined.
+    const MEMBERS: &[&str] = &[
+        "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil", "clz32",
+        "cos", "cosh", "exp", "expm1", "f16round", "floor", "fround", "hypot", "imul", "log",
+        "log1p", "log2", "log10", "max", "min", "pow", "random", "round", "sign", "sin", "sinh",
+        "sqrt", "tan", "tanh", "trunc",
+    ];
+
+    MEMBERS
+        .iter()
+        .any(|member| hir_debug.contains(&format!(r#"property: "{member}""#)))
+}
+
 fn imports_fs_promises_glob(hir_module: &perry_hir::Module) -> bool {
     hir_module.imports.iter().any(|import| {
         !import.type_only
@@ -397,10 +416,18 @@ pub(super) fn detect_optional_feature_usage(
         // lower to codegen intrinsics that never touch these tables, so a
         // surviving mention of the name means the namespace may be used as a
         // VALUE (`const m = Math`, `Object.keys(JSON)`) — exactly when the
-        // members must exist. Bare-substring matching keeps this
-        // over-approximate on purpose (a user identifier containing the name
-        // only costs size).
-        if hir_debug.contains("\"Math\"") {
+        // members must exist. Math value reads lose that name entirely, so
+        // also scan its supported member names. Class bodies are stored
+        // separately from init/functions; include them for Math so an
+        // extracted method in a constructor, method, accessor, or field
+        // initializer cannot be pruned. Bare matching stays over-approximate
+        // on purpose (a false positive only costs size).
+        let class_hir_debug = format!("{:?}", &hir_module.classes);
+        if hir_debug.contains("\"Math\"")
+            || class_hir_debug.contains("\"Math\"")
+            || debug_hir_uses_global_math_member(&hir_debug)
+            || debug_hir_uses_global_math_member(&class_hir_debug)
+        {
             ctx.uses_global_math = true;
         }
         if hir_debug.contains("\"JSON\"") {
@@ -568,7 +595,7 @@ pub(super) fn detect_optional_feature_usage(
 #[cfg(test)]
 mod tests {
     use super::{
-        debug_hir_uses_get_builtin_module, debug_hir_uses_regex,
+        debug_hir_uses_get_builtin_module, debug_hir_uses_global_math_member, debug_hir_uses_regex,
         debug_hir_uses_string_normalization, debug_hir_uses_zlib_brotli, debug_hir_uses_zlib_zstd,
         imports_fs_promises_glob,
     };
@@ -642,6 +669,23 @@ mod tests {
         ));
         assert!(!debug_hir_uses_string_normalization(
             r#"StringMethod { method: "toLowerCase" }"#
+        ));
+    }
+
+    #[test]
+    fn global_math_gate_detects_extracted_members_but_not_direct_intrinsics() {
+        assert!(debug_hir_uses_global_math_member(
+            r#"PropertyGet { object: GlobalGet(0), property: "cos", optional: false }"#
+        ));
+        assert!(debug_hir_uses_global_math_member(
+            r#"PropertyGet { object: GlobalGet(0), property: "imul", optional: false }"#
+        ));
+        assert!(debug_hir_uses_global_math_member(
+            r#"PropertyGet { object: GlobalGet(0), property: "f16round", optional: false }"#
+        ));
+        assert!(!debug_hir_uses_global_math_member("MathCos(Number(0.0))"));
+        assert!(!debug_hir_uses_global_math_member(
+            r#"PropertyGet { object: GlobalGet(0), property: "stringify", optional: false }"#
         ));
     }
 

--- a/crates/perry/tests/issue_9051_extracted_math.rs
+++ b/crates/perry/tests/issue_9051_extracted_math.rs
@@ -1,0 +1,86 @@
+//! Regression coverage for #9051: auto-optimization must retain the reified
+//! Math namespace when a method is read as a first-class function.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        // This regression exists only in the default feature-pruned runtime.
+        .env_remove("PERRY_NO_AUTO_OPTIMIZE")
+        .env("PERRY_WORKSPACE_ROOT", workspace_root())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: extracted Math method was undefined)\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn extracted_math_methods_survive_auto_optimization() {
+    // Class bodies live outside module init/functions in final HIR. Keep this
+    // case first so a detector that forgets `hir_module.classes` cannot pass
+    // because another compile already warmed a global-math archive.
+    let class_method = compile_and_run(
+        r#"
+class Trig {
+  cosAtZero() {
+    const cos = Math.cos;
+    return cos(0);
+  }
+}
+
+console.log(new Trig().cosAtZero());
+console.log(Math.cos(0));
+"#,
+    );
+    assert_eq!(class_method, "1\n1\n");
+
+    let top_level = compile_and_run(
+        r#"
+const cos = Math.cos;
+console.log(cos(0));
+console.log(Math.cos(0));
+"#,
+    );
+    assert_eq!(top_level, "1\n1\n");
+}


### PR DESCRIPTION
Fixes #9051.

Auto-optimization now recognizes first-class reads of supported `Math` methods after lowering has replaced the namespace with the global sentinel. The detector also scans class HIR, and the end-to-end regression covers top-level and class-method extraction.

Includes focused feature-detection coverage and a default auto-optimized CLI compile/run regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where auto-optimized binaries could lose callable `Math` namespace methods when those methods were captured as values.
  - Preserved extracted `Math` methods used inside class bodies and at the top level.

- **Tests**
  - Added regression coverage confirming extracted methods such as `Math.cos` continue to execute correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->