### PR TITLE
ci(simctl): invalidate cached Geisterhand archives

### DIFF
--- a/.github/workflows/simctl-tests.yml
+++ b/.github/workflows/simctl-tests.yml
@@ -48,6 +48,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      # These archives embed the Perry commit, while the builder treats an
+      # existing archive as fresh. Keep the broader target cache warm, but
+      # force this commit-stamped subtree to be rebuilt after every restore.
+      - name: Invalidate cached Geisterhand archives (#9037)
+        run: |
+          rm -rf target/geisterhand
+          test ! -e target/geisterhand
+
       - name: Build perry + iOS UI lib
         run: |
           cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static


### PR DESCRIPTION
Fixes #9037

## Summary
- discard `target/geisterhand` immediately after restoring the simulator Cargo cache
- retain registry, dependency, and other `target` cache entries
- assert the commit-stamped archive subtree is absent before the build and Geisterhand compile smoke

## Testing
- parsed `.github/workflows/simctl-tests.yml` with PyYAML
- statically verified cache → invalidation → Geisterhand smoke ordering
- simulated a restored stale `target/geisterhand/.../libperry_runtime.a` and verified cleanup preserves unrelated `target/release` artifacts
- `git diff --check`

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated builds to reliably regenerate Geisterhand archives after restoring cached build data.
  * Prevented stale archives from being incorrectly reused during simulator test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->