### PR TITLE
fix(runtime): tombstone squeeze published stale facts — un-aborts the runtime suite (#9108)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -1252,7 +1252,14 @@ unsafe fn squeeze_holes_and_delete(
         crate::gc::runtime_write_barrier_external_slot_span(keys as usize, elements as usize, out);
     }
     super::rebuild_array_layout_from_slots(keys);
-    set_object_live_slot_count(obj, std::cmp::min(out, alloc_limit) as u32);
+    // Publish the squeezed shape BEFORE touching the live-slot bound: the
+    // squeeze changed the keys array's length in place, and
+    // `set_object_live_slot_count`'s unchanged-bound early return asserts
+    // parity against the STAMPED descriptor — which still carries the
+    // pre-squeeze logical_key_count until the publish below runs. At scale
+    // the floored bound is usually unchanged, so that assert fired mid-
+    // transition (#9108, reserved_floor at-scale test SIGABRT).
+    //
     // Slots moved: the per-array key index and any stale descriptors for the
     // pre-squeeze states are wrong now. Drop the index (rebuilt on demand)
     // and publish the squeezed shape at exactly the surviving hole count —
@@ -1260,4 +1267,5 @@ unsafe fn squeeze_holes_and_delete(
     // for an iterator-family one.
     crate::object::shapes::shape_drop(keys);
     super::shapes::publish_object_shape_holes(obj, floor as u32);
+    set_object_live_slot_count(obj, std::cmp::min(out, alloc_limit) as u32);
 }

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -226,9 +226,17 @@ pub(crate) unsafe fn publish_object_shape_holes(
     if generation == 0 {
         super::shape_id_exhausted_abort();
     }
+    // The key count comes from the ARRAY, not the lineage: the O(1) hole
+    // delete leaves the length untouched (array == lineage), but the squeeze
+    // shrinks it in place before republishing — carrying the lineage count
+    // there left a descriptor disagreeing with the authoritative keys edge,
+    // which the very next parity assert caught (#9108: reserved_floor
+    // at-scale SIGABRT took the whole suite down behind it).
+    let keys_ptr = current.keys as usize as *mut super::ArrayHeader;
+    let logical_key_count = crate::array::keys_array_len_capped_to_capacity(keys_ptr) as u32;
     let id = super::publish_shape_result(super::shape_descriptor_ensure_with_holes(
-        current.keys as usize as *mut super::ArrayHeader,
-        current.logical_key_count,
+        keys_ptr,
+        logical_key_count,
         current.live_inline_slot_count,
         generation,
         current.object_kind,


### PR DESCRIPTION
Fixes #9108 — my tombstone default-on fallout (kill switch `PERRY_OBJECT_TOMBSTONES=0` cures the abort, which is how it was attributed). The squeeze shrank the keys array in place, then `set_object_live_slot_count`'s unchanged-bound early return asserted parity against the still-stamped pre-squeeze descriptor → double panic → SIGABRT at `object::reserved_floor::…at_scale`, silently masking the ~1000 tests behind it on every branch (and the re-exec child's '1 passed' line can masquerade as green in tail-style greps — see the issue).

Two coherence fixes: the squeeze orders `shape_drop → publish_object_shape_holes → set_object_live_slot_count`; and `publish_object_shape_holes` takes `logical_key_count` from the ARRAY rather than the lineage (identical for the O(1) hole delete where length is untouched; the only correct source after a squeeze). Release binaries were never affected — debug_assert only — which is why all differential batteries stayed byte-identical while the suite died.

Verification: `reserved_floor` suite 6/0; **full perry-runtime lib suite runs to completion, 2819 passed / 0 failed** (was: abort at ~test 1804). Suite-integrity blocker for everyone's verification, so flagging for a fast merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object property deletion and shape updates to keep internal object state consistent.
  * Fixed edge cases that could trigger assertion failures when removing properties.
  * Ensured logical property counts remain accurate after object shapes are republished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->