### PR TITLE
fix(runtime): coerce class refs before dynamic addition

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -168,9 +168,22 @@ unsafe fn is_nonprimitive_object_value(value: f64) -> bool {
 
 unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
     let jsval = JSValue::from_bits(value.to_bits());
-    if !jsval.is_pointer() || is_symbol_value(value) {
+    let is_class_ref = crate::object::class_ref_id(value).is_some();
+    if (!jsval.is_pointer() && !is_class_ref) || is_symbol_value(value) {
         return value;
     }
+
+    // #9087: a declared class used as a value is an Object even though Perry
+    // stores it as an INT32-tagged class id. It must therefore participate in
+    // ToPrimitive instead of reaching the numeric int32 arm below. Perform the
+    // ordinary Function-object valueOf/toString sequence; the
+    // inherited toString produces the class's synthetic function source and
+    // makes the addition concatenate. This also preserves an own static
+    // valueOf/toString override.
+    if is_class_ref {
+        return crate::value::ordinary_to_primitive_for_toprimitive(value, false);
+    }
+
     let ptr = jsval.as_pointer::<u8>() as usize;
     if ptr < 0x1000 {
         return value;

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -337,7 +337,7 @@ fn is_primitive_value(value: f64) -> bool {
     let jsval = JSValue::from_bits(value.to_bits());
     jsval.is_any_string()
         || jsval.is_number()
-        || jsval.is_int32()
+        || (jsval.is_int32() && crate::object::class_ref_id(value).is_none())
         || jsval.is_bool()
         || jsval.is_null()
         || jsval.is_undefined()

--- a/crates/perry/tests/issue_9087_class_ref_add.rs
+++ b/crates/perry/tests/issue_9087_class_ref_add.rs
@@ -1,0 +1,72 @@
+//! Regression for #9087: a declared class used as a value is represented by
+//! an INT32-tagged class id, but it is still a Function object for ECMAScript
+//! coercion. Dynamic `+` must ToPrimitive the class to its source string
+//! instead of adding the numeric class-id payload.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str) -> Output {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    Command::new(&output).output().expect("run compiled binary")
+}
+
+#[test]
+fn class_refs_use_string_concatenation_for_dynamic_add() {
+    let run = compile_and_run(
+        r#"
+class K { static m(): number { return 1; } }
+
+const ctor: any = K;
+const right = ctor + 1;
+const left = 1 + ctor;
+console.log(typeof right, right);
+console.log(typeof left, left);
+
+let accumulator: any = K;
+for (let i = 0; i < 8; i++) accumulator += i;
+console.log(typeof accumulator, accumulator);
+
+class Valued { static valueOf(): number { return 40; } }
+const valued: any = Valued;
+console.log(valued + 2);
+"#,
+    );
+    assert!(
+        run.status.success(),
+        "compiled program failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "string function K() { [native code] }1\n",
+            "string 1function K() { [native code] }\n",
+            "string function K() { [native code] }01234567\n",
+            "42\n"
+        )
+    );
+}


### PR DESCRIPTION
## Summary

- recognize registered INT32-tagged class references as Function objects in dynamic `+` coercion
- run the ordinary `valueOf`/`toString` sequence so default classes concatenate their function source while static overrides remain observable
- add an end-to-end regression for both operand orders and the looped `+=` reproducer

No version bump.

## Tests

Run on `root@perrymaster.skelpo.net`:

- `cargo fmt --all -- --check`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime dynamic_arith --lib`
- `cargo build --release -p perry-runtime-static`
- `cargo test -p perry --test issue_9087_class_ref_add -- --nocapture`

Closes #9087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected addition and string coercion for declared classes used as values.
  * Class values now behave like function objects during dynamic `+` operations instead of being treated as numeric identifiers.
  * Preserved custom `valueOf` behavior and correct results for both operand orders and repeated additions.

* **Tests**
  * Added regression coverage for class coercion, accumulator operations, and custom `valueOf` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->