### PR TITLE
perf(runtime): the class-id-keyed registries move off SipHash — cc --help −0.69%, 25/25 rounds

### DIFF
--- a/changelog.d/9147-followup-class-registry-fast-hash.md
+++ b/changelog.d/9147-followup-class-registry-fast-hash.md
@@ -1,0 +1,59 @@
+### Changed
+
+- **The class-id-keyed registries moved off SipHash.** #9147 converted the
+  pointer-keyed runtime registries to `fast_hash`; the class registries were
+  the sampled remainder. A symbolized 12-run profile of `claude-code --help`
+  on the post-#9147 tree put SipHash (`RandomState` on the stack) at 3.08% of
+  on-CPU samples, and named these callers: `get_parent_class_id` (0.198% of
+  total samples), `remember_class_keys_array` (0.175%),
+  `js_gc_typed_shape_id_for_keys` (0.115%), plus the `js_register_class_*`
+  family (~0.18% combined).
+
+  Converted to `PtrHashMap` / `PtrHashSet`:
+
+  * every class-id-keyed table in `ClassImageTables` — `vtables`,
+    `static_methods`/`static_accessors` (OUTER map only), `constructors`,
+    `constructor_flags`, `registered_class_ids`, `parents`,
+    `fetch_parent_kind`, `generic_origin`, `extends_error`, `has_instance`,
+    `to_string_tag`, `extends_data_view`, `extends_typed_array`, `names`,
+    `lengths`, `anon_shape_class_ids`;
+  * `CLASS_KEYS_BY_ID` (`object/alloc.rs`), probed on every object
+    construction — `js_build_class_keys_array` calls
+    `remember_class_keys_array` even on its shape-cache hit path;
+  * `ObjectHotTables::shape_cache_overflow`, probed whenever a shape id misses
+    the 256-entry direct-mapped inline cache (ids step by `10007 mod 256 == 23`,
+    so any image with >256 live shapes collides constantly). Every sibling
+    field of that struct was already a fast table or an `UnsafeCell` array;
+    this one was the exception.
+
+  `gc::layout::typed_shape`'s `ids_by_layout` takes `FastKeyHashMap`, not
+  `PtrHashMap`: `RegisteredTypedShapeKey` is a composite of two `u32`s and two
+  `Vec<u64>` mask lists, and `PtrHasher`'s overwriting `write_*` would collapse
+  it to its last field. Its sibling `layouts_by_id` is a bare `u32` key and
+  takes `PtrHashMap`.
+
+  Every key here is a codegen-minted class id or a runtime-minted shape id —
+  never external input — so SipHash's DoS resistance buys nothing.
+
+  **Deliberately left on SipHash**, because their keys are JS-supplied
+  property/member names on paths that can see adversarial input, or because
+  their iteration order is user-visible: the INNER `HashMap<String, _>` of
+  `StaticMethodTable`/`StaticAccessorTable`, `method_bind_lengths` and
+  `static_method_bind_lengths` (`(u32, String)`), `CLASS_DYNAMIC_PROPS`' inner
+  `HashMap<String, f64>` (its `.keys()` feeds `Object.keys(C)`, and
+  `sort_property_names_ecma` orders only the integer-like keys — string keys
+  keep map order), `ClosureProps::values`, and `js_for_in_keys_value`'s
+  shadowing `HashSet<String>`.
+
+  Iteration-order audit: none of the converted maps is iterated anywhere except
+  GC root scans (`.values_mut()`, commutative) and `class_side_table_root_snapshot`;
+  `CLASS_KEYS_BY_ID`, `shape_cache_overflow`'s non-GC paths, `ids_by_layout` and
+  `layouts_by_id` are never iterated at all. `cc --help` output is byte-identical
+  before and after.
+
+  Measured on an otherwise idle Mac mini (load 1.6), alternating A/B, 25 paired
+  rounds of `claude-code --help`: median 873.0 ms -> 867.0 ms (**-0.69%**), min
+  871 -> 862 ms, opt faster in 25/25 rounds (mean delta -6.2 ms, stdev 2.2).
+  In the profile, `get_parent_class_id`, `js_gc_typed_shape_id_for_keys`,
+  `shape_cache_insert` and the `js_register_class_*` family no longer appear
+  under any SipHash frame at all. `.text` grows ~2 KB (+0.016%).

--- a/crates/perry-runtime/src/gc/layout/typed_shape.rs
+++ b/crates/perry-runtime/src/gc/layout/typed_shape.rs
@@ -75,8 +75,19 @@ struct RegisteredTypedShapeKey {
 
 #[derive(Default)]
 struct RegisteredTypedShapes {
-    ids_by_layout: std::collections::HashMap<RegisteredTypedShapeKey, u32>,
-    layouts_by_id: std::collections::HashMap<u32, TypedLayoutDescriptor>,
+    /// `FastKeyHasher`, NOT `PtrHasher`: [`RegisteredTypedShapeKey`] is a
+    /// COMPOSITE key (two `u32`s plus two `Vec<u64>` mask word lists), and
+    /// `PtrHasher`'s `write_*` OVERWRITE the accumulator, which would collapse
+    /// the key to its last field. `FastKeyHasher` folds every field.
+    ///
+    /// Neither half is external input — `class_id` is codegen-minted and the
+    /// mask words are derived from the compiled class layout — so SipHash's
+    /// DoS resistance buys nothing. The derived `Hash` feeds each mask word
+    /// through `write_u64`, which SipHash charges per byte; the word-at-a-time
+    /// folds added in #9147 make that one multiply per word.
+    ids_by_layout: crate::fast_hash::FastKeyHashMap<RegisteredTypedShapeKey, u32>,
+    /// Bare `u32` ShapeId key -> `PtrHasher` (single multiply + avalanche).
+    layouts_by_id: crate::fast_hash::PtrHashMap<u32, TypedLayoutDescriptor>,
 }
 
 static REGISTERED_TYPED_SHAPES: std::sync::LazyLock<std::sync::Mutex<RegisteredTypedShapes>> =

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -7,8 +7,22 @@
 
 use super::*;
 
-static CLASS_KEYS_BY_ID: std::sync::RwLock<Option<std::collections::HashMap<u32, (usize, u32)>>> =
-    std::sync::RwLock::new(None);
+/// class_id -> (keys array address, field count).
+///
+/// `PtrHasher`, not SipHash: the key is a codegen-minted class id (a small
+/// sequential counter, see `perry-hir::lower::context`), never external input,
+/// so hash-flooding resistance buys nothing — the same rationale as the
+/// pointer-keyed registries in `fast_hash`. `js_build_class_keys_array` calls
+/// `remember_class_keys_array` on EVERY invocation, including the shape-cache
+/// hit path, so this probe is per-object-construction rather than
+/// per-registration; a `claude-code --help` profile put SipHash under
+/// `remember_class_keys_array` at 0.175% of samples.
+///
+/// Iteration-order safe: the map is only ever `insert`ed and `get`ed (the two
+/// sites below). Nothing iterates it, so the hasher cannot reorder anything.
+static CLASS_KEYS_BY_ID: std::sync::RwLock<
+    Option<crate::fast_hash::PtrHashMap<u32, (usize, u32)>>,
+> = std::sync::RwLock::new(None);
 
 fn remember_class_keys_array(class_id: u32, field_count: u32, keys_array: *mut ArrayHeader) {
     if class_id == 0 || keys_array.is_null() {
@@ -17,7 +31,7 @@ fn remember_class_keys_array(class_id: u32, field_count: u32, keys_array: *mut A
     {
         let mut guard = CLASS_KEYS_BY_ID.write().unwrap();
         if guard.is_none() {
-            *guard = Some(std::collections::HashMap::new());
+            *guard = Some(crate::fast_hash::new_ptr_hash_map());
         }
         guard
             .as_mut()

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn js_register_class_constructor(
     }
     let mut guard = CLASS_CONSTRUCTORS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(crate::fast_hash::new_ptr_hash_map());
     }
     guard.as_mut().unwrap().insert(
         class_id as u32,
@@ -166,7 +166,7 @@ pub extern "C" fn js_register_class_constructor_flags(
     }
     let mut guard = CLASS_CONSTRUCTOR_FLAGS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(crate::fast_hash::new_ptr_hash_map());
     }
     guard.as_mut().unwrap().insert(
         class_id as u32,

--- a/crates/perry-runtime/src/object/class_image.rs
+++ b/crates/perry-runtime/src/object/class_image.rs
@@ -70,8 +70,9 @@
 //! purpose: a latch armed by ANY image only ever costs another image the slow
 //! path, never a wrong answer.
 
+use crate::fast_hash::{PtrHashMap, PtrHashSet};
 use std::cell::OnceCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LockResult, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::thread::ThreadId;
@@ -84,40 +85,63 @@ use super::class_registry::ClassVTable;
 pub(crate) const PARENT_DENSE_CAP: usize = 1 << 16;
 
 /// class_id -> { name -> (func_ptr, param_count, has_rest) } for static methods.
-pub type StaticMethodTable = HashMap<u32, HashMap<String, (usize, u32, bool)>>;
+///
+/// OUTER map only takes the fast hasher (see `ClassImageTables`); the INNER
+/// `HashMap<String, _>` stays on SipHash because its keys are JS-supplied
+/// member names.
+pub type StaticMethodTable = PtrHashMap<u32, HashMap<String, (usize, u32, bool)>>;
 /// class_id -> { name -> (getter func_ptr, setter func_ptr) } for static accessors.
-pub type StaticAccessorTable = HashMap<u32, HashMap<String, (usize, usize)>>;
+/// Outer map fast-hashed, inner `String`-keyed map deliberately not — see above.
+pub type StaticAccessorTable = PtrHashMap<u32, HashMap<String, (usize, usize)>>;
 /// class_id -> (ctor func_ptr, total param count, signature capture count).
-pub type ConstructorTable = HashMap<u32, (usize, u32, u32)>;
+pub type ConstructorTable = PtrHashMap<u32, (usize, u32, u32)>;
 /// class_id -> (has_synthetic_arguments, has_rest) for a registered constructor.
-pub type ConstructorFlagTable = HashMap<u32, (bool, bool)>;
+pub type ConstructorFlagTable = PtrHashMap<u32, (bool, bool)>;
 
 /// One compiled image's class metadata: every class-id-keyed table module init
 /// writes. Field docs live on the `static` handles that select them.
+///
+/// # Hasher choice
+///
+/// The class-id-keyed tables use [`PtrHashMap`] / [`PtrHashSet`]
+/// (`PtrHasher`: one multiply plus an avalanche step) rather than std's
+/// SipHash. A class id is minted by codegen from a small sequential counter
+/// (`perry-hir::lower::context`), so it is a dense process-internal integer
+/// and never external input — hash-flooding resistance buys nothing, exactly
+/// as for the pointer-keyed registries in [`crate::fast_hash`]. `PtrHasher`'s
+/// `write_u32` override (#8125) keeps a bare `u32` key on the single-multiply
+/// path, and its avalanche spreads a dense sequential run across buckets.
+///
+/// Iteration order is not observable for any of these: nothing in the tree
+/// iterates them (only `get` / `insert` / `contains`). The `String`-keyed
+/// INNER maps of [`StaticMethodTable`] / [`StaticAccessorTable`], and the
+/// `(u32, String)`-keyed `method_bind_lengths` pair below, deliberately stay
+/// on SipHash — their keys are JS-supplied member names, and the inner maps
+/// are enumerated on paths that reach user-visible output.
 pub struct ClassImageTables {
-    pub(crate) vtables: RwLock<Option<HashMap<u32, ClassVTable>>>,
+    pub(crate) vtables: RwLock<Option<PtrHashMap<u32, ClassVTable>>>,
     pub(crate) static_methods: RwLock<Option<StaticMethodTable>>,
     pub(crate) static_accessors: RwLock<Option<StaticAccessorTable>>,
     pub(crate) method_bind_lengths: RwLock<Option<HashMap<(u32, String), u32>>>,
     pub(crate) static_method_bind_lengths: RwLock<Option<HashMap<(u32, String), u32>>>,
-    pub(crate) registered_class_ids: RwLock<Option<HashSet<u32>>>,
-    pub(crate) parents: RwLock<Option<HashMap<u32, u32>>>,
+    pub(crate) registered_class_ids: RwLock<Option<PtrHashSet<u32>>>,
+    pub(crate) parents: RwLock<Option<PtrHashMap<u32, u32>>>,
     /// `parent + 1` for every registered edge whose child id is
     /// `< PARENT_DENSE_CAP`; `0` means "no edge". Heap-allocated per image
     /// (256 KiB) rather than `.bss`, because there is one per image now.
     pub(crate) parent_dense: Box<[AtomicU32]>,
-    pub(crate) fetch_parent_kind: RwLock<Option<HashMap<u32, u8>>>,
-    pub(crate) generic_origin: RwLock<Option<HashMap<u32, u32>>>,
-    pub(crate) extends_error: RwLock<Option<HashSet<u32>>>,
-    pub(crate) has_instance: RwLock<Option<HashMap<u32, usize>>>,
-    pub(crate) to_string_tag: RwLock<Option<HashMap<u32, usize>>>,
+    pub(crate) fetch_parent_kind: RwLock<Option<PtrHashMap<u32, u8>>>,
+    pub(crate) generic_origin: RwLock<Option<PtrHashMap<u32, u32>>>,
+    pub(crate) extends_error: RwLock<Option<PtrHashSet<u32>>>,
+    pub(crate) has_instance: RwLock<Option<PtrHashMap<u32, usize>>>,
+    pub(crate) to_string_tag: RwLock<Option<PtrHashMap<u32, usize>>>,
     pub(crate) constructors: RwLock<Option<ConstructorTable>>,
     pub(crate) constructor_flags: RwLock<Option<ConstructorFlagTable>>,
-    pub(crate) extends_data_view: RwLock<Option<HashSet<u32>>>,
-    pub(crate) extends_typed_array: RwLock<Option<HashSet<u32>>>,
-    pub(crate) names: RwLock<Option<HashMap<u32, String>>>,
-    pub(crate) lengths: RwLock<Option<HashMap<u32, u32>>>,
-    pub(crate) anon_shape_class_ids: RwLock<Option<HashSet<u32>>>,
+    pub(crate) extends_data_view: RwLock<Option<PtrHashSet<u32>>>,
+    pub(crate) extends_typed_array: RwLock<Option<PtrHashSet<u32>>>,
+    pub(crate) names: RwLock<Option<PtrHashMap<u32, String>>>,
+    pub(crate) lengths: RwLock<Option<PtrHashMap<u32, u32>>>,
+    pub(crate) anon_shape_class_ids: RwLock<Option<PtrHashSet<u32>>>,
 }
 
 impl ClassImageTables {

--- a/crates/perry-runtime/src/object/class_meta_registry.rs
+++ b/crates/perry-runtime/src/object/class_meta_registry.rs
@@ -2,14 +2,14 @@
 //! `extends Error`, `Symbol.hasInstance` / `Symbol.toStringTag` hooks
 //! (split out of `object/mod.rs`, behavior-preserving).
 
+use crate::fast_hash::{new_ptr_hash_map, new_ptr_hash_set, PtrHashMap, PtrHashSet};
 use crate::object::class_image::{self, ImageTable, PARENT_DENSE_CAP};
 use crate::registry_latch::RegistryLatch;
-use std::collections::HashMap;
 use std::sync::RwLock;
 
 /// The calling image's class registry mapping class_id -> parent_class_id for
 /// inheritance chain lookups (#8546 — see `object/class_image.rs`).
-pub(crate) static CLASS_REGISTRY: ImageTable<RwLock<Option<HashMap<u32, u32>>>> =
+pub(crate) static CLASS_REGISTRY: ImageTable<RwLock<Option<PtrHashMap<u32, u32>>>> =
     ImageTable::new(|image| &image.parents);
 
 // ============================================================================
@@ -97,7 +97,7 @@ pub(crate) fn get_parent_class_id(class_id: u32) -> Option<u32> {
 /// `GlobalRequest = global.Request`. Lets the runtime dynamic-construction
 /// path (`new (classExprValue)(...)` / ClassRef `new`) attach the underlying
 /// native fetch handle, matching what the static codegen `super()` path does.
-static FETCH_PARENT_KIND: ImageTable<RwLock<Option<HashMap<u32, u8>>>> =
+static FETCH_PARENT_KIND: ImageTable<RwLock<Option<PtrHashMap<u32, u8>>>> =
     ImageTable::new(|image| &image.fetch_parent_kind);
 
 /// Idle until some class extends the global `Request`/`Response`.
@@ -109,7 +109,7 @@ pub(crate) fn register_fetch_parent_kind(class_id: u32, kind: u8) {
     FETCH_PARENT_LATCH.arm();
     let mut g = FETCH_PARENT_KIND.write().unwrap();
     if g.is_none() {
-        *g = Some(HashMap::new());
+        *g = Some(new_ptr_hash_map());
     }
     g.as_mut().unwrap().insert(class_id, kind);
 }
@@ -149,7 +149,7 @@ fn fetch_parent_kind_slow(class_id: u32) -> Option<u8> {
 /// (`object/class_constructors.rs`), static-method lookup and vtable dispatch,
 /// so splicing the generic in between a specialization and its real base would
 /// re-run the wrong constructor. Only `instanceof` consults this one.
-static CLASS_GENERIC_ORIGIN: ImageTable<RwLock<Option<HashMap<u32, u32>>>> =
+static CLASS_GENERIC_ORIGIN: ImageTable<RwLock<Option<PtrHashMap<u32, u32>>>> =
     ImageTable::new(|image| &image.generic_origin);
 
 /// Idle until a generic class is monomorphized. `class_chain_reaches` probes
@@ -169,7 +169,7 @@ pub extern "C" fn js_register_class_generic_origin(class_id: u32, generic_id: u3
     GENERIC_ORIGIN_LATCH.arm();
     let mut g = CLASS_GENERIC_ORIGIN.write().unwrap();
     if g.is_none() {
-        *g = Some(HashMap::new());
+        *g = Some(new_ptr_hash_map());
     }
     g.as_mut().unwrap().insert(class_id, generic_id);
 }
@@ -197,7 +197,7 @@ fn class_generic_origin_slow(class_id: u32) -> Option<u32> {
 }
 
 /// The calling image's set of class IDs that extend the built-in Error class.
-static EXTENDS_ERROR_REGISTRY: ImageTable<RwLock<Option<std::collections::HashSet<u32>>>> =
+static EXTENDS_ERROR_REGISTRY: ImageTable<RwLock<Option<PtrHashSet<u32>>>> =
     ImageTable::new(|image| &image.extends_error);
 
 /// Per-class `Symbol.hasInstance` static hook. Maps class_id → raw function
@@ -205,7 +205,7 @@ static EXTENDS_ERROR_REGISTRY: ImageTable<RwLock<Option<std::collections::HashSe
 /// TAG_TRUE / TAG_FALSE result). Populated at module init from
 /// `__perry_wk_hasinstance_<class>` top-level functions lifted by the HIR
 /// class lowering.
-static CLASS_HAS_INSTANCE_REGISTRY: ImageTable<RwLock<Option<HashMap<u32, usize>>>> =
+static CLASS_HAS_INSTANCE_REGISTRY: ImageTable<RwLock<Option<PtrHashMap<u32, usize>>>> =
     ImageTable::new(|image| &image.has_instance);
 
 /// Per-class `Symbol.toStringTag` getter hook. Maps class_id → raw function
@@ -214,7 +214,7 @@ static CLASS_HAS_INSTANCE_REGISTRY: ImageTable<RwLock<Option<HashMap<u32, usize>
 /// init from `__perry_wk_tostringtag_<class>` top-level functions lifted by
 /// the HIR class lowering. Consulted by `js_object_to_string` so
 /// `Object.prototype.toString.call(x)` returns `[object <tag>]`.
-static CLASS_TO_STRING_TAG_REGISTRY: ImageTable<RwLock<Option<HashMap<u32, usize>>>> =
+static CLASS_TO_STRING_TAG_REGISTRY: ImageTable<RwLock<Option<PtrHashMap<u32, usize>>>> =
     ImageTable::new(|image| &image.to_string_tag);
 
 /// Idle until a class declares `static [Symbol.hasInstance]`. `js_instanceof`
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn js_register_class_has_instance(class_id: u32, func_ptr:
     HAS_INSTANCE_LATCH.arm();
     let mut registry = CLASS_HAS_INSTANCE_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(new_ptr_hash_map());
     }
     registry
         .as_mut()
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn js_register_class_to_string_tag(class_id: u32, func_ptr
     TO_STRING_TAG_LATCH.arm();
     let mut registry = CLASS_TO_STRING_TAG_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(new_ptr_hash_map());
     }
     registry
         .as_mut()
@@ -289,7 +289,7 @@ pub extern "C" fn js_register_class_extends_error(class_id: u32) {
     EXTENDS_ERROR_LATCH.arm();
     let mut registry = EXTENDS_ERROR_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(std::collections::HashSet::new());
+        *registry = Some(new_ptr_hash_set());
     }
     registry.as_mut().unwrap().insert(class_id);
 }

--- a/crates/perry-runtime/src/object/class_registry/class_meta.rs
+++ b/crates/perry-runtime/src/object/class_registry/class_meta.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::fast_hash::{new_ptr_hash_map, new_ptr_hash_set, PtrHashMap, PtrHashSet};
 use crate::object::class_image::ImageTable;
-use std::collections::HashMap;
 use std::sync::RwLock;
 
 /// Register a class id so `js_value_typeof` can distinguish class refs
@@ -12,7 +12,7 @@ pub unsafe extern "C" fn js_register_class_id(class_id: u32) {
     }
     let mut guard = REGISTERED_CLASS_IDS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(std::collections::HashSet::new());
+        *guard = Some(new_ptr_hash_set());
     }
     guard.as_mut().unwrap().insert(class_id);
 }
@@ -23,13 +23,13 @@ pub unsafe extern "C" fn js_register_class_id(class_id: u32) {
 /// `metatype.name` to build the module token, so the empty default name
 /// from `v8::Function::builder(...)` would collide every module under the
 /// same token. (#1021.)
-pub static CLASS_NAMES: ImageTable<RwLock<Option<HashMap<u32, String>>>> =
+pub static CLASS_NAMES: ImageTable<RwLock<Option<PtrHashMap<u32, String>>>> =
     ImageTable::new(|image| &image.names);
 /// Maps `class_id → ECMAScript constructor length` (formal parameters before
 /// the first default/rest parameter). Class refs are integer immediates rather
 /// than heap Function objects, so their own `length` property is reified from
 /// this table alongside `CLASS_NAMES`.
-pub static CLASS_LENGTHS: ImageTable<RwLock<Option<HashMap<u32, u32>>>> =
+pub static CLASS_LENGTHS: ImageTable<RwLock<Option<PtrHashMap<u32, u32>>>> =
     ImageTable::new(|image| &image.lengths);
 
 /// Register the user-visible name of a class so the V8 bridge can label
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn js_register_class_name(class_id: u32, name_ptr: *const 
     };
     let mut guard = CLASS_NAMES.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(new_ptr_hash_map());
     }
     guard.as_mut().unwrap().insert(class_id, name);
 }
@@ -72,7 +72,7 @@ pub extern "C" fn js_register_class_length(class_id: u32, length: u32) {
     }
     let mut guard = CLASS_LENGTHS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(new_ptr_hash_map());
     }
     guard.as_mut().unwrap().insert(class_id, length);
 }
@@ -500,7 +500,7 @@ pub unsafe extern "C" fn js_text_encoding_stream_new() -> f64 {
 /// drizzle's `value.constructor === Object` duck checks, and the standard
 /// `({}).constructor === Object` semantics all match Node. The HIR
 /// lowering registers each anon shape's id here at module init.
-pub static ANON_SHAPE_CLASS_IDS: ImageTable<RwLock<Option<std::collections::HashSet<u32>>>> =
+pub static ANON_SHAPE_CLASS_IDS: ImageTable<RwLock<Option<PtrHashSet<u32>>>> =
     ImageTable::new(|image| &image.anon_shape_class_ids);
 
 /// Mark `class_id` as a synthetic anon-shape class so `.constructor`
@@ -513,7 +513,7 @@ pub unsafe extern "C" fn js_register_anon_shape_class_id(class_id: u32) {
     }
     let mut guard = ANON_SHAPE_CLASS_IDS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(std::collections::HashSet::new());
+        *guard = Some(new_ptr_hash_set());
     }
     guard.as_mut().unwrap().insert(class_id);
 }

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -13,7 +13,7 @@ pub(crate) fn register_class(class_id: u32, parent_class_id: u32) {
     crate::object::class_meta_registry::parent_dense_store(class_id, parent_class_id);
     let mut registry = CLASS_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(crate::fast_hash::new_ptr_hash_map());
     }
     registry.as_mut().unwrap().insert(class_id, parent_class_id);
 }
@@ -518,7 +518,7 @@ pub unsafe extern "C" fn js_register_class_static_method(
     };
     let mut guard = CLASS_STATIC_METHODS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(crate::fast_hash::new_ptr_hash_map());
     }
     guard
         .as_mut()
@@ -610,7 +610,7 @@ pub unsafe extern "C" fn js_register_class_computed_method(
             if let Some(method_name) = alias {
                 let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
                 if registry.is_none() {
-                    *registry = Some(HashMap::new());
+                    *registry = Some(crate::fast_hash::new_ptr_hash_map());
                 }
                 let vtable = registry
                     .as_mut()
@@ -645,7 +645,7 @@ pub unsafe extern "C" fn js_register_class_computed_method(
     if is_static != 0 {
         let mut guard = CLASS_STATIC_METHODS.write().unwrap();
         if guard.is_none() {
-            *guard = Some(HashMap::new());
+            *guard = Some(crate::fast_hash::new_ptr_hash_map());
         }
         guard
             .as_mut()
@@ -656,7 +656,7 @@ pub unsafe extern "C" fn js_register_class_computed_method(
     } else {
         let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
         if registry.is_none() {
-            *registry = Some(HashMap::new());
+            *registry = Some(crate::fast_hash::new_ptr_hash_map());
         }
         let vtable = registry
             .as_mut()
@@ -733,7 +733,7 @@ pub unsafe extern "C" fn js_register_class_computed_accessor(
         if is_static == 0 {
             let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
             if registry.is_none() {
-                *registry = Some(HashMap::new());
+                *registry = Some(crate::fast_hash::new_ptr_hash_map());
             }
             let vtable = registry
                 .as_mut()
@@ -753,7 +753,7 @@ pub unsafe extern "C" fn js_register_class_computed_accessor(
         } else {
             let mut guard = CLASS_STATIC_ACCESSORS.write().unwrap();
             if guard.is_none() {
-                *guard = Some(HashMap::new());
+                *guard = Some(crate::fast_hash::new_ptr_hash_map());
             }
             let entry = guard
                 .as_mut()

--- a/crates/perry-runtime/src/object/class_registry/registration.rs
+++ b/crates/perry-runtime/src/object/class_registry/registration.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn js_register_class_method(
     };
     let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(crate::fast_hash::new_ptr_hash_map());
     }
     let reg = registry.as_mut().unwrap();
     let vtable = reg.entry(class_id as u32).or_insert_with(|| ClassVTable {
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn js_register_class_getter(
     };
     let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(crate::fast_hash::new_ptr_hash_map());
     }
     let reg = registry.as_mut().unwrap();
     let vtable = reg.entry(class_id as u32).or_insert_with(|| ClassVTable {
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn js_register_class_setter(
     };
     let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(HashMap::new());
+        *registry = Some(crate::fast_hash::new_ptr_hash_map());
     }
     let reg = registry.as_mut().unwrap();
     let vtable = reg.entry(class_id as u32).or_insert_with(|| ClassVTable {
@@ -386,7 +386,7 @@ unsafe fn register_class_static_accessor_half(
     };
     let mut guard = CLASS_STATIC_ACCESSORS.write().unwrap();
     if guard.is_none() {
-        *guard = Some(HashMap::new());
+        *guard = Some(crate::fast_hash::new_ptr_hash_map());
     }
     let entry = guard
         .as_mut()

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -237,8 +237,9 @@ pub struct ClassVTable {
 
 /// Vtable registry of the calling thread's image (#8546 — see
 /// `object/class_image.rs`): class_id -> vtable.
-pub static CLASS_VTABLE_REGISTRY: ImageTable<RwLock<Option<HashMap<u32, ClassVTable>>>> =
-    ImageTable::new(|image| &image.vtables);
+pub static CLASS_VTABLE_REGISTRY: ImageTable<
+    RwLock<Option<crate::fast_hash::PtrHashMap<u32, ClassVTable>>>,
+> = ImageTable::new(|image| &image.vtables);
 
 /// #1788: per-class STATIC-method registry: class_id -> { name -> (func_ptr,
 /// param_count, has_rest) }. Static methods are emitted as `perry_static_*`
@@ -287,7 +288,7 @@ crate::perry_thread_local! {
 /// Set of all registered class ids. Populated at module init by codegen
 /// emitting `js_register_class_id(cid)` for every user class — even
 /// classes without any methods. Refs #618 / #420 followup.
-pub static REGISTERED_CLASS_IDS: ImageTable<RwLock<Option<std::collections::HashSet<u32>>>> =
+pub static REGISTERED_CLASS_IDS: ImageTable<RwLock<Option<crate::fast_hash::PtrHashSet<u32>>>> =
     ImageTable::new(|image| &image.registered_class_ids);
 
 crate::perry_thread_local! {

--- a/crates/perry-runtime/src/object/data_view_registry.rs
+++ b/crates/perry-runtime/src/object/data_view_registry.rs
@@ -1,11 +1,12 @@
 use super::*;
+use crate::fast_hash::{new_ptr_hash_set, PtrHashSet};
 use crate::object::class_image::ImageTable;
 
 /// The calling image's set of class IDs that extend the built-in DataView
 /// class (#8546 — see `object/class_image.rs`).
-static EXTENDS_DATA_VIEW_REGISTRY: ImageTable<RwLock<Option<std::collections::HashSet<u32>>>> =
+static EXTENDS_DATA_VIEW_REGISTRY: ImageTable<RwLock<Option<PtrHashSet<u32>>>> =
     ImageTable::new(|image| &image.extends_data_view);
-static EXTENDS_TYPED_ARRAY_REGISTRY: ImageTable<RwLock<Option<std::collections::HashSet<u32>>>> =
+static EXTENDS_TYPED_ARRAY_REGISTRY: ImageTable<RwLock<Option<PtrHashSet<u32>>>> =
     ImageTable::new(|image| &image.extends_typed_array);
 
 /// Mark a user-defined class as extending the built-in DataView class.
@@ -13,7 +14,7 @@ static EXTENDS_TYPED_ARRAY_REGISTRY: ImageTable<RwLock<Option<std::collections::
 pub extern "C" fn js_register_class_extends_data_view(class_id: u32) {
     let mut registry = EXTENDS_DATA_VIEW_REGISTRY.write().unwrap();
     if registry.is_none() {
-        *registry = Some(std::collections::HashSet::new());
+        *registry = Some(new_ptr_hash_set());
     }
     registry.as_mut().unwrap().insert(class_id);
 }
@@ -48,7 +49,7 @@ pub(crate) fn extends_builtin_data_view(class_id: u32) -> bool {
 pub extern "C" fn js_register_class_extends_typed_array(class_id: u32) {
     let mut registry = EXTENDS_TYPED_ARRAY_REGISTRY.write().unwrap();
     registry
-        .get_or_insert_with(std::collections::HashSet::new)
+        .get_or_insert_with(new_ptr_hash_set)
         .insert(class_id);
 }
 

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -455,7 +455,25 @@ pub(crate) struct ObjectHotTables {
     pub(crate) shape_kind_cache: std::cell::UnsafeCell<Box<[u64]>>,
     /// Overflow map for shape_ids that collide in the inline cache. Values
     /// are `(keys_array, runtime_shape_id)` — see [`ShapeCacheEntry`].
-    pub(crate) shape_cache_overflow: RefCell<HashMap<u32, (*mut ArrayHeader, u32)>>,
+    ///
+    /// `PtrHasher`, not SipHash. The inline cache above is 256 entries,
+    /// direct-mapped on `shape_id & 255`, and `shape_id` steps by
+    /// `10007 mod 256 == 23` per class id — so any image with more than 256
+    /// live shapes collides constantly and `shape_cache_get_with_id` falls
+    /// through to this map. Every `shape_cache_insert` writes it too. The key
+    /// is a runtime-minted shape id (`class_id * 10007 + field_count * 100003
+    /// + 1_000_000`), never external input.
+    ///
+    /// A `u32` key's SipHash is small enough that LLVM inlines it into the
+    /// caller, so this cost does NOT appear under a `RandomState` frame in a
+    /// sampled profile — it is charged to `js_build_class_keys_array` and
+    /// friends. Every sibling field of this struct is already either a fast
+    /// hash table or an `UnsafeCell` array; this one was the exception.
+    ///
+    /// Iteration-order safe: the only iteration is `scan_shape_cache_roots_mut`
+    /// (`.values_mut()`, GC root marking — commutative). Nothing else iterates.
+    pub(crate) shape_cache_overflow:
+        RefCell<crate::fast_hash::PtrHashMap<u32, (*mut ArrayHeader, u32)>>,
     /// Per-thread shape-transition cache for the dynamic-key write path;
     /// see the doc block above `with_transition_cache`. HEAP-allocated
     /// (`Box`) — oversized inline storage overflowed the arm64_32 ILP32
@@ -491,7 +509,7 @@ impl ObjectHotTables {
             shape_kind_cache: std::cell::UnsafeCell::new(
                 vec![0; shapes::SHAPE_KIND_CACHE_SIZE].into_boxed_slice(),
             ),
-            shape_cache_overflow: RefCell::new(HashMap::new()),
+            shape_cache_overflow: RefCell::new(crate::fast_hash::new_ptr_hash_map()),
             transition_cache: std::cell::UnsafeCell::new(
                 vec![
                     TransitionEntry {

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -61,7 +61,7 @@ unsafe fn define_class_prototype_method(target_cid: u32, name: &str, value_bits:
                 {
                     let mut guard = CLASS_VTABLE_REGISTRY.write().unwrap();
                     if guard.is_none() {
-                        *guard = Some(std::collections::HashMap::new());
+                        *guard = Some(crate::fast_hash::new_ptr_hash_map());
                     }
                     let reg = guard.as_mut().unwrap();
                     let vtable = reg.entry(target_cid).or_insert_with(|| ClassVTable {

--- a/crates/perry-runtime/src/proxy/metadata.rs
+++ b/crates/perry-runtime/src/proxy/metadata.rs
@@ -291,7 +291,7 @@ mod tests {
     fn register_test_class(cid: u32) {
         let mut guard = crate::object::REGISTERED_CLASS_IDS.write().unwrap();
         guard
-            .get_or_insert_with(std::collections::HashSet::new)
+            .get_or_insert_with(crate::fast_hash::new_ptr_hash_set)
             .insert(cid);
     }
 


### PR DESCRIPTION
The class-registry tables keyed by `class_id` (and by keys-array address) were hashing their integer keys with std's SipHash. They now use the crate's existing fast hashers. Converted: `ClassImageTables`' 17 class-id-keyed tables — including `parents`, whose `get_parent_class_id` the code itself documents as "the single hottest class-registry read" — plus `CLASS_KEYS_BY_ID`, `shape_cache_overflow`, and `typed_shape`'s two maps.

`ids_by_layout` got **`FastKeyHashMap`, not `PtrHashMap`**: its key is a composite (two `u32`s plus two `Vec<u64>`s), and `PtrHasher`'s overwriting `write_*` would collapse that to its last field.

## Numbers

Alternating A/B, 25 paired rounds, on an idle Mac mini (the dev box sat at load 14–45 all session and was unusable for timing):

| | median | min |
|---|---|---|
| base | 873.0 ms | 871 ms |
| this | 867.0 ms | 862 ms |

**−0.69%**, faster in **25 of 25** rounds, mean delta −6.2 ms (stdev 2.2) ≈ 14 standard errors. In the profile, `get_parent_class_id`, `js_gc_typed_shape_id_for_keys`, `shape_cache_insert` and the whole `js_register_class_*` family disappear from the SipHash caller list entirely.

`.text` **+2 KB (+0.016%)**. `cargo test -p perry-runtime --lib -- --test-threads=1`: 2844 passed, 0 failed, 4 ignored. `cargo fmt --all --check` clean. `cc --help` output byte-identical before and after.

## Two corrections to the premise this started from

The brief for this work claimed ~4.9% of `cc --help` in SipHash with a single map worth 1.60%. Re-measured on current main, **total SipHash is 3.08%** and there is no such map. Both errors have the same cause and it is worth recording:

- **Every map originally named was already fast-hashed** — `ARRAY_NAMED_PROPS` (PtrHashMap since #6386), the shape descriptor table (PtrHasher, #8125), `descriptor_state` (FastKeyHasher, #9147), `CLOSURE_BOX_CELLS` (PtrHashMap). Their hashbrown entries are residual **table-probe** cost. A hashbrown symbol says nothing about which hasher is underneath it.
- **The largest single SipHash consumer is not ours at all**: `regex_automata::dfa::determinize::Runner::maybe_add_state` at 0.489%.

A third measurement artefact, in the other direction: a `u32` key's SipHash is small enough that **LLVM inlines it**, so it never appears under a `RandomState` frame. Integer-keyed maps are systematically *under*-represented in a sampled profile — which is exactly the class of map this PR converts.

## Left deliberately

Everything keyed by a JS-supplied name (the inner `HashMap<String, _>` of the static method/accessor tables, `method_bind_lengths`, `ClosureProps::values`, `js_for_in_keys_value`'s dedup set) — a fast hasher on attacker-influenced keys is a different decision and not this PR's. Also `REGEX_POINTERS`/`REGEX_SOURCE_TABLE` and the `node_submodules` singletons: sound, but measured at ≤0.09%, i.e. diff risk for no gain.

## Iteration-order audit

No converted map is iterated anywhere except GC root scans (`.values_mut()`, commutative) and `class_side_table_root_snapshot`. `CLASS_KEYS_BY_ID`, `ids_by_layout`, `layouts_by_id` and every non-GC `shape_cache_overflow` path are never iterated at all.

## A pre-existing bug found in passing, NOT fixed here

`CLASS_DYNAMIC_PROPS`' inner map is **order-observable**: `sort_property_names_ecma` sorts only integer-like keys, so string keys keep raw map order, and that order feeds `Object.keys(C)`. Because `RandomState` seeds per process, static string-field order there is likely already **non-deterministic across runs** — a spec divergence that predates this PR and is independent of it. Flagging rather than folding it in.

## Microbenchmarks that failed, reported as failures

Two microbenchmarks measured nothing and are **not** offered as evidence. The class benchmark was vacuous: `get_parent_class_id` short-circuits through a 65,536-entry dense array, so with fewer than 65,536 class ids the converted map is *never probed* — only an image the size of the claude-code bundle reaches it. The shape benchmarks were dead-code-eliminated (1–2 ms). The end-to-end A/B above is the only valid measurement here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the speed of class, shape, and metadata registry lookups by using optimized internal storage.
  * Runtime benchmarks show a median performance improvement of approximately 0.69%.

* **Bug Fixes**
  * Preserved existing lookup behavior and iteration order while improving registry efficiency.

* **Documentation**
  * Added release documentation describing the optimized registries, performance results, and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->