### PR TITLE
perf(runtime,codegen): direct install for __export's get-only descriptors (groundwork; honest numbers inside)

### DIFF
--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -211,6 +211,25 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // (ToString, accessor descriptors, closure creation), leaving `obj`
         // and `key` stale in bare SSA registers across the collection point.
         Expr::ObjectDefineProperty(obj, key, value) => {
+            // Fast path: the esbuild `__export` / CJS-interop descriptor
+            // literal `{ get: <expr>, enumerable: true }` (either property
+            // order) lowers to a direct accessor-install call, skipping the
+            // descriptor allocation and its by-name field decode. `true` is
+            // effect-free, so evaluating only obj → key → getter preserves
+            // the literal's evaluation order; the runtime entrypoint owns the
+            // exact `defineProperty` semantics (see
+            // perry-runtime's object_ops/define_get_accessor.rs contract).
+            if let Some(getter) = get_only_descriptor_getter(ctx.classes, value) {
+                return rooting::with_operands_rooted(ctx, &[obj, key, getter], |ctx, vals| {
+                    let blk = ctx.block();
+                    blk.call(
+                        DOUBLE,
+                        "js_object_define_get_accessor",
+                        &[(DOUBLE, &vals[0]), (DOUBLE, &vals[1]), (DOUBLE, &vals[2])],
+                    );
+                    Ok(vals[0].clone())
+                });
+            }
             rooting::with_operands_rooted(ctx, &[obj, key, value], |ctx, vals| {
                 let blk = ctx.block();
                 blk.call(
@@ -1066,5 +1085,209 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
 
         // -------- set.clear() --------
         _ => unreachable!("expr/mod.rs dispatched a variant not handled by this submodule"),
+    }
+}
+
+/// The esbuild `__export` descriptor literal: a closed-shape two-field
+/// `{ get: <expr>, enumerable: true }` (either property order), lowered by
+/// perry-hir to `new __AnonShape_N(<get value>, true)`. Returns the getter's
+/// argument expression when — and only when — the descriptor is exactly that
+/// shape; anything else (extra fields, a non-`true`-literal `enumerable`, a
+/// non-anon-shape class, appended capture args) keeps the generic
+/// `js_object_define_property` lowering. Dropping the `enumerable` position
+/// is order-preserving because its argument is the effect-free literal
+/// `true`.
+fn get_only_descriptor_getter<'e>(
+    classes: &std::collections::HashMap<String, &perry_hir::Class>,
+    desc: &'e Expr,
+) -> Option<&'e Expr> {
+    let Expr::New {
+        class_name,
+        args,
+        cap_args_appended,
+        ..
+    } = desc
+    else {
+        return None;
+    };
+    if !class_name.starts_with("__AnonShape_") || *cap_args_appended != 0 || args.len() != 2 {
+        return None;
+    }
+    let class = classes.get(class_name)?;
+    // Anon-shape classes are pure field records; fail closed if this one is
+    // anything more (a parent chain or any method surface could change what
+    // constructing — or decoding — the literal observes).
+    if class.extends.is_some()
+        || class.extends_name.is_some()
+        || class.extends_expr.is_some()
+        || class.fields.len() != 2
+        || !class.methods.is_empty()
+        || !class.static_methods.is_empty()
+        || !class.getters.is_empty()
+        || !class.setters.is_empty()
+        || !class.computed_members.is_empty()
+        || !class.static_fields.is_empty()
+    {
+        return None;
+    }
+    let (get_idx, enumerable_idx) =
+        match (class.fields[0].name.as_str(), class.fields[1].name.as_str()) {
+            ("get", "enumerable") => (0usize, 1usize),
+            ("enumerable", "get") => (1, 0),
+            _ => return None,
+        };
+    matches!(args[enumerable_idx], Expr::Bool(true)).then(|| &args[get_idx])
+}
+
+#[cfg(test)]
+mod define_get_accessor_tests {
+    use super::*;
+    use crate::{compile_module, CompileOptions};
+    use perry_hir::types::Type;
+    use perry_hir::{Class, ClassField, Module, ModuleInitKind, Stmt};
+
+    const DESC_SHAPE: &str = "__AnonShape_00000000000desc";
+    const EMPTY_SHAPE: &str = "__AnonShape_0000000000empty";
+
+    fn anon_shape_class(id: u32, name: &str, fields: &[&str]) -> Class {
+        Class {
+            id,
+            name: name.to_string(),
+            type_params: Vec::new(),
+            extends: None,
+            extends_name: None,
+            native_extends: None,
+            extends_expr: None,
+            heritage_lexically_shadowed: false,
+            fields: fields
+                .iter()
+                .map(|field| ClassField {
+                    name: (*field).to_string(),
+                    key_expr: None,
+                    ty: Type::Any,
+                    init: None,
+                    is_private: false,
+                    is_readonly: false,
+                    decorators: Vec::new(),
+                })
+                .collect(),
+            constructor: None,
+            methods: Vec::new(),
+            getters: Vec::new(),
+            setters: Vec::new(),
+            static_accessor_names: Vec::new(),
+            static_accessor_fn_ids: Vec::new(),
+            computed_members: Vec::new(),
+            static_fields: Vec::new(),
+            static_methods: Vec::new(),
+            decorators: Vec::new(),
+            is_exported: false,
+            aliases: Vec::new(),
+            is_nested: false,
+            alloc_width_hint: 0,
+            specialized_from: None,
+        }
+    }
+
+    /// `const o = {}; Object.defineProperty(o, "a", new __AnonShape(<desc args>))`
+    fn define_property_module(desc_fields: &[&str], desc_args: Vec<Expr>) -> Module {
+        let mut m = Module::new("define_get_accessor.ts");
+        m.classes = vec![
+            anon_shape_class(701, EMPTY_SHAPE, &[]),
+            anon_shape_class(702, DESC_SHAPE, desc_fields),
+        ];
+        m.init = vec![
+            Stmt::Let {
+                id: 1,
+                name: "o".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::New {
+                    class_name: EMPTY_SHAPE.to_string(),
+                    args: Vec::new(),
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                    cap_args_appended: 0,
+                }),
+            },
+            Stmt::Expr(Expr::ObjectDefineProperty(
+                Box::new(Expr::LocalGet(1)),
+                Box::new(Expr::String("a".to_string())),
+                Box::new(Expr::New {
+                    class_name: DESC_SHAPE.to_string(),
+                    args: desc_args,
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                    cap_args_appended: 0,
+                }),
+            )),
+        ];
+        m.init_kind = ModuleInitKind::Eager;
+        m
+    }
+
+    fn emit(m: &Module) -> String {
+        let opts = CompileOptions {
+            is_entry_module: true,
+            emit_ir_only: true,
+            ..Default::default()
+        };
+        String::from_utf8(compile_module(m, opts).unwrap()).expect("LLVM IR should be UTF-8")
+    }
+
+    #[test]
+    fn get_enumerable_true_literal_takes_the_fast_call() {
+        for fields in [&["get", "enumerable"][..], &["enumerable", "get"][..]] {
+            let mut args = vec![Expr::Undefined, Expr::Bool(true)];
+            if fields[0] == "enumerable" {
+                args.reverse();
+            }
+            let ir = emit(&define_property_module(fields, args));
+            // Assert on CALL SITES (`@name(double %…`) — the runtime decl
+            // block declares both symbols in every module.
+            assert!(
+                ir.contains("@js_object_define_get_accessor(double %"),
+                "{fields:?}: the literal shape must lower to the direct accessor install"
+            );
+            assert!(
+                !ir.contains("@js_object_define_property(double %"),
+                "{fields:?}: the descriptor allocation + generic decode must be gone"
+            );
+        }
+    }
+
+    #[test]
+    fn non_matching_descriptors_keep_the_generic_call() {
+        // `enumerable: false`, `enumerable: <non-literal>`, a third field, and
+        // a get-less two-field record all stay on the generic path.
+        let cases: Vec<(Vec<&str>, Vec<Expr>)> = vec![
+            (
+                vec!["get", "enumerable"],
+                vec![Expr::Undefined, Expr::Bool(false)],
+            ),
+            (
+                vec!["get", "enumerable"],
+                vec![Expr::Undefined, Expr::LocalGet(1)],
+            ),
+            (
+                vec!["get", "enumerable", "configurable"],
+                vec![Expr::Undefined, Expr::Bool(true), Expr::Bool(true)],
+            ),
+            (
+                vec!["value", "enumerable"],
+                vec![Expr::Undefined, Expr::Bool(true)],
+            ),
+        ];
+        for (fields, args) in cases {
+            let ir = emit(&define_property_module(&fields, args));
+            assert!(
+                ir.contains("@js_object_define_property(double %"),
+                "{fields:?}: must keep the generic lowering"
+            );
+            assert!(
+                !ir.contains("@js_object_define_get_accessor(double %"),
+                "{fields:?}: must not take the fast call"
+            );
+        }
     }
 }

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -256,6 +256,15 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, DOUBLE],
     );
+    // Fast path for the `{ get: <expr>, enumerable: true }` descriptor
+    // literal (esbuild `__export` / CJS interop re-export getters) — see
+    // expr/misc_methods.rs and perry-runtime's
+    // object_ops/define_get_accessor.rs.
+    module.declare_function(
+        "js_object_define_get_accessor",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function(
         "js_object_get_own_property_descriptor",
         DOUBLE,

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -10,6 +10,7 @@
 use super::*;
 
 mod accessors;
+mod define_get_accessor;
 mod define_properties;
 mod define_property;
 mod descriptor_helpers;
@@ -24,6 +25,7 @@ pub use accessors::{
     js_object_define_getter, js_object_define_setter, js_object_get_own_field_or_undef,
     js_object_lookup_getter, js_object_lookup_setter,
 };
+pub use define_get_accessor::js_object_define_get_accessor;
 pub use define_properties::{js_object_define_properties, js_object_set_prototype_of};
 pub use define_property::js_object_define_property;
 pub use from_entries::js_object_from_entries;

--- a/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
@@ -110,8 +110,7 @@ unsafe fn try_fast_install(
     // allocates — the first possible collection point, hence the rooted
     // re-reads below). Admission proved the key is a string, so no user
     // `toString` runs here.
-    let (_, key_value) = key_handle.across_nanbox(|| ());
-    let key_str = crate::builtins::js_string_coerce(key_value);
+    let key_str = crate::builtins::js_string_coerce(key_handle.get_nanbox_f64());
     if key_str.is_null() {
         return None;
     }
@@ -121,31 +120,35 @@ unsafe fn try_fast_install(
     if obj.is_null() {
         return None;
     }
-    let (_, mut key_str) = key_str_handle.across_const::<crate::StringHeader, _>(|| ());
-
     // The key as a Rust-heap string for the descriptor side tables — immune
-    // to evacuation, safe across every call below.
-    let key_rust: String = {
-        let name_ptr = crate::string::string_data(key_str);
-        let name_len = (*key_str).byte_len as usize;
-        std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
-            .ok()?
-            .to_string()
-    };
+    // to evacuation, safe across every call below. The accompanying indexed
+    // presence probe is non-allocating, so both uses share one scoped read.
+    let (key_rust, indexed_present) =
+        key_str_handle.with_const_ptr(|key_str: *const crate::StringHeader| {
+            let name_ptr = crate::string::string_data(key_str);
+            let name_len = (*key_str).byte_len as usize;
+            let key_rust = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                .ok()?
+                .to_string();
+            Some((key_rust, own_key_present_via_index(obj, key_str)))
+        })?;
 
     // Brand-new keys only: a redefinition carries the non-configurable
     // validation and omitted-field retention semantics the generic arm owns.
     // Same presence probe, same order, as the generic `existing_attrs` read.
-    let present = match own_key_present_via_index(obj, key_str) {
-        Some(present) => present,
-        None => super::super::obj_value_has_own_key(obj_value, key_handle.get_nanbox_f64()),
+    let (present, refreshed_key_str) = match indexed_present {
+        Some(present) => (present, None),
+        None => {
+            let (present, key_str) = key_str_handle.across_const::<crate::StringHeader, _>(|| {
+                super::super::obj_value_has_own_key(obj_value, key_handle.get_nanbox_f64())
+            });
+            (present, Some(key_str))
+        }
     };
     // (`obj_value_has_own_key` string-coerces its key internally and can
     // allocate — refresh before the next deref.)
     obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
     obj = extract_obj_ptr(obj_value);
-    let (_, refreshed_key_str) = key_str_handle.across_const::<crate::StringHeader, _>(|| ());
-    key_str = refreshed_key_str;
     if present || obj.is_null() {
         return None;
     }
@@ -153,8 +156,15 @@ unsafe fn try_fast_install(
     // ---- Committed: mirror the generic ordinary-object accessor arm. ----
     super::super::mark_object_dynamic_shape_unknown(obj);
     // Make the key discoverable (hasOwn / keys / getOwnPropertyNames) — the
-    // accessor itself lives in the side table, not in a value slot.
-    ensure_key_in_keys_array(obj, key_str);
+    // accessor itself lives in the side table, not in a value slot. The entry
+    // point roots both arguments before its first possible allocation.
+    if let Some(key_str) = refreshed_key_str {
+        ensure_key_in_keys_array(obj, key_str);
+    } else {
+        key_str_handle.with_const_ptr(|key_str: *const crate::StringHeader| {
+            ensure_key_in_keys_array(obj, key_str)
+        });
+    }
     obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
     obj = extract_obj_ptr(obj_value);
     if obj.is_null() {
@@ -165,7 +175,7 @@ unsafe fn try_fast_install(
     // `clone_closure_rebind_this` clones-and-rebinds CAPTURES_THIS closures
     // and passes every other value through untouched — identical to the
     // generic arm's treatment of the descriptor's `get` field.
-    let (_, getter) = getter_handle.across_nanbox(|| ());
+    let getter = getter_handle.get_nanbox_f64();
     let get_bits = if crate::JSValue::from_bits(getter.to_bits()).is_undefined() {
         0
     } else {

--- a/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
@@ -1,0 +1,365 @@
+//! `Object.defineProperty` fast path for the get-only descriptor literal
+//! `{ get: <expr>, enumerable: true }`.
+//!
+//! esbuild emits `__export(target, { name: () => binding, … })` re-export
+//! blocks at module TOP LEVEL — always executed at startup. pi's 13 MB bundle
+//! carries 44 such sites totalling ~1,245 getter installs, and its CJS
+//! interop blocks add `Object.defineProperty(exports, "X", { enumerable:
+//! true, get: … })` on top. Every one of those previously allocated a
+//! two-field descriptor object and re-decoded it by field name inside
+//! `js_object_define_property`. Codegen recognises the literal descriptor
+//! shape (`perry-codegen/src/expr/misc_methods.rs`) and calls this entrypoint
+//! with the getter value directly, skipping the descriptor allocation.
+//!
+//! ## Contract
+//!
+//! Observable behaviour is byte-for-byte
+//! `js_object_define_property(obj, key, { get, enumerable: true })`, split in
+//! two arms:
+//!
+//! * the **fast arm** reproduces the generic ordinary-object accessor arm's
+//!   exact effects for the one case it admits — plain extensible
+//!   `GC_TYPE_OBJECT` receiver, plain non-numeric string key, brand-new own
+//!   property, callable-or-`undefined` getter, unpolluted `Object.prototype`;
+//! * **everything else** materialises the two-field descriptor and delegates
+//!   to `js_object_define_property`, so exotic receivers (proxy / handle /
+//!   class-ref / closure / typed array / buffer / frozen / sealed), symbol
+//!   and numeric keys, redefinitions and the descriptor-validation
+//!   TypeErrors are decided by exactly the code that decides them today.
+//!
+//! Two generic-path arms need no admission probe because they are no-ops for
+//! this descriptor shape: the declared-class prototype-object arm
+//! (`class_id_for_decl_prototype_object`) only routes descriptors that carry
+//! a `value` field, and `arguments_object_after_define` only acts on
+//! canonical array-index keys, which the key probe already rejects.
+use super::descriptor_helpers::{object_prototype_has_desc_field, value_is_callable};
+use super::*;
+
+/// Can the fast arm reproduce the generic path bit-for-bit for this
+/// receiver / key / getter triple? Pure probes — no allocation, no user code.
+unsafe fn fast_path_admissible(obj_value: f64, key_value: f64, getter: f64) -> bool {
+    // Receiver: a plain, extensible, ordinary heap object. `extract_obj_ptr`
+    // rejects the handle bands (zlib/fetch/timer/proxy registry ids) and
+    // accepts both the tagged and the raw-I64 pointer encodings, mirroring
+    // the generic entry classification.
+    let obj = extract_obj_ptr(obj_value);
+    if obj.is_null() {
+        return false;
+    }
+    let addr = obj as usize;
+    match crate::value::addr_class::try_read_gc_header(addr) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT => {}
+        _ => return false, // array / typed array / closure / Map / Date / …
+    }
+    // RegExp is an OBJECT-typed exotic cell; Date/Error route their defines
+    // through the expando side tables.
+    if super::super::exotic_expando::exotic_expando_kind(addr).is_some() {
+        return false;
+    }
+    // ArrayBuffer/SharedArrayBuffer/DataView keep named-property descriptors
+    // in the buffer expando tables.
+    if crate::buffer::is_registered_buffer(addr) {
+        return false;
+    }
+    // Frozen / sealed / preventExtensions receivers must throw
+    // "Cannot define property …, object is not extensible" — generic arm.
+    if (*gc_header_for(obj))._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+        return false;
+    }
+    // Key: a plain string (heap or SSO) that is neither numeric (canonical
+    // index semantics: the Object.prototype hole flag, arguments-object
+    // index mapping, the Array-subclass elements deopt) nor `length` (the
+    // other elements-deopt key).
+    let kv = crate::JSValue::from_bits(key_value.to_bits());
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let Some(bytes) = crate::string::js_string_key_bytes(kv, &mut sso) else {
+        return false; // symbol / number / object keys → generic
+    };
+    if !bytes.is_empty() && bytes.iter().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    if bytes == b"length" {
+        return false;
+    }
+    // Getter: `{ get: undefined }` installs an undefined getter; any other
+    // non-callable value must raise `ToPropertyDescriptor`'s exact
+    // "Getter must be a function: …" TypeError — generic arm.
+    let g = crate::JSValue::from_bits(getter.to_bits());
+    if !g.is_undefined() && !value_is_callable(getter) {
+        return false;
+    }
+    // `ToPropertyDescriptor` reads absent fields through the prototype chain,
+    // so `Object.prototype.set = …`-style pollution must take the generic
+    // decode (the same guard `try_decode_descriptor` applies).
+    if object_prototype_has_desc_field() {
+        return false;
+    }
+    true
+}
+
+/// The fast arm. Returns `Some(obj)` when it performed the define, `None`
+/// when a rooted-phase re-probe says the generic arm must decide (existing
+/// own key, non-UTF-8 key, coercion surprise).
+unsafe fn try_fast_install(
+    scope: &crate::gc::RuntimeHandleScope,
+    obj_handle: &crate::gc::RuntimeHandle<'_>,
+    key_handle: &crate::gc::RuntimeHandle<'_>,
+    getter_handle: &crate::gc::RuntimeHandle<'_>,
+) -> Option<f64> {
+    // Materialise the key's heap form (identity for a heap string; an SSO key
+    // allocates — the first possible collection point, hence the rooted
+    // re-reads below). Admission proved the key is a string, so no user
+    // `toString` runs here.
+    let key_str = crate::builtins::js_string_coerce(key_handle.get_nanbox_f64());
+    if key_str.is_null() {
+        return None;
+    }
+    let key_str_handle = scope.root_string_ptr(key_str);
+    let mut obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
+    let mut obj = extract_obj_ptr(obj_value);
+    if obj.is_null() {
+        return None;
+    }
+    let mut key_str = key_str_handle.get_raw_const_ptr::<crate::StringHeader>();
+
+    // The key as a Rust-heap string for the descriptor side tables — immune
+    // to evacuation, safe across every call below.
+    let key_rust: String = {
+        let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key_str).byte_len as usize;
+        std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+            .ok()?
+            .to_string()
+    };
+
+    // Brand-new keys only: a redefinition carries the non-configurable
+    // validation and omitted-field retention semantics the generic arm owns.
+    // Same presence probe, same order, as the generic `existing_attrs` read.
+    let present = match own_key_present_via_index(obj, key_str) {
+        Some(present) => present,
+        None => super::super::obj_value_has_own_key(obj_value, key_handle.get_nanbox_f64()),
+    };
+    // (`obj_value_has_own_key` string-coerces its key internally and can
+    // allocate — refresh before the next deref.)
+    obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
+    obj = extract_obj_ptr(obj_value);
+    key_str = key_str_handle.get_raw_const_ptr::<crate::StringHeader>();
+    if present || obj.is_null() {
+        return None;
+    }
+
+    // ---- Committed: mirror the generic ordinary-object accessor arm. ----
+    super::super::mark_object_dynamic_shape_unknown(obj);
+    // Make the key discoverable (hasOwn / keys / getOwnPropertyNames) — the
+    // accessor itself lives in the side table, not in a value slot.
+    ensure_key_in_keys_array(obj, key_str);
+    obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
+    obj = extract_obj_ptr(obj_value);
+    if obj.is_null() {
+        return Some(obj_value);
+    }
+
+    // Issue #450: the getter runs with `this === obj`.
+    // `clone_closure_rebind_this` clones-and-rebinds CAPTURES_THIS closures
+    // and passes every other value through untouched — identical to the
+    // generic arm's treatment of the descriptor's `get` field.
+    let getter = getter_handle.get_nanbox_f64();
+    let get_bits = if crate::JSValue::from_bits(getter.to_bits()).is_undefined() {
+        0
+    } else {
+        // `recv_box` is derived from the CURRENT receiver, one statement
+        // before the clone that can move it (the callee roots its operands).
+        let recv_box = crate::value::js_nanbox_pointer(obj as i64);
+        crate::closure::clone_closure_rebind_this(getter.to_bits(), recv_box)
+    };
+    obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
+    obj = extract_obj_ptr(obj_value);
+    if obj.is_null() {
+        return Some(obj_value);
+    }
+    set_accessor_descriptor(
+        obj as usize,
+        key_rust.clone(),
+        AccessorDescriptor {
+            get: get_bits,
+            set: 0,
+        },
+    );
+    // New-property attributes for `{ get, enumerable: true }`: `enumerable`
+    // explicit, omitted `configurable` → false, and the internal writable bit
+    // stays `true` for a brand-new accessor (the generic arm's `has_accessor`
+    // default) so data lookups before the accessor override don't reject a
+    // legitimate fallthrough write.
+    set_property_attrs(
+        obj as usize,
+        key_rust,
+        PropertyAttrs::new(true, true, false),
+    );
+    Some(f64::from_bits(obj_handle.get_heap_word_u64()))
+}
+
+/// `Object.defineProperty(obj, key, { get: getter, enumerable: true })`,
+/// without the descriptor allocation on the admissible path. Returns the
+/// object (NaN-boxed), like `js_object_define_property`.
+#[no_mangle]
+pub extern "C" fn js_object_define_get_accessor(
+    obj_value: f64,
+    key_value: f64,
+    getter_value: f64,
+) -> f64 {
+    unsafe {
+        // ONE handle scope shared by both arms (see define_property.rs #7963:
+        // an inner scope dropped while an outer one is still taking handles
+        // truncates the outer container). The callee-owned scopes (string
+        // coerce, keys append, the generic define) nest and drop entirely
+        // inside their calls.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let obj_handle = scope.root_heap_word_u64(obj_value.to_bits());
+        let key_handle = scope.root_nanbox_f64(key_value);
+        let getter_handle = scope.root_nanbox_f64(getter_value);
+
+        if fast_path_admissible(obj_value, key_value, getter_value) {
+            if let Some(ret) = try_fast_install(&scope, &obj_handle, &key_handle, &getter_handle) {
+                return ret;
+            }
+        }
+
+        // Generic arm: materialise `{ get, enumerable: true }` — exactly what
+        // the descriptor literal would have allocated — and let
+        // `js_object_define_property` decide everything: validation
+        // TypeErrors, exotic receivers, redefinition, retention. Mirrors the
+        // Annex B `define_accessor_annexb` builder one file over.
+        let desc = js_object_alloc(0, 2);
+        if desc.is_null() {
+            return f64::from_bits(obj_handle.get_heap_word_u64());
+        }
+        let desc_handle = scope.root_raw_mut_ptr(desc);
+        let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
+        js_object_set_field_by_name(
+            desc_handle.get_raw_mut_ptr::<ObjectHeader>(),
+            get_key,
+            getter_handle.get_nanbox_f64(),
+        );
+        let enum_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+        let true_v = f64::from_bits(crate::JSValue::bool(true).bits());
+        js_object_set_field_by_name(
+            desc_handle.get_raw_mut_ptr::<ObjectHeader>(),
+            enum_key,
+            true_v,
+        );
+        let desc_val = f64::from_bits(
+            crate::JSValue::pointer(desc_handle.get_raw_mut_ptr::<u8>() as *const u8).bits(),
+        );
+        js_object_define_property(
+            f64::from_bits(obj_handle.get_heap_word_u64()),
+            key_handle.get_nanbox_f64(),
+            desc_val,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{
+        get_accessor_descriptor, get_property_attrs, js_object_alloc, js_object_set_field_by_name,
+    };
+    use super::*;
+
+    unsafe fn heap_key(name: &str) -> *const crate::StringHeader {
+        crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32)
+            as *const crate::StringHeader
+    }
+
+    unsafe fn obj_val(obj: *mut ObjectHeader) -> f64 {
+        f64::from_bits(crate::JSValue::pointer(obj as *const u8).bits())
+    }
+
+    unsafe fn str_val(name: &str) -> f64 {
+        f64::from_bits(crate::JSValue::string_ptr(heap_key(name) as *mut _).bits())
+    }
+
+    const UNDEF: f64 = f64::from_bits(crate::value::TAG_UNDEFINED);
+
+    /// Fast arm: a brand-new non-numeric string key on a plain object takes
+    /// the inline install, and its side-table state is identical to what the
+    /// generic `js_object_define_property` arm records for the same
+    /// descriptor.
+    #[test]
+    fn fast_arm_matches_generic_state() {
+        let _global = crate::gc::global_side_table_test_lock();
+        unsafe {
+            // Fast arm.
+            let fast = js_object_alloc(0, 0);
+            let ret = js_object_define_get_accessor(obj_val(fast), str_val("alpha"), UNDEF);
+            assert_eq!(ret.to_bits(), obj_val(fast).to_bits(), "returns the object");
+
+            // Generic reference: same shape through the descriptor decode.
+            let generic = js_object_alloc(0, 0);
+            let desc = js_object_alloc(0, 2);
+            js_object_set_field_by_name(desc, heap_key("get"), UNDEF);
+            js_object_set_field_by_name(
+                desc,
+                heap_key("enumerable"),
+                f64::from_bits(crate::JSValue::bool(true).bits()),
+            );
+            js_object_define_property(obj_val(generic), str_val("alpha"), obj_val(desc));
+
+            for (label, obj) in [("fast", fast), ("generic", generic)] {
+                let acc = get_accessor_descriptor(obj as usize, "alpha")
+                    .unwrap_or_else(|| panic!("{label}: accessor entry installed"));
+                assert_eq!(acc.get, 0, "{label}: undefined getter records 0");
+                assert_eq!(acc.set, 0, "{label}: no setter");
+                let attrs = get_property_attrs(obj as usize, "alpha")
+                    .unwrap_or_else(|| panic!("{label}: attrs recorded"));
+                assert!(attrs.writable(), "{label}: new-accessor writable default");
+                assert!(attrs.enumerable(), "{label}: explicit enumerable: true");
+                assert!(!attrs.configurable(), "{label}: omitted configurable");
+                assert!(
+                    own_key_present(obj, heap_key("alpha")),
+                    "{label}: key in keys_array"
+                );
+            }
+        }
+    }
+
+    /// Numeric keys are inadmissible (canonical-index semantics) and must
+    /// flow through the materialised-descriptor generic arm — which still
+    /// installs the accessor with the same attributes.
+    #[test]
+    fn numeric_key_takes_generic_arm() {
+        let _global = crate::gc::global_side_table_test_lock();
+        unsafe {
+            let obj = js_object_alloc(0, 0);
+            js_object_define_get_accessor(obj_val(obj), str_val("7"), UNDEF);
+            let acc =
+                get_accessor_descriptor(obj as usize, "7").expect("generic arm installs accessor");
+            assert_eq!((acc.get, acc.set), (0, 0));
+            let attrs = get_property_attrs(obj as usize, "7").expect("attrs recorded");
+            assert!(attrs.writable() && attrs.enumerable() && !attrs.configurable());
+        }
+    }
+
+    /// Redefining an EXISTING own data property is inadmissible: the generic
+    /// arm converts data → accessor and RETAINS the omitted `configurable`
+    /// from the existing property (`true` for a plain assigned field) — the
+    /// new-property `false` default must NOT apply.
+    #[test]
+    fn existing_key_takes_generic_arm_and_retains_configurable() {
+        let _global = crate::gc::global_side_table_test_lock();
+        unsafe {
+            let obj = js_object_alloc(0, 1);
+            js_object_set_field_by_name(obj, heap_key("x"), 42.0);
+            js_object_define_get_accessor(obj_val(obj), str_val("x"), UNDEF);
+            assert!(
+                get_accessor_descriptor(obj as usize, "x").is_some(),
+                "data property converted to accessor"
+            );
+            let attrs = get_property_attrs(obj as usize, "x").expect("attrs recorded");
+            assert!(
+                attrs.configurable(),
+                "retained from the existing plain property, not the new-property false default"
+            );
+            assert!(attrs.enumerable(), "explicit enumerable: true");
+        }
+    }
+}

--- a/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_get_accessor.rs
@@ -110,7 +110,8 @@ unsafe fn try_fast_install(
     // allocates — the first possible collection point, hence the rooted
     // re-reads below). Admission proved the key is a string, so no user
     // `toString` runs here.
-    let key_str = crate::builtins::js_string_coerce(key_handle.get_nanbox_f64());
+    let (_, key_value) = key_handle.across_nanbox(|| ());
+    let key_str = crate::builtins::js_string_coerce(key_value);
     if key_str.is_null() {
         return None;
     }
@@ -120,12 +121,12 @@ unsafe fn try_fast_install(
     if obj.is_null() {
         return None;
     }
-    let mut key_str = key_str_handle.get_raw_const_ptr::<crate::StringHeader>();
+    let (_, mut key_str) = key_str_handle.across_const::<crate::StringHeader, _>(|| ());
 
     // The key as a Rust-heap string for the descriptor side tables — immune
     // to evacuation, safe across every call below.
     let key_rust: String = {
-        let name_ptr = (key_str as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_ptr = crate::string::string_data(key_str);
         let name_len = (*key_str).byte_len as usize;
         std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
             .ok()?
@@ -143,7 +144,8 @@ unsafe fn try_fast_install(
     // allocate — refresh before the next deref.)
     obj_value = f64::from_bits(obj_handle.get_heap_word_u64());
     obj = extract_obj_ptr(obj_value);
-    key_str = key_str_handle.get_raw_const_ptr::<crate::StringHeader>();
+    let (_, refreshed_key_str) = key_str_handle.across_const::<crate::StringHeader, _>(|| ());
+    key_str = refreshed_key_str;
     if present || obj.is_null() {
         return None;
     }
@@ -163,7 +165,7 @@ unsafe fn try_fast_install(
     // `clone_closure_rebind_this` clones-and-rebinds CAPTURES_THIS closures
     // and passes every other value through untouched — identical to the
     // generic arm's treatment of the descriptor's `get` field.
-    let getter = getter_handle.get_nanbox_f64();
+    let (_, getter) = getter_handle.across_nanbox(|| ());
     let get_bits = if crate::JSValue::from_bits(getter.to_bits()).is_undefined() {
         0
     } else {
@@ -235,21 +237,17 @@ pub extern "C" fn js_object_define_get_accessor(
         }
         let desc_handle = scope.root_raw_mut_ptr(desc);
         let get_key = crate::string::js_string_from_bytes(b"get".as_ptr(), 3);
-        js_object_set_field_by_name(
-            desc_handle.get_raw_mut_ptr::<ObjectHeader>(),
-            get_key,
-            getter_handle.get_nanbox_f64(),
-        );
+        desc_handle.with_mut_ptr(|desc: *mut ObjectHeader| {
+            js_object_set_field_by_name(desc, get_key, getter_handle.get_nanbox_f64())
+        });
         let enum_key = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
         let true_v = f64::from_bits(crate::JSValue::bool(true).bits());
-        js_object_set_field_by_name(
-            desc_handle.get_raw_mut_ptr::<ObjectHeader>(),
-            enum_key,
-            true_v,
-        );
-        let desc_val = f64::from_bits(
-            crate::JSValue::pointer(desc_handle.get_raw_mut_ptr::<u8>() as *const u8).bits(),
-        );
+        desc_handle.with_mut_ptr(|desc: *mut ObjectHeader| {
+            js_object_set_field_by_name(desc, enum_key, true_v)
+        });
+        let desc_val = desc_handle.with_mut_ptr(|desc: *mut u8| {
+            f64::from_bits(crate::JSValue::pointer(desc as *const u8).bits())
+        });
         js_object_define_property(
             f64::from_bits(obj_handle.get_heap_word_u64()),
             key_handle.get_nanbox_f64(),

--- a/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
+++ b/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
@@ -38,7 +38,7 @@ pub(crate) unsafe fn describe_value_for_type_error(value: f64) -> String {
         return String::new();
     }
     let len = (*s).byte_len as usize;
-    let data = (s as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+    let data = crate::string::string_data(s);
     let bytes = std::slice::from_raw_parts(data, len);
     std::str::from_utf8(bytes).unwrap_or("").to_string()
 }

--- a/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
+++ b/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
@@ -197,7 +197,7 @@ fn desc_field_index(b: &[u8]) -> Option<usize> {
 /// `Object.prototype.enumerable = true` is spec-visible through
 /// `ToPropertyDescriptor`'s inherited-field reads, so a polluted prototype
 /// forces the general path.
-unsafe fn object_prototype_has_desc_field() -> bool {
+pub(super) unsafe fn object_prototype_has_desc_field() -> bool {
     let op = crate::object::builtin_prototype_value("Object");
     let ptr = extract_obj_ptr(op);
     if ptr.is_null() {

--- a/scripts/string_payload_access_baseline.txt
+++ b/scripts/string_payload_access_baseline.txt
@@ -12,7 +12,7 @@ inline-offset | perry-ext-nodemailer | 1
 inline-offset | perry-ext-pg | 2
 inline-offset | perry-ext-zlib | 3
 inline-offset | perry-ffi | 3
-inline-offset | perry-runtime | 364
+inline-offset | perry-runtime | 363
 inline-offset | perry-stdlib | 48
 inline-offset | perry-updater | 5
 reader-helper | perry-ext-ethers | 1

--- a/test-files/test_gap_9053_export_getter_descriptor.ts
+++ b/test-files/test_gap_9053_export_getter_descriptor.ts
@@ -1,0 +1,91 @@
+// #9053: the esbuild `__export` descriptor literal `{ get, enumerable: true }`
+// lowers to a direct accessor install (js_object_define_get_accessor) instead
+// of allocating a two-field descriptor object and re-decoding it by name in
+// js_object_define_property. pi's 13MB bundle runs ~1,245 of these at startup.
+// This fixture pins the fast path's observable parity with node: an
+// __export-style install loop, reads through the live getters, enumeration
+// order, descriptor reflection, redefinition over a fast-installed getter
+// (both the spec-forbidden and the spec-allowed shapes), and the near-miss
+// literals ({get, enumerable: false} / 3-field) staying on the generic path.
+const __defProp = Object.defineProperty;
+const __export = (target: any, all: any) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+
+let hits = 0;
+const state = { a: 1, b: 2, c: 3 };
+const exportsObj: any = {};
+__export(exportsObj, {
+  a: () => { hits++; return state.a; },
+  b: () => { hits++; return state.b; },
+  c: () => { hits++; return state.c; },
+});
+
+// Reads go through the getters; re-export live-binding semantics.
+console.log("reads:", exportsObj.a, exportsObj.b, exportsObj.c, "hits:", hits);
+state.b = 20;
+console.log("live-binding:", exportsObj.b, "hits:", hits);
+
+// Enumeration order and full descriptor reflection must match node exactly.
+console.log("keys:", JSON.stringify(Object.keys(exportsObj)));
+const d: any = Object.getOwnPropertyDescriptor(exportsObj, "a");
+console.log(
+  "desc:",
+  typeof d.get,
+  "set=" + String(d.set),
+  "enumerable=" + String(d.enumerable),
+  "configurable=" + String(d.configurable),
+  "writable=" + String(d.writable)
+);
+console.log("has:", "a" in exportsObj, Object.prototype.hasOwnProperty.call(exportsObj, "b"));
+
+// The install is non-configurable (configurable omitted -> false), so
+// redefining with a DIFFERENT getter must throw exactly like node...
+let msg = "no-throw";
+try {
+  __defProp(exportsObj, "a", { get: () => 111, enumerable: true });
+} catch (e: any) {
+  msg = e.message;
+}
+console.log("redefine-different:", msg, "value:", exportsObj.a);
+
+// ...while the no-change redefine (same getter object, same flags) is
+// spec-ALLOWED on a non-configurable accessor: the fast path must not have
+// frozen anything beyond what defineProperty semantics say.
+const keep = Object.getOwnPropertyDescriptor(exportsObj, "c")!.get;
+let msg2 = "no-throw";
+try {
+  __defProp(exportsObj, "c", { get: keep, enumerable: true });
+} catch (e: any) {
+  msg2 = e.message;
+}
+console.log("redefine-same:", msg2, "value:", exportsObj.c);
+
+// A getter installed CONFIGURABLE via the 3-field literal (generic path) can
+// then be overridden by the 2-field fast-path literal: the redefine retains
+// configurable: true and swaps the getter.
+const cfgTarget: any = {};
+// (direct-callee form on purpose — the alias form is covered above)
+Object.defineProperty(cfgTarget, "cfg", { get: () => "old", enumerable: true, configurable: true });
+Object.defineProperty(cfgTarget, "cfg", { get: () => "new", enumerable: true });
+const dc: any = Object.getOwnPropertyDescriptor(cfgTarget, "cfg");
+console.log(
+  "override:", cfgTarget.cfg,
+  "enumerable=" + String(dc.enumerable),
+  "configurable=" + String(dc.configurable)
+);
+
+// Near-miss literal `{ get, enumerable: false }` takes the generic path and
+// still behaves: readable, non-enumerable, non-configurable.
+const hidden: any = {};
+__defProp(hidden, "h", { get: () => 42, enumerable: false });
+const dh: any = Object.getOwnPropertyDescriptor(hidden, "h");
+console.log(
+  "hidden:", hidden.h,
+  "keys=" + JSON.stringify(Object.keys(hidden)),
+  "enumerable=" + String(dh.enumerable),
+  "configurable=" + String(dh.configurable)
+);
+
+console.log("final-hits:", hits);


### PR DESCRIPTION
Startup-lane groundwork from the pi/cc campaign, with an honest negative-ish finding attached.

esbuild's `__export` runs ~1,245 always-executed `Object.defineProperty(target, name, {get, enumerable:true})` calls at pi startup. This adds `js_object_define_get_accessor` (fast arm strictly limited to plain extensible objects / fresh non-numeric string keys / callable-or-undefined getters / unpolluted Object.prototype — everything else, incl. proxies, redefines, symbol keys, and every ToPropertyDescriptor TypeError, delegates to the generic path via a materialized descriptor) plus HIR-level recognition of the two-field descriptor literal in either field order, fail-closed.

**The honest measurement** (quiet mini, min-of-runs, path selection verified in kept IR before trusting any number): the descriptor alloc+decode this removes is ~1-2% of perry's install cost (−2.0% micro, −1.2% realistic 28-key shape). Node is still ~40x faster on the install itself — the gap lives in the accessor INSTALL machinery: two `HashMap<(usize,String)>` side-table inserts, epoch bumps, and inline-guard invalidation per install. That follow-up (side-table install path) is queued next in the lane; this PR contributes the entrypoint the follow-up needs, the admission analysis, and the parity fixture.

**Validation**: perry-codegen 1349/0 (2 new IR-emission tests incl. both field orders + 4 near-miss shapes staying generic); perry-runtime 2821/0 (one pre-existing SIGABRT excluded, verified identical on pristine main f3f405271c via stash); gap fixture `test_gap_9053_export_getter_descriptor.ts` byte-identical to node incl. redefine TypeErrors and the enumerable:false near-miss; census/file-size/fmt green.

Implemented by a subagent in an isolated worktree; reviewed and shipped by the coordinating session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved performance for common getter-based `Object.defineProperty` operations used by module re-exports and interoperability scenarios.

- **Bug Fixes**
  - Preserved standard behavior for enumeration, getter access, redefinitions, descriptor reflection, and validation errors.
  - Maintained existing behavior for numeric keys, symbols, existing properties, and unsupported descriptor forms.

- **Tests**
  - Added coverage for getter installation, live values, enumeration order, descriptor inspection, redefinitions, and near-matching descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->