### PR TITLE
codegen: byte-array reads reach the numeric proofs (bench_int_arithmetic 475 → 395 ms)

### DIFF
--- a/changelog.d/typed-array-byte-read-numeric-proofs.md
+++ b/changelog.d/typed-array-byte-read-numeric-proofs.md
@@ -1,0 +1,52 @@
+Two numeric-lowering fixes for byte-array reads, found while working
+`benchmarks/suite/bench_int_arithmetic.ts` (7.7× Node before this change; 6.2×
+after — the rest is a separate index-shape gap, noted below).
+
+**`acc += px[i]` on a `Uint8Array` no longer takes the dynamic add.** The HIR
+lowers `px[i]` on a binding it already knows is a `Uint8Array`/`Buffer` to the
+dedicated `Uint8ArrayGet` node, but the number-by-construction fixpoint's
+number-or-`undefined` view-read rule — and the not-BigInt predicate beside it —
+only recognised the `IndexGet` spelling. The accumulator was therefore never
+admitted, and every `+=` lowered through `js_dynamic_string_or_number_add` with
+`acc` kept in a GC-rooted shadow slot.
+
+That fix has a correctness half. Once the add is a raw `fadd`, an out-of-bounds
+read's NaN-boxed `undefined` survives it — IEEE arithmetic preserves the NaN
+payload — and the accumulator reads back as `undefined` where the spec says
+`NaN`. Number-context lowering now canonicalizes the value first, preferring the
+guarded inline load (which sinks the NaN into its own out-of-bounds arm) and
+otherwise emitting one compare plus a select, never a call. The `undefined` box
+is the only non-double this node can produce, so the test is exact.
+
+**Compound buffer indices can now prove their bounds.** `bounds_for_buffer_access_width`
+proved only a single index local carrying a bounded-pair fact, or a constant, so
+an index like `i * 2 + 1` or `y * 30 + x` fell back to a per-element
+`js_uint8array_index_get_value` call. The interval analysis can bound those: every
+leaf is a counter with a range fact or a compile-time constant, and `int_range_expr`
+composes them with checked arithmetic, answering `None` as soon as a leaf is
+unknown or a step overflows. When the whole interval fits inside a *constant*
+buffer length, the access is in bounds on every iteration. A non-constant length
+still declines — there is nothing to compare the interval against.
+
+Measured on an idle Mac mini, min of three, self-timed: `bench_int_arithmetic`
+475 → 395 ms (Node 64); a `pixels[y * SIZE + x]` variant 636 → 356 ms; a probe
+whose reads all qualify drops from 54 per-element helper calls to none.
+
+Verified byte-identical to Node on two differentials that are part of neither
+suite: eight cases around the byte read itself (in-bounds accumulate, an
+out-of-bounds read inside `+=`, an out-of-bounds read as a value, string
+concatenation, negative and fractional indices, a `Buffer` receiver, a mixed
+numeric/string accumulator) and seven around the new bounds proof (the exact
+kernel shape, an interval touching the last element, a counter mutated inside
+the loop body, a deliberately out-of-range interval, a one-past-the-end read, a
+negative composite index, and a buffer whose length is not a compile-time
+constant).
+
+Left for a follow-up: `bench_int_arithmetic`'s own `(y + ky) * SIZE + (x + kx)`
+still declines the interval proof, so its 54 reads per pixel remain calls.
+Also worth knowing — `f64_kind_from_class` maps `"Uint8Array"` and
+`"Uint8ClampedArray"` to a typed-array kind, but the checked load it feeds reads
+the length at `handle + 0` and elements at `handle + 16`. Perry's
+`new Uint8Array(n)` is buffer-backed (length at `data - 8`), so handing that path
+one of those receivers makes every index compare out of bounds and silently
+yields `undefined`. Nothing does today; the call site now says why.

--- a/crates/perry-codegen/src/collectors/number_by_construction.rs
+++ b/crates/perry-codegen/src/collectors/number_by_construction.rs
@@ -696,5 +696,4 @@ mod tests {
         let numeric = run_fixpoint(&stmts, &HashSet::new());
         assert!(!numeric.contains(&acc));
     }
-
 }

--- a/crates/perry-codegen/src/collectors/number_by_construction.rs
+++ b/crates/perry-codegen/src/collectors/number_by_construction.rs
@@ -633,4 +633,68 @@ mod tests {
         assert!(!without.contains(&x_id));
         assert!(!without.contains(&s_id));
     }
+
+    // The HIR lowers `px[i]` on a binding it knows is a `Uint8Array` to the
+    // dedicated `Uint8ArrayGet` node, not `IndexGet`. The Add rule's
+    // number-or-`undefined` view read must recognise both spellings, or the
+    // canonical `const px = new Uint8Array(n); ... acc += px[i]` accumulator
+    // (bench_int_arithmetic) never leaves the dynamic-add tier.
+    fn uint8array_get_stmts(px: u32, i: u32, acc: u32) -> Vec<Stmt> {
+        vec![
+            Stmt::Let {
+                id: px,
+                name: "px".to_string(),
+                ty: HirType::Named("Uint8Array".to_string()),
+                mutable: false,
+                init: Some(Expr::Uint8ArrayNew(Some(Box::new(Expr::Integer(16))))),
+            },
+            Stmt::Let {
+                id: i,
+                name: "i".to_string(),
+                ty: HirType::Number,
+                mutable: true,
+                init: Some(Expr::Integer(0)),
+            },
+            Stmt::Let {
+                id: acc,
+                name: "acc".to_string(),
+                ty: HirType::Number,
+                mutable: true,
+                init: Some(Expr::Number(0.0)),
+            },
+            Stmt::Expr(Expr::LocalSet(
+                acc,
+                Box::new(add(
+                    Expr::LocalGet(acc),
+                    Expr::Uint8ArrayGet {
+                        array: Box::new(Expr::LocalGet(px)),
+                        index: Box::new(Expr::LocalGet(i)),
+                    },
+                )),
+            )),
+        ]
+    }
+    #[test]
+    fn uint8array_get_node_admits_the_accumulator_like_index_get() {
+        let (px, i, acc) = (10u32, 11u32, 12u32);
+        let stmts = uint8array_get_stmts(px, i, acc);
+        let numeric = run_fixpoint(&stmts, &HashSet::new());
+        assert!(
+            numeric.contains(&acc),
+            "`acc += px[i]` on a const Uint8Array binding must be Number by construction"
+        );
+    }
+    #[test]
+    fn uint8array_get_node_with_string_write_stays_dynamic() {
+        // One non-numeric write to the accumulator must still reject it.
+        let (px, i, acc) = (10u32, 11u32, 12u32);
+        let mut stmts = uint8array_get_stmts(px, i, acc);
+        stmts.push(Stmt::Expr(Expr::LocalSet(
+            acc,
+            Box::new(add(Expr::LocalGet(acc), Expr::String("x".to_string()))),
+        )));
+        let numeric = run_fixpoint(&stmts, &HashSet::new());
+        assert!(!numeric.contains(&acc));
+    }
+
 }

--- a/crates/perry-codegen/src/collectors/ptr_shape_numeric.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_numeric.rs
@@ -553,8 +553,19 @@ pub(super) fn expr_numeric_by_construction(
     // an out-of-bounds read is not itself a Number and must not become a
     // general raw-f64 proof.
     let numeric_view_value_or_undefined = |x: &Expr| {
-        let Expr::IndexGet { object, index } = x else {
-            return false;
+        // The HIR lowers `u8[i]` on a binding it already knows is a
+        // `Uint8Array`/`Buffer` to the dedicated `Uint8ArrayGet` node
+        // (`lower/expr_member/member_tail.rs`), so a `const px = new
+        // Uint8Array(n)` receiver — the very binding this rule is written
+        // for — never arrived here as `IndexGet`, and `acc += px[i]` fell
+        // out of the fixpoint: every `+=` lowered through
+        // `js_dynamic_string_or_number_add` with `acc` as a rooted slot
+        // (bench_int_arithmetic: 7.7x node; `acc += (px[i] | 0)` was 2000x
+        // faster than `acc += px[i]`). Both nodes read the same storage.
+        let (object, index) = match x {
+            Expr::IndexGet { object, index } => (object, index),
+            Expr::Uint8ArrayGet { array, index } => (array, index),
+            _ => return false,
         };
         let Expr::LocalGet(view_id) = object.as_ref() else {
             return false;
@@ -761,6 +772,12 @@ pub(super) fn expr_provably_not_bigint(e: &Expr, not_bigint_locals: &HashSet<u32
         | Expr::PodLayoutAlignOf { .. }
         | Expr::PodLayoutOffsetOf { .. } => true,
         Expr::LocalGet(id) => not_bigint_locals.contains(id),
+        // A `Uint8Array`/`Buffer` element read is a byte (a Number) in
+        // bounds and `undefined` out of bounds — never a BigInt. This is what
+        // lets `acc += px[i] * k` reach the Number path: `*` needs only ONE
+        // provably-non-BigInt operand (a BigInt mixed with anything else
+        // throws), so the byte read carries the whole product.
+        Expr::Uint8ArrayGet { .. } | Expr::BufferIndexGet { .. } => true,
         Expr::Unary { op, operand } => match op {
             perry_hir::UnaryOp::Pos => true, // `+x` throws for BigInt
             perry_hir::UnaryOp::Neg | perry_hir::UnaryOp::BitNot => {

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -401,6 +401,44 @@ fn lower_arithmetic_operand(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<(String,
     // not an unconditional raw f64. In arithmetic context the OOB `undefined`
     // must become canonical NaN. Sink that conversion into the OOB/cold arms
     // so the in-bounds hot path remains a guard plus native load.
+    // The HIR spells the same read `Uint8ArrayGet` when it already knows the
+    // receiver is a `Uint8Array`/`Buffer`. Its value is a byte or (OOB)
+    // `undefined`; in number context that `undefined` must become canonical
+    // NaN BEFORE any `fadd`/`fmul` — IEEE arithmetic propagates the NaN-box
+    // payload, so a raw `fadd acc, <undefined box>` would leave `acc` reading
+    // as `undefined` (caught by the OOB differential: `a += px[17]` printed
+    // `undefined`). Prefer the guarded inline load (NaN sunk into the OOB
+    // arm, in-bounds path untouched); when it declines, canonicalize the
+    // generic read inline with one compare + select — never a call — which
+    // is exact because the only non-double this node can yield is the
+    // `undefined` box.
+    if let Expr::Uint8ArrayGet { index, .. } = expr {
+        if is_numeric_expr(ctx, index) {
+            // Deliberately NOT routed through
+            // `ta_param_f64_read::try_lower_ta_f64_read_for_number_context`:
+            // its checked load reads the length at `handle + 0` and the
+            // elements at `handle + 16`, which is the typed-array object
+            // layout. Perry's `new Uint8Array(n)` is buffer-backed (length at
+            // `data - 8`), so that load treats every index as out of bounds and
+            // silently yields `undefined` — measured as `checksum:0` on
+            // benchmarks/suite/bench_int_arithmetic.ts. `f64_kind_from_class`
+            // still maps "Uint8Array"/"Uint8ClampedArray" to a kind, so the
+            // same hazard waits for any future caller that hands it one of
+            // those receivers.
+            //
+            // `lower_expr` picks the correct tier for this node (the inline
+            // buffer-view load when the receiver is a tracked view, else
+            // `js_uint8array_index_get_value`); the only value it can return
+            // that is not a double is the `undefined` box, so one compare +
+            // select canonicalizes it exactly, with no call.
+            let raw = lower_expr(ctx, expr)?;
+            let blk = ctx.block();
+            let bits = blk.bitcast_double_to_i64(&raw);
+            let is_undef = blk.icmp_eq(I64, &bits, crate::nanbox::TAG_UNDEFINED_I64);
+            let canonical = blk.select(I1, &is_undef, DOUBLE, "0x7FF8000000000000", &raw);
+            return Ok((canonical, true));
+        }
+    }
     if let Expr::IndexGet { object, index } = expr {
         if let Some(value) =
             super::ta_param_f64_read::try_lower_ta_f64_read_for_number_context(ctx, object, index)?

--- a/crates/perry-codegen/src/expr/range_facts.rs
+++ b/crates/perry-codegen/src/expr/range_facts.rs
@@ -732,6 +732,41 @@ pub(crate) fn bounds_for_buffer_access_width(
             return bounds;
         }
     }
+    // A COMPOUND index (`(y + ky) * SIZE + (x + kx)`) is neither a single
+    // index local with a bounded-pair fact nor a constant, so both routes above
+    // decline and the read falls back to a per-element runtime call
+    // (`js_uint8array_index_get_value`: 54 calls per pixel in
+    // benchmarks/suite/bench_int_arithmetic.ts). The interval analysis can
+    // still bound it: every leaf is a counter with an `int_range_facts` range
+    // or a compile-time constant, and `int_range_expr` composes those with
+    // checked arithmetic, returning `None` the moment a leaf is unknown or a
+    // step overflows. When the whole interval sits inside a CONSTANT buffer
+    // length, the access is in bounds for every iteration.
+    //
+    // Deliberately narrow: a non-constant length (a parameter, a grown array)
+    // still declines, because then there is nothing to compare the interval
+    // against.
+    if let Some(view) = ctx.buffer_view_slots.get(&buffer_local_id) {
+        if let Some(length) = view
+            .length_source
+            .as_ref()
+            .and_then(|source| length_source_constant(ctx, source))
+        {
+            if let Some(range) = int_range_expr(ctx, index) {
+                let width = i64::from(bounds_width_units);
+                if range.min >= 0
+                    && range
+                        .max
+                        .checked_add(width)
+                        .is_some_and(|end| end <= length)
+                {
+                    return BoundsState::Proven {
+                        proof: BoundsProof::ExplicitGuard,
+                    };
+                }
+            }
+        }
+    }
     if let Some(index_value) = constant_i64_expr(ctx, index) {
         let Some(view) = ctx.buffer_view_slots.get(&buffer_local_id) else {
             return BoundsState::Unknown;

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -461,6 +461,10 @@ pub(crate) fn expr_may_return_boxed_value_from_raw_f64_fallback(
             expr_may_return_boxed_value_from_raw_f64_fallback(ctx, left)
                 || expr_may_return_boxed_value_from_raw_f64_fallback(ctx, right)
         }
+        // A `Uint8Array`/`Buffer` byte read is a Number in bounds and the
+        // `undefined` box out of bounds: a raw-f64 consumer must coerce it
+        // (the number-context arm in `expr/binary.rs` does so inline).
+        Expr::Uint8ArrayGet { .. } | Expr::BufferIndexGet { .. } => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Two numeric-lowering fixes for byte-array reads, both found working `benchmarks/suite/bench_int_arithmetic.ts` — the worst entry on a fresh perry-vs-node sweep (7.7× Node before this; 6.2× after, with the remaining gap identified below).

## 1. `acc += px[i]` on a `Uint8Array` took the dynamic add

The HIR lowers a read on a binding it already knows is a `Uint8Array`/`Buffer` to the dedicated `Uint8ArrayGet` node. The number-by-construction fixpoint's number-or-`undefined` view-read rule — and the not-BigInt predicate beside it — only recognised the `IndexGet` spelling, so the accumulator was never admitted and every `+=` lowered through `js_dynamic_string_or_number_add`, with `acc` pinned in a GC-rooted shadow slot.

**This fix has a correctness half.** Once the add is a raw `fadd`, an out-of-bounds read's NaN-boxed `undefined` survives it — IEEE arithmetic preserves the NaN payload — and the accumulator reads back as `undefined` where the spec says `NaN`. Number-context lowering now canonicalizes the value first: one compare plus a select, never a call. The `undefined` box is the only non-double this node can produce, so the test is exact.

## 2. Compound buffer indices could not prove their bounds

`bounds_for_buffer_access_width` proved only a single index local carrying a bounded-pair fact, or a constant. An index like `i * 2 + 1` or `y * 30 + x` therefore fell back to a per-element `js_uint8array_index_get_value` call. The interval analysis can bound those: every leaf is a counter with a range fact or a compile-time constant, and `int_range_expr` composes them with checked arithmetic, answering `None` as soon as a leaf is unknown or a step overflows. When the whole interval fits inside a **constant** buffer length, the access is in bounds on every iteration. A non-constant length still declines — there is nothing to compare the interval against.

## Measurements

Idle Mac mini, min of three, self-timed (the benchmark's own printed elapsed, not wall clock — node's ~76 ms startup otherwise flatters perry):

| probe | before | after | node |
|---|---:|---:|---:|
| `bench_int_arithmetic` | 475 ms | **395 ms** | 64 ms |
| `pixels[y * SIZE + x]` variant | 636 ms | **356 ms** | 35 ms |
| all-qualifying-reads probe | 54 helper calls/iter | **0** | — |

## Correctness

Byte-identical to node on two differentials that belong to neither suite:

- **eight cases around the byte read** — in-bounds accumulate, an out-of-bounds read inside `+=`, an out-of-bounds read as a value, string concatenation, negative and fractional indices, a `Buffer` receiver, and a mixed numeric/string accumulator;
- **seven cases around the new bounds proof** — the exact kernel shape, an interval touching the last element, a counter mutated inside the loop body, a deliberately out-of-range interval, a one-past-the-end read, a negative composite index, and a buffer whose length is not a compile-time constant.

`perry-codegen`: 10 collector tests and all 284 `native_proof_regressions` pass.

## Two things left on the table, deliberately

- The bench's own `(y + ky) * SIZE + (x + kx)` still declines the interval proof (54 reads per pixel remain calls), so this is a step, not the finish. It is not the counters' negative start — a non-negative rewrite still declines.
- **Landmine, now documented at the call site:** `f64_kind_from_class` maps `"Uint8Array"` and `"Uint8ClampedArray"` to a typed-array kind, but the checked load it feeds reads the length at `handle + 0` and elements at `handle + 16`. Perry's `new Uint8Array(n)` is buffer-backed (length at `data - 8`), so handing that path one of those receivers makes every index compare out of bounds and silently yields `undefined` — I hit exactly that (`checksum:0` instead of `5760000`) while writing this, and backed it out. Nothing reaches it today; `Int32Array`/`Float64Array` and `Uint8Array` parameters are unaffected.

An earlier attempt to also make the kernel read `K[ky+1][kx+1]` a native multiply is **not** in this PR: the flat-const rodata lowering is not what actually runs for that shape, so claiming the value is a canonical raw double would have been unsound, and the residual coercions it added measured net-negative (475 → 518 ms).

https://claude.ai/code/session_012Ys25ni6VwDKE71o1NTYAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric handling for `Uint8Array` and `Buffer` byte reads, including arithmetic and compound assignments.
  * Out-of-bounds byte reads now consistently produce `NaN` when used in numeric operations.
  * Improved safety checks for calculated indices when buffer lengths are known.
* **Tests**
  * Added coverage for numeric byte accumulation and dynamic values introduced through string writes.
* **Documentation**
  * Documented supported numeric-lowering scenarios, verification results, and remaining index-proof limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->