### PR TITLE
perf(hir): constant-fold adjacent ASCII string literals (8.11→1.25 ns)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
@@ -221,11 +221,38 @@ pub(crate) fn lower_bin_expr(ctx: &mut LoweringContext, bin: &ast::BinExpr) -> R
 
     match bin.op {
         // Arithmetic
-        ast::BinaryOp::Add => Ok(Expr::Binary {
-            op: BinaryOp::Add,
-            left,
-            right,
-        }),
+        ast::BinaryOp::Add => {
+            // Two adjacent string literals are a compile-time constant, but
+            // nothing downstream could fold them: the pair lowers to a
+            // runtime concat call, which LLVM cannot see through (numeric
+            // literal folding happens there and is why `3 + 4` costs the
+            // empty loop while `"a" + "b"` cost 8.1 ns/iteration and
+            // `"a" + "b" + "c"` cost 19.7 — versus 0.5 in node).
+            //
+            // Left-associativity makes this fold the whole chain: `"a" + "b"
+            // + "c"` parses as `("a" + "b") + "c"`, and the inner pair has
+            // already been folded to `String("ab")` by the time this runs.
+            //
+            // ASCII-only, deliberately. A non-ASCII pair would need the
+            // runtime's WTF-8 rules — `canonicalize_surrogate_pairs` merges a
+            // high/low surrogate pair across the join into one astral code
+            // point (#6728), and `utf16_len` / `isWellFormed` depend on that.
+            // Rather than restate those rules here, non-ASCII literals keep
+            // the runtime path they have today.
+            if let (Expr::String(l), Expr::String(r)) = (left.as_ref(), right.as_ref()) {
+                if l.is_ascii() && r.is_ascii() {
+                    let mut folded = String::with_capacity(l.len() + r.len());
+                    folded.push_str(l);
+                    folded.push_str(r);
+                    return Ok(Expr::String(folded));
+                }
+            }
+            Ok(Expr::Binary {
+                op: BinaryOp::Add,
+                left,
+                right,
+            })
+        }
         ast::BinaryOp::Sub => Ok(Expr::Binary {
             op: BinaryOp::Sub,
             left,


### PR DESCRIPTION
## What

Two adjacent string literals are a compile-time constant, but nothing
downstream could fold them: the pair lowers to a runtime concat call, and LLVM —
where numeric literal folding happens — cannot see through it. So `3 + 4` costs
the empty loop while `"a" + "b"` ran a real concat on **every evaluation**, and
the cost scaled with the number of literals.

Mac mini, ns/op (loop reads `.length` so nothing is dead-code eliminated):

| expression | before | after | node |
|---|---|---|---|
| `"id-" + "x"` | 8.11 | **1.25** | 0.49 |
| `"a" + "b" + "c"` | 19.71 | **1.56** | 0.52 |
| `"id-x"` (single literal, reference point) | 1.25 | 1.25 | 0.49 |
| `3 + 4` (numeric fold, reference point) | 0.94 | 0.94 | 0.54 |
| `` `id-${"x"}` `` (template — separate fold, untouched) | 9.94 | 9.99 | 0.48 |

The folded rows land on the single-literal baseline, which is the point: the
concatenation disappears entirely rather than getting cheaper.

Left-associativity folds whole chains for free — `"a" + "b" + "c"` parses as
`("a" + "b") + "c"`, so the inner pair is already `String("ab")` when the outer
one runs.

## ASCII-only, deliberately

A non-ASCII pair needs the runtime's WTF-8 rules: `canonicalize_surrogate_pairs`
merges a high/low surrogate pair **across the join** into one astral code point
(#6728), and `utf16_len` / `isWellFormed` depend on that. Node agrees —
`"\uD83D" + "\uDE00"` is one emoji of length 2 that *is* well-formed, while
`"\uD800" + "x"` is length 2 and is *not*. Rather than restate those rules in the
compiler, non-ASCII literals keep the runtime path they have today.

## Correctness

Differential covering folded and unfolded pairs, empty strings, mixed
literal/variable operands, number/boolean/`null`/`undefined` coercions, accented
and CJK pairs, an astral surrogate pair, a lone surrogate, escapes and quotes
inside literals, `charCodeAt`/`slice`/`indexOf`/`repeat` on the result, computed
property keys, the `in` operator, object indexing, a `switch` discriminant,
template literals and `Array#join`: **identical to a build without the fold**,
and identical to node except one pre-existing lone-surrogate print that main
produces too (verified against a non-fold build of the same tree).

Gates: (placeholder)

https://claude.ai/code/session_01F1dt1jfzK2cheMZyus6y6p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Adjacent ASCII string literals joined with `+` are now combined at compile time.
  * Other string concatenation scenarios continue to work through the existing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->