### PR TITLE
fix(runtime): expose iterator helper next values

### DIFF
--- a/changelog.d/9068-iterator-helper-next-read.md
+++ b/changelog.d/9068-iterator-helper-next-read.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Iterator-helper objects now inherit a real `Iterator Helper.prototype.next`
+  method. Reading `helper.next` therefore returns a callable with the same
+  receiver and brand-check behavior as Node, so patterns such as
+  `const original = helper.next.bind(helper)` can delegate to the builtin
+  advance instead of failing because the property read returned `undefined`
+  (#9068).

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -435,11 +435,14 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
         | Expr::ArrayWith { .. }
         | Expr::ObjectValues(_)
         | Expr::ObjectEntries(_)
-        | Expr::ArrayEntries { .. }
-        | Expr::ArrayKeys { .. }
-        | Expr::ArrayValues { .. }
         | Expr::StringMatch { .. } => hir_inferred_refinable_type(ctx, init)
             .or_else(|| Some(HirType::Array(Box::new(HirType::Any)))),
+        // #9068: these are iterator objects, despite their Array-producing
+        // receivers. Refining them to Array makes a later `.map()` emit
+        // `js_array_map` against the iterator object's header.
+        Expr::ArrayEntries { .. } | Expr::ArrayKeys { .. } | Expr::ArrayValues { .. } => {
+            Some(HirType::Object(Default::default()))
+        }
         Expr::StringMatchAll { .. } => Some(HirType::Any),
         // TextEncoder.encode(str) — runtime returns a BufferHeader with
         // packed u8 bytes (same shape as `new Uint8Array([...])`). Refining

--- a/crates/perry-hir/src/analysis/value_types.rs
+++ b/crates/perry-hir/src/analysis/value_types.rs
@@ -778,12 +778,13 @@ pub fn infer_expr_type<F: HirTypeFacts + ?Sized>(expr: &Expr, env: &F) -> Type {
         Expr::ArrayReverseValue { receiver } | Expr::ArrayCopyWithinValue { receiver, .. } => {
             infer_expr_type(receiver, env)
         }
-        Expr::ArrayEntries(array) => Type::Array(Box::new(Type::Tuple(vec![
-            Type::Number,
-            array_element_type_from_expr(array, env),
-        ]))),
-        Expr::ArrayKeys(_) => Type::Array(Box::new(Type::Number)),
-        Expr::ArrayValues(array) => array_type_from_expr(array, env),
+        // These HIR nodes lower to real `.next()`-bearing Array Iterator
+        // objects, not eager arrays (#2384). Keeping an Array type here makes
+        // codegen devirtualize chained helper calls such as
+        // `[1].values().map(f)` back into `Array.prototype.map` (#9068).
+        Expr::ArrayEntries(_) | Expr::ArrayKeys(_) | Expr::ArrayValues(_) => {
+            Type::Object(ObjectType::default())
+        }
         Expr::ArrayPop(array_id) | Expr::ArrayShift(array_id) => {
             optional_type(array_element_type_from_local(*array_id, env))
         }

--- a/crates/perry-hir/src/analysis/value_types_tests.rs
+++ b/crates/perry-hir/src/analysis/value_types_tests.rs
@@ -1101,11 +1101,11 @@ fn infers_array_methods_from_receiver_facts() {
     );
     assert_eq!(
         infer_expr_type(&Expr::ArrayValues(Box::new(Expr::LocalGet(1))), &env),
-        Type::Array(Box::new(Type::String))
+        Type::Object(Default::default())
     );
     assert_eq!(
         infer_expr_type(&Expr::ArrayEntries(Box::new(Expr::LocalGet(1))), &env),
-        Type::Array(Box::new(Type::Tuple(vec![Type::Number, Type::String])))
+        Type::Object(Default::default())
     );
     assert_eq!(
         infer_expr_type(

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1743,9 +1743,9 @@ pub enum Expr {
         start: Box<Expr>,
         end: Option<Box<Expr>>,
     }, // Array.prototype.copyWithin.call(arrayLike, target, start, end?) -> same receiver
-    ArrayEntries(Box<Expr>), // arr.entries() -> Array<[index, value]> (eager materialization)
-    ArrayKeys(Box<Expr>),    // arr.keys() -> Array<index>
-    ArrayValues(Box<Expr>),  // arr.values() -> Array<value> (essentially clone)
+    ArrayEntries(Box<Expr>), // arr.entries() -> Array Iterator object
+    ArrayKeys(Box<Expr>),    // arr.keys() -> Array Iterator object
+    ArrayValues(Box<Expr>),  // arr.values() -> Array Iterator object
 
     /// `Array.prototype.<method>.call/apply(receiver, ...args)` (and the
     /// bound-local form `const m = [].map; m.call(receiver, ...)`) dispatched

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -207,15 +207,13 @@ fn chain_roots_at_stream(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     }
 }
 
-/// #2874: does this expression's method chain originate from
-/// `Iterator.from(...)` (optionally through lazy helpers `map`/`filter`/
-/// `take`/`drop`/`flatMap`)? Such a chain yields a lazy iterator-helper
-/// OBJECT, not an array, so it must NOT be folded into `Expr::Array<Method>`
-/// ops — `js_array_map` would read garbage out of the helper's header. Keep it
-/// on dynamic dispatch so `dispatch_iterator_helper_method` runs. Mirrors
-/// `chain_roots_at_stream`; AST-only (no type info), so it catches the common
-/// inline-chain form.
-fn chain_roots_at_iterator_from(expr: &ast::Expr) -> bool {
+/// #2874 / #9068: does this expression's method chain originate from a builtin
+/// iterator producer (`Iterator.from(...)` or an Array's `.values()` / `.keys()`
+/// / `.entries()`), optionally through lazy iterator helpers? Such a chain
+/// yields an iterator OBJECT, not an array, so it must NOT be folded into
+/// `Expr::Array<Method>` ops. Keep it on dynamic dispatch so the iterator-helper
+/// dispatcher runs. Mirrors `chain_roots_at_stream`.
+fn chain_roots_at_builtin_iterator(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
     let expr = unwrap_transparent_expr(expr);
     let ast::Expr::Call(call) = expr else {
         return false;
@@ -235,8 +233,14 @@ fn chain_roots_at_iterator_from(expr: &ast::Expr) -> bool {
             unwrap_transparent_expr(m.obj.as_ref()),
             ast::Expr::Ident(i) if i.sym.as_ref() == "Iterator"
         ),
+        // Array iterator factories are lazy iterator objects. Require a proven
+        // Array root so a user object's unrelated `values()` method is not
+        // captured by this builtin-only guard.
+        "values" | "keys" | "entries" => chain_roots_at_array(ctx, &m.obj),
         // Lazy helpers preserve the helper — recurse into the receiver.
-        "map" | "filter" | "take" | "drop" | "flatMap" => chain_roots_at_iterator_from(&m.obj),
+        "map" | "filter" | "take" | "drop" | "flatMap" => {
+            chain_roots_at_builtin_iterator(ctx, &m.obj)
+        }
         _ => false,
     }
 }
@@ -624,7 +628,7 @@ pub(super) fn try_array_only_methods(
                 // dynamic dispatch so the runtime's iterator-helper stubs run.
                 let recv_is_class = recv_is_class
                     || chain_roots_at_stream(ctx, member_obj)
-                    || chain_roots_at_iterator_from(member_obj)
+                    || chain_roots_at_builtin_iterator(ctx, member_obj)
                     || is_util_mime_params_receiver(ctx, member_obj);
                 // thisArg routing: the dense `Expr::Array<Method>` fast paths
                 // carry only the callback and silently drop a 2nd positional

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -52,6 +52,25 @@ fn array_inference_is_revoked_after_plain_object_assignment() {
 }
 
 #[test]
+fn array_iterator_helper_chain_is_not_lowered_as_array_map() {
+    let source = "const helper = [1, 2].values().map((x) => x * 2);";
+    let module =
+        perry_parser::parse_typescript(source, "iterator-helper-map.ts").expect("source parses");
+    let hir = super::lower_module(&module, "iterator-helper-map", "iterator-helper-map.ts")
+        .expect("source lowers");
+    let dump = format!("{hir:#?}");
+
+    assert!(
+        dump.contains("ArrayValues"),
+        "the Array iterator producer must remain in the lowered chain: {dump}"
+    );
+    assert!(
+        !dump.contains("ArrayMap"),
+        "an iterator's `.map()` must use dynamic helper dispatch, not Array.prototype.map: {dump}"
+    );
+}
+
+#[test]
 fn local_declaration_span_survives_ast_to_hir_lowering() {
     let source = "function build() {\n  const boxed = makeValue();\n  return boxed;\n}\n";
     let module = perry_parser::parse_typescript(source, "span.ts").expect("source parses");

--- a/crates/perry-runtime/src/gc/tests/lazy_intrinsic_towers.rs
+++ b/crates/perry-runtime/src/gc/tests/lazy_intrinsic_towers.rs
@@ -253,7 +253,7 @@ fn realm_owned_intrinsic_module_and_storage_roots_are_distinct() {
     let a = a.join().expect("agent A panicked");
     let b = b.join().expect("agent B panicked");
 
-    assert_eq!(a.len(), 25, "the gate must cover every #8002/#8003 root");
+    assert_eq!(a.len(), 26, "the gate must cover every #8002/#8003 root");
     assert_eq!(a.len(), b.len());
     for ((a_name, a_slot, a_root), (b_name, b_slot, b_root)) in a.iter().zip(&b) {
         assert_eq!(a_name, b_name, "snapshot wiring diverged between agents");

--- a/crates/perry-runtime/src/iterator_helpers.rs
+++ b/crates/perry-runtime/src/iterator_helpers.rs
@@ -221,6 +221,11 @@ unsafe fn alloc_helper(op: i32, source: f64, arg: f64) -> f64 {
         _ => f64::from_bits(TAG_UNDEFINED),
     };
     js_object_set_field(obj, 3, JSValue::from_bits(state.to_bits()));
+    // Helper objects have their own `%Iterator Helper Prototype%`, whose
+    // intrinsic `next` is readable as a function value. This also gives every
+    // helper the shared `%IteratorPrototype%` parent used by the other builtin
+    // iterator families.
+    crate::object::attach_iterator_prototype(obj, ITERATOR_HELPER_CLASS_ID);
     js_nanbox_pointer(obj as i64)
 }
 
@@ -346,6 +351,14 @@ unsafe fn helper_next(obj: *mut ObjectHeader) -> f64 {
     }
 }
 
+/// Run the intrinsic `Iterator Helper.prototype.next` algorithm without
+/// consulting instance or prototype overrides. The canonical prototype thunk
+/// uses this entry point so a saved `helper.next.bind(helper)` keeps advancing
+/// the helper it captured even if user code later replaces a `next` property.
+pub(crate) unsafe fn iterator_helper_next_builtin(obj: *mut ObjectHeader) -> f64 {
+    helper_next(obj)
+}
+
 /// Drain the helper iterator fully into a `*mut ArrayHeader` (NaN-box yourself).
 unsafe fn helper_to_array(obj: *mut ObjectHeader) -> f64 {
     let mut arr = crate::array::js_array_alloc(8);
@@ -415,6 +428,31 @@ pub unsafe fn maybe_dispatch_helper_on_iterator(
     }
     let self_f64 = js_nanbox_pointer(obj as i64);
     let wrapped = js_iterator_from(self_f64);
+    let wrapped_ptr = js_nanbox_get_pointer(wrapped) as *mut ObjectHeader;
+    Some(dispatch_iterator_helper_method(
+        wrapped_ptr,
+        method_name,
+        args_ptr,
+        args_len,
+    ))
+}
+
+/// Dispatch an iterator-helper method on a runtime builtin iterator object.
+/// The native iterator class-id arms normally handle protocol methods such as
+/// `next` directly; helper names must instead wrap that iterator and enter the
+/// lazy helper dispatcher. Callers have already verified the builtin iterator
+/// class id before reaching this function.
+pub unsafe fn maybe_dispatch_helper_on_builtin_iterator(
+    obj: *mut ObjectHeader,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if !is_iterator_helper_method(method_name) {
+        return None;
+    }
+    let source = js_nanbox_pointer(obj as i64);
+    let wrapped = js_iterator_from(source);
     let wrapped_ptr = js_nanbox_get_pointer(wrapped) as *mut ObjectHeader;
     Some(dispatch_iterator_helper_method(
         wrapped_ptr,

--- a/crates/perry-runtime/src/iterator_helpers/tests.rs
+++ b/crates/perry-runtime/src/iterator_helpers/tests.rs
@@ -230,6 +230,88 @@ fn iterator_from_on_an_existing_helper_returns_it_unchanged() {
 }
 
 #[test]
+fn helper_inherits_a_callable_next_from_its_shared_prototype() {
+    unsafe {
+        let h = helper_over(&[1.0]);
+        let obj = crate::value::js_nanbox_get_pointer(h) as *const ObjectHeader;
+        let expected = crate::object::iterator_prototype_for_class_id(ITERATOR_HELPER_CLASS_ID)
+            .expect("iterator-helper class id must have a prototype");
+        assert_eq!(
+            crate::object::prototype_chain::object_static_prototype(obj as usize),
+            Some(expected.to_bits()),
+            "a helper allocation must attach the helper-family prototype"
+        );
+        assert_eq!(
+            crate::object::js_object_get_prototype_of(h).to_bits(),
+            expected.to_bits(),
+            "Object.getPrototypeOf(helper) must return the helper-family prototype"
+        );
+
+        let next_key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+        let next = crate::object::js_object_get_field_by_name(obj, next_key);
+        let next_ptr = crate::value::js_nanbox_get_pointer(f64::from_bits(next.bits()));
+        assert!(
+            crate::closure::is_closure_ptr(next_ptr as usize),
+            "helper.next must resolve to a callable inherited method"
+        );
+    }
+}
+
+#[test]
+fn helper_created_from_a_raw_iterator_inherits_the_same_next() {
+    unsafe {
+        let array = number_array(&[1.0]);
+        let array_iter = crate::array::array_values_iter(array);
+        let helper = tower(array_iter, "map", &[closure1(double_it)]);
+        let obj = crate::value::js_nanbox_get_pointer(helper) as *const ObjectHeader;
+        assert_eq!((*obj).class_id, ITERATOR_HELPER_CLASS_ID);
+
+        let expected = crate::object::iterator_prototype_for_class_id(ITERATOR_HELPER_CLASS_ID)
+            .expect("iterator-helper class id must have a prototype");
+        assert_eq!(
+            crate::object::prototype_chain::object_static_prototype(obj as usize),
+            Some(expected.to_bits()),
+            "raw-iterator helper dispatch must preserve the helper prototype"
+        );
+        let next_key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+        let next = crate::object::js_object_get_field_by_name(obj, next_key);
+        let next_ptr = crate::value::js_nanbox_get_pointer(f64::from_bits(next.bits()));
+        assert!(crate::closure::is_closure_ptr(next_ptr as usize));
+    }
+}
+
+#[test]
+fn helper_next_rejects_a_non_helper_iterator_receiver() {
+    unsafe {
+        let array_iter = crate::array::array_values_iter(number_array(&[9.0]));
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let array_iter_h = scope.root_nanbox_f64(array_iter);
+
+        let helper = helper_over(&[1.0]);
+        let helper_obj = crate::value::js_nanbox_get_pointer(helper) as *const ObjectHeader;
+        let next_key = crate::string::js_string_from_bytes(b"next".as_ptr(), 4);
+        let next = crate::object::js_object_get_field_by_name(helper_obj, next_key);
+        let next_h = scope.root_nanbox_f64(f64::from_bits(next.bits()));
+
+        // This is the runtime equivalent of `helper.next.call(arrayIter)`. The
+        // canonical helper method must enforce the Iterator Helper brand; it
+        // cannot fall through to the array iterator's own `next` algorithm.
+        let rebound = crate::closure::clone_closure_rebind_this(
+            next_h.get_nanbox_u64(),
+            array_iter_h.get_nanbox_f64(),
+        );
+        let rebound_h = scope.root_nanbox_f64(f64::from_bits(rebound));
+        let result = crate::exception::js_call_catching(|| {
+            crate::closure::js_native_call_value(rebound_h.get_nanbox_f64(), std::ptr::null(), 0)
+        });
+        assert!(
+            result.is_err(),
+            "%Iterator Helper Prototype%.next must throw on an array iterator receiver"
+        );
+    }
+}
+
+#[test]
 fn map_returns_a_helper_and_transforms_lazily() {
     unsafe {
         let m = tower(helper_over(&[1.0, 2.0, 3.0]), "map", &[closure1(double_it)]);

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -1,5 +1,6 @@
 //! Shared `%IteratorPrototype%`-style prototype singletons for the built-in
-//! iterator objects (Array / Map / Set / String iterators).
+//! iterator objects (Array / Map / Set / String / RegExp-string / Iterator
+//! Helper iterators).
 //!
 //! test262's `verifyProperty` suite (built-ins/{Array,Map,Set,String}
 //! IteratorPrototype) requires that:
@@ -47,6 +48,7 @@ crate::perry_thread_local! {
     static SET_ITERATOR_PROTOTYPE_PTR_SLOT: AtomicI64 = const { AtomicI64::new(0) };
     static STRING_ITERATOR_PROTOTYPE_PTR_SLOT: AtomicI64 = const { AtomicI64::new(0) };
     static REGEXP_STRING_ITERATOR_PROTOTYPE_PTR_SLOT: AtomicI64 = const { AtomicI64::new(0) };
+    static ITERATOR_HELPER_PROTOTYPE_PTR_SLOT: AtomicI64 = const { AtomicI64::new(0) };
 }
 
 pub(crate) static ITERATOR_PROTOTYPE_PTR: super::RealmAtomicI64 =
@@ -61,6 +63,24 @@ pub(crate) static STRING_ITERATOR_PROTOTYPE_PTR: super::RealmAtomicI64 =
     super::RealmAtomicI64::new(&STRING_ITERATOR_PROTOTYPE_PTR_SLOT);
 pub(crate) static REGEXP_STRING_ITERATOR_PROTOTYPE_PTR: super::RealmAtomicI64 =
     super::RealmAtomicI64::new(&REGEXP_STRING_ITERATOR_PROTOTYPE_PTR_SLOT);
+pub(crate) static ITERATOR_HELPER_PROTOTYPE_PTR: super::RealmAtomicI64 =
+    super::RealmAtomicI64::new(&ITERATOR_HELPER_PROTOTYPE_PTR_SLOT);
+
+/// Resolve and validate the implicit-`this` object shared by the family
+/// prototype thunks. Keeping the raw-address probe here gives both the generic
+/// family dispatcher and the helper-specific brand check one audited path.
+unsafe fn implicit_this_iterator_object() -> Option<*mut ObjectHeader> {
+    let this = super::js_implicit_this_get();
+    let jv = JSValue::from_bits(this.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let obj = jv.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    if obj.is_null() || !super::is_valid_obj_ptr(obj as *const u8) {
+        return None;
+    }
+    Some(obj)
+}
 
 /// Dispatch `method` on the implicit-`this` iterator instance, routing by class
 /// id to the matching existing iterator dispatcher. Shared by the per-family
@@ -69,15 +89,9 @@ pub(crate) static REGEXP_STRING_ITERATOR_PROTOTYPE_PTR: super::RealmAtomicI64 =
 /// throw when `this` is not a recognized iterator (test262 `this-not-object` /
 /// `does-not-have-...-internal-slots` brand checks).
 unsafe fn dispatch_on_implicit_this(method: &str) -> f64 {
-    let this = super::js_implicit_this_get();
-    let jv = JSValue::from_bits(this.to_bits());
-    if !jv.is_pointer() {
+    let Some(obj) = implicit_this_iterator_object() else {
         return brand_type_error(method);
-    }
-    let obj = jv.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
-    if obj.is_null() || !super::is_valid_obj_ptr(obj as *const u8) {
-        return brand_type_error(method);
-    }
+    };
     let class_id = (*obj).class_id;
     // The `_builtin` variants skip the own-`next` override probe (#9019):
     // these thunks ARE the canonical prototype `next` functions, so invoking
@@ -143,6 +157,24 @@ extern "C" fn regexp_string_iterator_next_thunk(
     unsafe { dispatch_on_implicit_this("next") }
 }
 
+/// `%Iterator Helper Prototype%.next` has a helper-specific brand check. Use
+/// the intrinsic algorithm directly rather than the general method dispatcher:
+/// a saved/bound canonical method must not re-enter a later `next` override.
+extern "C" fn iterator_helper_next_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    unsafe {
+        let Some(obj) = implicit_this_iterator_object() else {
+            return brand_type_error("next");
+        };
+        if (*obj).class_id != crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID {
+            return brand_type_error("next");
+        }
+        crate::iterator_helpers::iterator_helper_next_builtin(obj)
+    }
+}
+
 /// `%IteratorPrototype%[Symbol.iterator]()` returns `this` (the iterator).
 extern "C" fn iterator_proto_symbol_iterator_thunk(
     _c: *const crate::closure::ClosureHeader,
@@ -199,6 +231,8 @@ fn build_iterator_prototypes() {
         "RegExp String Iterator",
         shared,
     );
+    let iterator_helper_proto =
+        build_family_proto(iterator_helper_next_thunk, "Iterator Helper", shared);
 
     ITERATOR_PROTOTYPE_PTR.store(shared as i64, Ordering::Release);
     ARRAY_ITERATOR_PROTOTYPE_PTR.store(array_proto as i64, Ordering::Release);
@@ -206,6 +240,7 @@ fn build_iterator_prototypes() {
     SET_ITERATOR_PROTOTYPE_PTR.store(set_proto as i64, Ordering::Release);
     STRING_ITERATOR_PROTOTYPE_PTR.store(string_proto as i64, Ordering::Release);
     REGEXP_STRING_ITERATOR_PROTOTYPE_PTR.store(regexp_string_proto as i64, Ordering::Release);
+    ITERATOR_HELPER_PROTOTYPE_PTR.store(iterator_helper_proto as i64, Ordering::Release);
 }
 
 /// Install `[Symbol.iterator]` on the shared parent as a real method whose
@@ -319,6 +354,7 @@ pub(crate) fn iterator_prototype_for_class_id(class_id: u32) -> Option<f64> {
         crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
         crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
         crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID => &REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
+        crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID => &ITERATOR_HELPER_PROTOTYPE_PTR,
         _ => return None,
     };
     let ptr = slot.load(Ordering::Acquire);
@@ -344,6 +380,7 @@ pub(crate) fn attach_iterator_prototype(obj_ptr: *mut ObjectHeader, class_id: u3
         crate::collection_iter_object::SET_ITERATOR_CLASS_ID => &SET_ITERATOR_PROTOTYPE_PTR,
         crate::string::STRING_ITERATOR_CLASS_ID => &STRING_ITERATOR_PROTOTYPE_PTR,
         crate::regex::REGEXP_STRING_ITERATOR_CLASS_ID => &REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
+        crate::iterator_helpers::ITERATOR_HELPER_CLASS_ID => &ITERATOR_HELPER_PROTOTYPE_PTR,
         _ => return,
     };
     let proto_ptr = slot.load(Ordering::Acquire);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1241,9 +1241,9 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
     }
     async_generator_queue::scan_async_generator_queue_roots_mut(visitor);
     collection_proto_thunks::scan_builtin_collection_method_roots_mut(visitor);
-    // Shared `%IteratorPrototype%`-style singletons for Array/Map/Set/String
-    // iterator objects. Each iterator instance's `[[Prototype]]` points here, so
-    // these must stay live for the lifetime of any iterator.
+    // Shared `%IteratorPrototype%`-style singletons for builtin iterator
+    // objects. Each iterator instance's `[[Prototype]]` points here, so these
+    // must stay live for the lifetime of any iterator.
     for slot in [
         &iterator_prototypes::ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::ARRAY_ITERATOR_PROTOTYPE_PTR,
@@ -1251,6 +1251,7 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         &iterator_prototypes::SET_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::STRING_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
+        &iterator_prototypes::ITERATOR_HELPER_PROTOTYPE_PTR,
     ] {
         slot.with_slot(|slot| {
             visitor.visit_atomic_i64_slot(slot, Ordering::Acquire, Ordering::Release);

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -363,6 +363,21 @@ pub(super) unsafe fn dispatch_raw_pointer(
                     ),
                 );
             }
+            // #9068: raw-pointer builtin iterators need lazy helper methods to
+            // enter the iterator-helper dispatcher before their protocol-only
+            // class-id dispatchers return `undefined` for the method name.
+            if crate::array::is_builtin_iterator_class_id(obj as usize) {
+                if let Some(result) =
+                    crate::iterator_helpers::maybe_dispatch_helper_on_builtin_iterator(
+                        obj as *mut ObjectHeader,
+                        method_name,
+                        args_ptr,
+                        args_len,
+                    )
+                {
+                    return Some(result);
+                }
+            }
             // Issue #1206: same class-id check as the NaN-boxed path above
             // so a raw-pointer iterator value (uncommon, but possible after
             // a bitcast) still routes through the iterator dispatcher.

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -804,6 +804,22 @@ pub(super) unsafe fn dispatch_handle(
                     ),
                 );
             }
+            // #9068: Array/Map/Set/String iterator objects expose lazy helper
+            // methods through Iterator.prototype. Their class-id dispatchers
+            // only implement protocol methods (`next`, `return`, ...), so route
+            // helper names through the wrapper before those early-return arms.
+            if crate::array::is_builtin_iterator_class_id(obj as usize) {
+                if let Some(result) =
+                    crate::iterator_helpers::maybe_dispatch_helper_on_builtin_iterator(
+                        obj as *mut ObjectHeader,
+                        method_name,
+                        args_ptr,
+                        args_len,
+                    )
+                {
+                    return Some(result);
+                }
+            }
             // Issue #1206: Buffer iterators returned from `buf.values()` etc.
             // have a dedicated class id so `.next()` lands here and dispatches
             // to the iterator-protocol helper without paying the generic

--- a/crates/perry-runtime/src/object/test_root_helpers.rs
+++ b/crates/perry-runtime/src/object/test_root_helpers.rs
@@ -192,6 +192,10 @@ pub(crate) fn test_realm_owned_root_snapshot() -> Vec<(&'static str, usize, u64)
             "REGEXP_STRING_ITERATOR_PROTOTYPE_PTR",
             &iterator_prototypes::REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
         ),
+        (
+            "ITERATOR_HELPER_PROTOTYPE_PTR",
+            &iterator_prototypes::ITERATOR_HELPER_PROTOTYPE_PTR,
+        ),
     ] {
         roots.push((
             name,

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -2109,6 +2109,11 @@
     },
     {
       "file": "crates/perry-runtime/src/object/iterator_prototypes.rs",
+      "name": "ITERATOR_HELPER_PROTOTYPE_PTR_SLOT",
+      "scanner": "scan_object_cache_roots_mut"
+    },
+    {
+      "file": "crates/perry-runtime/src/object/iterator_prototypes.rs",
       "name": "ITERATOR_PROTOTYPE_PTR_SLOT"
     },
     {

--- a/test-files/test_gap_iterator_helper_next_value_9068.ts
+++ b/test-files/test_gap_iterator_helper_next_value_9068.ts
@@ -1,0 +1,28 @@
+// #9068: iterator-helper objects dispatch `.next()` by class id but did not
+// inherit a callable `next` value.  Reading the method therefore returned
+// `undefined`, which made the standard bind-and-delegate pattern impossible.
+
+const helper: any = [1, 2].values().map((x: number) => x * 2);
+console.log("type", typeof helper.next);
+console.log("own", Object.prototype.hasOwnProperty.call(helper, "next"));
+const direct: any = Iterator.from([7]).map((x: number) => x);
+console.log("direct type", typeof direct.next);
+
+const helperPrototype = Object.getPrototypeOf(helper);
+console.log("prototype owns", Object.prototype.hasOwnProperty.call(helperPrototype, "next"));
+console.log("shared prototype", Object.getPrototypeOf([3].values().map((x: number) => x)) === helperPrototype);
+console.log("prototype tag", helperPrototype[Symbol.toStringTag]);
+
+const originalNext = helper.next.bind(helper);
+console.log("bound 1", JSON.stringify(originalNext()));
+console.log("bound 2", JSON.stringify(originalNext()));
+console.log("bound done", JSON.stringify(originalNext()));
+
+const other: any = [5].values().map((x: number) => x + 1);
+console.log("call other", JSON.stringify(helper.next.call(other)));
+
+try {
+  helper.next.call([9].values());
+} catch (error: any) {
+  console.log("brand", error.name);
+}


### PR DESCRIPTION
Fixes #9068

## Summary

- expose a shared `%Iterator Helper Prototype%` with an inherited callable `next` and the required helper brand check
- route raw built-in array iterators into iterator-helper dispatch and prevent eager `Array.prototype.map` lowering for `.values()`, `.keys()`, and `.entries()` chains
- correct stale HIR/codegen types for array iterator factories and add runtime, lowering, type-analysis, and Node-parity regressions

## Testing

Validated on `root@perrymaster.skelpo.net`:

- `scripts/run_lint_gates.sh` — all 60 gates passed; 2 CI-only gates skipped
- `cargo test -p perry-runtime iterator_helpers --no-fail-fast` — 19 passed
- `cargo test -p perry-hir --lib` — 358 passed, 1 ignored
- `cargo test -p perry-codegen --lib` — 1345 passed, 1 ignored
- `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --filter test_gap_iterator_helper_next_value_9068` — 1/1 passed, byte-identical to Node

No version bump is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Iterator helpers now expose a callable inherited `next` method.
  * Bound `next` methods continue advancing the correct helper, even after overrides.
  * Invalid receivers are rejected with the expected brand-check behavior.
  * Array iterator methods such as `keys()`, `values()`, and `entries()` now preserve iterator-helper behavior through chained operations.
  * Iterator-producing methods are correctly treated as iterators rather than eagerly materialized arrays.

* **Tests**
  * Added coverage for iterator-helper inheritance, chaining, binding, and receiver validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->