### PR TITLE
perf(hir): admit method shorthand into the closed-shape record route (method literals 671→19 ns, −97%)

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -668,10 +668,57 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                     }
                 }
                 ast::Prop::Shorthand(_) => {}
+                // Method shorthand `m() { … }` with a static key lowers exactly
+                // like `m: function () { … }` (dynamic `this`, a plain
+                // pointer-bearing field slot), so it joins the closed-shape
+                // record route instead of falling to the by-name/shape-cache
+                // `Expr::Object` path whose field READS degrade to by-name
+                // dispatch (114–461 ns per literal on a 3-prop object vs 44 ns
+                // for the function-expression spelling). What is NOT admitted:
+                // `super` (needs the object home slot the IIFE route
+                // provides), async/generator methods (their own lowering
+                // shapes), computed keys, and `__proto__`.
+                ast::Prop::Method(method) => {
+                    if is_noncomputed_proto_key(&method.key) {
+                        return false;
+                    }
+                    match &method.key {
+                        ast::PropName::Ident(_) | ast::PropName::Str(_) | ast::PropName::Num(_) => {}
+                        _ => return false,
+                    }
+                    if method.function.is_async
+                        || method.function.is_generator
+                        || function_body_uses_super(&method.function)
+                    {
+                        return false;
+                    }
+                }
                 _ => return false,
             }
         }
         true
+    }
+
+    /// Conservative: any `super.x` / `super[x]` / `super(...)` anywhere in the
+    /// body — nested functions and classes included — keeps the method on the
+    /// home-object-carrying route.
+    fn function_body_uses_super(function: &ast::Function) -> bool {
+        use swc_ecma_visit::{Visit, VisitWith};
+        struct Finder(bool);
+        impl Visit for Finder {
+            fn visit_super_prop_expr(&mut self, _: &ast::SuperPropExpr) {
+                self.0 = true;
+            }
+            fn visit_callee(&mut self, callee: &ast::Callee) {
+                if matches!(callee, ast::Callee::Super(_)) {
+                    self.0 = true;
+                }
+                callee.visit_children_with(self);
+            }
+        }
+        let mut finder = Finder(false);
+        function.visit_with(&mut finder);
+        finder.0
     }
     // #6812 (w16): `{}` — the builder-pattern seed — lowers to `new
     // __AnonShape_<site-hash>()`, a unique 0-field shape-only class per
@@ -695,7 +742,15 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
             cap_args_appended: 0,
         });
     }
-    if is_closed_shape(obj) {
+    // Directly exported method literals stay on the seeded IIFE route below:
+    // a consumer module's guarded direct call on an imported object keys on
+    // the producer's shape-only seed class and slot order, and this routing
+    // is what that capability was built against.
+    let exported_method_literal = prefer_exported_method_shape_seed
+        && obj.props.iter().any(|prop| {
+            matches!(prop, ast::PropOrSpread::Prop(p) if matches!(p.as_ref(), ast::Prop::Method(_)))
+        });
+    if is_closed_shape(obj) && !exported_method_literal {
         let mut fields: Vec<(String, Type, Expr)> = Vec::new();
         let mut bail = false;
         let mut seen = std::collections::HashSet::new();
@@ -782,6 +837,61 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         break;
                     };
                     fields.push((name, ty, value));
+                }
+                ast::Prop::Method(method) => {
+                    // `is_closed_shape` admitted only static-key, non-async,
+                    // non-generator, super-free methods. Lower the body with
+                    // the shared method lowering, then take the closure as a
+                    // dynamic-`this` value — identical to the function-
+                    // expression spelling — so no post-construction `this`
+                    // patch is needed and `t.m()` / `f.call(other)` both bind
+                    // the call receiver, as the spec says.
+                    let Some((mkey, value_expr, _uses_this)) = lower_method_prop(ctx, method)?
+                    else {
+                        bail = true;
+                        break;
+                    };
+                    let MethodKeyKind::Static(key) = mkey else {
+                        bail = true;
+                        break;
+                    };
+                    if !seen.insert(key.clone()) {
+                        bail = true;
+                        break;
+                    }
+                    let value = match value_expr {
+                        Expr::Closure {
+                            func_id,
+                            params,
+                            return_type,
+                            body,
+                            captures,
+                            mutable_captures,
+                            captures_this: _,
+                            captures_new_target,
+                            enclosing_class: _,
+                            is_arrow,
+                            is_async,
+                            is_generator,
+                            is_strict,
+                        } => Expr::Closure {
+                            func_id,
+                            params,
+                            return_type,
+                            body,
+                            captures,
+                            mutable_captures,
+                            captures_this: false,
+                            captures_new_target,
+                            enclosing_class: None,
+                            is_arrow,
+                            is_async,
+                            is_generator,
+                            is_strict,
+                        },
+                        other => other,
+                    };
+                    fields.push((key, Type::Any, value));
                 }
                 _ => unreachable!(),
             }

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -163,23 +163,44 @@ const computed = { [key]() { return 1; } };
             .unwrap_or_else(|| panic!("missing init for {name}"))
     };
 
-    let Expr::Object(props) = local_init("fast") else {
+    // A static-key, super-free method literal is a closed-shape RECORD: it
+    // lowers to the anonymous-shape class allocation (fixed-slot reads, no
+    // builder IIFE), with each method carried as a dynamic-`this` closure
+    // argument — the function-expression spelling's semantics — so no
+    // post-construction `this` patch exists to get wrong.
+    let Expr::New {
+        class_name, args, ..
+    } = local_init("fast")
+    else {
         panic!(
-            "static method literal should be a direct object: {:#?}",
+            "static method literal should be a closed-shape record allocation: {:#?}",
             hir.init
         );
     };
-    assert_eq!(
-        props
-            .iter()
-            .map(|(key, _)| key.as_str())
-            .collect::<Vec<_>>(),
-        ["plain", "captured", "dynamicThis"]
+    assert!(
+        class_name.starts_with("__AnonShape_"),
+        "record class expected, got {class_name}"
     );
+    let record = hir
+        .classes
+        .iter()
+        .find(|class| &class.name == class_name)
+        .unwrap_or_else(|| panic!("record class {class_name} must be synthesized"));
+    assert_eq!(
+        record
+            .fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        ["plain", "captured", "dynamicThis"],
+        "field order must follow source order"
+    );
+    assert_eq!(args.len(), 3);
     assert!(matches!(
-        &props[2].1,
+        &args[2],
         Expr::Closure {
-            captures_this: true,
+            captures_this: false,
+            enclosing_class: None,
             ..
         }
     ));


### PR DESCRIPTION
## What

`is_closed_shape` (the gate for lowering an object literal to a `new __AnonShape_…` record class — fixed-slot reads, preinstalled shape stamp, class allocation) admitted only `key: value` and shorthand props. A method-shorthand prop `m() { … }` — semantically the same value as `m: function () { … }` for everything except `super` — fell to the `Expr::Object` route, where the literal's own field reads degrade to by-name dispatch and each `this`-method needs a post-construction patch. Measured on the mini for a 3-prop literal: `m: function(){ this.a }` 44 ns, `m(){ 1 }` 114 ns, `m(){ this.a }` 234 ns, two methods 461 ns (node 5–17).

This admits static-key, non-async, non-generator, `super`-free method shorthand into the closed-shape route: the shared `lower_method_prop` lowers the body, and the resulting closure is taken as a **dynamic-`this`** value (`captures_this: false`, no `enclosing_class`) exactly like the function-expression spelling — so `t.m()` and `f.call(other)` bind the call receiver per spec and no patch is needed. `super` is detected with an swc `Visit` over the whole body (nested functions/classes included) because with no object home slot on the stack, `super.x` would otherwise fall to class-`super` lowering.

## Measurements

Mac mini (quiet host), 3 interleaved rounds each, median ns/op for a 3-prop escaping literal (build + one field read); `main` = current main routing, `node` on the same box:

| literal | main | **this PR** | Δ | node | vs node (was) |
|---|---|---|---|---|---|
| `{ a, b, m() { return this.a + 1 } }` | 671.3 | **19.2** | **−97.1%** | 4.0 | 4.8× (was 168×) |
| `{ a, b, m() { return 1 } }` | 170.6 | **10.8** | **−93.7%** | 4.5 | 2.4× (was 38×) |
| `{ a, b, m1() { this.a }, m2() { this.b } }` | 1046.2 | **38.9** | **−96.3%** | 7.1 | 5.5× (was 147×) |
| `{ a, b, inc: function () { this.a + 1 } }` (already a record) | 45.7 | 21.8 | −52.3% | 4.8 | 4.5× |
| `{ a, b, f: (x) => x + k }` (captured arrow field, already a record) | 49.6 | 49.5 | −0.2% | 5.9 | 8.4× |

Spread on every row ≤0.1 ns across rounds. The function-expression row also moved and is not attributed to a code path this PR touches — reported as measured. The residual on the moved rows is now the per-instance closure allocation (~46 ns for a capturing closure vs ~4 in node — its own family) plus the record class allocation.

## Correctness

- Five differentials vs node on the new build: method-literal `this` binding (params, arrays, extracted `.call`), the #9122 method-literal set, the 300k-birth churn set, and a function-expression `this` set — all **byte-identical**. Two probes covering the exotic surface (`Object.keys`/`for…in` order, spread and `Object.assign` copies, `delete` then call → TypeError, later shadowing, nested literal methods, quoted/numeric keys, `__proto__` + `super`, `this`-returning chains, generators/async/getters/`toPrimitive` methods) are **byte-identical between the old and new routes**; the only lines where either differs from node are pre-existing on main — method `.prototype` existence, `new obj.m()` constructibility, and captureless-method identity (`{n(){}}.n === {n(){}}.n` is `true`, the `FuncRef` singleton) — and are unchanged by this PR.
- perry-hir unit tests 360/0; the #8793 routing test now pins the record form for the static case (source-ordered record fields, dynamic-`this` closure argument) and keeps its `super`/computed fail-closed assertions; directly exported method literals stay on the seeded IIFE route that imported-object capabilities key on.
- Gates: full battery running on this branch — results in a comment.

## Binary size

HIR-level routing only: a method literal now compiles as a record class allocation (one `new`) instead of a shape-cache allocation plus per-method patch sequence — fewer emitted instructions per literal site, no new inline sequences. Fixture (five method-literal loops, arm64, `size -m`): `__text` 10,962,516 → 10,959,316 = **−3,200 B (−0.03%)**.

https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved object creation for eligible method-shorthand properties by using a more efficient optimized path.

- **Behavior**
  - Preserved dynamic `this` behavior when these methods are called.
  - Methods using `super`, async/generator methods, computed keys, and directly exported method literals continue using their existing handling.

- **Tests**
  - Updated coverage to verify method ordering, closure behavior, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->