### PR TITLE
fix(codegen): root pointer locals of constructor bodies inlined into other frames

### DIFF
--- a/changelog.d/9102-inlined-ctor-body-locals-rooting.md
+++ b/changelog.d/9102-inlined-ctor-body-locals-rooting.md
@@ -1,0 +1,44 @@
+### Fixed
+
+- **Moving GC no longer corrupts pointer locals of constructor bodies inlined
+  into other frames** (#9081). Codegen splices constructor bodies inline at
+  five sites — the `super(...)` parent-body inline in a derived constructor
+  (`expr/this_super_call.rs`), the `new`-site own/inherited-ctor inlines
+  (`lower_call/new.rs`), and `let_stmt`'s scalar-ctor variants — but the
+  enclosing function's shadow-slot map was computed by
+  `collect_pointer_typed_locals` over that function's OWN params and body, so
+  a spliced body's pointer locals (and its ctor params, bound by
+  `bind_inline_constructor_params`) landed in plain entry allocas the
+  collector never rewrites. A moving minor between a local's store and a
+  later use left the local holding the pre-move address.
+
+  The reported shape: three.js 0.180.0 under `compilePackages` with a 1 MiB
+  nursery. `RenderTarget`'s ctor body, spliced by the super() inline into the
+  standalone `WebGLRenderTarget_constructor`, holds `const texture = new
+  Texture(image)` across `this.textures = []` and the attachment loop; the
+  retired-from-space `texture` then made `Texture.copy()` read
+  `source.mipmaps` as undefined — `TypeError: Cannot read properties of
+  undefined (reading 'slice')`. The from-space quarantine
+  (`PERRY_GC_PROTECT_FROMSPACE=1`, depth 800) named the stale header deref
+  inside the constructor, and the emitted IR showed the spliced `texture`
+  alloca carried no root bind while the standalone `RenderTarget_constructor`
+  rooted the same local at slot 4.
+
+  Fix: `expr/shadow_slot.rs::root_inlined_ctor_pointer_locals`, called at all
+  five splice sites before lowering the spliced body. It runs the same
+  pointer-locals collector over the spliced params+body and extends the frame
+  through `reserve_shadow_slot`, which grows the already-emitted frame in
+  place on both root backends (native stack maps and shadow frames — the bug
+  reproduced under both `PERRY_RS4GC` arms). Already-bound ctor params are
+  bound immediately and re-bound on a repeated inline of the same
+  constructor; module-unique local ids make the map extension alias-free, and
+  nested `super()` chains recurse through the same site.
+
+  Regression test `test_gap_gc_inlined_ctor_body_locals_rooting.ts`
+  (registered in the gc-repsel corpus) runs the seeded every-poll evacuating
+  schedule with the quarantine armed: the unfixed compiler SIGSEGVs at minor
+  #0; fixed, it is byte-exact with the oracle on both backends. The original
+  three.js reproduction passes on default heap, forced 1 MiB nursery,
+  quarantine, and the `PERRY_RS4GC=0` build, with `PERRY_GC_DIAG` confirming
+  live copying collections. Also relocates `is_global_this_value` from
+  `let_stmt.rs` to `let_stmt_facts.rs` (pure move, 2000-line cap).

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -210,7 +210,7 @@ pub(crate) use shadow_slot::{
     current_closure_ptr_value, emit_persistent_shadow_root_barrier,
     emit_shadow_slot_bind_for_local, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
     enable_persistent_shadow_slot_for_array_alias, expr_is_known_non_pointer_shadow_value,
-    try_current_closure_ptr_value,
+    root_inlined_ctor_pointer_locals, try_current_closure_ptr_value,
 };
 
 /// One in-flight inline-constructor return target. See

--- a/crates/perry-codegen/src/expr/shadow_slot.rs
+++ b/crates/perry-codegen/src/expr/shadow_slot.rs
@@ -345,6 +345,55 @@ pub(crate) fn emit_persistent_shadow_root_barrier(ctx: &mut FnCtx<'_>, value_bit
     ctx.current_block = done_idx;
 }
 
+/// #9081: root the pointer locals of a constructor body spliced inline into
+/// the CURRENT function — the `super(...)` parent-body inline, the `new`-site
+/// own/inherited-ctor inline, and `let_stmt`'s scalar-ctor variants.
+///
+/// The enclosing function's `shadow_slot_map` was computed by
+/// `collect_pointer_typed_locals` over that function's OWN params and body;
+/// an inlined constructor body's locals are invisible to it. Its `Let`s then
+/// land in plain entry allocas that are neither shadow slots nor temp roots,
+/// so a moving minor during the body leaves them holding the pre-move
+/// address (three.js: `RenderTarget`'s `const texture = new Texture(...)`
+/// inlined into `WebGLRenderTarget_constructor`, stale by `texture.clone()`).
+///
+/// Runs the same collector over the spliced params+body and extends the map
+/// through `reserve_shadow_slot`, which grows the already-emitted frame in
+/// place on both root backends (stack-map count and shadow-frame push).
+/// `Let`/assignment sites then mirror stores through the ordinary bind path.
+/// An id already in `ctx.locals` (a ctor param bound by the caller before
+/// this runs) is bound here — unconditionally, because a second inline of
+/// the same constructor in this function binds fresh param allocas that must
+/// re-point the existing slot. Local ids are module-unique, so extending the
+/// map never aliases an enclosing local.
+pub(crate) fn root_inlined_ctor_pointer_locals(
+    ctx: &mut FnCtx<'_>,
+    params: &[perry_hir::Param],
+    body: &[perry_hir::Stmt],
+) {
+    if !crate::codegen::helpers::precise_root_analysis_enabled() {
+        return;
+    }
+    let flat_const_ids: std::collections::HashSet<u32> =
+        ctx.flat_const_arrays.keys().copied().collect();
+    let pointer_locals =
+        crate::collectors::collect_pointer_typed_locals(params, body, &flat_const_ids);
+    // Slot indices must not depend on HashMap iteration order.
+    let mut ids: Vec<u32> = pointer_locals.keys().copied().collect();
+    ids.sort_unstable();
+    for id in ids {
+        if !ctx.shadow_slot_map.contains_key(&id) {
+            let Some(slot_idx) = ctx.func.reserve_shadow_slot() else {
+                return;
+            };
+            ctx.shadow_slot_map.insert(id, slot_idx);
+        }
+        if ctx.locals.contains_key(&id) {
+            emit_shadow_slot_bind_for_local(ctx, id);
+        }
+    }
+}
+
 pub(crate) fn emit_shadow_slot_update_for_expr(
     ctx: &mut FnCtx<'_>,
     local_id: u32,

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -1502,6 +1502,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     super_args,
                     parent_capture_fill,
                 );
+                // #9081: the parent body is lowered into THIS function's
+                // frame, but the frame's slot map never saw the parent's
+                // locals — root them (and the params just bound) before any
+                // statement of the body can allocate.
+                crate::expr::root_inlined_ctor_pointer_locals(
+                    ctx,
+                    &parent_ctor.params,
+                    &parent_ctor.body,
+                );
 
                 let parent_is_derived = effective_parent_class.extends.is_some()
                     || effective_parent_class.extends_name.is_some()

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1125,6 +1125,12 @@ fn lower_new_impl_inner<'a>(
     let mut saved_scope_for_ctor = class.constructor.as_ref().map(|ctor| {
         bind_inline_constructor_params(ctx, &ctor.params, &lowered_args, args, ctor_capture_fill)
     });
+    // #9081: the ctor body below is lowered into the CALLER's frame, whose
+    // slot map never saw the ctor's locals. Root them (and the params just
+    // bound) before the field initializers or body can allocate.
+    if let Some(ctor) = &class.constructor {
+        crate::expr::root_inlined_ctor_pointer_locals(ctx, &ctor.params, &ctor.body);
+    }
 
     // A dynamic parent constructor owns the fields above its registered edge.
     // Every local class from the edge owner through the leaf is derived, so
@@ -1228,6 +1234,13 @@ fn lower_new_impl_inner<'a>(
                         &lowered_args,
                         args,
                         parent_capture_fill,
+                    );
+                    // #9081: same frame-splice rooting as the own-ctor
+                    // inline above, for the inherited body.
+                    crate::expr::root_inlined_ctor_pointer_locals(
+                        ctx,
+                        &parent_ctor.params,
+                        &parent_ctor.body,
                     );
 
                     // Push the parent class name so `this` inside the

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -1,9 +1,9 @@
 use super::let_buffer_views::{math_min_length_buffer_ids, register_noalias_buffer_view};
 use super::let_object_facts::{is_object_literal_init, record_imported_object_alias};
 use super::let_stmt_facts::{
-    buffer_local_alias_source, collect_scalar_class_data, native_i32_alias_source,
-    note_ptr_shape_scalar_replaced, pod_view_count_source, record_array_length_snapshot,
-    record_pod_rejection, record_scalar_aggregate_field,
+    buffer_local_alias_source, collect_scalar_class_data, is_global_this_value,
+    native_i32_alias_source, note_ptr_shape_scalar_replaced, pod_view_count_source,
+    record_array_length_snapshot, record_pod_rejection, record_scalar_aggregate_field,
 };
 use super::unused_expr::lower_unused_expr;
 use super::*;
@@ -18,16 +18,6 @@ use crate::native_value::{
 };
 use crate::type_analysis::is_string_expr;
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
-
-fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
-    matches!(expr, perry_hir::Expr::GlobalGet(_))
-        || matches!(
-            expr,
-            perry_hir::Expr::PropertyGet { object, property, .. }
-                if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
-                    && property == "globalThis"
-        )
-}
 
 pub(crate) fn lower_let(
     ctx: &mut FnCtx<'_>,
@@ -1088,6 +1078,9 @@ pub(crate) fn lower_let(
                             ctx.proven_local_types.insert(param.id, proof.clone());
                         }
                     }
+                    // #9081: the body is spliced into the enclosing frame,
+                    // whose slot map never saw the ctor's locals.
+                    crate::expr::root_inlined_ctor_pointer_locals(ctx, &ctor.params, &ctor.body);
                     crate::stmt::lower_stmts(ctx, &ctor.body)?;
                     ctx.locals = saved_locals;
                     ctx.local_types = saved_local_types;
@@ -1126,6 +1119,13 @@ pub(crate) fn lower_let(
                                 }
                                 ctx.class_stack.pop();
                                 ctx.class_stack.push(pname.clone());
+                                // #9081: same frame-splice rooting as the
+                                // own-ctor inline above.
+                                crate::expr::root_inlined_ctor_pointer_locals(
+                                    ctx,
+                                    &parent_ctor.params,
+                                    &parent_ctor.body,
+                                );
                                 crate::stmt::lower_stmts(ctx, &parent_ctor.body)?;
                                 ctx.class_stack.pop();
                                 ctx.class_stack.push(class_name.clone());

--- a/crates/perry-codegen/src/stmt/let_stmt_facts.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt_facts.rs
@@ -180,3 +180,15 @@ pub(super) fn note_ptr_shape_scalar_replaced(ctx: &crate::expr::FnCtx<'_>, id: u
         )),
     });
 }
+
+/// `globalThis` (or `globalThis.globalThis`) as an init value — moved here
+/// from `let_stmt.rs` for the 2000-line cap; no behavior change.
+pub(super) fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
+    matches!(expr, perry_hir::Expr::GlobalGet(_))
+        || matches!(
+            expr,
+            perry_hir::Expr::PropertyGet { object, property, .. }
+                if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
+                    && property == "globalThis"
+        )
+}

--- a/test-files/test_gap_gc_inlined_ctor_body_locals_rooting.ts
+++ b/test-files/test_gap_gc_inlined_ctor_body_locals_rooting.ts
@@ -1,0 +1,172 @@
+// parity-env: PERRY_GC_MOVING_LOOP_POLLS=1 PERRY_GC_SCHEDULE_SEED=9081 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_ALLOC_KB=0 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+//
+// #9081: pointer locals of a constructor body INLINED into another function's
+// frame must get shadow slots in THAT frame.
+//
+// Codegen splices constructor bodies inline at four kinds of sites: the
+// `super(...)` parent-body inline inside a derived constructor
+// (`expr/this_super_call.rs`), the `new`-site own-ctor and inherited-ctor
+// inlines (`lower_call/new.rs`), and `let_stmt`'s scalar-ctor variants. Each
+// enclosing function's shadow-slot map is computed by
+// `collect_pointer_typed_locals` over that function's OWN params and body, so
+// a spliced body's `Let`s (and its bound ctor params) landed in plain entry
+// allocas — neither shadow slots nor temp roots — invisible to the collector.
+// A moving minor between the local's store and a later use then leaves it
+// holding the pre-move address.
+//
+// This is how three.js `new WebGLRenderTarget()` died under a small nursery:
+// `RenderTarget`'s ctor body — spliced by the super() inline into the
+// standalone `WebGLRenderTarget_constructor`, which the entry module CALLS as
+// a symbol — holds `const texture = new Texture(image)` across
+// `this.textures = []` and the attachment loop; the retired-from-space
+// `texture` then made `Texture.copy()` read `source.mipmaps` as undefined
+// ("Cannot read properties of undefined (reading 'slice')").
+//
+// The dynamic arm below reproduces that exact configuration: constructing
+// through `holder.ctor` routes through `js_new_function_construct`, which
+// replays the STANDALONE derived constructor — the compiled method whose
+// frame contains the super() splice of Base's body. The direct-new arms cover
+// the `new`-site splices.
+//
+// OBSERVABLE AFTER THE SPLICED LOCAL GOES STALE, with no dependence on lucky
+// from-space reuse: each round also stores the vulnerable local's object into
+// an instance field, so the object is reachable and MOVES on every minor (the
+// collector rewrites the instance field but cannot see the spliced local).
+// After the churn, `stampRound` writes the round number through the rewritten
+// path (an opaque function boundary), and the round reads the stamp back
+// THROUGH THE SPLICED LOCAL. A stale local still points at the first
+// pre-churn copy, which never received the write — and under the seeded
+// every-poll schedule that copy's pages have long been retired and recycled,
+// so the read comes back as garbage instead of the round number.
+//
+// THE `parity-env` LINE IS PART OF THE TEST: RATE=1 + ALLOC_KB=0 turns every
+// loop back-edge poll into an evacuating minor, so the churn loop guarantees
+// collections inside the vulnerable window deterministically instead of
+// relying on allocation pacing.
+
+class Payload {
+  arr: number[];
+  stamp: number;
+  constructor() {
+    this.arr = [1, 2, 3];
+    this.stamp = -1;
+  }
+}
+
+// Opaque write path for the test: writes land through the collector-rewritten
+// instance fields, never through the spliced body's locals.
+function stampRound(o: Base, n: number): void {
+  o.p.stamp = n;
+  o.opts.stamp = n;
+}
+
+class Base {
+  p: Payload;
+  opts: any;
+  fromLocal: number;
+  fromParam: number;
+  kept: number;
+  constructor(n: number, opts: any) {
+    // The vulnerable spliced LOCAL, and the vulnerable spliced PARAM
+    // (`opts`): both live in plain allocas of the enclosing frame when this
+    // body is inlined. Rooting them through `this` gives the collector a
+    // path it DOES rewrite, so a move makes the two paths diverge.
+    const payload = new Payload();
+    this.p = payload;
+    this.opts = opts;
+    // Every back-edge of this loop is an evacuating minor under the seeded
+    // schedule; the allocations keep the heap live enough that from-space
+    // pages are recycled before the reads below.
+    let window: any[] = [];
+    let kept = 0;
+    for (let i = 0; i < 64; i++) {
+      window.push({ i: i, s: "pad-" + i });
+      if (window.length === 16) {
+        kept += window.length;
+        window = [];
+      }
+    }
+    stampRound(this, n);
+    // Read back through the spliced local/param. Stale copies never saw
+    // `stampRound`'s writes.
+    this.fromLocal = payload.stamp;
+    this.fromParam = opts.stamp;
+    this.kept = kept;
+  }
+}
+
+// Own ctor calling super(): Base's body is spliced into this constructor's
+// frame by the super() parent-body inline.
+class DerivedOwnCtor extends Base {
+  m: number;
+  constructor(n: number, opts: any) {
+    super(n, opts);
+    this.m = n * 2;
+  }
+}
+
+// No own ctor: Base's body is spliced into the frame of whatever function
+// lowers a direct `new DerivedDefaultCtor(...)` site (inherited-ctor inline).
+class DerivedDefaultCtor extends Base {}
+
+function checkOne(o: Base, n: number): number {
+  let bad = 0;
+  if (o.fromLocal !== n) {
+    bad++;
+  }
+  if (o.fromParam !== n) {
+    bad++;
+  }
+  if (o.p.arr.length !== 3 || o.p.arr[0] !== 1 || o.p.arr[2] !== 3) {
+    bad++;
+  }
+  if (o.kept !== 64) {
+    bad++;
+  }
+  return bad;
+}
+
+// The three.js configuration: a runtime-dispatched construction replays the
+// STANDALONE derived constructor, whose own frame holds the super() splice.
+function constructDynamic(holder: any, n: number): Base {
+  return new holder.ctor(n, { stamp: -1 });
+}
+
+function runDynamicOwnCtor(): number {
+  let bad = 0;
+  const holder = { ctor: DerivedOwnCtor };
+  for (let r = 0; r < 6; r++) {
+    bad += checkOne(constructDynamic(holder, r), r);
+  }
+  return bad;
+}
+
+function runOwnCtor(): number {
+  let bad = 0;
+  for (let r = 0; r < 6; r++) {
+    bad += checkOne(new DerivedOwnCtor(r, { stamp: -1 }), r);
+  }
+  return bad;
+}
+
+function runDefaultCtor(): number {
+  let bad = 0;
+  for (let r = 0; r < 6; r++) {
+    bad += checkOne(new DerivedDefaultCtor(r, { stamp: -1 }), r);
+  }
+  return bad;
+}
+
+function runBaseDirect(): number {
+  // The `new`-site own-ctor inline: Base's body spliced into this function.
+  let bad = 0;
+  for (let r = 0; r < 6; r++) {
+    bad += checkOne(new Base(r, { stamp: -1 }), r);
+  }
+  return bad;
+}
+
+console.log("dynamic", runDynamicOwnCtor());
+console.log("own", runOwnCtor());
+console.log("default", runDefaultCtor());
+console.log("base", runBaseDirect());

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -535,6 +535,18 @@ test_gap_gc_symbol_local_rooting
 # into one `bad N`.
 test_gap_gc_dynamic_construct_receiver_rooting
 
+# --- #9081: INLINED CONSTRUCTOR BODIES — spliced locals need the SPLICING ----
+# frame's slots. The super() parent-body inline, the `new`-site own/inherited
+# ctor inlines, and let_stmt's scalar-ctor variants all lower a ctor body into
+# the enclosing function, whose shadow-slot map was computed from that
+# function's own body alone — the spliced body's pointer locals (and bound
+# ctor params) sat in plain entry allocas the collector never rewrites. This
+# is how three.js `new WebGLRenderTarget()` lost RenderTarget's `texture`
+# local across `this.textures = []` under a small nursery. The test's
+# parity-env quarantine turns the stale deref into a SIGSEGV on a regression;
+# the stamp read-back catches it by value when the pages were recycled.
+test_gap_gc_inlined_ctor_body_locals_rooting
+
 # --- #7280: OPTIONAL PARAMETERS — the residual that held #7161's stopgap -----
 # THE file for #7154's surviving residual. zod `util.ts`'s
 # `clone(inst, def?, params?: { parent: boolean })` gave `params` no shadow slot


### PR DESCRIPTION
Fixes #9081

## Root cause

Codegen splices constructor bodies inline into other functions at five sites: the `super(...)` parent-body inline in a derived constructor (`expr/this_super_call.rs`), the `new`-site own-ctor and inherited-ctor inlines (`lower_call/new.rs`), and `let_stmt`'s scalar-ctor variants. The enclosing function's shadow-slot map is computed by `collect_pointer_typed_locals` over that function's **own** params and body, so a spliced body's pointer locals — and its ctor params, bound by `bind_inline_constructor_params` — landed in plain entry allocas that are neither shadow slots nor temp roots. The collector never rewrites them, and a moving minor between the local's store and a later use leaves it holding the pre-move address (the CLAUDE.md "root-store dominance" class, `#7207` shape, introduced by body splicing).

That is exactly how three.js died under `compilePackages` with a small nursery: `RenderTarget`'s ctor body, spliced by the super() inline into the standalone `WebGLRenderTarget_constructor` (which the entry module calls as a symbol), holds `const texture = new Texture(image)` across `this.textures = []` and the attachment loop. The from-space quarantine (`PERRY_GC_PROTECT_FROMSPACE=1`, depth 800) pinpointed the stale header deref inside that constructor; the emitted IR shows the spliced `texture` alloca has **no** `js_shadow_slot_bind`, while the standalone `RenderTarget_constructor` — whose own compile pass saw the body — roots the same local at slot 4. Downstream, `Texture.copy()` reads `source.mipmaps` off the retired address as `undefined` → `TypeError: Cannot read properties of undefined (reading 'slice')`.

## Fix

`expr/shadow_slot.rs` gains `root_inlined_ctor_pointer_locals`, called at all five splice sites before lowering the spliced body. It runs the same pointer-locals collector over the spliced params+body and extends the frame via `reserve_shadow_slot`, which grows the already-emitted frame in place on **both** root backends (native stack maps and shadow frames) — matching the bug reproducing under both `PERRY_RS4GC` arms. `Let`/assignment sites then mirror stores through the ordinary bind path; an id already bound in `ctx.locals` (a spliced ctor param) is bound immediately, and re-bound on a repeated inline of the same constructor so the slot tracks the newest alloca. Local ids are module-unique (one counter per lowering context), so extending the map never aliases an enclosing local, and a nested `super()` chain recurses through the same site naturally.

`is_global_this_value` moved from `let_stmt.rs` to `let_stmt_facts.rs` (pure relocation) to stay under the 2000-line cap.

## Regression test

`test-files/test_gap_gc_inlined_ctor_body_locals_rooting.ts`, registered in the gc-repsel corpus. Its `parity-env` runs the seeded every-poll evacuating schedule with the from-space quarantine armed, and its stamp discriminator makes a stale spliced local observable by value after a single move (write through the collector-rewritten instance field, read back through the spliced local). Four arms: the dynamic-construct route that replays the standalone derived ctor (the exact three.js configuration), direct `new` of the derived/default/base classes.

## Validation (on the issue's reproduction host)

- New gap test on the **unfixed** compiler: SIGSEGV at minor #0 through the harness (`CRASHED`), quarantine naming the stale spliced-local deref. Fixed: byte-exact with the oracle under default env and parity-env, on both `PERRY_RS4GC` backends.
- Original three.js repro (`new WebGLRenderTarget()`, three 0.180.0 via `compilePackages`): passes on default heap, forced 1 MiB nursery, forced nursery + quarantine (depth 800), and the `PERRY_RS4GC=0` build. `PERRY_GC_DIAG` confirms 2 copying collections, so the stress is live, not vacuous.
- `gc_repsel_matrix.sh --arms pr` on the new test: 7/7 cells byte-exact vs pinned node 26.5.1; the moving arms (`evac_minor`, `force_verify`) are live (3,469 objects moved).
- Full `test_gap_` sweep A/B on the same host, same oracle: failure lists byte-identical between the unfixed and fixed compilers except the new test (crash → pass). The pre-existing deltas on that host are its ext-feature link gaps (http2/net) and known snapshot entries.
- `cargo test -p perry-codegen`: 1347 passed. `scripts/run_lint_gates.sh`: green except the known worktree-only `cargo fmt --all` manifest quirk (changed files are rustfmt-clean); the test-registration gate passes with the new corpus entry.

https://claude.ai/code/session_0131AxDes1mwPJJ343CxS4oX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause object references in inlined constructors to become invalid during garbage collection.
  * Improved reliability for object creation across direct, inherited, and dynamic constructor paths.

* **Tests**
  * Added regression coverage for garbage collection during constructor execution and object allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->