### PR TITLE
perf(codegen): entry resolution reaches Any-typed callback params — __commonJS-shape calls 7.4 → 4.5 ns (typed parity)

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -1767,11 +1767,22 @@ pub(super) fn emit_callee_binding_resolutions(
         if ctx.local_closure_func_ids.contains_key(&id) {
             continue;
         }
-        if !matches!(
-            ctx.local_type_hint(&id),
+        // A `Function`-hinted binding is consumed by the guarded
+        // direct-dispatch arm. An UNTYPED (or `Any`) PARAMETER is consumed by
+        // the closure-call fallthrough's map check instead — that is the
+        // esbuild `__commonJS`/`__esm` shape, where every module factory's
+        // callback parameter erases to `Any` and paid the full dispatcher per
+        // call. A binding hinted as something else stays out: the resolution
+        // could only ever return null for it.
+        let hint = ctx.local_type_hint(&id);
+        let function_hinted = matches!(
+            hint,
             Some(perry_hir::types::Type::Function(function))
                 if !function.is_async && !function.is_generator
-        ) {
+        );
+        let any_param =
+            param_ids.contains(&id) && matches!(hint, None | Some(perry_hir::types::Type::Any));
+        if !function_hinted && !any_param {
             continue;
         }
         let value_box = if let Some(&capture_idx) = ctx.closure_captures.get(&id) {

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -389,7 +389,17 @@ pub fn try_lower_closure_typed_local_call(
         }
         // The checked closure-unbox path below validates the current callee;
         // the erased type only decides whether to try that guarded dispatch.
-        if matches!(ctx.local_type_hint(id), Some(HirType::Function(_))) {
+        // #9105 follow-up: an entry-resolved binding takes this guarded arm
+        // even when its type hint erased to `Any` — the esbuild
+        // `__commonJS`/`__esm` factory-callback shape. The arm's runtime
+        // behavior is hint-independent (checked unbox, resolved-target
+        // diamond, full-dispatcher fallback); the hint only ever selected who
+        // enters it.
+        if matches!(ctx.local_type_hint(id), Some(HirType::Function(_)))
+            || ctx
+                .resolved_arrow_callback_targets
+                .contains_key(&(*id, args.len()))
+        {
             // #7803: the callee outlives the arguments here too, and this is
             // the arm on the failing stack — `core/schemas.ts` closure 138,
             // whose callee is a mutable-capture box read (`js_box_get_bits`)


### PR DESCRIPTION
## What

Entry resolution (#9071) reaches **`Any`-typed callback parameters** — the
esbuild `__commonJS`/`__esm` factory shape, where every module-init callback
erases to `Any` and paid the full `js_closure_callN` dispatcher per call:

* the emission gate in `emit_callee_binding_resolutions` admits a PARAMETER
  whose hint is absent or `Any` (a binding hinted as something
  non-function stays out — its resolution could only return null);
* the consuming arm's gate in `early_branches.rs` accepts a callee with a
  resolved-target map entry even when the `Function` hint is missing — the
  arm's runtime behavior (checked unbox, null-guarded direct diamond, full
  dispatcher fallback) was always hint-independent; the hint only selected
  who enters.

A resolution over a non-closure value (a number, `undefined`, a bound
function, a generator) returns null at entry and every call keeps the exact
dispatcher path.

## Numbers

Single-shape 50M-call probes, quiet Linux, same-build
`PERRY_CALLEE_BINDING_RESOLUTION=0` A/B:

| shape | off | on | node |
|---|---|---|---|
| `Any`-param callback loop (`__commonJS` shape) | 7.4 | **4.5** | 0.5 |
| typed-param control (#9071 path) | 8.1 | 4.5 | 0.5 |
| `Any`-param, conditionally called | 7.3 | **4.6** | — |

The `Any` shape reaches exact parity with the typed shape. This is the
"partial until the param-hint gate lifts" band flagged in #9105 and in the
claude-code startup profile split — the cc `--help` re-profile is gated on
this PR landing (plus #9105 and the #9106 fix).

## Semantics

Differential vs node identical: non-function/`undefined` through the `Any`
param (TypeError at the call), the param REASSIGNED mid-body (collector
excludes; the new value is observed), bound functions and ordinary functions
(`this === undefined`) through the `Any` param, arity-mismatch and rest
arrows, capture mutation between calls, generator functions. Kill-switch build
output-identical; the #9105 corpora re-run clean (the one diff is the
documented pre-existing no-TDZ-for-globals `TypeError` vs `ReferenceError`
line, gate-independent).

## Testing

* `RUSTFLAGS=-D warnings cargo check` (host excludes) — clean;
  `perry-codegen` 1830/0 — green.
* `perry-runtime --lib`: 1804 tests pass, then the suite ABORTS at
  `object::reserved_floor::…::user_properties_read_back_through_the_get_path_at_scale`
  (`shapes.rs:1539` ShapeId/ObjectHeader disagreement, double panic) — a main
  regression filed as **#9108** that masks the suite tail for every branch;
  this PR contains no `perry-runtime` files.
* Pinned-worktree integration battery; note `issue_8690` /
  `issue_8773` carry one pre-existing failure each on current main
  (**#9106**, the versioned-loop-clone regression — window
  `8b40634abd..f3f405271c`, owned by the claudecode session), identical on
  base and branch.
* Lint: census, address-class, gc-store-site, file-size, raw-handle debt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of direct calls through untyped or broadly typed callback parameters.
  * Enhanced compatibility with bundled module factory patterns.
  * Improved closure call performance by using faster resolution paths when safe.
  * Preserved existing runtime behavior with fallback safeguards for other callback types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->