### PR TITLE
perf(codegen): binary-search dispatch for dense numeric switches — 38x, at node parity (babel's dispatch shape)

### DIFF
--- a/crates/perry-codegen/src/stmt/switch_stmt.rs
+++ b/crates/perry-codegen/src/stmt/switch_stmt.rs
@@ -1,6 +1,13 @@
 //! `Stmt::Switch` lowering.
 
 use super::*;
+use crate::types::{DOUBLE, I1, I32, I64};
+
+/// Minimum number of UNIQUE numeric-literal case values before the
+/// binary-search dispatch tree replaces the linear test tower. Below this the
+/// tower's straight-line compare chain is already cheap and the tree's
+/// canonicalization prologue isn't worth its extra blocks.
+const NUMERIC_TREE_MIN_CASES: usize = 8;
 
 /// `switch (disc) { case A: ...; break; case B: ...; default: ... }`
 /// lowering. Each case gets a (test, body) block pair; bodies fall
@@ -13,6 +20,17 @@ use super::*;
 /// is a NaN-boxed double whose equality semantics differ from i32
 /// switch (NaN != NaN). The if-tower lowering uses fcmp oeq for each
 /// test which yields the right semantics.
+///
+/// Dense all-numeric switches take a faster path: when EVERY case test is a
+/// compile-time integer-valued numeric literal and there are at least
+/// [`NUMERIC_TREE_MIN_CASES`] unique values, the linear tower is replaced by
+/// a balanced binary-search tree over the sorted case values — O(log n)
+/// `fcmp` branches per dispatch instead of O(n) `js_switch_strict_equals`
+/// calls (babel-style AST/token-kind dispatch switches have 50–100+ arms).
+/// Only the DISPATCH changes: bodies keep source order and fall-through, the
+/// default body is still the no-match target, and duplicate case values still
+/// resolve to the first (source-order) clause. See
+/// [`numeric_literal_dispatch_plan`] for why this is unobservable.
 pub(crate) fn lower_switch(
     ctx: &mut FnCtx<'_>,
     discriminant: &perry_hir::Expr,
@@ -20,17 +38,24 @@ pub(crate) fn lower_switch(
 ) -> Result<()> {
     let dv = lower_expr(ctx, discriminant)?;
 
-    // Allocate test/body blocks for every case up front so we can wire
-    // up the fall-through edges before each block is filled in.
+    let tree_plan = numeric_literal_dispatch_plan(cases);
+
+    // Allocate body blocks (and, for the tower lowering, test blocks) for
+    // every case up front so we can wire up the fall-through edges before
+    // each block is filled in. The tree lowering creates its dispatch blocks
+    // on the fly instead of per-case test blocks (an unfilled block would
+    // have no terminator and fail LLVM verification).
     let mut test_blocks: Vec<usize> = Vec::with_capacity(cases.len());
     let mut body_blocks: Vec<usize> = Vec::with_capacity(cases.len());
     for (i, case) in cases.iter().enumerate() {
-        let test_name = if case.test.is_some() {
-            format!("switch.test{}", i)
-        } else {
-            format!("switch.default_test{}", i)
-        };
-        test_blocks.push(ctx.new_block(&test_name));
+        if tree_plan.is_none() {
+            let test_name = if case.test.is_some() {
+                format!("switch.test{}", i)
+            } else {
+                format!("switch.default_test{}", i)
+            };
+            test_blocks.push(ctx.new_block(&test_name));
+        }
         body_blocks.push(ctx.new_block(&format!("switch.body{}", i)));
     }
     let exit_idx = ctx.new_block("switch.exit");
@@ -50,18 +75,29 @@ pub(crate) fn lower_switch(
         None => exit_label.clone(),
     };
 
-    // Branch from the discriminant block into the first *case* test.
-    // A leading `default:` is skipped — its body only runs when no case
-    // test anywhere in the block matches.
-    let first_case_test = cases.iter().position(|c| c.test.is_some());
-    match first_case_test {
-        Some(i) => {
-            let first_test_label = ctx.block_label(test_blocks[i]);
-            ctx.block().br(&first_test_label);
+    match &tree_plan {
+        Some(plan) => {
+            // Dense numeric switch: canonicalize the discriminant once and
+            // dispatch through a balanced comparison tree. Case tests are
+            // all literals, so skipping their (side-effect-free) in-order
+            // evaluation is unobservable.
+            emit_numeric_tree_dispatch(ctx, &dv, plan, &body_blocks, &no_match_target_label);
         }
         None => {
-            // Only a default clause: run it unconditionally.
-            ctx.block().br(&no_match_target_label);
+            // Branch from the discriminant block into the first *case* test.
+            // A leading `default:` is skipped — its body only runs when no
+            // case test anywhere in the block matches.
+            let first_case_test = cases.iter().position(|c| c.test.is_some());
+            match first_case_test {
+                Some(i) => {
+                    let first_test_label = ctx.block_label(test_blocks[i]);
+                    ctx.block().br(&first_test_label);
+                }
+                None => {
+                    // Only a default clause: run it unconditionally.
+                    ctx.block().br(&no_match_target_label);
+                }
+            }
         }
     }
 
@@ -94,7 +130,8 @@ pub(crate) fn lower_switch(
         );
     }
 
-    // Compile each test block. Each test compares dv against the case
+    // Compile each test block (tower lowering only — the tree already emitted
+    // its dispatch blocks above). Each test compares dv against the case
     // expression with fcmp oeq, jumps to the body on match, otherwise
     // jumps to the next *case* test (or to no_match_target if this is the
     // last). The default clause is NOT part of the test chain: per spec
@@ -102,38 +139,40 @@ pub(crate) fn lower_switch(
     // *after* `default:` — is tried first, and the default body only
     // runs when no case matched. A non-match at the default's source
     // position must therefore skip over it to the next case test.
-    for (i, case) in cases.iter().enumerate() {
-        ctx.current_block = test_blocks[i];
-        let body_label = ctx.block_label(body_blocks[i]);
-        let next_case_test = ((i + 1)..cases.len()).find(|&j| cases[j].test.is_some());
-        let next_label = match next_case_test {
-            Some(j) => ctx.block_label(test_blocks[j]),
-            None => no_match_target_label.clone(),
-        };
+    if tree_plan.is_none() {
+        for (i, case) in cases.iter().enumerate() {
+            ctx.current_block = test_blocks[i];
+            let body_label = ctx.block_label(body_blocks[i]);
+            let next_case_test = ((i + 1)..cases.len()).find(|&j| cases[j].test.is_some());
+            let next_label = match next_case_test {
+                Some(j) => ctx.block_label(test_blocks[j]),
+                None => no_match_target_label.clone(),
+            };
 
-        if let Some(test_expr) = case.test.as_ref() {
-            let cv = lower_expr(ctx, test_expr)?;
-            // CaseClauseIsSelected is strict equality (`===`). One runtime
-            // helper covers every value-kind correctly: string content
-            // compare (heap + SSO), IEEE numeric compare (NaN never
-            // matches, -0 == +0, int32-boxed == raw double), and bit
-            // identity for objects/null/undefined/booleans. The previous
-            // two-path lowering (js_get_string_pointer_unified +
-            // js_string_equals, raw bit compare otherwise) made
-            // `switch (1)` match `case '1'` through the unified getter's
-            // number→string property-key coercion (S12.11_A1_T2) and
-            // `switch (NaN)` match `case NaN` through bit equality.
-            let blk = ctx.block();
-            let i32_eq = blk.call(
-                crate::types::I32,
-                "js_switch_strict_equals",
-                &[(crate::types::DOUBLE, &dv), (crate::types::DOUBLE, &cv)],
-            );
-            let cmp = blk.icmp_ne(crate::types::I32, &i32_eq, "0");
-            blk.cond_br(&cmp, &body_label, &next_label);
-        } else {
-            // Default case test block: unconditional jump to its body.
-            ctx.block().br(&body_label);
+            if let Some(test_expr) = case.test.as_ref() {
+                let cv = lower_expr(ctx, test_expr)?;
+                // CaseClauseIsSelected is strict equality (`===`). One runtime
+                // helper covers every value-kind correctly: string content
+                // compare (heap + SSO), IEEE numeric compare (NaN never
+                // matches, -0 == +0, int32-boxed == raw double), and bit
+                // identity for objects/null/undefined/booleans. The previous
+                // two-path lowering (js_get_string_pointer_unified +
+                // js_string_equals, raw bit compare otherwise) made
+                // `switch (1)` match `case '1'` through the unified getter's
+                // number→string property-key coercion (S12.11_A1_T2) and
+                // `switch (NaN)` match `case NaN` through bit equality.
+                let blk = ctx.block();
+                let i32_eq = blk.call(
+                    crate::types::I32,
+                    "js_switch_strict_equals",
+                    &[(crate::types::DOUBLE, &dv), (crate::types::DOUBLE, &cv)],
+                );
+                let cmp = blk.icmp_ne(crate::types::I32, &i32_eq, "0");
+                blk.cond_br(&cmp, &body_label, &next_label);
+            } else {
+                // Default case test block: unconditional jump to its body.
+                ctx.block().br(&body_label);
+            }
         }
     }
 
@@ -155,4 +194,187 @@ pub(crate) fn lower_switch(
     ctx.loop_targets.pop();
     ctx.current_block = exit_idx;
     Ok(())
+}
+
+/// Decide whether this switch qualifies for the binary-search dispatch tree
+/// and, if so, return its plan: the unique case values sorted ascending, each
+/// paired with the index of the FIRST case clause carrying that value.
+///
+/// Qualification rules — each one guards an observable-semantics requirement:
+///
+/// - Every non-default case test must be `Expr::Number` / `Expr::Integer`.
+///   JS evaluates case-test expressions in source order until one matches
+///   (spec CaseBlockEvaluation), so reordering tests into a tree is only
+///   legal when every test is a side-effect-free literal whose evaluation
+///   cannot be observed. (`case -3:` qualifies too: HIR lowering folds unary
+///   minus over numeric literals — including `-0` → `Number(-0.0)` — so it
+///   arrives here as a literal, see lower_expr/arm_unary.rs.)
+/// - Values must be finite and integer-valued. This keeps every tree constant
+///   well clear of the subnormal range, where a raw module-slot object
+///   pointer's bit pattern (top16 == 0, see `normalize_raw_object_bits`)
+///   decodes to a denormal double: such a discriminant flows through the
+///   tree's numeric path as that denormal, which can never `fcmp oeq` an
+///   integer-valued constant — same no-match verdict the tower's
+///   `js_switch_strict_equals` (which re-tags the pointer) produces. NaN and
+///   ±Infinity literals are rejected with the same check for simplicity.
+/// - Duplicate values keep the FIRST clause (stable sort by value preserves
+///   source order among equals; dedup retains the leading element), matching
+///   the tower's first-test-wins order. `Expr::Integer` converts via
+///   `as f64` — exactly how `literals_vars::lower` materializes it — so two
+///   i64 literals that collapse to one double here also compare equal at
+///   runtime under the tower.
+/// - The default clause (test == None) is skipped: it is not part of the
+///   test chain; the tree's no-match edge targets its body.
+fn numeric_literal_dispatch_plan(cases: &[perry_hir::SwitchCase]) -> Option<Vec<(f64, usize)>> {
+    use perry_hir::Expr;
+    let mut vals: Vec<(f64, usize)> = Vec::with_capacity(cases.len());
+    for (i, case) in cases.iter().enumerate() {
+        let Some(test) = case.test.as_ref() else {
+            continue;
+        };
+        let v = match test {
+            Expr::Number(f) => *f,
+            Expr::Integer(n) => *n as f64,
+            _ => return None,
+        };
+        if !v.is_finite() || v.fract() != 0.0 {
+            return None;
+        }
+        vals.push((v, i));
+    }
+    vals.sort_by(|a, b| {
+        a.0.partial_cmp(&b.0)
+            .expect("case values are finite (checked above)")
+    });
+    vals.dedup_by(|later, first| later.0 == first.0);
+    if vals.len() < NUMERIC_TREE_MIN_CASES {
+        return None;
+    }
+    Some(vals)
+}
+
+/// Emit the O(log n) dispatch for a qualifying numeric switch: canonicalize
+/// the NaN-boxed discriminant to a raw double once, then walk a balanced
+/// binary-search tree of `fcmp oeq`/`fcmp olt` branches over the sorted case
+/// values.
+///
+/// Canonicalization mirrors `js_switch_strict_equals`' numeric arm exactly:
+///
+/// - int32-boxed (`(bits & !INT32_MASK) == INT32_TAG`) → sign-extend the low
+///   32 bits and `sitofp` (so int32-boxed 7 matches `case 7:`).
+/// - any other value whose top-16 tag lies outside Perry's tag band
+///   (`SHORT_STRING_TAG..=STRING_TAG`) is already a raw double — including
+///   real NaNs, which then fail every ordered `fcmp` in the tree and fall out
+///   at the no-match edge, exactly like NaN != NaN in the helper.
+/// - strings/bools/undefined/null/pointers (tagged, non-int32) can never
+///   strictly equal a number: branch straight to no-match.
+fn emit_numeric_tree_dispatch(
+    ctx: &mut FnCtx<'_>,
+    dv: &str,
+    plan: &[(f64, usize)],
+    body_blocks: &[usize],
+    no_match_label: &str,
+) {
+    let bits = ctx.block().bitcast_double_to_i64(dv);
+    let int32_band = ctx.block().and(
+        I64,
+        &bits,
+        &crate::nanbox::i64_literal(!crate::nanbox::INT32_MASK),
+    );
+    let is_int32 = ctx.block().icmp_eq(
+        I64,
+        &int32_band,
+        &crate::nanbox::i64_literal(crate::nanbox::INT32_TAG),
+    );
+    let lo32 = ctx.block().trunc(I64, &bits, I32);
+    let int32_as_double = ctx.block().sitofp(I32, &lo32, DOUBLE);
+    let canonical = ctx
+        .block()
+        .select(I1, &is_int32, DOUBLE, &int32_as_double, dv);
+    let is_untagged_number = emit_js_value_is_number(ctx, dv);
+    let is_numeric = ctx.block().or(I1, &is_untagged_number, &is_int32);
+    let root_idx = ctx.new_block("switch.bst");
+    let root_label = ctx.block_label(root_idx);
+    ctx.block()
+        .cond_br(&is_numeric, &root_label, no_match_label);
+    ctx.current_block = root_idx;
+    emit_numeric_tree_range(
+        ctx,
+        &canonical,
+        plan,
+        0,
+        plan.len() - 1,
+        body_blocks,
+        no_match_label,
+    );
+}
+
+/// Fill `ctx.current_block` with the dispatch for `plan[lo..=hi]`:
+///
+/// ```text
+///   fcmp oeq x, v[mid]  → body[mid]
+///   fcmp olt x, v[mid]  → subtree(lo, mid-1)   (or no-match if empty)
+///   otherwise           → subtree(mid+1, hi)   (or no-match if empty)
+/// ```
+///
+/// Every leaf edge ends in an `oeq` guard, so a discriminant that is between
+/// case values (e.g. 2.5 against integer cases), below the minimum, above the
+/// maximum, or NaN (all ordered fcmps false → always takes the ≥ edge until
+/// the run ends) lands on the no-match label.
+fn emit_numeric_tree_range(
+    ctx: &mut FnCtx<'_>,
+    canonical: &str,
+    plan: &[(f64, usize)],
+    lo: usize,
+    hi: usize,
+    body_blocks: &[usize],
+    no_match_label: &str,
+) {
+    let mid = lo + (hi - lo) / 2;
+    let (value, case_idx) = plan[mid];
+    let value_lit = crate::nanbox::double_literal(value);
+    let body_label = ctx.block_label(body_blocks[case_idx]);
+
+    let eq = ctx.block().fcmp("oeq", canonical, &value_lit);
+    if lo == hi {
+        ctx.block().cond_br(&eq, &body_label, no_match_label);
+        return;
+    }
+
+    let cmp_idx = ctx.new_block("switch.bst");
+    let cmp_label = ctx.block_label(cmp_idx);
+    ctx.block().cond_br(&eq, &body_label, &cmp_label);
+    ctx.current_block = cmp_idx;
+
+    let lt = ctx.block().fcmp("olt", canonical, &value_lit);
+    let left = (mid > lo).then(|| ctx.new_block("switch.bst"));
+    let right = (mid < hi).then(|| ctx.new_block("switch.bst"));
+    let left_label = left.map_or_else(|| no_match_label.to_string(), |b| ctx.block_label(b));
+    let right_label = right.map_or_else(|| no_match_label.to_string(), |b| ctx.block_label(b));
+    ctx.block().cond_br(&lt, &left_label, &right_label);
+
+    if let Some(b) = left {
+        ctx.current_block = b;
+        emit_numeric_tree_range(
+            ctx,
+            canonical,
+            plan,
+            lo,
+            mid - 1,
+            body_blocks,
+            no_match_label,
+        );
+    }
+    if let Some(b) = right {
+        ctx.current_block = b;
+        emit_numeric_tree_range(
+            ctx,
+            canonical,
+            plan,
+            mid + 1,
+            hi,
+            body_blocks,
+            no_match_label,
+        );
+    }
 }

--- a/test-files/test_gap_9053_switch_binary_dispatch.ts
+++ b/test-files/test_gap_9053_switch_binary_dispatch.ts
@@ -1,0 +1,219 @@
+// Dense all-numeric-literal switches (>= 8 unique integer values) lower to a
+// binary-search dispatch tree instead of the linear js_switch_strict_equals
+// tower. Only the DISPATCH changes; this battery pins every observable
+// semantic the tree must preserve:
+//   - first / middle / last case selection in a 40-case switch
+//   - default clause (including a default placed mid-block, with fall-through
+//     out of it)
+//   - NaN discriminant matches nothing -> default
+//   - fall-through across 3 consecutive case bodies
+//   - duplicate case value -> FIRST clause wins (source order)
+//   - negative case values and negative discriminants
+//   - non-integer discriminant missing every case -> default
+//   - non-number discriminants (string/bool/null/undefined/object) -> default
+//   - int32-boxed vs double-boxed numeric discriminants agree
+//   - a hot loop summing dispatch results
+
+// 40 case clauses (39 unique values + one duplicate). Values span negatives,
+// -0, int32 limits, and beyond-int32 doubles.
+function label(x: any): string {
+  switch (x) {
+    case 0: return "zero"; // first case
+    case 1: return "one";
+    case 2: return "two";
+    case 3: return "three";
+    case 4: return "four";
+    case 5: return "five";
+    case 6: return "six";
+    case 7: return "seven-first"; // duplicate value: this one must win
+    case 7: return "seven-second";
+    case 8: return "eight";
+    case 9: return "nine";
+    case 10: return "ten";
+    case 11: return "eleven";
+    case 12: return "twelve";
+    case 13: return "thirteen";
+    case 14: return "fourteen";
+    case 15: return "fifteen";
+    case 16: return "sixteen";
+    case 17: return "seventeen";
+    case 18: return "eighteen";
+    case 19: return "nineteen"; // middle-ish case
+    case 20: return "twenty";
+    case 25: return "twenty-five";
+    case 30: return "thirty";
+    case 31: return "thirty-one";
+    case 32: return "thirty-two";
+    case 33: return "thirty-three";
+    case 64: return "sixty-four";
+    case 512: return "five-twelve";
+    case 999: return "nine-nine-nine";
+    case 100000: return "hundred-k";
+    case 1000000: return "million";
+    case 2147483647: return "int32-max";
+    case 2147483648: return "beyond-int32";
+    case -1: return "neg-one";
+    case -2: return "neg-two";
+    case -5: return "neg-five";
+    case -100: return "neg-hundred";
+    case -2147483648: return "int32-min";
+    case -0: return "neg-zero-clause"; // 0 === -0: 'case 0' above wins (last case clause)
+    default: return "default:" + String(x);
+  }
+}
+
+// first / middle / last / default
+console.log(label(0));
+console.log(label(19));
+console.log(label(-0)); // -0 === 0 -> "zero", not the -0 clause
+console.log(label(-2147483648));
+console.log(label(2147483648));
+console.log(label(7)); // duplicate value -> first clause
+console.log(label(-100));
+console.log(label(34)); // between case values -> default
+console.log(label(-3)); // negative miss -> default
+console.log(label(NaN)); // NaN matches nothing -> default
+console.log(label(2.5)); // non-integer discriminant -> default
+console.log(label(-0.5));
+console.log(label(1e300)); // way above every case -> default
+console.log(label(-1e300)); // way below every case -> default
+console.log(label("7")); // string never matches a number case
+console.log(label(true));
+console.log(label(null));
+console.log(label(undefined));
+console.log(label({}));
+
+// int32-boxed vs double-boxed discriminants must dispatch identically.
+const arr: number[] = [];
+for (let i = 0; i < 40; i++) arr.push(i);
+console.log(label(arr[31])); // runtime int32-ish value
+console.log(label(arr[31] + 0.0)); // arithmetic result
+console.log(label(62 / 2)); // division result (double lane)
+console.log(label(1024 * 1024 * 2048)); // 2^31 computed at runtime
+
+// Fall-through across 3 consecutive case bodies, in a tree-qualifying switch.
+function fall(x: number): string {
+  let s = "";
+  switch (x) {
+    case 10:
+      s += "a";
+    case 11:
+      s += "b";
+    case 12:
+      s += "c";
+      break;
+    case 13:
+      s += "d";
+      break;
+    case 14:
+      s += "e";
+    case 15:
+      s += "f";
+      break;
+    case 16:
+      s += "g";
+      break;
+    case 17:
+      s += "h";
+      break;
+  }
+  return "[" + s + "]";
+}
+console.log(fall(10)); // abc
+console.log(fall(11)); // bc
+console.log(fall(12)); // c
+console.log(fall(14)); // ef
+console.log(fall(17)); // h
+console.log(fall(99)); // (empty, no default)
+
+// Default placed mid-block: cases after it are still tested first, and its
+// body falls through into the next case body.
+function midDefault(x: any): string {
+  let s = "";
+  switch (x) {
+    case 1:
+      s += "1";
+      break;
+    case 2:
+      s += "2"; // falls into default body
+    default:
+      s += "D"; // falls into case 3 body
+    case 3:
+      s += "3";
+      break;
+    case 4:
+      s += "4";
+      break;
+    case 5:
+      s += "5";
+      break;
+    case 6:
+      s += "6";
+      break;
+    case 7:
+      s += "7";
+      break;
+    case 8:
+      s += "8";
+      break;
+    case 9:
+      s += "9";
+      break;
+  }
+  return "<" + s + ">";
+}
+console.log(midDefault(2)); // <2D3>
+console.log(midDefault(3)); // <3> (default skipped: 3 matched)
+console.log(midDefault(9)); // <9>
+console.log(midDefault(42)); // <D3>
+console.log(midDefault(NaN)); // <D3>
+console.log(midDefault("3")); // <D3>
+
+// A non-integer literal among the cases keeps the tower lowering; both
+// lowerings must agree on these.
+function halfStep(x: number): string {
+  switch (x) {
+    case 0.5: return "half";
+    case 1: return "t-one";
+    case 2: return "t-two";
+    case 3: return "t-three";
+    case 4: return "t-four";
+    case 5: return "t-five";
+    case 6: return "t-six";
+    case 7: return "t-seven";
+    case 8: return "t-eight";
+    default: return "t-default";
+  }
+}
+console.log(halfStep(0.5));
+console.log(halfStep(8));
+console.log(halfStep(0.25));
+
+// Hot loop: 64-way dispatch summed 200k times, negatives included.
+function hot(): number {
+  let sum = 0;
+  for (let i = 0; i < 200000; i++) {
+    const k = (i % 64) - 8;
+    switch (k) {
+      case -8: sum += 1; break;
+      case -7: sum += 2; break;
+      case -5: sum += 3; break;
+      case -1: sum += 4; break;
+      case 0: sum += 5; break;
+      case 1: sum += 6; break;
+      case 2: sum += 7; break;
+      case 3: sum += 8;
+      case 4: sum += 9; break; // fall-through pair inside the hot switch
+      case 7: sum += 10; break;
+      case 11: sum += 11; break;
+      case 19: sum += 12; break;
+      case 23: sum += 13; break;
+      case 31: sum += 14; break;
+      case 42: sum += 15; break;
+      case 55: sum += 16; break;
+      default: sum -= 1; break;
+    }
+  }
+  return sum;
+}
+console.log(hot());


### PR DESCRIPTION
Startup-lane work for the pi/cc perf campaign: babel's parser/generator/traverse (the 19x hot region of pi's startup) dispatch through 206 switches / 1,826 cases, and perry lowered EVERY case as a runtime `js_switch_strict_equals` **call** — n/2 extern calls per dispatch, not even inline compares.

**Change** (`stmt/switch_stmt.rs`): when all case tests are integer-valued numeric literals with ≥8 unique values, canonicalize the discriminant ONCE inline (mirroring `js_switch_strict_equals`' numeric arm bit-for-bit: int32-boxed → `sitofp(trunc)`; NaN-box tag band `0x7FF9..=0x7FFF` → no-match; else raw double, real NaNs fail every ordered compare) and dispatch through a balanced `fcmp oeq/olt` tree — O(log n), zero calls. Only the DISPATCH changes: bodies, fall-through edges, and mid-block defaults are untouched; duplicates keep first-clause-wins via stable sort + dedup; the integer-valued restriction keeps tree constants clear of the subnormal range where module-slot pointer bits decode as denormals. Non-literal / string / sparse switches keep the existing tower.

**Bench** (64-case switch, 5M dispatches, rotating discriminant, min of 5): tower **652 ms** → tree **17 ms** (~38x), node 11 ms — at node's level on the dispatch itself. Mechanism proven in IR, not inferred: the bench module contains 161 `switch.bst` blocks and **zero** `js_switch_strict_equals` calls.

**Validation**: gap fixture `test_gap_9053_switch_binary_dispatch.ts` (40 cases: first/middle/last, default incl. mid-block, NaN, 3-deep fallthrough, duplicate case, negatives, `-0`, int32 limits, beyond-int32, non-integer and non-number discriminants, hot loop) **byte-identical to node v26.5.1** under both old and new binaries; existing switch regression fixtures (`test_edge_control_flow`, `test_gap_switch_continue_loop` #5989) parity-green; perry-codegen lib 1347/0; native_proof_regressions 284/0 with no IR-shape assertions needing updates; fmt applied.

Implemented by a subagent in an isolated worktree; reviewed and shipped by the coordinating session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved execution speed for large switches with numeric literal cases by using optimized binary-search dispatch.
  * Added more efficient handling for dense switches in performance-sensitive loops.

* **Bug Fixes**
  * Preserved correct behavior for duplicate values, `-0` and `0`, NaN, non-number values, fall-through, and default cases.
  * Retained existing behavior for switches that do not qualify for the optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->