### PR TITLE
fix(perry): register PERRY_OBJECT_LITERAL_SHAPE_METHODS as a build-cache input

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -62,6 +62,10 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // settings emit different call sequences, so a cached object from one
     // must not serve the other.
     "PERRY_METHOD_INLINE_PROBE",
+    // #9122: gates the shape-cache path for object literals whose methods
+    // capture `this` — on and off emit different literal-birth sequences,
+    // so a cached object from one must not serve the other.
+    "PERRY_OBJECT_LITERAL_SHAPE_METHODS",
     // #9060: gates whether a reduce accumulator earns the stable-packed fast
     // clone's numeric proof — with it on, `s += arr[i]` lowers to an inline
     // fadd instead of `js_dynamic_string_or_number_add`, so the two settings


### PR DESCRIPTION
`codegen_env_vars_are_build_cache_inputs` is red on `main`.

#9122 introduced `PERRY_OBJECT_LITERAL_SHAPE_METHODS` (a codegen kill switch) without registering it in `BUILD_CACHE_ENV_VARS`. I caught that during review and prepared the registration, but it did not make it into the commit that merged — my cherry-pick of the fix resolved against the wrong branch and silently no-op'd, so I merged #9122 without it. My mistake, not the PR author's.

```
these codegen env vars key neither the build cache nor an exclusion (#6394's rule):
["PERRY_OBJECT_LITERAL_SHAPE_METHODS"]
```

The knob selects between two different literal-birth emission sequences, so it is a genuine cache key rather than an exclusion candidate — a cached object built with it on must not serve a build with it off.

Verified on this branch: the gate test passes (`1 passed`), fmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incompatible cached object results from being reused when object methods capture `this`.
  * Ensured build cache behavior remains consistent across different object-literal compilation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->