### PR TITLE
fix(hir): keep dynamic import walkers aligned

### DIFF
--- a/changelog.d/9236-dynamic-import-walker-alignment.md
+++ b/changelog.d/9236-dynamic-import-walker-alignment.md
@@ -1,0 +1,3 @@
+Dynamic imports inside closures and top-level dynamic imports now keep their
+resolution outcomes aligned, preventing valid literal imports from being
+lowered as runtime-computed import errors.

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -753,6 +753,56 @@ fn worker_new_visitor_descends_into_closure_bodies() {
 }
 
 #[test]
+fn dynamic_import_visitors_keep_closure_and_toplevel_order_in_lockstep() {
+    fn dynamic_import(path: &str) -> Expr {
+        Expr::DynamicImport {
+            paths: vec![],
+            arg: Box::new(Expr::String(path.to_string())),
+            byte_offset: 0,
+            deferred_error: None,
+            synchronous: false,
+        }
+    }
+
+    fn path(expr: &Expr) -> String {
+        match expr {
+            Expr::DynamicImport { arg, .. } => match arg.as_ref() {
+                Expr::String(path) => path.clone(),
+                other => panic!("expected string dynamic import, got {other:?}"),
+            },
+            other => panic!("expected dynamic import, got {other:?}"),
+        }
+    }
+
+    let mut module = Module::new("dynamic-import-order");
+    module.init.push(Stmt::Expr(Expr::Closure {
+        func_id: 1,
+        params: vec![],
+        return_type: Type::Void,
+        body: vec![Stmt::Expr(dynamic_import("closure"))],
+        captures: vec![],
+        mutable_captures: vec![],
+        captures_this: false,
+        captures_new_target: false,
+        enclosing_class: None,
+        is_arrow: false,
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+    }));
+    module.init.push(Stmt::Expr(dynamic_import("toplevel")));
+
+    let mut immutable = Vec::new();
+    for_each_dynamic_import(&module, &mut |expr| immutable.push(path(expr)));
+
+    let mut mutable = Vec::new();
+    for_each_dynamic_import_mut(&mut module, &mut |expr| mutable.push(path(expr)));
+
+    assert_eq!(immutable, ["closure", "toplevel"]);
+    assert_eq!(mutable, immutable);
+}
+
+#[test]
 fn resolve_web_worker_url_relative_to_import_meta() {
     let expr = Expr::UrlNew {
         url: Box::new(Expr::String("./rpc-worker.ts".to_string())),

--- a/crates/perry-hir/src/dynamic_import/visitors.rs
+++ b/crates/perry-hir/src/dynamic_import/visitors.rs
@@ -463,13 +463,6 @@ fn visit_expr_for_dyn_imports_ref<F: FnMut(&Expr)>(expr: &Expr, f: &mut F) {
             visit_stmt_for_dyn_imports_ref(s, f);
         }
     }
-    // Closure bodies — mirror the mutable visitor so the collect pass and the
-    // fill pass traverse dynamic import sites in the same order.
-    if let Expr::Closure { body, .. } = expr {
-        for s in body {
-            visit_stmt_for_dyn_imports_ref(s, f);
-        }
-    }
     walk_expr_children(expr, &mut |child| visit_expr_for_dyn_imports_ref(child, f));
 }
 


### PR DESCRIPTION
Closes #9236.

Removes the duplicate closure-body traversal in the immutable dynamic-import walker so the collect and mutable fill passes stay 1:1. Adds a direct order/count regression test.

Release evidence:
- `cargo fmt --check --all`
- 48 `dynamic_import::tests` passed
- all 6 `issue_6660_closure_dynamic_import` tests passed serially
- exact previously failing `closure_and_toplevel_dynamic_imports_stay_aligned` test now passes

Failed release job: https://github.com/PerryTS/perry/actions/runs/33341614590/job/99338182929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dynamic import handling when imports appear both inside closures and at the top level.
  - Valid literal imports now retain the correct resolution instead of being incorrectly treated as runtime-computed errors.
  - Ensured dynamic imports are processed consistently across supported code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->