### PR TITLE
fix(runtime): hide collection iterator return/throw methods

### DIFF
--- a/changelog.d/9093-collection-iterator-control-methods.md
+++ b/changelog.d/9093-collection-iterator-control-methods.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Map and Set iterator objects no longer expose synthetic `return` and `throw`
+  methods. Those generator-only properties now resolve through ordinary
+  prototype lookup, while `[Symbol.iterator]()` continues to return the
+  iterator itself and user-defined overrides still work (#9086).

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -144,11 +144,12 @@ pub(crate) unsafe fn own_data_field_by_name(
 /// the reserved floor since #9019 — shadows every synthetic method. This is
 /// also what makes user data properties on iterators readable at all: the
 /// old arm returned `undefined` for every non-`next` key without consulting
-/// own fields, so a stored value was write-only. Then the legacy bound
-/// synthetic methods (`return`/`throw`/`@@iterator`); `next` deliberately
-/// resolves through the caller's generic scans (`None`) so
-/// `iterator.next.call(other)` receives `other` and brand-checks; any other
-/// key is absent (`Some(undefined)`).
+/// own fields, so a stored value was write-only. `@@iterator` remains the only
+/// synthetic bound method: ordinary collection iterators do not have the
+/// generator-only `return`/`throw` methods (#9086). `next`, `return`, and
+/// `throw` deliberately resolve through the caller's generic scans (`None`),
+/// so the prototype chain remains authoritative; any other key is absent
+/// (`Some(undefined)`).
 pub(crate) unsafe fn map_set_iterator_property(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
@@ -160,8 +161,6 @@ pub(crate) unsafe fn map_set_iterator_property(
     let key_len = (*key).byte_len as usize;
     let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
     let bind_name: Option<&'static [u8]> = match key_bytes {
-        b"return" => Some(b"return"),
-        b"throw" => Some(b"throw"),
         b"@@iterator" => Some(b"@@iterator"),
         _ => None,
     };
@@ -170,7 +169,7 @@ pub(crate) unsafe fn map_set_iterator_property(
         let result = super::super::js_class_method_bind(this_f64, name.as_ptr(), name.len());
         return Some(JSValue::from_bits(result.to_bits()));
     }
-    if key_bytes == b"next" {
+    if matches!(key_bytes, b"next" | b"return" | b"throw") {
         return None;
     }
     Some(JSValue::undefined())

--- a/crates/perry/tests/issue_9086_collection_iterator_methods.rs
+++ b/crates/perry/tests/issue_9086_collection_iterator_methods.rs
@@ -1,0 +1,156 @@
+//! Regression coverage for #9086: ordinary collection/string iterators do not
+//! expose the generator-only `return` and `throw` methods.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    if cfg!(windows) {
+        target.join("x86_64-pc-windows-msvc").join("debug")
+    } else {
+        target.join("debug")
+    }
+}
+
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let mut command = Command::new(cargo);
+        command
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static");
+        if cfg!(windows) {
+            command.arg("--target").arg("x86_64-pc-windows-msvc");
+        }
+        let build = command.output().expect("build runtime archives");
+        assert!(
+            build.status.success(),
+            "runtime build failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let entry = dir.path().join("main.ts");
+    let binary = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write fixture");
+    ensure_runtime_archive();
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("--no-cache")
+        .arg("-o")
+        .arg(&binary)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", target_debug_dir())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&binary)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn ordinary_iterators_omit_generator_control_methods() {
+    let stdout = compile_and_run(
+        r#"
+function check(label: string, iterator: any) {
+  console.log(
+    label,
+    typeof iterator.return,
+    typeof iterator.throw,
+    "return" in iterator,
+    "throw" in iterator,
+    typeof iterator[Symbol.iterator],
+    iterator[Symbol.iterator]() === iterator,
+  );
+}
+
+check("map", new Map([[1, "a"]]).entries());
+check("set", new Set([1, 2]).values());
+check("string", "ab"[Symbol.iterator]());
+
+const patched: any = new Set([1, 2]).values();
+const ownReturn = function () {};
+const ownThrow = function () {};
+patched.return = ownReturn;
+patched.throw = ownThrow;
+console.log(
+  "own methods",
+  patched.return === ownReturn,
+  patched.throw === ownThrow,
+  "return" in patched,
+  "throw" in patched,
+);
+
+const inherited: any = new Map([[1, "a"]]).entries();
+const inheritedReturn = function () {};
+const inheritedThrow = function () {};
+const customPrototype = Object.create(Object.getPrototypeOf(inherited));
+customPrototype.return = inheritedReturn;
+customPrototype.throw = inheritedThrow;
+Object.setPrototypeOf(inherited, customPrototype);
+console.log(
+  "inherited methods",
+  inherited.return === inheritedReturn,
+  inherited.throw === inheritedThrow,
+  "return" in inherited,
+  "throw" in inherited,
+);
+
+function* values() { yield 1; }
+const generator: any = values();
+console.log("generator", typeof generator.return, typeof generator.throw);
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "map undefined undefined false false function true\n\
+         set undefined undefined false false function true\n\
+         string undefined undefined false false function true\n\
+         own methods true true true true\n\
+         inherited methods true true true true\n\
+         generator function function\n"
+    );
+}


### PR DESCRIPTION
## Summary

Stops ordinary Map and Set iterator objects from exposing generator-only `return` and `throw` methods while preserving their standard iterable identity and normal prototype lookup.

## Changes

- Removes the synthetic `return` / `throw` bindings from Map and Set iterator property reads.
- Falls through to ordinary prototype lookup for those names, preserving own and inherited user overrides.
- Adds executable regression coverage for Map, Set, string, and generator iterator behavior.

## Related issue

Fixes #9086

## Test plan

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] `cargo test -p perry --test issue_9086_collection_iterator_methods -- --nocapture`
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] (if user-facing) Added a `#[test]` integration regression in the affected crate.
- [x] (if CLI / stdlib / runtime API changed) Documentation is not needed; this restores existing ECMAScript behavior without adding an API.
- [ ] (if touching a platform UI backend) Not applicable.

## Screenshots / output

The regression test verifies that ordinary iterator `return` / `throw` reads are `undefined`, `in` reports them absent, `Symbol.iterator` remains callable and returns the receiver, own/inherited overrides still resolve, and generator methods remain functions.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Collection and string iterators no longer incorrectly expose generator-only `return` and `throw` methods.
  - Iterator property lookup now correctly respects inherited prototype methods and user-defined overrides.
  - The standard `[Symbol.iterator]()` behavior remains unchanged.
  - Generator iterators continue to provide their expected `return` and `throw` methods.

- **Tests**
  - Added regression coverage for map, set, string, and generator iterator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->