### PR TITLE
test(perry): honor configured runtime dir

### DIFF
--- a/crates/perry/tests/issue_5247_runtime_error_source_location.rs
+++ b/crates/perry/tests/issue_5247_runtime_error_source_location.rs
@@ -57,6 +57,9 @@ fn ensure_runtime_archive() {
 }
 
 fn runtime_dir() -> PathBuf {
+    if let Some(runtime_dir) = std::env::var_os("PERRY_RUNTIME_DIR") {
+        return PathBuf::from(runtime_dir);
+    }
     ensure_runtime_archive();
     target_debug_dir()
 }


### PR DESCRIPTION
Closes #9174.

The release/full-CI shard already prebuilds exact release archives and exports PERRY_RUNTIME_DIR. This fixture was the exception: it ignored that path and hardcoded target/debug, allowing a restored archive stamped with the previous commit to fail the provenance guard before the test ran.

Honor PERRY_RUNTIME_DIR when supplied and preserve the existing build/debug fallback for ordinary local runs.

The failure was reproduced on the dedicated Linux server with compiler 69ab025b828 and cached runtime 16e739df359. The surrounding source-graph and trusted-box suites are green; this change only corrects fixture setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression test setup by supporting a configurable runtime directory through an environment variable.
  * Ensured test compilation uses the configured runtime location consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->