### PR TITLE
perf(gc): build the stack-map index on first collection, not at startup (−26% startup, −42% RSS)

### DIFF
--- a/changelog.d/9191-lazy-stack-map-index.md
+++ b/changelog.d/9191-lazy-stack-map-index.md
@@ -1,0 +1,29 @@
+`js_gc_init` decoded the whole gc-map section at every process start. For
+claude-code that is 17.4 MB, 72,713 functions and 2,151,926 records, producing a
+117 MB index — and a run that never collects never reads a byte of it.
+
+The build moves to the three functions every collection funnels through
+(`gc_collect_minor_with_trigger`, `gc_collect_forced_evacuating_minor`,
+`gc_collect_full_mark_sweep_with_trigger`), which is as late as it can go:
+allocation is still legal there, and the root scan itself must stay
+allocation-free once the collector owns the heap. `initialize` re-arms rather
+than builds, so a newly loaded image's section is decoded by the next
+collection. `PERRY_LAZY_STACK_MAPS` switches one binary between the two.
+
+On a 1,500-function program carrying 3.87 MB of source, medians of interleaved
+pairs of 40 runs: startup 12.77 ms vs 17.25 ms (−26%), peak RSS 35.6 MB vs
+61.4 MB (−42%). A hello-world is unchanged, which is the expected shape — its
+section is small, so there was little to defer. Scope worth stating: a
+non-collecting run avoids the decode entirely, while a run that does collect
+only has it deferred.
+
+This is step 2 of the sequence #9182 opened, and the reason that PR landed
+first. Scanning against an unbuilt index is indistinguishable from an image with
+no native roots, so correctness rests on every path into the root scan passing
+through the build — an enumeration that could not be established by reading the
+code. The fail-closed assert caught three unenumerated entry points and one
+misplacement: the build had been put in `gc_finish_arena_trigger_collection` and
+`gc_finish_malloc_trigger_collection`, which take a `GcCollectOutcome` and
+therefore run *after* the collection they name — useless, invisible to every
+timing test, and a silent heap corruption weeks later. It aborted loudly in
+minutes instead, four separate times.

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -221,6 +221,13 @@ pub fn gc_collect_minor() -> u64 {
 }
 
 pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    // Build the stack-map index if it is still owed. This is the chokepoint:
+    // every collection funnels through one of these three entries, and here
+    // allocation is still legal — the root scan itself must stay
+    // allocation-free once the collector owns the heap, which is why the build
+    // cannot be deferred any further than this.
+    roots::ensure_stack_maps_built();
+
     gc_collect_minor_with_trigger_inner(trigger, FullEscalation::Allowed)
 }
 
@@ -246,6 +253,13 @@ pub(super) enum FullEscalation {
 /// (#6946). Refuses the pacing escalation, so the caller gets the moving
 /// collection the knob promises rather than a full sweep that moves nothing.
 pub(super) fn gc_collect_forced_evacuating_minor(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    // Build the stack-map index if it is still owed. This is the chokepoint:
+    // every collection funnels through one of these three entries, and here
+    // allocation is still legal — the root scan itself must stay
+    // allocation-free once the collector owns the heap, which is why the build
+    // cannot be deferred any further than this.
+    roots::ensure_stack_maps_built();
+
     gc_collect_minor_with_trigger_inner(trigger, FullEscalation::Refused)
 }
 
@@ -682,6 +696,13 @@ fn gc_collect_inner_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome
 }
 
 fn gc_collect_full_mark_sweep_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    // Build the stack-map index if it is still owed. This is the chokepoint:
+    // every collection funnels through one of these three entries, and here
+    // allocation is still legal — the root scan itself must stay
+    // allocation-free once the collector owns the heap, which is why the build
+    // cannot be deferred any further than this.
+    roots::ensure_stack_maps_built();
+
     // PERRY_GC_SAFEPOINT_ONLY: see gc_collect_minor_with_trigger. Manual
     // gc() engages its own force_full_scan first, which this detects as
     // already-Scan and no-ops.

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -8,6 +8,7 @@ mod scanner_shims;
 mod shadow_stack;
 mod stack_maps;
 mod temp_roots;
+pub(super) use stack_maps::ensure_built as ensure_stack_maps_built;
 pub(super) use stack_maps::initialize as initialize_stack_maps;
 pub(super) use stack_maps::native_maps_active as native_stack_maps_active;
 pub(super) use stack_maps::publish_rewrite_walk_stats as stack_maps_publish_rewrite_walk_stats;

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -649,7 +649,51 @@ pub(in crate::gc) fn record_native_stack_walk_source(
     }
 }
 
+/// Mark the stack-map index as owed, without building it.
+///
+/// Decoding the gc-map section is the single largest cost in process startup
+/// for a big image — 17.4MB, 72,713 functions, 2.15M records and a 117MB index
+/// for claude-code — and a run that never collects never reads any of it.
+/// `cc --version` is exactly that run.
+///
+/// The build is therefore deferred to [`ensure_built`], which every path that
+/// can reach a root scan calls while allocation is still legal. Missing one of
+/// those paths would mean scanning against an unbuilt index, which is
+/// indistinguishable from "this image has no native roots" and frees live
+/// objects silently — so the assert at the top of `visit_stack_map_root_slots`
+/// (#9182) exists to turn that into a loud abort instead. It landed first, on
+/// purpose.
+///
+/// Re-arms on every call: a newly loaded image calls `js_gc_init` again, and
+/// the next collection must decode its section too.
 pub(in crate::gc) fn initialize() {
+    STACK_MAPS_INITIALIZED.store(false, Ordering::Release);
+    if !lazy_stack_maps_enabled() {
+        ensure_built();
+    }
+}
+
+/// `PERRY_LAZY_STACK_MAPS=0` restores the eager decode at `js_gc_init`, for
+/// A/B measurement of what the deferral is worth.
+fn lazy_stack_maps_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        !matches!(
+            std::env::var("PERRY_LAZY_STACK_MAPS").as_deref(),
+            Ok("0") | Ok("off") | Ok("false")
+        )
+    })
+}
+
+/// Build the stack-map index if it is owed. Safe to call redundantly.
+///
+/// MUST be called before any path that can reach [`visit_stack_map_root_slots`],
+/// and while allocation is still legal — the parser allocates its index once,
+/// and root scans must stay allocation-free while the collector owns the heap.
+pub(in crate::gc) fn ensure_built() {
+    if STACK_MAPS_INITIALIZED.load(Ordering::Acquire) {
+        return;
+    }
     STACK_MAPS.rebuild();
     // Publish AFTER the rebuild: a reader that observes the flag must be able
     // to observe the index it promises.


### PR DESCRIPTION
Step 2 of the sequence #9182 opened. **#9182 must be in main before this** — it is, and this is what it was for.

## What was wrong

`js_gc_init` decoded the entire gc-map section at every process start. For claude-code: **17.4 MB, 72,713 functions, 2,151,926 records**, producing a **117 MB index**. A run that never collects never reads a byte of it.

## Numbers

One binary switched with `PERRY_LAZY_STACK_MAPS`. A 1,500-function program carrying 3.87 MB of source; medians of interleaved pairs of 40 runs on a quiet machine:

| | lazy | eager |
|---|---|---|
| startup | **12.77 ms** | 17.25 ms — **−26%** |
| peak RSS | **35.6 MB** | 61.4 MB — **−42%** |

A hello-world is unchanged (3.47 vs 3.51 ms), which is the shape to expect: its section is small, so there was little to defer.

## Why this was not safe before, and is now

Scanning against an unbuilt index is **indistinguishable** from an image with no native roots — both are empty — so the collector finds no roots on the frame and frees live objects with no diagnostic at all. Correctness therefore rests on every path that can reach the root scan first passing through the build, and **that enumeration could not be established**: an initial claim of "two chokepoints" was withdrawn as unverified, and tracing found at least three fan-in points plus untraced allocation-triggered entries.

So the fail-closed assert landed **first** (#9182), against the eager build, where it could not fire.

**That decision paid immediately, and this is the part worth reading.** The assert caught three entry points I had not enumerated — including the first safepoint-triggered collection — and it caught a mistake of mine: I had put the build in `gc_finish_arena_trigger_collection` and `gc_finish_malloc_trigger_collection`, which take a `GcCollectOutcome` and therefore **run after the collection they name**. A placement that is useless, invisible to every timing test, and would have been a silent heap corruption discovered weeks later. Instead it was a loud abort in minutes, four separate times.

That is precisely the failure the two-PR sequence was designed to catch, catching precisely that failure, on the first run.

## Where the build goes

The three functions every collection funnels through — `gc_collect_minor_with_trigger`, `gc_collect_forced_evacuating_minor`, `gc_collect_full_mark_sweep_with_trigger` — where **allocation is still legal**. That is the constraint that stops the build being deferred any further: the root scan itself must stay allocation-free once the collector owns the heap, which is why it was hoisted to init in the first place.

`initialize` re-arms rather than builds, so a newly loaded image's section is decoded by the next collection.

## Scope of the win

Worth stating so the 26% is not quoted for the wrong workload: a **non-collecting** run (`--version`, shell completions, health checks) avoids the decode entirely. A run that **does** collect — `cc --help` spends 16.4% of wall time in minor collections — only has it **deferred**, not removed. Avoiding the decode for functions never on a stack needs the per-function `stream_offset` in a v5 map format, which is a separate change.

## Validation

**39 runs across 13 programs** under `PERRY_GC_PROTECT_FROMSPACE` with seeded aggressive collection schedules — up to **193,052 moved objects** — with the assert firing **zero** times and output byte-identical to node.

Two programs differ from node in both arms: the `Buffer.isBuffer` defect (#9173) and a class-prototype accessor-descriptor gap. Both reproduce identically with `PERRY_LAZY_STACK_MAPS=0`, so they are pre-existing and not from this change.

## Gates

`-D warnings` clean; hir 591/0; codegen 1842/0; runtime lib 2847/0; census, address-classification, file-size and raw-handle-debt lints all pass with none raised. Integration: 7/7, 5/5, 7/7, 2/2, 3/3, 3/3.

## Kill switch

`PERRY_LAZY_STACK_MAPS=0` restores the eager decode at `js_gc_init`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred garbage-collection metadata preparation until the first collection, reducing startup work and memory usage.
  * Added an option to disable deferred preparation when eager initialization is preferred.

* **Bug Fixes**
  * Improved garbage collection reliability by ensuring required metadata is prepared before collection begins.
  * Prevented allocation during critical collection phases, reducing the risk of collection-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->