### PR TITLE
fix(codegen): preserve generator lexical this

### DIFF
--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -474,18 +474,27 @@ pub(crate) fn lower_object_literal(
             protect_handle,
             |ctx, obj| {
                 for (i, (_, value_expr)) in props.iter().enumerate() {
-                    if let Expr::Closure {
-                        params: cparams,
-                        body: cbody,
-                        captures: ccaps,
-                        captures_this: true,
-                        ..
-                    } = value_expr
-                    {
-                        let auto_caps = compute_auto_captures(ctx, cparams, cbody, ccaps);
-                        shape_this_patches
-                            .borrow_mut()
-                            .push((i as u32, auto_caps.len() as u32));
+                    // A synthesized generator iterator's `{ next, return,
+                    // throw }` closures already capture the generator
+                    // invocation's lexical `this`. Rebinding that reserved
+                    // slot to the iterator object makes `this.method()` inside
+                    // a class generator dispatch against the iterator instead
+                    // of the class instance (#9155). Ordinary object-literal
+                    // methods still need the completed object patched in.
+                    if !generator_iterator_object {
+                        if let Expr::Closure {
+                            params: cparams,
+                            body: cbody,
+                            captures: ccaps,
+                            captures_this: true,
+                            ..
+                        } = value_expr
+                        {
+                            let auto_caps = compute_auto_captures(ctx, cparams, cbody, ccaps);
+                            shape_this_patches
+                                .borrow_mut()
+                                .push((i as u32, auto_caps.len() as u32));
+                        }
                     }
                     let v = lower_expr(ctx, value_expr)?;
                     let idx_str = i.to_string();


### PR DESCRIPTION
Fixes #9155.

## Root cause

#9122 taught the object-literal shape-cache path to patch every `captures_this` closure after constructing its object. Synthesized generator iterator objects (`{ next, return, throw }`) are intentionally recognized separately: their step closures already capture the generator invocation's lexical `this`. The generic patch loop overwrote that capture with the iterator object, so class-generator code such as `this.charAt(0)` dispatched against the iterator and threw.

## Fix

Keep recognized generator iterator literals out of the post-build dynamic-`this` patch list. Ordinary object-literal method closures continue to receive their completed object exactly as before.

## Validation

- `cargo fmt --all --check`
- dedicated Linux server: all 5 cases in `issue_6065_class_method_shadows_string_char_access`
- dedicated Linux server: 13 `perry-codegen` object-literal unit tests
- release `compiler-output-regression` job 99242371438 passed before the failed run was cancelled
- release Simulator run 33305506496 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `this` handling in class generator methods.
  * Calls such as `this.method()` now correctly reference the class instance instead of the generator’s internal iterator object.
  * Preserved existing method behavior for regular object literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->