### PR TITLE
perf(runtime): cache handle stack after TLS publication

### DIFF
--- a/changelog.d/9211-runtime-handle-tls.md
+++ b/changelog.d/9211-runtime-handle-tls.md
@@ -1,0 +1,6 @@
+On Apple aarch64, runtime-handle scope creation, pushes and reads now take the
+handle-stack address from the already-published `HotTls` cache instead of
+resolving the thread-local on every operation. Startup retains a raw TLS
+fallback that cannot recursively enter `HotTls::fill`, and a teardown guard
+clears the cached address before the stack storage is destroyed. Other targets
+keep their ordinary fixed-offset TLS path.

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -20,7 +20,9 @@ pub(super) use runtime_handles::{
     new_runtime_handle_root_scan_state, scan_runtime_handle_roots_mut,
     scan_runtime_handle_roots_mut_step,
 };
-pub(crate) use runtime_handles::{runtime_handle_stack_restore, runtime_handle_stack_savepoint};
+pub(crate) use runtime_handles::{
+    runtime_handle_stack_hot_addr, runtime_handle_stack_restore, runtime_handle_stack_savepoint,
+};
 pub use runtime_handles::{RuntimeHandle, RuntimeHandleScope};
 pub use scanner_shims::{
     async_context_mutable_root_scanner, async_context_root_scanner,
@@ -108,7 +110,6 @@ crate::perry_thread_local! {
     pub(super) static FFI_MUTABLE_ROOT_SCANNERS: RefCell<Vec<PerryFfiMutableRootScanner>> = RefCell::new(Vec::new());
     pub(super) static FFI_NAMED_MUTABLE_ROOT_SCANNERS: RefCell<Vec<(PerryFfiNamedMutableRootScanner, usize)>> = RefCell::new(Vec::new());
     pub(super) static GLOBAL_ROOTS: RefCell<Vec<*mut u64>> = const { RefCell::new(Vec::new()) };
-    pub(super) static RUNTIME_HANDLE_STACK: RefCell<Vec<RuntimeHandleSlot>> = const { RefCell::new(Vec::new()) };
     pub(super) static GC_ROOT_LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 

--- a/crates/perry-runtime/src/gc/roots/runtime_handles.rs
+++ b/crates/perry-runtime/src/gc/roots/runtime_handles.rs
@@ -1,5 +1,54 @@
 use super::*;
 
+struct RuntimeHandleStackHotGuard;
+
+impl Drop for RuntimeHandleStackHotGuard {
+    fn drop(&mut self) {
+        crate::tls_hot::unpublish_runtime_handle_stack();
+    }
+}
+
+thread_local! {
+    /// This stays a raw `thread_local!` as the initialization fallback for its
+    /// named `HotTls` slot. Going through `perry_thread_local!` here would call
+    /// `hot()` while `HotTls::fill` is still resolving this address (#9183).
+    static RUNTIME_HANDLE_STACK: RefCell<Vec<RuntimeHandleSlot>> = const { RefCell::new(Vec::new()) };
+    /// Registered after the stack itself, so reverse-order TLS destruction
+    /// clears the named cache pointer before the stack storage is destroyed.
+    static RUNTIME_HANDLE_STACK_HOT_GUARD: RuntimeHandleStackHotGuard = const { RuntimeHandleStackHotGuard };
+}
+
+/// Resolve this thread's runtime-handle stack without entering `HotTls`.
+/// Called once by `tls_hot::fill`, and by handle operations only until the
+/// Darwin direct-TSD cache has been published.
+#[inline(always)]
+pub(crate) fn runtime_handle_stack_hot_addr() -> *mut u8 {
+    let addr = RUNTIME_HANDLE_STACK.with(|stack| stack as *const _ as *mut u8);
+    RUNTIME_HANDLE_STACK_HOT_GUARD.with(|_| {});
+    addr
+}
+
+/// Borrow this thread's transient-handle stack.
+///
+/// On Apple aarch64 the steady-state path reads the address from an already
+/// published `HotTls`. During `HotTls::fill` (and on every other target) it
+/// uses the ordinary thread-local directly, so opening a handle scope cannot
+/// recursively initialize the cache (#9183).
+#[inline(always)]
+fn with_runtime_handle_stack<R>(f: impl FnOnce(&RefCell<Vec<RuntimeHandleSlot>>) -> R) -> R {
+    if let Some(hot) = crate::tls_hot::hot_if_published() {
+        let stack = hot.runtime_handle_stack.get();
+        if stack.is_null() {
+            return RUNTIME_HANDLE_STACK.with(f);
+        }
+        // SAFETY: `fill` stores this thread's `RUNTIME_HANDLE_STACK` address
+        // before publishing the cache, and the address is stable for the
+        // lifetime of the thread.
+        return f(unsafe { &*(stack as *const RefCell<Vec<RuntimeHandleSlot>>) });
+    }
+    RUNTIME_HANDLE_STACK.with(f)
+}
+
 /// Scoped owner for transient runtime handles.
 ///
 /// Handles are mutable GC roots for values that live only in a runtime
@@ -12,14 +61,14 @@ pub struct RuntimeHandleScope {
 impl RuntimeHandleScope {
     #[inline]
     pub fn new() -> Self {
-        let base = RUNTIME_HANDLE_STACK.with(|stack| stack.borrow().len());
+        let base = with_runtime_handle_stack(|stack| stack.borrow().len());
         Self { base }
     }
 
     #[inline]
     pub(super) fn push<'scope>(&'scope self, slot: RuntimeHandleSlot) -> RuntimeHandle<'scope> {
         runtime_handle_slot_write_barrier(slot);
-        let index = RUNTIME_HANDLE_STACK.with(|stack| {
+        let index = with_runtime_handle_stack(|stack| {
             let mut stack = stack.borrow_mut();
             let index = stack.len();
             stack.push(slot);
@@ -111,7 +160,7 @@ impl RuntimeHandleScope {
 
     #[cfg(test)]
     pub(crate) fn active_len_for_tests() -> usize {
-        RUNTIME_HANDLE_STACK.with(|stack| stack.borrow().len())
+        with_runtime_handle_stack(|stack| stack.borrow().len())
     }
 }
 
@@ -119,12 +168,12 @@ impl RuntimeHandleScope {
 /// Rust frames. `longjmp` skips `RuntimeHandleScope::drop`, so exception
 /// unwinding restores this depth explicitly.
 pub(crate) fn runtime_handle_stack_savepoint() -> usize {
-    RUNTIME_HANDLE_STACK.with(|stack| stack.borrow().len())
+    with_runtime_handle_stack(|stack| stack.borrow().len())
 }
 
 /// Discard transient roots owned by Rust frames skipped by a JS exception.
 pub(crate) fn runtime_handle_stack_restore(savepoint: usize) {
-    RUNTIME_HANDLE_STACK.with(|stack| stack.borrow_mut().truncate(savepoint));
+    with_runtime_handle_stack(|stack| stack.borrow_mut().truncate(savepoint));
 }
 
 #[inline]
@@ -149,7 +198,7 @@ impl Default for RuntimeHandleScope {
 impl Drop for RuntimeHandleScope {
     #[inline]
     fn drop(&mut self) {
-        RUNTIME_HANDLE_STACK.with(|stack| {
+        with_runtime_handle_stack(|stack| {
             stack.borrow_mut().truncate(self.base);
         });
     }
@@ -182,7 +231,7 @@ fn handle_kind_mismatch(expected: &str) -> ! {
 impl<'scope> RuntimeHandle<'scope> {
     #[inline]
     pub(super) fn with_slot<R>(&self, f: impl FnOnce(RuntimeHandleSlot) -> R) -> R {
-        RUNTIME_HANDLE_STACK.with(|stack| {
+        with_runtime_handle_stack(|stack| {
             let stack = stack.borrow();
             let slot = match stack.get(self.index) {
                 Some(slot) => *slot,
@@ -194,7 +243,7 @@ impl<'scope> RuntimeHandle<'scope> {
 
     #[inline]
     pub(super) fn with_slot_mut<R>(&self, f: impl FnOnce(&mut RuntimeHandleSlot) -> R) -> R {
-        RUNTIME_HANDLE_STACK.with(|stack| {
+        with_runtime_handle_stack(|stack| {
             let mut stack = stack.borrow_mut();
             let slot = match stack.get_mut(self.index) {
                 Some(slot) => slot,
@@ -404,7 +453,7 @@ impl<'scope> RuntimeHandle<'scope> {
 }
 
 pub(crate) fn scan_runtime_handle_roots_mut(visitor: &mut RuntimeRootVisitor<'_>) {
-    RUNTIME_HANDLE_STACK.with(|stack| {
+    with_runtime_handle_stack(|stack| {
         let mut stack = stack.borrow_mut();
         for slot in stack.iter_mut() {
             match slot {
@@ -439,7 +488,7 @@ pub(crate) fn scan_runtime_handle_roots_mut_step(
     let state = state
         .downcast_mut::<RuntimeHandleRootScanState>()
         .expect("runtime handle root scanner state type");
-    RUNTIME_HANDLE_STACK.with(|stack| {
+    with_runtime_handle_stack(|stack| {
         let mut stack = stack.borrow_mut();
         while *remaining > 0 && state.cursor < stack.len() {
             match &mut stack[state.cursor] {
@@ -477,7 +526,7 @@ pub(crate) fn scan_runtime_handle_roots_mut_step(
 
 #[no_mangle]
 pub extern "C" fn js_ffi_root_scope_enter() -> usize {
-    RUNTIME_HANDLE_STACK.with(|stack| stack.borrow().len())
+    with_runtime_handle_stack(|stack| stack.borrow().len())
 }
 
 /// Root a raw heap ADDRESS (e.g. an `i64` closure pointer from an ext
@@ -486,7 +535,7 @@ pub extern "C" fn js_ffi_root_scope_enter() -> usize {
 pub extern "C" fn js_ffi_root_push_heap_addr(addr: u64) -> usize {
     let slot = RuntimeHandleSlot::HeapWord(addr);
     runtime_handle_slot_write_barrier(slot);
-    RUNTIME_HANDLE_STACK.with(|stack| {
+    with_runtime_handle_stack(|stack| {
         let mut stack = stack.borrow_mut();
         let index = stack.len();
         stack.push(slot);
@@ -496,7 +545,7 @@ pub extern "C" fn js_ffi_root_push_heap_addr(addr: u64) -> usize {
 
 #[no_mangle]
 pub extern "C" fn js_ffi_root_get_heap_addr(index: usize) -> u64 {
-    RUNTIME_HANDLE_STACK.with(|stack| match stack.borrow().get(index) {
+    with_runtime_handle_stack(|stack| match stack.borrow().get(index) {
         Some(RuntimeHandleSlot::HeapWord(bits)) => *bits,
         _ => 0,
     })
@@ -507,7 +556,7 @@ pub extern "C" fn js_ffi_root_get_heap_addr(index: usize) -> u64 {
 pub extern "C" fn js_ffi_root_push_nanbox(bits: u64) -> usize {
     let slot = RuntimeHandleSlot::Nanbox(bits);
     runtime_handle_slot_write_barrier(slot);
-    RUNTIME_HANDLE_STACK.with(|stack| {
+    with_runtime_handle_stack(|stack| {
         let mut stack = stack.borrow_mut();
         let index = stack.len();
         stack.push(slot);
@@ -517,7 +566,7 @@ pub extern "C" fn js_ffi_root_push_nanbox(bits: u64) -> usize {
 
 #[no_mangle]
 pub extern "C" fn js_ffi_root_get_nanbox(index: usize) -> u64 {
-    RUNTIME_HANDLE_STACK.with(|stack| match stack.borrow().get(index) {
+    with_runtime_handle_stack(|stack| match stack.borrow().get(index) {
         Some(RuntimeHandleSlot::Nanbox(bits)) => *bits,
         _ => 0,
     })
@@ -525,5 +574,5 @@ pub extern "C" fn js_ffi_root_get_nanbox(index: usize) -> u64 {
 
 #[no_mangle]
 pub extern "C" fn js_ffi_root_scope_exit(base: usize) {
-    RUNTIME_HANDLE_STACK.with(|stack| stack.borrow_mut().truncate(base));
+    with_runtime_handle_stack(|stack| stack.borrow_mut().truncate(base));
 }

--- a/crates/perry-runtime/src/tls_hot.rs
+++ b/crates/perry-runtime/src/tls_hot.rs
@@ -31,7 +31,7 @@
 //!
 //! # Do not add a field — declare with [`crate::perry_thread_local`]
 //!
-//! The sixteen named fields below are a **closed set**. They are the
+//! The seventeen named fields below are a **closed set**. They are the
 //! allocation path, they have fixed offsets, and they are kept because a fixed
 //! offset is one load cheaper than a claimed slot on the hottest path in the
 //! runtime. Nothing else belongs there.
@@ -59,7 +59,7 @@
 //! fields do not have at all. `scripts/check_thread_locals.py` makes a new raw
 //! `thread_local!` a build error unless it is recorded as deliberately cold,
 //! and `scripts/tls_budget_gate.sh` measures the outcome on two programs whose
-//! paths are deliberately *not* among these sixteen.
+//! paths are deliberately *not* among these seventeen.
 //!
 //! # Lifetime
 //!
@@ -190,9 +190,12 @@ pub(crate) struct HotTls {
     pub(crate) i32_box_ptr_cache: [Cell<usize>; INLINE_BOX_PTR_CACHE_SLOTS],
     pub(crate) bool_box_ptr_cache: [Cell<usize>; INLINE_BOX_PTR_CACHE_SLOTS],
     /// Generic slots, one per [`crate::perry_thread_local`] declaration that
-    /// this thread has resolved at least once. Last, so the named fields above
-    /// keep their small fixed offsets.
+    /// this thread has resolved at least once. Kept at its established offset
+    /// so the named fields and inline values above do not move.
     slots: [Cell<*mut u8>; HOT_SLOT_CAPACITY],
+    /// `gc::roots::RUNTIME_HANDLE_STACK`. Appended after the generic slots so
+    /// none of the offsets consumed by generated code move (#9183).
+    pub(crate) runtime_handle_stack: Cell<*mut u8>,
 }
 
 /// Byte offsets generated code hard-codes into its inline hot-cache access
@@ -256,6 +259,7 @@ impl HotTls {
         i32_box_ptr_cache: [const { Cell::new(0) }; INLINE_BOX_PTR_CACHE_SLOTS],
         bool_box_ptr_cache: [const { Cell::new(0) }; INLINE_BOX_PTR_CACHE_SLOTS],
         slots: [const { Cell::new(std::ptr::null_mut()) }; HOT_SLOT_CAPACITY],
+        runtime_handle_stack: Cell::new(std::ptr::null_mut()),
     };
 }
 
@@ -294,6 +298,9 @@ fn fill(slots: *mut HotTls) {
         (*slots).per_object_layouts_nonempty = crate::gc::per_object_layouts_nonempty_hot_addr();
         (*slots).shape_install_memo = crate::gc::shape_install_memo_hot_addr();
         (*slots).learned_inline_fields = crate::object::learned_inline_fields_hot_addr();
+        (*slots)
+            .runtime_handle_stack
+            .set(crate::gc::runtime_handle_stack_hot_addr());
         // Last, and the field `hot()` tests: every other slot is already
         // written by the time this one is non-null, so a re-entrant call from
         // inside one of the providers above cannot observe a half-filled cache
@@ -471,6 +478,54 @@ fn hot_uncached() -> &'static HotTls {
     slots
 }
 
+/// Return this thread's cache only after the Darwin direct-TSD path has
+/// published it. Unlike [`hot`], this never resolves `HOT` and never calls
+/// [`fill`], so initialization-sensitive users can safely fall back to their
+/// own thread-local while the cache is being built (#9183).
+#[cfg(all(
+    target_vendor = "apple",
+    target_arch = "aarch64",
+    target_pointer_width = "64"
+))]
+#[inline(always)]
+pub(crate) fn hot_if_published() -> Option<&'static HotTls> {
+    let key = darwin_tsd::KEY.load(std::sync::atomic::Ordering::Relaxed);
+    if key == darwin_tsd::NO_KEY {
+        return None;
+    }
+    // SAFETY: `key` is a live pthread key. A non-null value was published
+    // from this thread's const-initialized `HOT` after `fill` completed.
+    let slots = unsafe { darwin_tsd::get(key) } as *mut HotTls;
+    if slots.is_null() {
+        None
+    } else {
+        Some(unsafe { &*slots })
+    }
+}
+
+/// The published-cache shortcut is Darwin-specific. Other targets keep the
+/// ordinary TLS path, where resolving a thread-local is already a fixed
+/// offset and the extra cache indirection has no demonstrated benefit.
+#[cfg(not(all(
+    target_vendor = "apple",
+    target_arch = "aarch64",
+    target_pointer_width = "64"
+)))]
+#[inline(always)]
+pub(crate) fn hot_if_published() -> Option<&'static HotTls> {
+    None
+}
+
+/// Stop serving the named handle-stack pointer before its raw thread-local is
+/// destroyed. The generic-slot form had this teardown protection through
+/// `SlotGuard`; the named fast path must preserve it (#9183).
+#[inline(always)]
+pub(crate) fn unpublish_runtime_handle_stack() {
+    if let Some(hot) = hot_if_published() {
+        hot.runtime_handle_stack.set(std::ptr::null_mut());
+    }
+}
+
 /// The per-thread address cache. On Apple aarch64 this is an `mrs` plus two
 /// loads with no call at all; elsewhere it is the single TLS access the field
 /// cache already collapsed the whole allocation path down to.
@@ -481,17 +536,8 @@ fn hot_uncached() -> &'static HotTls {
 ))]
 #[inline(always)]
 pub(crate) fn hot() -> &'static HotTls {
-    let key = darwin_tsd::KEY.load(std::sync::atomic::Ordering::Relaxed);
-    if key != darwin_tsd::NO_KEY {
-        // SAFETY: `key` is a live pthread key, so the slot exists; it holds
-        // either null (this thread has not published yet) or the address this
-        // thread published from `HOT`.
-        let slots = unsafe { darwin_tsd::get(key) } as *mut HotTls;
-        if !slots.is_null() {
-            // SAFETY: published from `HOT`, which is const-init with no `Drop`
-            // — see the module docs on lifetime.
-            return unsafe { &*slots };
-        }
+    if let Some(slots) = hot_if_published() {
+        return slots;
     }
     hot_uncached()
 }
@@ -604,7 +650,7 @@ pub fn published_slots() -> usize {
 /// three times. The line reports:
 ///
 /// * `claimed` — declarations that took a slot process-wide. A program that
-///   exercises paths outside the sixteen named fields drives this well past
+///   exercises paths outside the seventeen named fields drives this well past
 ///   zero; a program that does not, does not.
 /// * `published` — slots this thread actually filled.
 /// * `direct_tsd` — whether `hot()` is the `mrs`-plus-two-loads path. `0`
@@ -867,7 +913,7 @@ impl<T: 'static> HotKey<T> {
 ///
 /// # Why this is the default rather than an allowlist
 ///
-/// The named fields at the top of this file are an opt-in list of sixteen,
+/// The named fields at the top of this file are an opt-in list of seventeen,
 /// curated against whichever workload was profiled last. Every hot path the
 /// list did not anticipate silently paid full price: `churn` read 0% of
 /// `_tlv_get_addr` for months while `asyncpipe` — Map/Set registries, buffer
@@ -1036,6 +1082,11 @@ mod tests {
             crate::gc::temp_roots_hot_addr(),
             "temp_roots"
         );
+        assert_eq!(
+            hot.runtime_handle_stack.get(),
+            crate::gc::runtime_handle_stack_hot_addr(),
+            "runtime_handle_stack"
+        );
     }
 
     /// No slot may be null after `hot()` — a null would mean `fill` skipped a
@@ -1069,9 +1120,36 @@ mod tests {
             ("shape_install_memo", hot.shape_install_memo),
             ("learned_inline_fields", hot.learned_inline_fields),
             ("temp_roots", hot.temp_roots),
+            ("runtime_handle_stack", hot.runtime_handle_stack.get()),
         ] {
             assert!(!ptr.is_null(), "{name} slot was left null by fill()");
         }
+    }
+
+    /// Handle scopes are used while a thread is still starting. Their cold
+    /// fallback must therefore remain usable without recursively filling the
+    /// cache that is trying to discover the handle-stack address (#9183).
+    #[test]
+    fn runtime_handles_do_not_fill_an_unpublished_cache() {
+        std::thread::spawn(|| {
+            let slots = super::HOT.with(|cell| cell.get());
+            // SAFETY: this is the current thread's const-initialized `HOT`.
+            assert!(unsafe { (*slots).temp_roots.is_null() });
+            assert!(super::hot_if_published().is_none());
+
+            {
+                let scope = crate::gc::RuntimeHandleScope::new();
+                let handle = scope.root_heap_word_u64(0);
+                assert_eq!(handle.get_heap_word_u64(), 0);
+            }
+
+            // Scope creation, push, read and drop all stayed on the fallback;
+            // none was allowed to re-enter `fill`.
+            assert!(unsafe { (*slots).temp_roots.is_null() });
+            assert!(super::hot_if_published().is_none());
+        })
+        .join()
+        .expect("unpublished-cache probe thread panicked");
     }
 
     /// The direct thread-specific-data path must be live on this platform.

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -2015,10 +2015,6 @@
       "name": "ROOT_SCANNERS"
     },
     {
-      "file": "crates/perry-runtime/src/gc/roots.rs",
-      "name": "RUNTIME_HANDLE_STACK"
-    },
-    {
       "file": "crates/perry-runtime/src/gc/roots/stack_maps.rs",
       "name": "LAST_REWRITE_WALK"
     },

--- a/scripts/thread_local_cold_allowlist.json
+++ b/scripts/thread_local_cold_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Files still declaring raw `thread_local!`. Every entry is a declaration that pays `_tlv_get_addr` on Darwin; the count is a ratchet, so adding one to an already-listed file fails too. New code should use `crate::perry_thread_local!` \u2014 see crates/perry-runtime/src/tls_hot.rs. Regenerate with scripts/check_thread_locals.py --update.",
-  "_hot_declarations": 271,
+  "_hot_declarations": 275,
   "files": {
     "crates/perry-runtime/src/agent.rs": 1,
     "crates/perry-runtime/src/arena/block.rs": 2,
@@ -38,6 +38,7 @@
     "crates/perry-runtime/src/gc/old_free.rs": 1,
     "crates/perry-runtime/src/gc/policy.rs": 6,
     "crates/perry-runtime/src/gc/promote_in_place.rs": 1,
+    "crates/perry-runtime/src/gc/roots/runtime_handles.rs": 1,
     "crates/perry-runtime/src/gc/roots/scan_mode.rs": 1,
     "crates/perry-runtime/src/gc/roots/shadow_stack.rs": 2,
     "crates/perry-runtime/src/gc/roots/temp_roots.rs": 1,


### PR DESCRIPTION
## What

Closes #9183.

- Append the runtime-handle stack address to `HotTls` without moving any codegen-consumed offsets.
- Add `hot_if_published()`, which reads only the already-published Darwin TSD slot and never enters `fill()`.
- Route scope creation, pushes, reads, scans, savepoints, and FFI roots through the named pointer on Apple aarch64.
- Keep startup and non-Darwin accesses on the ordinary thread-local path, so initialization cannot recurse and Linux does not gain an unnecessary cache indirection.
- Clear the named pointer before the handle stack's TLS destructor runs, preserving the teardown protection the previous generic cache supplied.

This deliberately claims only the Darwin TLS win described by the corrected issue. It does not attribute or promise recovery of the Linux profile's inlined closure work.

## Initialization contract

`RUNTIME_HANDLE_STACK` is the exceptional raw TLS declaration because it is needed while `HotTls` itself is being initialized. Its address is filled before the existing `temp_roots` readiness sentinel, but handle operations consult it only after the Darwin cache has been published. Before publication they use the raw declaration directly.

A fresh-thread regression exercises scope creation, push, read, and drop while asserting that `HotTls` remains unfilled. The exact worker timer test that stack-overflowed under the direct implementation is also covered.

## Validation

On `root@perrymaster.skelpo.net`:

- `cargo test --profile perry-dev -p perry-runtime tls_hot::tests::runtime_handles_do_not_fill_an_unpublished_cache -- --exact --nocapture`
- `cargo test --profile perry-dev -p perry-runtime agent_dispatch_tests::a_worker_neither_fires_nor_eats_a_primary_agent_timer -- --exact --nocapture`
- `cargo test --profile perry-dev -p perry-runtime -- --test-threads=1 --quiet` — 2,833 passed, 4 ignored; doc tests 0 failed
- `cargo check --profile perry-dev -p perry-runtime --target aarch64-apple-darwin --no-default-features`
- Apple aarch64 `--emit=asm` inspection: steady `new`/`push` use `PERRY_HOT_TSD_KEY`, `mrs TPIDRRO_EL0`, and the appended fixed-offset load; only the unpublished branch reaches the TLV accessor
- `cargo fmt --all -- --check`
- `python3 scripts/check_thread_locals.py`
- `scripts/check_file_size.sh`

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime handle operations on Apple silicon by reusing a cached thread-local address, reducing repeated lookups.
  * Preserved reliable fallback behavior during initialization and on other platforms.

* **Reliability**
  * Added teardown safeguards to prevent access to runtime handle data after thread-local storage is destroyed.
  * Expanded coverage for initialization and cache population scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->