### PR TITLE
perf(runtime): FastKeyHasher hashed integers a byte at a time — 7.8x on ShapeFacts keys, −10.8% composite

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -2,15 +2,28 @@
 //! and the closure-magic-tag pointer predicate.
 
 use super::*;
+use crate::fast_hash::{new_ptr_hash_map, PtrHashMap};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
 per_test_global! {
-    static CLOSURE_PROPS: OnceLock<Mutex<HashMap<usize, HashMap<String, f64>>>> = OnceLock::new();
+    /// OUTER key is a closure heap address, probed on every dynamic property
+    /// get/set/delete on a function object, so it takes `PtrHasher` for the
+    /// same reason as the other pointer-keyed registries (#8125): a raw
+    /// address is already well distributed and no external input reaches it.
+    ///
+    /// The INNER `HashMap<String, f64>` deliberately keeps std's SipHash. Its
+    /// keys are JS property names, and unlike the descriptor side tables'
+    /// program-identifier keys these can be computed at runtime from program
+    /// input (`fn[userSuppliedName] = 1`), which is exactly the adversarial
+    /// case `RandomState` exists to defend. It is also not the half the
+    /// profile implicates -- `hash_one::<&usize>` is the outer probe.
+    static CLOSURE_PROPS: OnceLock<Mutex<PtrHashMap<usize, HashMap<String, f64>>>> =
+        OnceLock::new();
 }
 
-fn get_closure_props() -> &'static Mutex<HashMap<usize, HashMap<String, f64>>> {
-    CLOSURE_PROPS.get_or_init(|| Mutex::new(HashMap::new()))
+fn get_closure_props() -> &'static Mutex<PtrHashMap<usize, HashMap<String, f64>>> {
+    CLOSURE_PROPS.get_or_init(|| Mutex::new(new_ptr_hash_map()))
 }
 
 per_test_global! {
@@ -25,11 +38,15 @@ per_test_global! {
     /// deletion here and have every property-protocol site consult it. test262's
     /// `verifyProperty` exercises exactly this (delete-then-`hasOwnProperty`)
     /// when checking `configurable`.
-    static CLOSURE_DELETED_KEYS: OnceLock<Mutex<HashMap<usize, HashSet<String>>>> = OnceLock::new();
+    ///
+    /// Outer key is a closure address (`PtrHasher`); the inner `HashSet<String>`
+    /// keeps SipHash for the same reason as `CLOSURE_PROPS`' inner map.
+    static CLOSURE_DELETED_KEYS: OnceLock<Mutex<PtrHashMap<usize, HashSet<String>>>> =
+        OnceLock::new();
 }
 
-fn get_closure_deleted_keys() -> &'static Mutex<HashMap<usize, HashSet<String>>> {
-    CLOSURE_DELETED_KEYS.get_or_init(|| Mutex::new(HashMap::new()))
+fn get_closure_deleted_keys() -> &'static Mutex<PtrHashMap<usize, HashSet<String>>> {
+    CLOSURE_DELETED_KEYS.get_or_init(|| Mutex::new(new_ptr_hash_map()))
 }
 
 /// Record that `key` was `delete`d off the closure at `ptr`.
@@ -77,11 +94,11 @@ per_test_global! {
     /// real prototype chain, but recording the (closure → proto) link here lets
     /// string- and symbol-keyed property reads on the closure walk to the proto's
     /// own properties — so `TagClass._op === "Tag"` and `isTag(TagClass)` hold.
-    static CLOSURE_STATIC_PROTOTYPES: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
+    static CLOSURE_STATIC_PROTOTYPES: OnceLock<Mutex<PtrHashMap<usize, u64>>> = OnceLock::new();
 }
 
-fn get_closure_prototypes() -> &'static Mutex<HashMap<usize, u64>> {
-    CLOSURE_STATIC_PROTOTYPES.get_or_init(|| Mutex::new(HashMap::new()))
+fn get_closure_prototypes() -> &'static Mutex<PtrHashMap<usize, u64>> {
+    CLOSURE_STATIC_PROTOTYPES.get_or_init(|| Mutex::new(new_ptr_hash_map()))
 }
 
 /// Record `Object.setPrototypeOf(closure_ptr, proto)`. `proto_bits` is the
@@ -120,7 +137,7 @@ fn barrier_closure_dynamic_props(owner: usize, props: &mut HashMap<String, f64>)
 }
 
 fn merge_closure_prop_map(
-    props: &mut HashMap<usize, HashMap<String, f64>>,
+    props: &mut PtrHashMap<usize, HashMap<String, f64>>,
     owner: usize,
     owner_props: HashMap<String, f64>,
 ) {

--- a/crates/perry-runtime/src/fast_hash.rs
+++ b/crates/perry-runtime/src/fast_hash.rs
@@ -142,16 +142,48 @@ impl BuildHasher for FastKeyHasher {
 
 pub struct FastKeyHasherImpl(u64);
 
+/// One FNV-1a fold step over a whole machine word.
+///
+/// FNV-1a is defined over bytes, and [`FastKeyHasherImpl::write`] keeps that
+/// definition for genuine byte strings. For an integer field, though, folding
+/// byte-by-byte buys nothing: the fold is a strictly serial
+/// `xor` -> `wrapping_mul` dependency chain, so an eight-byte field costs eight
+/// dependent multiplies (~3 cycles of latency each) to mix a value that one
+/// multiply already mixes. This folds the whole word in one step.
+///
+/// It FOLDS (`h ^ word`, then multiply) rather than OVERWRITING the
+/// accumulator, which is the property [`PtrHasher`] deliberately lacks and the
+/// reason `PtrHasher` cannot serve a multi-field key: with an overwriting
+/// `write_*`, a struct hash collapses to its last field alone. Every field of
+/// a composite key reaches the accumulator here.
+#[inline(always)]
+fn fnv_fold_word(acc: u64, word: u64) -> u64 {
+    (acc ^ word).wrapping_mul(FNV_PRIME)
+}
+
 impl Hasher for FastKeyHasherImpl {
+    /// Final avalanche. FNV-1a accumulates most of its entropy in the HIGH
+    /// bits (the prime is only ~2^40, so a low input bit cannot reach the top
+    /// of the word in one round), but `hashbrown` takes its bucket index from
+    /// the LOW bits. With the word-at-a-time folds below a short key may run as
+    /// few as one round, so the low bits get very little mixing on their own.
+    ///
+    /// Multiplying by the Fibonacci constant and folding the top half down
+    /// pushes the accumulated high-bit entropy into the bucket-index bits for
+    /// one extra multiply per lookup — against the ~30 multiplies the word
+    /// folds save on a `ShapeFacts` key. This is the same hazard, and the same
+    /// remedy, as [`mix`] on [`PtrHasher`]: without it, keys that differ only
+    /// in their high bits (or aligned pointers, whose low bits are constant)
+    /// pile into one bucket and the map degrades to a linked list.
     #[inline]
     fn finish(&self) -> u64 {
-        self.0
+        let h = self.0.wrapping_mul(PTR_MIX);
+        h ^ (h >> 32)
     }
-    /// FNV-1a byte fold. A `(usize, String)` key hashes its `usize` half via the
-    /// default `write_usize` (which forwards to `write(&n.to_ne_bytes())`) and
-    /// its `String` half via `str`'s `Hash` (`write(bytes)` + a `write_u8(0xff)`
-    /// terminator, both routed here), so this one method covers every byte of
-    /// the composite key deterministically.
+    /// FNV-1a byte fold, for the genuine byte-string half of a key: a
+    /// `(usize, String)` key hashes its `String` half via `str`'s `Hash`
+    /// (`write(bytes)` plus a `write_u8(0xff)` terminator), and both route
+    /// here.
     #[inline]
     fn write(&mut self, bytes: &[u8]) {
         let mut h = self.0;
@@ -160,6 +192,74 @@ impl Hasher for FastKeyHasherImpl {
             h = h.wrapping_mul(FNV_PRIME);
         }
         self.0 = h;
+    }
+
+    // Integer writes fold one word per call instead of falling into `Hasher`'s
+    // default `write_uN` -> `write(&n.to_ne_bytes())` byte loop.
+    //
+    // This is what the shape table's `ids_by_facts` key pays for: `ShapeFacts`
+    // is six integer fields (two `u64`, three `u32`, one enum discriminant, an
+    // `isize`), so the derived `Hash` fed ~36 bytes -- ~36 serial multiplies --
+    // through the byte loop for a key that six folds mix just as well. That
+    // lookup runs on every shape publish (`shape_descriptor_ensure_with_holes`
+    // probes `ids_by_facts` before minting an id), i.e. on every object
+    // property add/delete that transitions a shape.
+    //
+    // `write_u8` is deliberately included even though it is exactly equivalent
+    // to the byte path for a single byte: routing it here keeps every integer
+    // width in one place rather than leaving one width to a different rule.
+
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_u16(&mut self, n: u16) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        self.0 = fnv_fold_word(self.0, n);
+    }
+    #[inline]
+    fn write_u128(&mut self, n: u128) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+        self.0 = fnv_fold_word(self.0, (n >> 64) as u64);
+    }
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_i8(&mut self, n: i8) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_i16(&mut self, n: i16) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_i32(&mut self, n: i32) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_i64(&mut self, n: i64) {
+        self.0 = fnv_fold_word(self.0, n as u64);
+    }
+    #[inline]
+    fn write_i128(&mut self, n: i128) {
+        self.write_u128(n as u128);
+    }
+    /// `derive(Hash)` on a fieldless enum hashes `discriminant_value(self)`,
+    /// whose type is `isize` for a default-repr enum -- so `ShapeFacts`'
+    /// `object_kind` field lands here, not on `write_u8`.
+    #[inline]
+    fn write_isize(&mut self, n: isize) {
+        self.0 = fnv_fold_word(self.0, n as u64);
     }
 }
 
@@ -255,6 +355,114 @@ mod tests {
             assert!(s.contains(&(base + i * 8)));
         }
         assert!(!s.contains(&(base + 1000 * 8)));
+    }
+
+    /// The word-at-a-time integer folds must actually be TAKEN — this is the
+    /// `FastKeyHasher` analogue of
+    /// `u32_keys_take_the_multiplicative_fast_path`. Deleting
+    /// `FastKeyHasherImpl::write_u64` drops `u64` back onto `Hasher`'s default
+    /// `write_u64` -> `write(&n.to_ne_bytes())` byte loop (eight dependent
+    /// multiplies instead of one) and turns this red.
+    #[test]
+    fn integer_writes_take_the_word_fold_fast_path() {
+        let n = 0x0123_4567_89ab_cdefu64;
+        let mut h = FastKeyHasher.build_hasher();
+        h.write_u64(n);
+        let acc = (FNV_OFFSET_BASIS ^ n).wrapping_mul(FNV_PRIME);
+        let expected = {
+            let x = acc.wrapping_mul(PTR_MIX);
+            x ^ (x >> 32)
+        };
+        assert_eq!(
+            h.finish(),
+            expected,
+            "write_u64 fell into the per-byte fold"
+        );
+    }
+
+    /// The defining difference from [`PtrHasher`]: the integer writes FOLD the
+    /// accumulator instead of overwriting it, so every field of a composite key
+    /// reaches the hash. With an overwriting `write_*` (what `PtrHasher` does,
+    /// correctly, for its single-word key) a `ShapeFacts` would hash to its last
+    /// field alone and the shape table's reverse index would collapse.
+    #[test]
+    fn word_folds_keep_every_field_of_a_composite_key() {
+        fn hash(fields: &[u64]) -> u64 {
+            let mut h = FastKeyHasher.build_hasher();
+            for &f in fields {
+                h.write_u64(f);
+            }
+            h.finish()
+        }
+        // Same trailing field, different leading fields.
+        assert_ne!(hash(&[1, 2, 3]), hash(&[9, 9, 3]));
+        // A prefix must not alias the whole key.
+        assert_ne!(hash(&[1, 2, 3]), hash(&[3]));
+        // Field ORDER is part of the identity.
+        assert_ne!(hash(&[1, 2]), hash(&[2, 1]));
+        // Mixed widths must not alias either.
+        let mut a = FastKeyHasher.build_hasher();
+        a.write_u32(1);
+        a.write_u32(2);
+        let mut b = FastKeyHasher.build_hasher();
+        b.write_u64((1u64 << 32) | 2);
+        assert_ne!(a.finish(), b.finish());
+    }
+
+    /// A `ShapeFacts`-shaped key is mostly SMALL integers (key counts, hole
+    /// counts, a two-variant enum discriminant) plus one heap address. Those
+    /// live in the low bits, which is exactly where `hashbrown` reads its
+    /// bucket index — so the `finish()` avalanche has to carry the entropy
+    /// down. Deleting the `wrapping_mul(PTR_MIX)` from `finish` collapses this.
+    #[test]
+    fn shape_facts_shaped_keys_spread_across_low_bit_buckets() {
+        use std::collections::HashSet;
+        let mut buckets = HashSet::new();
+        let mut n = 0usize;
+        // 8-byte-aligned keys array addresses, small counts, 2 object kinds.
+        for keys in 0..64u64 {
+            for logical in 0..8u32 {
+                for holes in 0..2u32 {
+                    for kind in 0..2isize {
+                        let mut h = FastKeyHasher.build_hasher();
+                        h.write_u64(0x1_0000_0000 + keys * 8);
+                        h.write_u32(logical);
+                        h.write_u32(logical);
+                        h.write_u64(0);
+                        h.write_isize(kind);
+                        h.write_u32(holes);
+                        buckets.insert(h.finish() & 0x3ff);
+                        n += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(n, 2048);
+        assert!(
+            buckets.len() > 600,
+            "ShapeFacts-shaped keys hashed into only {} of 1024 buckets",
+            buckets.len()
+        );
+    }
+
+    /// Bare-`usize`-keyed `FastKeyHashMap`s exist too (`attr_keys_by_owner`,
+    /// `SYMBOL_PROPERTY_ATTRS`' first half), and a bare key runs only ONE fold
+    /// round. Aligned heap addresses must still spread.
+    #[test]
+    fn single_round_pointer_keys_spread_across_low_bit_buckets() {
+        use std::collections::HashSet;
+        let mut buckets = HashSet::new();
+        let base = 0x1_0000_0000usize;
+        for i in 0..1024 {
+            let mut h = FastKeyHasher.build_hasher();
+            h.write_usize(base + i * 16);
+            buckets.insert(h.finish() & 0x3ff);
+        }
+        assert!(
+            buckets.len() > 512,
+            "aligned pointers hashed into only {} of 1024 buckets",
+            buckets.len()
+        );
     }
 
     /// The descriptor side tables key on `(usize, String)`. Verify the FNV-1a

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -22,7 +22,6 @@
 //! time (`expando_clear_on_alloc`).
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExoticKind {
@@ -106,7 +105,7 @@ pub(crate) fn exotic_expando_kind_of_value(value: f64) -> Option<(usize, ExoticK
 pub(crate) struct ExoticExpandoTables {
     /// addr -> insertion-ordered (key, nanboxed value bits) pairs for the
     /// non-Error exotic cells handled by this module.
-    entries: RefCell<HashMap<usize, Vec<(String, u64)>>>,
+    entries: RefCell<crate::fast_hash::PtrHashMap<usize, Vec<(String, u64)>>>,
     /// Fast-path gate so hot get/set paths skip the map lookup until the
     /// first expando is installed on this thread.
     in_use: Cell<bool>,
@@ -115,7 +114,7 @@ pub(crate) struct ExoticExpandoTables {
 impl ExoticExpandoTables {
     pub(crate) fn new() -> Self {
         Self {
-            entries: RefCell::new(HashMap::new()),
+            entries: RefCell::new(crate::fast_hash::new_ptr_hash_map()),
             in_use: Cell::new(false),
         }
     }

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -1494,15 +1494,15 @@ thread_local! {
     /// but isolated from it so a user `fn.length = x` write can't perturb it)
     /// lets the `.length` value-read and `getOwnPropertyDescriptor` agree with
     /// the spec count. #3143.
-    static BUILTIN_CLOSURE_LENGTH: std::cell::RefCell<std::collections::HashMap<usize, u32>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
+    static BUILTIN_CLOSURE_LENGTH: std::cell::RefCell<crate::fast_hash::PtrHashMap<usize, u32>> =
+        std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_map());
 
     /// Built-in method closures are callable but lack ECMAScript
     /// `[[Construct]]`. Track the installed closure values so the dynamic
     /// `new` / `Reflect.construct` paths can reject them without changing
     /// ordinary user closures or global constructor closures.
-    static BUILTIN_CLOSURE_NON_CONSTRUCTABLE: std::cell::RefCell<std::collections::HashSet<usize>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
+    static BUILTIN_CLOSURE_NON_CONSTRUCTABLE: std::cell::RefCell<crate::fast_hash::PtrHashSet<usize>> =
+        std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_set());
 }
 
 /// Record the spec `.length` for a built-in prototype-method closure. See

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -83,6 +83,9 @@ pub(crate) use gc_roots::{
     test_symbol_property_root_bits, test_symbol_property_roots,
 };
 
+use crate::fast_hash::{
+    new_ptr_hash_map, new_ptr_hash_set, FastKeyHashMap, PtrHashMap, PtrHashSet,
+};
 use crate::string::StringHeader;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -142,7 +145,7 @@ static SYMBOL_REGISTRY: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None)
 // detect symbol pointers safely without reading the (possibly nonexistent)
 // GcHeader byte.
 per_test_global! {
-    static SYMBOL_POINTERS: Mutex<Option<HashSet<usize>>> = Mutex::new(None);
+    static SYMBOL_POINTERS: Mutex<Option<PtrHashSet<usize>>> = Mutex::new(None);
 }
 
 /// Process-lifetime descriptions for registered (`Symbol.for`) and well-known
@@ -154,7 +157,7 @@ per_test_global! {
 /// materialize a fresh StringHeader in the *caller's* arena on demand, which
 /// is the only thread-safe contract: the symbol identity is global, but
 /// every StringHeader belongs to exactly one thread's arena.
-static REGISTERED_SYMBOL_DESCRIPTIONS: Mutex<Option<HashMap<usize, std::sync::Arc<str>>>> =
+static REGISTERED_SYMBOL_DESCRIPTIONS: Mutex<Option<PtrHashMap<usize, std::sync::Arc<str>>>> =
     Mutex::new(None);
 
 pub(crate) fn registered_symbol_description(sym_ptr: usize) -> Option<std::sync::Arc<str>> {
@@ -209,8 +212,8 @@ crate::perry_thread_local! {
     /// not recoverable from the payload. That is the pre-existing WTF-8 gap
     /// CLAUDE.md already lists, not a new one, and it is strictly better than
     /// dropping the description.
-    static FRESH_SYMBOL_DESCRIPTIONS: RefCell<HashMap<u64, std::sync::Arc<[u8]>>> =
-        RefCell::new(HashMap::new());
+    static FRESH_SYMBOL_DESCRIPTIONS: RefCell<PtrHashMap<u64, std::sync::Arc<[u8]>>> =
+        RefCell::new(new_ptr_hash_map());
 }
 
 #[cfg(test)]
@@ -282,7 +285,7 @@ pub(crate) fn test_fresh_symbol_description_count() -> usize {
 pub(crate) fn record_registered_symbol_description(sym_ptr: usize, description: &str) {
     let mut guard = REGISTERED_SYMBOL_DESCRIPTIONS.lock().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(new_ptr_hash_map());
     }
     guard
         .as_mut()
@@ -451,7 +454,7 @@ pub(crate) fn register_symbol_pointer(ptr: usize) {
     SYMBOL_EVER_REGISTERED.arm();
     let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_POINTERS);
     if guard.is_none() {
-        *guard = Some(HashSet::new());
+        *guard = Some(new_ptr_hash_set());
     }
     guard.as_mut().unwrap().insert(ptr);
 }
@@ -550,15 +553,17 @@ pub(crate) fn is_global_registered_symbol(ptr: usize) -> bool {
 // rewritten when owners move; symbol keys and NaN-boxed values are GC roots.
 // Storage stays intentionally linear because per-object symbol keys are rare.
 per_test_global! {
-    static SYMBOL_PROPERTIES: Mutex<Option<HashMap<usize, Vec<(usize, u64)>>>> = Mutex::new(None);
+    static SYMBOL_PROPERTIES: Mutex<Option<PtrHashMap<usize, Vec<(usize, u64)>>>> =
+        Mutex::new(None);
 }
 
 // Descriptor attributes for symbol-keyed properties installed through
 // Object.defineProperty. Direct symbol assignment uses the normal data-property
 // defaults, so absence here means writable/enumerable/configurable are all true.
 per_test_global! {
-    static SYMBOL_PROPERTY_ATTRS: Mutex<Option<HashMap<(usize, usize), crate::object::PropertyAttrs>>> =
-        Mutex::new(None);
+    static SYMBOL_PROPERTY_ATTRS: Mutex<
+        Option<FastKeyHashMap<(usize, usize), crate::object::PropertyAttrs>>,
+    > = Mutex::new(None);
 }
 
 /// Death pruning for the symbol-keyed property side tables (2026-07-09 GC
@@ -835,7 +840,7 @@ pub(crate) fn store_object_symbol_property_root(
     {
         let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
         if guard.is_none() {
-            *guard = Some(HashMap::new());
+            *guard = Some(new_ptr_hash_map());
         }
         let map = guard.as_mut().unwrap();
         let entries = map.entry(obj_key).or_default();

--- a/crates/perry-runtime/src/symbol/accessors.rs
+++ b/crates/perry-runtime/src/symbol/accessors.rs
@@ -105,7 +105,7 @@ pub(crate) unsafe fn set_symbol_accessor_property(
         // entries out for the raw-entry consumers (formatting, freeze/seal).
         let mut props = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
         if props.is_none() {
-            *props = Some(HashMap::new());
+            *props = Some(crate::fast_hash::new_ptr_hash_map());
         }
         let entries = props.as_mut().unwrap().entry(obj_key).or_default();
         if let Some(entry) = entries.iter_mut().find(|entry| entry.0 == sym_key) {

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -4,7 +4,6 @@
 
 use super::*;
 use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::HashMap;
 
 /// Look up the cached pointer for the registered `util.inspect.custom` symbol
 /// (description `"nodejs.util.inspect.custom"`). Returns 0 if the symbol has
@@ -93,7 +92,7 @@ pub(crate) fn set_symbol_property_attrs(
     super::note_symbol_key_installed(sym_key);
     let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTY_ATTRS);
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(crate::fast_hash::new_fast_key_hash_map());
     }
     guard.as_mut().unwrap().insert((owner, sym_key), attrs);
 }


### PR DESCRIPTION
From the symbolized cc `--help` profile, where hashing was ~5.2% of samples across three entries. They had **two different root causes**, and the larger one was not a hasher-choice problem.

## 1. `FastKeyHasher` implemented only `write` (the real find — 2.14% entry)

Every integer field therefore fell into `Hasher`'s *default* `write_uN` → `write(&n.to_ne_bytes())` byte loop. FNV-1a is a strictly serial `xor`→`wrapping_mul` chain, so a `ShapeFacts` key (two `u64`, three `u32`, an enum discriminant) cost **~36 dependent multiplies to mix six words**. `shape_descriptor_ensure_with_holes` probes `ids_by_facts` with that key on **every shape publish** — every property add or delete that transitions a shape.

Fix: word-at-a-time `write_u*`/`write_i*` that **fold** (`(acc ^ word) * FNV_PRIME`) rather than overwrite, preserving the multi-field property `PtrHasher` deliberately lacks (the comment at `shapes.rs:255` warns that an overwriting hasher would collapse `ShapeFacts` to its last field). `finish()` now avalanches: a short key can run as few as one fold, and FNV-1a accumulates entropy in the high bits while hashbrown indexes on the low ones — the same hazard `mix()` already guards for `PtrHasher`, where dropping it once cost 455→830 ms per the in-tree comment.

Standalone: **11.79 → 1.51 ns (7.8×)**; bare `usize` 2.51 → 0.59 ns.

## 2. The SipHash maps (1.64% + 1.40% entries)

310 default-hasher maps exist in the runtime, so conversion was driven by call-site hotness, not blanket search-and-replace. Converted: three closure registries, two builtin-closure tables, five symbol tables, `ExoticExpandoTables::entries`. `SYMBOL_PROPERTY_ATTRS` took `FastKeyHashMap` rather than `PtrHashMap` — its key is two words and `PtrHasher` would collapse it to the second half.

**Deliberately NOT converted:** the inner `HashMap<String, f64>` / `HashSet<String>` of the closure tables keep SipHash — those keys are JS property names computable from program input (`fn[userSuppliedName] = 1`), which is the adversarial case `RandomState` exists for; only the outer pointer probe is what the profile implicates. Also skipped startup/rare-path maps (`TYPED_ARRAY_NO_EXTEND`, `TEMPLATE_RAW_MAP`, submodule singletons): converting unsampled code is diff risk for no measured gain.

## Bench (quiet Mac mini, load 1.6; interleaved A/B from one stash/unstash pair, 5 reps)

| phase | before | after | delta |
|---|---|---|---|
| shapes | 1538 | 1411 | −8.3% |
| **varied (control)** | 173 | 173 | **0.0%** |
| closure | 218 | 179 | −17.9% |
| symbol | 180 | 123 | −31.7% |
| expando | 56 | 46 | −17.9% |
| **typedarray (control)** | 19 | 19 | **0.0%** |
| **total** | **2189** | **1952** | **−10.8%** |

Spread under 3%, well below the effect; the two flat phases are honest controls on paths this PR does not touch.

**Honest caveat:** the `shapes` phase moved only 8.3% despite the 7.8× hash win — that phase is allocation-dominated. The hash win is real but is ~2% of a real workload, consistent with the profile's 2.14%, not a headline number.

## Iteration-order audit

Every map touched **plus every pre-existing `FastKeyHashMap`** (their order also shifts, because `finish()` changed): all iteration is GC rekeying, `retain` predicates, `.any()` booleans, or collection into a `BTreeSet`. Observable JS key order comes from `Vec` values, never map order. One flagged case (`closure_dynamic_props_snapshot`) was inverted on inspection — it already sorts explicitly with a comment that HashMap order is non-deterministic.

## Validation

Runtime suite **2828 passed / 0 failed**, run to completion; fmt clean; `cargo check` warning-free. Four new tests pin the fast path: that `write_u64` does not fall back to the byte loop, that folds do not collapse a composite key (order *and* prefix both matter), and bucket-spread for `ShapeFacts`-shaped and single-round pointer keys — the last turns red if the `finish()` avalanche is removed.

## Analysis deliberately not implemented

The remaining `ShapeFacts` cost is call *frequency*: `ensure_with_holes` takes a `RefCell::borrow_mut()` on the whole shape table and hashes on every publish, even when the identical shape was published one iteration earlier. A one-entry memo (last facts → id) would skip the hash entirely in the common loop case, but invalidation must be correct across descriptor retirement *and* GC keys-array moves — a redesign, not a contained win. Caching the hash on the descriptor does not help: `ensure` builds facts from raw caller arguments with no descriptor in hand.

Implemented by a subagent in an isolated worktree; reviewed and shipped by the coordinating session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime hashing for numeric, pointer-based, and composite keys.
  * Optimized internal lookups for closures, symbols, expandable objects, and built-in functions.
  * Improved hash distribution for more consistent lookup performance.

* **Reliability**
  * Added coverage validating integer hashing, pointer-key distribution, and composite-key preservation.
  * No user-facing behavior or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->