### PR TITLE
test(perry): isolate ws IR checks from runtime archives

### DIFF
--- a/changelog.d/9209-ws-ir-only-tests.md
+++ b/changelog.d/9209-ws-ir-only-tests.md
@@ -1,0 +1,5 @@
+The WebSocket cross-function dispatch regression suite now compiles its
+IR-inspection cases with linking disabled, so those checks no longer rebuild
+or depend on runtime and extension archives. The one case that verifies
+same-named nested handlers at runtime still links and runs with its required
+well-known modules forced on.

--- a/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
+++ b/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
@@ -26,14 +26,15 @@ fn perry_bin() -> PathBuf {
 
 /// Compile `source` and return the concatenated LLVM IR text of all emitted
 /// modules (via `PERRY_SAVE_LL`). Asserts the compile succeeds.
-fn compile_to_ir(dir: &Path, source: &str) -> String {
+fn compile_to_ir_impl(dir: &Path, source: &str, link: bool) -> String {
     let entry = dir.join("main.ts");
     let output = dir.join("main_bin");
     let ll_dir = dir.join("ll");
     std::fs::create_dir_all(&ll_dir).expect("mk ll dir");
     std::fs::write(&entry, source).expect("write entry");
 
-    let compile = Command::new(perry_bin())
+    let mut command = Command::new(perry_bin());
+    command
         .current_dir(dir)
         .arg("compile")
         .arg(&entry)
@@ -43,9 +44,20 @@ fn compile_to_ir(dir: &Path, source: &str) -> String {
         // actually written for this build.
         .env("PERRY_SAVE_LL", &ll_dir)
         .env("PERRY_LLVM_KEEP_IR", "1")
-        .env("PERRY_NO_CACHE", "1")
-        .output()
-        .expect("run perry compile");
+        .env("PERRY_NO_CACHE", "1");
+    if link {
+        // Only the semantic nested-scope test needs an executable. Keep its
+        // provider set deterministic without making this HIR suite test
+        // automatic well-known binding discovery too.
+        command.env("PERRY_FORCE_WELL_KNOWN", "http,ws");
+    } else {
+        // IR-only assertions do not need runtime or extension archives.
+        command
+            .arg("--no-auto-optimize")
+            .arg("--no-link")
+            .env("PERRY_DISABLE_WELL_KNOWN", "1");
+    }
+    let compile = command.output().expect("run perry compile");
     assert!(
         compile.status.success(),
         "perry compile failed\nstdout:\n{}\nstderr:\n{}",
@@ -63,6 +75,14 @@ fn compile_to_ir(dir: &Path, source: &str) -> String {
     }
     assert!(!ir.is_empty(), "no .ll IR was emitted");
     ir
+}
+
+fn compile_to_ir(dir: &Path, source: &str) -> String {
+    compile_to_ir_impl(dir, source, false)
+}
+
+fn compile_to_ir_and_link(dir: &Path, source: &str) -> String {
+    compile_to_ir_impl(dir, source, true)
 }
 
 /// True if the IR contains a `call` instruction targeting `@<symbol>` (i.e. a
@@ -348,7 +368,7 @@ server.listen(0, () => {});
 #[test]
 fn same_named_function_is_not_cross_tagged() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let ir = compile_to_ir(
+    let ir = compile_to_ir_and_link(
         dir.path(),
         r#"
 import { createServer } from "node:http";


### PR DESCRIPTION
## Summary

Make the WebSocket cross-function dispatch suite test HIR/codegen independently of separately built runtime and extension archives, while preserving its one semantic native-execution check.

## Changes

- Compile IR-only assertions with `--no-auto-optimize --no-link` and disable well-known archive discovery.
- Keep the same-named nested-function semantic case linked and executed, with its `http` and `ws` providers made explicit.
- Preserve the existing non-WebSocket runtime control unchanged.

## Related issue

Closes #9172

## Test plan

On `root@perrymaster.skelpo.net`:

- `cargo test --profile perry-dev -p perry --test ws_client_handle_cross_function_dispatch` — 11 passed, 0 failed (7.26s warm)
- `cargo fmt --all -- --check` — clean
- `scripts/check_file_size.sh` — pass

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output

n/a (test-only change)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I have read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded cross-function dispatch coverage across linked and non-linked compilation scenarios.
  * Improved regression checks for same-named handlers and WebSocket behavior.
  * Streamlined test execution by removing unnecessary runtime and extension dependencies from IR-only checks.

* **Documentation**
  * Added a changelog entry describing the updated WebSocket dispatch regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->