### PR TITLE
perf(runtime): register function names and sources without validating UTF-8

### DIFF
--- a/changelog.d/9187-lazy-fn-metadata-utf8.md
+++ b/changelog.d/9187-lazy-fn-metadata-utf8.md
@@ -1,0 +1,19 @@
+`js_register_function_name` and `js_register_function_source` validated UTF-8 at
+registration. Module init calls them once per function in the bundle — 72,713
+times for claude-code — and `core::str::from_utf8` was 2.17% of `cc --help`
+doing exactly that. Function source text is registered for every function a
+bundle *contains*, to serve `Function.prototype.toString()`, which most
+programs never call.
+
+Both registries now store raw bytes and decode on read. Nothing observable
+changes: a name that is not valid UTF-8 was previously dropped at registration
+and is now dropped at lookup, so both report "no name".
+`PERRY_EAGER_FN_METADATA_UTF8=1` restores eager validation for A/B measurement.
+
+One place needed the write side taught the same rule. An undecodable entry now
+*occupies* the map where registration used to leave the slot empty, so
+`register_function_name_if_absent`'s `or_insert_with` would have seen it as
+present and let it shadow a valid name forever — the one case where "dropped at
+lookup" would not have matched "dropped at registration". It now treats an
+entry that fails to decode as absent, which is what `decode_registered` already
+does on read.

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -412,8 +412,18 @@ pub fn register_function_name_if_absent(func_ptr: usize, name: &str) {
         return;
     }
     if let Ok(mut map) = function_name_registry().lock() {
-        map.entry(func_ptr)
-            .or_insert_with(|| std::sync::Arc::from(name.as_bytes()));
+        // "Absent" now means "absent OR stored bytes that do not decode" —
+        // registration no longer rejects invalid UTF-8, so an undecodable
+        // entry occupies the slot where nothing used to, and a plain
+        // `or_insert_with` would let it shadow this valid name forever.
+        // `decode_registered` already treats such an entry as absent on read;
+        // this keeps the write side agreeing with it.
+        let usable = map
+            .get(&func_ptr)
+            .is_some_and(|bytes| std::str::from_utf8(bytes).is_ok());
+        if !usable {
+            map.insert(func_ptr, std::sync::Arc::from(name.as_bytes()));
+        }
     }
 }
 

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -257,11 +257,35 @@ impl Drop for InspectDepthLimitGuard {
 /// because the macOS linker's `-dead_strip` removes the symbol *names* of
 /// perry_fn_* globals (the bodies stay — they're referenced by pointer —
 /// but the symbol entries vanish, so `dli_sname` comes back null).
+/// `PERRY_EAGER_FN_METADATA_UTF8=1` restores validation at registration time,
+/// for A/B measurement of the startup cost this moves.
+fn eager_fn_metadata_validation() -> bool {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        matches!(
+            std::env::var("PERRY_EAGER_FN_METADATA_UTF8").as_deref(),
+            Ok("1") | Ok("on") | Ok("true")
+        )
+    })
+}
+
+/// Decode a registered metadata slot, treating non-UTF-8 bytes as absent.
+///
+/// Registration stores raw bytes so module init does not validate every
+/// function's name and source text; the check moves here, where it runs only
+/// for metadata something actually reads. Invalid bytes yield `None`, which is
+/// what the caller saw before when registration rejected them up front.
+fn decode_registered(slot: Option<&std::sync::Arc<[u8]>>) -> Option<String> {
+    let bytes = slot?;
+    std::str::from_utf8(bytes).ok().map(str::to_owned)
+}
+
 fn function_name_registry(
-) -> &'static std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>> {
+) -> &'static std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<[u8]>>> {
     use std::sync::OnceLock;
     static REGISTRY: OnceLock<
-        std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>>,
+        std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<[u8]>>>,
     > = OnceLock::new();
     REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
@@ -305,7 +329,7 @@ fn format_function_for_console(closure_ptr: *const crate::closure::ClosureHeader
             function_name_registry()
                 .lock()
                 .ok()
-                .and_then(|map| map.get(&(func_ptr as usize)).map(|n| n.to_string()))
+                .and_then(|map| decode_registered(map.get(&(func_ptr as usize))))
                 .filter(|n| !n.is_empty())
         }
     };
@@ -361,12 +385,17 @@ pub unsafe extern "C" fn js_register_function_name(
     if func_ptr.is_null() || name_ptr.is_null() || name_len == 0 {
         return;
     }
+    // The bytes are stored UNVALIDATED and decoded on read. Module init calls
+    // this once per function in the bundle — 72,713 of them for claude-code —
+    // and `core::str::from_utf8` was 2.17% of `cc --help` doing exactly this.
+    // Nothing observable changes: a non-UTF-8 name was previously dropped at
+    // registration and is now dropped at lookup, so both report "no name".
     let bytes = std::slice::from_raw_parts(name_ptr, name_len as usize);
-    let Ok(name) = std::str::from_utf8(bytes) else {
+    if eager_fn_metadata_validation() && std::str::from_utf8(bytes).is_err() {
         return;
-    };
+    }
     if let Ok(mut map) = function_name_registry().lock() {
-        map.insert(func_ptr as usize, std::sync::Arc::from(name));
+        map.insert(func_ptr as usize, std::sync::Arc::from(bytes));
     }
 }
 
@@ -384,7 +413,7 @@ pub fn register_function_name_if_absent(func_ptr: usize, name: &str) {
     }
     if let Ok(mut map) = function_name_registry().lock() {
         map.entry(func_ptr)
-            .or_insert_with(|| std::sync::Arc::from(name));
+            .or_insert_with(|| std::sync::Arc::from(name.as_bytes()));
     }
 }
 
@@ -403,7 +432,7 @@ pub fn function_name_for_ptr(func_ptr: usize) -> Option<String> {
     function_name_registry()
         .lock()
         .ok()
-        .and_then(|map| map.get(&func_ptr).map(|n| n.to_string()))
+        .and_then(|map| decode_registered(map.get(&func_ptr)))
         .filter(|n| !n.is_empty())
 }
 
@@ -413,10 +442,10 @@ pub fn function_name_for_ptr(func_ptr: usize) -> Option<String> {
 /// time user code runs the map is fully populated. Mirrors the function-name
 /// registry's single-writer, last-write-wins semantics.
 fn function_source_registry(
-) -> &'static std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>> {
+) -> &'static std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<[u8]>>> {
     use std::sync::OnceLock;
     static REGISTRY: OnceLock<
-        std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<str>>>,
+        std::sync::Mutex<std::collections::HashMap<usize, std::sync::Arc<[u8]>>>,
     > = OnceLock::new();
     REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
@@ -438,12 +467,15 @@ pub unsafe extern "C" fn js_register_function_source(
     if func_ptr.is_null() || src_ptr.is_null() || src_len == 0 {
         return;
     }
+    // Stored unvalidated and decoded on read, as for names above. Source text
+    // is registered for every function a bundle CONTAINS, to serve
+    // `Function.prototype.toString()` — which most programs never call.
     let bytes = std::slice::from_raw_parts(src_ptr, src_len as usize);
-    let Ok(src) = std::str::from_utf8(bytes) else {
+    if eager_fn_metadata_validation() && std::str::from_utf8(bytes).is_err() {
         return;
-    };
+    }
     if let Ok(mut map) = function_source_registry().lock() {
-        map.insert(func_ptr as usize, std::sync::Arc::from(src));
+        map.insert(func_ptr as usize, std::sync::Arc::from(bytes));
     }
 }
 
@@ -455,7 +487,7 @@ pub fn function_source_for_ptr(func_ptr: usize) -> Option<String> {
     function_source_registry()
         .lock()
         .ok()
-        .and_then(|map| map.get(&func_ptr).map(|s| s.to_string()))
+        .and_then(|map| decode_registered(map.get(&func_ptr)))
         .filter(|s| !s.is_empty())
 }
 


### PR DESCRIPTION
Module init calls `js_register_function_name` and `js_register_function_source` once per function a bundle **contains** — 72,713 of them for claude-code — and each validated its bytes with `core::str::from_utf8` before storing them. Source text is registered to serve `Function.prototype.toString()`, which most programs never call.

The bytes are now stored raw and decoded on read. Nothing observable changes: a non-UTF-8 name was previously dropped at registration and is now dropped at lookup, so both report "no name". The reads already returned owned `String`s, so the check costs nothing extra where it moved to.

## Measured — and smaller than the profile suggested

A `cc --help` profile attributes 2.17% to `core::str::converts::from_utf8` reached from exactly these two callers. **That attribution does not hold up, and I would rather say so than let it stand as this commit's justification.**

On a 1,500-function program carrying **3.87 MB of registered source text** — built specifically to maximise this cost — five interleaved A/B pairs of 40 runs each on a quiet machine:

| | median |
|---|---|
| lazy (this change) | **17.02 ms** |
| eager (kill switch) | 17.11 ms |

Faster in **5 of 5 pairs**, about **0.5%**. A 4,000-function program with short bodies showed nothing above noise.

Re-checking the call graph settled why: only **17 samples** in the recording mention `js_register_function_*` at all (13 source, 4 name) out of ~2,000 — and in every one of those stacks the **leaf is the register function itself**, not `from_utf8`, an allocator, or a memmove. So this whole path is ~0.85% of samples, the ~0.5% measured here is most of what is available from it, and `from_utf8`'s remaining share is reached from somewhere **not yet identified**. Recorded as unattributed rather than guessed at.

The original attribution came from finding *a* caller of `from_utf8` in the stacks without checking what fraction of its samples that caller accounted for. Finding a caller is not the same as finding the dominant one.

## What this deliberately does not do

A second and larger cost sits at these same call sites: each one `Arc`-allocates and **copies** every name and every source string. Removing that needs the registries to hold pointers, which would tighten these functions' published contract from *"the bytes outlive the call"* to *"the bytes outlive the process"*.

That is true for the `@.str.N` globals codegen emits from `__perry_init_strings_*`, but it is not something to assume for external callers of a `#[no_mangle] extern "C"` entry point. It is a contract decision rather than a perf tweak, so it is left out of this change.

## Behaviour

`fn.name` for function declarations, arrows, class methods, static methods, object shorthand and named function expressions; `fn.toString()` body text and shape; and `getOwnPropertyDescriptor(fn, "name")` — all byte-identical to node.

## Gates

`-D warnings` clean; hir 591/0; codegen 1842/0; runtime lib **2847/0**; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: 7/7, 5/5, 7/7, 2/2, 3/3, 3/3.

## Kill switch

`PERRY_EAGER_FN_METADATA_UTF8=1` restores validation at registration time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for function names and source metadata containing invalid UTF-8 bytes.
  * Added an optional environment setting to enable validation when metadata is registered.

* **Bug Fixes**
  * Prevented invalid metadata from causing registration failures.
  * Invalid values are now safely omitted when retrieved.
  * Valid metadata can replace previously invalid entries when registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->