### PR TITLE
fix(codegen): preserve undefined from OOB byte reads

### DIFF
--- a/changelog.d/9077-byte-read-oob-undefined.md
+++ b/changelog.d/9077-byte-read-oob-undefined.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Out-of-bounds `Uint8Array` and `Buffer` reads now preserve `undefined` when
+  their value is stored in a plain array instead of silently becoming `0`.

--- a/crates/perry-codegen/src/collectors/int_valued_ta_locals.rs
+++ b/crates/perry-codegen/src/collectors/int_valued_ta_locals.rs
@@ -25,8 +25,8 @@
 //! An integer typed-array or guarded numeric-array element read is numeric only
 //! **in-bounds**. An OOB / negative / fractional index yields **`undefined`**
 //! (a NaN-boxed value), NOT an integer.
-//! (`Uint8ArrayGet` is safely integer-valued because its accessor returns `0`
-//! OOB — a general typed-array read does not.) So marking such a local i32
+//! (`Uint8ArrayGet` / `BufferIndexGet` have the same Number-or-`undefined`
+//! contract as a general typed-array read.) So marking such a local i32
 //! unconditionally would let `let x = S[oob]; console.log(x)` print a number
 //! (`fptosi(undefined)` garbage / the seeded `0`) where JS prints `undefined`.
 //!
@@ -157,6 +157,19 @@ fn uint8array_get_is_byte_read(index: &Expr, numeric_locals: &HashSet<u32>) -> b
     super::uint8array_get_reads_a_byte(index, &mut |id| numeric_locals.contains(&id))
 }
 
+/// Byte element reads have the same possibly-OOB `undefined` seed semantics
+/// as the general integer typed-array reads above. Keep them out of the
+/// unconditional integer-local proof and admit them only through this
+/// analysis, whose observation walk proves that `undefined` and its i32 image
+/// `0` cannot be distinguished.
+fn is_byte_i32_image_seed_read(e: &Expr, numeric_locals: &HashSet<u32>) -> bool {
+    match e {
+        Expr::Uint8ArrayGet { index, .. } => uint8array_get_is_byte_read(index, numeric_locals),
+        Expr::BufferIndexGet { .. } => true,
+        _ => false,
+    }
+}
+
 fn is_bitwise_binop(op: BinaryOp) -> bool {
     matches!(
         op,
@@ -187,7 +200,9 @@ fn write_is_i32_producing_safe(
         // already guarantees every observation is ToInt32-coercing — so an
         // `undefined` write is indistinguishable from the 0 it becomes.
         Expr::Undefined => true,
-        // Byte reads: `0` OOB, always integer — #7700: with a numeric key.
+        // Byte reads are integer in-bounds and `undefined` OOB. Rule (2)
+        // makes the latter observationally equivalent to its i32 image `0`.
+        // #7700: `Uint8ArrayGet` qualifies only with a numeric key.
         Expr::Uint8ArrayGet { index, .. } => uint8array_get_is_byte_read(index, numeric_locals),
         Expr::BufferIndexGet { .. } => true,
         // Int-kind typed-array element read (possibly OOB → `undefined`).
@@ -215,12 +230,10 @@ fn write_establishes_exact_i32(
     e: &Expr,
     types: &HashMap<u32, HirType>,
     ta_lens: &HashMap<u32, i64>,
-    numeric_locals: &HashSet<u32>,
+    _numeric_locals: &HashSet<u32>,
 ) -> bool {
     match e {
         Expr::Integer(n) => super::i32_locals::integer_literal_fits_i32(*n),
-        Expr::Uint8ArrayGet { index, .. } => uint8array_get_is_byte_read(index, numeric_locals),
-        Expr::BufferIndexGet { .. } => true,
         Expr::IndexGet { object, index } => {
             receiver_is_int_kind_ta(object, types)
                 && matches!(object.as_ref(), Expr::LocalGet(arr)
@@ -271,7 +284,7 @@ struct Facts<'a> {
 /// legs, all enforced by the caller:
 /// - operands must be undefined-free EXACT int32 values — an in-bounds-PROVEN
 ///   int-TA read (static window < known constant length), an i32 literal, a
-///   bitwise/`~`/`Math.imul` result, a byte read, or another wrap-i32/strict
+///   bitwise/`~`/`Math.imul` result, or another wrap-i32/strict
 ///   candidate (whose slot holds the ToInt32 image by induction);
 /// - the additive write must be STRAIGHT-LINE (not inside any loop): a
 ///   loop-carried additive chain grows the true float unboundedly until f64
@@ -293,9 +306,6 @@ fn additive_write_admissible(
     match e {
         Expr::Integer(n) => super::i32_locals::integer_literal_fits_i32(*n),
         Expr::LocalGet(id) => pool.contains(id),
-        // #7700: a byte read only with a numeric key.
-        Expr::Uint8ArrayGet { index, .. } => uint8array_get_is_byte_read(index, numeric_locals),
-        Expr::BufferIndexGet { .. } => true,
         // In-bounds-proven int-kind typed-array read: never `undefined`.
         Expr::IndexGet { object, index } => {
             receiver_is_int_kind_ta(object, types)
@@ -343,10 +353,6 @@ pub(super) fn write_establishes_number(
 ) -> bool {
     match e {
         Expr::Integer(_) | Expr::Number(_) => true,
-        // Byte reads return `0` OOB — always a number, with a numeric key
-        // (#7700).
-        Expr::Uint8ArrayGet { index, .. } => uint8array_get_is_byte_read(index, numeric_locals),
-        Expr::BufferIndexGet { .. } => true,
         // Bitwise / `~` / `Math.imul` are number-or-throw (a throw means the
         // write never completes).
         Expr::Binary { op, .. } if is_bitwise_binop(*op) => true,
@@ -681,6 +687,18 @@ pub fn collect_int_valued_ta_locals(
         false,
         &mut facts,
     );
+    // The ordinary integer-local proof cannot admit byte reads because their
+    // value is `undefined` out of bounds. Seed them here instead, beside the
+    // general int-typed-array reads, so coercing-only users retain the i32
+    // optimization while bare consumers preserve the boxed value.
+    facts
+        .seeded
+        .extend(facts.writes.iter().filter_map(|(id, writes)| {
+            writes
+                .iter()
+                .any(|(write, _)| is_byte_i32_image_seed_read(write, &numeric_locals))
+                .then_some(*id)
+        }));
     // Flow leg of the wrap-i32 additive extension: targets of additive-shaped
     // writes whose spine operands were not provably NUMBERS at the write site
     // (an `undefined`-able operand breaks `image == ToInt32(true)` through a

--- a/crates/perry-codegen/src/collectors/int_valued_ta_locals/tests.rs
+++ b/crates/perry-codegen/src/collectors/int_valued_ta_locals/tests.rs
@@ -35,6 +35,13 @@ fn idx_get(arr_id: u32, idx: Expr) -> Expr {
     }
 }
 
+fn u8_get(arr_id: u32, idx: Expr) -> Expr {
+    Expr::Uint8ArrayGet {
+        array: Box::new(Expr::LocalGet(arr_id)),
+        index: Box::new(idx),
+    }
+}
+
 /// Params: `arr: Int32Array` (id 0), `off: number` (id 1) unless overridden.
 fn int32_array_param(id: u32) -> Param {
     Param {
@@ -200,6 +207,64 @@ fn returned_bitwise_result_keeps_local_eligible() {
         got.contains(&5),
         "bitwise-only local wrongly excluded: {got:?}"
     );
+}
+
+fn assert_byte_read_uses_observation_constrained_i32_proof(read: Expr) {
+    let bare_push = vec![
+        let_stmt(5, HirType::Any, Some(read.clone())),
+        Stmt::Expr(Expr::ArrayPush {
+            array_id: 6,
+            value: Box::new(Expr::LocalGet(5)),
+            field_writeback: None,
+        }),
+    ];
+    let ordinary = super::super::integer_locals::collect_integer_locals(
+        &bare_push,
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::new(),
+    );
+    assert!(
+        !ordinary.contains(&5),
+        "an OOB-capable byte read must not enter the unconditional proof: {ordinary:?}"
+    );
+    assert!(
+        !run(&bare_push, &[]).contains(&5),
+        "a bare push observes undefined-vs-zero"
+    );
+
+    let coerced = vec![
+        let_stmt(5, HirType::Any, Some(read)),
+        Stmt::Return(Some(bin(
+            BinaryOp::BitOr,
+            Expr::LocalGet(5),
+            Expr::Integer(0),
+        ))),
+    ];
+    assert!(
+        run(&coerced, &[]).contains(&5),
+        "a ToInt32-only observation should retain the byte-read i32 image"
+    );
+}
+
+#[test]
+fn uint8array_read_uses_observation_constrained_i32_proof() {
+    // `u8[99]` is `undefined`, not the byte accessor's native `0` sentinel.
+    // A bare array push observes that distinction, while `u8[99] | 0` does
+    // not. The ordinary integer proof must reject both; only this analysis may
+    // recover the coercing case.
+    assert_byte_read_uses_observation_constrained_i32_proof(u8_get(0, Expr::Integer(99)));
+}
+
+#[test]
+fn buffer_read_uses_observation_constrained_i32_proof() {
+    // Buffer has the same OOB value contract and native byte sentinel as
+    // Uint8Array, so it must follow the same representation proof.
+    assert_byte_read_uses_observation_constrained_i32_proof(Expr::BufferIndexGet {
+        buffer: Box::new(Expr::LocalGet(0)),
+        index: Box::new(Expr::Integer(99)),
+    });
 }
 
 #[test]

--- a/crates/perry-codegen/src/collectors/integer_locals.rs
+++ b/crates/perry-codegen/src/collectors/integer_locals.rs
@@ -767,13 +767,6 @@ fn int32_producing_deps(
             deps.insert(*id);
             true
         }
-        // #7700: a byte read, hence integer-valued, only when the KEY is a
-        // number. `const it = u8[Symbol.iterator]` is a function; answering
-        // `true` here gave it an i32 slot and `typeof it` reported `number`.
-        Expr::Uint8ArrayGet { index, .. } => {
-            super::uint8array_get_reads_a_byte(index, &mut |id| numeric_locals.contains(&id))
-        }
-        Expr::BufferIndexGet { .. } => true,
         Expr::MathImul(_, _) => true,
         // Issue #50 bridge: element access on a flat-const 2D int array
         // produces i32. The flat-const facts are immutable within this
@@ -1032,8 +1025,6 @@ pub fn collect_flat_row_aliases(
 ///   - (issue #49) `LocalGet(id)` when `id` is itself in `known_int_locals` —
 ///     enables the accumulator pattern `acc = acc + int_expr` without
 ///     requiring a `| 0` wrapper on every write.
-///   - (issue #49) `Uint8ArrayGet` / `BufferIndexGet`: typed-array byte
-///     reads return u8 values; always fit in i32.
 ///   - (issue #49) `Add` / `Sub` / `Mul` when both operands are
 ///     int-producing. The sum/product may overflow i32, but the existing
 ///     i32-slot machinery already accepts this risk — the double slot is
@@ -1101,11 +1092,6 @@ pub fn is_int32_producing_expr(
                 | BinaryOp::UShr
         ),
         Expr::LocalGet(id) => known_int_locals.contains(id),
-        // #7700: a byte read, hence integer-valued, only with a numeric key.
-        Expr::Uint8ArrayGet { index, .. } => {
-            super::uint8array_get_reads_a_byte(index, &mut |id| numeric_locals.contains(&id))
-        }
-        Expr::BufferIndexGet { .. } => true,
         Expr::MathImul(_, _) => true, // Math.imul always returns i32
         // Issue #50 bridge: element access on a flat-const 2D int array
         // produces i32. Two shapes:

--- a/test-files/test_gap_uint8array_oob_push_9039.ts
+++ b/test-files/test_gap_uint8array_oob_push_9039.ts
@@ -1,0 +1,9 @@
+const u = new Uint8Array([7, 8, 9]);
+const a: number[] = [];
+
+for (let i = 0; i < 3; i++) {
+  const x = u[99];
+  a.push(x);
+}
+
+console.log(JSON.stringify(a), u[99], typeof u[99]);


### PR DESCRIPTION
## Summary

- keep out-of-bounds-capable Uint8Array and Buffer reads out of the unconditional integer-local proof
- route byte-read locals through the observation-constrained i32 analysis so coercing consumers stay optimized while bare consumers preserve undefined
- add unit coverage plus a Node-parity regression for the array-push reproducer

## Tests

- cargo fmt --all -- --check
- cargo test -p perry-codegen --lib (1346 passed, 1 ignored)
- ./run_parity_tests.sh --filter uint8array_oob_push_9039
- ./run_parity_tests.sh --filter uint8array_nonnumeric_key_7700

Closes #9039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed out-of-bounds `Uint8Array` and `Buffer` reads so they remain `undefined` when stored in regular arrays, instead of becoming `0`.
  * Corrected type handling for byte reads while preserving expected behavior when values are explicitly coerced to integers.

* **Tests**
  * Added coverage for out-of-bounds typed-array and buffer reads, including array contents and reported value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->