### PR TITLE
fix(hir): function expressions keep their declared parameter and signature types (12.55→5.71 ns/call)

### DIFF
--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -633,12 +633,18 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
             continue;
         }
         let is_rest = is_rest_param(&param.pat);
-        let param_id = ctx.define_local_spanned(param_name.clone(), Type::Any, param.span);
+        // Declared parameter types were dropped here while the arrow path
+        // (`lower_arrow`) and the object-method path both keep them. An `Any`
+        // parameter costs the closure its typed clone and its call sites the
+        // guarded direct path — the whole gap between
+        // `const f = function (x: number) { … }` and the identical arrow.
+        let param_ty = crate::lower_patterns::get_pat_type(&param.pat, ctx);
+        let param_id = ctx.define_local_spanned(param_name.clone(), param_ty.clone(), param.span);
         ctx.shadow_native_instance_if_present(&param_name);
         params.push(Param {
             id: param_id,
             name: param_name,
-            ty: Type::Any,
+            ty: param_ty,
             default: None,
             decorators: Vec::new(),
             is_rest,

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -827,6 +827,52 @@ fn infer_type_from_expr_inner(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
             })
         }
 
+        // A function EXPRESSION is the same value as the arrow above for
+        // typing purposes — only `this` / `arguments` / constructability
+        // differ, none of which affect the signature. Without this arm
+        // `const f = function (x: number): number { … }` inferred `Any`, so
+        // the binding lost its `Function(...)` hint and every call site fell
+        // to the fully generic closure path (measured 12.55 ns/call against
+        // 5.69 for the identical arrow; node is 0.51 for both).
+        ast::Expr::Fn(fn_expr) => {
+            let function = &fn_expr.function;
+            let has_explicit_return_annotation = function.return_type.is_some();
+            let annotated = function
+                .return_type
+                .as_ref()
+                .map(|rt| extract_ts_type(&rt.type_ann))
+                .unwrap_or(Type::Any);
+            let return_type = if !has_explicit_return_annotation
+                && matches!(annotated, Type::Any)
+                && !function.is_generator
+            {
+                let inferred = function
+                    .body
+                    .as_ref()
+                    .and_then(|block| infer_body_return_type(&block.stmts, ctx));
+                match inferred {
+                    Some(t) if function.is_async => Type::Promise(Box::new(t)),
+                    Some(t) => t,
+                    None => Type::Any,
+                }
+            } else {
+                annotated
+            };
+            Type::Function(crate::types::FunctionType {
+                params: function
+                    .params
+                    .iter()
+                    .map(|p| {
+                        let name = get_pat_name(&p.pat).unwrap_or_default();
+                        let ty = extract_param_type_with_ctx(&p.pat, None);
+                        (name, ty, false)
+                    })
+                    .collect(),
+                return_type: Box::new(return_type),
+                is_async: function.is_async,
+                is_generator: function.is_generator,
+            })
+        }
         _ => Type::Any,
     }
 }


### PR DESCRIPTION
## What

`infer_type_from_expr` has an `ast::Expr::Arrow` arm that builds a
`Function(params, return_type)` type, but **no `ast::Expr::Fn` arm** — and
`lower_fn_expr_anon` hardcodes `Type::Any` for every parameter, where the arrow
path calls `get_pat_type` and the object-method path calls
`extract_param_type_with_ctx`. So two spellings of the same value lower
differently:

```ts
const a = (x: number): number => x + 1;        // Let ty: Function([("x", Number)], Number), Param { ty: Number }
const b = function (x: number): number { … };  // Let ty: Any,                              Param { ty: Any }
```

The `Any` parameter costs the closure its typed clone, and the `Any` binding
hint costs every call site the guarded direct path — so the function-expression
form falls all the way to `js_closure_unbox_callee_checked` +
`js_closure_call1_receiverless`.

This adds the missing inference arm and keeps declared parameter types in
`lower_fn_expr_anon`.

## Measurements

Probe with identical bodies (`x + 1`) and identical loop arithmetic — the only
variable is how the callee is spelled. Mac mini, ns/op:

| callee spelling | before | after | node |
|---|---|---|---|
| `const f = function (x: number): number { … }` | 12.55 | **5.71** | 0.51 |
| `const f = (x: number): number => x + 1` | 5.70 | 5.71 | 0.51 |
| `function f(x: number): number { … }` (inlined) | 0.94 | 0.94 | 0.51 |
| empty loop (baseline) | 0.94 | 0.94 | 0.51 |

The function-expression row lands exactly on the identical arrow's number, which
is the point: the two spellings now lower the same way. Spread across runs ≤0.01.

## Scope — please read before assuming this helps bundles

This is a **consistency fix, not a bundle win.** Counted in the real
`cli_2.1.112.js` (13.7 MB): `function` declarations 15,511, const-bound arrows
661, and const-bound function expressions **64**. Bundled output is also
minified, so there are no parameter annotations left to preserve — for cc and pi
the only effect is the binding's `Function(...)` hint (with `Any` params), which
is what the `function_hinted` gate consumes. The measured 2.2× applies to the
shape, and the shape is common in hand-written TypeScript and in
non-minified builds, not in bundles.

## Correctness

- **Function-expression semantics** vs node — `.name`, `.length`, `.prototype`, named self-reference (recursive `fact`), construction with `new` + `instanceof`, `arguments` (including extra args), `this` via `call`/`apply` and as an object method, default parameters, rest parameters, destructuring parameters, async function expressions, generator function expressions, use as a callback, and reassignment through `let`: **byte-identical**.
- **Annotation lies** into a `number`-annotated parameter — string, boolean, `null`, `undefined`, object — plus `-0`, `NaN`, `Infinity`, `2**53`: **byte-identical**. (The typed clone guards on entry exactly as it does for arrows; a lie takes the generic clone.)
- Regression differentials on the same build — object literals with methods, the 300k-literal churn set, closure births (async/`new.target`/boxed/identity/nested/10-capture), function-expression `this`, and the 264-line number-formatting set: identical. One line of the method-shorthand probe differs from node (`{n(){}}.n === {n(){}}.n` is `true` in perry, the captureless `FuncRef` singleton) — that is pre-existing on main and unrelated to this change.
- Suites: perry-hir **586/0**, perry-codegen **1832/0**. (HIR-only change; the runtime suite is unaffected and was 2822/0 on the same base.)

https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for function expressions, including parameter and return types.
  * Added support for correctly recognizing asynchronous functions and generator metadata.
  * Preserved declared TypeScript parameter types for more accurate type checking and safer function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->