### PR TITLE
fix(buffer): complete Buffer brand and prototype chain

### DIFF
--- a/changelog.d/9213-buffer-prototype-chain.md
+++ b/changelog.d/9213-buffer-prototype-chain.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `Buffer.isBuffer` now rejects non-Buffer byte-storage objects such as
+  `ArrayBuffer` and `DataView`, while Buffer instances inherit through
+  `Buffer.prototype` and `Uint8Array.prototype` as they do in Node.

--- a/crates/perry-runtime/src/buffer/exotic_view.rs
+++ b/crates/perry-runtime/src/buffer/exotic_view.rs
@@ -65,6 +65,21 @@ pub fn is_non_indexed_buffer_view(addr: usize) -> bool {
     super::is_any_array_buffer(addr) || super::is_data_view(addr)
 }
 
+/// `true` only for a Node `Buffer`, not for another JS type that happens to
+/// share Perry's `BufferHeader` storage and registry entry.
+///
+/// Keep this stricter than [`is_byte_indexed_buffer`]: a plain `Uint8Array` is
+/// also byte-indexed, but `Buffer.isBuffer(new Uint8Array(...))` must be false.
+/// ArrayBuffer, SharedArrayBuffer, and DataView are excluded independently
+/// because none of them carries the Uint8Array-constructor marker.
+#[inline]
+pub fn is_node_buffer(addr: usize) -> bool {
+    super::is_registered_buffer(addr)
+        && !super::is_any_array_buffer(addr)
+        && !super::is_data_view(addr)
+        && !super::is_uint8array_buffer(addr)
+}
+
 /// The own-property key a NUMERIC computed key names on a non-indexed buffer
 /// view, or `None` when the key is not a number at all.
 ///

--- a/crates/perry-runtime/src/buffer/exotic_view_tests.rs
+++ b/crates/perry-runtime/src/buffer/exotic_view_tests.rs
@@ -114,6 +114,11 @@ fn only_array_buffer_and_data_view_are_non_indexed_views() {
     assert!(crate::buffer::is_byte_indexed_buffer(b));
     assert!(crate::buffer::is_byte_indexed_buffer(u8a));
 
+    assert!(crate::buffer::is_node_buffer(b));
+    assert!(!crate::buffer::is_node_buffer(u8a));
+    assert!(!crate::buffer::is_node_buffer(ab));
+    assert!(!crate::buffer::is_node_buffer(dv));
+
     // A plain array is not a buffer at all — the two `false` answers above are
     // NOT the same answer as this one, which is why `is_non_indexed_buffer_view`
     // exists separately from `!is_byte_indexed_buffer`.

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -83,7 +83,9 @@ pub use own_props::{
 // `ArrayBuffer` / `SharedArrayBuffer` / `DataView` share `BufferHeader` and the
 // buffer registry with `Buffer` / `Uint8Array` but have NO integer-indexed own
 // properties. See `exotic_view`.
-pub use exotic_view::{canonical_index_key, is_byte_indexed_buffer, is_non_indexed_buffer_view};
+pub use exotic_view::{
+    canonical_index_key, is_byte_indexed_buffer, is_node_buffer, is_non_indexed_buffer_view,
+};
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----
 pub use from::{

--- a/crates/perry-runtime/src/buffer/query.rs
+++ b/crates/perry-runtime/src/buffer/query.rs
@@ -67,11 +67,9 @@ pub unsafe extern "C" fn js_value_buffer_or_typedarray_data(
 static KEEP_JS_VALUE_BUFFER_OR_TYPEDARRAY_DATA: unsafe extern "C" fn(f64, *mut u32) -> *const u8 =
     js_value_buffer_or_typedarray_data;
 
-/// Check if an object uses the shared Buffer/Uint8Array representation.
-#[no_mangle]
-pub extern "C" fn js_buffer_is_buffer(ptr: i64) -> i32 {
+fn buffer_addr_from_raw(ptr: i64) -> Option<usize> {
     if ptr == 0 || (ptr as u64) < 0x1000 {
-        return 0;
+        return None;
     }
     // Strip NaN-boxing tags if present
     let addr = if ((ptr as u64) >> 48) != 0 {
@@ -79,11 +77,16 @@ pub extern "C" fn js_buffer_is_buffer(ptr: i64) -> i32 {
     } else {
         ptr as u64
     };
-    if is_registered_buffer(addr as usize) {
-        1
-    } else {
-        0
-    }
+    Some(addr as usize)
+}
+
+/// Check whether a value uses Perry's shared BufferHeader storage.
+///
+/// Native consumers intentionally accept Buffer-backed Uint8Arrays and other
+/// byte views, so this remains broader than the JavaScript Buffer brand check.
+#[no_mangle]
+pub extern "C" fn js_buffer_is_buffer(ptr: i64) -> i32 {
+    buffer_addr_from_raw(ptr).is_some_and(is_registered_buffer) as i32
 }
 
 /// Check if an object has the Node `Buffer` brand.
@@ -95,15 +98,7 @@ pub extern "C" fn js_buffer_is_buffer(ptr: i64) -> i32 {
 /// this discriminator for the public `Buffer.isBuffer()` identity check.
 #[no_mangle]
 pub extern "C" fn js_buffer_is_node_buffer(ptr: i64) -> i32 {
-    if js_buffer_is_buffer(ptr) == 0 {
-        return 0;
-    }
-    let addr = if ((ptr as u64) >> 48) != 0 {
-        (ptr as u64) & 0x0000_FFFF_FFFF_FFFF
-    } else {
-        ptr as u64
-    } as usize;
-    (!is_uint8array_buffer(addr)) as i32
+    buffer_addr_from_raw(ptr).is_some_and(is_node_buffer) as i32
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/node_api_host/buffers.rs
+++ b/crates/perry-runtime/src/node_api_host/buffers.rs
@@ -124,13 +124,6 @@ pub unsafe extern "C" fn napi_create_external_buffer(
     write_pointer_handle(env, buffer.cast(), result)
 }
 
-fn is_node_buffer(owner: usize) -> bool {
-    crate::buffer::is_registered_buffer(owner)
-        && !crate::buffer::is_any_array_buffer(owner)
-        && !crate::buffer::is_data_view(owner)
-        && !crate::buffer::is_uint8array_buffer(owner)
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn napi_is_buffer(
     env: NapiEnv,
@@ -140,7 +133,7 @@ pub unsafe extern "C" fn napi_is_buffer(
     if result.is_null() {
         return set_status(env, NapiStatus::InvalidArg, "result must not be null");
     }
-    *result = pointer_owner(env, value).is_ok_and(is_node_buffer);
+    *result = pointer_owner(env, value).is_ok_and(crate::buffer::is_node_buffer);
     ok(env)
 }
 

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -148,6 +148,29 @@ pub(crate) fn populate_global_this_builtins(singleton_at_entry: *mut ObjectHeade
             let name_key =
                 crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
             let ctor_value = super::super::native_module::buffer_constructor_value();
+
+            // #9173: Buffer instances resolve to Buffer.prototype, whose own
+            // [[Prototype]] is Uint8Array.prototype. Both objects already
+            // exist here (Buffer is deliberately last in the constructor
+            // table), so link the real prototype objects without recursively
+            // initializing globalThis from buffer_constructor_value().
+            let ctor = JSValue::from_bits(ctor_value.to_bits());
+            if ctor.is_pointer() {
+                let buffer_proto = crate::closure::closure_get_dynamic_prop(
+                    ctor.as_pointer::<crate::closure::ClosureHeader>() as usize,
+                    "prototype",
+                );
+                let buffer_proto_value = JSValue::from_bits(buffer_proto.to_bits());
+                let uint8_proto = builtin_prototype_value("Uint8Array");
+                if buffer_proto_value.is_pointer()
+                    && JSValue::from_bits(uint8_proto.to_bits()).is_pointer()
+                {
+                    super::super::prototype_chain::object_set_static_prototype(
+                        buffer_proto_value.as_pointer::<ObjectHeader>() as usize,
+                        uint8_proto.to_bits(),
+                    );
+                }
+            }
             js_object_set_field_by_name(singleton(), name_key, ctor_value);
             super::super::set_builtin_property_attrs(
                 singleton() as usize,

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -322,6 +322,17 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
             None
         }
     };
+    let node_buffer_prototype = |addr: usize| -> Option<f64> {
+        if !crate::buffer::is_node_buffer(addr) {
+            return None;
+        }
+        let proto = crate::object::builtin_prototype_value("Buffer");
+        if proto.to_bits() != crate::value::TAG_UNDEFINED {
+            Some(proto)
+        } else {
+            None
+        }
+    };
     let buffer_backed_uint8array_prototype = |addr: usize| -> Option<f64> {
         if !crate::buffer::is_uint8array_buffer(addr) {
             return None;
@@ -427,6 +438,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 return proto;
             }
             if let Some(proto) = buffer_backed_prototype(raw_addr as usize) {
+                return proto;
+            }
+            if let Some(proto) = node_buffer_prototype(raw_addr as usize) {
                 return proto;
             }
             if let Some(proto) = buffer_backed_uint8array_prototype(raw_addr as usize) {
@@ -610,6 +624,9 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
             return proto;
         }
         if let Some(proto) = buffer_backed_prototype(bits as usize) {
+            return proto;
+        }
+        if let Some(proto) = node_buffer_prototype(bits as usize) {
             return proto;
         }
         if let Some(proto) = buffer_backed_uint8array_prototype(bits as usize) {

--- a/crates/perry/tests/issue_9173_buffer_identity.rs
+++ b/crates/perry/tests/issue_9173_buffer_identity.rs
@@ -1,0 +1,51 @@
+//! Regression coverage for #9173: Uint8Array shares Perry's BufferHeader
+//! storage but not Node's Buffer brand, and Buffer.prototype inherits from
+//! Uint8Array.prototype.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+#[test]
+fn buffer_brand_and_uint8array_prototype_chain_match_node() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = workspace_root().join("test-files/test_issue_9173_buffer_identity.ts");
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "buffer brand: true\nbuffer is uint8: true\nuint8 brand: false\nuint8 is uint8: true\narray buffer brand: false\ndata view brand: false\ncaptured brand: true false\nbuffer prototype: true\nbuffer parent prototype: true\nprototype link: true\n"
+    );
+}

--- a/test-files/test_issue_9173_buffer_identity.ts
+++ b/test-files/test_issue_9173_buffer_identity.ts
@@ -1,0 +1,25 @@
+import { Buffer as NodeBuffer } from "node:buffer";
+
+const buf = Buffer.from([1, 2, 3]);
+const u8 = new Uint8Array([4, 5]);
+
+console.log("buffer brand:", Buffer.isBuffer(buf));
+console.log("buffer is uint8:", buf instanceof Uint8Array);
+console.log("uint8 brand:", Buffer.isBuffer(u8));
+console.log("uint8 is uint8:", u8 instanceof Uint8Array);
+console.log("array buffer brand:", Buffer.isBuffer(new ArrayBuffer(2)));
+console.log(
+  "data view brand:",
+  Buffer.isBuffer(new DataView(new ArrayBuffer(2))),
+);
+const capturedIsBuffer = NodeBuffer.isBuffer;
+console.log("captured brand:", capturedIsBuffer(buf), capturedIsBuffer(u8));
+console.log("buffer prototype:", Object.getPrototypeOf(buf) === Buffer.prototype);
+console.log(
+  "buffer parent prototype:",
+  Object.getPrototypeOf(Object.getPrototypeOf(buf)) === Uint8Array.prototype,
+);
+console.log(
+  "prototype link:",
+  Object.getPrototypeOf(Buffer.prototype) === Uint8Array.prototype,
+);


### PR DESCRIPTION
Closes #9173

## Summary

- complete the public `Buffer.isBuffer` brand check by rejecting `ArrayBuffer` and `DataView` while preserving the broader internal BufferHeader storage probe
- resolve Buffer instances to `Buffer.prototype` and link that prototype to `Uint8Array.prototype`
- share the strict Buffer predicate with the N-API path
- cover Buffer, Uint8Array, ArrayBuffer, DataView, captured-call, and prototype-chain behavior

## Testing

- `cargo test -p perry-runtime node_buffer --lib`
- `cargo test -p perry-runtime only_array_buffer_and_data_view_are_non_indexed_views --lib`
- `cargo build --release -p perry-runtime-static`
- `cargo test -p perry --test issue_9173_buffer_identity -- --nocapture`
- Buffer Node differential suite: 134/134 passing
- `cargo fmt --all -- --check`
- `git diff --check`

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Buffer.isBuffer` accuracy so it rejects `ArrayBuffer`, `DataView`, and plain `Uint8Array` values.
  - Updated Buffer prototype relationships to match Node.js behavior.
  - Improved Buffer identity and prototype checks across typed-array scenarios.

- **Tests**
  - Added regression coverage for Buffer branding, inheritance, and identity behavior.

- **Documentation**
  - Documented the corrected Buffer detection and prototype chain behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->