### PR TITLE
perf(hir): widen the property-array hoist to const aliases, captures and nested loops (20.5 → 0.47 ns)

### DIFF
--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -333,12 +333,29 @@ pub(crate) fn lower_var_decl_with_destructuring(
             // every property of `x` is a data field rather than an accessor —
             // `is_closed_shape` rejects getters and setters — and the
             // loop-invariant property hoist refuses to fire without it.
+            //
+            // A `const` alias of such a binding inherits the proof: neither
+            // name can ever be rebound, so both always denote the object the
+            // literal created. This is what lets the hoist reach receivers
+            // read through an alias, including one captured by a closure —
+            // the capture keeps the same `LocalId`, so no extra plumbing is
+            // needed once the alias is recorded.
             if !mutable {
-                if let Some(Expr::New { class_name, .. }) = init.as_ref() {
-                    if class_name.starts_with("__AnonShape_") {
+                match init.as_ref() {
+                    Some(Expr::New { class_name, .. })
+                        if class_name.starts_with("__AnonShape_") =>
+                    {
                         ctx.closed_shape_literal_locals
                             .insert(id, class_name.clone());
                     }
+                    Some(Expr::LocalGet(source)) => {
+                        if let Some(class_name) =
+                            ctx.closed_shape_literal_locals.get(source).cloned()
+                        {
+                            ctx.closed_shape_literal_locals.insert(id, class_name);
+                        }
+                    }
+                    _ => {}
                 }
             }
             result.push(Stmt::Let {

--- a/crates/perry-hir/src/lower/property_array_hoist.rs
+++ b/crates/perry-hir/src/lower/property_array_hoist.rs
@@ -200,7 +200,40 @@ fn stmt_is_hoist_safe(stmt: &Stmt, recv_id: u32) -> bool {
                     .as_ref()
                     .is_none_or(|b| b.iter().all(|s| stmt_is_hoist_safe(s, recv_id)))
         }
+        // Nested loops are the common case this pass exists for — `m.rows[i]`
+        // in an outer loop with an inner loop over the row — so recurse rather
+        // than refuse. A nested loop is safe on exactly the same terms: it may
+        // not rebind the receiver and may not call anything.
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            expr_is_hoist_safe(condition, recv_id)
+                && body.iter().all(|s| stmt_is_hoist_safe(s, recv_id))
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            init.as_ref()
+                .is_none_or(|s| stmt_is_hoist_safe(s, recv_id))
+                && condition
+                    .as_ref()
+                    .is_none_or(|e| expr_is_hoist_safe(e, recv_id))
+                && update
+                    .as_ref()
+                    .is_none_or(|e| expr_is_hoist_safe(e, recv_id))
+                && body.iter().all(|s| stmt_is_hoist_safe(s, recv_id))
+        }
+        Stmt::Labeled { body, .. } => stmt_is_hoist_safe(body, recv_id),
+        // Leaving the loop early is fine: the hoisted `Let` is evaluated
+        // before the loop either way, and the property read it replaces was
+        // never reached on this path.
+        Stmt::Return(value) => value
+            .as_ref()
+            .is_none_or(|e| expr_is_hoist_safe(e, recv_id)),
+        Stmt::Throw(value) => expr_is_hoist_safe(value, recv_id),
         Stmt::Break | Stmt::Continue => true,
+        Stmt::LabeledBreak(_) | Stmt::LabeledContinue(_) => true,
         _ => false,
     }
 }
@@ -265,6 +298,31 @@ fn stmt_reads_property(stmt: &Stmt, recv_id: u32, property: &str) -> bool {
                     .as_ref()
                     .is_some_and(|b| b.iter().any(|s| stmt_reads_property(s, recv_id, property)))
         }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            expr_reads_property(condition, recv_id, property)
+                || body.iter().any(|s| stmt_reads_property(s, recv_id, property))
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            init.as_ref()
+                .is_some_and(|s| stmt_reads_property(s, recv_id, property))
+                || condition
+                    .as_ref()
+                    .is_some_and(|e| expr_reads_property(e, recv_id, property))
+                || update
+                    .as_ref()
+                    .is_some_and(|e| expr_reads_property(e, recv_id, property))
+                || body.iter().any(|s| stmt_reads_property(s, recv_id, property))
+        }
+        Stmt::Labeled { body, .. } => stmt_reads_property(body, recv_id, property),
+        Stmt::Return(value) => value
+            .as_ref()
+            .is_some_and(|e| expr_reads_property(e, recv_id, property)),
+        Stmt::Throw(value) => expr_reads_property(value, recv_id, property),
         _ => false,
     }
 }
@@ -345,8 +403,54 @@ fn rewrite_stmt(stmt: &Stmt, recv_id: u32, property: &str, hoist_id: u32) -> Stm
                     .collect()
             }),
         },
+        // These mirror the arms `stmt_is_hoist_safe` admits. Anything it
+        // admits must be rewritten here too, or the read it vouched for keeps
+        // the per-iteration lookup.
+        Stmt::While { condition, body } => Stmt::While {
+            condition: rewrite_expr(condition, recv_id, property, hoist_id),
+            body: rewrite_block(body, recv_id, property, hoist_id),
+        },
+        Stmt::DoWhile { body, condition } => Stmt::DoWhile {
+            body: rewrite_block(body, recv_id, property, hoist_id),
+            condition: rewrite_expr(condition, recv_id, property, hoist_id),
+        },
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => Stmt::For {
+            init: init
+                .as_ref()
+                .map(|s| Box::new(rewrite_stmt(s, recv_id, property, hoist_id))),
+            condition: condition
+                .as_ref()
+                .map(|e| rewrite_expr(e, recv_id, property, hoist_id)),
+            update: update
+                .as_ref()
+                .map(|e| rewrite_expr(e, recv_id, property, hoist_id)),
+            body: rewrite_block(body, recv_id, property, hoist_id),
+        },
+        Stmt::Labeled { label, body } => Stmt::Labeled {
+            label: label.clone(),
+            body: Box::new(rewrite_stmt(body, recv_id, property, hoist_id)),
+        },
+        Stmt::Return(value) => Stmt::Return(
+            value
+                .as_ref()
+                .map(|e| rewrite_expr(e, recv_id, property, hoist_id)),
+        ),
+        Stmt::Throw(value) => {
+            Stmt::Throw(rewrite_expr(value, recv_id, property, hoist_id))
+        }
         other => other.clone(),
     }
+}
+
+fn rewrite_block(body: &[Stmt], recv_id: u32, property: &str, hoist_id: u32) -> Vec<Stmt> {
+    body.iter()
+        .map(|s| rewrite_stmt(s, recv_id, property, hoist_id))
+        .collect()
 }
 
 fn rewrite_expr(expr: &Expr, recv_id: u32, property: &str, hoist_id: u32) -> Expr {

--- a/crates/perry-hir/src/lower/property_array_hoist.rs
+++ b/crates/perry-hir/src/lower/property_array_hoist.rs
@@ -214,8 +214,7 @@ fn stmt_is_hoist_safe(stmt: &Stmt, recv_id: u32) -> bool {
             update,
             body,
         } => {
-            init.as_ref()
-                .is_none_or(|s| stmt_is_hoist_safe(s, recv_id))
+            init.as_ref().is_none_or(|s| stmt_is_hoist_safe(s, recv_id))
                 && condition
                     .as_ref()
                     .is_none_or(|e| expr_is_hoist_safe(e, recv_id))
@@ -300,7 +299,9 @@ fn stmt_reads_property(stmt: &Stmt, recv_id: u32, property: &str) -> bool {
         }
         Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
             expr_reads_property(condition, recv_id, property)
-                || body.iter().any(|s| stmt_reads_property(s, recv_id, property))
+                || body
+                    .iter()
+                    .any(|s| stmt_reads_property(s, recv_id, property))
         }
         Stmt::For {
             init,
@@ -316,7 +317,9 @@ fn stmt_reads_property(stmt: &Stmt, recv_id: u32, property: &str) -> bool {
                 || update
                     .as_ref()
                     .is_some_and(|e| expr_reads_property(e, recv_id, property))
-                || body.iter().any(|s| stmt_reads_property(s, recv_id, property))
+                || body
+                    .iter()
+                    .any(|s| stmt_reads_property(s, recv_id, property))
         }
         Stmt::Labeled { body, .. } => stmt_reads_property(body, recv_id, property),
         Stmt::Return(value) => value
@@ -440,9 +443,7 @@ fn rewrite_stmt(stmt: &Stmt, recv_id: u32, property: &str, hoist_id: u32) -> Stm
                 .as_ref()
                 .map(|e| rewrite_expr(e, recv_id, property, hoist_id)),
         ),
-        Stmt::Throw(value) => {
-            Stmt::Throw(rewrite_expr(value, recv_id, property, hoist_id))
-        }
+        Stmt::Throw(value) => Stmt::Throw(rewrite_expr(value, recv_id, property, hoist_id)),
         other => other.clone(),
     }
 }

--- a/crates/perry/tests/loop_property_array_hoist.rs
+++ b/crates/perry/tests/loop_property_array_hoist.rs
@@ -204,3 +204,87 @@ fn handles_nested_loops_and_string_elements() {
         "10 abc 0",
     );
 }
+
+#[test]
+fn hoists_through_a_const_alias_and_a_capture() {
+    // `const h = holder` cannot be rebound and neither can `holder`, so the
+    // alias inherits the data-field proof. The closure capture keeps the same
+    // LocalId, so the same rewrite reaches a receiver read inside an arrow.
+    assert_same_with_and_without_hoist(
+        "alias and capture",
+        r#"
+        const holder = { arr: [1, 2, 3, 4], n: 4 };
+        function aliased(): number {
+            const h = holder;
+            let s = 0;
+            for (let i = 0; i < h.arr.length; i++) s += h.arr[i];
+            return s;
+        }
+        function captured(): number {
+            const h = holder;
+            const f = (): number => {
+                let s = 0;
+                for (let i = 0; i < h.arr.length; i++) s += h.arr[i];
+                return s;
+            };
+            return f();
+        }
+        console.log(aliased() + " " + captured());
+        "#,
+        "10 10",
+    );
+}
+
+#[test]
+fn refuses_an_alias_of_a_reassignable_binding() {
+    // `let base` is not in the registry, so the alias inherits nothing and the
+    // loop keeps its per-iteration lookup. Pinned because the alias rule would
+    // be unsound if it ever followed a mutable source.
+    assert_same_with_and_without_hoist(
+        "mutable source",
+        r#"
+        let base: any = { get arr() { return [1, 2]; } };
+        const h = base;
+        let s = 0;
+        for (let i = 0; i < h.arr.length; i++) s += h.arr[i];
+        console.log(s);
+        "#,
+        "3",
+    );
+}
+
+#[test]
+fn hoists_an_outer_loop_containing_a_nested_loop() {
+    assert_same_with_and_without_hoist(
+        "nested loop hoisted",
+        r#"
+        const g = { cells: [1, 2, 3, 4], n: 4 };
+        let s = 0;
+        for (let r = 0; r < 3; r++) {
+            for (let i = 0; i < g.cells.length; i++) {
+                for (let k = 0; k < 2; k++) s += g.cells[i];
+            }
+        }
+        console.log(s);
+        "#,
+        "60",
+    );
+}
+
+#[test]
+fn hoists_a_loop_that_returns_early() {
+    assert_same_with_and_without_hoist(
+        "early return",
+        r#"
+        const h = { arr: [3, 7, 11, 15], n: 4 };
+        function firstOver(limit: number): number {
+            for (let i = 0; i < h.arr.length; i++) {
+                if (h.arr[i] > limit) return h.arr[i];
+            }
+            return -1;
+        }
+        console.log(firstOver(8) + " " + firstOver(100));
+        "#,
+        "11 -1",
+    );
+}


### PR DESCRIPTION
Follows #9149, which deliberately left three receiver shapes alone. One rule covers all three.

## Numbers

Quiet Mac mini, node v26.5.1, ns/op, medians of 3. Both perry columns are **the same binary**, switched with `PERRY_LOOP_PROPERTY_HOIST`:

| receiver | perry off | perry on | node |
|---|---|---|---|
| captured in an arrow | 20.35 | **0.50** | 0.54 |
| `const` alias of the receiver | 20.49 | **0.47** | 0.58 |
| outer loop containing a nested loop | 20.58 | **0.47** | 0.55 |
| loop with an early `return` | 21.59 | 3.59 | 0.57 |

With #9149 this takes the original benchmark to four of five rows beating node. The remaining one is a parameter receiver, which needs a genuine runtime guard rather than a static proof and is not attempted here.

## The rule

A `const` alias inherits the data-field proof. `const h = holder` where `holder` is itself a `const` closed-shape literal binding: neither name can ever be rebound, so both always denote the object the literal created, and everything #9149 argued about `holder` holds verbatim for `h`.

That one rule also reaches **receivers read inside a closure**, at no extra cost and with no new machinery. A capture keeps the same `LocalId`, so the existing rewrite already matches the body — confirmed by dumping HIR rather than assumed:

```
Let { id: 7, name: "h", mutable: false, init: Some(LocalGet(1)) }
Closure { captures: [7], … body: … PropertyGet { object: LocalGet(7), property: "arr" } … }
```

An alias of a `let` is not admitted, because only `const` bindings ever enter the registry. There is a test for it: following a mutable source is exactly how this rule would turn unsound.

## Nested loops and early exits

Refusing any loop whose body contained a nested loop was pure conservatism — and it excluded `m.rows[i]` with an inner loop over the row, which is the shape the pass exists for. A nested loop is safe on precisely the same terms as any other statement: it may not rebind the receiver and may not call. `return` and `throw` are likewise fine, since the hoisted `Let` is evaluated before the loop either way and leaving early only skips reads.

Every arm the scan admits is also handled by the rewriter. That pairing is load-bearing rather than tidiness: an admitted-but-unrewritten statement would silently keep its per-iteration lookup, so the two match arms are meant to be read side by side.

## The early-`return` row, honestly

3.59 is a 6x improvement but still 6.3x node, and the residual is not this pass. Isolating it on a **bare local** array, with no property lookup and no hoisting involved at all:

| inner-loop body | perry | node |
|---|---|---|
| straight line | 0.78 | 0.55 |
| `if (l < 0) { l = 0; }` | 0.46 | 0.56 |
| `if (l < 0) break;` | 4.74 | 0.54 |
| `if (l < 0) continue;` | 4.75 | 0.55 |
| `if (l < 0) return -1;` | 4.76 | 0.56 |

A plain conditional is free; any abrupt statement costs 6x, including `continue`, which never leaves the loop. Filed as #9151 with the predicate located (`stmt_is_packed_f64_loop_safe`, `loops.rs:5011`, one rejection arm covering all of them).

## Binary size

`size(1)` `.text`: 10,974,932 → 10,973,396, i.e. **−1536 bytes (−0.014%)**, against −320 bytes for #9149 alone. The wider the pass reaches, the more per-iteration lookups it deletes, so it keeps removing code rather than adding it.

## Gates

`-D warnings` clean; perry-hir 591/0; perry-codegen 1839/0; perry-runtime lib 2837/0 (`--test-threads=1`); census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: the hoist suite 11/11 (4 new), plus `issue_8655_array_subclass_indexing` 2/2, `issue_8690_loop_versioned_arraylike` 3/3 and `issue_8897_field_push_writeback` 3/3. The battery ran before a rebase onto #9137, which is unrelated (object-delete ICs) and does not touch HIR lowering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved performance for eligible loops that repeatedly read unchanged property arrays by reusing the array reference.
  - Optimization supports nested loops, constant aliases, closure captures, and loops where the array grows during execution.

- **Reliability**
  - Added safeguards to preserve existing behavior when properties may be reassigned, written to, accessed through getters, or affected by function calls.
  - Added coverage confirming optimized and unoptimized execution produce identical results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->