### PR TITLE
perf(codegen): packed loops keep the fast path across break/continue/return — 4.75 → 0.58 ns (#9151)

### DIFF
--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -4975,6 +4975,15 @@ fn local_is_u32_array(ctx: &FnCtx<'_>, local_id: u32) -> bool {
     )
 }
 
+/// `PERRY_PACKED_LOOP_ABRUPT=0` restores the pre-#9151 behaviour, where any
+/// abrupt statement kept the loop on the generic path.
+fn packed_loop_abrupt_enabled() -> bool {
+    !matches!(
+        std::env::var("PERRY_PACKED_LOOP_ABRUPT").as_deref(),
+        Ok("0") | Ok("off") | Ok("false")
+    )
+}
+
 fn stmt_is_packed_f64_loop_safe(
     ctx: &FnCtx<'_>,
     stmt: &Stmt,
@@ -5008,12 +5017,34 @@ fn stmt_is_packed_f64_loop_safe(
         // Conservative: a box release clears cells; keep it out of packed
         // f64 loop bodies (it never appears in one today).
         Stmt::ReleaseBoxes(_) => false,
-        Stmt::Return(_)
-        | Stmt::Throw(_)
-        | Stmt::Break
-        | Stmt::Continue
-        | Stmt::LabeledBreak(_)
+        // Leaving *this* loop early neither calls out nor touches the array, so
+        // the relaxation the caller documents still holds: the entry guard has
+        // already revalidated the receiver, and an iteration that exits simply
+        // performs fewer reads than the guard admitted. `stmt_array_length_effect`
+        // and `stmt_preserves_array_length` already answer `Preserves`/`true`
+        // for these two.
+        //
+        // Unlabeled only. A nested loop is rejected below, so a bare `break` or
+        // `continue` here can only target the loop being analysed, and the fast
+        // clone's exit edge is the right destination. A LABELED break targets an
+        // enclosing loop and must unwind past this one, which the clone does not
+        // do: admitting it made
+        //   outer: for (r…) { for (i…) { s += a[i]; if (a[i] === 10 && r === 2) break outer; } }
+        // return 4032 instead of 4087, silently dropping the partial iteration.
+        Stmt::Break | Stmt::Continue => packed_loop_abrupt_enabled(),
+        // Same argument, once the returned expression itself is safe — it is
+        // evaluated in the loop body like any other operand.
+        Stmt::Return(value) => {
+            packed_loop_abrupt_enabled()
+                && value.as_ref().is_none_or(|expr| {
+                    expr_is_packed_f64_loop_safe(ctx, expr, arr_id, counter_id)
+                })
+        }
+        // `throw` stays out: the thrown value is typically constructed
+        // (`throw new Error(…)`), which is a call in the loop body.
+        Stmt::LabeledBreak(_)
         | Stmt::LabeledContinue(_)
+        | Stmt::Throw(_)
         | Stmt::While { .. }
         | Stmt::DoWhile { .. }
         | Stmt::For { .. }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -5036,9 +5036,9 @@ fn stmt_is_packed_f64_loop_safe(
         // evaluated in the loop body like any other operand.
         Stmt::Return(value) => {
             packed_loop_abrupt_enabled()
-                && value.as_ref().is_none_or(|expr| {
-                    expr_is_packed_f64_loop_safe(ctx, expr, arr_id, counter_id)
-                })
+                && value
+                    .as_ref()
+                    .is_none_or(|expr| expr_is_packed_f64_loop_safe(ctx, expr, arr_id, counter_id))
         }
         // `throw` stays out: the thrown value is typically constructed
         // (`throw new Error(…)`), which is a call in the loop body.

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -66,6 +66,10 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // counted for-loops — on and off emit different loop bodies, so a cached
     // object from one must not serve the other.
     "PERRY_LOOP_PROPERTY_HOIST",
+    // #9154: gates keeping the packed fast path across break/continue/return —
+    // on and off emit different loop exits, so a cached object from one must
+    // not serve the other.
+    "PERRY_PACKED_LOOP_ABRUPT",
     // #9122: gates the shape-cache path for object literals whose methods
     // capture `this` — on and off emit different literal-birth sequences,
     // so a cached object from one must not serve the other.

--- a/crates/perry/tests/packed_loop_abrupt_statements.rs
+++ b/crates/perry/tests/packed_loop_abrupt_statements.rs
@@ -1,0 +1,164 @@
+//! Packed-array counted loops keep their fast path when the body contains an
+//! unlabeled `break`, `continue` or `return` (#9151).
+//!
+//! Every program here ACTUALLY takes its exit, at varying indices and with
+//! observable effects before it. That matters: a never-taken exit exercises
+//! only the admission decision, not the emitted clone, and the first cut of
+//! this change was wrong in a way only a taken exit could reveal — a labeled
+//! `break` must unwind past the loop being analysed, which the fast clone does
+//! not do, so `labeled_break_still_unwinds_the_outer_loop` below returned 4032
+//! instead of 4087 and silently dropped a partial iteration.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run: Output = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_owned()
+}
+
+const PRELUDE: &str = r#"
+const arr: number[] = [];
+for (let i = 0; i < 64; i++) arr.push(i);
+"#;
+
+#[test]
+fn break_exits_at_the_right_index() {
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        function breakAt(k: number): number {{
+            let s = 0;
+            for (let i = 0; i < arr.length; i++) {{ s += arr[i]; if (arr[i] === k) break; }}
+            return s;
+        }}
+        console.log(breakAt(0) + \" \" + breakAt(1) + \" \" + breakAt(31) + \" \" + breakAt(63) + \" \" + breakAt(999));
+        "
+    ));
+    assert_eq!(out, "0 1 496 2016 2016");
+}
+
+#[test]
+fn continue_skips_exactly_the_guarded_iterations() {
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        let s = 0;
+        for (let i = 0; i < arr.length; i++) {{ if (arr[i] % 2 === 1) continue; s += arr[i]; }}
+        console.log(s);
+        "
+    ));
+    assert_eq!(out, "992");
+}
+
+#[test]
+fn return_leaves_the_function_at_the_right_index() {
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        function returnAt(k: number): number {{
+            for (let i = 0; i < arr.length; i++) {{ if (arr[i] === k) return i; }}
+            return -1;
+        }}
+        console.log(returnAt(0) + \" \" + returnAt(17) + \" \" + returnAt(63) + \" \" + returnAt(999));
+        "
+    ));
+    assert_eq!(out, "0 17 63 -1");
+}
+
+#[test]
+fn effects_before_a_break_happen_exactly_once() {
+    // A clone that replayed the exiting iteration would double an entry here.
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        function effectsThenBreak(k: number): string {{
+            let out = \"\";
+            for (let i = 0; i < arr.length; i++) {{ out += arr[i] + \",\"; if (arr[i] === k) break; }}
+            return out;
+        }}
+        console.log(effectsThenBreak(3) + \" \" + effectsThenBreak(0));
+        "
+    ));
+    assert_eq!(out, "0,1,2,3, 0,");
+}
+
+#[test]
+fn labeled_break_still_unwinds_the_outer_loop() {
+    // The regression that gated this change. A labeled break targets an
+    // enclosing loop, so it must unwind past the analysed one; admitting it
+    // into the fast clone dropped the whole partial iteration (4032 vs 4087).
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        let s = 0;
+        outer: for (let r = 0; r < 4; r++) {{
+            for (let i = 0; i < arr.length; i++) {{ s += arr[i]; if (arr[i] === 10 && r === 2) break outer; }}
+        }}
+        console.log(s);
+        "
+    ));
+    assert_eq!(out, "4087");
+}
+
+#[test]
+fn break_in_a_loop_whose_array_grows() {
+    let out = compile_and_run(
+        r#"
+        const a = [1, 2, 3];
+        let s = 0;
+        for (let i = 0; i < a.length; i++) { s += a[i]; if (a.length < 6) a.push(9); if (i === 4) break; }
+        console.log(s + ":" + a.length);
+        "#,
+    );
+    assert_eq!(out, "24:6");
+}
+
+#[test]
+fn throw_inside_the_loop_is_still_correct() {
+    // `throw` is deliberately NOT admitted (the thrown value is constructed),
+    // but it must keep working on the generic path.
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        function throwAt(k: number): string {{
+            try {{
+                let s = 0;
+                for (let i = 0; i < arr.length; i++) {{ s += arr[i]; if (arr[i] === k) throw new Error(\"hit\" + s); }}
+                return \"none\" + s;
+            }} catch (e) {{ return String((e as Error).message); }}
+        }}
+        console.log(throwAt(5) + \" \" + throwAt(999));
+        "
+    ));
+    assert_eq!(out, "hit15 none2016");
+}


### PR DESCRIPTION
Fixes #9151.

`stmt_is_packed_f64_loop_safe` (`loops.rs:5011`) lumped every abrupt statement into a single rejection arm, so a counted loop over a packed array fell to the generic path the moment its body *could* break, continue or return — whether or not the exit was ever taken. Find-first, any/all and early-out scans are exactly that shape, and they were paying 6x for an exit they usually never take.

That all four forms measured identically at 4.75 ns was the tell that this was one gate rather than four.

## Numbers

Quiet Mac mini, node v26.5.1, ns/op, best of 3. Both perry columns are **the same binary**, switched with `PERRY_PACKED_LOOP_ABRUPT`:

| inner-loop body | perry off | perry on | node |
|---|---|---|---|
| `if (l < 0) break;` | 4.75 | **0.58** | 0.54 |
| `if (l < 0) return -1;` | 4.76 | **0.58** | 0.56 |
| `if (l < 0) continue;` | 4.76 | **0.50** | 0.55 |
| `if (l < 0) throw …;` | 4.75 | 4.75 | 0.56 |
| straight-line body | 0.75 | 0.76 | 0.55 |
| `break` in the outer loop | 0.46 | 0.46 | 0.54 |

The array is a bare local, so no receiver or property-lookup effect is involved. `throw` is deliberately left out: the thrown value is normally constructed, and that is a call in the loop body.

## Why it is sound

The relaxation the caller documents already covers these statements:

> A call-free READ body earns the same relaxation the store arm below documents: the entry guard revalidates the actual receiver/layout and the matched body cannot call out or invalidate it … A wrong static hint is one failed guard -> slow clone, never a wrong answer.

`break`, `continue` and a bare `return` do not call out, do not touch the array, and do not invalidate the entry guard; an iteration that exits early simply performs fewer reads than the guard admitted. Two neighbours in this same file already answer `Preserves`/`true` for exactly this set — `stmt_array_length_effect` (`loops.rs:7439`) and `stmt_preserves_array_length` (`loops.rs:7872`). A returned expression is checked with the same `expr_is_packed_f64_loop_safe` as any other operand.

## Unlabeled only — the part that bit me

My first version admitted `LabeledBreak`/`LabeledContinue` too, and it was **a silent wrong answer**:

```ts
outer: for (let r = 0; r < 4; r++) {
  for (let i = 0; i < arr.length; i++) { s += arr[i]; if (arr[i] === 10 && r === 2) break outer; }
}
```

returned **4032** where node returns **4087** — the whole partial iteration was dropped. A labeled break targets an *enclosing* loop and must unwind past the one being analysed, which the fast clone does not do.

The restriction to unlabeled is principled rather than a patch: a nested loop is still rejected by this predicate, so a bare `break` or `continue` can only ever target the loop being analysed, and the clone's exit edge is the right destination.

## Tests — read `labeled_break_still_unwinds_the_outer_loop` first

`crates/perry/tests/packed_loop_abrupt_statements.rs` is the regression pin, and the labeled case above is in it explicitly for the next person who widens this predicate.

**Every fixture actually takes its exit**, at varying indices, with observable effects before it. That is the point rather than thoroughness for its own sake: all of my original timing probes used a never-taken exit, and every one of them passed the broken version. "The fast clone is entered" and "the fast clone is correct when it exits early" are different properties, and only the second one catches this.

Beyond the unit tests, two generated differentials against node:

- 336 cases — 4 array shapes (including single-element and empty) x 3 loop kinds (`for`/`while`/`do-while`) x 3 exit kinds x 4 guard predicates x 3 limits chosen to exit at the first index, the middle, and never — byte-identical to node with the switch both on and off.
- 54 labeled-break/continue cases across nested-loop trip counts and hit positions — byte-identical to node, i.e. the excluded form still lowers correctly.

## Binary size

`size(1)` `.text`: 10,949,332 → 10,949,844, i.e. **+512 bytes (+0.005%)** for 3 newly admitted loops, about 171 bytes per site. This one genuinely adds code — a fast clone is now emitted where none was — but at clone-per-admitted-loop rather than anything that scales with body size.

## Kill switch

`PERRY_PACKED_LOOP_ABRUPT=0` restores the previous behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packed-array counted loops now support unlabeled `break`, `continue`, and safe `return` statements while preserving expected behavior.
  * Loop handling remains compatible with growing arrays and exception paths.
  * The packed-loop optimization can be disabled with `PERRY_PACKED_LOOP_ABRUPT=0`, `off`, or `false`.

* **Bug Fixes**
  * Improved correctness for loop exits, including observable actions performed before exiting.
  * Labeled loop exits and `throw` statements continue to use safe handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->