### PR TITLE
perf(runtime): registry probes stop paying a hash and a mutex to say "no" (5.3% of cc --help)

### DIFF
--- a/changelog.d/9176-registry-probe-prefilter.md
+++ b/changelog.d/9176-registry-probe-prefilter.md
@@ -1,0 +1,29 @@
+`is_registered_buffer` and `is_uint8array_buffer` sit on generic paths — every
+untyped element access reaches the second one — and both had an idle latch that
+stops helping the moment a program registers its first buffer. After that, all
+~216 probe sites paid a TLS access, a `RefCell` borrow and a hash lookup to ask
+whether an arbitrary pointer was a buffer, and almost every caller was asking
+about something that was not. Together they were 5.3% of `cc --help`.
+
+Each thread-local registry now tracks the smallest and largest address ever
+inserted, as a conservative filter in front of the hash. The range only widens
+and every registration extends it before inserting, so an address outside it
+cannot be in the set: rejecting is sound and accepting falls through to the
+lookup that was already there. `PERRY_BUFFER_RANGE_FILTER=0` restores the
+unconditional lookup.
+
+`is_uint8array_buffer_slow` also took the process-global mutex on every
+thread-local miss — the one probe in this family whose miss cost a lock rather
+than a hash. It now consults that registry only behind a
+`EXTERNAL_UINT8ARRAYS_NONEMPTY` latch, matching the gate
+`is_registered_buffer_slow` already had.
+
+That latch made the two inserters into the global registry a matched pair, and
+`js_buffer_mark_as_crypto_key_external` was not arming it — so a WebCrypto key
+registered on one thread became invisible to `is_uint8array_buffer` on every
+other thread: the address was in the registry and the probe answered "no". The
+registry is process-global precisely to be visible across threads, and the
+thread-local set that masks the bug on the registering thread covers no other.
+Both inserters now go through one helper that arms before inserting, and
+`buffer/header_latch_tests.rs` asks from a fresh thread, which is the only
+vantage point where the thread-local set cannot answer first.

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -21,7 +21,7 @@ fn buffer_payload_size(capacity: usize) -> usize {
 /// Since BufferHeader has the same layout as ArrayHeader (no type_id field),
 /// we track buffer pointers separately to distinguish them from arrays.
 use crate::fast_hash::{new_ptr_hash_map, new_ptr_hash_set, PtrHashMap, PtrHashSet};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
@@ -33,6 +33,15 @@ static EXTERNAL_BUFFER_REGISTRY: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new
 static EXTERNAL_BUFFERS_NONEMPTY: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 static EXTERNAL_UINT8ARRAY_REGISTRY: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+/// Latched by the first external Uint8Array registration, exactly as
+/// `EXTERNAL_BUFFERS_NONEMPTY` does for buffers.
+///
+/// Without it `is_uint8array_buffer_slow` took the global mutex on every
+/// thread-local MISS — that is, on every value that is not a Uint8Array —
+/// which is the cost `UINT8ARRAY_EVER_MARKED` was added to avoid and which
+/// came straight back the moment any program marked its first Uint8Array.
+static EXTERNAL_UINT8ARRAYS_NONEMPTY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 static EXTERNAL_CRYPTO_KEY_META_REGISTRY: OnceLock<Mutex<HashMap<usize, CryptoKeyMeta>>> =
     OnceLock::new();
 
@@ -78,6 +87,22 @@ pub type CryptoKeyMeta = (u8, u8, u8, bool, u32, u32);
 
 crate::perry_thread_local! {
     static BUFFER_REGISTRY: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
+
+    /// Smallest and largest address ever inserted into `BUFFER_REGISTRY` on
+    /// this thread, as a conservative filter in front of the hash lookup.
+    ///
+    /// The latch above answers "has anything EVER been registered?", which
+    /// stops being useful the moment a program registers its first buffer —
+    /// after that all ~216 probe sites pay a TLS access, a `RefCell` borrow
+    /// and a hash lookup to ask whether an arbitrary pointer is a buffer, and
+    /// almost every caller is asking about something that is not one.
+    ///
+    /// The range only ever widens and every registration extends it before
+    /// inserting, so an address outside it cannot be in the set: rejecting is
+    /// sound, and accepting merely falls through to the lookup that was
+    /// already there. Thread-local like the registry it guards, so there is
+    /// no ordering to reason about.
+    static BUFFER_ADDR_RANGE: Cell<(usize, usize)> = const { Cell::new((usize::MAX, 0)) };
     /// `BufferHeader` wrappers whose bytes live in memory owned by native
     /// code. The wrapper itself is an ordinary, non-moving GC object; only
     /// its data pointer is external. `bun:ffi.toArrayBuffer`/`toBuffer` use
@@ -87,6 +112,10 @@ crate::perry_thread_local! {
     /// Buffers that were specifically created via `new Uint8Array(...)` —
     /// formatted as `Uint8Array(N) [ a, b, c ]` instead of `<Buffer aa bb cc>`.
     static UINT8ARRAY_FROM_CTOR: RefCell<PtrHashSet<usize>> = RefCell::new(new_ptr_hash_set());
+
+    /// Address range of `UINT8ARRAY_FROM_CTOR`, on the same terms as
+    /// `BUFFER_ADDR_RANGE`.
+    static UINT8ARRAY_ADDR_RANGE: Cell<(usize, usize)> = const { Cell::new((usize::MAX, 0)) };
     /// Issue #579: buffers allocated as `new ArrayBuffer(n)` — sources that
     /// `new Uint8Array(ab)` should ALIAS rather than copy. Survives across
     /// `mark_as_uint8array` calls so a second view of the same ArrayBuffer
@@ -276,7 +305,12 @@ pub fn register_buffer(ptr: *const BufferHeader) {
     // this buffer is in the registry while `is_registered_buffer` still takes
     // the idle fast path and denies it. See `crate::registry_latch`.
     BUFFER_LIKE_EVER_REGISTERED.arm();
-    BUFFER_REGISTRY.with(|r| r.borrow_mut().insert(ptr as usize));
+    let addr = ptr as usize;
+    BUFFER_ADDR_RANGE.with(|r| {
+        let (lo, hi) = r.get();
+        r.set((lo.min(addr), hi.max(addr)));
+    });
+    BUFFER_REGISTRY.with(|r| r.borrow_mut().insert(addr));
 }
 
 /// Historical tier boundary, retained for callers that size test fixtures
@@ -306,10 +340,30 @@ pub fn is_registered_buffer(addr: usize) -> bool {
     is_registered_buffer_slow(addr)
 }
 
+/// `PERRY_BUFFER_RANGE_FILTER=0` restores the unconditional hash lookup.
+fn buffer_range_filter_enabled() -> bool {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        !matches!(
+            std::env::var("PERRY_BUFFER_RANGE_FILTER").as_deref(),
+            Ok("0") | Ok("off") | Ok("false")
+        )
+    })
+}
+
 /// Out of line so the idle check inlines into its ~200 call sites.
 #[inline(never)]
 fn is_registered_buffer_slow(addr: usize) -> bool {
-    if BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr)) {
+    // Outside the registered range ⟹ not in the thread-local set, so skip the
+    // borrow and the hash. The external and shared-SAB registries below keep
+    // their own gates and are unaffected.
+    let (lo, hi) = if buffer_range_filter_enabled() {
+        BUFFER_ADDR_RANGE.with(|r| r.get())
+    } else {
+        (0, usize::MAX)
+    };
+    if addr >= lo && addr <= hi && BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr)) {
         return true;
     }
     if EXTERNAL_BUFFERS_NONEMPTY.load(std::sync::atomic::Ordering::Acquire)
@@ -330,6 +384,10 @@ fn is_registered_buffer_slow(addr: usize) -> bool {
 /// formats as `Uint8Array(N) [ ... ]` rather than `<Buffer ...>`.
 pub fn mark_as_uint8array(addr: usize) {
     UINT8ARRAY_EVER_MARKED.arm();
+    UINT8ARRAY_ADDR_RANGE.with(|r| {
+        let (lo, hi) = r.get();
+        r.set((lo.min(addr), hi.max(addr)));
+    });
     UINT8ARRAY_FROM_CTOR.with(|r| {
         r.borrow_mut().insert(addr);
     });
@@ -350,6 +408,10 @@ pub extern "C" fn js_buffer_register_external(addr: usize) {
 #[no_mangle]
 pub extern "C" fn js_buffer_mark_as_uint8array_external(addr: usize) {
     mark_as_uint8array(addr);
+    // Latch BEFORE the insert, matching `js_buffer_register_external`: a
+    // probe that observed the latch after the insert-but-before-the-store
+    // window would skip the mutex and miss an already-registered address.
+    EXTERNAL_UINT8ARRAYS_NONEMPTY.store(true, std::sync::atomic::Ordering::Release);
     if let Ok(mut r) = external_uint8arrays().lock() {
         r.insert(addr);
     }
@@ -505,8 +567,19 @@ pub fn is_uint8array_buffer(addr: usize) -> bool {
 
 #[inline(never)]
 fn is_uint8array_buffer_slow(addr: usize) -> bool {
-    UINT8ARRAY_FROM_CTOR.with(|r| r.borrow().contains(&addr))
-        || external_uint8arrays()
+    let (lo, hi) = if buffer_range_filter_enabled() {
+        UINT8ARRAY_ADDR_RANGE.with(|r| r.get())
+    } else {
+        (0, usize::MAX)
+    };
+    if addr >= lo && addr <= hi && UINT8ARRAY_FROM_CTOR.with(|r| r.borrow().contains(&addr)) {
+        return true;
+    }
+    // Only reach for the global mutex once something has actually been
+    // registered externally. This is the gate `is_registered_buffer_slow`
+    // already had and this probe did not.
+    EXTERNAL_UINT8ARRAYS_NONEMPTY.load(std::sync::atomic::Ordering::Acquire)
+        && external_uint8arrays()
             .lock()
             .map(|r| r.contains(&addr))
             .unwrap_or(false)

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -408,9 +408,23 @@ pub extern "C" fn js_buffer_register_external(addr: usize) {
 #[no_mangle]
 pub extern "C" fn js_buffer_mark_as_uint8array_external(addr: usize) {
     mark_as_uint8array(addr);
-    // Latch BEFORE the insert, matching `js_buffer_register_external`: a
-    // probe that observed the latch after the insert-but-before-the-store
-    // window would skip the mutex and miss an already-registered address.
+    register_external_uint8array(addr);
+}
+
+/// Insert into the process-global external-Uint8Array registry, arming
+/// `EXTERNAL_UINT8ARRAYS_NONEMPTY` first.
+///
+/// Latch BEFORE the insert, matching `js_buffer_register_external`: a probe
+/// that observed the latch in the insert-but-before-the-store window would
+/// skip the mutex and miss an already-registered address.
+///
+/// Both inserters go through here on purpose. `is_uint8array_buffer_slow`
+/// now consults that global map ONLY when the latch is armed, so a path that
+/// inserts without arming makes the map invisible — the entry is there and
+/// the probe answers "no". That is not hypothetical: this registry is global
+/// precisely so an address registered on one thread is visible from another,
+/// and the thread-local set that would otherwise cover it is not.
+fn register_external_uint8array(addr: usize) {
     EXTERNAL_UINT8ARRAYS_NONEMPTY.store(true, std::sync::atomic::Ordering::Release);
     if let Ok(mut r) = external_uint8arrays().lock() {
         r.insert(addr);
@@ -478,9 +492,7 @@ pub extern "C" fn js_buffer_mark_as_crypto_key_external(
     if let Ok(mut r) = external_buffers().lock() {
         r.insert(addr);
     }
-    if let Ok(mut r) = external_uint8arrays().lock() {
-        r.insert(addr);
-    }
+    register_external_uint8array(addr);
     if let Ok(mut r) = external_crypto_keys().lock() {
         r.insert(
             addr,

--- a/crates/perry-runtime/src/buffer/header_latch_tests.rs
+++ b/crates/perry-runtime/src/buffer/header_latch_tests.rs
@@ -1,0 +1,55 @@
+//! Every path that inserts into the process-global external-Uint8Array
+//! registry must arm `EXTERNAL_UINT8ARRAYS_NONEMPTY` first.
+//!
+//! `is_uint8array_buffer_slow` consults that map ONLY when the latch is armed,
+//! so an inserter that forgets to arm makes its own entry invisible: the
+//! address is in the registry and the probe answers "no". The registry is
+//! process-global precisely so an address registered on one thread is visible
+//! from another, and the thread-local set that covers the registering thread
+//! does not cover any other — which is why this test asks from a fresh thread.
+
+use super::header::*;
+
+/// Synthetic addresses. Every path under test is address-keyed and never
+/// dereferences the pointer, so these need not be real allocations — but they
+/// must not collide with a live buffer, hence the deliberately absurd base.
+const CRYPTO_KEY_ADDR: usize = 0x9176_0000_1000;
+const PLAIN_MARK_ADDR: usize = 0x9176_0000_2000;
+
+/// Ask from a thread that has never registered anything, so the thread-local
+/// set and its address range cannot answer and the global registry must.
+fn visible_from_a_fresh_thread(addr: usize) -> bool {
+    std::thread::spawn(move || is_uint8array_buffer(addr))
+        .join()
+        .expect("probe thread must not panic")
+}
+
+#[test]
+fn crypto_key_external_registration_arms_the_uint8array_latch() {
+    js_buffer_mark_as_crypto_key_external(CRYPTO_KEY_ADDR, 1, 1, 1, 1, 0, 256);
+    let seen = visible_from_a_fresh_thread(CRYPTO_KEY_ADDR);
+    // Drop the synthetic entry from every address-keyed table before
+    // asserting, so a failure cannot poison the rest of this binary.
+    finalize_collected_dead_buffer(CRYPTO_KEY_ADDR);
+    assert!(
+        seen,
+        "js_buffer_mark_as_crypto_key_external inserts into external_uint8arrays() \
+         but did not arm EXTERNAL_UINT8ARRAYS_NONEMPTY, so is_uint8array_buffer \
+         skipped the mutex and denied a registered address"
+    );
+}
+
+/// The sibling path, which established the invariant. Included so the pair is
+/// checked together: if this one ever regresses the same way, the failure
+/// names the same cause instead of looking like a crypto-key-only quirk.
+#[test]
+fn plain_external_uint8array_registration_arms_the_latch() {
+    js_buffer_mark_as_uint8array_external(PLAIN_MARK_ADDR);
+    let seen = visible_from_a_fresh_thread(PLAIN_MARK_ADDR);
+    finalize_collected_dead_buffer(PLAIN_MARK_ADDR);
+    assert!(
+        seen,
+        "js_buffer_mark_as_uint8array_external must arm EXTERNAL_UINT8ARRAYS_NONEMPTY \
+         before inserting"
+    );
+}

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -22,6 +22,9 @@ mod exotic_view;
 mod exotic_view_tests;
 mod from;
 mod header;
+/// #9176: the external-Uint8Array latch must be armed by every inserter.
+#[cfg(test)]
+mod header_latch_tests;
 mod iter;
 mod mutate;
 mod numeric;

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -5,7 +5,7 @@
     "",
     "An entry that matches no such holder FAILS the gate. That is deliberate: it is what",
     "makes a fix delete its own entry, and it is why 'covered_elsewhere' is a verdict rather",
-    "than a suppression \u2014 if the scanner that covers it is ever deleted, the holder stays",
+    "than a suppression — if the scanner that covers it is ever deleted, the holder stays",
     "uncovered, the entry stays matched, and nothing tells you. Read the named scanner if you",
     "touch it.",
     "",
@@ -39,7 +39,7 @@
       "file": "crates/perry-ext-http/src/lib.rs",
       "name": "HTTP_PENDING_EVENTS",
       "verdict": "not_a_gc_pointer",
-      "why": "Client-side pending-event queue. Every variant carries a perry-ffi registry Handle, strings, Bytes, or an errno i64 (rule S fired on TransportError.errno) \u2014 no NaN-boxed value. The closures the drain fires live in ClientRequestHandle (response_callback/end_callback/pending_write_callbacks/listeners), which scan_http_roots visits."
+      "why": "Client-side pending-event queue. Every variant carries a perry-ffi registry Handle, strings, Bytes, or an errno i64 (rule S fired on TransportError.errno) — no NaN-boxed value. The closures the drain fires live in ClientRequestHandle (response_callback/end_callback/pending_write_callbacks/listeners), which scan_http_roots visits."
     },
     {
       "file": "crates/perry-ext-http/src/server/https_server.rs",
@@ -75,7 +75,7 @@
       "file": "crates/perry-ext-net/src/lib.rs",
       "name": "P",
       "verdict": "not_a_gc_pointer",
-      "why": "pending_events(): Vec<PendingNetEvent>; every variant carries socket/server ids, Bytes, String, bool, or DropInfo (SocketAddrs) \u2014 no closures or NaN-boxed values. Listener closures live in listeners(), visited by scan_net_roots."
+      "why": "pending_events(): Vec<PendingNetEvent>; every variant carries socket/server ids, Bytes, String, bool, or DropInfo (SocketAddrs) — no closures or NaN-boxed values. Listener closures live in listeners(), visited by scan_net_roots."
     },
     {
       "file": "crates/perry-ext-net/src/lib.rs",
@@ -138,6 +138,22 @@
       "why": "#[cfg(test)] AtomicUsize one-shot flag that asks resolve_async_resource_handle to force a collection; stores only 0 or 1 and is absent from shipped binaries."
     },
     {
+      "file": "crates/perry-runtime/src/buffer/header.rs",
+      "name": "BUFFER_ADDR_RANGE",
+      "count": 1,
+      "classification": "not_a_gc_pointer",
+      "verdict": "not_a_gc_pointer",
+      "why": "Records only the smallest and largest address ever inserted into the sibling thread-local buffer registry, as a conservative min/max filter in front of that registry's hash lookup (#9176). The two usizes are compared (`addr >= lo && addr <= hi`) and never dereferenced, never handed out, and never used to reach an object; a value outside the range is rejected, a value inside falls through to the lookup that was already there. The range only ever widens, so it cannot go stale in the unsafe direction: a bound that no longer matches reality can only admit more addresses to the real lookup, never deny a registered one."
+    },
+    {
+      "file": "crates/perry-runtime/src/buffer/header.rs",
+      "name": "UINT8ARRAY_ADDR_RANGE",
+      "count": 1,
+      "classification": "not_a_gc_pointer",
+      "verdict": "not_a_gc_pointer",
+      "why": "Records only the smallest and largest address ever inserted into the sibling thread-local buffer registry, as a conservative min/max filter in front of that registry's hash lookup (#9176). The two usizes are compared (`addr >= lo && addr <= hi`) and never dereferenced, never handed out, and never used to reach an object; a value outside the range is rejected, a value inside falls through to the lookup that was already there. The range only ever widens, so it cannot go stale in the unsafe direction: a bound that no longer matches reality can only admit more addresses to the real lookup, never deny a registered one."
+    },
+    {
       "file": "crates/perry-runtime/src/child_process/reactor.rs",
       "name": "CP_NEXT_LIVE_ID",
       "verdict": "not_a_gc_pointer",
@@ -147,7 +163,7 @@
       "file": "crates/perry-runtime/src/closure/alloc.rs",
       "name": "CAPTURED_MISS_STREAK",
       "verdict": "not_a_gc_pointer",
-      "why": "Keyed by the closure's func_ptr \u2014 a CODE address, which the collector neither moves nor traces; the value is a miss-streak count."
+      "why": "Keyed by the closure's func_ptr — a CODE address, which the collector neither moves nor traces; the value is a miss-streak count."
     },
     {
       "file": "crates/perry-runtime/src/closure/alloc.rs",
@@ -172,6 +188,15 @@
       "name": "NEXT_READ_LINES_ID",
       "verdict": "not_a_gc_pointer",
       "why": "Monotonic id counter for READ_LINES_REGISTRY keys. The registry's own heap values are visited by scan_filehandle_roots_mut (fs/filehandle.rs:65), reached from scan_fs_handle_roots_mut."
+    },
+    {
+      "file": "crates/perry-runtime/src/map.rs",
+      "name": "MAP_FOREACH_STACK",
+      "count": 1,
+      "classification": "not_a_gc_pointer",
+      "verdict": "not_a_gc_pointer",
+      "why": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves — see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there.",
+      "reason": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves — see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there."
     },
     {
       "file": "crates/perry-runtime/src/net.rs",
@@ -234,34 +259,34 @@
       "file": "crates/perry-runtime/src/node_submodules/diagnostics_tail.rs",
       "name": "DIAG_STORE_SCOPES",
       "verdict": "not_a_gc_pointer",
-      "why": "DiagStoreScopeState.handles are store KEYS produced by store_handle() (diagnostics_tail.rs:72), which admits only an INT32-tagged value, a POINTER_TAG value inside the handle band (raw < 0x10000), or a finite float \u2014 a real heap pointer returns None, so one cannot be stored here by construction. The store CONTEXT objects live in DIAG_CHANNELS[*].stores, which scan_node_submodule_singleton_roots_mut visits."
+      "why": "DiagStoreScopeState.handles are store KEYS produced by store_handle() (diagnostics_tail.rs:72), which admits only an INT32-tagged value, a POINTER_TAG value inside the handle band (raw < 0x10000), or a finite float — a real heap pointer returns None, so one cannot be stored here by construction. The store CONTEXT objects live in DIAG_CHANNELS[*].stores, which scan_node_submodule_singleton_roots_mut visits."
     },
     {
       "file": "crates/perry-runtime/src/node_vm.rs",
       "name": "VM_INTRINSIC_GLOBAL",
       "verdict": "covered_elsewhere",
       "scanner": "gc::roots::visit_global_root_slots, reached by js_gc_register_global_root (gc/roots.rs:325 pushes the slot into GLOBAL_ROOTS; gc/roots.rs:1433 hands it to the mutable-root walk)",
-      "why": "Caches the shared VM intrinsic realm's globalThis as NaN-boxed bits. The single site that writes the cell \u2014 fresh_intrinsic_global, node_vm.rs:1080 \u2014 calls js_gc_register_global_root(slot.as_ptr()) in the same `with` closure, immediately after the store and with no allocation in between; the early return on a non-zero cell means that store happens at most once per thread, so there is no path that populates the cell without registering it. GLOBAL_ROOTS is thread_local, exactly like the cell, and visit_mutable_root_slots feeds it to BOTH the marker and the post-evacuation rewrite (gc/tests/copying.rs:1272, test_copying_minor_rewrites_shadow_and_global_roots), so the cached pointer is marked and forwarded rather than left stale."
+      "why": "Caches the shared VM intrinsic realm's globalThis as NaN-boxed bits. The single site that writes the cell — fresh_intrinsic_global, node_vm.rs:1080 — calls js_gc_register_global_root(slot.as_ptr()) in the same `with` closure, immediately after the store and with no allocation in between; the early return on a non-zero cell means that store happens at most once per thread, so there is no path that populates the cell without registering it. GLOBAL_ROOTS is thread_local, exactly like the cell, and visit_mutable_root_slots feeds it to BOTH the marker and the post-evacuation rewrite (gc/tests/copying.rs:1272, test_copying_minor_rewrites_shadow_and_global_roots), so the cached pointer is marked and forwarded rather than left stale."
     },
     {
       "file": "crates/perry-runtime/src/object/class_registry/state.rs",
       "name": "CLASS_OBJECT_VALUES",
       "verdict": "covered_elsewhere",
       "scanner": "object::scan_class_side_table_roots_mut and its budgeted step twin (class_registry/gc_roots.rs:138 and :256)",
-      "why": "The class side tables are declared in state.rs and scanned from gc_roots.rs. Both twins visit it \u2014 #7239 diffed all eight budgeted (FULL, STEP) pairs and found no drift."
+      "why": "The class side tables are declared in state.rs and scanned from gc_roots.rs. Both twins visit it — #7239 diffed all eight budgeted (FULL, STEP) pairs and found no drift."
     },
     {
       "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
       "name": "THREAD_GLOBAL_THIS",
       "verdict": "covered_elsewhere",
-      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_get_global_this) and marked+rewritten as a mutable global root",
+      "scanner": "gc::roots GLOBAL_ROOTS — the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_get_global_this) and marked+rewritten as a mutable global root",
       "why": "A raw-pointer cache slot registered as a global root at first population; the registration is a call, not a scanner body, so the walk cannot see it."
     },
     {
       "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
       "name": "THREAD_MODULE_TOP_THIS",
       "verdict": "covered_elsewhere",
-      "scanner": "gc::roots GLOBAL_ROOTS \u2014 the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_module_top_this)",
+      "scanner": "gc::roots GLOBAL_ROOTS — the cell's address is registered with js_gc_register_global_root (fetch_globals.rs, js_module_top_this)",
       "why": "Same shape as THREAD_GLOBAL_THIS: a NaN-boxed cache slot registered as a mutable global root at first population."
     },
     {
@@ -269,6 +294,12 @@
       "name": "TEST_BOUND_METHOD_MOVE",
       "verdict": "test_only",
       "why": "#[cfg(test)] diagnostic trace for the bound-method moving-GC regression: records the (before, after) addresses a test-forced minor produced so the test can assert the relocation happened. The addresses are compared as integers, never dereferenced, and the cell is dead in a shipped binary."
+    },
+    {
+      "file": "crates/perry-runtime/src/object/read_stub.rs",
+      "name": "READ_STUB",
+      "verdict": "not_a_gc_pointer",
+      "why": "Megamorphic property-read stub cache, the read twin of WRITE_STUB: 2-way ways of (shape_token, key_bits, slot) plain u64s. The token is a shape id and the slot an index; key_bits are content-derived by construction, because read_stub_key_bits returns short_ascii_sso_bits(key) — the key's characters packed inline — and yields None for any key that would otherwise be stored under a pointer. No way holds a heap address, so nothing here keeps an object alive, and a stale entry cannot hit: receiver_shape_token returns None for a receiver with no live shape, and the token identifies the exact key set and order, so a shape change yields a different token."
     },
     {
       "file": "crates/perry-runtime/src/os/signal.rs",
@@ -301,7 +332,7 @@
       "name": "PROCESS_FINALIZATION_BEFORE_EXIT_LISTENER",
       "verdict": "covered_elsewhere",
       "scanner": "process::scan_process_finalization_roots_mut (process/finalization.rs:171; visits the cell at :184-189 via visit_raw_const_ptr_slot; reg_scanner! at gc/mod.rs:1008)",
-      "why": "Declared in process.rs, scanned from the process/finalization.rs submodule \u2014 same file split as the MODULE_LOADER_* siblings."
+      "why": "Declared in process.rs, scanned from the process/finalization.rs submodule — same file split as the MODULE_LOADER_* siblings."
     },
     {
       "file": "crates/perry-runtime/src/promise/microtasks.rs",
@@ -321,12 +352,6 @@
       "name": "WRITE_STUB",
       "verdict": "not_a_gc_pointer",
       "why": "Megamorphic dynamic-write stub cache: 4096 ways of (shape_token, key_bits, slot) plain u64s. The token is a shape id and the slot an index; key_bits are content-derived by construction, because stub_key_bits admits only SSO immediates (and short ASCII heap strings folded to the SSO bits of their content) and rejects every key that would otherwise be stored under a pointer. No way holds a heap address, so nothing here keeps an object alive, and a stale entry is rejected by dyn_ic_try_store's per-hit shape-token/flags/slot-bound revalidation."
-    },
-    {
-      "file": "crates/perry-runtime/src/object/read_stub.rs",
-      "name": "READ_STUB",
-      "verdict": "not_a_gc_pointer",
-      "why": "Megamorphic property-read stub cache, the read twin of WRITE_STUB: 2-way ways of (shape_token, key_bits, slot) plain u64s. The token is a shape id and the slot an index; key_bits are content-derived by construction, because read_stub_key_bits returns short_ascii_sso_bits(key) \u2014 the key's characters packed inline \u2014 and yields None for any key that would otherwise be stored under a pointer. No way holds a heap address, so nothing here keeps an object alive, and a stale entry cannot hit: receiver_shape_token returns None for a receiver with no live shape, and the token identifies the exact key set and order, so a shape change yields a different token."
     },
     {
       "file": "crates/perry-runtime/src/pty/mod.rs",
@@ -350,9 +375,18 @@
     },
     {
       "file": "crates/perry-runtime/src/set.rs",
+      "name": "SET_FOREACH_STACK",
+      "count": 1,
+      "classification": "not_a_gc_pointer",
+      "verdict": "not_a_gc_pointer",
+      "why": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves — see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there.",
+      "reason": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves — see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there."
+    },
+    {
+      "file": "crates/perry-runtime/src/set.rs",
       "name": "SET_INDEX",
       "verdict": "not_a_gc_pointer",
-      "why": "Derived cache of the Set's own elements array, which is the canonical scanned storage (GcRewriteDescriptorKind::Set element-slot walk). Not root-scanner-shaped: the outer address key is rekeyed on relocation by GcMoveHookKind::SetSideTables -> set_header_moved_for_gc (set.rs:352), the JSValueKey inner keys are rebuilt post-rewrite by GcRewriteHookKind::SetIndex -> rebuild_set_index_for_gc (set.rs:315, fired from gc/copying.rs:669/798, gc/barrier/mod.rs:195, gc/verify.rs:114), and finalize_set_side_allocation_for_gc (set.rs:374) prunes dead owners \u2014 the same three-hook design as MAP_INDEX."
+      "why": "Derived cache of the Set's own elements array, which is the canonical scanned storage (GcRewriteDescriptorKind::Set element-slot walk). Not root-scanner-shaped: the outer address key is rekeyed on relocation by GcMoveHookKind::SetSideTables -> set_header_moved_for_gc (set.rs:352), the JSValueKey inner keys are rebuilt post-rewrite by GcRewriteHookKind::SetIndex -> rebuild_set_index_for_gc (set.rs:315, fired from gc/copying.rs:669/798, gc/barrier/mod.rs:195, gc/verify.rs:114), and finalize_set_side_allocation_for_gc (set.rs:374) prunes dead owners — the same three-hook design as MAP_INDEX."
     },
     {
       "file": "crates/perry-runtime/src/string/format.rs",
@@ -370,7 +404,7 @@
       "file": "crates/perry-runtime/src/symbol/properties.rs",
       "name": "CACHED",
       "verdict": "not_a_gc_pointer",
-      "why": "Memoizes the sym_key of the Symbol.for('NextInternalRequestMeta') REGISTERED symbol. Registered / well-known symbols are Box::leak'd (symbol.rs's SYMBOL_REGISTRY / WELL_KNOWN_SYMBOLS), so they live outside the GC arena and their addresses are stable for the process. A FRESH Symbol() would not be \u2014 see #7246."
+      "why": "Memoizes the sym_key of the Symbol.for('NextInternalRequestMeta') REGISTERED symbol. Registered / well-known symbols are Box::leak'd (symbol.rs's SYMBOL_REGISTRY / WELL_KNOWN_SYMBOLS), so they live outside the GC arena and their addresses are stable for the process. A FRESH Symbol() would not be — see #7246."
     },
     {
       "file": "crates/perry-runtime/src/text.rs",
@@ -379,16 +413,16 @@
       "why": "Keyed by decoder handle id; DecoderState is Rust-owned (encoding enum, label, flags), no JS values."
     },
     {
-      "file": "crates/perry-runtime/src/timer.rs",
-      "name": "TIMER_HANDLE_KINDS",
-      "verdict": "not_a_gc_pointer",
-      "why": "Maps scalar timer handle IDs to the CallbackTimerKind enum so clearTimeout/clearInterval can destroy the matching async_hooks resource. Neither the i64 keys nor the enum values contain a JS heap address."
-    },
-    {
       "file": "crates/perry-runtime/src/thread.rs",
       "name": "ACTIVE_THREAD_JOBS",
       "verdict": "not_a_gc_pointer",
       "why": "In-flight job counter for perry/thread."
+    },
+    {
+      "file": "crates/perry-runtime/src/timer.rs",
+      "name": "TIMER_HANDLE_KINDS",
+      "verdict": "not_a_gc_pointer",
+      "why": "Maps scalar timer handle IDs to the CallbackTimerKind enum so clearTimeout/clearInterval can destroy the matching async_hooks resource. Neither the i64 keys nor the enum values contain a JS heap address."
     },
     {
       "file": "crates/perry-stdlib/src/fetch/body_metadata.rs",
@@ -1549,7 +1583,7 @@
       "file": "crates/perry-ui-windows-winui/src/app.rs",
       "name": "APPS",
       "verdict": "not_a_gc_pointer",
-      "why": "AppState holds a Rust-owned title String, the two f64 window dimensions, an i64 WIDGET handle (root: a 1-based index into widgets::NODES, not an address), two Option<(f64, f64)> size constraints and a PresenterKind enum \u2014 no NaN-boxed JavaScript value, so rule S fired on the f64/i64 fields rather than on a heap pointer. This module's real callback roots (ON_ACTIVATE / ON_TERMINATE / PENDING_TIMERS, each a raw closure pointer unboxed by js_nanbox_get_pointer) are visited by scan_winui_app_gc_roots."
+      "why": "AppState holds a Rust-owned title String, the two f64 window dimensions, an i64 WIDGET handle (root: a 1-based index into widgets::NODES, not an address), two Option<(f64, f64)> size constraints and a PresenterKind enum — no NaN-boxed JavaScript value, so rule S fired on the f64/i64 fields rather than on a heap pointer. This module's real callback roots (ON_ACTIVATE / ON_TERMINATE / PENDING_TIMERS, each a raw closure pointer unboxed by js_nanbox_get_pointer) are visited by scan_winui_app_gc_roots."
     },
     {
       "file": "crates/perry-ui-windows/src/app.rs",
@@ -1784,27 +1818,9 @@
       "name": "WINDOW_ROOTS",
       "verdict": "not_a_gc_pointer",
       "why": "Window-root registry maps numeric window handles to numeric root-widget handles; neither value is a JavaScript heap pointer."
-    },
-    {
-      "file": "crates/perry-runtime/src/set.rs",
-      "name": "SET_FOREACH_STACK",
-      "count": 1,
-      "classification": "not_a_gc_pointer",
-      "verdict": "not_a_gc_pointer",
-      "why": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves \u2014 see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there.",
-      "reason": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves \u2014 see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there."
-    },
-    {
-      "file": "crates/perry-runtime/src/map.rs",
-      "name": "MAP_FOREACH_STACK",
-      "count": 1,
-      "classification": "not_a_gc_pointer",
-      "verdict": "not_a_gc_pointer",
-      "why": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves \u2014 see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there.",
-      "reason": "Holds Set/Map header ADDRESSES as identity keys for in-flight forEach walks (#9082); the values are only ever compared (`contains`, `pop` equality) and truncated, never dereferenced, so no collector edge originates here. Correctness across evacuation is maintained by set_header_moved_for_gc / map_header_moved_for_gc, which rewrite every matching entry when a header moves \u2014 see the SET_FOREACH_STACK/MAP_FOREACH_STACK rewrite loops there."
     }
   ],
-  "_FRONTIER_README": "Identity-pinned debt ratchet over new perry-ui* candidates and otherwise-unclassified core perry_thread_local! declarations (see the census docstring, \u201cThe identity-pinned frontier\u201d). A new uncovered holder fails until it is scanned, receives a researched holders verdict, or is deliberately pinned as debt. Moving a researched false positive to holders graduates it from this list. A fixed or classified holder makes its old frontier pin stale, so the receipt must be deleted.",
+  "_FRONTIER_README": "Identity-pinned debt ratchet over new perry-ui* candidates and otherwise-unclassified core perry_thread_local! declarations (see the census docstring, “The identity-pinned frontier”). A new uncovered holder fails until it is scanned, receives a researched holders verdict, or is deliberately pinned as debt. Moving a researched false positive to holders graduates it from this list. A fixed or classified holder makes its old frontier pin stale, so the receipt must be deleted.",
   "frontier": [
     {
       "file": "crates/perry-runtime/src/array/element_shape.rs",


### PR DESCRIPTION
From the `cc --help` profile: `is_registered_buffer_slow` 3.53% and `is_uint8array_buffer_slow` 1.74%, together the largest entries in the registry-probe group.

## What was wrong

Both probes have an idle-latch fast path, and **each latch stops helping the moment a program registers its first buffer**. After that, all ~216 probe sites pay a TLS access, a `RefCell` borrow and a hash lookup to ask whether an arbitrary pointer is a buffer — and almost every caller is asking about something that is not one.

`is_uint8array_buffer_slow` was worse: on every thread-local **miss** — that is, on every value that is not a Uint8Array — it took the **global mutex**. That is precisely the cost `UINT8ARRAY_EVER_MARKED` was introduced to avoid, and its own comment says so:

> before the latch this locked `external_uint8arrays()` on EVERY thread-local miss, i.e. on every non-Uint8Array value, in every process — the one probe in this family whose miss cost a lock rather than a hash.

That cost returned in full as soon as any program marked its first Uint8Array. `is_registered_buffer_slow` already had the gate (`EXTERNAL_BUFFERS_NONEMPTY`); this probe simply never got it.

## Two changes

**An address range, thread-local like the registry it guards.** Every registration widens it before inserting, so an address outside it cannot be in the set — rejecting is sound, and accepting merely falls through to the lookup that was already there. Thread-local rather than atomic specifically so there is no ordering to reason about.

Both registries are inserted into at exactly **one** site — `register_buffer` and `mark_as_uint8array`, both widened here. Every other use is a removal or an iteration, and a removal leaving the range too wide is harmless: the address just reaches the lookup, which correctly says no. (I checked all of them; that audit is the load-bearing part of the soundness argument, since a missed insertion site would be a silent false negative.)

**The missing emptiness latch** for the external Uint8Array registry, armed before the insert for the same reason `js_buffer_register_external` arms its own before publishing.

## Measurement

`JSON.stringify` over a 300-row object graph — the shape that probes every pointer it serializes (#6009) — with a Buffer allocated first so the latches are armed. Best of 3, quiet Mac mini:

| | ms/op |
|---|---|
| armed, before | 0.2340 |
| armed, after | **0.2281** |
| idle — latches never armed, i.e. the floor | 0.2098 |

About a quarter of the arming penalty, from the range filter alone. The mutex removal is on top of that and does not show in a single-threaded probe at all.

**Pre-registered cc prediction**, since the last several perf changes were flat at app level and this one should not be: `is_registered_buffer_slow` and `is_uint8array_buffer_slow` should drop toward zero in the `cc --help` profile. At 3.53% and 1.74% that is measurable, unlike the arithmetic changes. If they don't move, the mechanism is wrong and I want to know.

## Behaviour

A buffer-identity differential — `Buffer.isBuffer`, `instanceof Uint8Array`, `toString`, `JSON.stringify`, `concat`, `subarray`, buffers allocated *after* 200 unrelated objects (so their addresses fall outside any early range), and 200 interleaved non-buffers — produces **byte-identical output with the filter on and off**. perry-runtime lib 2841/0.

That differential also surfaced a pre-existing defect, filed separately as **#9173**: `Buffer.isBuffer(new Uint8Array(...))` returns `true`, because `js_buffer_is_buffer` is exactly this registry test and `new Uint8Array` registers into the same set. It is independent of this change — both arms here agree with each other and differ from node identically.

## Gates

`-D warnings` clean; perry-hir 591/0; perry-codegen 1841/0; perry-runtime lib 2841/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: 7/7, 5/5, 7/7, 2/2, 3/3, 3/3.

## Kill switch

`PERRY_BUFFER_RANGE_FILTER=0` restores the unconditional lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved buffer and typed-array detection by quickly filtering out addresses that cannot match, reducing unnecessary lookups.
  * Added an opt-out environment setting for the address-range optimization.

* **Bug Fixes**
  * Fixed WebCrypto keys not being recognized as typed-array buffers across threads.

* **Tests**
  * Added coverage confirming external typed arrays and WebCrypto keys are visible across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->