### PR TITLE
docs(skills): port-npm-to-perry stops labeling supported constructs unsupported

### DIFF
--- a/.claude/skills/port-npm-to-perry/SKILL.md
+++ b/.claude/skills/port-npm-to-perry/SKILL.md
@@ -38,11 +38,10 @@ grep -rn "new Function(" <pkg>/
 grep -rn "require(" <pkg>/ | grep -v "^.*://"   # dynamic require
 grep -rn "await import(" <pkg>/
 
-# Unsupported primitives
-grep -rn "\bSymbol(" <pkg>/
-grep -rn "new Proxy(" <pkg>/
-grep -rn "new WeakMap(" <pkg>/
-grep -rn "new WeakRef(" <pkg>/
+# Supported, but with caveats — surface for review, not blockers
+grep -rn "new Proxy(" <pkg>/    # limited trapping: docs/src/language/limitations.md#limited-proxy-trapping
+grep -rn "new WeakMap(" <pkg>/  # targets retained, never collected: docs/src/language/limitations.md#weak-references-retain-their-targets
+grep -rn "new WeakRef(" <pkg>/  # same retention caveat
 
 # Reflection / metadata
 grep -rn "Reflect\." <pkg>/
@@ -65,8 +64,8 @@ Make a punch list. For each hit, decide: can it be patched, or does it rule the 
 
 ### 3. Triage
 
-- **Rules the package out**: native addons, heavy `eval`/`Function`, packages whose core API depends on `Proxy` (e.g., ORMs, validation DSLs).
-- **Patchable**: decorators (often removable with a light rewrite), occasional `Symbol` uses (swap for unique string sentinels), lookbehind regex (rewrite as a two-pass match), simple computed keys (hoist to explicit assignment), `Object.setPrototypeOf` in isomorphic fallback paths (often dead code for native targets).
+- **Rules the package out**: native addons, heavy `eval`/`Function`, packages whose core API needs exotic `Proxy` trap behavior beyond Perry's supported surface (full engine-level trapping of every dynamic access — see [Limited Proxy Trapping](../../../docs/src/language/limitations.md#limited-proxy-trapping)). Plain `Proxy` use is fine.
+- **Patchable**: decorators (often removable with a light rewrite), lookbehind regex (rewrite as a two-pass match), simple computed keys (hoist to explicit assignment), `Object.setPrototypeOf` in isomorphic fallback paths (often dead code for native targets).
 - **Defer to `jsEval` fallback** if patching is unreasonable but only a small surface is affected.
 
 Report the triage to the user before patching anything substantial, so they can decide whether to keep going.
@@ -109,7 +108,7 @@ Tell the user:
 
 ## Important
 
-- **Don't patch blindly.** A grep hit isn't always real — `Symbol` inside a string, `eval` in a comment, `Proxy` as an identifier name, etc. Read the actual usage.
+- **Don't patch blindly.** A grep hit isn't always real — `eval` in a comment, `Proxy` as an identifier name, etc. Read the actual usage.
 - **Don't commit patches to the user's repo without asking.** Show the diff, let them decide.
 - **Respect the experimental label.** If something doesn't work, say so — don't paper over it. Report back so issue #115 gets real feedback.
 


### PR DESCRIPTION
# Problem

The `port-npm-to-perry` skill's gap scan groups `Symbol`, `Proxy`, `WeakMap`, and `WeakRef` under an `# Unsupported primitives` header, and its triage step rules out any package "whose core API depends on `Proxy`." All four constructs are supported, so the scan mislabels them and the triage rule rules out portable packages on its own.

# Solution

Stop asserting these are unsupported. Surface them for review with their real caveats, linked to `docs/src/language/limitations.md`, and scope the Proxy triage rule to the one case that actually rules a package out.

# This PR

Edits only `.claude/skills/port-npm-to-perry/SKILL.md` (docs/tooling, no `crates/` change, so no changelog fragment).

## Changes

1. **Rename the scan group.** `# Unsupported primitives` → "Supported, but with caveats — surface for review, not blockers." Drop the `Symbol` grep entirely — `Symbol` is fully supported with no caveat ([no section in limitations.md](https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md); computed `Symbol.iterator` / `yield*` lowering fixed in #6676, #6696). Keep `Proxy`/`WeakMap`/`WeakRef`, each linked to its limitation:
   - [Limited Proxy Trapping](https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md#limited-proxy-trapping)
   - [Weak References Retain Their Targets](https://github.com/PerryTS/perry/blob/main/docs/src/language/limitations.md#weak-references-retain-their-targets)
2. **Narrow the Proxy triage rule.** Rules out only packages needing exotic trap behavior beyond Perry's supported surface, not any `Proxy` use. Adds "Plain `Proxy` use is fine."
3. **Drop stale Symbol advice.** Removed the "swap `Symbol` for string sentinels" patchable tip and the `Symbol`-in-a-string false-positive example, both left over from treating `Symbol` as unsupported.

Fixes #9112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8NeyZTthezLR2dMUxqpKQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package compatibility guidance for `Symbol`, `Proxy`, `WeakMap`, and `WeakRef`.
  * Clarified that standard `Proxy` usage is supported, while advanced trap behavior may remain incompatible.
  * Removed outdated guidance recommending string replacements for `Symbol` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->