### PR TITLE
codegen: name the packed-loop admission's rejection reason under PERRY_PACKED_LOOP_TRACE

### DIFF
--- a/changelog.d/9204-packed-loop-trace.md
+++ b/changelog.d/9204-packed-loop-trace.md
@@ -1,0 +1,11 @@
+`match_packed_f64_versioned_loop`'s admission decision is a chain of independent
+conditions, and when a loop unexpectedly stayed on the generic path there was no
+way to tell which one declined it without reading the code and guessing — three
+separate attempts on #9151 each found a different gate that way.
+`PERRY_PACKED_LOOP_TRACE=1` names the rejection reason instead.
+
+`packed_loop_reject` prints and returns `None` either way, so the emitted code
+is identical with the flag on and off. It is registered in
+`BUILD_CACHE_ENV_EXCLUSIONS` rather than `BUILD_CACHE_ENV_VARS` for that
+reason: making it a cache input would cost every trace run a rebuild and buy
+nothing.

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -4103,6 +4103,13 @@ fn lower_object_array_write_versioned_for(
 
     let fast_call_free = (fast_scan_start..ctx.func.num_blocks())
         .all(|idx| !ctx.func.blocks()[idx].contains_gc_unsafe_call());
+    if !fast_call_free {
+        // Reached when the matcher ADMITTED the loop but an emitted block in
+        // the clone carries a call, so the clone is built and never entered.
+        // That is invisible from the matcher's own rejection reasons, which is
+        // why it gets its own trace line.
+        let _ = packed_loop_reject("fast_clone_not_call_free");
+    }
     ctx.current_block = preheader_idx;
     let mut guard_ok = ctx.block().icmp_ne(I64, &packed_slots, "0");
     for (g_packed, _) in &extra_guards {
@@ -4753,6 +4760,22 @@ fn record_loop_array_length_effect(
     );
 }
 
+/// Diagnostic for `match_packed_f64_versioned_loop`'s rejection points.
+///
+/// The admission decision is a chain of independent conditions, and when a loop
+/// unexpectedly stays on the generic path there is no way to tell WHICH one
+/// declined it by reading the code — three separate attempts on #9151 each
+/// found a different gate by guessing. `PERRY_PACKED_LOOP_TRACE=1` prints the
+/// reason instead, turning that into one run.
+fn packed_loop_reject(reason: &'static str) -> Option<PackedF64VersionedLoop> {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    if *ON.get_or_init(|| std::env::var("PERRY_PACKED_LOOP_TRACE").as_deref() == Ok("1")) {
+        eprintln!("[packed-loop] rejected: {reason}");
+    }
+    None
+}
+
 fn match_packed_f64_versioned_loop(
     ctx: &FnCtx<'_>,
     init: Option<&perry_hir::Stmt>,
@@ -4761,7 +4784,7 @@ fn match_packed_f64_versioned_loop(
     body: &[Stmt],
 ) -> Option<PackedF64VersionedLoop> {
     if !ctx.pending_labels.is_empty() {
-        return None;
+        return packed_loop_reject("pending_labels");
     }
     let ordinary_hoist =
         condition.and_then(|cond| classify_for_length_hoist(ctx, cond, update, body));
@@ -4769,13 +4792,13 @@ fn match_packed_f64_versioned_loop(
         condition.and_then(|cond| classify_for_length_hoist_impl(ctx, cond, update, body, true))
     })?;
     if !matches!(hoist.op, perry_hir::CompareOp::Lt) || hoist.lhs_addend != 0 {
-        return None;
+        return packed_loop_reject("compare_op_not_lt");
     }
     if !ctx.integer_locals.contains(&hoist.counter_id)
         || !loop_counter_bounds_are_safe(ctx, hoist.counter_id, update, body)
         || !loop_counter_entry_i32_range_is_safe(init, hoist.counter_id)
     {
-        return None;
+        return packed_loop_reject("counter_not_integer");
     }
     let store_array_kind =
         supported_packed_numeric_loop_store_kind(ctx, body, hoist.arr_id, hoist.counter_id);
@@ -4794,7 +4817,7 @@ fn match_packed_f64_versioned_loop(
     // loop; call-free read bodies now qualify by the argument above. Every
     // other body keeps the ordinary materialization-hazard gate.
     if ordinary_hoist.is_none() && store_array_kind.is_none() && !read_body_is_safe {
-        return None;
+        return packed_loop_reject("body_not_admissible");
     }
     let binding_is_eligible = if store_array_kind.is_some() || read_body_is_safe {
         // A helper call that produced the binding marks it with the
@@ -4809,7 +4832,7 @@ fn match_packed_f64_versioned_loop(
         packed_loop_array_binding_is_eligible(ctx, hoist.arr_id)
     };
     if !binding_is_eligible {
-        return None;
+        return packed_loop_reject("binding_not_eligible");
     }
     let array_kind = if let Some(store_array_kind) = store_array_kind {
         // The accepted store body is exactly `arr[i] = <numeric expression>`
@@ -4837,14 +4860,14 @@ fn match_packed_f64_versioned_loop(
         // non-packed array fails the guard into the slow clone.)
         PackedNumericLoopKind::F64
     } else {
-        return None;
+        return packed_loop_reject("array_kind_unknown");
     };
     if !local_is_number_array(ctx, hoist.arr_id) {
-        return None;
+        return packed_loop_reject("guard_emit_declined");
     }
     let body_is_supported = store_array_kind.is_some() || read_body_is_safe;
     if !body_is_supported {
-        return None;
+        return packed_loop_reject("clone_not_call_free");
     }
     Some(PackedF64VersionedLoop {
         counter_id: hoist.counter_id,

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -206,6 +206,11 @@ const BUILD_CACHE_ENV_EXCLUSIONS: &[&str] = &[
     // Human-facing telemetry only; never changes IR or object bytes.
     "PERRY_CODEGEN_PROGRESS",
     "PERRY_CODEGEN_UNIT_TIMINGS",
+    // `packed_loop_reject` prints the admission chain's declining condition and
+    // returns `None` either way — the rejection is what the caller already got
+    // without the flag, so the emitted code is identical. An input, rather than
+    // an exclusion, would make every trace run miss the cache for nothing.
+    "PERRY_PACKED_LOOP_TRACE",
     // Entry outlining report output is observational only.
     "PERRY_OUTLINE_ENTRY_REPORT",
     // Only read on an already-fatal dialect-construction failure (a unit that


### PR DESCRIPTION
## Why

Whether a counted loop gets its packed-f64 clone is a chain of independent conditions. When one unexpectedly declines, there is no way to tell *which* except by reading the code and guessing.

That is not hypothetical — it is the direct cost of the last few hours. Three attempts on #9151 each guessed a different gate and each was wrong in a different way: the HIR statement predicate (`stmt_is_packed_f64_loop_safe`), then the emitted-block call scan (`contains_gc_unsafe_call`), then a block-region property for the throw's operand. Two were built, measured as **no-ops**, and reverted. The information needed to skip all three was a single string.

## What

`PERRY_PACKED_LOOP_TRACE=1` prints the reason. The eight rejection points in `match_packed_f64_versioned_loop` each name themselves, and the post-emission `fast_call_free` check gets its own line.

That last one is the important addition rather than an afterthought: it is reached when the matcher **admitted** the loop and an emitted block carries a call anyway, so the clone is built and never entered. That case is invisible in the matcher's own rejection reasons, and it is precisely the confusion that cost two of the three attempts.

Off by default, read once through a `OnceLock` — a branch on an already-cold path, nothing when unset.

## It already earned its place

On the #9151 shape:

- a loop containing `try` → `[packed-loop] rejected: body_not_admissible` — correct, and the control that proves the trace fires when it should
- `throw new Error(…)` → **silent**, which proves both the matcher *and* the array-loop call-free scan innocent for that case, and moves the search to whatever decides it later

A silence that rules out two suspects is worth more than three more guesses — but only because the control run establishes that silence means something. I have recorded that pairing on #9151 along with the narrowed residual: on current main, `throw String(l)` and `throw "bad" + l` already take the fast path at 0.58 ns, and **only `new` is still blocked**.

## Gates

perry-codegen 1842/0 — unchanged from main. `-D warnings` clean. Verified the trace fires with the flag set and emits nothing without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Expanded optional packed-loop tracing to identify specific reasons an optimization remains on the generic path.
  * Reports rejected fast clones when generated code contains garbage-collection-unsafe calls.
  * Includes diagnostics for invalid comparisons or counters, unsupported loop bodies or bindings, unknown array types, pending labels, guard failures, and other admission checks.
  * Enable tracing with `PERRY_PACKED_LOOP_TRACE=1`; tracing does not alter generated code or build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->