### PR TITLE
perf(codegen): a throw that does not construct keeps the packed fast path (4.76 → 0.58 ns)

### DIFF
--- a/changelog.d/9185-throw-keeps-packed-fast-path.md
+++ b/changelog.d/9185-throw-keeps-packed-fast-path.md
@@ -1,0 +1,24 @@
+`stmt_is_packed_f64_loop_safe` rejected every `throw` in a packed-f64 loop
+body, on the reasoning that the thrown value is typically constructed
+(`throw new Error(…)`) and the construction is a call in the loop. That is
+true of the construction, not of the `throw` — a loop that throws an
+already-built value lost the fast path for a call it never makes.
+
+`contains_gc_unsafe_call` now answers `false` for a block whose last
+instruction is `unreachable`. That is sound for the reason the whole
+call-free check exists: the check verifies at compile time that nothing in
+the fast clone can trigger a collection and move the preheader-cached
+receiver *before something reads it again*. A block ending in `unreachable`
+has no such "again" — control does not return to the loop, so no cached value
+is read after the call. `push_inst` drops anything pushed after a terminator,
+so a block's last instruction is its terminator; `instructions.last()` being
+`Unreachable` therefore means the block genuinely ends there rather than
+carrying dead code past a `br`. A `throw` that constructs its value is still
+rejected, because the construction is emitted in blocks that precede the
+terminating one.
+
+`Stmt::Try` inside the loop body remains a rejection, so the throw's handler
+can never be inside the loop being cloned — which is what would otherwise
+return control to a loop holding a stale cached pointer.
+
+bench: 4.76 → 0.58 ns.

--- a/crates/perry-codegen/src/block.rs
+++ b/crates/perry-codegen/src/block.rs
@@ -297,6 +297,9 @@ impl LlBlock {
     /// check cannot be invalidated mid-loop). Intrinsic/libm-style calls
     /// never enter the perry runtime, so they cannot trigger a collection.
     pub fn contains_gc_unsafe_call(&self) -> bool {
+        if matches!(self.instructions.last(), Some(crate::inst::LlInst::Unreachable)) {
+            return false;
+        }
         self.instructions.iter().any(|i| i.is_gc_unsafe_call())
     }
 

--- a/crates/perry-codegen/src/block.rs
+++ b/crates/perry-codegen/src/block.rs
@@ -297,7 +297,10 @@ impl LlBlock {
     /// check cannot be invalidated mid-loop). Intrinsic/libm-style calls
     /// never enter the perry runtime, so they cannot trigger a collection.
     pub fn contains_gc_unsafe_call(&self) -> bool {
-        if matches!(self.instructions.last(), Some(crate::inst::LlInst::Unreachable)) {
+        if matches!(
+            self.instructions.last(),
+            Some(crate::inst::LlInst::Unreachable)
+        ) {
             return false;
         }
         self.instructions.iter().any(|i| i.is_gc_unsafe_call())

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -5042,9 +5042,9 @@ fn stmt_is_packed_f64_loop_safe(
         }
         // `throw` stays out: the thrown value is typically constructed
         // (`throw new Error(…)`), which is a call in the loop body.
+        Stmt::Throw(_) => packed_loop_abrupt_enabled(),
         Stmt::LabeledBreak(_)
         | Stmt::LabeledContinue(_)
-        | Stmt::Throw(_)
         | Stmt::While { .. }
         | Stmt::DoWhile { .. }
         | Stmt::For { .. }

--- a/crates/perry/tests/packed_loop_abrupt_statements.rs
+++ b/crates/perry/tests/packed_loop_abrupt_statements.rs
@@ -145,9 +145,39 @@ fn break_in_a_loop_whose_array_grows() {
 }
 
 #[test]
+fn a_throw_that_does_not_construct_takes_the_fast_path_correctly() {
+    // A `throw` whose value is already built is admitted: its block ends in
+    // `unreachable`, so control never returns to the loop and nothing reads
+    // what the clone cached. A throw that CONSTRUCTS its value is not, because
+    // the construction is emitted in blocks preceding the terminating one.
+    let out = compile_and_run(&format!(
+        "{PRELUDE}
+        const PRE = new Error(\"boom\");
+        function throwPre(k: number): string {{
+            try {{
+                let s = 0;
+                for (let i = 0; i < arr.length; i++) {{ s += arr[i]; if (arr[i] === k) throw PRE; }}
+                return \"none\" + s;
+            }} catch (e) {{ return (e as Error).message + \":\" + k; }}
+        }}
+        function throwValue(k: number): string {{
+            try {{
+                let s = 0;
+                for (let i = 0; i < arr.length; i++) {{ s += arr[i]; if (arr[i] === k) throw s; }}
+                return \"none\" + s;
+            }} catch (e) {{ return \"v\" + String(e); }}
+        }}
+        console.log(throwPre(4) + \" \" + throwPre(999) + \" \" + throwValue(0) + \" \" + throwValue(7));
+        "
+    ));
+    assert_eq!(out, "boom:4 none2016 v0 v28");
+}
+
+#[test]
 fn throw_inside_the_loop_is_still_correct() {
-    // `throw` is deliberately NOT admitted (the thrown value is constructed),
-    // but it must keep working on the generic path.
+    // A throw that CONSTRUCTS its value is not admitted (the construction is a
+    // call in a block that does not end in `unreachable`), but it must keep
+    // working on the generic path.
     let out = compile_and_run(&format!(
         "{PRELUDE}
         function throwAt(k: number): string {{


### PR DESCRIPTION
Third attempt at this row, and the two failures were the cost of learning why.

## Two gates, and relaxing either alone does nothing

`stmt_is_packed_f64_loop_safe` rejects `Stmt::Throw` at the HIR level. Independently, `fast_clone_call_free` scans the **emitted** clone blocks through `contains_gc_unsafe_call`, and constructing a thrown value is a call. My first attempt relaxed the HIR gate and measured nothing; my second relaxed the block scan and measured nothing. Both are needed.

## The argument

A throw is the one place a call in the loop body is harmless. Codegen already emits `unreachable` after `js_throw` (`stmt/mod.rs:591`), so control never returns to the loop — there is no second read of anything the clone cached, which is precisely what the scan exists to protect. `contains_gc_unsafe_call` now says so directly: a block whose last instruction is `unreachable` has no "after".

## Numbers, including the one that didn't move

Quiet Mac mini, node v26.5.1, ns/op, one binary switched with `PERRY_PACKED_LOOP_ABRUPT`:

| loop body | perry off | perry on | node |
|---|---|---|---|
| `throw <pre-built error>` | 4.76 | **0.58** | 0.56 |
| `throw <number>` | 4.76 | **0.58** | 0.56 |
| `throw new Error(…)` | 4.78 | 4.78 | 0.56 |

**The third row is the important one.** A throw that *constructs* its value is still rejected, because the construction is emitted in blocks that **precede** the `unreachable`-terminated one, so a per-block check cannot cover them. Admitting it needs a region property — every path from the block leads to an unwind without re-entering the loop — which is a dominance question and a larger change.

That split is what identifies the remaining blocker as a region property rather than a third unknown gate. Two attempts failed trying to establish it by reasoning; one experiment settled it.

Rethrowing a caught error, throwing a sentinel, and throwing a value are the shapes this covers.

## Validation

Differentials where the throws **actually fire**, at varying indices, with observable effects before them — a never-taken throw would exercise only the admission decision, not the emitted clone. Byte-identical to node, and identical again under `PERRY_GC_PROTECT_FROMSPACE` with seeded aggressive collection schedules.

The heavy case is the one that matters for a change admitting a call into the clone region: arrays escaping into a sink so they are not scalar-replaced, 120 rounds, throws firing every round — **identical across seeds at 193,052 moved objects**.

## Gates

`-D warnings` clean; hir 591/0; codegen 1842/0; runtime lib 2844/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: `packed_loop_abrupt_statements` 8/8 (one new), plus 7/7, 5/5, 2/2, 3/3, 3/3.

## Kill switch

`PERRY_PACKED_LOOP_ABRUPT=0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreachable code to prevent incorrect safety warnings.
  * Packed loops now support throws using already-prepared values while retaining optimized execution.
  * Throws requiring value construction continue to use the safer fallback path.

* **Tests**
  * Added coverage for throw statements in packed loops, including optimized and fallback behavior.
  * Verified that existing abrupt-control-flow safeguards remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->