### PR TITLE
fix(transform): route labeled breaks through yielding switches

### DIFF
--- a/changelog.d/9189-labeled-switch-break.md
+++ b/changelog.d/9189-labeled-switch-break.md
@@ -1,0 +1,3 @@
+Fixed async functions that used `await` inside a labeled `switch` and then
+executed `break <label>`; the generated binary could previously spin forever
+instead of continuing after the switch.

--- a/changelog.d/9194-loop-property-hoist-stack.md
+++ b/changelog.d/9194-loop-property-hoist-stack.md
@@ -1,0 +1,2 @@
+Fixed a compiler stack overflow while lowering some JavaScript dependency
+graphs with the loop-property-array optimization enabled.

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -32,6 +32,47 @@ use detect::{
 
 use for_await::lower_runtime_for_await_iterator_body;
 
+// Keep the property-hoist pass and its large `Stmt`/`Expr` return place out of
+// recursive `lower_body_stmt` frames. At the unoptimized test profile, adding
+// those temporaries to the monolithic lowering function exhausted Rust's
+// default 2 MiB test-thread stack while compiling an unrelated dependency
+// graph (#9194). The call boundary is intentional, including in optimized
+// compiler builds.
+#[inline(never)]
+fn finish_for_with_property_array_hoist(
+    ctx: &mut LoweringContext,
+    init: Option<Box<Stmt>>,
+    condition: Option<Expr>,
+    update: Option<Expr>,
+    body: Vec<Stmt>,
+) -> Vec<Stmt> {
+    if let Some((hoist, new_condition, new_body)) = condition.as_ref().and_then(|cond| {
+        crate::lower::property_array_hoist::hoist_loop_invariant_property_array(
+            ctx,
+            cond,
+            update.as_ref(),
+            &body,
+        )
+    }) {
+        return vec![
+            hoist,
+            Stmt::For {
+                init,
+                condition: Some(new_condition),
+                update,
+                body: new_body,
+            },
+        ];
+    }
+
+    vec![Stmt::For {
+        init,
+        condition,
+        update,
+        body,
+    }]
+}
+
 pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Vec<Stmt>> {
     let mut result = Vec::new();
 
@@ -880,32 +921,10 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             // 20.58 ns/iteration versus 0.50 hand-hoisted (node: 0.54). The
             // pass refuses unless the read is provably side-effect free and
             // the loop cannot rebind or write it — see the module docs.
-            let hoisted = condition.as_ref().and_then(|cond| {
-                crate::lower::property_array_hoist::hoist_loop_invariant_property_array(
-                    ctx,
-                    cond,
-                    update.as_ref(),
-                    &body,
-                )
-            });
+            let lowered_for =
+                finish_for_with_property_array_hoist(ctx, init, condition, update, body);
             ctx.pop_block_scope(for_scope_mark);
-            match hoisted {
-                Some((hoist, new_condition, new_body)) => {
-                    result.push(hoist);
-                    result.push(Stmt::For {
-                        init,
-                        condition: Some(new_condition),
-                        update,
-                        body: new_body,
-                    });
-                }
-                None => result.push(Stmt::For {
-                    init,
-                    condition,
-                    update,
-                    body,
-                }),
-            }
+            result.extend(lowered_for);
         }
         ast::Stmt::Try(try_stmt) => {
             // try body is its own lexical scope

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -1595,7 +1595,7 @@ pub fn linearize_body(
                     Stmt::For { body, .. }
                     | Stmt::While { body, .. }
                     | Stmt::DoWhile { body, .. } => {
-                        rewrite_labeled_bc_in_stmts(body, label);
+                        rewrite_labeled_bc_in_stmts(body, label, next_local_id);
                     }
                     // A labeled yielding SWITCH: `break label` at case-body
                     // level is the switch's own break — rewrite it to plain
@@ -1603,7 +1603,7 @@ pub fn linearize_body(
                     // into the done-flag (#5868).
                     Stmt::Switch { cases, .. } => {
                         for case in cases.iter_mut() {
-                            rewrite_labeled_bc_in_stmts(&mut case.body, label);
+                            rewrite_labeled_bc_in_stmts(&mut case.body, label, next_local_id);
                         }
                     }
                     _ => {}
@@ -1670,14 +1670,45 @@ pub fn linearize_body(
 /// Within a labeled loop's body, rewrite `break label` / `continue label`
 /// that target THIS label into plain `break` / `continue`, so the loop's own
 /// For/While linearization (which only knows about plain break/continue) maps
-/// them to the loop's state targets. Descends only through `if` / `try`
-/// (which don't capture break/continue), mirroring the scoping of
-/// `rewrite_break_continue_in_stmt`. Stops at nested loops and `switch` —
-/// a `break label` from inside one of those still targets this loop, but the
-/// current single-sentinel scheme can't express that, so those are left
-/// as-is (pre-existing limitation).
-fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
-    for s in stmts.iter_mut() {
+/// them to the loop's state targets. Descends through `if` / `try`, which do
+/// not capture either completion. Nested loops remain a boundary because a
+/// plain break/continue there would bind to the nested loop.
+///
+/// A switch is also a boundary for a plain `break`, but not for a labeled
+/// break targeting the enclosing loop. When such a break is present, desugar
+/// the switch first: its own plain breaks become the switch done-flag, while
+/// the still-named outer break lands in the resulting `if` chain and can then
+/// safely become the enclosing loop's plain break. This is especially
+/// important for source `label: switch (...)` statements: HIR represents the
+/// non-loop label as a labeled run-once do-while, and generator linearization
+/// otherwise drops that label target while splitting an awaited case (#9186).
+fn rewrite_labeled_bc_in_stmts(stmts: &mut Vec<Stmt>, label: &str, next_local_id: &mut u32) {
+    let mut i = 0;
+    while i < stmts.len() {
+        let desugared_switch = match &stmts[i] {
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } if cases
+                .iter()
+                .any(|case| stmts_have_labeled_break_for(&case.body, label)) =>
+            {
+                Some(super::break_continue::desugar_switch_to_ifs(
+                    discriminant,
+                    cases,
+                    next_local_id,
+                ))
+            }
+            _ => None,
+        };
+        if let Some(desugared) = desugared_switch {
+            stmts.splice(i..=i, desugared);
+            // Reprocess at the same position. The replacement consists of
+            // lets/ifs, so recursion below rewrites the preserved named break.
+            continue;
+        }
+
+        let s = &mut stmts[i];
         match s {
             Stmt::LabeledBreak(l) if l == label => *s = Stmt::Break,
             Stmt::LabeledContinue(l) if l == label => *s = Stmt::Continue,
@@ -1686,9 +1717,9 @@ fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
                 else_branch,
                 ..
             } => {
-                rewrite_labeled_bc_in_stmts(then_branch, label);
+                rewrite_labeled_bc_in_stmts(then_branch, label, next_local_id);
                 if let Some(eb) = else_branch.as_mut() {
-                    rewrite_labeled_bc_in_stmts(eb, label);
+                    rewrite_labeled_bc_in_stmts(eb, label, next_local_id);
                 }
             }
             Stmt::Try {
@@ -1696,12 +1727,12 @@ fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
                 catch,
                 finally,
             } => {
-                rewrite_labeled_bc_in_stmts(body, label);
+                rewrite_labeled_bc_in_stmts(body, label, next_local_id);
                 if let Some(c) = catch.as_mut() {
-                    rewrite_labeled_bc_in_stmts(&mut c.body, label);
+                    rewrite_labeled_bc_in_stmts(&mut c.body, label, next_local_id);
                 }
                 if let Some(f) = finally.as_mut() {
-                    rewrite_labeled_bc_in_stmts(f, label);
+                    rewrite_labeled_bc_in_stmts(f, label, next_local_id);
                 }
             }
             // #5975: a `continue <label>` that targets THIS enclosing labeled
@@ -1709,14 +1740,6 @@ fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
             // `continue`, so it continues the loop — rewrite it to a plain
             // `continue` here so the loop's linearization (and the #5868
             // yielding-switch desugar) map it to the loop's re-entry sentinel.
-            // Without this the `LabeledContinue` survives verbatim into the
-            // desugared switch's state machine, where nothing lowers it, and a
-            // `loop: while (…) { switch (…) { case …: yield …; continue loop } }`
-            // (e.g. the `yaml` package's block-scalar / indicator lexer, a
-            // generator) spins forever. `break <label>` is deliberately NOT
-            // rewritten in a nested switch: a switch DOES capture `break`, so a
-            // plain `break` would exit only the switch, not the loop — that is
-            // the pre-existing single-sentinel limitation documented above.
             Stmt::Switch { cases, .. } => {
                 for case in cases.iter_mut() {
                     rewrite_labeled_continue_in_stmts(&mut case.body, label);
@@ -1724,7 +1747,47 @@ fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
             }
             _ => {}
         }
+        i += 1;
     }
+}
+
+/// Whether a statement list can reach `break label` without crossing a loop
+/// or another labeled statement. Switches do not capture named breaks, so they
+/// are traversed and individually desugared by the caller when necessary.
+fn stmts_have_labeled_break_for(stmts: &[Stmt], label: &str) -> bool {
+    stmts.iter().any(|stmt| match stmt {
+        Stmt::LabeledBreak(found) => found == label,
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            stmts_have_labeled_break_for(then_branch, label)
+                || else_branch
+                    .as_ref()
+                    .is_some_and(|branch| stmts_have_labeled_break_for(branch, label))
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            stmts_have_labeled_break_for(body, label)
+                || catch
+                    .as_ref()
+                    .is_some_and(|clause| stmts_have_labeled_break_for(&clause.body, label))
+                || finally
+                    .as_ref()
+                    .is_some_and(|body| stmts_have_labeled_break_for(body, label))
+        }
+        Stmt::Switch { cases, .. } => cases
+            .iter()
+            .any(|case| stmts_have_labeled_break_for(&case.body, label)),
+        Stmt::For { .. } | Stmt::While { .. } | Stmt::DoWhile { .. } | Stmt::Labeled { .. } => {
+            false
+        }
+        _ => false,
+    })
 }
 
 /// Rewrite `continue <label>` → plain `continue` for `label`, descending

--- a/crates/perry/tests/issue_5868_switch_state_machine.rs
+++ b/crates/perry/tests/issue_5868_switch_state_machine.rs
@@ -20,7 +20,8 @@
 //! --experimental-strip-types` prints.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 fn perry_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_perry"))
@@ -47,14 +48,33 @@ fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
         String::from_utf8_lossy(&compile.stderr)
     );
 
-    let run = Command::new(&output)
+    // Bound the generated program itself. A broken state transition can spin
+    // forever; without this guard one regression test consumed the entire
+    // two-hour cargo-test shard budget before CI exposed the culprit (#9186).
+    let mut child = Command::new(&output)
         .current_dir(dir)
-        .output()
-        .expect("run compiled binary");
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll compiled binary") {
+            break status;
+        }
+        if start.elapsed() > timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("compiled binary did not exit within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let run = child.wait_with_output().expect("collect compiled output");
     assert!(
-        run.status.success(),
+        status.success(),
         "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
-        run.status.code(),
+        status.code(),
         String::from_utf8_lossy(&run.stdout),
         String::from_utf8_lossy(&run.stderr)
     );

--- a/crates/perry/tests/loop_property_array_hoist.rs
+++ b/crates/perry/tests/loop_property_array_hoist.rs
@@ -95,6 +95,21 @@ fn hoists_a_loop_invariant_property_array() {
 }
 
 #[test]
+fn generated_hoist_name_does_not_shadow_a_source_binding() {
+    assert_same_with_and_without_hoist(
+        "generated name collision",
+        r#"
+        const __perry_hoist_arr = 99;
+        const holder = { arr: [1, 2, 3] };
+        let sum = 0;
+        for (let i = 0; i < holder.arr.length; i++) sum += holder.arr[i];
+        console.log(__perry_hoist_arr + " " + sum);
+        "#,
+        "99 6",
+    );
+}
+
+#[test]
 fn refuses_when_the_receiver_is_rebound_in_the_loop() {
     // Both objects share a shape, so no runtime shape check could catch this:
     // the rewrite has to refuse it syntactically. A stale array would keep

--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -143,6 +143,7 @@ _CODEGEN_SUITES = [
     "scalar_replaced_slot_roots",
     "spec_abi_typed_array_local_length",
     "static_symbol_hygiene",
+    "string_array_length_9160",
     "temp_root_operand_temporaries",
     "typed_array_rmw_8692",
     "typed_shape_declared_at_allocation",


### PR DESCRIPTION
Closes #9186.

## What changed

- When generator linearization finds a switch containing a named break to its enclosing labeled loop, desugar the switch before rewriting the named completion.
- Switch-local plain breaks still become the switch done flag; the named break then reaches the enclosing loop state target through the resulting if-chain.
- Add a 30-second runtime deadline to the #5868 integration helper so a future state-machine spin fails with the exact test name instead of consuming the full cargo shard timeout.

## Root cause

HIR lowers a labeled non-loop statement such as `l: switch (...)` to a labeled run-once `do ... while(false)`. The yielding-loop linearizer removes that label wrapper, while the existing labeled break rewrite deliberately stopped at nested switches. After await splitting, `LabeledBreak("l")` therefore survived into a dispatch state and codegen fell back to the dispatch loop target, spinning forever.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p perry-transform`
- dedicated Linux server, exact commit and LLVM 22:
  - `issue_5868_switch_state_machine`: 9/9 passed
  - `issue_5975_labeled_continue_in_yielding_switch`: 4/4 passed
- the formerly hanging `labeled_switch_break_label` case completes in about 6 seconds; before the fix it spun until CI killed the two-hour shard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed async functions with `await` inside labeled switches so `break` continues execution instead of hanging.
  * Prevented compiler stack overflows when processing certain JavaScript dependency graphs with loop-property optimization enabled.
  * Prevented generated loop variables from conflicting with existing application variables.

* **Reliability**
  * Added timeout protection to regression test execution, preventing stalled processes from blocking test runs.

* **Testing**
  * Improved end-to-end test coverage and automatic test selection for string-array length scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->