### PR TITLE
perf(runtime): BigInt division fast paths — pi's #1 startup symbol, 33.8x (67.6x → 2.0x of node)

### DIFF
--- a/crates/perry-runtime/src/bigint/arith.rs
+++ b/crates/perry-runtime/src/bigint/arith.rs
@@ -263,7 +263,31 @@ fn effective_limb_len(limbs: &[u64; BIGINT_LIMBS]) -> usize {
     1
 }
 
-/// Unsigned binary long division on magnitude limbs
+/// Index of the highest set bit across the limbs, or `None` if all zero.
+#[inline(always)]
+fn highest_set_bit(limbs: &[u64; BIGINT_LIMBS]) -> Option<usize> {
+    for i in (0..BIGINT_LIMBS).rev() {
+        if limbs[i] != 0 {
+            return Some(i * 64 + 63 - limbs[i].leading_zeros() as usize);
+        }
+    }
+    None
+}
+
+/// Unsigned binary long division on magnitude limbs.
+///
+/// Callers pass non-negative magnitudes (`b` nonzero — division by zero is
+/// thrown before reaching here) and re-apply signs themselves. Three tiers:
+///
+/// 1. **Power-of-two divisor** (single set bit at position `k`, e.g. the
+///    `% 2^64n` / `% 2^32n` idiom common in JS hashing code such as TypeBox's
+///    FNV-1a `Value.Hash`): remainder = low `k` bits of the dividend,
+///    quotient = dividend `>> k`. O(limbs). `k == 0` means divisor 1 —
+///    remainder 0, quotient = dividend.
+/// 2. **Single-limb divisor** (covers `% prime` for primes < 2^64): one
+///    hardware `u128 / u64` per dividend limb, top-down.
+/// 3. **General case**: bit-at-a-time long division, bounded by the
+///    dividend's actual bit length instead of all 1024 bits.
 fn unsigned_div_limbs(
     a: &[u64; BIGINT_LIMBS],
     b: &[u64; BIGINT_LIMBS],
@@ -271,7 +295,67 @@ fn unsigned_div_limbs(
     let mut quotient = ZERO_LIMBS;
     let mut remainder = ZERO_LIMBS;
 
-    for i in (0..BIGINT_BITS).rev() {
+    let Some(a_top_bit) = highest_set_bit(a) else {
+        // 0 / b == 0 rem 0.
+        return (quotient, remainder);
+    };
+    let Some(b_top_bit) = highest_set_bit(b) else {
+        // Unreachable: `js_bigint_div`/`js_bigint_mod` both throw a RangeError
+        // on a zero divisor before computing magnitudes. Return 0 rem 0 rather
+        // than unwinding out of an `extern "C"` frame (which would abort).
+        debug_assert!(false, "unsigned_div_limbs called with a zero divisor");
+        return (quotient, remainder);
+    };
+
+    // Dividend smaller than divisor: quotient 0, remainder = dividend.
+    if a_top_bit < b_top_bit {
+        return (quotient, *a);
+    }
+
+    // Tier 1: divisor is a power of two (exactly one set bit).
+    let b_top_limb = b_top_bit / 64;
+    if b[b_top_limb].is_power_of_two() && b[..b_top_limb].iter().all(|&l| l == 0) {
+        let k = b_top_bit;
+        let (limb_k, bit_k) = (k / 64, k % 64);
+        // remainder = low k bits of the dividend's magnitude.
+        remainder[..limb_k].copy_from_slice(&a[..limb_k]);
+        if bit_k > 0 {
+            remainder[limb_k] = a[limb_k] & ((1u64 << bit_k) - 1);
+        }
+        // quotient = a >> k.
+        for i in 0..BIGINT_LIMBS {
+            let src = i + limb_k;
+            let lo = if src < BIGINT_LIMBS { a[src] } else { 0 };
+            quotient[i] = if bit_k == 0 {
+                lo
+            } else {
+                let hi = if src + 1 < BIGINT_LIMBS {
+                    a[src + 1]
+                } else {
+                    0
+                };
+                (lo >> bit_k) | (hi << (64 - bit_k))
+            };
+        }
+        return (quotient, remainder);
+    }
+
+    // Tier 2: single-limb divisor — hardware division limb by limb.
+    if b_top_limb == 0 {
+        let d = b[0];
+        let mut rem = 0u64;
+        for i in (0..=a_top_bit / 64).rev() {
+            let cur = ((rem as u128) << 64) | a[i] as u128;
+            quotient[i] = (cur / d as u128) as u64;
+            rem = (cur % d as u128) as u64;
+        }
+        remainder[0] = rem;
+        return (quotient, remainder);
+    }
+
+    // Tier 3: general bit-at-a-time long division over the dividend's
+    // significant bits only.
+    for i in (0..=a_top_bit).rev() {
         // Shift remainder left by 1
         let mut carry = 0u64;
         for limb in remainder.iter_mut() {

--- a/crates/perry-runtime/src/bigint/tests.rs
+++ b/crates/perry-runtime/src/bigint/tests.rs
@@ -545,3 +545,218 @@ fn bigint_from_f64_parses_sso_numeric_strings() {
         assert_eq!(got, s, "BigInt({s:?}) mismatch");
     }
 }
+
+// -- unsigned_div_limbs fast paths: power-of-two divisor, single-limb --
+// -- divisor, and the bit-length-bounded general loop --
+
+/// Read the raw limbs of a freshly-allocated bigint.
+fn limbs_of(p: *const BigIntHeader) -> [u64; BIGINT_LIMBS] {
+    unsafe { (*p).limbs }
+}
+
+/// Build a bigint from the given low limbs (rest zero — non-negative value).
+fn bigint_from_low_limbs(low: &[u64]) -> *mut BigIntHeader {
+    let mut limbs = ZERO_LIMBS;
+    limbs[..low.len()].copy_from_slice(low);
+    bigint_alloc_with_limbs(limbs)
+}
+
+#[test]
+fn pow2_divisor_mod_and_div_multi_limb() {
+    // 192-bit dividend % 2^64: remainder = low limb, quotient = high limbs.
+    let a = bigint_from_low_limbs(&[0xAAAA_AAAA_AAAA_AAAA, 0xBBBB_BBBB_BBBB_BBBB, 0xCCCC]);
+    let two_pow_64 = bigint_from_low_limbs(&[0, 1]);
+
+    let r = limbs_of(js_bigint_mod(a, two_pow_64));
+    assert_eq!(r[0], 0xAAAA_AAAA_AAAA_AAAA);
+    assert!(r[1..].iter().all(|&l| l == 0));
+
+    let q = limbs_of(js_bigint_div(a, two_pow_64));
+    assert_eq!(q[0], 0xBBBB_BBBB_BBBB_BBBB);
+    assert_eq!(q[1], 0xCCCC);
+    assert!(q[2..].iter().all(|&l| l == 0));
+
+    // Non-limb-aligned power of two: % 2^13 keeps the low 13 bits.
+    let two_pow_13 = js_bigint_from_i64(1 << 13);
+    let r = limbs_of(js_bigint_mod(a, two_pow_13));
+    assert_eq!(r[0], 0xAAAA_AAAA_AAAA_AAAA & ((1 << 13) - 1));
+    assert!(r[1..].iter().all(|&l| l == 0));
+
+    // 2^70 (bit 6 of limb 1): quotient must stitch bits across limbs.
+    let two_pow_70 = bigint_from_low_limbs(&[0, 1 << 6]);
+    let q = limbs_of(js_bigint_div(a, two_pow_70));
+    assert_eq!(q[0], (0xBBBB_BBBB_BBBB_BBBBu64 >> 6) | (0xCCCCu64 << 58));
+    assert_eq!(q[1], 0xCCCC >> 6);
+    assert!(q[2..].iter().all(|&l| l == 0));
+}
+
+#[test]
+fn pow2_divisor_mod_sign_of_dividend_and_canonical_zero() {
+    let two_pow_64 = bigint_from_low_limbs(&[0, 1]);
+
+    // -(2^100 + 5) % 2^64 === -5 (sign follows dividend; ECMA remainder).
+    let mag = bigint_from_low_limbs(&[5, 1 << 36]);
+    let a = js_bigint_neg(mag);
+    assert_eq!(read_as_i64(js_bigint_mod(a, two_pow_64)), -5);
+
+    // -(2^100) % 2^64 === 0 with NO negative-zero pattern: all limbs zero.
+    let mag = bigint_from_low_limbs(&[0, 1 << 36]);
+    let a = js_bigint_neg(mag);
+    assert_eq!(limbs_of(js_bigint_mod(a, two_pow_64)), ZERO_LIMBS);
+}
+
+#[test]
+fn pow2_divisor_edge_cases() {
+    let two_pow_64 = bigint_from_low_limbs(&[0, 1]);
+
+    // Dividend smaller than divisor: unchanged. (2^64 exceeds i64, so this
+    // exercises the limb path, not the i64 fast path.)
+    let five = js_bigint_from_i64(5);
+    assert_eq!(read_as_i64(js_bigint_mod(five, two_pow_64)), 5);
+
+    // Dividend == divisor: remainder 0, quotient 1.
+    let a = bigint_from_low_limbs(&[0, 1]);
+    assert_eq!(limbs_of(js_bigint_mod(a, two_pow_64)), ZERO_LIMBS);
+    assert_eq!(read_as_i64(js_bigint_div(a, two_pow_64)), 1);
+
+    // Multi-limb dividend % 1n == 0n, / 1n == dividend.
+    let one = js_bigint_from_i64(1);
+    let big = bigint_from_low_limbs(&[7, 8, 9]);
+    assert_eq!(limbs_of(js_bigint_mod(big, one)), ZERO_LIMBS);
+    assert_eq!(limbs_of(js_bigint_div(big, one)), limbs_of(big));
+}
+
+#[test]
+fn single_limb_divisor_hardware_div() {
+    // (2^64) % FNV prime — expected value computed independently via u128.
+    let prime = 1_099_511_628_211u64;
+    let two_pow_64 = bigint_from_low_limbs(&[0, 1]);
+    let b = js_bigint_from_i64(prime as i64);
+    let expected = ((1u128 << 64) % prime as u128) as u64;
+    let r = limbs_of(js_bigint_mod(two_pow_64, b));
+    assert_eq!(r[0], expected);
+    assert!(r[1..].iter().all(|&l| l == 0));
+
+    // 200+-bit dividend: verify the division identity a == q*b + r, r < b,
+    // using independently-tested mul/add/cmp.
+    let a = bigint_from_low_limbs(&[12345, 0xDEAD_BEEF, 0, 0x1_0000]);
+    let q = js_bigint_div(a, b);
+    let r = js_bigint_mod(a, b);
+    assert_eq!(js_bigint_cmp(r, b), -1);
+    let recomposed = js_bigint_add(js_bigint_mul(q, b), r);
+    assert_eq!(limbs_of(recomposed), limbs_of(a));
+}
+
+#[test]
+fn general_path_multi_limb_divisor_identity() {
+    // Divisor 2^64 + 1: two limbs, not a power of two → general bit loop.
+    let a = bigint_from_low_limbs(&[0x1111_2222_3333_4444, 0x5555, 0, 0, 0xF00D]);
+    let b = bigint_from_low_limbs(&[1, 1]);
+    let q = js_bigint_div(a, b);
+    let r = js_bigint_mod(a, b);
+    assert_eq!(js_bigint_cmp(r, b), -1);
+    let recomposed = js_bigint_add(js_bigint_mul(q, b), r);
+    assert_eq!(limbs_of(recomposed), limbs_of(a));
+}
+
+/// Deterministic xorshift64* — keeps the cross-check reproducible.
+fn xorshift64(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    *state = x;
+    x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+}
+
+fn limbs_from_i128(v: i128) -> [u64; BIGINT_LIMBS] {
+    let mut limbs = ZERO_LIMBS;
+    write_i128(v, &mut limbs);
+    limbs
+}
+
+fn bigint_from_i128(v: i128) -> *mut BigIntHeader {
+    bigint_alloc_with_limbs(limbs_from_i128(v))
+}
+
+/// Randomized differential check of `js_bigint_div`/`js_bigint_mod` against
+/// host `i128` arithmetic, which has exactly JS BigInt semantics (`/`
+/// truncates toward zero, `%` takes the sign of the dividend). Divisor
+/// shapes are chosen to hit all three `unsigned_div_limbs` tiers:
+/// power-of-two, single-limb, and multi-limb-general.
+#[test]
+fn div_mod_cross_check_against_i128_all_tiers() {
+    let mut s = 0x9E37_79B9_7F4A_7C15u64;
+    for iter in 0..3000u32 {
+        // Dividend: random, width-varied, masked to 127 bits so it is a
+        // non-negative i128 whose negation cannot overflow.
+        let width = (xorshift64(&mut s) % 128) as u32;
+        let a128 =
+            (((xorshift64(&mut s) as u128) << 64) | xorshift64(&mut s) as u128) >> (127 - width);
+        let a_i = (a128 & (u128::MAX >> 1)) as i128;
+
+        // Divisor: cycle the three tiers.
+        let b_i = match iter % 3 {
+            // Tier 1: exact power of two, 2^0 .. 2^126.
+            0 => 1i128 << (xorshift64(&mut s) % 127),
+            // Tier 2: single 64-bit limb (nonzero).
+            1 => (xorshift64(&mut s) | 1) as i128,
+            // Tier 3: two limbs, high limb nonzero (never a power of two
+            // because bit 0 is forced on).
+            _ => {
+                let hi = xorshift64(&mut s) | 1;
+                ((((hi as u128) << 64) | (xorshift64(&mut s) | 1) as u128) & (u128::MAX >> 1))
+                    as i128
+            }
+        };
+        assert!(b_i > 0, "divisor must be positive and nonzero");
+
+        for &(sa, sb) in &[(1i128, 1i128), (-1, 1), (1, -1), (-1, -1)] {
+            let av = sa * a_i;
+            let bv = sb * b_i;
+            let a = bigint_from_i128(av);
+            let b = bigint_from_i128(bv);
+
+            assert_eq!(
+                limbs_of(js_bigint_div(a, b)),
+                limbs_from_i128(av / bv),
+                "div mismatch iter={iter} a={av} b={bv}"
+            );
+            assert_eq!(
+                limbs_of(js_bigint_mod(a, b)),
+                limbs_from_i128(av % bv),
+                "mod mismatch iter={iter} a={av} b={bv}"
+            );
+        }
+    }
+}
+
+#[test]
+fn zero_dividend_and_wide_pow2_edges() {
+    let zero = js_bigint_from_i64(0);
+    let two_pow_64 = bigint_from_low_limbs(&[0, 1]);
+    assert_eq!(limbs_of(js_bigint_mod(zero, two_pow_64)), ZERO_LIMBS);
+    assert_eq!(limbs_of(js_bigint_div(zero, two_pow_64)), ZERO_LIMBS);
+
+    // Dividend one below the divisor: passes straight through.
+    let all_ones = bigint_from_low_limbs(&[u64::MAX]);
+    assert_eq!(limbs_of(js_bigint_mod(all_ones, two_pow_64)), {
+        let mut e = ZERO_LIMBS;
+        e[0] = u64::MAX;
+        e
+    });
+    assert_eq!(limbs_of(js_bigint_div(all_ones, two_pow_64)), ZERO_LIMBS);
+
+    // Near-widest power-of-two divisor: 2^1021, dividend 2^1022 + 12345
+    // (top bit of the top limb stays clear, so the value is positive).
+    // q = 2, r = 12345.
+    let mut b = ZERO_LIMBS;
+    b[BIGINT_LIMBS - 1] = 1u64 << 61; // 2^1021
+    let mut a = ZERO_LIMBS;
+    a[BIGINT_LIMBS - 1] = 1u64 << 62; // 2^1022
+    a[0] = 12345;
+    let a = bigint_alloc_with_limbs(a);
+    let b = bigint_alloc_with_limbs(b);
+    assert_eq!(read_as_i64(js_bigint_mod(a, b)), 12345);
+    assert_eq!(read_as_i64(js_bigint_div(a, b)), 2);
+}

--- a/test-files/test_gap_9092_bigint_pow2_mod.ts
+++ b/test-files/test_gap_9092_bigint_pow2_mod.ts
@@ -1,0 +1,138 @@
+// BigInt remainder fast paths (power-of-two divisor, single-limb divisor)
+// must preserve exact ECMA BigInt::remainder semantics: sign follows the
+// DIVIDEND, canonical zero (no -0n), and non-power-of-two divisors are
+// unchanged. Motivated by TypeBox Value.Hash's FNV-1a `% 2^64` idiom, which
+// previously went through full 1024-bit binary long division per byte.
+
+// Sign follows dividend.
+console.log("a:", ((-7n) % 4n).toString());            // -3
+console.log("b:", (7n % -4n).toString());              // 3
+console.log("c:", ((-7n) % -4n).toString());           // -3
+
+// Exact multiple of a power of two: canonical zero, never -0n.
+const z = (-8n) % 8n;
+console.log("d:", z.toString(), z === 0n);             // 0 true
+const z2 = (-(2n ** 100n)) % (2n ** 64n);
+console.log("e:", z2.toString(), z2 === 0n);           // 0 true
+
+// Dividend smaller than the divisor: unchanged (both signs).
+console.log("f:", (5n % (2n ** 64n)).toString());      // 5
+console.log("g:", ((-5n) % (2n ** 64n)).toString());   // -5
+console.log("h:", (123456789n % (2n ** 200n)).toString());
+
+// Dividend === divisor.
+console.log("i:", ((2n ** 64n) % (2n ** 64n)).toString());   // 0
+console.log("j:", ((2n ** 64n) / (2n ** 64n)).toString());   // 1
+
+// Huge (multi-limb, 200+ bit) dividends.
+const huge = 2n ** 250n + 2n ** 129n + 2n ** 64n + 987654321987654321n;
+console.log("k:", (huge % (2n ** 64n)).toString());
+console.log("l:", (huge % (2n ** 13n)).toString());
+console.log("m:", ((-huge) % (2n ** 64n)).toString());
+console.log("n:", ((-huge) % (2n ** 13n)).toString());
+console.log("o:", (huge / (2n ** 64n)).toString());
+console.log("p:", ((-huge) / (2n ** 64n)).toString());
+console.log("q:", (huge % (2n ** 70n)).toString());    // non-limb-aligned pow2
+
+// Modulo 1n is always 0n; division by 1n is identity.
+console.log("r:", (huge % 1n).toString(), ((-huge) % 1n).toString());
+console.log("s:", (huge / 1n).toString());
+
+// Single-limb non-power-of-two divisors (FNV prime).
+const prime = 1099511628211n;
+console.log("t:", ((2n ** 64n) % prime).toString());
+console.log("u:", (huge % prime).toString());
+console.log("v:", ((-huge) % prime).toString());
+console.log("w:", (huge / prime).toString());
+
+// Multi-limb non-power-of-two divisors take the general path, unchanged.
+console.log("x:", (huge % (2n ** 64n + 1n)).toString());
+console.log("y:", (huge % (2n ** 64n + 3n)).toString());
+console.log("z:", (huge / (2n ** 64n + 1n)).toString());
+console.log("A:", ((-huge) % (2n ** 64n + 1n)).toString());
+
+// Division by zero still throws RangeError before any fast path.
+try {
+  console.log((huge % 0n).toString());
+} catch (e) {
+  console.log("B:", e instanceof RangeError);
+}
+
+// The FNV-1a 64 loop itself (TypeBox Value.Hash idiom) — checksum must
+// match node bit-for-bit.
+const Prime = BigInt("1099511628211");
+const Size = BigInt("18446744073709551616");
+const Bytes = Array.from({ length: 256 }, (_, i) => BigInt(i));
+let Accumulator = BigInt("14695981039346656037");
+let s32 = 0x12345678;
+for (let i = 0; i < 4096; i++) {
+  s32 ^= (s32 << 13); s32 >>>= 0;
+  s32 ^= (s32 >>> 17);
+  s32 ^= (s32 << 5); s32 >>>= 0;
+  Accumulator = Accumulator ^ Bytes[s32 & 0xff];
+  Accumulator = (Accumulator * Prime) % Size;
+}
+console.log("C:", Accumulator.toString());
+
+// Negative power-of-two DIVISOR (magnitude taken via two's-complement
+// negation before the fast path; result sign still follows the dividend).
+const p64 = 2n ** 64n;
+console.log("D:", (huge % -p64).toString());
+console.log("E:", ((-huge) % -p64).toString());
+console.log("F:", (huge / -p64).toString());
+console.log("G:", ((-huge) / -p64).toString());
+
+// Zero dividend on every tier.
+console.log("H:", (0n % p64).toString(), (0n / p64).toString());
+console.log("I:", (0n % prime).toString(), (0n % (p64 + 1n)).toString());
+
+// Dividend exactly one below a power-of-two divisor.
+console.log("J:", ((p64 - 1n) % p64).toString(), ((p64 - 1n) / p64).toString());
+
+// Dividend === divisor on the non-power-of-two tiers.
+console.log("K:", (prime % prime).toString(), (prime / prime).toString());
+console.log("L:", ((p64 + 1n) % (p64 + 1n)).toString());
+
+// Very wide power-of-two divisor (bit 1021) with a 1022-bit dividend.
+const wide = 2n ** 1022n + 12345n;
+console.log("M:", (wide % (2n ** 1021n)).toString());
+console.log("N:", (wide / (2n ** 1021n)).toString());
+console.log("O:", ((-wide) % (2n ** 1021n)).toString());
+
+// Power-of-two divisors across the limb boundary, both signs of dividend.
+for (const k of [1n, 7n, 63n, 64n, 65n, 127n, 128n, 129n, 200n]) {
+  const d = 2n ** k;
+  console.log("P" + k + ":", (huge % d).toString(), ((-huge) % d).toString(), (huge / d).toString());
+}
+
+// Identity check a === (a / b) * b + (a % b) across mixed signs and tiers.
+// Two shapes deliberately avoided here because they trip pre-existing perry
+// lowering gaps that have nothing to do with division: `-arr[i]` on a BigInt
+// above 2^53 float-negates, and inlining `(a / d) * d + (a % d)` on for-of
+// bound BigInts drops the remainder term. Quotient and remainder are bound to
+// locals first, and every negation is applied to a named local.
+const d64 = 2n ** 64n;
+const d13 = 2n ** 13n;
+const dWide = p64 + 1n;
+const nhuge = -huge;
+const divisors = [
+  d64, -d64, d13, -d13, prime, -prime, dWide, -dWide, 3n, -3n, 1n, -1n,
+];
+const dividends = [huge, nhuge, 12345n, -12345n, 0n, d64, -d64, d64 - 1n];
+let identityOk = true;
+let remainderInRange = true;
+let signOk = true;
+for (const d of divisors) {
+  for (const a of dividends) {
+    const q = a / d;
+    const r = a % d;
+    if (q * d + r !== a) identityOk = false;
+    // |r| < |d|, expressed without negating an array element.
+    const rmag = r < 0n ? 0n - r : r;
+    const dmag = d < 0n ? 0n - d : d;
+    if (rmag >= dmag) remainderInRange = false;
+    // The remainder is either exactly zero or carries the dividend's sign.
+    if (r !== 0n && (r < 0n) !== (a < 0n)) signOk = false;
+  }
+}
+console.log("Q:", identityOk, remainderInRange, signOk);


### PR DESCRIPTION
Found by the first named-symbol profile of pi's native startup: `perry_runtime::bigint::arith::unsigned_div_limbs` was the **top CPU symbol at ~17% of samples**. Cause: TypeBox's `Value.Hash` runs, per hashed byte,

```js
var [Prime, Size] = [BigInt("1099511628211"), BigInt("18446744073709551616") /* 2^64 */];
Accumulator = (Accumulator ^ Bytes[byte]) * Prime % Size;
```

so every byte of every schema hashed at startup took a full limb-division loop where node masks.

**Four tiers** in `unsigned_div_limbs` (magnitudes only; signs re-applied by callers, untouched): (0) zero dividend or dividend < divisor returns directly; (1) **power-of-two divisor** → remainder is the low k bits, quotient is `a >> k`, O(limbs); (2) **single-limb divisor** → one hardware `u128/u64` per dividend limb; (3) the original bit loop, now bounded by the dividend's real bit length instead of a fixed 1024. Tiers only add early exits and shrink tier 3's bound, so there is no regression path.

**Benchmark** — FNV1A64 over 200k bytes, min of 3, quiet Mac mini (the dev box was at load 52-144 from other agents and unusable for timing):

| | ms | vs node |
|---|---|---|
| node v26.5.1 | 20 | 1.0x |
| perry before | 1352 | 67.6x |
| perry after | **40** | **2.0x** |

Accumulator `11550294541936438046` byte-equal to node in every run; before/after built from an exact stash/unstash of the same tree with `perry-auto-*` cleared and archives confirmed rebuilt.

**Validation**: runtime suite **2829 passed / 0 failed** (run twice, no SIGABRT); `test_gap_9092_bigint_pow2_mod.ts` byte-identical to node **both before and after** — the before-run is the control proving the baseline was already semantically correct. It covers `(-7n)%4n === -3n`, negative divisors, canonical zero on exact multiples, dividend < / == divisor, 250-bit dividends % 2^64 / 2^13 / 2^70, a 1022-bit dividend % 2^1021, `% 1n`, `% 0n` throwing RangeError, non-power-of-two single- and multi-limb divisors, a k-sweep across the limb boundary, and a 96-case identity/sign/range sweep. Added `div_mod_cross_check_against_i128_all_tiers`: 12,000 randomized differential cases against host `i128` across all tiers and sign combinations, **mutation-tested** (clearing one mask bit makes it fail). Also replaced an inherited `expect()` on the divisor-nonzero path — a panic inside an `extern "C"` frame aborts the process — with a debug assert plus a safe return.

**Next in this area** (not this PR): tier 3 is now the outlier at 154 ns vs node 15 for multi-limb non-power-of-two divisors; Knuth algorithm D would close it.

Implemented by subagents in an isolated worktree (across two sessions after a rate-limit interruption); reviewed and shipped by the coordinating session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigInt division and remainder calculations across power-of-two, small, and large values.
  * Corrected handling for zero values, negative operands, wide numbers, and results near the 1024-bit range.
  * Prevented incorrect behavior for division by zero while preserving expected error handling.
  * Improved performance by using optimized calculation paths instead of a fixed-length iteration.

* **Tests**
  * Added comprehensive coverage for BigInt quotient and remainder behavior, including randomized and cross-limb scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->