### PR TITLE
perf(codegen): hoist the versioned loop's length bound; admit float arithmetic in masked-window stores

### DIFF
--- a/changelog.d/9070-versioned-len-hoist-masked-arith.md
+++ b/changelog.d/9070-versioned-len-hoist-masked-arith.md
@@ -1,0 +1,1 @@
+Hoisted the packed versioned loop's `arr.length` bound to a single pre-validated i32 read (length-bound store loops 1.3 → 0.7 ns), and extended masked-window dense stores to float-arithmetic values — `a[i & K] = b[i & K] + c` now lowers to a raw load, one float op, and a raw store (15.9 → 0.5 ns, ahead of Node).

--- a/crates/perry-codegen/src/expr/masked_window.rs
+++ b/crates/perry-codegen/src/expr/masked_window.rs
@@ -225,13 +225,19 @@ pub(crate) fn masked_window_store_fact_for_index(
 ///   raw-f64 number (and TA-tier loads materialize via `sitofp`/`uitofp` /
 ///   raw f64 loads).
 ///
-/// Deliberately NO binary/unary arithmetic in this v1: an operand typed `Any`
-/// can route `+` through a runtime helper whose result is boxed. Arithmetic
-/// over genuine doubles is a candidate extension once its lowering is pinned.
+/// Float arithmetic (`+ - * /`, unary negation) over these operands is also
+/// admitted: both sides being genuine doubles pins the numeric lowering to a
+/// bare float instruction (the boxed-`+`-helper hazard needs a non-numeric
+/// operand, and every admitted operand is numeric by construction), and the
+/// pinning test asserts the fast clone stays call-free so a lowering change
+/// that broke this would go red, not silent. `%` and `**` stay excluded —
+/// they can lower through runtime helpers.
 ///
 /// Closed under IEEE semantics: a raw-f64 slot never holds a payload-NaN in
 /// the box tag range (that is the raw-f64 invariant canonicalization exists
-/// to maintain), and none of these shapes fabricates one.
+/// to maintain), none of these shapes fabricates one, and a float op over
+/// canonical operands produces the default quiet NaN (0x7FF8...), which is a
+/// genuine double.
 pub(crate) fn masked_store_rhs_is_genuine_f64(ctx: &FnCtx<'_>, expr: &Expr) -> bool {
     match expr {
         Expr::Number(_) | Expr::Integer(_) => true,
@@ -242,6 +248,20 @@ pub(crate) fn masked_store_rhs_is_genuine_f64(ctx: &FnCtx<'_>, expr: &Expr) -> b
             }
             _ => false,
         },
+        Expr::Binary { op, left, right } => {
+            matches!(
+                op,
+                perry_hir::BinaryOp::Add
+                    | perry_hir::BinaryOp::Sub
+                    | perry_hir::BinaryOp::Mul
+                    | perry_hir::BinaryOp::Div
+            ) && masked_store_rhs_is_genuine_f64(ctx, left)
+                && masked_store_rhs_is_genuine_f64(ctx, right)
+        }
+        Expr::Unary {
+            op: perry_hir::UnaryOp::Neg,
+            operand,
+        } => masked_store_rhs_is_genuine_f64(ctx, operand),
         _ => false,
     }
 }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -595,13 +595,30 @@ fn lower_packed_f64_versioned_for(
         allow_holes: false,
         window_validated: false,
     });
-    lower_for_after_init(
+    // The guard just proved a live, non-forwarded plain array, and the
+    // matched body cannot change its length (in-bounds stores only, no
+    // calls/closures/awaits) — so hoist the length ONCE as the fast clone's
+    // i32 bound instead of re-evaluating `i < arr.length` per iteration
+    // (the un-hoisted condition paid ~20 inline instructions per iteration:
+    // handle decode + GC-header checks + the length load, which LLVM cannot
+    // hoist past the body's raw element stores). A mid-loop GC move changes
+    // the array's ADDRESS, never its length, so the hoisted VALUE stays
+    // correct. Same mechanism as the range-versioned fast copy (#6011).
+    let hoisted_len_i32 = {
+        let blk = ctx.block();
+        let arr_bits = blk.bitcast_double_to_i64(&arr_box);
+        let arr_handle = blk.and(I64, &arr_bits, crate::nanbox::POINTER_MASK_I64);
+        let len_ptr = blk.inttoptr(I64, &arr_handle);
+        blk.load(I32, &len_ptr)
+    };
+    lower_for_after_init_with_i32_bound(
         ctx,
         init,
         condition,
         update,
         body,
         &format!("for.{loop_label}_fast"),
+        Some((matched.counter_id, hoisted_len_i32)),
     )?;
     ctx.packed_f64_loop_facts
         .retain(|fact| fact.scope_id != packed_scope_id);
@@ -1227,6 +1244,23 @@ fn dense_masked_store_rhs_is_admissible(
                 && crate::collectors::static_index_window(index)
                     .is_some_and(|(lo, hi)| lo >= 0 && hi < i64::from(i32::MAX))
         }
+        // Float arithmetic over admitted operands — see the lowering-side
+        // twin (`masked_store_rhs_is_genuine_f64`) for the argument. `%`/`**`
+        // stay excluded (runtime-helper lowerings).
+        Expr::Binary { op, left, right } => {
+            matches!(
+                op,
+                perry_hir::BinaryOp::Add
+                    | perry_hir::BinaryOp::Sub
+                    | perry_hir::BinaryOp::Mul
+                    | perry_hir::BinaryOp::Div
+            ) && dense_masked_store_rhs_is_admissible(ctx, left, counter_id, _accesses)
+                && dense_masked_store_rhs_is_admissible(ctx, right, counter_id, _accesses)
+        }
+        Expr::Unary {
+            op: perry_hir::UnaryOp::Neg,
+            operand,
+        } => dense_masked_store_rhs_is_admissible(ctx, operand, counter_id, _accesses),
         _ => false,
     }
 }

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -2642,6 +2642,84 @@ fn masked_window_dense_store_inlines_raw_store_without_calls() {
 }
 
 #[test]
+fn masked_window_dense_store_admits_float_arithmetic_rhs() {
+    // `a[i & 7] = a[(i + 1) & 7] + 0.5` — arithmetic over admitted operands
+    // (an in-window masked load and a literal). The fast clone must stay
+    // call-free: the RHS lowers to a raw in-window load plus a bare `fadd`,
+    // and the store stays the inline range store. This pins the predicate's
+    // central claim — that admitted arithmetic never routes through a
+    // boxed-result helper.
+    let bitand = |left: Expr, right: Expr| Expr::Binary {
+        op: BinaryOp::BitAnd,
+        left: Box::new(left),
+        right: Box::new(right),
+    };
+    let module = module_with_classes_and_params(
+        "masked_window_dense_store_arith.ts",
+        Vec::new(),
+        Vec::new(),
+        Type::Number,
+        vec![
+            number_array_let(1, "values", vec![1, 2, 3, 4, 5, 6, 7, 8]),
+            for_loop(
+                4,
+                int(64),
+                vec![array_set(
+                    1,
+                    bitand(local(4), int(7)),
+                    add(
+                        index_get(1, bitand(add(local(4), int(1)), int(7))),
+                        number(0.5),
+                    ),
+                )],
+            ),
+            Stmt::Return(Some(index_get(1, int(0)))),
+        ],
+    );
+
+    let ir = compile_ir_for_module_with_opts(module.clone(), empty_opts()).unwrap();
+    assert!(
+        ir.contains("call i32 @js_typed_feedback_packed_f64_range_loop_guard_dense"),
+        "arith masked store loop should get the f64 dense range guard:\n{ir}"
+    );
+    let fast_start = ir
+        .find("\nfor.packed_f64_range_fast")
+        .map(|pos| pos + 1)
+        .expect("expected dense fast clone");
+    let fast_region_end = ir[fast_start..]
+        .find("\nfor.packed_f64_range_slow")
+        .map(|off| fast_start + off)
+        .unwrap_or(ir.len());
+    let fast_clone = &ir[fast_start..fast_region_end];
+    for forbidden in [
+        "js_typed_feedback_numeric_array_index_set_guard",
+        "js_typed_feedback_array_set_f64_extend",
+        "js_add",
+        "js_dyn_index_set_strict",
+    ] {
+        assert!(
+            !fast_clone.contains(forbidden),
+            "arith dense fast clone must not call {forbidden}:\n{fast_clone}\n\n{ir}"
+        );
+    }
+    assert!(
+        fast_clone.contains("fadd double") && fast_clone.contains("store double"),
+        "arith dense fast clone should be a raw load + fadd + raw store:\n{fast_clone}\n\n{ir}"
+    );
+
+    let artifact = compile_artifact_json_for_module(module);
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "MaskedWindowStore"
+                && record["consumer"] == "packed_f64_masked_window_store"
+                && record["access_mode"] == "checked_native"
+        }),
+        "expected a checked masked-window store record for the arith RHS:\n{artifact:#}"
+    );
+}
+
+#[test]
 fn masked_window_dense_store_rejects_unproven_rhs() {
     // Same loop, but the RHS is a plain number PARAMETER — numeric by type
     // yet potentially INT32-boxed at runtime, and dense mode has no side


### PR DESCRIPTION
Two follow-ups to #9041/#9063, stacked on #9063 (`2e6c0c387c`) — merge after it.

## 1. Versioned-loop length-bound hoist

The versioned packed loop's fast clone re-evaluated `i < arr.length` per iteration — ~20 inline instructions of handle decode + GC-header checks + the length load, which LLVM cannot hoist past the body's raw element stores. The entry guard just proved a live, non-forwarded plain array whose length the matched body cannot change (in-bounds stores only, no calls), so hoist the length ONCE in the fast preheader and hand it to `lower_for_after_init_with_i32_bound`, exactly like the range-versioned fast copy (#6011). A mid-loop GC move changes the array's address, never its length, so the hoisted VALUE stays correct.

**`i < a.length` store loops: 1.3 → 0.70 ns/store** (node 0.59); constant-bound and hoisted-local-bound variants also gain (3.3 → 2.2, 3.6 → 2.8).

## 2. Float arithmetic in masked-window store values

#9063 admitted only literal / counter / in-window-load RHS values. Extend both predicates with float arithmetic (`+ − * /`, unary negation) over admitted operands: both sides being genuine doubles pins the numeric lowering to a bare float instruction — the boxed-`+`-helper hazard needs a non-numeric operand — and a float op over canonical operands cannot fabricate a NaN-box pattern (the default quiet NaN 0x7FF8 is a genuine double). `%` and `**` stay excluded (runtime-helper lowerings).

**`a[i & K] = b[i & K] + 1.5`: 15.9 → 0.50 ns/store — ahead of node's 1.33.** IR census of the fast clone: one raw load, one `fadd`, one raw store, the loop poll — no calls.

## Correctness

- Seven-probe arithmetic differential vs node, **byte-identical**: NaN propagation, x/0 → ±Infinity, 0/0 → NaN, −0 quotients and products, overflow to Infinity, denormals, read-modify-write of the same slot, and a mixed-type source array whose guard failure routes through the slow clone where JS `+` string concatenation applies.
- New pin: the arith fast clone is call-free with `fadd double` + `store double` and never routes through `js_add`; all masked/packed pins green (9/9 in the two families).
- Full host gate on `4ca7bee8cb`: all real lint steps pass, ratchets clean, suites green (one known parallel-only stack_maps flake, passes in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dense numeric loop performance by reusing validated array length bounds.
  * Optimized masked indexed stores for number arrays, including values produced by floating-point arithmetic.
  * Reduced overhead for eligible array updates by using direct numeric loads and stores.

* **Bug Fixes**
  * Preserved safe handling for unsupported or non-numeric store patterns.

* **Tests**
  * Added regression coverage for masked stores using floating-point arithmetic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->