### PR TITLE
test(transform): split aggregate escape regressions

### DIFF
--- a/crates/perry-transform/src/aggregate_scalar.rs
+++ b/crates/perry-transform/src/aggregate_scalar.rs
@@ -1849,79 +1849,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn reference_from_generated_function_keeps_materialized_aggregate() {
-        let mut module = aggregate_fixture(false);
-        module.functions.push(Function {
-            id: 99,
-            name: "__obj_method_computed".to_string(),
-            type_params: Vec::new(),
-            params: Vec::new(),
-            return_type: Type::Any,
-            body: vec![Stmt::Return(Some(Expr::LocalGet(1)))],
-            is_async: false,
-            is_generator: false,
-            is_strict: false,
-            is_exported: false,
-            captures: Vec::new(),
-            decorators: Vec::new(),
-            was_plain_async: false,
-            was_unrolled: false,
-        });
-
-        run(&mut module);
-
-        assert!(module.init.iter().any(|stmt| {
-            matches!(
-                stmt,
-                Stmt::Let {
-                    id: 1,
-                    init: Some(Expr::Array(_)),
-                    ..
-                }
-            )
-        }));
-    }
-
-    #[test]
-    fn module_local_reference_from_closure_body_keeps_materialized_aggregate() {
-        let mut module = aggregate_fixture(false);
-        *module.init.last_mut().expect("observer statement") = Stmt::Expr(Expr::Closure {
-            func_id: 99,
-            params: Vec::new(),
-            return_type: Type::Any,
-            body: vec![Stmt::Return(Some(property(
-                Expr::IndexGet {
-                    object: Box::new(Expr::LocalGet(1)),
-                    index: Box::new(Expr::Integer(0)),
-                },
-                "component",
-            )))],
-            captures: Vec::new(),
-            mutable_captures: Vec::new(),
-            captures_this: false,
-            captures_new_target: false,
-            enclosing_class: None,
-            is_arrow: true,
-            is_async: false,
-            is_generator: false,
-            is_strict: true,
-        });
-
-        run(&mut module);
-
-        assert!(module.init.iter().any(|stmt| {
-            matches!(
-                stmt,
-                Stmt::Let {
-                    id: 1,
-                    init: Some(Expr::Array(_)),
-                    ..
-                }
-            )
-        }));
-    }
-
     fn shape_new(name: &str, args: Vec<Expr>) -> Expr {
         Expr::New {
             class_name: name.to_string(),
@@ -2041,3 +1968,7 @@ mod tests {
 #[cfg(test)]
 #[path = "aggregate_scalar_export_tests.rs"]
 mod export_tests;
+
+#[cfg(test)]
+#[path = "aggregate_scalar_closure_tests.rs"]
+mod closure_tests;

--- a/crates/perry-transform/src/aggregate_scalar_closure_tests.rs
+++ b/crates/perry-transform/src/aggregate_scalar_closure_tests.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+fn property(object: Expr, name: &str) -> Expr {
+    Expr::PropertyGet {
+        object: Box::new(object),
+        property: name.to_string(),
+        byte_offset: 0,
+    }
+}
+
+fn assert_carrier_is_materialized(module: &Module) {
+    assert!(module.init.iter().any(|stmt| {
+        matches!(
+            stmt,
+            Stmt::Let {
+                id: 1,
+                init: Some(Expr::Array(_)),
+                ..
+            }
+        )
+    }));
+}
+
+#[test]
+fn reference_from_generated_function_keeps_materialized_aggregate() {
+    let mut module = tests::aggregate_fixture(false);
+    module.functions.push(Function {
+        id: 99,
+        name: "__obj_method_computed".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Any,
+        body: vec![Stmt::Return(Some(Expr::LocalGet(1)))],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    });
+
+    run(&mut module);
+
+    assert_carrier_is_materialized(&module);
+}
+
+#[test]
+fn module_local_reference_from_closure_body_keeps_materialized_aggregate() {
+    let mut module = tests::aggregate_fixture(false);
+    *module.init.last_mut().expect("observer statement") = Stmt::Expr(Expr::Closure {
+        func_id: 99,
+        params: Vec::new(),
+        return_type: Type::Any,
+        body: vec![Stmt::Return(Some(property(
+            Expr::IndexGet {
+                object: Box::new(Expr::LocalGet(1)),
+                index: Box::new(Expr::Integer(0)),
+            },
+            "component",
+        )))],
+        captures: Vec::new(),
+        mutable_captures: Vec::new(),
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: true,
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+    });
+
+    run(&mut module);
+
+    assert_carrier_is_materialized(&module);
+}


### PR DESCRIPTION
The combined #9048 and #9053 fixes pushed `aggregate_scalar.rs` to 2,043 lines, failing the 2,000-line release gate. Move the generated-function and closure escape tests into a sibling test module without changing production behavior.

Verified:
- `cargo test -p perry-transform` (121/121)
- `./scripts/check_file_size.sh`