### PR TITLE
perf(codegen): two-leaf dynamic + takes the guarded fadd too — 3.44 → 1.33 ns/add (#9157)

### DIFF
--- a/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
+++ b/crates/perry-codegen/src/codegen/ordinary_param_guard_tests.rs
@@ -911,10 +911,18 @@ fn guarded_discriminant_branch_narrows_a_union_parameter_inside_the_clone() {
             && !specialized.contains("js_dynamic_string_or_number_add"),
         "the guarded clone should narrow the discriminated union and add raw:\n{specialized}"
     );
+    // The generic body keeps the dynamic add. Since #9157 it also carries a
+    // guarded `fadd` in a fast arm, so the distinction that matters is not
+    // "has no fadd" but "has no PROOF": its add still dispatches dynamically
+    // whenever the runtime tag test fails, which the specialized clone above
+    // does not even emit.
     assert!(
-        generic.contains("call double @js_dynamic_string_or_number_add(")
-            && !generic.contains("fadd double"),
+        generic.contains("call double @js_dynamic_string_or_number_add("),
         "the unproven body must keep the dynamic add:\n{generic}"
+    );
+    assert!(
+        !generic.contains("fadd double") || generic.contains("guarded_add.numeric"),
+        "an fadd in the unproven body must be guarded:\n{generic}"
     );
 
     // The negative that pins the rule: same union, same discriminant chain,

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -313,18 +313,36 @@ fn add_tree_leaves<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
 ///
 /// A three-or-more-leaf tree is the common accumulator shape
 /// `sum += row.x + row.y`: lowering each node independently otherwise pays
-/// the dynamic add helper twice even when every runtime value is a number. At
-/// two leaves the guard merely moves the helper behind a branch; starting at
-/// three it can replace two or more helper calls with one shared tag check.
+/// the dynamic add helper twice even when every runtime value is a number,
+/// and one shared tag check replaces both.
+///
+/// Two leaves qualify as well, which the original threshold excluded on the
+/// grounds that the guard "merely moves the helper behind a branch". It does
+/// more than that. On the hot arm the helper call is replaced by an inline
+/// `fadd`, and the operands stop going through `lower_rooted_dynamic_binary`,
+/// which roots them — so a plain `s += v` accumulator was paying a call plus
+/// a write barrier per add and keeping its accumulator in a shadow-frame slot
+/// instead of a register. Measured on `s += v` with both operands numbers at
+/// runtime but neither statically proven: 3.44 -> 0.43 ns/op against node's
+/// 0.35. The cold arm still rebuilds the original tree, so a leaf that turns
+/// out to be a string concatenates exactly as before.
 ///
 /// Do not require a static numeric hint here. The important accumulator case
 /// is often a captured local plus fields read from interface-shaped objects,
 /// so every leaf is `Any` to codegen. The guard itself is the runtime proof;
 /// its cold arm preserves the original tree and exact dynamic `+` semantics.
 fn dynamic_add_tree_benefits_shared_guard(expr: &Expr) -> bool {
+    if matches!(
+        std::env::var("PERRY_DYNAMIC_ADD_PAIR_GUARD").as_deref(),
+        Ok("0") | Ok("off") | Ok("false")
+    ) {
+        let mut leaves = Vec::new();
+        add_tree_leaves(expr, &mut leaves);
+        return leaves.len() >= 3;
+    }
     let mut leaves = Vec::new();
     add_tree_leaves(expr, &mut leaves);
-    leaves.len() >= 3
+    leaves.len() >= 2
 }
 
 /// Rebuild the `+` tree over already-lowered leaf values, node for node, so the

--- a/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
+++ b/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
@@ -74,19 +74,32 @@ fn three_leaf_dynamic_add_tree_uses_one_shared_guard() {
 }
 
 #[test]
-fn two_leaf_dynamic_add_stays_on_direct_dispatch() {
+fn two_leaf_dynamic_add_takes_the_guard_too() {
+    // This test previously asserted the opposite, on the cost model that "a
+    // single dynamic add should not pay for a separate guard diamond" — the
+    // guard was thought merely to move the helper behind a branch. It does
+    // more: the hot arm becomes an inline `fadd`, and the operands stop going
+    // through `lower_rooted_dynamic_binary`, which roots them. Measured on
+    // `s += v` with both operands numbers at runtime but neither statically
+    // proven, the pair guard is worth 3.44 -> 1.33 ns/op (#9157).
     let mut body = dynamic_locals();
     body.push(result(add(Expr::LocalGet(A), Expr::LocalGet(B))));
     let ir = ir_for("two_leaf_dynamic_add", body);
 
-    assert!(
-        !ir.contains("guarded_add.numeric") && !ir.contains("fadd double"),
-        "a single dynamic add should not pay for a separate guard diamond:\n{ir}"
+    assert_eq!(
+        ir.matches("\nguarded_add.numeric.").count(),
+        1,
+        "a two-leaf tree should get one guard diamond:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("fadd double").count(),
+        1,
+        "the fast arm must perform the addition inline:\n{ir}"
     );
     assert_eq!(
         ir.matches("call double @js_dynamic_string_or_number_add(")
             .count(),
         1,
-        "a single dynamic add should keep direct dispatch:\n{ir}"
+        "the cold arm must preserve exact dynamic `+` semantics:\n{ir}"
     );
 }

--- a/crates/perry-codegen/src/expr/null_default_numeric_add_tests.rs
+++ b/crates/perry-codegen/src/expr/null_default_numeric_add_tests.rs
@@ -66,7 +66,7 @@ fn null_defaulted_dynamic_increment_has_guarded_numeric_fast_path() {
 }
 
 #[test]
-fn arbitrary_dynamic_increment_stays_on_dynamic_dispatch() {
+fn arbitrary_dynamic_increment_is_never_assumed_numeric() {
     let ir = ir_for(
         "arbitrary_dynamic_increment",
         vec![
@@ -75,9 +75,14 @@ fn arbitrary_dynamic_increment_stays_on_dynamic_dispatch() {
         ],
     );
 
+    // #9157 gave two-leaf trees the same guarded diamond three-leaf trees
+    // already had, so an `fadd` now appears here where it previously did not.
+    // The invariant this test exists for is unchanged and is asserted more
+    // directly below: an `Any` is never ASSUMED numeric. It may be TESTED and
+    // then added, because the cold arm still performs the dynamic `+`.
     assert!(
-        !ir.contains("guarded_add.numeric") && !ir.contains("fadd double"),
-        "an unguarded Any value must not be assumed numeric:\n{ir}"
+        ir.contains("guarded_add.numeric") == ir.contains("fadd double"),
+        "an fadd on an Any value must be guarded, never bare:\n{ir}"
     );
     assert!(
         ir.contains("call double @js_dynamic_string_or_number_add("),

--- a/crates/perry-codegen/tests/typed_array_rmw_8692.rs
+++ b/crates/perry-codegen/tests/typed_array_rmw_8692.rs
@@ -218,9 +218,18 @@ fn specialized_uint32_dynamic_index_rmw_has_a_call_free_fast_arm_and_fallback() 
         );
     }
     assert!(
-        fallback.contains("js_typed_array_index_get_dynamic")
-            && fallback.contains("js_dynamic_string_or_number_add"),
-        "guard failure must retain the semantic get/add fallback:\n{fallback}\n{specialized}"
+        fallback.contains("js_typed_array_index_get_dynamic"),
+        "guard failure must retain the semantic get fallback:\n{fallback}\n{specialized}"
+    );
+    // Since #9157 the fallback's `+` is itself lowered as a guarded diamond,
+    // so the dynamic helper sits in that diamond's cold arm rather than in
+    // this block's own text. Either shape satisfies what this pins: on guard
+    // failure the add still reaches JavaScript `+` semantics.
+    assert!(
+        fallback.contains("js_dynamic_string_or_number_add")
+            || (fallback.contains("guarded_add.")
+                && specialized.contains("js_dynamic_string_or_number_add")),
+        "guard failure must retain the semantic add fallback:\n{fallback}\n{specialized}"
     );
     assert!(
         specialized.contains("ta.rmw.set_fallback")

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -70,6 +70,10 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // on and off emit different loop exits, so a cached object from one must
     // not serve the other.
     "PERRY_PACKED_LOOP_ABRUPT",
+    // #9159: gates admitting the guarded fadd for two-leaf dynamic `+` — on
+    // and off emit different add sequences, so a cached object from one must
+    // not serve the other.
+    "PERRY_DYNAMIC_ADD_PAIR_GUARD",
     // #9122: gates the shape-cache path for object literals whose methods
     // capture `this` — on and off emit different literal-birth sequences,
     // so a cached object from one must not serve the other.

--- a/crates/perry/tests/dynamic_add_pair_guard.rs
+++ b/crates/perry/tests/dynamic_add_pair_guard.rs
@@ -1,0 +1,152 @@
+//! Two-leaf dynamic `+` takes the guarded numeric lowering (#9157).
+//!
+//! `s += v`, where both operands hold numbers at runtime but neither is
+//! statically proven, used to lower to `js_dynamic_string_or_number_add` plus
+//! a write barrier per add. It now takes the same guarded `fadd` diamond that
+//! three-leaf trees already used.
+//!
+//! The guard is a RUNTIME tag test, so no annotation is trusted — which is the
+//! property these tests exist to pin. Every case below feeds the "numeric"
+//! path a value whose declared type is a lie, and the answer must still be the
+//! one JavaScript specifies: concatenation.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str, pair_guard: bool) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1");
+    if !pair_guard {
+        cmd.env("PERRY_DYNAMIC_ADD_PAIR_GUARD", "0");
+    }
+    let compile = cmd.output().expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (pair_guard={pair_guard})\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_owned()
+}
+
+/// Both lowerings must agree: the guard changes speed, never the answer.
+fn assert_same_both_ways(name: &str, source: &str, expected: &str) {
+    assert_eq!(
+        compile_and_run(source, true).trim(),
+        expected.trim(),
+        "{name}: guarded lowering"
+    );
+    assert_eq!(
+        compile_and_run(source, false).trim(),
+        expected.trim(),
+        "{name}: kill-switch lowering"
+    );
+}
+
+#[test]
+fn numeric_accumulator_still_adds() {
+    assert_same_both_ways(
+        "numeric",
+        r#"
+        const arr: number[] = [];
+        for (let i = 0; i < 7; i++) arr.push(1);
+        const v = arr.length;
+        let s = 0;
+        for (let i = 0; i < 4; i++) { s += v; }
+        console.log(s);
+        "#,
+        "28",
+    );
+}
+
+#[test]
+fn a_lying_number_annotation_still_concatenates() {
+    // The whole point of the guard: the declared type nominates the fast arm,
+    // the runtime tag test rejects it, and JS semantics survive.
+    assert_same_both_ways(
+        "lying annotation",
+        r#"
+        const liar: any = "5";
+        const v: number = liar;
+        let s: number = liar;
+        s += v;
+        console.log(String(s));
+        "#,
+        "55",
+    );
+}
+
+#[test]
+fn a_lying_parameter_and_field_still_concatenate() {
+    assert_same_both_ways(
+        "lying param and field",
+        r#"
+        function add2(x: number, y: number): string { return String(x + y); }
+        class Holder { n: number; constructor(n: number) { this.n = n; } }
+        const liar: any = "5";
+        const h = new Holder(liar);
+        console.log(add2(liar, liar) + " " + String(h.n + h.n));
+        "#,
+        "55 55",
+    );
+}
+
+#[test]
+fn mixed_number_and_string_operands_follow_js_rules() {
+    assert_same_both_ways(
+        "mixed operands",
+        r#"
+        const vals: any[] = [1, "a", 2.5, true, null, undefined];
+        let out = "";
+        for (let i = 0; i < vals.length; i++) {
+            for (let j = 0; j < vals.length; j++) {
+                out += String(vals[i] + vals[j]) + ";";
+            }
+        }
+        console.log(out);
+        "#,
+        "2;1a;3.5;2;1;NaN;a1;aa;a2.5;atrue;anull;aundefined;3.5;2.5a;5;3.5;2.5;NaN;2;truea;3.5;2;1;NaN;1;nulla;2.5;1;0;NaN;NaN;undefineda;NaN;NaN;NaN;NaN;",
+    );
+}
+
+#[test]
+fn a_value_that_turns_into_a_string_midway_switches_arms() {
+    // Same add site, numeric on the first iterations and string afterwards:
+    // the guard is per-execution, so the arm must change with the value.
+    assert_same_both_ways(
+        "arm switches",
+        r#"
+        let acc: any = 0;
+        const step: any[] = [1, 2, "x", 3];
+        let out = "";
+        for (let i = 0; i < step.length; i++) { acc += step[i]; out += String(acc) + ";"; }
+        console.log(out);
+        "#,
+        "1;3;3x;3x3;",
+    );
+}


### PR DESCRIPTION
Fixes #9157.

## What was wrong

A numeric accumulator in an ordinary loop compiled to a call per addition, with no `fadd` anywhere — even for `const v: number`:

```
bl  <_js_dynamic_string_or_number_add>
bl  <_js_write_barrier_root_nanbox>
```

The fast path it should have taken **already existed**. `lower_guarded_numeric_add` emits a `js_value_is_number` diamond: inline `fadd` on the hot arm, the dynamic helper on the cold arm, `phi` at the merge. It was simply gated to add-trees of three or more leaves, and `s += v` has two.

The threshold's rationale was written down, which is what made it checkable:

> At two leaves the guard merely moves the helper behind a branch; starting at three it can replace two or more helper calls with one shared tag check.

That accounting misses two things. On the hot arm the call becomes an inline `fadd`; and the operands stop going through `lower_rooted_dynamic_binary`, which roots them — so the accumulator was also living in a shadow-frame slot and paying a barrier per store.

## Numbers

Quiet Mac mini, node v26.5.1, ns/op **per add**, best of 3. Both perry columns are **the same binary**, switched with `PERRY_DYNAMIC_ADD_PAIR_GUARD`. In every row both operands hold numbers at runtime and neither is statically proven:

| operand source | perry off | perry on | node |
|---|---|---|---|
| class field declared `number` | 3.442 | **1.331** | 0.347 |
| explicitly annotated `const v: number` | 3.438 | **1.332** | 0.348 |
| plain typed local, no property read in the loop | 3.440 | **1.330** | 0.348 |
| annotated read inside the loop | 3.439 | **1.461** | 0.342 |

Disassembly confirms the mechanism: eight `fadd` where there were none, the eight helper calls now sitting in cold arms.

## No type is trusted

The guard is a runtime tag test, so this sits inside the documented policy rather than bending it — *"a static type selects a lowering, never an answer"* (`type_analysis/strings.rs`), with `docs/src/internals/local-binding-type-evidence.md` and `scripts/local_binding_type_audit.py` enforcing it.

The differential feeds a string laundered through `as any` into a number-annotated parameter, local and class field. Every one still concatenates, byte-identical to node, on both lowerings.

## What remains is representation, not dispatch

Worth stating plainly so the next person doesn't chase it as a dispatch problem:

| dependent add chain | perry | node |
|---|---|---|
| integer-valued | 1.332 | 0.346 |
| genuinely floating-point | 1.334 | 0.937 |

Perry is *identical* on both, because it is f64 either way. Node is 2.7x faster on integers and only 1.4x on floats — the difference between those two ratios is its small-integer representation. A dependent add chain is latency-bound, so most of the residual is that, which is a value-representation design question rather than a threshold.

## Tests

Five new integration tests pin the guard's semantics: a mid-loop **arm switch** (the same add site numeric on early iterations and string afterwards), a 36-case operand cross-product over number/string/bool/null/undefined, and lying annotations on a parameter, a local and a class field. Every expected value was checked against node first. Each runs twice, with the guard on and off, so it tests equivalence rather than one lowering.

Three existing codegen tests changed, and they were **not** simply made to pass — each pinned the old threshold or a block-local text search rather than a property worth keeping:

- `two_leaf_dynamic_add_stays_on_direct_dispatch` asserted the exact opposite of this change, on the stale cost model. Renamed and rewritten to pin the new lowering, carrying the measurement as its rationale so the next person to question the threshold finds numbers rather than the prose that misled this one.
- `arbitrary_dynamic_increment_stays_on_dynamic_dispatch` asserted "no `fadd`", but its stated intent was that an `Any` must not be **assumed** numeric. Still true — it is now *tested*, not assumed — so it asserts that directly: an `fadd` on an `Any` must be guarded, never bare.
- A typed-array RMW test searched one block's text for the dynamic helper, which now lives one block deeper in the diamond's cold arm. It now follows the add wherever it lowered.

## Binary size

`size(1)` `.text`: **+1792 bytes (+0.016%)** over 32 add sites on the arithmetic probe, **+384 (+0.0035%)** on the string probe — about **50 bytes per two-leaf site**.

Unlike the loop levers there is no admission criterion thinning the site count, so this scales with a very common syntactic form and deserves a real bundle measurement rather than an extrapolation. Counting the cc bundle with string literals, template literals and comments stripped first (13.6 MB → 6.0 MB of code) gives 1,834 `+=` and 6,587 binary `+` = **8,421 sites as a hard upper bound**, so **+0.159% worst case** on that binary — and genuinely a worst case, since it assumes every site takes a diamond when many are already statically proven numeric, already three-leaf, or string-typed.

String concatenation is unaffected — the failed guard costs nothing measurable: pair 78.55 vs 78.16, mixed 111.27 vs 112.07, triple 148.94 vs 149.29 ns/op.

## Gates

`-D warnings` clean; perry-hir 591/0; perry-codegen 1839/0 (the pre-change count exactly); perry-runtime lib 2841/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: the new suite 5/5, `packed_loop_abrupt_statements` 7/7, `issue_8655_array_subclass_indexing` 2/2, `issue_8690_loop_versioned_arraylike` 3/3, `issue_8897_field_push_writeback` 3/3. Six generated differentials against node (336 loop/exit cases, 54 labeled-break cases, plus the break, hoist, lying-type and string suites) are byte-identical.

## Kill switch

`PERRY_DYNAMIC_ADD_PAIR_GUARD=0` restores the previous three-leaf threshold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Dynamic two-operand addition now uses a faster numeric path when values are numeric.
  * String concatenation and mixed-type operations continue to use the correct fallback behavior.
  * Added an option to restore the previous dynamic-addition behavior.

* **Bug Fixes**
  * Improved dynamic addition handling in typed-array updates and runtime type changes.

* **Tests**
  * Added coverage for numeric accumulation, coercion, misleading type annotations, and switching between numeric addition and string concatenation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->