### PR TITLE
fix(hir,codegen): `x ?? null` with an unknown left no longer costs the local its GC root

### DIFF
--- a/changelog.d/9135-coalesce-unknown-left-gc-root.md
+++ b/changelog.d/9135-coalesce-unknown-left-gc-root.md
@@ -1,0 +1,25 @@
+Fixed a moving-GC use-after-move for locals initialised with `x ?? null` (or
+`?? <anything>`) where the left side is not statically typed — most commonly an
+optional chain: `const masks = opts?.masks ?? null`. A Three.js world builder
+compiled with Perry read from-space on its first copying minor (SIGBUS under
+`PERRY_GC_PROTECT_FROMSPACE=1`, wrong vertex colours or an aborted build
+otherwise).
+
+Two defects, one rule. Both copies of the `??` type-inference rule
+(`perry-hir` `analysis/value_types.rs` and `lower_types.rs`) answered the RIGHT
+operand's type whenever the left was unknown, so the binding above was declared
+`null`. The codegen pointer-locals collector ignores declared types by design
+(#7846) and proves pointer-ness from the initializer — but it had no arm for
+logical operators, fell back to that same inference, took `null` as proof, and
+gave the local no GC root: the array's NaN-boxed address sat in a plain
+`alloca double` across the loop poll and the next `masks[0]` dereferenced the
+pre-collection address. An explicit `number[] | null` annotation could not help
+(the collector distrusts annotations); a plain ternary was rooted all along.
+
+The `??` rule is now one shared `coalesce_type`: an unknown left stays unknown,
+a nullish left takes the right type, a nullable union gains the right's members.
+The collector gets an explicit `Logical` arm that requires both operands to
+classify before it answers, so a root decision never rides on the inference
+again. Pinned by unit tests on the exact HIR, a lowering test, and a registered
+`test_gap_gc_coalesce_local_root` witness (`?? null` over an array and over a
+closure, live across loop polls).

--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -362,6 +362,33 @@ pub fn collect_pointer_typed_locals(
                     None
                 }
             }
+            // `a ?? b` / `a || b` / `a && b` select one OPERAND, so the result
+            // is classifiable only when both operands are — the same `?`
+            // discipline as `Conditional` below. This arm exists so the answer
+            // never comes from the generic `infer_expr_type` fallback at the
+            // bottom: that inference is structural, and it typed
+            // `const masks = opts?.masks ?? null` as `Null` (the left is an
+            // `Any`-typed conditional, and the old `??` rule answered the
+            // right operand for an unknown left). `Null` is definitely
+            // non-pointer, so the local lost its shadow slot and the array's
+            // pre-collection address sat in a plain `alloca double` across the
+            // loop poll. The HIR rule is fixed too, but a root decision must
+            // not depend on it: an unclassifiable operand keeps the slot.
+            Expr::Logical { op, left, right } => {
+                let left_ty =
+                    expr_value_type(left, local_types, local_value_types, non_pointer_locals)?;
+                let right_ty =
+                    expr_value_type(right, local_types, local_value_types, non_pointer_locals)?;
+                match op {
+                    perry_hir::LogicalOp::Coalesce
+                        if matches!(left_ty, Type::Null | Type::Void) =>
+                    {
+                        Some(right_ty)
+                    }
+                    _ if left_ty == right_ty => Some(left_ty),
+                    _ => Some(Type::Union(vec![left_ty, right_ty])),
+                }
+            }
             Expr::Conditional {
                 then_expr,
                 else_expr,
@@ -1369,6 +1396,105 @@ mod tests {
         let slots = collect_pointer_typed_locals(&[], &stmts, &HashSet::new());
         assert!(!slots.contains_key(&1));
         assert!(slots.contains_key(&2));
+    }
+
+    /// The `Accum.add` shape from the Claude-of-Duty native profile — the
+    /// exact HIR `--trace hir` printed for
+    ///
+    /// ```ts
+    /// add(count: number, opts: { masks: number[] } | null) {
+    ///   const masks = opts?.masks ?? null;
+    /// ```
+    ///
+    /// HIR typed the binding `Null` (the old `??` rule answered the right
+    /// operand for an `Any` left), and `expr_value_type`'s generic fallback
+    /// accepted that as proof the local holds no pointer. The local then sat
+    /// in a plain `alloca double` across the loop poll, the copying minor moved
+    /// the array, and `masks[0]` dereferenced from-space (SIGBUS under
+    /// `PERRY_GC_PROTECT_FROMSPACE=1`).
+    ///
+    /// Two things are pinned on purpose: the `Let` type stays `Null`, so the
+    /// collector must not need the HIR fix to keep the slot; and the receiver
+    /// is a PARAMETER, whose type never enters `local_value_types`, so the
+    /// property read is unclassifiable exactly as it was in the failing build.
+    #[test]
+    fn a_coalesced_optional_chain_read_keeps_its_shadow_slot() {
+        let params = vec![Param {
+            id: 5,
+            name: "opts".to_string(),
+            ty: Type::Union(vec![Type::Object(Default::default()), Type::Null]),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }];
+        let stmts = vec![Stmt::Let {
+            id: 6,
+            name: "masks".to_string(),
+            ty: Type::Null,
+            mutable: false,
+            init: Some(Expr::Logical {
+                op: perry_hir::LogicalOp::Coalesce,
+                left: Box::new(Expr::Conditional {
+                    condition: Box::new(Expr::Compare {
+                        op: perry_hir::CompareOp::LooseEq,
+                        left: Box::new(Expr::LocalGet(5)),
+                        right: Box::new(Expr::Null),
+                    }),
+                    then_expr: Box::new(Expr::Undefined),
+                    else_expr: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(5)),
+                        property: "masks".to_string(),
+                        byte_offset: 0,
+                    }),
+                }),
+                right: Box::new(Expr::Null),
+            }),
+        }];
+
+        let slots = collect_pointer_typed_locals(&params, &stmts, &HashSet::new());
+        assert!(
+            slots.contains_key(&6),
+            "`opts?.masks ?? null` can bind a heap array; without a shadow slot the local \
+             keeps the pre-collection address across the loop poll"
+        );
+    }
+
+    /// The precision the `Logical` arm must keep: a `??` / `||` over two
+    /// proven scalars is still a scalar and pays no slot.
+    #[test]
+    fn a_logical_operator_over_proven_scalars_still_pays_no_slot() {
+        let stmts = vec![
+            Stmt::Let {
+                id: 1,
+                name: "n".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Logical {
+                    op: perry_hir::LogicalOp::Coalesce,
+                    left: Box::new(Expr::Integer(1)),
+                    right: Box::new(Expr::Integer(2)),
+                }),
+            },
+            Stmt::Let {
+                id: 2,
+                name: "m".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Logical {
+                    op: perry_hir::LogicalOp::Or,
+                    left: Box::new(Expr::Integer(0)),
+                    right: Box::new(Expr::Bool(true)),
+                }),
+            },
+        ];
+
+        let slots = collect_pointer_typed_locals(&[], &stmts, &HashSet::new());
+        assert!(!slots.contains_key(&1), "`1 ?? 2` is a proven number");
+        assert!(
+            !slots.contains_key(&2),
+            "`0 || true` is a proven scalar union"
+        );
     }
 
     #[test]

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -18,6 +18,7 @@ mod uses_this;
 pub(crate) use uses_this::{closure_uses_new_target, closure_uses_this, uses_this_stmt};
 
 mod value_types;
+pub(crate) use value_types::coalesce_type;
 pub use value_types::{infer_expr_type, infer_refinable_expr_type, HirTypeEnv, HirTypeFacts};
 
 /// Whether a function BODY reads the dynamic `this` binding — directly via

--- a/crates/perry-hir/src/analysis/value_types.rs
+++ b/crates/perry-hir/src/analysis/value_types.rs
@@ -1717,12 +1717,53 @@ fn infer_logical_type<F: HirTypeFacts + ?Sized>(
         }
         LogicalOp::Coalesce => {
             let left_ty = infer_expr_type(left, env);
-            if matches!(left_ty, Type::Any | Type::Null | Type::Void) {
-                infer_expr_type(right, env)
-            } else {
-                left_ty
-            }
+            coalesce_type(left_ty, || infer_expr_type(right, env))
         }
+    }
+}
+
+/// Result type of `left ?? right`, given the left operand's type and the
+/// right's on demand.
+///
+/// `a ?? b` evaluates to `a` unless `a` is nullish, so the right operand only
+/// contributes on the path where the left is `null`/`undefined`:
+///
+/// * a left that is definitely nullish yields the right type;
+/// * a left that MAY be nullish (a union with a `Null`/`Void` member) keeps its
+///   members and gains the right type; an unknown right collapses to `Any`;
+/// * a left that is UNKNOWN (`Any`/`Unknown`) stays unknown. It may be a
+///   non-nullish heap value, and the right operand says nothing about it.
+///   Both copies of this rule (here and `lower_types::infer_type_from_expr`)
+///   used to answer the RIGHT type for an unknown left, which typed
+///   `const masks = opts?.masks ?? null` as `Null` — optional chaining lowers
+///   its left side to an `Any`-typed conditional. The codegen pointer analysis
+///   (`collectors/pointer_locals.rs`) took that as proof the local holds no
+///   pointer and dropped its GC root, so an evacuating minor at the loop poll
+///   left the array's from-space address in a plain `alloca double` and the
+///   next `masks[0]` read from-space;
+/// * any other left is never nullish, so the right operand is unreachable.
+pub(crate) fn coalesce_type(left: Type, right: impl FnOnce() -> Type) -> Type {
+    match left {
+        Type::Any | Type::Unknown => left,
+        Type::Null | Type::Void => right(),
+        Type::Union(mut variants)
+            if variants
+                .iter()
+                .any(|variant| matches!(variant, Type::Null | Type::Void)) =>
+        {
+            let members = match right() {
+                Type::Any | Type::Unknown => return Type::Any,
+                Type::Union(members) => members,
+                other => vec![other],
+            };
+            for member in members {
+                if !variants.contains(&member) {
+                    variants.push(member);
+                }
+            }
+            Type::Union(variants)
+        }
+        other => other,
     }
 }
 

--- a/crates/perry-hir/src/analysis/value_types_tests.rs
+++ b/crates/perry-hir/src/analysis/value_types_tests.rs
@@ -1646,6 +1646,105 @@ fn logical_and_or_unions_both_operands() {
     assert_eq!(infer_expr_type(&same, &env), Type::String);
 }
 
+/// `a ?? b` selects `a` unless `a` is nullish. An UNKNOWN left may be a
+/// non-nullish heap value, so the result must stay unknown: the previous rule
+/// answered the right operand's type, which typed `opts?.masks ?? null` as
+/// `Null` and cost that local its GC root (see `coalesce_type`).
+#[test]
+fn nullish_coalescing_keeps_an_unknown_left_operand_unknown() {
+    let env = empty_env();
+    // An unresolved local is `Any`.
+    let unknown = Expr::Logical {
+        op: LogicalOp::Coalesce,
+        left: Box::new(Expr::LocalGet(999)),
+        right: Box::new(Expr::Null),
+    };
+    assert_eq!(infer_expr_type(&unknown, &env), Type::Any);
+
+    // The exact lowering of `opts?.masks ?? null` on a receiver whose type the
+    // environment does not know: `opts == null ? undefined : opts.masks`.
+    let optional_chain = Expr::Logical {
+        op: LogicalOp::Coalesce,
+        left: Box::new(Expr::Conditional {
+            condition: Box::new(Expr::Compare {
+                op: CompareOp::LooseEq,
+                left: Box::new(Expr::LocalGet(5)),
+                right: Box::new(Expr::Null),
+            }),
+            then_expr: Box::new(Expr::Undefined),
+            else_expr: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(5)),
+                property: "masks".to_string(),
+                byte_offset: 0,
+            }),
+        }),
+        right: Box::new(Expr::Null),
+    };
+    assert_eq!(infer_expr_type(&optional_chain, &env), Type::Any);
+}
+
+#[test]
+fn nullish_coalescing_takes_the_right_operand_only_for_a_nullish_left() {
+    let env = empty_env();
+    let coalesce = |left: Expr, right: Expr| Expr::Logical {
+        op: LogicalOp::Coalesce,
+        left: Box::new(left),
+        right: Box::new(right),
+    };
+    assert_eq!(
+        infer_expr_type(&coalesce(Expr::Null, Expr::Integer(1)), &env),
+        Type::Number
+    );
+    assert_eq!(
+        infer_expr_type(
+            &coalesce(Expr::Undefined, Expr::String("x".to_string())),
+            &env
+        ),
+        Type::String
+    );
+    // A never-nullish left makes the right operand unreachable.
+    assert_eq!(
+        infer_expr_type(
+            &coalesce(Expr::Integer(1), Expr::String("x".to_string())),
+            &env
+        ),
+        Type::Number
+    );
+}
+
+#[test]
+fn coalesce_type_widens_a_nullable_union_by_the_right_operand() {
+    let nullable_array = Type::Union(vec![Type::Array(Box::new(Type::Number)), Type::Null]);
+    // `(number[] | null) ?? null` — the right adds nothing new.
+    assert_eq!(
+        coalesce_type(nullable_array.clone(), || Type::Null),
+        nullable_array
+    );
+    // `(number | undefined) ?? "x"` can be a string.
+    assert_eq!(
+        coalesce_type(Type::Union(vec![Type::Number, Type::Void]), || Type::String),
+        Type::Union(vec![Type::Number, Type::Void, Type::String])
+    );
+    // A nested union on the right is merged member-wise.
+    assert_eq!(
+        coalesce_type(Type::Union(vec![Type::Number, Type::Void]), || Type::Union(
+            vec![Type::Number, Type::String]
+        )),
+        Type::Union(vec![Type::Number, Type::Void, Type::String])
+    );
+    // An unknown right on a nullable left is unknown.
+    assert_eq!(
+        coalesce_type(Type::Union(vec![Type::Number, Type::Void]), || Type::Any),
+        Type::Any
+    );
+    // A union with no nullish member never reaches the right operand.
+    assert_eq!(
+        coalesce_type(Type::Union(vec![Type::Number, Type::String]), || Type::Null),
+        Type::Union(vec![Type::Number, Type::String])
+    );
+    assert_eq!(coalesce_type(Type::Unknown, || Type::Null), Type::Unknown);
+}
+
 #[test]
 fn resolves_this_and_super_in_class_context() {
     let mut module = Module::new("test");

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -1848,3 +1848,36 @@ fn assert_capture_stash_follows_super(source: &str, class_name: &str) {
         ctor.body
     );
 }
+
+/// `const masks = opts?.masks ?? null` must not be declared `Null`. The
+/// AST-level `??` rule used to answer the right operand's type whenever the
+/// left inferred `Any` — and an optional chain always does — so the binding
+/// was typed `Null`, which downstream read as "holds no pointer".
+#[test]
+fn nullish_coalescing_over_an_optional_chain_is_not_typed_by_its_right_operand() {
+    let source = r#"
+        function add(opts: { masks: number[] } | null) {
+            const masks = opts?.masks ?? null;
+            return masks;
+        }
+    "#;
+    let module = perry_parser::parse_typescript(source, "coalesce.ts").expect("source parses");
+    let hir = super::lower_module(&module, "coalesce", "coalesce.ts").expect("source lowers");
+    let add = hir
+        .functions
+        .iter()
+        .find(|f| f.name == "add")
+        .expect("`add` lowers");
+    let masks_ty = add
+        .body
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Let { name, ty, .. } if name == "masks" => Some(ty),
+            _ => None,
+        })
+        .expect("`masks` lowers to a Let");
+    assert!(
+        !matches!(masks_ty, Type::Null | Type::Void),
+        "`opts?.masks ?? null` is an array on the non-null path; got {masks_ty:?}"
+    );
+}

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -462,13 +462,14 @@ fn infer_type_from_expr_inner(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
                         Type::Any
                     }
                 }
+                // One rule with the HIR-level `??` inference: an unknown left
+                // stays unknown, only a nullish left takes the right type.
+                // Pre-fix this arm answered the RIGHT type for an `Any` left,
+                // so `opts?.masks ?? null` (an `OptChain` left, which has no
+                // arm here) declared its binding `Null` — see `coalesce_type`.
                 NullishCoalescing => {
                     let left = infer_type_from_expr(&bin.left, ctx);
-                    if !matches!(left, Type::Any) {
-                        left
-                    } else {
-                        infer_type_from_expr(&bin.right, ctx)
-                    }
+                    crate::analysis::coalesce_type(left, || infer_type_from_expr(&bin.right, ctx))
                 }
             }
         }

--- a/crates/perry-hir/src/monomorph/infer.rs
+++ b/crates/perry-hir/src/monomorph/infer.rs
@@ -107,9 +107,14 @@ fn infer_expr_type(expr: &Expr, module: &Module, idx: &ModuleIndex) -> Option<Ty
                         .or_else(|| infer_expr_type(right, module, idx))
                 }
                 LogicalOp::Coalesce => {
-                    // Returns non-null operand
-                    infer_expr_type(left, module, idx)
-                        .or_else(|| infer_expr_type(right, module, idx))
+                    // `a ?? b` is `a` unless `a` is nullish. An un-inferable
+                    // left says nothing about the selected value, so the
+                    // answer stays `None` rather than borrowing the right
+                    // operand's type (see `analysis::coalesce_type`).
+                    match infer_expr_type(left, module, idx)? {
+                        Type::Null | Type::Void => infer_expr_type(right, module, idx),
+                        left_ty => Some(left_ty),
+                    }
                 }
             }
         }

--- a/docs/src/internals/gc-rooting-invariant.md
+++ b/docs/src/internals/gc-rooting-invariant.md
@@ -60,7 +60,7 @@ wrong:
 Four instances shipped in a single day. The detection lag, not the fix, was the
 cost every time.
 
-## The five ways it has actually broken
+## The six ways it has actually broken
 
 ### 1. Slot index past the frame (#7184)
 
@@ -128,6 +128,35 @@ reads emitted LLVM IR and cannot see a runtime table. The instruments that catch
 are `PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`
 on a real workload. When adding a cache of a heap pointer, register it in
 `gc_register_mutable_root_scanner` in `gc/mod.rs` in the same commit.
+
+### 6. The root decision trusted a structural type inference (`?? null`)
+
+`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional
+chaining lowers the left side to an `Any`-typed conditional, and the `??`
+inference rule (`analysis/value_types.rs`, with an AST-level twin in
+`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so the
+binding was declared `Null`. `collectors/pointer_locals.rs` distrusts declared
+types on purpose (#7846) and proves pointer-ness from the initializer — but its
+generic `expr_value_type` fallback ran that same inference and took `Null` as
+proof. No shadow slot, so no `ptr addrspace(1)` retype and nothing for
+`root_reload` to reload: the array's NaN-boxed address sat in a plain
+`alloca double` across the loop back-edge poll, the copying minor moved the
+array, and `masks[0]` read from-space (SIGBUS under
+`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise).
+
+An explicit `number[] | null` annotation changed the HIR type and nothing else.
+A plain ternary was rooted all along, because the collector's `Conditional` arm
+fails closed when either branch is unclassifiable — which is how the `??` path
+was isolated. The fix is both halves: `coalesce_type` keeps an unknown left
+unknown, and the collector's `Logical` arm requires both operands to classify
+before it answers, so a root decision never again rides on the inference.
+
+*Tell:* a local whose HIR type is `Null`, `Void` or `Number` while its
+initializer reads a property, calls, or coalesces. `--unrooted-allocas` was
+silent here: the stored value's provenance is a property read
+(`js_object_get_field_*`, an inline-cache slot load), which its heap-source
+vocabulary does not include — the same one-load gap #7664 closed for string
+handles, still open for field reads.
 
 ## How to check your work
 

--- a/test-files/test_gap_gc_coalesce_local_root.ts
+++ b/test-files/test_gap_gc_coalesce_local_root.ts
@@ -1,0 +1,74 @@
+// `const masks = opts?.masks ?? null` lost its GC root.
+//
+// Reduced from a Three.js world builder (`Accum.add`): an array-valued option
+// is read through `?.` + `??` into a local before a long allocating loop and
+// indexed inside it. Under the moving nursery the compiled program died with a
+// from-space read on the first copying minor — SIGBUS under
+// `PERRY_GC_PROTECT_FROMSPACE=1`, garbage colours or a crash otherwise.
+//
+// WHAT IT CATCHES. Optional chaining lowers `opts?.masks` to an `Any`-typed
+// conditional, and the `??` inference rule answered the RIGHT operand's type
+// for an unknown left, so the binding was declared `Null`. The codegen pointer
+// analysis (`collectors/pointer_locals.rs`) took that structural inference as
+// proof the local holds no pointer and gave it no shadow slot: the array's
+// NaN-boxed address sat in a plain `alloca double` across the loop back-edge
+// poll, the copying minor moved the array, and `masks[0]` dereferenced
+// from-space. An explicit `number[] | null` annotation does NOT help — the
+// collector distrusts declared types by design (#7846) — so the witness keeps
+// the untyped form. A plain ternary (`opts === null ? null : opts.masks`) was
+// rooted all along, which is how the `??` path was isolated.
+//
+// LIVE BY CONSTRUCTION: every iteration pushes into two arrays and allocates
+// an object and an array, so the loop poll collects many times while `masks`
+// and `paint` are live. The second arm holds a CLOSURE through the same `??`
+// shape and calls it after the polls — the form in which the defect surfaced
+// first (a helper's object result arriving as `undefined`). Compared
+// byte-for-byte against Node.
+
+class Accum {
+  pos: number[] = [];
+  col: number[] = [];
+  keep: Array<{ i: number; a: number[] }> = [];
+
+  add(
+    count: number,
+    opts: { masks: number[]; paint: (i: number) => number } | null,
+  ): number {
+    const masks = opts?.masks ?? null;
+    const paint = opts?.paint ?? null;
+    let painted = 0;
+    for (let i = 0; i < count; i++) {
+      this.pos.push(i, i + 0.25, i + 0.5);
+      if ((i & 4095) === 0) {
+        this.keep = [];
+      }
+      this.keep.push({ i, a: [i, i + 1, i + 2] });
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      if (masks) {
+        r = Math.max(r, masks[0]);
+        g = Math.max(g, masks[1]);
+        b = Math.max(b, masks[2]);
+      }
+      if (paint) {
+        painted += paint(i);
+      }
+      this.col.push(r, g, b);
+    }
+    return painted;
+  }
+}
+
+const masks = [0.35, 0.25, 0.1];
+const accum = new Accum();
+const painted = accum.add(200_000, { masks, paint: (i) => i & 1 });
+const last = accum.col.length - 3;
+console.log(
+  accum.col.length,
+  accum.col[last],
+  accum.col[last + 1],
+  accum.col[last + 2],
+  painted,
+  masks[0],
+);

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -836,3 +836,12 @@ test_gap_gc_string_copy_source_rooting
 # #8443: `String.prototype.repeat` held its receiver unrooted across a
 # re-entrant count coercion. Same reason.
 test_gap_gc_string_repeat_reentrant_count
+
+# --- `?? null` local rooting ------------------------------------------------
+# `const masks = opts?.masks ?? null` was declared `Null` by the `??` inference
+# rule (an unknown left took the RIGHT operand's type), and the pointer-locals
+# collector accepted that as proof the local holds no pointer: no shadow slot,
+# a from-space array address in a plain `alloca double` across the loop poll.
+# Pre-fix: SIGBUS after the first copying minor under
+# PERRY_GC_PROTECT_FROMSPACE=1; post-fix: `600000 0.35 0.25 0.1 100000 0.35`.
+test_gap_gc_coalesce_local_root


### PR DESCRIPTION
## Symptom

A Three.js world builder (`Accum.add`) compiled with Perry read from-space on its first copying minor: SIGBUS under `PERRY_GC_PROTECT_FROMSPACE=1`, wrong vertex colours / an aborted weapon build otherwise. The quarantine named a 40-byte array retired by minor #0, holder outside the arena — a stack slot. Disassembly put the stale use on `masks[0]` in

```ts
add(count: number, opts: { masks: number[] } | null) {
  const masks = opts?.masks ?? null;
  for (…) { …allocate…; if (masks) { r = Math.max(r, masks[0]); … } }
}
```

## Root cause — two defects, one rule

**1. The `??` type rule answered the RIGHT operand for an unknown left.** Both copies — `crates/perry-hir/src/analysis/value_types.rs` (`infer_logical_type`) and its AST twin in `crates/perry-hir/src/lower_types.rs` (`infer_type_from_expr`, `NullishCoalescing`) — did `if left is Any { infer(right) }`. Optional chaining lowers `opts?.masks` to an `Any`-typed conditional, so `opts?.masks ?? null` was declared **`Null`** (`--trace hir`: `Let { name: "masks", ty: Null, … }`). `unknown ?? null` is unknown, not `null`.

**2. The pointer-locals collector took that inference as proof.** `crates/perry-codegen/src/collectors/pointer_locals.rs` deliberately ignores declared types (#7846) and proves pointer-ness from the initializer through `expr_value_type` — which had no `Logical` arm, so the `??` fell to the generic `infer_expr_type` fallback, got `Null`, and the local was proven non-pointer: no shadow slot, so `precise_roots.rs` never retyped it to `ptr addrspace(1)` and `root_reload.rs` had nothing to reload. `%r4 = alloca double` held the NaN-boxed array address across `js_gc_loop_safepoint`; `arr.guard.deref` dereferenced from-space.

Controls (same binary flags, `PERRY_GC_SCAVENGE_NURSERY_MB=1 PERRY_GC_INCREMENTAL=0 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`):

| Initializer | HIR `Let` type | slot in `add` / `add$pshape` | protected run |
|---|---|---|---|
| `opts?.masks ?? null` | `Null` | `alloca double`, no bind | SIGBUS after minor #0 |
| `const masks: number[] \| null = opts?.masks ?? null` | `Union([Array(Number), Null])` | `alloca double`, no bind | SIGBUS after minor #0 |
| `opts === null ? null : opts.masks` | `Any` | `alloca ptr addrspace(1)` | passes |

The annotation is honoured in HIR but cannot help rooting (by design); the ternary passes because the collector's `Conditional` arm fails closed when a branch is unclassifiable. That isolates the `??` path.

## Fix

- `analysis/value_types.rs`: one shared `coalesce_type` — `Any`/`Unknown` left stays unknown; `Null`/`Void` left takes the right type; a union with a nullish member gains the right's members (unknown right → `Any`); anything else is never nullish so the right is unreachable. `lower_types.rs` now calls it; `monomorph/infer.rs` gets the same rule (`None` left stays `None`).
- `collectors/pointer_locals.rs`: an explicit `Expr::Logical` arm ahead of the fallback, with the same `?` discipline as `Conditional`: both operands must classify; `Coalesce` with a nullish left yields the right; equal types collapse; otherwise a union. A root decision no longer rides on the inference at all — an unclassifiable operand keeps the slot. Proven scalars (`1 ?? 2`, `0 || true`) still pay no slot.

## Tests

- `pointer_locals.rs`: the exact HIR the trace printed (parameter receiver, `Let` typed `Null` on purpose) keeps its slot; scalar `??`/`||` still pays none.
- `value_types_tests.rs`: `unknown ?? null` is `Any` (bare local and the full optional-chain lowering); nullish left takes the right; `coalesce_type` union cases.
- `lower/tests.rs`: `const masks = opts?.masks ?? null` is not typed `Null`/`Void`.
- `test-files/test_gap_gc_coalesce_local_root.ts`, registered in `test-parity/gc_repsel_corpus.txt`: `?? null` over an array and over a closure, both live across loop polls, compared against Node.
- Docs: `gc-rooting-invariant.md` gains this as way #6.

Locally: `cargo test -p perry-hir` (lib + integration) and `cargo test -p perry-codegen --lib` green; `cargo fmt --all --check`, clippy, `check_test_registration.py`, `check_gc_doc_claims.py`, `check_gc_env_knobs.py`, `local_binding_type_audit.py` clean.

End-to-end, release build of this branch, the untyped reproducer, same flags that faulted on `35447e706e` (`PERRY_GC_SCAVENGE_NURSERY_MB=1 PERRY_GC_INCREMENTAL=0 PERRY_GC_PROTECT_FROMSPACE=1 PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`): HIR `Let masks ty: Any`; `%r4 = alloca ptr addrspace(1)` in `add`, `add$pshape` and `add$ptr_arrays`; exit 0, `900000 0.35 0.25 0.1 0.35`, 3 copying minors (10,868 objects moved in the first). Before the fix the same run died with SIGBUS on minor #0.

## Not in this PR

`scripts/gc_root_dominance_check.py --unrooted-allocas` reported 0 on the failing IR: the stored value's provenance is a property read (`js_object_get_field_by_name_f64`, `js_object_get_field_ic_miss`, an inline-cache slot load through `inttoptr`), which its heap-source vocabulary (`ALLOC_RE`, `HEAP_SOURCE_CALLS`, `REWRITTEN_LOAD_RE`) does not include. Adding a property-read source class would have caught this; it will also change corpus counts, so it is left for a follow-up.

https://claude.ai/code/session_01XAYMwhwY3emqxEFT88gQUn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection issues affecting values assigned through nullish coalescing, including optional-chain expressions using `??`.
  * Prevented stale references, crashes, incorrect results, and corrupted data during memory collection.
  * Improved type handling so unknown values are not incorrectly treated as `null`.

* **Tests**
  * Added coverage for nullish coalescing, optional chains, logical expressions, and long-running garbage-collection scenarios.

* **Documentation**
  * Documented the addressed garbage-collection rooting failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->