### PR TITLE
ci: classify string_array_length_9160 so e2e-scoped stops failing every PR

### DIFF
--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -143,6 +143,7 @@ _CODEGEN_SUITES = [
     "scalar_replaced_slot_roots",
     "spec_abi_typed_array_local_length",
     "static_symbol_hygiene",
+    "string_array_length_9160",
     "temp_root_operand_temporaries",
     "typed_array_rmw_8692",
     "typed_shape_declared_at_allocation",


### PR DESCRIPTION
`e2e-scoped` is red on **every core PR** right now, and has been since #9160 merged. It fails at its very first step:

```
ci_e2e_scope: these crates/perry-codegen/tests/*.rs suites are in neither
SOURCE_SUITE_MAP nor SUITE_EXCLUSIONS: string_array_length_9160.
```

`crates/perry-codegen/tests/string_array_length_9160.rs` landed without a `_CODEGEN_SUITES` entry. That map is complete-by-construction for the crate — `_assert_map_covers_codegen_suites` requires every `crates/perry-codegen/tests/*.rs` on disk to be either mapped or listed in `SUITE_EXCLUSIONS` — so `--self-test` fails, and `e2e-scoped` runs the self-test before it does anything else. `pr-gate` fails behind it. Reproduced on a clean `84185b5656`, no local changes.

The gate is doing exactly what #7708 built it for: refusing to let a new suite be silently invisible to per-PR CI. The fix is the one-line classification it is asking for.

**Map, not exclusion.** `SUITE_EXCLUSIONS` entries require a *failing* test and an issue number, and there is neither — `cargo test -p perry-codegen --test string_array_length_9160` is 1/1 green on `84185b5656`. The suite is also the same shape as the other 28 mapped ones: an in-process compile of hand-built HIR, 0.02 s of test time, no `perry compile` subprocess, no link, no runtime. It belongs in the map on its merits, not just to quiet the gate.

**Verified**

- `python3 scripts/ci_e2e_scope.py --self-test` → `ok` (fails before the change)
- a `crates/perry-codegen/src/` change now selects it: `perry-codegen string_array_length_9160 300` (mapped timeout)
- a direct edit of the suite file still selects it at `1500` (named timeout)
- `cargo test -p perry-codegen --test string_array_length_9160` → `1 passed; 0 failed`

No changelog fragment: `scripts/` only, nothing under `crates/`.

https://claude.ai/code/session_01TE3JXAYXtdnKcLu8TCFWR6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added the `string_array_length_9160` end-to-end test suite to the set of tests selected for relevant code generation changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->