### PR TITLE
fix(runtime): honor collection iterator return overrides

### DIFF
--- a/changelog.d/9127-collection-iterator-close.md
+++ b/changelog.d/9127-collection-iterator-close.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- User-installed `return` methods on Map and Set iterator objects now run for
+  direct calls and `IteratorClose` on `break`, escaping `throw`, function
+  `return`, and partial destructuring instead of being bypassed by the native
+  class-id dispatcher (#9098).

--- a/crates/perry-runtime/src/collection_iter_object.rs
+++ b/crates/perry-runtime/src/collection_iter_object.rs
@@ -35,6 +35,15 @@ const KIND_KEYS: i32 = 1;
 const KIND_VALUES: i32 = 0;
 const KIND_ENTRIES: i32 = 2;
 
+/// Methods implemented intrinsically by the Map/Set iterator class-id
+/// dispatcher. `return` and `throw` deliberately are not here: ordinary
+/// collection iterators do not define them, and a user-installed own or
+/// inherited method must flow through ordinary method lookup (#9098).
+#[inline]
+pub(crate) fn is_intrinsic_iterator_method(method_name: &str) -> bool {
+    matches!(method_name, "next" | "Symbol.iterator" | "@@iterator")
+}
+
 /// `true` when `addr` carries a Map iterator object's class id.
 pub fn is_map_iterator_addr(addr: usize) -> bool {
     iterator_class_id(addr) == Some(MAP_ITERATOR_CLASS_ID)
@@ -326,7 +335,6 @@ unsafe fn dispatch_map_iterator_method_emit(
             emit_iter_result(&scope, &iter_h, emit_cached, value, false)
         }
         "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj() as i64),
-        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
         _ => f64::from_bits(TAG_UNDEFINED),
     }
 }
@@ -404,7 +412,6 @@ unsafe fn dispatch_set_iterator_method_emit(
             emit_iter_result(&scope, &iter_h, emit_cached, value, false)
         }
         "Symbol.iterator" | "@@iterator" => js_nanbox_pointer(iter_obj() as i64),
-        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
         _ => f64::from_bits(TAG_UNDEFINED),
     }
 }

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -394,14 +394,20 @@ pub(super) unsafe fn dispatch_raw_pointer(
                     method_name,
                 ));
             }
-            // #2856: same Map/Set-iterator class-id checks as the NaN-boxed path.
-            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID {
+            // #2856/#9098: same intrinsic-only Map/Set iterator class-id
+            // checks as the NaN-boxed path. Non-intrinsic names must continue
+            // into ordinary method lookup so own overrides are callable.
+            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
+                && crate::collection_iter_object::is_intrinsic_iterator_method(method_name)
+            {
                 return Some(crate::collection_iter_object::dispatch_map_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 ));
             }
-            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
+            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID
+                && crate::collection_iter_object::is_intrinsic_iterator_method(method_name)
+            {
                 return Some(crate::collection_iter_object::dispatch_set_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -847,15 +847,22 @@ pub(super) unsafe fn dispatch_handle(
             }
             // #2856: Map/Set iterators returned from a value-level
             // `m.entries()`/`.keys()`/`.values()` / `s.entries()` etc. carry
-            // dedicated class ids so `.next()` lands in the matching iterator
-            // dispatcher (mirroring the array iterator above).
-            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID {
+            // dedicated class ids so intrinsic protocol methods land in the
+            // matching iterator dispatcher (mirroring the array iterator
+            // above). #9098: do not claim `return`, `throw`, or another
+            // non-intrinsic method here. They must reach the ordinary field /
+            // prototype scans below so a user-installed method is invoked.
+            if (*obj).class_id == crate::collection_iter_object::MAP_ITERATOR_CLASS_ID
+                && crate::collection_iter_object::is_intrinsic_iterator_method(method_name)
+            {
                 return Some(crate::collection_iter_object::dispatch_map_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,
                 ));
             }
-            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID {
+            if (*obj).class_id == crate::collection_iter_object::SET_ITERATOR_CLASS_ID
+                && crate::collection_iter_object::is_intrinsic_iterator_method(method_name)
+            {
                 return Some(crate::collection_iter_object::dispatch_set_iterator_method(
                     obj as *mut ObjectHeader,
                     method_name,

--- a/crates/perry/tests/issue_9098_collection_iterator_close.rs
+++ b/crates/perry/tests/issue_9098_collection_iterator_close.rs
@@ -1,0 +1,170 @@
+//! Regression coverage for #9098: user-installed `return` methods on Map/Set
+//! iterators must win over the native iterator dispatcher and participate in
+//! IteratorClose.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    if cfg!(windows) {
+        target.join("x86_64-pc-windows-msvc").join("debug")
+    } else {
+        target.join("debug")
+    }
+}
+
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static")
+            .output()
+            .expect("build runtime archives");
+        assert!(
+            build.status.success(),
+            "runtime build failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let entry = dir.path().join("main.ts");
+    let binary = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write fixture");
+    ensure_runtime_archive();
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("--no-cache")
+        .arg("-o")
+        .arg(&binary)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", target_debug_dir())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&binary)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn collection_iterator_overrides_are_called_directly_and_by_iterator_close() {
+    let stdout = compile_and_run(
+        r#"
+const directMap: any = new Map([[1, "a"]]).values();
+directMap.return = () => ({ value: 42, done: true });
+const directSet: any = new Set([1]).values();
+directSet.return = () => ({ value: 84, done: true });
+console.log("direct", directMap.return().value, directSet.return().value);
+
+const inherited: any = new Map([[1, "a"]]).values();
+const inheritedPrototype = Object.create(Object.getPrototypeOf(inherited));
+let inheritedThis = false;
+inheritedPrototype.return = function () {
+  inheritedThis = this === inherited;
+  return { value: 21, done: true };
+};
+Object.setPrototypeOf(inherited, inheritedPrototype);
+console.log("inherited", inherited.return().value, inheritedThis);
+
+const unpatched: any = new Set([1]).values();
+let missingThrows = false;
+try {
+  unpatched.return();
+} catch (error) {
+  missingThrows = error instanceof TypeError;
+}
+console.log("missing", missingThrows);
+
+const breakIter: any = new Set([1, 2, 3]).values();
+let breakClosed = 0;
+breakIter.return = function () { breakClosed++; return { done: true }; };
+const seen: number[] = [];
+for (const value of breakIter) {
+  seen.push(value);
+  if (value === 2) break;
+}
+console.log("break", seen.join(","), breakClosed);
+
+const throwIter: any = new Map([[1, "a"], [2, "b"]]).values();
+let throwClosed = 0;
+throwIter.return = function () { throwClosed++; return { done: true }; };
+let thrown = "";
+try {
+  for (const value of throwIter) {
+    if (value === "a") throw new Error("boom");
+  }
+} catch (error: any) {
+  thrown = error.message;
+}
+console.log("throw", thrown, throwClosed);
+
+const returnIter: any = new Set([7, 8]).values();
+let returnClosed = 0;
+returnIter.return = function () { returnClosed++; return { done: true }; };
+function leaveLoop(): number {
+  for (const value of returnIter) return value;
+  return -1;
+}
+console.log("return", leaveLoop(), returnClosed);
+
+const destructureIter: any = new Map([[1, 5], [2, 6], [3, 7]]).values();
+let destructureClosed = 0;
+destructureIter.return = function () { destructureClosed++; return { done: true }; };
+const [a, b] = destructureIter;
+console.log("destructure", a, b, destructureClosed);
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "direct 42 84\n\
+         inherited 21 true\n\
+         missing true\n\
+         break 1,2 1\n\
+         throw boom 1\n\
+         return 7 1\n\
+         destructure 5 6 1\n"
+    );
+}


### PR DESCRIPTION
## Summary

Makes user-installed `return` methods on Map and Set iterators callable through both direct method syntax and `IteratorClose`.

## Changes

- Restricts the collection-iterator class-id call fast path to actual intrinsic methods (`next` and iterator identity).
- Lets `return`, `throw`, and other non-intrinsic names continue through ordinary own/prototype method resolution.
- Removes the remaining synthetic Map/Set iterator `return`/`throw` results from the intrinsic dispatcher.
- Adds executable coverage for direct own and inherited calls, absent methods, early `break`, escaping `throw`, function `return`, and partial destructuring.

## Related issue

Fixes #9098

## Test plan

- [x] `cargo build --release` clean on `root@perrymaster.skelpo.net`
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run; repository guidance uses affected-crate scopes)
- [x] `cargo test -p perry --test issue_9098_collection_iterator_close -- --nocapture`
- [x] `cargo test -p perry --test issue_9086_collection_iterator_methods -- --nocapture`
- [x] `cargo test --lib -p perry-runtime` (2798 passed, 4 ignored)
- [x] `RUST_MIN_STACK=33554432 RUST_TEST_THREADS=1 cargo test --bins -p perry` (1056 passed; the host default stack overflows in an unrelated CJS preamble canary)
- [x] Affected bin/lib scopes for `perry-ffi`, `perry-ui`, and `perry-updater`
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Added an executable regression test in the affected crate.
- [x] Documentation is not needed; this restores existing ECMAScript behavior without adding an API.
- [ ] Platform UI backend build is not applicable.

## Screenshots / output

Before the fix, direct calls returned `undefined` and `break` / `throw` / function `return` left the close counter at 0. The regression now observes the user result for direct calls and exactly one close for every abrupt-completion case; partial destructuring remains exactly once.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Map and Set iterator `return` methods so custom user-defined overrides are now honored.
  * Improved iterator cleanup when exiting loops, handling exceptions, returning from functions, or partially destructuring iterators.
  * Corrected behavior for direct and inherited iterator method calls, including cases where no `return` method exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->