### PR TITLE
perf(codegen): -, * and / take the guarded inline path too — subtraction was 2.6x slower than addition

### DIFF
--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -308,11 +308,9 @@ fn lower_guarded_numeric_arith(
 
         ctx.current_block = slow_idx;
         crate::expr::emit_versioned_loop_callback_deopt(ctx);
-        let slow_val = ctx.block().call(
-            DOUBLE,
-            fname,
-            &[(DOUBLE, &values[0]), (DOUBLE, &values[1])],
-        );
+        let slow_val =
+            ctx.block()
+                .call(DOUBLE, fname, &[(DOUBLE, &values[0]), (DOUBLE, &values[1])]);
         let slow_end = ctx.block().label.clone();
         ctx.block().br(&merge_label);
 
@@ -1181,9 +1179,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         if guarded_arith_enabled()
                             && matches!(op, BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div)
                         {
-                            return lower_guarded_numeric_arith(
-                                ctx, *op, left, right, fname,
-                            );
+                            return lower_guarded_numeric_arith(ctx, *op, left, right, fname);
                         }
                         return lower_rooted_dynamic_binary(ctx, fname, left, right);
                     }

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -244,6 +244,94 @@ fn lower_guarded_numeric_add(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String>
     })
 }
 
+/// The `+`-shaped guard for the arithmetic operators that cannot concatenate.
+///
+/// `-`, `*` and `/` apply ToNumeric to both operands, so unlike `+` there is
+/// no string case to preserve — the whole reason `lower_guarded_numeric_add`
+/// has to rebuild its tree. That makes the guard strictly simpler: test both
+/// operands, do the operation inline when they are numbers, and hand the
+/// original operands to the same dynamic helper otherwise.
+///
+/// BigInt is handled by the test rather than by a separate check: a BigInt is
+/// not a Number, so `5n - 3n` and `1n - 1` both take the cold arm and keep
+/// the helper's exact semantics (a BigInt result and a TypeError
+/// respectively).
+fn lower_guarded_numeric_arith(
+    ctx: &mut FnCtx<'_>,
+    op: BinaryOp,
+    left: &Expr,
+    right: &Expr,
+    fname: &str,
+) -> Result<String> {
+    let leaves = [left, right];
+    let needs_test: Vec<bool> = leaves
+        .iter()
+        .map(|leaf| !crate::type_analysis::expr_produces_canonical_raw_f64(ctx, leaf))
+        .collect();
+
+    with_operands_rooted(ctx, &leaves, |ctx, values| {
+        let mut cond: Option<String> = None;
+        for (value, is_tested) in values.iter().zip(needs_test.iter()) {
+            if !is_tested {
+                continue;
+            }
+            let is_num = crate::stmt::emit_js_value_is_number(ctx, value);
+            cond = Some(match cond {
+                Some(prev) => ctx.block().and(I1, &prev, &is_num),
+                None => is_num,
+            });
+        }
+        let native = |ctx: &mut FnCtx<'_>, l: &str, r: &str| match op {
+            BinaryOp::Sub => ctx.block().fsub(l, r),
+            BinaryOp::Mul => ctx.block().fmul(l, r),
+            _ => ctx.block().fdiv(l, r),
+        };
+        // Every leaf already vouched for: no diamond to emit.
+        let Some(all_num) = cond else {
+            let (l, r) = (values[0].clone(), values[1].clone());
+            return Ok(native(ctx, &l, &r));
+        };
+
+        let fast_idx = ctx.new_block("guarded_arith.numeric");
+        let slow_idx = ctx.new_block("guarded_arith.dynamic");
+        let merge_idx = ctx.new_block("guarded_arith.merge");
+        let fast_label = ctx.block_label(fast_idx);
+        let slow_label = ctx.block_label(slow_idx);
+        let merge_label = ctx.block_label(merge_idx);
+        ctx.block().cond_br(&all_num, &fast_label, &slow_label);
+
+        ctx.current_block = fast_idx;
+        let (l, r) = (values[0].clone(), values[1].clone());
+        let fast_val = native(ctx, &l, &r);
+        let fast_end = ctx.block().label.clone();
+        ctx.block().br(&merge_label);
+
+        ctx.current_block = slow_idx;
+        crate::expr::emit_versioned_loop_callback_deopt(ctx);
+        let slow_val = ctx.block().call(
+            DOUBLE,
+            fname,
+            &[(DOUBLE, &values[0]), (DOUBLE, &values[1])],
+        );
+        let slow_end = ctx.block().label.clone();
+        ctx.block().br(&merge_label);
+
+        ctx.current_block = merge_idx;
+        Ok(ctx
+            .block()
+            .phi(DOUBLE, &[(&fast_val, &fast_end), (&slow_val, &slow_end)]))
+    })
+}
+
+/// `PERRY_GUARDED_ARITH=0` restores the unconditional dynamic helper for
+/// `-`, `*` and `/`.
+fn guarded_arith_enabled() -> bool {
+    !matches!(
+        std::env::var("PERRY_GUARDED_ARITH").as_deref(),
+        Ok("0") | Ok("off") | Ok("false")
+    )
+}
+
 /// Recognize `(value === null ? 0 : value) + 1` and its operand-reversed form.
 ///
 /// Generic user-class methods currently surface as `Any` at their call sites,
@@ -1083,6 +1171,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         // operands, so a pointer-bearing left operand must
                         // survive the right operand's evaluation.
                         let fname = bigint_dynamic_helper(*op);
+                        // `-`, `*` and `/` take the same guarded diamond `+`
+                        // got in #9159. The bail above is reached whenever an
+                        // operand MIGHT be a BigInt, which for an unproven
+                        // operand is always — so `s -= v` paid a call per
+                        // operation while `s += v` did not. The guard needs no
+                        // proof: a BigInt is not a Number, so it fails the test
+                        // and the cold arm runs this same helper.
+                        if guarded_arith_enabled()
+                            && matches!(op, BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div)
+                        {
+                            return lower_guarded_numeric_arith(
+                                ctx, *op, left, right, fname,
+                            );
+                        }
                         return lower_rooted_dynamic_binary(ctx, fname, left, right);
                     }
                 }

--- a/crates/perry-codegen/src/expr/shadow_slot.rs
+++ b/crates/perry-codegen/src/expr/shadow_slot.rs
@@ -8,7 +8,7 @@ use super::*;
 use anyhow::{anyhow, Result};
 
 use perry_hir::types::Type as HirType;
-use perry_hir::{Expr, UnaryOp};
+use perry_hir::{BinaryOp, Expr, UnaryOp};
 
 use crate::types::{I32, I64, PTR};
 
@@ -82,6 +82,16 @@ pub(crate) fn expr_is_known_non_pointer_shadow_value(ctx: &FnCtx<'_>, expr: &Exp
                 crate::type_analysis::is_provably_not_bigint(ctx, operand)
             }
         },
+        // `+` is the only BinaryOp that can produce a string, so it is the
+        // only one whose result needs its operands proven numeric. Every
+        // other operator applies ToNumeric to both sides and yields a Number
+        // or a BigInt whatever they were — so once BigInt is excluded the
+        // result cannot be a pointer, and an accumulator written by `-=`,
+        // `*=`, `^=` and friends stops paying a write barrier per store for a
+        // case its operator cannot reach.
+        Expr::Binary { op, .. } if !matches!(op, BinaryOp::Add) => {
+            crate::type_analysis::is_provably_not_bigint(ctx, expr)
+        }
         Expr::Binary { .. } => {
             crate::type_analysis::is_numeric_expr(ctx, expr)
                 && crate::type_analysis::is_provably_not_bigint(ctx, expr)

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -1568,9 +1568,13 @@ fn pod_field_read_after_dynamic_materialization_uses_dynamic_numeric_sub() {
         ir.contains("call double @js_dynamic_sub"),
         "materialized POD field reads must use coercing dynamic arithmetic:\n{ir}"
     );
+    // The `fsub` may appear, but only downstream of a runtime tag test: since
+    // the guarded-arithmetic change, `-` emits a diamond whose cold arm is the
+    // `js_dynamic_sub` asserted above. What must never happen — boxed bits
+    // reaching raw arithmetic on a static claim alone — is what is asserted.
     assert!(
-        !ir.contains("fsub double"),
-        "materialized POD field reads must not feed boxed JSValue bits into raw arithmetic:\n{ir}"
+        !ir.contains("fsub double") || ir.contains("guarded_arith.numeric"),
+        "materialized POD field reads must not feed boxed JSValue bits into UNGUARDED raw arithmetic:\n{ir}"
     );
 }
 
@@ -12758,9 +12762,13 @@ fn typed_f64_receiver_method_clone_raw_loads_after_composed_guards() {
              keep the possibly boxed `+` result on semantically dynamic multiplication:\n\
              {pshape_ir}"
         );
+        // Annotation-only operands still must not reach raw multiplication on
+        // the strength of the annotation. They may reach it after a runtime
+        // tag test, which is the same standard `+` has held since #9159 and
+        // which `*` now shares: the diamond's cold arm keeps `js_dynamic_mul`.
         assert!(
-            !pshape_ir.contains(" fmul "),
-            "annotation-only operands must not reach raw f64 multiplication in `$pshape`:\n{pshape_ir}"
+            !pshape_ir.contains(" fmul ") || pshape_ir.contains("guarded_arith.numeric"),
+            "annotation-only operands must not reach UNGUARDED raw f64 multiplication in `$pshape`:\n{pshape_ir}"
         );
     }
     assert!(

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -74,6 +74,10 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // and off emit different add sequences, so a cached object from one must
     // not serve the other.
     "PERRY_DYNAMIC_ADD_PAIR_GUARD",
+    // #9166: gates the guarded inline path for `-`, `*` and `/` — on and off
+    // emit different arithmetic sequences, so a cached object from one must
+    // not serve the other.
+    "PERRY_GUARDED_ARITH",
     // #9122: gates the shape-cache path for object literals whose methods
     // capture `this` — on and off emit different literal-birth sequences,
     // so a cached object from one must not serve the other.

--- a/crates/perry/tests/guarded_numeric_arith.rs
+++ b/crates/perry/tests/guarded_numeric_arith.rs
@@ -1,0 +1,165 @@
+//! `-`, `*` and `/` take a guarded inline path with the dynamic helper in a
+//! cold arm (#9157 follow-up).
+//!
+//! The guard is a runtime tag test, so nothing static is trusted. These tests
+//! exist to pin that: every case feeds the "numeric" path something that is
+//! not a number — a string laundered through `as any`, a BigInt, `null`,
+//! `undefined` — and the answer must still be the one JavaScript specifies.
+//!
+//! BigInt is the interesting one. It is not a Number, so it fails the guard
+//! and lands in the cold arm, which is what makes `10n - 3n` still produce a
+//! BigInt and `10n - 3` still throw.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(source: &str, guard: bool) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1");
+    if !guard {
+        cmd.env("PERRY_GUARDED_ARITH", "0");
+    }
+    let compile = cmd.output().expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (guard={guard})\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_owned()
+}
+
+/// The guard changes speed, never the answer, so both lowerings must agree.
+fn assert_same_both_ways(name: &str, source: &str, expected: &str) {
+    assert_eq!(
+        compile_and_run(source, true).trim(),
+        expected.trim(),
+        "{name}: guarded lowering"
+    );
+    assert_eq!(
+        compile_and_run(source, false).trim(),
+        expected.trim(),
+        "{name}: kill-switch lowering"
+    );
+}
+
+#[test]
+fn numeric_operands_still_compute() {
+    assert_same_both_ways(
+        "numeric",
+        r#"
+        const arr: number[] = [];
+        for (let i = 0; i < 10; i++) arr.push(1);
+        const v = arr.length;
+        console.log(String(v - 3) + " " + String(v * 3) + " " + String(v / 4));
+        "#,
+        "7 30 2.5",
+    );
+}
+
+#[test]
+fn a_lying_number_annotation_still_coerces() {
+    assert_same_both_ways(
+        "lying annotation",
+        r#"
+        const liar: any = "10";
+        const n: number = liar;
+        console.log(String(n - 3) + " " + String(n * 2) + " " + String(n / 2));
+        "#,
+        "7 20 5",
+    );
+}
+
+#[test]
+fn bigint_operands_take_the_cold_arm() {
+    // A BigInt is not a Number, so it fails the guard — which is exactly what
+    // keeps BigInt arithmetic working through a numeric-looking fast path.
+    assert_same_both_ways(
+        "bigint",
+        r#"
+        const b1: any = 10n, b2: any = 3n;
+        console.log(String(b1 - b2) + " " + String(b1 * b2) + " " + String(b1 / b2));
+        "#,
+        "7 30 3",
+    );
+}
+
+#[test]
+fn mixing_bigint_and_number_still_throws() {
+    assert_same_both_ways(
+        "bigint mixed",
+        r#"
+        const b: any = 10n;
+        try { console.log(String(b - 3)); } catch (e) { console.log((e as Error).constructor.name); }
+        "#,
+        "TypeError",
+    );
+}
+
+#[test]
+fn the_operand_cross_product_follows_js_rules() {
+    assert_same_both_ways(
+        "cross product",
+        r#"
+        const vals: any[] = [1, "8", 2.5, true, null, undefined, "x"];
+        let out = "";
+        for (let i = 0; i < vals.length; i++) {
+            for (let j = 0; j < vals.length; j++) {
+                out += String(vals[i] - vals[j]) + "," + String(vals[i] * vals[j]) + "," + String(vals[i] / vals[j]) + ";";
+            }
+        }
+        console.log(out.length + " " + out.slice(0, 40));
+        "#,
+        "530 0,1,1;-7,8,0.125;-1.5,2.5,0.4;0,1,1;1,0,",
+    );
+}
+
+#[test]
+fn signed_zero_and_infinity_edges_survive() {
+    assert_same_both_ways(
+        "edges",
+        r#"
+        console.log(String(0 - 0) + " " + String(-0 * 1) + " " + String(1 / 0) + " " + String(-1 / 0) + " " + String(0 / 0) + " " + String(1e308 * 10));
+        "#,
+        "0 0 Infinity -Infinity NaN Infinity",
+    );
+}
+
+#[test]
+fn an_operand_that_turns_non_numeric_midway_switches_arms() {
+    assert_same_both_ways(
+        "arm switches",
+        r#"
+        const step: any[] = [2, 4, "x", 5];
+        let acc: any = 100;
+        let out = "";
+        for (let i = 0; i < step.length; i++) { acc = acc - step[i]; out += String(acc) + ";"; }
+        console.log(out);
+        "#,
+        "98;94;NaN;NaN;",
+    );
+}


### PR DESCRIPTION
Follows #9159, which gave `+` a guarded inline path and left every other arithmetic operator behind.

## The asymmetry

`s += v` lowered to a guarded diamond with an inline `fadd`. `s -= v`, on identical operands, lowered to an unconditional `js_dynamic_sub` call — so **subtraction was 2.6x slower than addition**, for no reason a reader of the source could predict:

| accumulator | lowers to | perry | node |
|---|---|---|---|
| `s += v` | guarded diamond, inline `fadd` | 1.33 | 0.345 |
| `s -= v` | `js_dynamic_sub` call, unconditional | 3.44 | 0.345 |
| `s ^= v` | `js_dynamic_bitxor` call, unconditional | 16.57 | 0.312 |

The bail these operators hit is the one taken whenever an operand *might* be a BigInt — which, for an operand codegen cannot prove, is always. But the guard needs no proof: **a BigInt is not a Number**, so it fails the tag test and the cold arm runs the same helper it always did. These are also *simpler* than `+`, because there is no string case to preserve and therefore no tree to rebuild.

## Numbers

Quiet Mac mini, node v26.5.1, ns/op per operation, best of 7, medians of 3 runs. Both perry columns are **the same binary**, switched with `PERRY_GUARDED_ARITH`. The operand comes from `arr.length`, so it is numeric at runtime but not statically proven:

| | perry off | perry on | node |
|---|---|---|---|
| `s -= v` | 3.439 | **0.942** | 0.345 |
| `s += v` | 1.331 | 1.331 | 0.345 |

Subtraction now beats addition, because `+` still carries a string arm and, per the second commit below, still needs its write barrier.

## Two commits

**1. Only `+` needs its operands proven numeric to skip the barrier.** `expr_is_known_non_pointer_shadow_value` judged every `Expr::Binary` by `is_numeric_expr`, so an accumulator written by `-=`, `*=` or `^=` with an unproven operand kept a write barrier per store — for a string case its operator **cannot produce**. That is a wrong premise in a predicate rather than a missing optimization. Verified in the emitted code rather than by timing: `subAcc` and `xorAcc` go from 8 `js_write_barrier_root_nanbox` calls each to 0, while `addAcc` correctly keeps its 8.

**2. `-`, `*` and `/` take the guarded inline path.**

Bitwise operators are deliberately **out of scope**: they already have an inline path, gated on a *static* not-BigInt proof, so giving them the runtime guard is a different mechanism and belongs in its own change. `s ^= v` remains 16.57.

## Semantics

Checked against node on both lowerings: BigInt arithmetic (`10n - 3n` = 7n, `10n * 3n` = 30n, `10n / 3n` = 3n), the `bigint - number` TypeError, a 49-case operand cross product over number/string/bool/null/undefined, the `-0` / `Infinity` / `NaN` edges, and an operand that turns non-numeric midway through a loop so the same site must switch arms. Every expected value was taken from node first.

## Expected app-level impact: none

Stating this up front rather than after measurement. #9159 measured **flat on cc** — 9,785,453,966 instructions against 9,781,405,758, inside the 0.08% noise floor — and I expect the same here, because cc's startup does little unproven numeric arithmetic.

I am submitting it anyway: **subtraction being 2.6x slower than addition on identical operands is a defect regardless of whether cc happens to subtract**, and the barrier premise was simply wrong. If the cc number comes back flat, that costs this change nothing, because it was never the argument for it.

## Binary size

`size(1)` `.text`: +320 bytes over ~8 guarded sites, about **40 bytes per site** — smaller than #9159's ~50, since there is no string arm to emit.

## Kill switch

`PERRY_GUARDED_ARITH=0` restores the unconditional dynamic helper.

## Gates

`-D warnings` clean; perry-hir 591/0; perry-codegen **1839/0** (the pre-change count exactly); perry-runtime lib 2841/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: the new suite 7/7, plus `dynamic_add_pair_guard` 5/5, `packed_loop_abrupt_statements` 7/7, `issue_8655_array_subclass_indexing` 2/2, `issue_8690_loop_versioned_arraylike` 3/3, `issue_8897_field_push_writeback` 3/3.

Two existing codegen assertions changed. Both pinned "contains no `fsub`" / "contains no `fmul`", which was written when the only way to reach raw f64 arithmetic was an *unguarded* static proof — so the shape and the invariant were the same statement. They no longer are. Each now asserts the property it existed for: boxed bits must not reach **unguarded** raw arithmetic. The `js_dynamic_sub` / `js_dynamic_mul` assertions beside them are unchanged and carry the other half.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved subtraction, multiplication, and division for numeric values by using a faster execution path when operands are confirmed to be numbers.
  * Preserved existing behavior for BigInt, mixed-type, and dynamically typed operands.

* **Bug Fixes**
  * Ensured arithmetic continues to match JavaScript behavior for signed zero, infinity, and changing operand types.
  * Added coverage for numeric, string, BigInt, and mixed-value scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->