### PR TITLE
fix(runtime): class-ref receiver satisfies its own private brand check — pi's startup crash (3/3)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/ic_miss/private_member_access.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss/private_member_access.rs
@@ -270,6 +270,21 @@ fn private_evaluation_brand_matches(
     brand_owner: f64,
     declaring_class_id: u32,
 ) -> Option<bool> {
+    // A bare class REF receiver names the class's lexical self-binding
+    // (`class c { static create() { c.#o = ... } }` — the lru-cache guard
+    // pattern, minified into pi's bundle). Codegen hands the runtime the
+    // template ref, which carries no per-evaluation brand, so both brand
+    // paths below compared None against Some(_) and every closure-nested
+    // class expression's static private access threw "did not declare it".
+    // A private access with the ref as receiver can only be emitted from
+    // inside the class's own body (outside it, `c.#o` is a syntax error),
+    // where the self-binding denotes the CURRENT evaluation — the exact
+    // verdict the pre-brand static fallback (`class_ref_id(obj) == id`)
+    // always gave.
+    if crate::object::native_module::class_ref_id(obj) == Some(declaring_class_id) {
+        return Some(true);
+    }
+
     if let Some(expected) = current_private_lexical_brand(declaring_class_id) {
         let actual = private_evaluation_brand(obj, declaring_class_id);
         return Some(actual == Some(expected));

--- a/test-files/test_gap_9052_class_expr_self_ref_static_private.ts
+++ b/test-files/test_gap_9052_class_expr_self_ref_static_private.ts
@@ -1,0 +1,19 @@
+// lru-cache's construction-gate pattern (minified into pi's bundle): a
+// closure-nested NAMED class expression whose static method flips a static
+// private through the lexical self-binding. Codegen hands the runtime the
+// bare class REF as the receiver; the per-evaluation brand paths compared
+// its (nonexistent) brand against the current evaluation's and threw
+// "Cannot access private member from an object whose class did not declare
+// it" — pi's startup crash. A self-ref receiver can only be emitted from
+// inside the class's own body, where it denotes the current evaluation.
+const make = (): any => class c {
+  static #o = false;
+  static create(): any { c.#o = true; const i = new c(); c.#o = false; return i; }
+  ok = 0;
+  constructor() { if (!c.#o) throw new TypeError("gate"); this.ok = 1; }
+};
+const A: any = make(); const B: any = make();
+console.log("A:", A.create().ok, "B:", B.create().ok);
+let caught = "";
+try { new A(); } catch (e) { caught = "gated"; }
+console.log("direct-new:", caught);


### PR DESCRIPTION
The last of pi's three bring-up walls (with #9069 and #9073). **lru-cache's construction gate**, minified into pi's bundle:

```js
var make = () => class c {
  static #o = false;
  static create() { c.#o = true; const i = new c(); c.#o = false; return i; }
  constructor() { if (!c.#o) throw new TypeError(...); }
};
```

Codegen emits the bare class REF (INT32-tagged template id) as the receiver of `c.#o`. The ref carries no per-evaluation brand, so both evaluation-brand paths in `private_evaluation_brand_matches` compared `None` against the current evaluation's brand and threw `Cannot access private member from an object whose class did not declare it` at pi startup. Top-level class expressions dodge it (the lexical-brand machinery doesn't engage), which is why simple probes all passed — found by instrumenting the runtime throw to print the field name + ids (`name=#o`, declaring == receiver id) and grepping the bundle.

**Fix:** accept a class-ref receiver whose id equals the declaring class at the top of the matcher. Sound because a private access with the self-ref as receiver can only be emitted from inside that class's own body (outside it, `c.#o` is a syntax error), where the self-binding denotes the current evaluation — the same verdict the pre-brand static fallback always gave.

**Verification:** gap fixture `test_gap_9052` — two separate evaluations each gating on their own `#o`, plus the direct-`new` throw — node-identical; the closure-nested and top-level repro battery node-identical; 2807 runtime tests; fmt green. With all three fixes pi compiles AND boots (`--version` runs; GC-share numbers to follow on the PRs' shared branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed static private member access when referenced through a class’s own self-reference.
  * Prevented valid class operations from incorrectly failing with a declaration error.
  * Improved behavior for independently evaluated, closure-nested named classes.
  * Added coverage ensuring valid gated instances work while direct construction remains rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->