### PR TITLE
perf(runtime): literal births stamp the cached ShapeId without re-minting (method literals −24.5%)

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -799,14 +799,32 @@ pub extern "C" fn js_object_alloc_with_shape(
 
     unsafe {
         let obj_ptr = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
-        set_object_keys_array_with_live(obj_ptr, keys_arr, field_count);
-        // #6804: birth-stamp the runtime ShapeId (see `ShapeCacheEntry`) —
-        // newborn literals carry their stable identity immediately, so
-        // typed_feedback tokens and the id-keyed FIELD_CACHE never see a
-        // pre-stamp window for shape-cached objects.
-        // #8113: `field_count` is the LOGICAL live-slot bound; the extra
-        // physical slots above it stay available for dynamic growth.
-        crate::object::shapes::birth_stamp_object_shape(obj_ptr, runtime_shape_id, field_count);
+        // A shape-cache HIT hands back the canonical keys array paired with
+        // its already-minted ShapeId, so stamp the newborn straight from that
+        // immutable descriptor — the same `try_birth_stamp_preinstalled_shape`
+        // the compiled-class allocator uses — instead of re-canonicalizing
+        // the identical facts on every birth. The publish-then-stamp path
+        // below (`publish_object_shape_from` hashing `ShapeFacts`, plus three
+        // descriptor lookups in `birth_stamp_object_shape`) was the bulk of a
+        // 257 ns `{ a, b, m() {} }` literal; a miss (first birth of the shape,
+        // worker-local id not yet installed, bound mismatch) keeps it.
+        let stamped_from_cache = runtime_shape_id != 0
+            && crate::object::shapes::try_birth_stamp_preinstalled_shape(
+                obj_ptr,
+                runtime_shape_id,
+                keys_arr,
+                field_count,
+            );
+        if !stamped_from_cache {
+            set_object_keys_array_with_live(obj_ptr, keys_arr, field_count);
+            // #6804: birth-stamp the runtime ShapeId (see `ShapeCacheEntry`) —
+            // newborn literals carry their stable identity immediately, so
+            // typed_feedback tokens and the id-keyed FIELD_CACHE never see a
+            // pre-stamp window for shape-cached objects.
+            // #8113: `field_count` is the LOGICAL live-slot bound; the extra
+            // physical slots above it stay available for dynamic growth.
+            crate::object::shapes::birth_stamp_object_shape(obj_ptr, runtime_shape_id, field_count);
+        }
     }
 
     obj_handle.get_raw_mut_ptr::<ObjectHeader>()


### PR DESCRIPTION
## What

On a shape-cache **hit**, `js_object_alloc_with_shape` still ran `set_object_keys_array_with_live` → `publish_object_shape_from` (hashes `ShapeFacts`, `shape_descriptor_ensure_with_holes`) and then `birth_stamp_object_shape` (three `shape_descriptor_by_id` lookups) for every newborn literal — re-canonicalizing facts the cache entry already carries (the canonical keys array paired with its minted ShapeId). That was the bulk of a 257 ns `{ a, b, m() {} }` build (node: 1.1 ns).

The compiled-class allocator solved exactly this with `try_birth_stamp_preinstalled_shape` (alloc.rs, #8113 lineage); the literal path now uses it for cache hits. A miss (first birth of the shape, worker-local id not installed, live-slot bound mismatch) keeps the publish-then-stamp path unchanged. A fresh birth has `hole_count == 0` by construction — the same fact the class path already relies on.

One call, runtime only; no latch / delete / squeeze / transition-cache anchors touched.

## Measurements

Mac mini (quiet host), interleaved pairs, median ns/op:

| shape | before | after | Δ |
|---|---|---|---|
| `{ a, b, inc() { return this.a + 1 } }` build (escaping), on top of #9122's shape routing | 253.7 | **191.6** | **−24.5%** |
| escaping plain `{ a, b, c }` literal | 5.8 | 5.8 | 0 (takes the `new __AnonShape` class route, never this allocator) |

Only `Expr::Object` literals (methods, spreads, computed keys) reach `js_object_alloc_with_shape`; closed-shape record literals are already anonymous-shape class allocations with the preinstalled stamp — this PR brings the literal allocator in line with them. The remaining ~190 ns on the method-literal row decomposes into the per-instance closure allocation (~46 ns, own family) and the field reads on a literal that carries a method degrading to by-name dispatch (the `is_closed_shape` admission excludes method shorthand while `m: function(){}` is admitted at 44 ns) — the next lever, filed separately.

## Correctness

- 300k-birth churn differential (survivors crossing minors, dynamic growth + delete after birth, two same-shape sites with different method bodies, JSON round-trips): **byte-identical vs node**
- Object-literal method differential (#9122's set): **byte-identical vs node** (plus the 264-line number-formatting differential, also identical)
- `object/tombstone_tests.rs` pins (literal-born objects feed the tombstone delete paths): **20 passed / 0 failed** (`cargo test -p perry-runtime tombstone`, single-threaded)
- Tombstone enumeration differential vs node (`battery/tombstone_enum.ts`, perrymaster Linux build of this branch): **identical**
- Gates: full battery running on the PR branch (runtime suite included, this is a runtime change) — results in a comment.

## Binary size

Runtime-only change: no generated-code delta (`.text` of compiled programs unchanged; the runtime archive shrinks by the removed publish call inline).

https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved object creation speed in cases where a reusable shape is available.
  * Retained the existing creation path when the optimized path cannot be used, preserving compatibility and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->