### PR TITLE
fix(runtime): skip Map and Set tombstones in forEach

### DIFF
--- a/changelog.d/9076-map-set-foreach-tombstones.md
+++ b/changelog.d/9076-map-set-foreach-tombstones.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `Map.prototype.forEach` and `Set.prototype.forEach` now skip tombstones left
+  by callback-side deletes and continue through the raw insertion-order extent,
+  so deleting the current or an earlier entry no longer exposes hole values or
+  skips later live entries.

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -3052,16 +3052,15 @@ fn js_map_foreach_impl(
         // The collection itself is the third callback argument and the
         // identity user code compares `self === m` against.
         // ECMA-262 24.1.3.5: forEach iterates [[MapData]] in insertion order,
-        // re-reading the live entry count each step. Entries appended during
-        // the callback (`map.set` inside the callback) MUST be visited, so the
-        // loop bound is re-evaluated against `(*map).size` every iteration
-        // rather than snapshotting the initial size — see the
-        // `iterates-values-added-after-foreach-begins` / `deleted-values`
-        // Test262 cases.
+        // and `used` is the raw [[MapData]] extent. It includes tombstones left
+        // by callback-side deletes, while `size` is only the live count. Walk
+        // the raw extent, skip holes, and re-read it each step so callback-side
+        // appends are visited too. Bounding the walk by `size` exposed holes
+        // and truncated later entries (#9072).
         let mut i = 0usize;
         loop {
             let map = map_handle.get_raw_const_ptr::<MapHeader>();
-            if i >= (*map).size as usize {
+            if i >= (*map).used as usize {
                 break;
             }
             // Re-derive the collection identity each step from a rooted handle
@@ -3075,9 +3074,10 @@ fn js_map_foreach_impl(
             let entries = entries_ptr(map);
             let key = ptr::read(entries.add(i * 2));
             let value = ptr::read(entries.add(i * 2 + 1));
-            // Root the visited key so the post-callback slot comparison below
-            // stays valid across a GC move during the callback.
-            let key_handle = scope.root_nanbox_f64(key);
+            i += 1;
+            if key.to_bits() == MAP_HOLE_KEY_BITS {
+                continue;
+            }
             let args = [value, key, map_value];
             let cb = callback_handle.get_nanbox_f64();
             let this_v = this_handle.get_nanbox_f64();
@@ -3087,19 +3087,6 @@ fn js_map_foreach_impl(
             let prev_this = crate::object::js_implicit_this_set(this_v);
             let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
             crate::object::js_implicit_this_set(prev_this);
-            // Deleting an entry compacts the backing vector (later entries
-            // shift left). If the callback deleted the just-visited entry (or
-            // an earlier one), slot `i` now holds the NEXT unvisited entry —
-            // advancing would skip it (ECMA-262 visits every not-yet-deleted
-            // entry; mirrors the `js_set_foreach_impl` fix). Only advance when
-            // slot `i` still holds the key just visited.
-            let map = map_handle.get_raw_const_ptr::<MapHeader>();
-            if i < (*map).size as usize {
-                let now_key = ptr::read(entries_ptr(map).add(i * 2));
-                if now_key.to_bits() == key_handle.get_nanbox_f64().to_bits() {
-                    i += 1;
-                }
-            }
         }
     }
 }

--- a/crates/perry-runtime/src/map_tombstone_tests.rs
+++ b/crates/perry-runtime/src/map_tombstone_tests.rs
@@ -9,7 +9,7 @@
 
 use super::*;
 
-thread_local! {
+crate::perry_thread_local! {
     static FOREACH_DELETE_VISITS: std::cell::RefCell<Vec<(u64, u64)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 }

--- a/crates/perry-runtime/src/map_tombstone_tests.rs
+++ b/crates/perry-runtime/src/map_tombstone_tests.rs
@@ -9,6 +9,49 @@
 
 use super::*;
 
+thread_local! {
+    static FOREACH_DELETE_VISITS: std::cell::RefCell<Vec<(u64, u64)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+extern "C" fn delete_current_map_entry(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    key: f64,
+    collection: f64,
+) -> f64 {
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().push((key.to_bits(), value.to_bits())));
+    let map = crate::value::js_nanbox_get_pointer(collection) as *mut MapHeader;
+    js_map_delete(map, key);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[test]
+fn foreach_skips_tombstones_created_by_callback_deletes() {
+    let map = js_map_alloc(4);
+    for (key, value) in [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)] {
+        js_map_set(map, key, value);
+    }
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().clear());
+    let callback = crate::closure::js_closure_alloc(delete_current_map_entry as *const u8, 0);
+
+    js_map_foreach(
+        map,
+        crate::value::js_nanbox_pointer(callback as i64),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
+
+    let visits = FOREACH_DELETE_VISITS.with(|visits| {
+        visits
+            .borrow_mut()
+            .drain(..)
+            .map(|(key, value)| (f64::from_bits(key), f64::from_bits(value)))
+            .collect::<Vec<_>>()
+    });
+    assert_eq!(visits, vec![(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]);
+    assert_eq!(js_map_size(map), 0);
+}
+
 #[test]
 fn ordered_delete_preserves_order_and_lookup_across_holes() {
     let map = js_map_alloc(8);

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -1837,15 +1837,15 @@ fn js_set_foreach_impl(
     let collection_handle = scope.root_nanbox_f64(collection_override);
     unsafe {
         // ECMA-262 24.2.3.6: Set.prototype.forEach iterates [[SetData]] in
-        // insertion order, re-reading the live entry count each step. Entries
-        // appended during the callback (`set.add` inside the callback) MUST be
-        // visited, so the loop bound is re-evaluated against `(*set).size` every
-        // iteration rather than snapshotting the initial size — mirrors
-        // `js_map_foreach_impl`.
+        // insertion order. `used` is the raw [[SetData]] extent: unlike `size`,
+        // it still spans tombstones left by callback-side deletes. Walk that
+        // extent, skipping holes, and re-read it each step so values appended
+        // during the callback are visited too. Bounding this by the live count
+        // surfaced holes and stopped before later live values (#9072).
         let mut i = 0usize;
         loop {
             let set = set_handle.get_raw_const_ptr::<SetHeader>();
-            if i >= (*set).size as usize {
+            if i >= (*set).used as usize {
                 break;
             }
             // The Set itself is the third callback argument / `self === s`.
@@ -1858,28 +1858,16 @@ fn js_set_foreach_impl(
             };
             let elements = elements_ptr(set);
             let value = ptr::read(elements.add(i));
-            // Root the visited value so the post-callback slot comparison below
-            // stays valid across a GC move during the callback.
-            let value_handle = scope.root_nanbox_f64(value);
+            i += 1;
+            if value.to_bits() == SET_HOLE_VALUE_BITS {
+                continue;
+            }
             let args = [value, value, set_value];
             let cb = callback_handle.get_nanbox_f64();
             let this_v = this_handle.get_nanbox_f64();
             let prev_this = crate::object::js_implicit_this_set(this_v);
             let _ = crate::closure::js_native_call_value(cb, args.as_ptr(), args.len());
             crate::object::js_implicit_this_set(prev_this);
-            // Deleting an entry compacts the backing vector (later entries
-            // shift left). If the callback deleted the just-visited entry (or
-            // an earlier one), slot `i` now holds the NEXT unvisited value —
-            // advancing would skip it (react-server-dom's task sweeps delete
-            // while iterating; ECMA-262 visits every not-yet-deleted entry).
-            // Only advance when slot `i` still holds the value just visited.
-            let set = set_handle.get_raw_const_ptr::<SetHeader>();
-            if i < (*set).size as usize {
-                let now = ptr::read(elements_ptr(set).add(i));
-                if now.to_bits() == value_handle.get_nanbox_f64().to_bits() {
-                    i += 1;
-                }
-            }
         }
     }
 }

--- a/crates/perry-runtime/src/set_tombstone_tests.rs
+++ b/crates/perry-runtime/src/set_tombstone_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-thread_local! {
+crate::perry_thread_local! {
     static FOREACH_DELETE_VISITS: std::cell::RefCell<Vec<u64>> =
         const { std::cell::RefCell::new(Vec::new()) };
 }

--- a/crates/perry-runtime/src/set_tombstone_tests.rs
+++ b/crates/perry-runtime/src/set_tombstone_tests.rs
@@ -2,6 +2,74 @@
 
 use super::*;
 
+thread_local! {
+    static FOREACH_DELETE_VISITS: std::cell::RefCell<Vec<u64>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+extern "C" fn delete_current_set_value(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    _value_again: f64,
+    collection: f64,
+) -> f64 {
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().push(value.to_bits()));
+    let set = crate::value::js_nanbox_get_pointer(collection) as *mut SetHeader;
+    js_set_delete(set, value);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn delete_earlier_set_value(
+    _closure: *const crate::closure::ClosureHeader,
+    value: f64,
+    _value_again: f64,
+    collection: f64,
+) -> f64 {
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().push(value.to_bits()));
+    if value == 2.0 {
+        let set = crate::value::js_nanbox_get_pointer(collection) as *mut SetHeader;
+        js_set_delete(set, 1.0);
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn take_foreach_delete_visits() -> Vec<f64> {
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().drain(..).map(f64::from_bits).collect())
+}
+
+fn foreach_callback(func: *const u8) -> f64 {
+    FOREACH_DELETE_VISITS.with(|visits| visits.borrow_mut().clear());
+    let callback = crate::closure::js_closure_alloc(func, 0);
+    crate::value::js_nanbox_pointer(callback as i64)
+}
+
+#[test]
+fn foreach_skips_tombstones_created_by_callback_deletes() {
+    let set = js_set_alloc(4);
+    for value in [1.0, 2.0] {
+        js_set_add(set, value);
+    }
+    js_set_foreach(
+        set,
+        foreach_callback(delete_current_set_value as *const u8),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
+    assert_eq!(take_foreach_delete_visits(), vec![1.0, 2.0]);
+    assert_eq!(js_set_size(set), 0);
+
+    let set = js_set_alloc(4);
+    for value in [1.0, 2.0, 3.0] {
+        js_set_add(set, value);
+    }
+    js_set_foreach(
+        set,
+        foreach_callback(delete_earlier_set_value as *const u8),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
+    assert_eq!(take_foreach_delete_visits(), vec![1.0, 2.0, 3.0]);
+    assert_eq!(js_set_size(set), 2);
+}
+
 #[test]
 fn ordered_delete_preserves_order_and_lookup_across_holes() {
     let set = js_set_alloc(8);


### PR DESCRIPTION
Fixes #9072.

`Map.prototype.forEach` and `Set.prototype.forEach` now walk the raw `used` extent and skip tombstone slots instead of bounding raw reads by the live `size`. This preserves insertion-order traversal when callbacks delete the current or an earlier entry, while still visiting callback-side appends.

Regression coverage exercises current-entry deletes for Map and Set plus deletion of an earlier Set entry.

Validation on `root@perrymaster.skelpo.net` (final head `241a16537` unless noted):
- focused gap parity fixture: PASS (100%, byte-identical to Node)
- focused Map/Set callback-delete tests: 2 passed
- Map and Set tombstone modules: 12 passed
- full `perry-runtime` run: 2,791 passed; two unrelated parallel/shared-host flakes both passed immediately in isolation
- thread-local policy checker: PASS
- `cargo clippy -p perry-runtime --lib --tests`: completed with pre-existing warnings only

Includes `changelog.d/9076-map-set-foreach-tombstones.md`. No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Map.prototype.forEach` and `Set.prototype.forEach` when callbacks delete entries during iteration.
  * Deleted entries are now skipped correctly without skipping later live entries or exposing empty slots.
  * Entries added during iteration continue to be visited in insertion order.

* **Tests**
  * Added coverage for deletion scenarios during `Map` and `Set` iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->