### PR TITLE
fix(codegen): guard erased BigInt arithmetic results

### DIFF
--- a/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
+++ b/crates/perry-codegen/src/expr/dynamic_add_tree_tests.rs
@@ -20,9 +20,33 @@ fn any_local(id: u32, name: &str, init: Expr) -> Stmt {
     }
 }
 
+fn erased_bigint_local(id: u32, name: &str, value: &str) -> Vec<Stmt> {
+    vec![
+        Stmt::Let {
+            id,
+            name: name.to_string(),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(Expr::Undefined),
+        },
+        Stmt::Expr(Expr::LocalSet(
+            id,
+            Box::new(Expr::BigInt(value.to_string())),
+        )),
+    ]
+}
+
 fn add(left: Expr, right: Expr) -> Expr {
     Expr::Binary {
         op: BinaryOp::Add,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+fn arithmetic(op: BinaryOp, left: Expr, right: Expr) -> Expr {
+    Expr::Binary {
+        op,
         left: Box::new(left),
         right: Box::new(right),
     }
@@ -102,4 +126,33 @@ fn two_leaf_dynamic_add_takes_the_guard_too() {
         1,
         "the cold arm must preserve exact dynamic `+` semantics:\n{ir}"
     );
+}
+
+#[test]
+fn dynamic_arithmetic_results_are_guarded_before_add() {
+    // #9143: for-of element bindings can be `Any` even when their runtime
+    // values are BigInts. The nested arithmetic helpers preserve BigInt, so
+    // their boxed results must not feed an unconditional native `fadd`.
+    let mut body = erased_bigint_local(A, "a", "123456789012345678901234567890");
+    body.extend(erased_bigint_local(B, "d", "1000000007"));
+    let quotient = arithmetic(BinaryOp::Div, Expr::LocalGet(A), Expr::LocalGet(B));
+    let product = arithmetic(BinaryOp::Mul, quotient, Expr::LocalGet(B));
+    let remainder = arithmetic(BinaryOp::Mod, Expr::LocalGet(A), Expr::LocalGet(B));
+    body.push(result(add(product, remainder)));
+    let ir = ir_for("dynamic_bigint_identity_add", body);
+
+    assert!(
+        ir.contains("\nguarded_add.numeric."),
+        "possibly-BigInt arithmetic results need a runtime number guard:\n{ir}"
+    );
+    assert!(
+        ir.contains("call double @js_dynamic_string_or_number_add("),
+        "the non-number arm must preserve BigInt addition:\n{ir}"
+    );
+    for helper in ["js_dynamic_div", "js_dynamic_mul", "js_dynamic_mod"] {
+        assert!(
+            ir.contains(&format!("call double @{helper}(")),
+            "the arithmetic subtree must retain {helper}:\n{ir}"
+        );
+    }
 }

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -205,7 +205,24 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             left,
             right,
         } => is_numeric_expr(ctx, left) && is_numeric_expr(ctx, right),
-        Expr::Binary { op, .. } => !matches!(op, BinaryOp::Add),
+        // Non-`+` arithmetic is numeric only when it cannot successfully
+        // produce a BigInt. With two erased operands, the lowering uses a
+        // BigInt-aware dynamic helper whose result may be a NaN-boxed BigInt;
+        // claiming that value is a raw double lets an enclosing operation
+        // perform native floating-point arithmetic on the box. For example,
+        // #9143's `(a / d) * d + (a % d)` treated both subtrees as doubles and
+        // `fadd` propagated the left NaN payload, silently dropping `% d`.
+        //
+        // One provably non-BigInt operand is enough: a mixed BigInt operation
+        // throws, while every successful result is then a Number. `>>>` is
+        // always Number-producing (or throws on BigInt), regardless of its
+        // operand proofs.
+        Expr::Binary {
+            op: BinaryOp::UShr, ..
+        } => true,
+        Expr::Binary { left, right, .. } => {
+            is_provably_not_bigint(ctx, left) || is_provably_not_bigint(ctx, right)
+        }
         // `x++`/`x--`/`++x`/`--x` evaluates to `ToNumeric(x) ± 1`, a Number —
         // EXCEPT when `x` is a BigInt, where it stays a BigInt (`5n++` → `6n`).
         // So this is NOT unconditionally numeric: mirror the `LocalGet` arm's
@@ -654,12 +671,10 @@ pub(crate) fn is_provably_not_bigint(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         return false;
     }
     // Handle arithmetic/bitwise/unary nodes STRUCTURALLY, before the
-    // `is_numeric_expr` shortcut below. `is_numeric_expr` blanket-treats every
-    // non-`Add` binary and every `-x`/`+x`/`~x` unary as numeric — fine for its
-    // own callers (they guard BigInt upstream), but it would over-approximate
-    // here: `anyA ^ anyB` could be `bigint ^ bigint` (a BigInt result), yet
-    // `is_bigint_expr` can't see it when both operands are `Any`. The
-    // structural rules recurse into the operands instead.
+    // `is_numeric_expr` shortcut below. This avoids a predicate cycle and
+    // directly answers the relevant ToNumeric question: `anyA ^ anyB` could
+    // be `bigint ^ bigint` (a BigInt result), even though `is_bigint_expr`
+    // cannot see it when both operands are `Any`.
     match e {
         // Every arithmetic / bitwise binary op yields a BigInt ONLY when BOTH
         // operands `ToNumeric` to BigInt (a mixed operand throws; a string

--- a/test-files/test_gap_9143_bigint_for_of_compound.ts
+++ b/test-files/test_gap_9143_bigint_for_of_compound.ts
@@ -1,0 +1,16 @@
+// Regression for #9143: BigInt operands bound by for-of must stay tagged
+// through nested arithmetic. The add previously treated the left subtree as
+// a Number and silently discarded the remainder term.
+
+for (const a of [123456789012345678901234567890n]) {
+  for (const d of [1000000007n]) {
+    console.log("identity", (a / d) * d + (a % d));
+    console.log("quotient", a / d);
+    console.log("remainder", a % d);
+    console.log("matches", (a / d) * d + (a % d) === a);
+  }
+}
+
+const plainA = 123456789012345678901234567890n;
+const plainD = 1000000007n;
+console.log("plain", (plainA / plainD) * plainD + (plainA % plainD));


### PR DESCRIPTION
Fixes #9143.

## Summary
- classify non-add arithmetic as numeric only when a successful result cannot be a BigInt
- keep `>>>` on its always-Number result path
- add IR coverage for erased BigInt arithmetic and an end-to-end `for...of` parity regression

## Testing
- `cargo test -p perry-codegen --lib` (1357 passed, 1 ignored)
- `./run_parity_tests.sh --filter test_gap_9143` (1/1 passed)
- direct Node/Perry output comparison on `perrymaster.skelpo.net`
- `cargo fmt --all --check`
- `git diff --check`

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic arithmetic handling for BigInt values in nested calculations.
  * Preserved BigInt behavior for compound arithmetic inside nested `for-of` loops.
  * Improved numeric type detection for division, multiplication, modulo, and related operations.

* **Tests**
  * Added regression coverage for dynamic arithmetic and BigInt identity calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->