### PR TITLE
fix(runtime): preserve function expando key order

### DIFF
--- a/changelog.d/9167-function-expando-order.md
+++ b/changelog.d/9167-function-expando-order.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Function-object expando properties now follow ECMAScript own-key ordering:
+  integer-index keys enumerate numerically, while other string keys retain
+  property-creation order. Overwriting a property keeps its position, and
+  deleting and re-adding it moves it to the tail (#9148).

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -6,23 +6,92 @@ use crate::fast_hash::{new_ptr_hash_map, PtrHashMap};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
+/// Per-function dynamic properties with ordinary property-creation order.
+///
+/// Reads stay O(1) through the hash map, while `order` records the string-key
+/// insertion order required by `OrdinaryOwnPropertyKeys`. Updating an existing
+/// property leaves its position unchanged; deleting it removes the position so
+/// a later re-add appends it at the end.
+#[derive(Default)]
+struct ClosureProps {
+    values: HashMap<String, f64>,
+    order: Vec<String>,
+}
+
+impl ClosureProps {
+    fn contains_key(&self, key: &str) -> bool {
+        self.values.contains_key(key)
+    }
+
+    fn get(&self, key: &str) -> Option<&f64> {
+        self.values.get(key)
+    }
+
+    fn insert(&mut self, key: String, value: f64) {
+        if !self.values.contains_key(&key) {
+            self.order.push(key.clone());
+        }
+        self.values.insert(key, value);
+    }
+
+    fn remove(&mut self, key: &str) -> Option<f64> {
+        let value = self.values.remove(key)?;
+        self.order.retain(|existing| existing != key);
+        Some(value)
+    }
+
+    fn merge_older(&mut self, mut older: ClosureProps) {
+        let newer = std::mem::take(self);
+        for key in newer.order {
+            if older.values.contains_key(&key) {
+                continue;
+            }
+            if let Some(value) = newer.values.get(&key).copied() {
+                older.insert(key, value);
+            }
+        }
+        *self = older;
+    }
+
+    fn snapshot(&self) -> Vec<(String, f64)> {
+        let mut indexed = Vec::new();
+        let mut strings = Vec::new();
+        for key in &self.order {
+            let Some(value) = self.values.get(key).copied() else {
+                continue;
+            };
+            if let Some(index) = crate::object::canonical_array_index(key) {
+                indexed.push((index, key.clone(), value));
+            } else {
+                strings.push((key.clone(), value));
+            }
+        }
+        indexed.sort_by_key(|(index, _, _)| *index);
+        indexed
+            .into_iter()
+            .map(|(_, key, value)| (key, value))
+            .chain(strings)
+            .collect()
+    }
+}
+
 per_test_global! {
     /// OUTER key is a closure heap address, probed on every dynamic property
     /// get/set/delete on a function object, so it takes `PtrHasher` for the
     /// same reason as the other pointer-keyed registries (#8125): a raw
     /// address is already well distributed and no external input reaches it.
     ///
-    /// The INNER `HashMap<String, f64>` deliberately keeps std's SipHash. Its
-    /// keys are JS property names, and unlike the descriptor side tables'
-    /// program-identifier keys these can be computed at runtime from program
-    /// input (`fn[userSuppliedName] = 1`), which is exactly the adversarial
-    /// case `RandomState` exists to defend. It is also not the half the
-    /// profile implicates -- `hash_one::<&usize>` is the outer probe.
-    static CLOSURE_PROPS: OnceLock<Mutex<PtrHashMap<usize, HashMap<String, f64>>>> =
+    /// `ClosureProps::values` deliberately keeps std's SipHash. Its keys are JS
+    /// property names, and unlike the descriptor side tables' program-identifier
+    /// keys these can be computed at runtime from program input
+    /// (`fn[userSuppliedName] = 1`), which is exactly the adversarial case
+    /// `RandomState` exists to defend. It is also not the half the profile
+    /// implicates -- `hash_one::<&usize>` is the outer probe.
+    static CLOSURE_PROPS: OnceLock<Mutex<PtrHashMap<usize, ClosureProps>>> =
         OnceLock::new();
 }
 
-fn get_closure_props() -> &'static Mutex<PtrHashMap<usize, HashMap<String, f64>>> {
+fn get_closure_props() -> &'static Mutex<PtrHashMap<usize, ClosureProps>> {
     CLOSURE_PROPS.get_or_init(|| Mutex::new(new_ptr_hash_map()))
 }
 
@@ -126,8 +195,8 @@ pub fn closure_static_prototype(closure_ptr: usize) -> Option<u64> {
         .and_then(|map| map.get(&closure_ptr).copied())
 }
 
-fn barrier_closure_dynamic_props(owner: usize, props: &mut HashMap<String, f64>) {
-    for value in props.values_mut() {
+fn barrier_closure_dynamic_props(owner: usize, props: &mut ClosureProps) {
+    for value in props.values.values_mut() {
         crate::gc::runtime_write_barrier_external_slot(
             owner,
             value as *mut f64 as usize,
@@ -137,13 +206,13 @@ fn barrier_closure_dynamic_props(owner: usize, props: &mut HashMap<String, f64>)
 }
 
 fn merge_closure_prop_map(
-    props: &mut PtrHashMap<usize, HashMap<String, f64>>,
+    props: &mut PtrHashMap<usize, ClosureProps>,
     owner: usize,
-    owner_props: HashMap<String, f64>,
+    owner_props: ClosureProps,
 ) {
     match props.entry(owner) {
         std::collections::hash_map::Entry::Occupied(mut entry) => {
-            entry.get_mut().extend(owner_props);
+            entry.get_mut().merge_older(owner_props);
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
             entry.insert(owner_props);
@@ -265,7 +334,7 @@ pub(crate) fn visit_closure_dynamic_prop_values_mut(owner: usize, mut visit: imp
         return;
     };
 
-    for value in owner_props.values_mut() {
+    for value in owner_props.values.values_mut() {
         visit(value);
     }
 
@@ -351,7 +420,7 @@ pub fn scan_closure_dynamic_props_roots_mut(visitor: &mut crate::gc::RuntimeRoot
         // `CopyingMark` this keeps `fn.errors = [...]` and its transitive
         // contents reachable; in rewrite phases it updates slot bits when a
         // value was forwarded.
-        for value in closure_props.values_mut() {
+        for value in closure_props.values.values_mut() {
             visitor.visit_nanbox_f64_slot(value);
         }
         if new_owner == owner {
@@ -760,7 +829,7 @@ pub(crate) fn closure_set_via_function_prototype_descriptor(
 /// Set a dynamic property on a closure.
 pub fn closure_set_dynamic_prop(ptr: usize, prop: &str, value: f64) {
     if let Ok(mut props) = get_closure_props().lock() {
-        let closure_props = props.entry(ptr).or_insert_with(HashMap::new);
+        let closure_props = props.entry(ptr).or_default();
         closure_props.insert(prop.to_string(), value);
         barrier_closure_dynamic_props(ptr, closure_props);
     }
@@ -808,20 +877,51 @@ pub(crate) fn test_clear_closure_side_tables() {
     }
 }
 
-/// Snapshot every dynamic property on a closure as `(name, value)` pairs.
-/// Sorted alphabetically for stable output (`HashMap` iteration order is
-/// non-deterministic). Used by `format_jsvalue` to emit `[Function: f]
-/// { ownProp: value }` for functions with user-attached properties. See
-/// #1203.
+/// Snapshot every dynamic property on a closure as `(name, value)` pairs in
+/// ECMA-262 own-key order: integer indices ascending, then other strings in
+/// property-creation order. Used by all function-object enumeration paths and
+/// by `format_jsvalue` to emit `[Function: f] { ownProp: value }`. See #1203
+/// and #9148.
 pub fn closure_dynamic_props_snapshot(ptr: usize) -> Vec<(String, f64)> {
     if let Ok(props) = get_closure_props().lock() {
         if let Some(map) = props.get(&ptr) {
-            let mut out: Vec<(String, f64)> = map.iter().map(|(k, v)| (k.clone(), *v)).collect();
-            out.sort_by(|a, b| a.0.cmp(&b.0));
-            return out;
+            return map.snapshot();
         }
     }
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests_9148 {
+    use super::ClosureProps;
+
+    fn names(props: &ClosureProps) -> Vec<String> {
+        props.snapshot().into_iter().map(|(name, _)| name).collect()
+    }
+
+    #[test]
+    fn closure_props_snapshot_uses_ecma_own_key_order() {
+        let mut props = ClosureProps::default();
+        props.insert("tag".to_string(), 1.0);
+        props.insert("other".to_string(), 2.0);
+        props.insert("10".to_string(), 10.0);
+        props.insert("2".to_string(), 2.0);
+
+        assert_eq!(names(&props), ["2", "10", "tag", "other"]);
+    }
+
+    #[test]
+    fn update_keeps_position_and_delete_readd_moves_to_tail() {
+        let mut props = ClosureProps::default();
+        props.insert("tag".to_string(), 1.0);
+        props.insert("other".to_string(), 2.0);
+        props.insert("tag".to_string(), 3.0);
+        assert_eq!(names(&props), ["tag", "other"]);
+
+        assert_eq!(props.remove("tag"), Some(3.0));
+        props.insert("tag".to_string(), 4.0);
+        assert_eq!(names(&props), ["other", "tag"]);
+    }
 }
 
 /// Unbind `this` from a detached method closure.

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -1568,6 +1568,7 @@ fn js_object_get_own_property_names_shape(obj_value: f64) -> f64 {
                 if has_prototype {
                     names.push("prototype".to_string());
                 }
+                sort_property_names_ecma(&mut names);
                 let result = crate::array::js_array_alloc(names.len() as u32);
                 for name in names {
                     let s = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);

--- a/crates/perry/tests/issue_9148_function_expando_order.rs
+++ b/crates/perry/tests/issue_9148_function_expando_order.rs
@@ -1,0 +1,56 @@
+//! #9148: function-object expandos must enumerate in property-creation order.
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+#[test]
+fn function_expandos_follow_ordinary_own_property_key_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = workspace_root().join("test-files/test_issue_9148_function_expando_order.ts");
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "[\"tag\",\"other\"]\n\
+[\"2\",\"10\",\"tag\",\"other\",\"alpha\"]\n\
+[\"two\",\"ten\",1,2,3]\n\
+[[\"2\",\"two\"],[\"10\",\"ten\"],[\"tag\",1],[\"other\",2],[\"alpha\",3]]\n\
+[\"2\",\"10\",\"tag\",\"other\",\"alpha\"]\n\
+[\"2\",\"10\",\"tag\",\"other\",\"alpha\"]\n\
+[\"2\",\"10\",\"tag\",\"other\",\"alpha\"]\n\
+[\"2\",\"10\",\"tag\",\"alpha\",\"other\"]\n\
+[\"2\",\"10\",\"tag\",\"alpha\",\"other\"]\n"
+    );
+}

--- a/test-files/test_issue_9148_function_expando_order.ts
+++ b/test-files/test_issue_9148_function_expando_order.ts
@@ -1,0 +1,34 @@
+// Issue #9148: function-object expandos follow OrdinaryOwnPropertyKeys.
+const f: any = function () {};
+
+f.tag = 1;
+f.other = 2;
+console.log(JSON.stringify(Object.keys(f)));
+
+// Integer-index keys precede strings even when added later. Other strings
+// retain creation order rather than HashMap/alphabetical order.
+f["10"] = "ten";
+f["2"] = "two";
+f.alpha = 3;
+console.log(JSON.stringify(Object.keys(f)));
+console.log(JSON.stringify(Object.values(f)));
+console.log(JSON.stringify(Object.entries(f)));
+
+const forIn: string[] = [];
+for (const key in f) forIn.push(key);
+console.log(JSON.stringify(forIn));
+console.log(JSON.stringify(Object.keys({ ...f })));
+
+// Updating does not move a key; deleting and re-adding does.
+f.tag = 4;
+console.log(JSON.stringify(Object.keys(f)));
+delete f.other;
+f.other = 5;
+console.log(JSON.stringify(Object.keys(f)));
+
+// getOwnPropertyNames includes intrinsic function keys, but its expando
+// subsequence obeys the same integer/string ordering.
+const ownNames = Object.getOwnPropertyNames(f).filter((key: string) =>
+  key === "2" || key === "10" || key === "tag" || key === "alpha" || key === "other"
+);
+console.log(JSON.stringify(ownNames));


### PR DESCRIPTION
## Summary

Preserves ECMA-262 own-key ordering for expando properties attached to function objects. Function expandos now match Node: integer-index keys enumerate numerically first, followed by other strings in property-creation order.

## Changes

- Keep O(1) function-expando lookup while recording property-creation order.
- Preserve overwrite position and move deleted/re-added properties to the tail.
- Apply the shared ECMA ordering helper to the complete function own-property name list.
- Add focused runtime and end-to-end regression coverage for keys, values, entries, `for...in`, spread, and reflection.

## Related issue

Fixes #9148

## Test plan

- [ ] `cargo build --release` clean (not run; equivalent affected targets built with the repository perry-dev profile)
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes (not run verbatim; affected-crate gate passed)
- [x] `cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static`
- [x] `RUST_TEST_THREADS=1 cargo test --profile perry-dev -p perry-runtime tests_9148 -- --test-threads=1`
- [x] `PERRY_RUNTIME_DIR=/root/perry-target-9148/perry-dev cargo test --profile perry-dev -p perry --test issue_9148_function_expando_order`
- [x] `RUST_MIN_STACK=33554432 ./scripts/test_affected_crates.sh --base origin/main`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Added a user-facing regression fixture under `test-files/`.
- [ ] Documentation update (not needed; no public runtime API changed)
- [ ] Platform UI backend build (not applicable)

## Screenshots / output

Before: `Object.keys(f)` produced `["other","tag"]`.

After: `Object.keys(f)` produces `["tag","other"]`, matching Node.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Function-object properties now enumerate in standard ECMAScript key order.
  * Numeric keys appear first in ascending order, followed by string keys in creation order.
  * Updating a property preserves its position, while deleting and re-adding it moves it to the end.
  * Consistent ordering is now applied across keys, values, entries, iteration, spreading, and own-property-name queries.

* **Tests**
  * Added coverage for function-property ordering and related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->