### PR TITLE
perf(runtime): small-int string cache in String() coercion + itoa integer operands in js_string_concat_box

### DIFF
--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -671,11 +671,13 @@ pub extern "C" fn js_string_coerce(value: f64) -> *mut StringHeader {
     } else if jsval.is_int32() {
         jsval.as_int32().to_string()
     } else {
-        // Regular number — ECMAScript NumberToString. #3987: route through the
-        // shared `js_format_f64` so `String(1e21)` → "1e+21" / `String(1e-7)`
-        // → "1e-7" (scientific notation for |n| >= 1e21 / < 1e-6) instead of
-        // Rust's full-decimal `to_string()`, matching `.toString()` and Node.
-        crate::string::js_format_f64(value)
+        // Regular number — delegate to `js_number_to_string`: its small-int
+        // cache answers `String(i)` for 0..255 with an interned longlived
+        // string and NO allocation (the `format!` machinery this arm used to
+        // run per call was ~15% of the string-ops profile), and its fallback
+        // is the same shared `js_format_f64` (#3987 scientific-notation
+        // semantics), so the output is bit-identical on every input.
+        return crate::string::js_number_to_string(value);
     };
 
     js_string_from_bytes(result.as_ptr(), result.len() as u32)

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -137,14 +137,67 @@ fn bytes_all_ascii(data: *const u8, len: u32) -> bool {
 pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
     let mut scratch_l = [0u8; crate::value::SHORT_STRING_MAX_LEN];
     let mut scratch_r = [0u8; crate::value::SHORT_STRING_MAX_LEN];
-    let (Some(l), Some(r)) = (
-        str_bytes_from_jsvalue(l_value, &mut scratch_l),
-        str_bytes_from_jsvalue(r_value, &mut scratch_r),
-    ) else {
-        // `str_bytes_from_jsvalue` returns `None` for exactly the non-string
-        // values, so this is the annotation-lie arm and nothing else.
-        return unsafe { crate::value::js_dynamic_string_or_number_add(l_value, r_value) };
-    };
+    // A PLAIN-F64 small-integer operand next to a string operand is the
+    // template-literal hot shape (`` `id-${i}` ``): itoa it into a stack
+    // buffer and flow it through the same SSO/heap assembly the two-string
+    // case uses, instead of handing the pair to the full dynamic `+` (whose
+    // ToPrimitive round trip and `format!` formatting were the template
+    // path's entire overhead). Only exact spec-identical cases are taken:
+    // an integral value in 0..=999_999_999 prints identically under itoa
+    // and `Number::toString`; anything else — fractional, negative, huge,
+    // NaN-boxed — keeps the dynamic arm. One side must still be a REAL
+    // string, so the annotation-lie semantics of the dynamic arm are
+    // unchanged for number+number.
+    #[inline]
+    fn itoa_operand(bits_value: f64, buf: &mut [u8; 32]) -> Option<(*const u8, u32)> {
+        let bits = bits_value.to_bits();
+        let tag = bits >> 48;
+        let is_plain_f64 = tag < 0x7FF8 || (tag == 0x7FF8 && (bits & 0x000F_FFFF_FFFF_FFFF) == 0);
+        if is_plain_f64
+            && bits_value.fract() == 0.0
+            && (0.0..=999_999_999.0).contains(&bits_value)
+        {
+            let len = fast_itoa_u32(bits_value as u32, buf);
+            Some((buf.as_ptr(), len as u32))
+        } else {
+            None
+        }
+    }
+    let l_str = str_bytes_from_jsvalue(l_value, &mut scratch_l);
+    let r_str = str_bytes_from_jsvalue(r_value, &mut scratch_r);
+    if let (Some(l), Some(r)) = (l_str, r_str) {
+        // Two real strings: straight to assembly, no number buffer touched
+        // (the itoa scratch below would cost this path a 32-byte memset).
+        return concat_byte_parts(l, r);
+    }
+    // Exactly one side can be a string here, so a single itoa buffer serves
+    // both mixed arms; it must outlive the call since `concat_byte_parts`
+    // reads through the raw pointer.
+    let mut num_buf = [0u8; 32];
+    match (l_str, r_str) {
+        (Some(l), None) => {
+            if let Some(r) = itoa_operand(r_value, &mut num_buf) {
+                return concat_byte_parts(l, r);
+            }
+        }
+        (None, Some(r)) => {
+            if let Some(l) = itoa_operand(l_value, &mut num_buf) {
+                return concat_byte_parts(l, r);
+            }
+        }
+        _ => {}
+    }
+    // `str_bytes_from_jsvalue` returns `None` for exactly the non-string
+    // values, so every remaining pair — number+number included — is the
+    // annotation-lie arm and nothing else.
+    unsafe { crate::value::js_dynamic_string_or_number_add(l_value, r_value) }
+}
+
+/// Shared tail of [`js_string_concat_box`]: assemble two raw byte slices
+/// (each a real string's payload or an itoa'd integer) into an SSO immediate
+/// when the total fits five ASCII bytes, a heap `StringHeader` otherwise.
+#[inline(always)]
+fn concat_byte_parts(l: (*const u8, u32), r: (*const u8, u32)) -> f64 {
     let total_blen = l.1 + r.1;
 
     // SSO encodes its length tag as the JS `.length`, so it is only sound for

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -153,9 +153,7 @@ pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
         let bits = bits_value.to_bits();
         let tag = bits >> 48;
         let is_plain_f64 = tag < 0x7FF8 || (tag == 0x7FF8 && (bits & 0x000F_FFFF_FFFF_FFFF) == 0);
-        if is_plain_f64
-            && bits_value.fract() == 0.0
-            && (0.0..=999_999_999.0).contains(&bits_value)
+        if is_plain_f64 && bits_value.fract() == 0.0 && (0.0..=999_999_999.0).contains(&bits_value)
         {
             let len = fast_itoa_u32(bits_value as u32, buf);
             Some((buf.as_ptr(), len as u32))


### PR DESCRIPTION
## What

Two surgical runtime changes on the string-concat hot paths:

1. **`String(n)` routes through the small-int cache.** `js_string_coerce`'s regular-number arm formatted every number with the `format!` machinery. It now delegates to `js_number_to_string`, whose `SMALL_INT_CACHE` answers `String(i)` for 0..255 with an interned longlived string and **no allocation**; the fallback is the same shared `js_format_f64` (#3987 scientific-notation semantics), so output is bit-identical on every input.

2. **`js_string_concat_box` itoas integral number operands.** The pairwise (template-literal) concat punted ANY non-string operand to `js_dynamic_string_or_number_add` — a full ToPrimitive round trip plus `format!` per op. An integral plain-f64 operand in `0..=999_999_999` (`fract()==0`; the NaN-box tag check excludes boxed values, and the sign bit excludes negatives and -0) is now itoa'd into a stack buffer and flows through the **same SSO/heap byte-assembly as the two-string case**. itoa and `Number::toString` print that range identically; fractional / negative / huge / NaN-boxed operands keep the dynamic arm, and number+number pairs never enter (one side must still be a real string), so the annotation-lie semantics are unchanged.

## Measurements

Mac mini (quiet benchmark host), 11 interleaved base/branch/node triples, median ns/op (min was within 0.1 everywhere):

| shape | base | branch | node | Δ | vs node |
|---|---|---|---|---|---|
| `String(i & 255)` | 35.4 | **4.6** | 4.9 | **−87.0%** | **0.9× — beats node** |
| `\`id-${i & 255}\`` (template) | 54.6 | **21.9** | 2.2 | **−59.9%** | 10.0× |
| `"id-" + (i & 255)` | 26.3 | 26.2 | 2.2 | −0.4% | 11.9× |
| `"id-" + "x"` | 8.1 | 8.1 | 0.5 | +0.0% | 16.2× |
| `a + b` (two vars) | 25.4 | 25.3 | 0.5 | −0.4% | 50.6× |
| `s += "ab"` (grow) | 14.6 | 14.6 | 4.2 | +0.0% | 3.5× |
| concat-then-compare | 26.1 | 25.9 | 6.9 | −0.8% | 3.8× |

Same-run A/B on the dev box agrees (string_of_int 36.9→4.8, template_int 57.0→22.9, rest flat). An earlier draft cost the pure two-string path ~0.4 ns (two zeroed 32-byte itoa buffers); the final structure routes two real strings to the assembly tail before any number buffer exists, and the in-pair delta on `"id-" + "x"` is 0.0.

The untouched rows are the next, separate lever: their remaining cost is one heap string allocation per op (`string_storage_alloc` + memmove; `"id-" + int` already itoas via `js_string_concat_value_box` but misses SSO at 6 bytes).

## Correctness

- 264-line differential vs node — `String(v)`, `` `id-${v}` ``, `"x"+v`, `v+"y"`, `""+v`, `v+""` over -0, ±1e-7, 1e20/1e21/1e22, NaN, ±Infinity, 2^31/2^32/2^53 boundaries, 5e-324, plus non-number operands (bool/null/undefined/object/array/bigint), Symbol-throws, and a mixed grow-concat: **byte-identical**.
- Runtime string/number/dynamic-add test filters: 106 passed.
- Full runtime suite (single-threaded, with #9110 cherry-picked on top for validation only — it fixes the pre-existing main SIGABRT at ~test 1804 this PR is otherwise subject to): **2825 passed / 0 failed**.
- Gate battery: `-D warnings` 0, codegen suite 1830/0, lints clean (addr-class, file-size, raw-handle debt none raised), integration: issue_8655 2/2, issue_8897 3/3. `issue_8690::read_only_loops_have_preheader_proofs_and_fallback_free_fast_blocks` fails on this branch **and is pre-existing #9106** (lost loop clones; the bisect there independently marks #9070/#9077 — both ancestors of this branch's base 0b6dea2f2e — as bad). This diff is runtime string code only; a pristine-base rerun is in flight and I'll comment with its result.
- The single-threaded runtime-lib line in the gate log shows the known re-exec masquerade of pre-existing #9108 (fixed by #9110); the overlay run above is the real full-suite verdict.


https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved efficiency when converting numbers to strings, especially for commonly used small integers.
  - Optimized string concatenation involving whole-number values, reducing unnecessary processing and allocations.
- **Compatibility**
  - Preserved existing number-to-string output and concatenation behavior, including special numeric values and number-to-number operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->