### PR TITLE
test(perry): serialize archive cache environment reads

### DIFF
--- a/changelog.d/9092-archive-cache-test-isolation.md
+++ b/changelog.d/9092-archive-cache-test-isolation.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Stabilized the archive-cache fallback/cache-hit test under the parallel `perry`
+  binary suite by serializing its process-global tool-environment reads with
+  sibling tests that temporarily replace `PATH`.

--- a/crates/perry/src/commands/compile/link/archive_cache.rs
+++ b/crates/perry/src/commands/compile/link/archive_cache.rs
@@ -314,6 +314,7 @@ fn hash_field(hasher: &mut Sha256, name: &str, value: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::env_lock;
 
     fn key(root: &Path, features: &[String], archives: &[PathBuf], target: &str) -> String {
         let runtime = root.join("runtime.a");
@@ -400,6 +401,10 @@ mod tests {
 
     #[test]
     fn preparation_safety_survives_fallback_and_cache_hit() {
+        // Cache keys include discovered archive tools, so every lookup reads
+        // process-global environment such as PATH. Keep sibling tests from
+        // changing that environment between this test's miss, store, and hit.
+        let _env = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         let runtime = root.join("runtime.a");


### PR DESCRIPTION
Fixes #9083.

The archive-cache safety test recomputes keys using discovered tool paths, so sibling tests that temporarily replace the process-global `PATH` can turn its expected cache hit into a miss. Acquire the shared test environment lock across the miss/store/hit sequence so all three lookups see one stable tool environment.

Validation:
- `cargo fmt --all -- --check`
- focused archive-cache test
- `RUST_MIN_STACK=16777216 cargo test -p perry --bins` (1056 passed)

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized archive-cache fallback and cache-hit tests when running in parallel.
  * Prevented intermittent test failures caused by concurrent environment setting changes.

* **Documentation**
  * Added a changelog entry describing the archive-cache test reliability improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->