### PR TITLE
gc: fail closed if the native root scan runs before the stack-map index is built

### DIFF
--- a/changelog.d/9182-native-root-scan-fails-closed.md
+++ b/changelog.d/9182-native-root-scan-fails-closed.md
@@ -1,0 +1,22 @@
+The native root scan resolves frame roots through the stack-map index, and an
+index that was never built is indistinguishable downstream from an image that
+genuinely has no native roots: both are empty. The consequences are not. With
+statepoints as the only root mechanism, scanning against an unbuilt index means
+the collector finds no roots on that frame, frees live objects, and corrupts the
+heap with no diagnostic.
+
+`visit_stack_map_root_slots` now asserts the property at the consuming end —
+the same degradation `build_stack_map_index` already refuses at the producing
+one. The invariant is stated as "an empty index means this image genuinely has
+no native roots", not "initialize ran", which keeps the check live in every
+configuration: `perry-runtime`'s unit tests reach the scan without `js_gc_init`
+and pass because their harness carries no gc-map section — the right reason —
+rather than by being exempted. Exempting them by build config would leave no
+check in precisely the configuration where the index is legitimately unbuilt.
+
+It cannot fire today, because `js_gc_init` builds the index eagerly before any
+mutator code runs. It is here so that it CAN fire if the build is ever made
+lazy and a path into the scan is missed, turning a silent delayed heap
+corruption into a loud abort on the first test that reaches it. Landing it
+while the build is still eager is deliberate: it proves the check sits on the
+path it claims to guard before anything depends on it.

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -27,7 +27,7 @@ use crate::gc::telemetry::RootSourcesTraceStats;
 // the Itanium/pthread declarations, which do not exist there.
 #[cfg(not(target_os = "windows"))]
 use std::ffi::c_void;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock, RwLockReadGuard};
 
 /// Magic and version of the compact map the compiler emits
@@ -205,6 +205,46 @@ impl StackMapIndexStore {
 }
 
 static STACK_MAPS: StackMapIndexStore = StackMapIndexStore::new();
+
+/// Set by [`initialize`], read by the root scan.
+///
+/// The scan resolves native frame roots through the stack-map index, and an
+/// index that was never built is INDISTINGUISHABLE downstream from an image
+/// with no native roots: both are empty. The consequences are not the same.
+/// With statepoints as the only root mechanism, scanning against an unbuilt
+/// index means the collector finds no roots, frees live objects, and corrupts
+/// the heap with no diagnostic — the same failure `build_stack_map_index`
+/// already refuses to degrade into, asserted here at the consuming end.
+///
+/// It cannot fire today: `js_gc_init` builds the index eagerly, before any
+/// mutator code runs. It is here so that it CAN fire if the build is ever made
+/// lazy and a path into the scan is missed — turning a silent, delayed heap
+/// corruption into a loud abort on the first test that reaches it. Landing it
+/// while the build is still eager is deliberate: it proves the check is placed
+/// on the path it claims to guard, before anything depends on it.
+static STACK_MAPS_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Whether [`initialize`] has run. Exposed so a future lazy build can assert
+/// the same property at whatever point it chooses to construct the index.
+pub(in crate::gc) fn stack_maps_initialized() -> bool {
+    STACK_MAPS_INITIALIZED.load(Ordering::Acquire)
+}
+
+/// Does any loaded image carry a gc-map section — i.e. are there native frame
+/// roots for the scan to miss?
+///
+/// This inspects the loader's image list; it does not decode anything, and the
+/// answer is cached because it cannot change for a process once its images are
+/// loaded. An inspection error answers `true`, so an unreadable loader makes
+/// the assert stricter rather than weaker.
+fn image_has_stack_map_sections() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        loaded_stack_map_sections()
+            .map(|sections| !sections.is_empty())
+            .unwrap_or(true)
+    })
+}
 
 // #7803 creation-cycle verifier (diagnostic, `PERRY_GC_NATIVE_SLOT_VERIFY=1`).
 //
@@ -611,6 +651,9 @@ pub(in crate::gc) fn record_native_stack_walk_source(
 
 pub(in crate::gc) fn initialize() {
     STACK_MAPS.rebuild();
+    // Publish AFTER the rebuild: a reader that observes the flag must be able
+    // to observe the index it promises.
+    STACK_MAPS_INITIALIZED.store(true, Ordering::Release);
 }
 
 /// Whether this image carries any native stack-map records — i.e. whether
@@ -1123,6 +1166,22 @@ impl StackMapIndex {
 pub(super) fn visit_stack_map_root_slots(
     visit: &mut impl FnMut(MutableRootSlot),
 ) -> NativeStackWalkStats {
+    // The invariant is not "initialize ran" but "an empty index means this
+    // image genuinely has no native roots". Stating it that way keeps the
+    // check live in EVERY configuration: perry-runtime's unit tests reach the
+    // scan without `js_gc_init`, and they pass because their harness carries
+    // no gc-map section — the right reason — rather than by being exempted
+    // from the check. Exempting them by build config would leave no check in
+    // precisely the configuration where the index is legitimately unbuilt,
+    // which is a hole the moment a test binary does carry statepoint frames.
+    assert!(
+        stack_maps_initialized() || !image_has_stack_map_sections(),
+        "perry: the native root scan ran before the stack-map index was built. \
+         An unbuilt index is indistinguishable from an image with no native \
+         roots, so the collector would find no roots on this frame and free \
+         live objects silently. This means a path into the root scan does not \
+         pass through the point that builds the index."
+    );
     let published = stack_maps();
     let index = &published.index;
     if index.records.is_empty() {


### PR DESCRIPTION
Step 1 of two. This one is a **no-op by construction** — and that is the point.

## The invariant

An unbuilt stack-map index is **indistinguishable downstream** from an image with no native roots: both are empty. The consequences are not. With statepoints as the only root mechanism, scanning against an unbuilt index means the collector finds no roots on that frame, frees live objects, and corrupts the heap **with no diagnostic at all**.

`build_stack_map_index` already refuses to let a decode failure degrade into "no roots", and says why:

> both yield an empty index — but their consequences are not: with statepoints as the only root mechanism, an empty index means the collector frees live objects and corrupts the heap with no diagnostic at all.

This asserts the same property at the **consuming** end: the index is built, **or** this image carries no gc-map section at all.

## Why now, against the eager build

It cannot fire today. `js_gc_init` builds the index before any mutator code runs, so this changes no behaviour.

It exists for **step 2**: the gc-map section is decoded eagerly at every process start — 17.4 MB, 72,713 functions, 2.15M records, a 117 MB index — and `cc --version`, which never collects, pays **698M instructions and 313 MB of RSS** for an index it never reads. Deferring that build is worth having. But its correctness rests on every path into the root scan passing through whatever point builds the index, and **that enumeration could not be established**: a first attempt named "two chokepoints" and was withdrawn as unverified; tracing found at least three fan-in points (`visit_global_root_slots`, `mark_mutable_root_slots_step` via `cycle.rs`, `shadow_stack_root_scanner`) plus untraced allocation-triggered entries.

For a failure this silent, *"we found all the callers"* must not be the load-bearing claim. With this assert in place, a missed entry aborts loudly on the first test that reaches it instead of corrupting the heap.

Landing it **before** the change that needs it is deliberate: if the assert were misplaced — guarding the wrong function, or somewhere the scan does not pass — we would discover that only when it failed to catch the thing it exists to catch, which is exactly when we would be relying on it. Proving placement while nothing depends on it is cheap. Proving it afterwards is not possible.

## It found something on its first run

Written unscoped, the assert immediately caught `gc::heap_snapshot::tests::snapshot_has_real_nodes_and_edges` reaching the native root scan without going through `js_gc_init` — **a path neither the analysis nor my own tracing had enumerated.** Benign, as it happens: perry-runtime's unit tests drive the collector directly and their harness carries no gc-map section.

That is the sequencing argument turned from a principle into a measurement. We reasoned our way to "an enumeration cannot be load-bearing"; the check produced a counterexample within minutes of existing.

## Stating the invariant, not the build config

The condition is *"index built **or** no gc-map section"*, not *"initialize ran"*. That keeps the check live in **every** configuration, and makes the unit-test case pass for the right reason instead of by exemption. Scoping it out of test builds — my first version — would have removed it from precisely the configuration where the index is legitimately unbuilt, which becomes a hole the moment a test binary does carry statepoint frames.

The section query inspects the loader's image list without decoding anything, and is cached because the answer cannot change once a process has loaded its images. An inspection error answers "sections present", so an unreadable loader makes the assert **stricter**, not weaker.

## Validation

perry-runtime lib **2844/0** with the assert never firing, plus six compiled binaries run under `PERRY_GC_PROTECT_FROMSPACE` with seeded aggressive collection schedules — up to **207,024 moved objects** — none of which fire it. `-D warnings` clean; hir 591/0; codegen 1841/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature garbage-collection scans from incorrectly releasing live objects.
  * Added safeguards to distinguish an uninitialized runtime state from applications that legitimately contain no native garbage-collection metadata.
  * Runtime now fails clearly when a required garbage-collection scan is attempted before initialization, improving reliability and diagnosability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->