### PR TITLE
fix(runtime): coerce class refs through ToPrimitive

### DIFF
--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -665,7 +665,10 @@ mod by_name_method_closure_tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let prev = std::env::var_os("PERRY_OBJECT_LITERAL_SHAPE_METHODS");
         std::env::set_var("PERRY_OBJECT_LITERAL_SHAPE_METHODS", value);
-        RoutingPin { prev, _guard: guard }
+        RoutingPin {
+            prev,
+            _guard: guard,
+        }
     }
 
     pub(super) fn method_literal_ir() -> String {
@@ -765,88 +768,83 @@ mod by_name_method_closure_tests {
         body.join("\n")
     }
 
-#[cfg(test)]
-mod shape_method_literal_tests {
-    //! Shape-path twins of `by_name_method_closure_tests`: the DEFAULT
-    //! routing for a `captures_this` method literal since the all-or-nothing
-    //! gate became a kill switch. Same HIR fixture, same hazards pinned —
-    //! deferred patches must run below every store, in source order — plus
-    //! the shape path's own discipline: each patched closure is RE-READ from
-    //! its field slot (`js_object_get_field`) instead of being kept alive in
-    //! a rooted slot, so a patch that reads anything else regresses to the
-    //! moved-from-address bug the by-name arm needed #8809 to fix.
-    use super::{build_fn, method_literal_ir, pin_routing};
+    #[cfg(test)]
+    mod shape_method_literal_tests {
+        //! Shape-path twins of `by_name_method_closure_tests`: the DEFAULT
+        //! routing for a `captures_this` method literal since the all-or-nothing
+        //! gate became a kill switch. Same HIR fixture, same hazards pinned —
+        //! deferred patches must run below every store, in source order — plus
+        //! the shape path's own discipline: each patched closure is RE-READ from
+        //! its field slot (`js_object_get_field`) instead of being kept alive in
+        //! a rooted slot, so a patch that reads anything else regresses to the
+        //! moved-from-address bug the by-name arm needed #8809 to fix.
+        use super::{build_fn, method_literal_ir, pin_routing};
 
-    #[test]
-    fn a_this_capturing_method_selects_the_shape_path() {
-        let _pin = pin_routing("1");
-        let ir = build_fn(&method_literal_ir());
-        assert!(
-            ir.contains("@js_object_alloc_with_shape("),
-            "the method literal must allocate through the shape cache:\n{ir}"
-        );
-        assert_eq!(
-            ir.matches("@js_object_set_field(").count(),
-            4,
-            "every property is stored by INDEX on this path:\n{ir}"
-        );
-        assert_eq!(
-            ir.matches("@js_object_set_field_by_name(").count(),
-            0,
-            "no by-name stores may remain:\n{ir}"
-        );
-    }
+        #[test]
+        fn a_this_capturing_method_selects_the_shape_path() {
+            let _pin = pin_routing("1");
+            let ir = build_fn(&method_literal_ir());
+            assert!(
+                ir.contains("@js_object_alloc_with_shape("),
+                "the method literal must allocate through the shape cache:\n{ir}"
+            );
+            assert_eq!(
+                ir.matches("@js_object_set_field(").count(),
+                4,
+                "every property is stored by INDEX on this path:\n{ir}"
+            );
+            assert_eq!(
+                ir.matches("@js_object_set_field_by_name(").count(),
+                0,
+                "no by-name stores may remain:\n{ir}"
+            );
+        }
 
-    #[test]
-    fn the_patches_run_below_every_store_and_reread_their_closure() {
-        let _pin = pin_routing("1");
-        let ir = build_fn(&method_literal_ir());
-        let last_store = ir
-            .rfind("@js_object_set_field(")
-            .expect("an indexed store");
-        let tail = &ir[last_store..];
-        assert_eq!(
-            tail.matches("@js_closure_set_capture_bits(").count(),
-            2,
-            "one patch per `this`-capturing method, all below the last store:\n{tail}"
-        );
-        assert_eq!(
-            tail.matches("@js_object_get_field(").count(),
-            2,
-            "each patch must RE-READ its closure from the object's field slot \
+        #[test]
+        fn the_patches_run_below_every_store_and_reread_their_closure() {
+            let _pin = pin_routing("1");
+            let ir = build_fn(&method_literal_ir());
+            let last_store = ir.rfind("@js_object_set_field(").expect("an indexed store");
+            let tail = &ir[last_store..];
+            assert_eq!(
+                tail.matches("@js_closure_set_capture_bits(").count(),
+                2,
+                "one patch per `this`-capturing method, all below the last store:\n{tail}"
+            );
+            assert_eq!(
+                tail.matches("@js_object_get_field(").count(),
+                2,
+                "each patch must RE-READ its closure from the object's field slot \
              (a kept register is stale after an evacuating initializer):\n{tail}"
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn the_patches_are_applied_in_source_order() {
-        let _pin = pin_routing("1");
-        let ir = build_fn(&method_literal_ir());
-        let last_store = ir
-            .rfind("@js_object_set_field(")
-            .expect("an indexed store");
-        let tail = &ir[last_store..];
-        // `add` sits at field index 0, `scale` at field index 2; the re-reads
-        // name the field, so source order is readable off the `i32 <idx>`
-        // argument of each `js_object_get_field`.
-        let idxs: Vec<&str> = tail
-            .lines()
-            .filter(|l| l.contains("@js_object_get_field("))
-            .map(|l| {
-                l.split("i32 ")
-                    .nth(1)
-                    .and_then(|v| v.split(')').next())
-                    .expect("the field index")
-            })
-            .collect();
-        assert_eq!(
-            idxs,
-            vec!["0", "2"],
-            "`add` (field 0) must be patched before `scale` (field 2):\n{tail}"
-        );
+        #[test]
+        fn the_patches_are_applied_in_source_order() {
+            let _pin = pin_routing("1");
+            let ir = build_fn(&method_literal_ir());
+            let last_store = ir.rfind("@js_object_set_field(").expect("an indexed store");
+            let tail = &ir[last_store..];
+            // `add` sits at field index 0, `scale` at field index 2; the re-reads
+            // name the field, so source order is readable off the `i32 <idx>`
+            // argument of each `js_object_get_field`.
+            let idxs: Vec<&str> = tail
+                .lines()
+                .filter(|l| l.contains("@js_object_get_field("))
+                .map(|l| {
+                    l.split("i32 ")
+                        .nth(1)
+                        .and_then(|v| v.split(')').next())
+                        .expect("the field index")
+                })
+                .collect();
+            assert_eq!(
+                idxs,
+                vec!["0", "2"],
+                "`add` (field 0) must be patched before `scale` (field 2):\n{tail}"
+            );
+        }
     }
-}
-
 
     /// Everything the lowering emits after the last property store: the
     /// deferred closure re-reads, the patch loop, and the releases.

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -683,7 +683,8 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         return false;
                     }
                     match &method.key {
-                        ast::PropName::Ident(_) | ast::PropName::Str(_) | ast::PropName::Num(_) => {}
+                        ast::PropName::Ident(_) | ast::PropName::Str(_) | ast::PropName::Num(_) => {
+                        }
                         _ => return false,
                     }
                     if method.function.is_async

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -636,8 +636,7 @@ pub(crate) enum WellKnownComputedMethod {
     /// `__perry_wk_tostringtag_<class>`); the caller skips the member.
     Lifted,
     /// A recognized well-known symbol in a form perry doesn't implement
-    /// yet (e.g. a static `[Symbol.toPrimitive]`) — the caller drops the
-    /// member, preserving the historical behavior.
+    /// yet — the caller drops the member, preserving the historical behavior.
     Unsupported,
 }
 
@@ -747,14 +746,13 @@ pub(crate) fn lower_well_known_computed_method(
             "@@asyncIterator".to_string(),
         )));
     }
-    // #2374: `[Symbol.toPrimitive](hint) {}` on a class — register under
-    // `@@toPrimitive` so the symbol resolver in `runtime/src/symbol.rs`
-    // (`well_known_symbol_method_key`) binds it as
-    // `instance[Symbol.toPrimitive]`. The runtime's ToPrimitive
-    // (`js_to_primitive`, consulted by unary `+` numeric coercion and
-    // template/`String()` string coercion) then invokes it with the
-    // appropriate hint before falling back to `valueOf`/`toString`.
-    if wk == "toPrimitive" && !method.is_static && matches!(method.kind, ast::MethodKind::Method) {
+    // #2374 / #9101: `[Symbol.toPrimitive](hint) {}` on a class — register
+    // under `@@toPrimitive` so the symbol resolver in `runtime/src/symbol.rs`
+    // (`well_known_symbol_method_key`) binds it as either the instance or
+    // constructor's `[Symbol.toPrimitive]`. The runtime's ToPrimitive then
+    // invokes it with the appropriate hint before falling back to
+    // `valueOf`/`toString`.
+    if wk == "toPrimitive" && matches!(method.kind, ast::MethodKind::Method) {
         return Ok(Some(WellKnownComputedMethod::Rename(
             "@@toPrimitive".to_string(),
         )));

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -524,7 +524,14 @@ pub extern "C" fn js_number_coerce(value: f64) -> f64 {
             f64::NAN
         }
     } else if jsval.is_int32() {
-        // INT32 NaN-boxed value → convert to f64
+        // A constructor ClassRef uses the INT32 tag but is a Function object:
+        // ToNumber must run ToPrimitive(number), not expose its class-id
+        // payload as a numeric value (#9101).
+        if crate::object::class_ref_id(value).is_some() {
+            let primitive = unsafe { crate::value::to_string::class_ref_to_primitive(value, 1) };
+            return js_number_coerce(primitive);
+        }
+        // Plain INT32 NaN-boxed value → convert to f64.
         jsval.as_int32() as f64
     } else if jsval.is_bigint() {
         // BigInt → number conversion
@@ -669,6 +676,12 @@ pub extern "C" fn js_string_coerce(value: f64) -> *mut StringHeader {
         // Delegate to js_jsvalue_to_string which handles arrays via join(",") and objects.
         return crate::value::js_jsvalue_to_string(value);
     } else if jsval.is_int32() {
+        // Constructor ClassRefs share the INT32 tag but are Function objects.
+        // Delegate so String(C) performs ToPrimitive(string) instead of
+        // exposing the numeric class-id payload (#9101).
+        if crate::object::class_ref_id(value).is_some() {
+            return crate::value::js_jsvalue_to_string(value);
+        }
         jsval.as_int32().to_string()
     } else {
         // Regular number — delegate to `js_number_to_string`: its small-int

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -468,6 +468,21 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
         if let Some(vb) = class_static_symbol_lookup(class_id, sym_f64) {
             return f64::from_bits(vb);
         }
+        // #9101: statically-known well-known-symbol METHODS are registered
+        // under synthetic names (`@@toPrimitive`, etc.), rather than in the
+        // class-static-symbol data-property table above. Reify a static method
+        // value with the constructor ClassRef as its receiver. This also makes
+        // an explicit `C[Symbol.toPrimitive]` read agree with the ToPrimitive
+        // consumer instead of returning undefined.
+        if let Some(method_name) = well_known_symbol_method_key(sym_f64) {
+            if crate::object::lookup_static_method_in_chain(class_id, method_name).is_some() {
+                return crate::object::js_class_method_bind(
+                    obj_f64,
+                    method_name.as_ptr(),
+                    method_name.len(),
+                );
+            }
+        }
         // #6173: a `static [S]() {}` (and, through a prototype ref, an
         // instance `[S]() {}`) registers in CLASS_SYMBOL_METHODS, which this
         // resolver never consulted — so reading `D[S]` as a VALUE returned

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -518,6 +518,12 @@ pub unsafe extern "C" fn js_to_primitive(value: f64, hint: i32) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let value_handle = scope.root_nanbox_f64(value);
     let value = value_handle.get_nanbox_f64();
+    // #9101: a declared class is a Function object despite Perry storing it
+    // as an INT32-tagged class id. Route it through the class-aware helper
+    // before the pointer-only object guard below.
+    if crate::object::class_ref_id(value).is_some() {
+        return crate::value::to_string::class_ref_to_primitive(value, hint);
+    }
     let bits = value.to_bits();
     let tag = bits & 0xFFFF_0000_0000_0000;
     if tag != POINTER_TAG {

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -98,6 +98,17 @@ unsafe fn to_numeric(value: f64) -> f64 {
     if jsval.is_bigint() {
         return value;
     }
+    // ClassRefs are INT32-tagged but are Function objects in JavaScript. Run
+    // ToPrimitive(number) before the non-pointer primitive fast path below;
+    // preserve a BigInt result for ToNumeric rather than collapsing it through
+    // ToNumber.
+    if crate::object::class_ref_id(value).is_some() {
+        let primitive = crate::value::to_string::class_ref_to_primitive(value, 1);
+        if JSValue::from_bits(primitive.to_bits()).is_bigint() {
+            return primitive;
+        }
+        return crate::builtins::js_number_coerce(primitive);
+    }
     // Non-object primitives (number/int32/string/bool/null/undefined) never
     // become a BigInt; defer to the existing ToNumber coercion.
     if !jsval.is_pointer() {
@@ -181,7 +192,7 @@ unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
     // makes the addition concatenate. This also preserves an own static
     // valueOf/toString override.
     if is_class_ref {
-        return crate::value::ordinary_to_primitive_for_toprimitive(value, false);
+        return crate::value::to_string::class_ref_to_primitive(value, 0);
     }
 
     let ptr = jsval.as_pointer::<u8>() as usize;

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -44,6 +44,7 @@ mod jsvalue;
 mod nanbox;
 mod tags;
 pub(crate) mod to_string;
+pub(crate) mod to_string_class_ref;
 mod truthy;
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -499,7 +499,7 @@ pub(crate) unsafe fn to_primitive_number(value: f64) -> OrdinaryToPrimitiveOutco
         return OrdinaryToPrimitiveOutcome::Primitive(value);
     }
 
-    match custom_to_primitive_number(value) {
+    match custom_to_primitive(value, b"number") {
         CustomToPrimitiveOutcome::Absent => {}
         CustomToPrimitiveOutcome::Primitive(p) => return OrdinaryToPrimitiveOutcome::Primitive(p),
         CustomToPrimitiveOutcome::TypeError => return OrdinaryToPrimitiveOutcome::TypeError,
@@ -508,7 +508,7 @@ pub(crate) unsafe fn to_primitive_number(value: f64) -> OrdinaryToPrimitiveOutco
     ordinary_to_primitive_number_for_add(value)
 }
 
-unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
+unsafe fn custom_to_primitive(value: f64, hint: &[u8]) -> CustomToPrimitiveOutcome {
     let scope = crate::gc::RuntimeHandleScope::new();
     let value_handle = scope.root_nanbox_f64(value);
     let to_primitive = crate::symbol::well_known_symbol("toPrimitive");
@@ -525,7 +525,7 @@ unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
         return CustomToPrimitiveOutcome::TypeError;
     }
     let method_handle = scope.root_nanbox_f64(method);
-    let hint_ptr = crate::string::js_string_from_bytes(b"number".as_ptr(), 6);
+    let hint_ptr = crate::string::js_string_from_bytes(hint.as_ptr(), hint.len() as u32);
     let hint_handle = scope.root_string_ptr(hint_ptr);
     let hint = f64::from_bits(
         STRING_TAG
@@ -554,6 +554,28 @@ unsafe fn custom_to_primitive_number(value: f64) -> CustomToPrimitiveOutcome {
         CustomToPrimitiveOutcome::Primitive(result)
     } else {
         CustomToPrimitiveOutcome::TypeError
+    }
+}
+
+/// Run full `ToPrimitive` for an INT32-tagged constructor ClassRef.
+///
+/// ClassRefs are objects at the language level but are not pointer-tagged in
+/// Perry, so the generic pointer-only coercion ladders cannot safely discover
+/// them. Keep the representation exception in one place: consult the static
+/// `Symbol.toPrimitive` hook first, then perform the ordinary Function-object
+/// `valueOf`/`toString` sequence with the hint-mandated ordering.
+pub(crate) unsafe fn class_ref_to_primitive(value: f64, hint: i32) -> f64 {
+    let (hint_name, string_first): (&[u8], bool) = match hint {
+        1 => (b"number", false),
+        2 => (b"string", true),
+        _ => (b"default", false),
+    };
+    match custom_to_primitive(value, hint_name) {
+        CustomToPrimitiveOutcome::Absent => {
+            ordinary_to_primitive_for_toprimitive(value, string_first)
+        }
+        CustomToPrimitiveOutcome::Primitive(p) => p,
+        CustomToPrimitiveOutcome::TypeError => throw_cannot_convert_to_primitive(),
     }
 }
 
@@ -1100,6 +1122,10 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
         let n = jsval.as_int32();
         let cid = (value.to_bits() & 0xFFFF_FFFF) as u32;
         if crate::object::is_class_id_registered(cid) {
+            if !skip_to_primitive {
+                let primitive = unsafe { class_ref_to_primitive(value, 2) };
+                return js_jsvalue_to_string(primitive);
+            }
             let name = crate::object::class_name_for_id(cid).unwrap_or_default();
             let s = format!("function {name}() {{ [native code] }}");
             return crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1,5 +1,7 @@
 //! NaN-boxed value to-string conversion helpers.
 
+pub(crate) use super::to_string_class_ref::class_ref_to_primitive;
+use super::to_string_class_ref::{custom_to_primitive, CustomToPrimitiveOutcome};
 use super::*;
 use std::cell::Cell;
 use std::sync::atomic::Ordering;
@@ -147,7 +149,7 @@ unsafe fn value_is_null_proto_object(value: f64) -> bool {
 }
 
 #[cold]
-fn throw_cannot_convert_to_primitive() -> ! {
+pub(crate) fn throw_cannot_convert_to_primitive() -> ! {
     let msg = b"Cannot convert object to primitive value";
     let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
     let err = crate::error::js_typeerror_new(s);
@@ -327,13 +329,7 @@ pub(crate) enum OrdinaryToPrimitiveOutcome {
     TypeError,
 }
 
-enum CustomToPrimitiveOutcome {
-    Absent,
-    Primitive(f64),
-    TypeError,
-}
-
-fn is_primitive_value(value: f64) -> bool {
+pub(crate) fn is_primitive_value(value: f64) -> bool {
     let jsval = JSValue::from_bits(value.to_bits());
     jsval.is_any_string()
         || jsval.is_number()
@@ -506,77 +502,6 @@ pub(crate) unsafe fn to_primitive_number(value: f64) -> OrdinaryToPrimitiveOutco
     }
 
     ordinary_to_primitive_number_for_add(value)
-}
-
-unsafe fn custom_to_primitive(value: f64, hint: &[u8]) -> CustomToPrimitiveOutcome {
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let value_handle = scope.root_nanbox_f64(value);
-    let to_primitive = crate::symbol::well_known_symbol("toPrimitive");
-    let sym_value = f64::from_bits(POINTER_TAG | (to_primitive as u64 & POINTER_MASK));
-    let method =
-        crate::symbol::js_object_get_symbol_property(value_handle.get_nanbox_f64(), sym_value);
-    let method_jsv = JSValue::from_bits(method.to_bits());
-    if method_jsv.is_undefined() || method_jsv.is_null() {
-        return CustomToPrimitiveOutcome::Absent;
-    }
-
-    let method_bits = method.to_bits();
-    if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
-        return CustomToPrimitiveOutcome::TypeError;
-    }
-    let method_handle = scope.root_nanbox_f64(method);
-    let hint_ptr = crate::string::js_string_from_bytes(hint.as_ptr(), hint.len() as u32);
-    let hint_handle = scope.root_string_ptr(hint_ptr);
-    let hint = f64::from_bits(
-        STRING_TAG
-            | (hint_handle.get_raw_const_ptr::<crate::string::StringHeader>() as u64
-                & POINTER_MASK),
-    );
-    let receiver = value_handle.get_nanbox_f64();
-    let method = method_handle.get_nanbox_f64();
-    let result = if crate::proxy::js_proxy_is_proxy(method) == 1 {
-        if !crate::proxy::proxy_wraps_callable(method) {
-            return CustomToPrimitiveOutcome::TypeError;
-        }
-        crate::proxy::call_proxy_value_with_this(method, receiver, &[hint])
-    } else {
-        let method_ptr = (method.to_bits() & POINTER_MASK) as usize;
-        if !crate::closure::is_closure_ptr(method_ptr) {
-            return CustomToPrimitiveOutcome::TypeError;
-        }
-        let prev_this = crate::object::js_implicit_this_set(receiver);
-        let result = crate::closure::js_native_call_value(method, &hint, 1);
-        crate::object::js_implicit_this_set(prev_this);
-        result
-    };
-
-    if is_primitive_value(result) {
-        CustomToPrimitiveOutcome::Primitive(result)
-    } else {
-        CustomToPrimitiveOutcome::TypeError
-    }
-}
-
-/// Run full `ToPrimitive` for an INT32-tagged constructor ClassRef.
-///
-/// ClassRefs are objects at the language level but are not pointer-tagged in
-/// Perry, so the generic pointer-only coercion ladders cannot safely discover
-/// them. Keep the representation exception in one place: consult the static
-/// `Symbol.toPrimitive` hook first, then perform the ordinary Function-object
-/// `valueOf`/`toString` sequence with the hint-mandated ordering.
-pub(crate) unsafe fn class_ref_to_primitive(value: f64, hint: i32) -> f64 {
-    let (hint_name, string_first): (&[u8], bool) = match hint {
-        1 => (b"number", false),
-        2 => (b"string", true),
-        _ => (b"default", false),
-    };
-    match custom_to_primitive(value, hint_name) {
-        CustomToPrimitiveOutcome::Absent => {
-            ordinary_to_primitive_for_toprimitive(value, string_first)
-        }
-        CustomToPrimitiveOutcome::Primitive(p) => p,
-        CustomToPrimitiveOutcome::TypeError => throw_cannot_convert_to_primitive(),
-    }
 }
 
 /// `OrdinaryToPrimitive(O, "number"|"default")` for addition. The method

--- a/crates/perry-runtime/src/value/to_string_class_ref.rs
+++ b/crates/perry-runtime/src/value/to_string_class_ref.rs
@@ -1,0 +1,86 @@
+//! `ToPrimitive` for INT32-tagged constructor ClassRefs (#9125).
+//!
+//! Split out of `to_string.rs`, which sits at the 2000-line cap. ClassRefs are
+//! objects at the language level but are not pointer-tagged in Perry, so the
+//! generic pointer-only coercion ladders cannot discover them; this module is
+//! the one place that representation exception lives.
+
+use super::to_string::{
+    is_primitive_value, ordinary_to_primitive_for_toprimitive, throw_cannot_convert_to_primitive,
+};
+use super::*;
+
+pub(crate) enum CustomToPrimitiveOutcome {
+    Absent,
+    Primitive(f64),
+    TypeError,
+}
+pub(crate) unsafe fn custom_to_primitive(value: f64, hint: &[u8]) -> CustomToPrimitiveOutcome {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    let to_primitive = crate::symbol::well_known_symbol("toPrimitive");
+    let sym_value = f64::from_bits(POINTER_TAG | (to_primitive as u64 & POINTER_MASK));
+    let method =
+        crate::symbol::js_object_get_symbol_property(value_handle.get_nanbox_f64(), sym_value);
+    let method_jsv = JSValue::from_bits(method.to_bits());
+    if method_jsv.is_undefined() || method_jsv.is_null() {
+        return CustomToPrimitiveOutcome::Absent;
+    }
+
+    let method_bits = method.to_bits();
+    if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
+        return CustomToPrimitiveOutcome::TypeError;
+    }
+    let method_handle = scope.root_nanbox_f64(method);
+    let hint_ptr = crate::string::js_string_from_bytes(hint.as_ptr(), hint.len() as u32);
+    let hint_handle = scope.root_string_ptr(hint_ptr);
+    // Scoped: the tag combine below allocates nothing, so the pointer cannot
+    // go stale inside the closure (#7341).
+    let hint = hint_handle.with_const_ptr(|p: *const crate::string::StringHeader| {
+        f64::from_bits(STRING_TAG | (p as u64 & POINTER_MASK))
+    });
+    let receiver = value_handle.get_nanbox_f64();
+    let method = method_handle.get_nanbox_f64();
+    let result = if crate::proxy::js_proxy_is_proxy(method) == 1 {
+        if !crate::proxy::proxy_wraps_callable(method) {
+            return CustomToPrimitiveOutcome::TypeError;
+        }
+        crate::proxy::call_proxy_value_with_this(method, receiver, &[hint])
+    } else {
+        let method_ptr = (method.to_bits() & POINTER_MASK) as usize;
+        if !crate::closure::is_closure_ptr(method_ptr) {
+            return CustomToPrimitiveOutcome::TypeError;
+        }
+        let prev_this = crate::object::js_implicit_this_set(receiver);
+        let result = crate::closure::js_native_call_value(method, &hint, 1);
+        crate::object::js_implicit_this_set(prev_this);
+        result
+    };
+
+    if is_primitive_value(result) {
+        CustomToPrimitiveOutcome::Primitive(result)
+    } else {
+        CustomToPrimitiveOutcome::TypeError
+    }
+}
+/// Run full `ToPrimitive` for an INT32-tagged constructor ClassRef.
+///
+/// ClassRefs are objects at the language level but are not pointer-tagged in
+/// Perry, so the generic pointer-only coercion ladders cannot safely discover
+/// them. Keep the representation exception in one place: consult the static
+/// `Symbol.toPrimitive` hook first, then perform the ordinary Function-object
+/// `valueOf`/`toString` sequence with the hint-mandated ordering.
+pub(crate) unsafe fn class_ref_to_primitive(value: f64, hint: i32) -> f64 {
+    let (hint_name, string_first): (&[u8], bool) = match hint {
+        1 => (b"number", false),
+        2 => (b"string", true),
+        _ => (b"default", false),
+    };
+    match custom_to_primitive(value, hint_name) {
+        CustomToPrimitiveOutcome::Absent => {
+            ordinary_to_primitive_for_toprimitive(value, string_first)
+        }
+        CustomToPrimitiveOutcome::Primitive(p) => p,
+        CustomToPrimitiveOutcome::TypeError => throw_cannot_convert_to_primitive(),
+    }
+}

--- a/crates/perry/tests/issue_9101_class_ref_coercion.rs
+++ b/crates/perry/tests/issue_9101_class_ref_coercion.rs
@@ -1,0 +1,82 @@
+//! Regression for #9101: constructor ClassRefs use an INT32 NaN-box even
+//! though they are Function objects. Every coercion path must still run the
+//! class's `Symbol.toPrimitive` / `valueOf` / `toString` hooks.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str) -> Output {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    Command::new(&output).output().expect("run compiled binary")
+}
+
+#[test]
+fn class_refs_run_the_complete_to_primitive_sequence() {
+    let run = compile_and_run(
+        r#"
+class WithToString { static toString() { return "CUSTOM"; } }
+let s = "";
+for (let i = 0; i < 3; i++) s += WithToString;
+console.log(s);
+
+class WithValueOf { static valueOf() { return 42; } }
+class WithBoth { static valueOf() { return 7; } static toString() { return "TS"; } }
+console.log(WithValueOf * 2, WithBoth - 1, +WithValueOf);
+
+class WithPrimitive {
+  static [Symbol.toPrimitive](hint: string) {
+    return hint === "number" ? 99 : "PRIM";
+  }
+  static valueOf() { return -1; }
+  static toString() { return "WRONG"; }
+}
+console.log(WithPrimitive + "", WithPrimitive * 2, String(WithPrimitive));
+console.log(typeof WithPrimitive[Symbol.toPrimitive]);
+
+const Expr: any = class {
+  static [Symbol.toPrimitive](hint: string) {
+    return hint === "number" ? 8 : "EXPR";
+  }
+};
+console.log(Expr - 3, "" + Expr);
+"#,
+    );
+    assert!(
+        run.status.success(),
+        "compiled program failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        concat!(
+            "CUSTOMCUSTOMCUSTOM\n",
+            "84 6 42\n",
+            "PRIM 198 PRIM\n",
+            "function\n",
+            "5 EXPR\n",
+        )
+    );
+}


### PR DESCRIPTION
Fixes #9101

## Summary

- preserve static `Symbol.toPrimitive` methods during class lowering and expose them as bound constructor methods
- route INT32-tagged class refs through class-aware `ToPrimitive` for default, number, and string hints
- cover looped string `+=`, numeric operators, direct `String()`, hook precedence, and named/class-expression forms

The separate class-source-text retention note in #9101 remains out of scope; this fixes the three coercion defects named in the issue title. No version bump is included.

## Testing

Run on `root@perrymaster.skelpo.net`:

- `cargo fmt --all -- --check`
- `cargo test -p perry --test issue_9101_class_ref_coercion -- --nocapture`
- `cargo test -p perry --test issue_9087_class_ref_add --test class_expr_well_known_symbol_methods -- --nocapture`
- `cargo test -p perry-runtime dynamic_arith --lib -- --nocapture`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed type coercion for class constructors used in arithmetic, string concatenation, unary operations, and `String()`.
  - Class constructors now correctly honor `Symbol.toPrimitive`, `valueOf`, and `toString` hooks.
  - Improved handling of numeric and string conversion hints.
  - Static and instance `Symbol.toPrimitive` methods are now resolved and invoked correctly.
- **Tests**
  - Added regression coverage for constructor coercion and custom conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->