### PR TITLE
perf(codegen): inline field precheck for typed-receiver method calls (12.8→3.8 ns) + #9124 review fixes

### DIFF
--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -234,6 +234,12 @@ pub(crate) fn emit_inline_direct_method_shape_guard(
     method_guard_slot: &str,
     fast_label: &str,
     fallback_label: &str,
+    // `true` at sites whose receiver may arrive in the internal raw-address
+    // form (top word zero); `false` where the receiver is a user-visible
+    // NaN-box, so that a plain double whose bit pattern happens to land in
+    // the heap address range (a positive subnormal) can never reach the
+    // header load — it misses to the runtime guard instead.
+    accept_raw_ptr: bool,
 ) {
     let deref_idx = ctx.new_block("method_direct.inline_deref");
     let deref_label = ctx.block_label(deref_idx);
@@ -263,8 +269,12 @@ pub(crate) fn emit_inline_direct_method_shape_guard(
         // double-sized slot. `normalize_raw_object_addr` accepts exactly this
         // top-word-zero form; all other non-pointer NaN-box tags remain
         // rejected before dereference.
-        let is_raw_ptr = blk.icmp_eq(I64, &tag, "0");
-        let is_ptr = blk.or(I1, &is_tagged_ptr, &is_raw_ptr);
+        let is_ptr = if accept_raw_ptr {
+            let is_raw_ptr = blk.icmp_eq(I64, &tag, "0");
+            blk.or(I1, &is_tagged_ptr, &is_raw_ptr)
+        } else {
+            is_tagged_ptr
+        };
         let above_floor = blk.icmp_uge(I64, &recv_handle, &heap_floor);
         let below_ceiling = blk.icmp_ult(I64, &recv_handle, &heap_ceiling);
         let in_heap_range = blk.and(I1, &above_floor, &below_ceiling);
@@ -1045,6 +1055,7 @@ pub(super) fn emit_guarded_direct_method_call(
             &method_guard_slot_str,
             &fast_label,
             &fallback_label,
+            true,
         );
     }
     if probe_before_runtime_guard {
@@ -1058,6 +1069,7 @@ pub(super) fn emit_guarded_direct_method_call(
             &method_guard_slot_str,
             &fast_label,
             &runtime_guard_label,
+            false,
         );
         ctx.current_block = runtime_guard_idx;
     }
@@ -1122,6 +1134,51 @@ pub(super) fn emit_guarded_direct_method_call(
                     None => ok,
                 });
             }
+            // Same dispensation as the method-direct probe above, for the
+            // receiver FIELD proof: the runtime field guard re-derives, per
+            // field and per call, facts the exact `(class_id, ShapeId)` pair
+            // already pins (slot count, key-at-slot) plus a descriptor lookup
+            // (`shape_descriptor_by_id`, a thread-local map) — it was ~80% of
+            // the probe-first `c.inc()` loop. The inline precheck the
+            // field-GET sites already use proves class/shape + not-forwarded +
+            // the per-OBJECT raw-f64 intact bit in a handful of loads, and
+            // because the intact bit is object-wide, ONE precheck vouches for
+            // every receiver field at once. Its miss edge runs the unchanged
+            // per-field runtime guard chain, so nothing is lost.
+            let inline_fields_proof = !receiver_info.fields.is_empty()
+                && !crate::expr::typed_feedback_emission_enabled()
+                && method_inline_probe_enabled();
+            let (fields_proven_idx, fields_merge_idx) = if inline_fields_proof {
+                let proven_idx = ctx.new_block("typed_f64_recv_method.fields_proven");
+                let proven_label = ctx.block_label(proven_idx);
+                let (obj_bits, obj_handle) = {
+                    let blk = ctx.block();
+                    let obj_bits = blk.bitcast_double_to_i64(recv_box);
+                    let obj_handle = blk.and(I64, &obj_bits, crate::nanbox::POINTER_MASK_I64);
+                    (obj_bits, obj_handle)
+                };
+                // Leaves `current_block` at the freshly created guardcall
+                // block, where the per-field runtime chain below is emitted.
+                let _guardcall = crate::expr::class_field_inline_guard::emit_class_field_inline_precheck(
+                    ctx,
+                    &obj_bits,
+                    &obj_handle,
+                    &expected_class_id_str,
+                    &expected_shape_id,
+                    true,
+                    None,
+                    &proven_label,
+                    &[],
+                );
+                // Created after the precheck's own blocks so the merge (and the
+                // typed/generic branch it feeds) follows the per-field guard
+                // calls in emission order.
+                let merge_idx = ctx.new_block("typed_f64_recv_method.fields_merge");
+                (Some(proven_idx), Some(merge_idx))
+            } else {
+                (None, None)
+            };
+            let mut fields_chain: Option<String> = None;
             for field in &receiver_info.fields {
                 let site_id = emit_typed_feedback_register_site(
                     ctx,
@@ -1151,9 +1208,33 @@ pub(super) fn emit_guarded_direct_method_call(
                     ],
                 );
                 let ok = ctx.block().icmp_ne(I32, &raw_guard, "0");
+                if inline_fields_proof {
+                    fields_chain = Some(match fields_chain {
+                        Some(prev) => ctx.block().and(I1, &prev, &ok),
+                        None => ok,
+                    });
+                } else {
+                    guard = Some(match guard {
+                        Some(prev) => ctx.block().and(I1, &prev, &ok),
+                        None => ok,
+                    });
+                }
+            }
+            if let (Some(proven_idx), Some(merge_idx)) = (fields_proven_idx, fields_merge_idx) {
+                let merge_label = ctx.block_label(merge_idx);
+                let chain_pred = ctx.block_label(ctx.current_block);
+                let chain_ok = fields_chain.clone().unwrap_or_else(|| "true".to_string());
+                ctx.block().br(&merge_label);
+                ctx.current_block = proven_idx;
+                let proven_pred = ctx.block_label(proven_idx);
+                ctx.block().br(&merge_label);
+                ctx.current_block = merge_idx;
+                let fields_ok = ctx
+                    .block()
+                    .phi(I1, &[("true", &proven_pred), (&chain_ok, &chain_pred)]);
                 guard = Some(match guard {
-                    Some(prev) => ctx.block().and(I1, &prev, &ok),
-                    None => ok,
+                    Some(prev) => ctx.block().and(I1, &prev, &fields_ok),
+                    None => fields_ok,
                 });
             }
 

--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -1159,17 +1159,18 @@ pub(super) fn emit_guarded_direct_method_call(
                 };
                 // Leaves `current_block` at the freshly created guardcall
                 // block, where the per-field runtime chain below is emitted.
-                let _guardcall = crate::expr::class_field_inline_guard::emit_class_field_inline_precheck(
-                    ctx,
-                    &obj_bits,
-                    &obj_handle,
-                    &expected_class_id_str,
-                    &expected_shape_id,
-                    true,
-                    None,
-                    &proven_label,
-                    &[],
-                );
+                let _guardcall =
+                    crate::expr::class_field_inline_guard::emit_class_field_inline_precheck(
+                        ctx,
+                        &obj_bits,
+                        &obj_handle,
+                        &expected_class_id_str,
+                        &expected_shape_id,
+                        true,
+                        None,
+                        &proven_label,
+                        &[],
+                    );
                 // Created after the precheck's own blocks so the merge (and the
                 // typed/generic branch it feeds) follows the per-field guard
                 // calls in emission order.

--- a/crates/perry-codegen/src/stmt/versioned_indexed_loop.rs
+++ b/crates/perry-codegen/src/stmt/versioned_indexed_loop.rs
@@ -579,6 +579,7 @@ pub(super) fn lower(
         &method_guard_slot,
         &fast_pre_label,
         &slow_pre_label,
+        true,
     );
 
     let method_fact = VersionedIndexedMethodFact {

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -12659,11 +12659,17 @@ fn typed_f64_receiver_method_clone_raw_loads_after_composed_guards() {
     let field_guard = caller_ir
         .find("call i32 @js_typed_feedback_class_field_get_guard")
         .unwrap_or_else(|| panic!("caller should guard raw-f64 receiver fields:\n{caller_ir}"));
+    // Same for the raw-f64 FIELD proof: one inline class-field precheck
+    // (the field-GET sites' form, first mentioned by its `deref` block in the
+    // branch that enters it) dominates the typed call, and the per-field
+    // runtime guard is that precheck's miss edge.
+    let inline_field_precheck = caller_ir.find("class_field_inline.deref");
+    let field_proof = inline_field_precheck.map_or(field_guard, |p| p.min(field_guard));
     let typed_call = caller_ir
         .find(&format!("call double @{typed}(i64 "))
         .unwrap_or_else(|| panic!("caller should call the receiver clone:\n{caller_ir}"));
     assert!(
-        method_proof < field_guard && field_guard < typed_call,
+        method_proof < field_proof && field_proof < typed_call,
         "receiver clone must run only after method-direct and raw-f64 field guards:\n{caller_ir}"
     );
     // #7506: this used to assert the guard-failure edge calls `$generic` BY


### PR DESCRIPTION
Follow-up to #9124, which merged with the **method-direct probe only** (the second commit hadn't been pushed yet). This PR carries the second half of that lever plus the review fixes.

## What

1. **One inline field precheck vouches for all typed-receiver fields.** With the method probe in front, a probe-first `c.inc()` loop was ~80% `js_typed_feedback_class_field_get_guard`: per receiver field, per call, a `shape_descriptor_by_id` lookup (thread-local map) plus the raw-f64 layout contract, re-deriving facts the exact `(class_id, ShapeId)` pair already pins. The field-GET sites already emit `emit_class_field_inline_precheck` ahead of that guard (class/shape + not-forwarded + the per-**object** raw-f64 intact bit); because the intact bit is object-wide, one precheck vouches for every receiver field at once. Its miss edge runs the unchanged per-field runtime chain, whose i1 result joins at a phi. Same kill switch (`PERRY_METHOD_INLINE_PROBE=0`), same emission-off gating.
2. **Review fix (#9124 / CodeRabbit):** `emit_inline_direct_method_shape_guard` takes `accept_raw_ptr`. Probe-first sites pass `false` — a user NaN-box receiver must carry the `0x7FFD` tag before any dereference, so a plain double whose bits land in the heap range (a positive subnormal) misses to the runtime guard instead of reaching the header load. The pre-existing shape-only site and `versioned_indexed_loop.rs` keep raw acceptance (their receivers can legitimately arrive in the internal raw-address ABI). The other review point (receiver lowered before arguments, no re-read) is the tower's pre-existing structure shared by the runtime guard and the shape-only inline guard; all of them reject a moved receiver via the forwarded header bit and fall to the runtime guard, which resolves forwarding — the probe adds no new window, and re-rooting the whole tower is a separate change.
3. The `typed_f64_receiver` IR-shape test measured both proofs by the runtime guards' text positions; it now measures the proof itself (inline marker or guard call, whichever dominates), and the fields merge block is created after the precheck's blocks so the typed/generic branch follows the guard calls in emission order.

## Measurements

Mac mini, 7 kill-switch pairs, monomorphic `c.inc()` (node 0.4–0.5 in all four shapes):

| receiver / host | #9124 as merged (method probe) | **+ field precheck** | Δ | vs node |
|---|---|---|---|---|
| typed **param**, plain fn | 12.8 | **3.8** | **−70%** (118.6→3.8 cumulative) | 7.6× |
| **captured** const, arrow | 13.1 | **3.8** | **−71%** | 7.6× |
| local `new C()`, plain fn | 4.4 | 4.4 | 0 | 8.8× |
| local `new C()`, arrow | 4.4 | 4.4 | 0 | 11.0× |

With both prechecks the loop has **zero runtime calls per iteration** (`sample`: 100% inside the generated function). Semantics differential (subclass through base param, virtual override, mid-program prototype monkey-patch, own-property override, annotation-lie receiver) identical to the off arm after all fixes.

## Binary size

~80 B per typed-receiver method site (one precheck per site regardless of field count); classhost fixture `.text` 10,938,772 → 10,939,092 (+320 B, +0.003%) on top of #9124's +384 B. cc-bundle `size(1)` on/off pair is compiling on perrymaster and will be posted as a comment.

## Gates

Validated on the #9124 branch base: `-D warnings` 0, codegen 1830/0, runtime 2819/0, lints clean, integration 8655 2/2 / 8690 3/3 / 8897 3/3. Rerunning on this base (main with #9103) — results in a comment.

https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method dispatch reliability for typed numeric values by validating receiver types and fields more consistently.
  * Added safer handling for supported raw pointer receiver forms during optimized method checks.
  * Strengthened validation sequencing to reduce incorrect execution paths.

* **Tests**
  * Updated regression coverage for inline field validation and receiver guard sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->